### PR TITLE
Maven fallback URLs

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -187,8 +187,8 @@ analyzer:
           revision: ""
           path: ""
         vcs_processed:
-          type: ""
-          url: ""
+          type: "Git"
+          url: "https://github.com/sbt/test-interface.git"
           revision: ""
           path: ""
       curations: []

--- a/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
@@ -953,8 +953,8 @@ analyzer:
           revision: ""
           path: ""
         vcs_processed:
-          type: ""
-          url: ""
+          type: "Git"
+          url: "https://github.com/sbt/test-interface.git"
           revision: ""
           path: ""
       curations: []

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -141,20 +141,23 @@ abstract class PackageManager(
         }
 
         /**
-         * Enrich a package's VCS information with information deduced from the package's VCS URL or an optional
-         * homepage URL.
+         * Enrich a package's VCS information with information deduced from the package's VCS URL or a list of fallback
+         * URLs.
          *
          * @param vcsFromPackage The [VcsInfo] of a [Package].
-         * @param homepageUrl The URL to the homepage of a [Package], if any.
+         * @param fallbackUrls The list of alternative URLs to to use as fallback for determining the [VcsInfo]. The
+         *                     first element of the list that is recognized as a VCS URL is used.
          */
-        fun processPackageVcs(vcsFromPackage: VcsInfo, homepageUrl: String = ""): VcsInfo {
+        fun processPackageVcs(vcsFromPackage: VcsInfo, fallbackUrls: List<String> = emptyList()): VcsInfo {
             val normalizedVcsFromPackage = vcsFromPackage.normalize()
 
-            val normalizedUrl = normalizedVcsFromPackage.url.takeIf {
-                it.isNotEmpty()
-            } ?: normalizeVcsUrl(homepageUrl).takeIf {
-                VersionControlSystem.forUrl(it) != null
-            }.orEmpty()
+            val normalizedUrl = normalizedVcsFromPackage.url.takeIf { it.isNotEmpty() }
+                ?: fallbackUrls
+                    .asSequence()
+                    .map { normalizeVcsUrl(it) }
+                    .filterNot { VersionControlSystem.forUrl(it) == null }
+                    .firstOrNull()
+                    .orEmpty()
 
             val vcsFromUrl = VcsHost.toVcsInfo(normalizedUrl)
             return vcsFromUrl.merge(normalizedVcsFromPackage)
@@ -165,18 +168,20 @@ abstract class PackageManager(
          * directory.
          *
          * Get a project's VCS information from the working tree and optionally enrich it with VCS information from
-         * another source (like meta-data) or a homepage URL.
+         * another source (like meta-data) or a list of fallback URLs.
          *
          * @param projectDir The working tree directory of the [Project].
          * @param vcsFromProject The project's [VcsInfo], if any.
-         * @param homepageUrl The URL to the homepage of the [Project], if any.
+         * @param fallbackUrls The list of alternative URLs to to use as fallback for determining the [VcsInfo]. The
+         *                     first element of the list that is recognized as a VCS URL is used.
          */
         fun processProjectVcs(
-            projectDir: File, vcsFromProject: VcsInfo = VcsInfo.EMPTY,
-            homepageUrl: String = ""
+            projectDir: File,
+            vcsFromProject: VcsInfo = VcsInfo.EMPTY,
+            fallbackUrls: List<String> = emptyList()
         ): VcsInfo {
             val vcsFromWorkingTree = VersionControlSystem.getPathInfo(projectDir).normalize()
-            return vcsFromWorkingTree.merge(processPackageVcs(vcsFromProject, homepageUrl))
+            return vcsFromWorkingTree.merge(processPackageVcs(vcsFromProject, fallbackUrls))
         }
     }
 

--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -241,7 +241,7 @@ class Bower(
                 definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                 declaredLicenses = projectPackage.declaredLicenses,
                 vcs = projectPackage.vcs,
-                vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, projectPackage.homepageUrl),
+                vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, listOf(projectPackage.homepageUrl)),
                 homepageUrl = projectPackage.homepageUrl,
                 scopes = sortedSetOf(dependenciesScope, devDependenciesScope)
             )

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -115,7 +115,7 @@ class Bundler(
                 definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                 declaredLicenses = declaredLicenses.toSortedSet(),
                 vcs = VcsInfo.EMPTY,
-                vcsProcessed = processProjectVcs(workingDir, homepageUrl = homepageUrl),
+                vcsProcessed = processProjectVcs(workingDir, fallbackUrls = listOf(homepageUrl)),
                 homepageUrl = homepageUrl,
                 scopes = scopes.toSortedSet()
             )
