### PR TITLE
ListLicensesCommand: Add a param to specify rules for which `--omit-excluded` should not take effect

### DIFF
--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -199,13 +199,17 @@ internal fun OrtResult.getLicenseFindingsById(id: Identifier): Map<String, Set<T
 }
 
 /**
- * Return all license [Identifiers]s which are associated with at least one [RuleViolation] with a [severity]
- * greater or equal to the given [minSeverity].
+ * Return all license [Identifiers]s which triggered at least one [RuleViolation] with a [severity]
+ * greater or equal to the given [minSeverity] associated with the rule names of all corresponding violated rules.
  */
-internal fun OrtResult.getOffendingLicensesById(id: Identifier, minSeverity: Severity): Set<String> =
-    getRuleViolations().filter {
-        it.pkg == id && it.severity.ordinal <= minSeverity.ordinal
-    }.mapNotNull { it.license }.toSet()
+internal fun OrtResult.getViolatedRulesByLicense(
+    id: Identifier,
+    minSeverity: Severity
+): Map<String, List<String>> =
+    getRuleViolations()
+        .filter { it.pkg == id && it.severity.ordinal <= minSeverity.ordinal && it.license != null }
+        .groupBy { it.license!! }
+        .mapValues { (_, ruleViolations) -> ruleViolations.map { it.rule } }
 
 /**
  * Return the Package with the given [id] denoting either a [Project] or a [Package].


### PR DESCRIPTION
…ngs.

This makes sense for rules which do adhere to the excluded state of license
findings. However for rules which do not consider the excluded state it makes
more sense to always show the text locations of the related license findings
no matter if these locations are excluded or not.

This new parameter allows specifying a comma separate list of rule identifiers
of the rules for which the `--omit-excluded` parameter should not take any effect.

Signed-off-by: Frank Viernau <frank.viernau@here.com>