### PR TITLE
Dockerfile: Switch to Ubuntu 18.04 as a base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,4 +131,6 @@ RUN /opt/ort/bin/import_proxy_certs.sh && \
         chmod -R o=u /usr/local/scancode-toolkit-$SCANCODE_VERSION && \
         ln -s /usr/local/scancode-toolkit-$SCANCODE_VERSION/scancode /usr/local/bin/scancode
 
+RUN /opt/ort/bin/ort requirements
+
 ENTRYPOINT ["/opt/ort/bin/ort"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN scripts/set_gradle_proxy.sh && \
     sed -i -r 's,(^distributionUrl=)(.+)-all\.zip$,\1\2-bin.zip,' gradle/wrapper/gradle-wrapper.properties && \
     ./gradlew --no-daemon --stacktrace :cli:distTar
 
-FROM openjdk:11-jre-slim-sid
+FROM adoptopenjdk:11-jre-hotspot-bionic
 
 COPY --from=build /usr/local/src/ort/scripts/import_proxy_certs.sh /opt/ort/bin/import_proxy_certs.sh
 COPY --from=build /usr/local/src/ort/scripts/set_gradle_proxy.sh /opt/ort/bin/set_gradle_proxy.sh
@@ -42,45 +42,57 @@ RUN tar xf /opt/ort.tar -C /opt/ort --strip-components 1 && rm /opt/ort.tar
 ENV \
     # Package manager versions.
     BOWER_VERSION=1.8.8 \
-    BUNDLER_VERSION=2.1.4-1 \
-    CARGO_VERSION=0.40.0-3 \
-    COMPOSER_VERSION=1.10.0-1 \
+    BUNDLER_VERSION=1.16.1-1 \
+    CARGO_VERSION=0.40.0-3ubuntu1~18.04.1 \
+    COMPOSER_VERSION=1.6.3-1 \
     CONAN_VERSION=1.18.0 \
     FLUTTER_VERSION=v1.7.8+hotfix.3-stable \
-    GO_DEP_VERSION=0.5.4-3 \
+    GO_DEP_VERSION=0.5.4 \
     GO_VERSION=1.13.4 \
-    HASKELL_STACK_VERSION=1.9.3.1-1 \
-    NPM_VERSION=6.14.2+ds-1 \
-    PYTHON_PIP_VERSION=18.1-5 \
+    HASKELL_STACK_VERSION=2.1.3 \
+    NPM_VERSION=6.14.2 \
+    PYTHON_PIP_VERSION=9.0.1-2.3~ubuntu1.18.04.1 \
     PYTHON_PIPENV_VERSION=2018.11.26 \
     PYTHON_VIRTUALENV_VERSION=15.1.0 \
-    SBT_VERSION=0.13.13-2 \
+    SBT_VERSION=1.3.8 \
     YARN_VERSION=1.21.1 \
     # Scanner versions.
     SCANCODE_VERSION=3.0.2 \
     # Installation directories.
-    FLUTTER_HOME=/opt/flutter
+    FLUTTER_HOME=/opt/flutter \
+    GOPATH=$HOME/go
 
-ENV PATH="$PATH:$FLUTTER_HOME/bin:$FLUTTER_HOME/bin/cache/dart-sdk/bin:/opt/go/bin"
+ENV \
+    DEBIAN_FRONTEND=noninteractive \
+    PATH="$PATH:$HOME/.local/bin:$FLUTTER_HOME/bin:$FLUTTER_HOME/bin/cache/dart-sdk/bin:$GOPATH/bin:/opt/go/bin"
 
 # Apt install commands.
-RUN apt-get update && \
+RUN \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gnupg && \
+    echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
+    curl -ksS "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key adv --import - && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
         # Install general tools required by this Dockerfile.
-        curl \
         lib32stdc++6 \
+        libffi-dev \
+        libgmp-dev \
+        make \
+        netbase \
         openssh-client \
+        xz-utils \
+        zlib1g-dev \
         # Install VCS tools (no specific versions required here).
         cvs \
         git \
         mercurial \
+        subversion \
         # Install package managers (in versions known to work).
         bundler=$BUNDLER_VERSION \
         cargo=$CARGO_VERSION \
         composer=$COMPOSER_VERSION \
-        go-dep=$GO_DEP_VERSION \
-        haskell-stack=$HASKELL_STACK_VERSION \
-        npm=$NPM_VERSION \
+        npm \
         python-pip=$PYTHON_PIP_VERSION \
         python-setuptools \
         python3-pip=$PYTHON_PIP_VERSION \
@@ -95,7 +107,7 @@ RUN /opt/ort/bin/import_proxy_certs.sh && \
     curl -ksS https://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo && \
     chmod a+x /usr/local/bin/repo && \
     # Install package managers (in versions known to work).
-    npm install --global bower@$BOWER_VERSION yarn@$YARN_VERSION && \
+    npm install --global npm@$NPM_VERSION bower@$BOWER_VERSION yarn@$YARN_VERSION && \
     pip install wheel && \
     pip install conan==$CONAN_VERSION pipenv==$PYTHON_PIPENV_VERSION virtualenv==$PYTHON_VIRTUALENV_VERSION && \
     curl -ksSO https://storage.googleapis.com/flutter_infra/releases/stable/linux/flutter_linux_$FLUTTER_VERSION.tar.xz && \
@@ -108,6 +120,9 @@ RUN /opt/ort/bin/import_proxy_certs.sh && \
     curl -ksSO https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz && \
     tar -C /opt -xzf go$GO_VERSION.linux-amd64.tar.gz && \
     rm go$GO_VERSION.linux-amd64.tar.gz && \
+    mkdir -p $GOPATH/bin && \
+    curl -ksS https://raw.githubusercontent.com/golang/dep/v$GO_DEP_VERSION/install.sh | sh && \
+    curl -ksS https://raw.githubusercontent.com/commercialhaskell/stack/v$HASKELL_STACK_VERSION/etc/scripts/get-stack.sh | sh && \
     # Add scanners (in versions known to work).
     curl -ksSL https://github.com/nexB/scancode-toolkit/archive/v$SCANCODE_VERSION.tar.gz | \
         tar -zxC /usr/local && \


### PR DESCRIPTION
The problem with Debian Sid is that it continuously unpublishes
previously existing packages, which breaks building the Docker image
until we update those packages manually. So switch to Ubuntu 18.04 which
is an LTS release.

Fixes #2384.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>