### PR TITLE
ScanCode: Revert to `substringAfter` in `transformVersion`

### DIFF
--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -245,7 +245,7 @@ class ScanCode(
     override fun transformVersion(output: String) =
         // "scancode --version" returns a string like "ScanCode version 2.0.1.post1.fb67a181", so simply remove
         // the prefix.
-        output.removePrefix("ScanCode version ")
+        output.substringAfter("ScanCode version ")
 
     override fun bootstrap(): File {
         val archive = when {


### PR DESCRIPTION
On the first run of ScanCode `removePrefix` is not sufficient, because
ScanCode prints an additional line before the version string:

* Configuring ScanCode for first use...
ScanCode version 3.0.2

This is a fixup for 6b83f55.