@@ -169,7 +169,7 @@ class Bundler(
                     binaryArtifact = RemoteArtifact.EMPTY,
                     sourceArtifact = gemSpec.artifact,
                     vcs = gemSpec.vcs,
-                    vcsProcessed = processPackageVcs(gemSpec.vcs, gemSpec.homepageUrl)
+                    vcsProcessed = processPackageVcs(gemSpec.vcs, listOf(gemSpec.homepageUrl))
                 )
 
                 val transitiveDependencies = mutableSetOf<PackageReference>()

--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -282,7 +282,7 @@ class Cargo(
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
             declaredLicenses = projectPkg.declaredLicenses,
             vcs = projectPkg.vcs,
-            vcsProcessed = processProjectVcs(workingDir, projectPkg.vcs, homepageUrl),
+            vcsProcessed = processProjectVcs(workingDir, projectPkg.vcs, listOf(homepageUrl)),
             homepageUrl = homepageUrl,
             scopes = sortedSetOf(dependenciesScope, devDependenciesScope, buildDependenciesScope)
         )

--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -129,7 +129,11 @@ class Conan(
                     definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                     declaredLicenses = projectPackage.declaredLicenses,
                     vcs = projectPackage.vcs,
-                    vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, projectPackage.homepageUrl),
+                    vcsProcessed = processProjectVcs(
+                        workingDir,
+                        projectPackage.vcs,
+                        listOf(projectPackage.homepageUrl)
+                    ),
                     homepageUrl = projectPackage.homepageUrl,
                     scopes = sortedSetOf(dependenciesScope, devDependenciesScope)
                 ),

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -162,7 +162,7 @@ class Maven(
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
             declaredLicenses = MavenSupport.parseLicenses(mavenProject),
             vcs = vcsFromPackage,
-            vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, mavenProject.url.orEmpty()),
+            vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, listOf(mavenProject.url.orEmpty())),
             homepageUrl = mavenProject.url.orEmpty(),
             scopes = scopes.values.toSortedSet()
         )

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -152,6 +152,8 @@ class Maven(
             workingDir
         }
 
+        val vcsFallbackUrls = listOfNotNull(mavenProject.scm?.url, mavenProject.url)
+
         val project = Project(
             id = Identifier(
                 type = managerName,
@@ -162,7 +164,7 @@ class Maven(
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
             declaredLicenses = MavenSupport.parseLicenses(mavenProject),
             vcs = vcsFromPackage,
-            vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, listOf(mavenProject.url.orEmpty())),
+            vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, vcsFallbackUrls),
             homepageUrl = mavenProject.url.orEmpty(),
             scopes = scopes.values.toSortedSet()
         )

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -308,7 +308,7 @@ open class Npm(
                     hash = hash
                 ),
                 vcs = vcsFromPackage,
-                vcsProcessed = processPackageVcs(vcsFromPackage, homepageUrl)
+                vcsProcessed = processPackageVcs(vcsFromPackage, listOf(homepageUrl))
             )
 
             require(module.id.name.isNotEmpty()) {
@@ -519,7 +519,7 @@ open class Npm(
             definitionFilePath = VersionControlSystem.getPathInfo(packageJson).path,
             declaredLicenses = declaredLicenses,
             vcs = vcsFromPackage,
-            vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, homepageUrl),
+            vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, listOf(homepageUrl)),
             homepageUrl = homepageUrl,
             scopes = scopes
         )

--- a/analyzer/src/main/kotlin/managers/PhpComposer.kt
+++ b/analyzer/src/main/kotlin/managers/PhpComposer.kt
@@ -234,7 +234,7 @@ class PhpComposer(
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
             declaredLicenses = parseDeclaredLicenses(json),
             vcs = vcs,
-            vcsProcessed = processProjectVcs(definitionFile.parentFile, vcs, homepageUrl),
+            vcsProcessed = processProjectVcs(definitionFile.parentFile, vcs, listOf(homepageUrl)),
             homepageUrl = homepageUrl,
             scopes = scopes
         )
@@ -269,7 +269,7 @@ class PhpComposer(
                     binaryArtifact = RemoteArtifact.EMPTY,
                     sourceArtifact = parseArtifact(pkgInfo),
                     vcs = vcsFromPackage,
-                    vcsProcessed = processPackageVcs(vcsFromPackage, homepageUrl)
+                    vcsProcessed = processPackageVcs(vcsFromPackage, listOf(homepageUrl))
                 )
             }
         }

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -400,7 +400,7 @@ class Pip(
                                 pkg.sourceArtifact
                             },
                             vcs = pkg.vcs,
