### PR TITLE
Merge VersionControlSystem.splitUrl() into VcsHost.toVcsInfo()

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -20,6 +20,7 @@
 package com.here.ort.analyzer
 
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.downloader.VcsHost
 import com.here.ort.model.Identifier
 import com.here.ort.model.Project
 import com.here.ort.model.ProjectAnalyzerResult
@@ -155,7 +156,7 @@ abstract class PackageManager(
                 VersionControlSystem.forUrl(it) != null
             }.orEmpty()
 
-            val vcsFromUrl = VersionControlSystem.splitUrl(normalizedUrl)
+            val vcsFromUrl = VcsHost.toVcsInfo(normalizedUrl)
             return vcsFromUrl.merge(normalizedVcsFromPackage)
         }
 

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -25,6 +25,7 @@ import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.analyzer.HTTP_CACHE_PATH
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.downloader.VcsHost
 import com.here.ort.model.Hash
 import com.here.ort.model.Identifier
 import com.here.ort.model.OrtIssue
@@ -304,7 +305,7 @@ data class GemSpec(
                 yaml["licenses"]?.asIterable()?.mapTo(sortedSetOf()) { it.textValue() } ?: sortedSetOf(),
                 yaml["description"].textValueOrEmpty(),
                 runtimeDependencies.orEmpty(),
-                VersionControlSystem.splitUrl(homepage),
+                VcsHost.toVcsInfo(homepage),
                 RemoteArtifact.EMPTY
             )
         }
@@ -317,7 +318,7 @@ data class GemSpec(
             }?.toSet()
 
             val vcs = if (json.hasNonNull("source_code_uri")) {
-                VersionControlSystem.splitUrl(json["source_code_uri"].textValue())
+                VcsHost.toVcsInfo(json["source_code_uri"].textValue())
             } else {
                 VcsInfo.EMPTY
             }

--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.here.ort.analyzer.AbstractPackageManagerFactory
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.downloader.VcsHost
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
 import com.here.ort.model.PackageLinkage
@@ -84,7 +85,7 @@ class Cargo(
     private fun extractRepositoryUrl(node: JsonNode) = node["repository"].textValueOrEmpty()
 
     private fun extractVcsInfo(node: JsonNode) =
-        VersionControlSystem.splitUrl(extractRepositoryUrl(node))
+        VcsHost.toVcsInfo(extractRepositoryUrl(node))
 
     private fun extractDeclaredLicenses(node: JsonNode) =
         node["license"].textValueOrEmpty().split("/")

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -32,6 +32,7 @@ import com.here.ort.analyzer.managers.utils.hasNpmLockFile
 import com.here.ort.analyzer.managers.utils.mapDefinitionFilesForNpm
 import com.here.ort.analyzer.managers.utils.readProxySettingFromNpmRc
 import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.downloader.VcsHost
 import com.here.ort.model.Hash
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
@@ -286,7 +287,7 @@ open class Npm(
                 }
             }
 
-            val vcsFromDownloadUrl = VersionControlSystem.splitUrl(expandNpmShortcutURL(downloadUrl))
+            val vcsFromDownloadUrl = VcsHost.toVcsInfo(expandNpmShortcutURL(downloadUrl))
             if (vcsFromDownloadUrl.url != downloadUrl) {
                 vcsFromPackage = vcsFromPackage.merge(vcsFromDownloadUrl)
             }

--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 
 import com.here.ort.analyzer.PackageManager
 import com.here.ort.analyzer.TOOL_NAME
-import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.downloader.VcsHost
 import com.here.ort.model.Hash
 import com.here.ort.model.Identifier
 import com.here.ort.model.Package
