### PR TITLE
reporter: Use https for the robotooling repository (BLOCKED)

### DIFF
--- a/reporter/build.gradle.kts
+++ b/reporter/build.gradle.kts
@@ -51,7 +51,7 @@ sourceSets.named("main") {
 repositories {
     exclusiveContent {
         forRepository {
-            maven("http://www.robotooling.com/maven/")
+            maven("https://www.robotooling.com/maven/")
         }
 
         filter {


### PR DESCRIPTION
To address an upcoming deprecation flagged by the Gradle build scan.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>