### PR TITLE
AnalyzerResult: Fix wrong value of `hasIssues`

### DIFF
--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -89,11 +89,7 @@ data class AnalyzerResult(
      * True if there were any issues during the analysis, false otherwise.
      */
     @Suppress("UNUSED") // Not used in code, but shall be serialized.
-    val hasIssues by lazy {
-        issues.any { it.value.isNotEmpty() } || projects.any { project ->
-            project.scopes.any { scope -> scope.dependencies.any { pkg -> pkg.hasIssues() } }
-        }
-    }
+    val hasIssues by lazy { collectIssues().isNotEmpty() }
 }
 
 class AnalyzerResultBuilder {


### PR DESCRIPTION
Sometimes the `hasIssues` property was `false' even though the analyzer
result contained issues. Fix this by checking if  `collectIssues()`
returns an empty result, instead of re-implementing the logic to search
for issues.