### PR TITLE
Scanner: Optionally skip scanning packages with a concluded license

### DIFF
--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -31,6 +31,12 @@ import org.ossreviewtoolkit.utils.storage.FileStorage
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ScannerConfiguration(
     /**
+     * A flag to indicate whether packages that have a concluded license and authors set (to derive copyrights from)
+     * should be skipped in the scan in favor of only using the declared information.
+     */
+    val skipConcluded: Boolean = false,
+
+    /**
      * Configuration of a [FileArchiver] that archives certain scanned files in an external [FileStorage].
      */
     val archive: FileArchiverConfiguration? = null,

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -38,6 +38,8 @@ ort {
   }
 
   scanner {
+    skipConcluded = true
+
     archive {
       fileStorage {
         localFileStorage {

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -204,6 +204,7 @@ scanner:
     variables: {}
     tool_versions: {}
   config:
+    skip_concluded: false
     archive: null
     create_missing_archives: false
     options: null

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -198,7 +198,7 @@ abstract class LocalScanner(
     }
 
     override suspend fun scanPackages(
-        packages: List<Package>,
+        packages: Collection<Package>,
         outputDirectory: File,
         downloadDirectory: File
     ): Map<Package, List<ScanResult>> {
@@ -229,7 +229,7 @@ abstract class LocalScanner(
         return resultsFromStorage + resultsFromScanner
     }
 
-    private fun readResultsFromStorage(packages: List<Package>, scannerCriteria: ScannerCriteria) =
+    private fun readResultsFromStorage(packages: Collection<Package>, scannerCriteria: ScannerCriteria) =
         when (val results = ScanResultsStorage.storage.read(packages, scannerCriteria)) {
             is Success -> results.result
             is Failure -> emptyMap()
@@ -243,7 +243,10 @@ abstract class LocalScanner(
                 scanResults.map { it.filterByVcsPath().filterByIgnorePatterns(scannerConfig.ignorePatterns) }
             }
 
-    private fun List<Package>.scan(outputDirectory: File, downloadDirectory: File): Map<Package, List<ScanResult>> {
+    private fun Collection<Package>.scan(
+        outputDirectory: File,
+        downloadDirectory: File
+    ): Map<Package, List<ScanResult>> {
         var index = 0
 
         return associateWith { pkg ->

--- a/scanner/src/main/kotlin/ScanResultsStorage.kt
+++ b/scanner/src/main/kotlin/ScanResultsStorage.kt
@@ -244,7 +244,10 @@ abstract class ScanResultsStorage {
      * of [ScanResult]s mapped to the [Identifier]s of the [packages], wrapped in a [Result], which is a [Failure] if
      * an unexpected error occurred and a [Success] otherwise.
      */
-    fun read(packages: List<Package>, scannerCriteria: ScannerCriteria): Result<Map<Identifier, List<ScanResult>>> {
+    fun read(
+        packages: Collection<Package>,
+        scannerCriteria: ScannerCriteria
+    ): Result<Map<Identifier, List<ScanResult>>> {
         val (result, duration) = measureTimedValue { readInternal(packages, scannerCriteria) }
 
         stats.numReads.addAndGet(packages.size)
@@ -343,7 +346,7 @@ abstract class ScanResultsStorage {
      * efficient way.
      */
     protected open fun readInternal(
-        packages: List<Package>,
+        packages: Collection<Package>,
         scannerCriteria: ScannerCriteria
     ): Result<Map<Identifier, List<ScanResult>>> {
         val results = runBlocking(Dispatchers.IO) {

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -66,13 +66,13 @@ abstract class Scanner(
     }
 
     /**
-     * Scan the list of [packages] and store the scan results in [outputDirectory]. The [downloadDirectory] is used to
-     * download the source code to for scanning. [ScanResult]s are returned associated by the [Package]. The map may
-     * contain multiple results for the same [Package] if the storage contains more than one result for the
-     * specification of this scanner.
+     * Scan the [packages] and store the scan results in [outputDirectory]. The [downloadDirectory] is used to download
+     * the source code to for scanning. [ScanResult]s are returned associated by the [Package]. The map may contain
+     * multiple results for the same [Package] if the storage contains more than one result for the specification of
+     * this scanner.
      */
     protected abstract suspend fun scanPackages(
-        packages: List<Package>,
+        packages: Collection<Package>,
         outputDirectory: File,
         downloadDirectory: File
     ): Map<Package, List<ScanResult>>

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -119,14 +119,14 @@ abstract class Scanner(
 
         // Add the projects as packages to scan.
         val consolidatedProjects = consolidateProjectPackagesByVcs(ortResult.getProjects(skipExcluded))
-        val consolidatedReferencePackages = consolidatedProjects.keys.toList()
+        val projectPackages = consolidatedProjects.keys.toList()
 
-        val referencePackageIdentifiers = consolidatedReferencePackages.map { it.id }
+        val projectPackageIds = projectPackages.map { it.id }
         val packages = ortResult.getPackages(skipExcluded)
-            .filter { it.pkg.id !in referencePackageIdentifiers }
+            .filter { it.pkg.id !in projectPackageIds }
             .map { it.pkg }
 
-        val packagesToScan = consolidatedReferencePackages + packages
+        val packagesToScan = projectPackages + packages
         val scanResults = runBlocking {
             scanPackages(packagesToScan, outputDirectory, downloadDirectory).mapKeys { it.key.id }
         }.toSortedMap()

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -119,7 +119,7 @@ abstract class Scanner(
 
         // Add the projects as packages to scan.
         val consolidatedProjects = consolidateProjectPackagesByVcs(ortResult.getProjects(skipExcluded))
-        val projectPackages = consolidatedProjects.keys.toList()
+        val projectPackages = consolidatedProjects.keys
 
         val projectPackageIds = projectPackages.map { it.id }
         val packages = ortResult.getPackages(skipExcluded)

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -152,7 +152,7 @@ class FossId(
         }
 
     override suspend fun scanPackages(
-        packages: List<Package>,
+        packages: Collection<Package>,
         outputDirectory: File,
         downloadDirectory: File
     ): Map<Package, List<ScanResult>> {

--- a/scanner/src/main/kotlin/storages/CompositeStorage.kt
+++ b/scanner/src/main/kotlin/storages/CompositeStorage.kt
@@ -68,7 +68,7 @@ class CompositeStorage(
         fetchReadResult { read(pkg, scannerCriteria) }
 
     override fun readInternal(
-        packages: List<Package>,
+        packages: Collection<Package>,
         scannerCriteria: ScannerCriteria
     ): Result<Map<Identifier, List<ScanResult>>> {
         if (readers.isEmpty()) return Success(emptyMap())

--- a/scanner/src/main/kotlin/storages/PostgresStorage.kt
+++ b/scanner/src/main/kotlin/storages/PostgresStorage.kt
@@ -181,7 +181,7 @@ class PostgresStorage(
     }
 
     override fun readInternal(
-        packages: List<Package>,
+        packages: Collection<Package>,
         scannerCriteria: ScannerCriteria
     ): Result<Map<Identifier, List<ScanResult>>> {
         if (packages.isEmpty()) return Success(emptyMap())


### PR DESCRIPTION
If we already know the concluded license and have authors, we do not
necessarily need to detect licenses and copyrights anymore.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>
