### PR TITLE
GitWorkingTree: Give "origin" preference over other remotes

### DIFF
--- a/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
+++ b/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
@@ -95,7 +95,7 @@ open class GitWorkingTree(workingDir: File, private val gitBase: GitBase) : Work
             val remoteForCurrentBranch = BranchConfig(repo.config, repo.branch).remote
 
             val remote = if (remotes.size <= 1 || remoteForCurrentBranch == null) {
-                remotes.firstOrNull()
+                remotes.find { it.name == "origin" } ?: remotes.firstOrNull()
             } else {
                 remotes.find { remote ->
                     remote.name == remoteForCurrentBranch


### PR DESCRIPTION
Previously, the first remote from the alphabetically sorted list of
remotes was used when determining the remote URL and no remote for the
current branch was set.

As "origin" is the default remote name in Git and the alphabetical order
of remotes has no inherent meaning, prefer "origin" if it exists.