### PR TITLE
docker: Pass proxy build args / env only if set

### DIFF
--- a/docker/lib
+++ b/docker/lib
@@ -19,8 +19,11 @@ buildWithoutContext () {
     DOCKER_FILE=$1
     DOCKER_IMAGE=$2
 
+    [ -n "$http_proxy" ] && HTTP_PROXY_ARG="--build-arg http_proxy=$http_proxy"
+    [ -n "$https_proxy" ] && HTTPS_PROXY_ARG="--build-arg https_proxy=$https_proxy"
+
     # Build the image without a context to avoid it being sent to the daemon every time.
-    docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy -t $DOCKER_IMAGE - < $DOCKER_FILE
+    docker build $HTTP_PROXY_ARG $HTTPS_PROXY_ARG -t $DOCKER_IMAGE - < $DOCKER_FILE
 }
 
 runAsUser () {
@@ -30,8 +33,11 @@ runAsUser () {
 
     DOCKER_RUN_AS_USER="-v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro -v $HOME:$HOME -u $(id -u $USER):$(id -g $USER)"
 
+    [ -n "$http_proxy" ] && HTTP_PROXY_ENV="-e http_proxy"
+    [ -n "$https_proxy" ] && HTTPS_PROXY_ENV="-e https_proxy"
+
     # Mount the project root into the image to run the command task from there.
-    docker run $DOCKER_ARGS $DOCKER_RUN_AS_USER -e http_proxy -e https_proxy -v /tmp:/tmp -v $PWD:/home/ort -w /home/ort $DOCKER_IMAGE $COMMAND
+    docker run $DOCKER_ARGS $DOCKER_RUN_AS_USER $HTTP_PROXY_ENV $HTTPS_PROXY_ENV -v /tmp:/tmp -v $PWD:/home/ort -w /home/ort $DOCKER_IMAGE $COMMAND
 }
 
 parseProxyToProps () {


### PR DESCRIPTION
Otherwise and empty string is tried to be used as a proxy, which fails.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch-si.com>