### PR TITLE
Revert "model: Use Identifier as return type for collectDependencies()"

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/DotNetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/DotNetSupport.kt
@@ -164,8 +164,8 @@ class DotNetSupport(packageReferencesMap: Map<String, String>) {
             scopeDependency?.let { scope.dependencies += it }
         }
 
-        scope.collectDependencies().forEach { id ->
-            val pkg = getPackageForId(id)
+        scope.collectDependencies().forEach { packageReference ->
+            val pkg = getPackageForId(packageReference.id)
 
             if (pkg != Package.EMPTY) {
                 packages += pkg

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -114,7 +114,7 @@ data class OrtResult(
                 val isScopeExcluded = getExcludes().isScopeExcluded(scope)
 
                 if (!isProjectExcluded(project.id) && !isScopeExcluded) {
-                    val dependencies = scope.collectDependencies()
+                    val dependencies = scope.collectDependencies().map { it.id }
                     includedPackages.addAll(dependencies)
                 }
             }
@@ -143,8 +143,8 @@ data class OrtResult(
      * depth of [maxLevel] where counting starts at 0 (for the [Project] or [Package] itself) and 1 are direct
      * dependencies etc. A value below 0 means to not limit the depth.
      */
-    fun collectDependencies(id: Identifier, maxLevel: Int = -1): Set<Identifier> {
-        val dependencies = mutableSetOf<Identifier>()
+    fun collectDependencies(id: Identifier, maxLevel: Int = -1): Set<PackageReference> {
+        val dependencies = mutableSetOf<PackageReference>()
 
         getProjects().forEach { project ->
             if (project.id == id) {

--- a/model/src/main/kotlin/PackageReference.kt
+++ b/model/src/main/kotlin/PackageReference.kt
@@ -74,8 +74,8 @@ data class PackageReference(
     fun collectDependencies(
         maxDepth: Int = -1,
         filterPredicate: (PackageReference) -> Boolean = { true }
-    ): Set<Identifier> {
-        val result = mutableSetOf<Identifier>()
+    ): Set<PackageReference> {
+        val result = mutableSetOf<PackageReference>()
 
         val queue: Deque<Pair<PackageReference, Int>> = LinkedList()
         fun enqueue(packages: Collection<PackageReference>, level: Int) {
@@ -88,7 +88,7 @@ data class PackageReference(
         while (queue.isNotEmpty()) {
             val (pkg, level) = queue.removeFirst()
 
-            if (filterPredicate(pkg)) result += pkg.id
+            if (filterPredicate(pkg)) result += pkg
 
             enqueue(pkg.dependencies, level + 1)
         }

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -105,7 +105,7 @@ data class Project(
     fun collectDependencies(
         maxDepth: Int = -1,
         filterPredicate: (PackageReference) -> Boolean = { true }
-    ): Set<Identifier> =
+    ): Set<PackageReference> =
         scopes.fold(mutableSetOf()) { refs, scope ->
             refs.also { it += scope.collectDependencies(maxDepth, filterPredicate) }
         }
@@ -148,7 +148,11 @@ data class Project(
     fun collectSubProjects(): SortedSet<Identifier> =
         scopes.fold(sortedSetOf()) { refs, scope ->
             refs.also {
-                it += scope.collectDependencies { ref -> ref.linkage in PackageLinkage.PROJECT_LINKAGE }
+                it += scope.collectDependencies { ref ->
+                    ref.linkage in PackageLinkage.PROJECT_LINKAGE
+                }.map { packageReference ->
+                    packageReference.id
+                }
             }
         }
 

--- a/model/src/main/kotlin/ProjectAnalyzerResult.kt
+++ b/model/src/main/kotlin/ProjectAnalyzerResult.kt
@@ -53,7 +53,7 @@ data class ProjectAnalyzerResult(
             // Exclude project dependencies in multi-projects from the check as these appear as references in the
             // dependency tree but not in the list of packages used.
             !it.hasIssues() && it.linkage !in PackageLinkage.PROJECT_LINKAGE
-        }
+        }.map { it.id }
 
         // Note that not all packageIds have to be contained in the referencedIds, e.g. for NPM optional dependencies.
         require(packageIds.containsAll(referencedIds)) {

--- a/model/src/main/kotlin/Scope.kt
+++ b/model/src/main/kotlin/Scope.kt
@@ -55,11 +55,11 @@ data class Scope(
     fun collectDependencies(
         maxDepth: Int = -1,
         filterPredicate: (PackageReference) -> Boolean = { true }
-    ): Set<Identifier> =
+    ): Set<PackageReference> =
         dependencies.fold(mutableSetOf()) { refs, ref ->
             refs.also {
                 if (maxDepth != 0) {
-                    if (filterPredicate(ref)) it += ref.id
+                    if (filterPredicate(ref)) it += ref
                     it += ref.collectDependencies(maxDepth - 1, filterPredicate)
                 }
             }
@@ -104,7 +104,7 @@ data class Scope(
             val parents: List<Identifier>
         )
 
-        val remainingIds = collectDependencies().toMutableSet()
+        val remainingIds = collectDependencies().map { it.id }.toMutableSet()
         val queue = LinkedList<QueueItem>()
         val result = sortedMapOf<Identifier, List<Identifier>>()
 

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -44,7 +44,7 @@ class OrtResultTest : WordSpec({
             val ortResult = readOrtResult("external/sbt-multi-project-example-expected-output.yml")
 
             val id = Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
-            val dependencies = ortResult.collectDependencies(id, 1).map { it.toCoordinates() }
+            val dependencies = ortResult.collectDependencies(id, 1).map { it.id.toCoordinates() }
 
             dependencies shouldContainExactlyInAnyOrder listOf(
                 "Maven:com.typesafe.akka:akka-actor_2.12:2.5.6",

--- a/model/src/test/kotlin/ProjectTest.kt
+++ b/model/src/test/kotlin/ProjectTest.kt
@@ -38,7 +38,7 @@ class ProjectTest : WordSpec({
         "get all dependencies by default" {
             val project = readAnalyzerResult("gradle-expected-output-lib.yml")
 
-            val dependencies = project.collectDependencies().map { it.toCoordinates() }
+            val dependencies = project.collectDependencies().map { it.id.toCoordinates() }
 
             dependencies shouldContainExactlyInAnyOrder listOf(
                 "Maven:junit:junit:4.12",
@@ -60,7 +60,7 @@ class ProjectTest : WordSpec({
         "get only direct dependencies for a depth of 1" {
             val project = readAnalyzerResult("gradle-expected-output-lib.yml")
 
-            val dependencies = project.collectDependencies(maxDepth = 1).map { it.toCoordinates() }
+            val dependencies = project.collectDependencies(maxDepth = 1).map { it.id.toCoordinates() }
 
             dependencies shouldContainExactlyInAnyOrder listOf(
                 "Maven:junit:junit:4.12",

--- a/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
@@ -123,7 +123,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
 
         input.ortResult.analyzer?.result?.projects?.forEach { project ->
             val pathExcludes = input.ortResult.getExcludes().findPathExcludes(project, input.ortResult)
-            val dependencies = project.collectDependencies()
+            val dependencies = project.collectDependencies().map { it.id }
             if (pathExcludes.isEmpty()) {
                 val info = packageExcludeInfo.getValue(project.id)
                 if (info.isExcluded) {
@@ -142,7 +142,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             }
             project.scopes.forEach { scope ->
                 val scopeExcludes = input.ortResult.getExcludes().findScopeExcludes(scope)
-                val scopeDependencies = scope.collectDependencies()
+                val scopeDependencies = scope.collectDependencies().map { it.id }
                 if (scopeExcludes.isNotEmpty()) {
                     scopeDependencies.forEach { id ->
                         val info = packageExcludeInfo.getOrPut(id) { PackageExcludeInfo(id, true) }

--- a/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/ReportTableModelMapper.kt
@@ -46,7 +46,7 @@ private fun Project.getScopesForDependencies(excludes: Excludes): Map<Identifier
 
     scopes.forEach { scope ->
         scope.collectDependencies().forEach { dependency ->
-            result.getOrPut(dependency, { mutableMapOf() })
+            result.getOrPut(dependency.id, { mutableMapOf() })
                 .getOrPut(scope.name, { excludes.findScopeExcludes(scope.name) })
         }
     }
@@ -114,7 +114,7 @@ class ReportTableModelMapper(
             val pathExcludes = excludes.findPathExcludes(project, ortResult)
 
             val allIds = sortedSetOf(project.id)
-            allIds += project.collectDependencies()
+            project.collectDependencies().mapTo(allIds) { it.id }
 
             val projectIssues = project.collectIssues()
             val tableRows = allIds.map { id ->


### PR DESCRIPTION
This reverts commit 5f3bc12 as we need the Linkage information for
dependencies.

In its commit message, 5f3bc12 talks about reducing the number of calls of
hashCode() / equals() required for insertion into a SortedSet, but in fact
does nothing else than changing Identifier to PackageReference and keeps
using a SortedSet. The change to use Set instead of SortedSet is done
later in 77da720.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>