-                            vcsProcessed = processPackageVcs(pkg.vcs, pkgHomepage)
+                            vcsProcessed = processPackageVcs(pkg.vcs, listOf(pkgHomepage))
                         )
                     } ?: run {
                         log.warn {
@@ -433,7 +433,7 @@ class Pip(
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
             declaredLicenses = declaredLicenses,
             vcs = VcsInfo.EMPTY,
-            vcsProcessed = processProjectVcs(workingDir, homepageUrl = setupHomepage),
+            vcsProcessed = processProjectVcs(workingDir, fallbackUrls = listOf(setupHomepage)),
             homepageUrl = setupHomepage,
             scopes = scopes
         )

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -382,7 +382,7 @@ class Pub(
             // Pub does not declare any licenses in the pubspec files, therefore we keep this empty.
             declaredLicenses = sortedSetOf(),
             vcs = vcs,
-            vcsProcessed = processProjectVcs(definitionFile.parentFile, vcs, homepageUrl),
+            vcsProcessed = processProjectVcs(definitionFile.parentFile, vcs, listOf(homepageUrl)),
             homepageUrl = homepageUrl,
             scopes = scopes
         )
@@ -454,7 +454,7 @@ class Pub(
                     // Pub does not create source artifacts, therefore use any empty artifact.
                     sourceArtifact = RemoteArtifact.EMPTY,
                     vcs = vcsFromPackage,
-                    vcsProcessed = processPackageVcs(vcsFromPackage, homepageUrl)
+                    vcsProcessed = processPackageVcs(vcsFromPackage, listOf(homepageUrl))
                 )
             }
         }

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -169,7 +169,7 @@ class Stack(
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
             declaredLicenses = projectPackage.declaredLicenses,
             vcs = projectPackage.vcs,
-            vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, projectPackage.homepageUrl),
+            vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, listOf(projectPackage.homepageUrl)),
             homepageUrl = projectPackage.homepageUrl,
             scopes = scopes
         )
@@ -355,7 +355,7 @@ class Stack(
             binaryArtifact = RemoteArtifact.EMPTY,
             sourceArtifact = artifact,
             vcs = vcs,
-            vcsProcessed = processPackageVcs(vcs, homepageUrl)
+            vcsProcessed = processPackageVcs(vcs, listOf(homepageUrl))
         )
     }
 }

--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -566,8 +566,8 @@ class MavenSupport(workspaceReader: WorkspaceReader) {
         val homepageUrl = mavenProject.url.orEmpty()
 
         val vcsProcessed = localDirectory?.let {
-            PackageManager.processProjectVcs(it, vcsFromPackage, homepageUrl)
-        } ?: PackageManager.processPackageVcs(vcsFromPackage, homepageUrl)
+            PackageManager.processProjectVcs(it, vcsFromPackage, listOf(homepageUrl))
+        } ?: PackageManager.processPackageVcs(vcsFromPackage, listOf(homepageUrl))
 
         return Package(
             id = Identifier(

--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -563,11 +563,12 @@ class MavenSupport(workspaceReader: WorkspaceReader) {
             }
         }
 
-        val homepageUrl = mavenProject.url.orEmpty()
+        val homepageUrl = mavenProject.url
+        val vcsFallbackUrls = listOfNotNull(mavenProject.scm?.url, homepageUrl)
 
         val vcsProcessed = localDirectory?.let {
-            PackageManager.processProjectVcs(it, vcsFromPackage, listOf(homepageUrl))
-        } ?: PackageManager.processPackageVcs(vcsFromPackage, listOf(homepageUrl))
+            PackageManager.processProjectVcs(it, vcsFromPackage, vcsFallbackUrls)
+        } ?: PackageManager.processPackageVcs(vcsFromPackage, vcsFallbackUrls)
 
         return Package(
             id = Identifier(
@@ -578,7 +579,7 @@ class MavenSupport(workspaceReader: WorkspaceReader) {
             ),
             declaredLicenses = parseLicenses(mavenProject),
             description = mavenProject.description.orEmpty(),
-            homepageUrl = homepageUrl,
+            homepageUrl = homepageUrl.orEmpty(),
             binaryArtifact = binaryRemoteArtifact,
             sourceArtifact = sourceRemoteArtifact,
             vcs = vcsFromPackage,


### PR DESCRIPTION
Also use the SCM URL as fallback when determining the VCS info for Maven projects and packages.