@@ -184,7 +184,7 @@ class MavenSupport(workspaceReader: WorkspaceReader) {
 
                             // Try to detect the Maven SCM provider from the URL only, e.g. by looking at the host or
                             // special URL paths.
-                            VersionControlSystem.splitUrl(fixedUrl).copy(revision = tag).also {
+                            VcsHost.toVcsInfo(fixedUrl).copy(revision = tag).also {
                                 log.info { "Fixed up invalid SCM connection '$connection' without a provider to $it." }
                             }
                         }

--- a/downloader/src/funTest/kotlin/BabelTest.kt
+++ b/downloader/src/funTest/kotlin/BabelTest.kt
@@ -55,7 +55,7 @@ class BabelTest : StringSpec() {
                 url = "https://github.com/babel/babel/tree/master/packages/babel-cli",
                 revision = ""
             )
-            val vcsFromUrl = VersionControlSystem.splitUrl(normalizeVcsUrl(vcsFromPackage.url))
+            val vcsFromUrl = VcsHost.toVcsInfo(normalizeVcsUrl(vcsFromPackage.url))
             val vcsMerged = vcsFromUrl.merge(vcsFromPackage)
 
             val pkg = Package(

--- a/downloader/src/test/kotlin/VcsHostTest.kt
+++ b/downloader/src/test/kotlin/VcsHostTest.kt
@@ -30,7 +30,7 @@ import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 
 class VcsHostTest : WordSpec({
-    "Bitbucket" should {
+    "The Bitbucket implementation" should {
         "be able to extract VCS information from a project URL" {
             BITBUCKET.toVcsInfo(
                 "https://bitbucket.org/facebook/lz4revlog/src/4c259957d2904604115a02543dc73f5be95761d7/COPYING"
@@ -58,7 +58,7 @@ class VcsHostTest : WordSpec({
         }
     }
 
-    "GitHub" should {
+    "The GitHub implementation" should {
         "be able to extract VCS information from a project URL" {
             GITHUB.toVcsInfo(
                 "https://github.com/oss-review-toolkit/ort/tree/da7e3a814fc0e6301bf3ed394eba1a661e4d88d7/README.md"
@@ -100,7 +100,7 @@ class VcsHostTest : WordSpec({
         }
     }
 
-    "GitLab" should {
+    "The GitLab implementation" should {
         "be able to extract VCS information from a project URL" {
             GITLAB.toVcsInfo(
                 "https://gitlab.com/mbunkus/mkvtoolnix/tree/ec80478f87f1941fe52f15c5f4fa7ee6a70d7006/NEWS.md"
@@ -142,7 +142,7 @@ class VcsHostTest : WordSpec({
         }
     }
 
-    "SourceHut" should {
+    "The SourceHut implementation" should {
         "be able to extract VCS information from a Git project URL" {
             SOURCEHUT.toVcsInfo(
                 "https://git.sr.ht/~ben/web/tree/2c3d173d/pkgs.nix"
@@ -192,6 +192,112 @@ class VcsHostTest : WordSpec({
             SOURCEHUT.toPermalink(vcsInfo, 9) shouldBe
                     "https://hg.sr.ht/~duangle/paniq_legacy/browse/f04521a92844/masagin/README.txt#L9"
             // SourceHut does not support an end line in permalinks to Mercural repos.
+        }
+    }
+
+    "The generic implementation" should {
+        "split paths from a URL to a Git repository" {
+            val actual = VcsHost.toVcsInfo(
+                "https://git-wip-us.apache.org/repos/asf/zeppelin.git"
+            )
+            val expected = VcsInfo(
+                type = VcsType.GIT,
+                url = "https://git-wip-us.apache.org/repos/asf/zeppelin.git",
+                revision = "",
+                path = ""
+            )
+            actual shouldBe expected
+        }
+
+        "split paths from a URL to a Git repository with path" {
+            val actual = VcsHost.toVcsInfo(
+                "https://git-wip-us.apache.org/repos/asf/zeppelin.git/zeppelin-interpreter"
+            )
+            val expected = VcsInfo(
+                type = VcsType.GIT,
+                url = "https://git-wip-us.apache.org/repos/asf/zeppelin.git",
+                revision = "",
+                path = "zeppelin-interpreter"
+            )
+            actual shouldBe expected
+        }
+
+        "split the revision from an NPM URL to a Git repository" {
+            val actual = VcsHost.toVcsInfo(
+                "git+ssh://sub.domain.com:42/foo-bar#b3b5b3c60dcdc39347b23cf94ab8f577239b7df3"
+            )
+            val expected = VcsInfo(
+                type = VcsType.GIT,
+                url = "ssh://sub.domain.com:42/foo-bar",
+                revision = "b3b5b3c60dcdc39347b23cf94ab8f577239b7df3",
+                path = ""
+            )
+            actual shouldBe expected
+        }
+
+        "split the revision from a NPM URL to a GitHub repository" {
+            val actual = VcsHost.toVcsInfo(
+                "https://github.com/mochajs/mocha.git#5bd33a0ba201d227159759e8ced86756595b0c54"
+            )
+            val expected = VcsInfo(
+                type = VcsType.GIT,
+                url = "https://github.com/mochajs/mocha.git",
+                revision = "5bd33a0ba201d227159759e8ced86756595b0c54",
+                path = ""
+            )
+            actual shouldBe expected
+        }
+
+        "separate an SVN branch into the revision" {
+            val actual = VcsHost.toVcsInfo(
+                "http://svn.osdn.net/svnroot/tortoisesvn/branches/1.13.x"
+            )
+            val expected = VcsInfo(
+                type = VcsType.SUBVERSION,
+                url = "http://svn.osdn.net/svnroot/tortoisesvn",
+                revision = "branches/1.13.x",
+                path = ""
+            )
+            actual shouldBe expected
+        }
+
+        "separate branch and path from an SVN URL" {
+            val actual = VcsHost.toVcsInfo(
+                "http://svn.osdn.net/svnroot/tortoisesvn/branches/1.13.x/src/gpl.txt"
+            )
+            val expected = VcsInfo(
+                type = VcsType.SUBVERSION,
+                url = "http://svn.osdn.net/svnroot/tortoisesvn",
+                revision = "branches/1.13.x",
+                path = "src/gpl.txt"
+            )
+            actual shouldBe expected
+        }
+
+        "separate an SVN tag into the revision" {
+            val actual = VcsHost.toVcsInfo(
+                "http://svn.terracotta.org/svn/ehcache/tags/ehcache-parent-2.21"
+            )
+            val expected = VcsInfo(
+                type = VcsType.SUBVERSION,
+                url = "http://svn.terracotta.org/svn/ehcache",
+                revision = "tags/ehcache-parent-2.21",
+                path = ""
+            )
+            actual shouldBe expected
+        }
+
+        "separate tag and path from an SVN URL" {
+            val actual = VcsHost.toVcsInfo(
+                "http://svn.terracotta.org/svn/ehcache/tags/ehcache-parent-2.21/pom.xml"
+            )
+            val expected = VcsInfo(
+                type = VcsType.SUBVERSION,
+                url = "http://svn.terracotta.org/svn/ehcache",
+                revision = "tags/ehcache-parent-2.21",
+                path = "pom.xml"
+            )
+            actual shouldBe expected
         }
     }
 })

--- a/downloader/src/test/kotlin/VersionControlSystemTest.kt
+++ b/downloader/src/test/kotlin/VersionControlSystemTest.kt
@@ -19,9 +19,6 @@
 
 package com.here.ort.downloader
 
-import com.here.ort.model.VcsInfo
-import com.here.ort.model.VcsType
-
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 
@@ -61,112 +58,6 @@ class VersionControlSystemTest : WordSpec({
             relVcsDir.getPathToRoot(relProjDir) shouldBe "downloader/src/test"
             relVcsDir.getPathToRoot(File("..")) shouldBe ""
             relVcsDir.getPathToRoot(File("src/test/kotlin")) shouldBe "downloader/src/test/kotlin"
-        }
-    }
-
-    "splitUrl" should {
-        "split paths from a URL to a Git repository" {
-            val actual = VersionControlSystem.splitUrl(
-                "https://git-wip-us.apache.org/repos/asf/zeppelin.git"
-            )
-            val expected = VcsInfo(
-                type = VcsType.GIT,
-                url = "https://git-wip-us.apache.org/repos/asf/zeppelin.git",
-                revision = "",
-                path = ""
-            )
-            actual shouldBe expected
-        }
-
-        "split paths from a URL to a Git repository with path" {
-            val actual = VersionControlSystem.splitUrl(
-                "https://git-wip-us.apache.org/repos/asf/zeppelin.git/zeppelin-interpreter"
-            )
-            val expected = VcsInfo(
-                type = VcsType.GIT,
-                url = "https://git-wip-us.apache.org/repos/asf/zeppelin.git",
-                revision = "",
-                path = "zeppelin-interpreter"
-            )
-            actual shouldBe expected
-        }
-
-        "split the revision from an NPM URL to a Git repository" {
-            val actual = VersionControlSystem.splitUrl(
-                "git+ssh://sub.domain.com:42/foo-bar#b3b5b3c60dcdc39347b23cf94ab8f577239b7df3"
-            )
-            val expected = VcsInfo(
-                type = VcsType.GIT,
-                url = "ssh://sub.domain.com:42/foo-bar",
-                revision = "b3b5b3c60dcdc39347b23cf94ab8f577239b7df3",
-                path = ""
-            )
-            actual shouldBe expected
-        }
-
-        "split the revision from a NPM URL to a GitHub repository" {
-            val actual = VersionControlSystem.splitUrl(
-                "https://github.com/mochajs/mocha.git#5bd33a0ba201d227159759e8ced86756595b0c54"
-            )
-            val expected = VcsInfo(
-                type = VcsType.GIT,
-                url = "https://github.com/mochajs/mocha.git",
-                revision = "5bd33a0ba201d227159759e8ced86756595b0c54",
-                path = ""
-            )
-            actual shouldBe expected
-        }
-
-        "separate an SVN branch into the revision" {
-            val actual = VersionControlSystem.splitUrl(
-                "http://svn.osdn.net/svnroot/tortoisesvn/branches/1.13.x"
-            )
-            val expected = VcsInfo(
-                type = VcsType.SUBVERSION,
-                url = "http://svn.osdn.net/svnroot/tortoisesvn",
-                revision = "branches/1.13.x",
-                path = ""
-            )
-            actual shouldBe expected
-        }
-
-        "separate branch and path from an SVN URL" {
-            val actual = VersionControlSystem.splitUrl(
-                "http://svn.osdn.net/svnroot/tortoisesvn/branches/1.13.x/src/gpl.txt"
-            )
-            val expected = VcsInfo(
-                type = VcsType.SUBVERSION,
-                url = "http://svn.osdn.net/svnroot/tortoisesvn",
-                revision = "branches/1.13.x",
-                path = "src/gpl.txt"
-            )
-            actual shouldBe expected
-        }
-
-        "separate an SVN tag into the revision" {
-            val actual = VersionControlSystem.splitUrl(
-                "http://svn.terracotta.org/svn/ehcache/tags/ehcache-parent-2.21"
-            )
-            val expected = VcsInfo(
-                type = VcsType.SUBVERSION,
-                url = "http://svn.terracotta.org/svn/ehcache",
-                revision = "tags/ehcache-parent-2.21",
-                path = ""
-            )
-            actual shouldBe expected
-        }
-
-        "separate tag and path from an SVN URL" {
-            val actual = VersionControlSystem.splitUrl(
-                "http://svn.terracotta.org/svn/ehcache/tags/ehcache-parent-2.21/pom.xml"
-            )
-            val expected = VcsInfo(
-                type = VcsType.SUBVERSION,
-                url = "http://svn.terracotta.org/svn/ehcache",
-                revision = "tags/ehcache-parent-2.21",
-                path = "pom.xml"
-            )
-            actual shouldBe expected
         }
     }
 })


### PR DESCRIPTION
It was confusing to have both very similar functions, so merge the former
into the latter. This bundles all static VCS URL parsing in VcsHost.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>