### PR TITLE
Pip: Stop removing the " License" suffix from license identifiers

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -33,6 +33,7 @@ packages:
     purl: "pkg:pypi/Flask@0.12"
     declared_licenses:
     - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "A microframework based on Werkzeug, Jinja2 and good intentions"
@@ -63,6 +64,7 @@ packages:
     purl: "pkg:pypi/Jinja2@2.8.1"
     declared_licenses:
     - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "A small but fast and easy to use stand-alone template engine written\
@@ -93,7 +95,7 @@ packages:
     id: "PyPI::MarkupSafe:1.1.1"
     purl: "pkg:pypi/MarkupSafe@1.1.1"
     declared_licenses:
-    - "BSD"
+    - "BSD License"
     - "BSD-3-Clause"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
@@ -124,7 +126,7 @@ packages:
     id: "PyPI::Werkzeug:1.0.0"
     purl: "pkg:pypi/Werkzeug@1.0.0"
     declared_licenses:
-    - "BSD"
+    - "BSD License"
     - "BSD-3-Clause"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
@@ -155,7 +157,7 @@ packages:
     id: "PyPI::click:7.1.1"
     purl: "pkg:pypi/click@7.1.1"
     declared_licenses:
-    - "BSD"
+    - "BSD License"
     - "BSD-3-Clause"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
@@ -187,6 +189,7 @@ packages:
     purl: "pkg:pypi/gunicorn@19.6.0"
     declared_licenses:
     - "MIT"
+    - "MIT License"
     declared_licenses_processed:
       spdx_expression: "MIT"
     description: "WSGI HTTP Server for UNIX"
@@ -217,6 +220,7 @@ packages:
     purl: "pkg:pypi/itsdangerous@1.1.0"
     declared_licenses:
     - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "Various helpers to pass data to untrusted environments and back."

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -3,7 +3,7 @@ project:
   id: "PIP::spdx-tools:0.5.4"
   definition_file_path: "setup.py"
   declared_licenses:
-  - "Apache Software"
+  - "Apache Software License"
   - "Apache-2.0"
   declared_licenses_processed:
     spdx_expression: "Apache-2.0"
@@ -35,6 +35,7 @@ packages:
     purl: "pkg:pypi/isodate@0.6.0"
     declared_licenses:
     - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "An ISO 8601 date/time/duration parser and formatter"
@@ -94,7 +95,7 @@ packages:
     id: "PyPI::pyparsing:2.4.6"
     purl: "pkg:pypi/pyparsing@2.4.6"
     declared_licenses:
-    - "MIT"
+    - "MIT License"
     declared_licenses_processed:
       spdx_expression: "MIT"
     description: "Python parsing module"
@@ -124,7 +125,7 @@ packages:
     id: "PyPI::rdflib:4.2.2"
     purl: "pkg:pypi/rdflib@4.2.2"
     declared_licenses:
-    - "BSD"
+    - "BSD License"
     - "https://raw.github.com/RDFLib/rdflib/master/LICENSE"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
@@ -157,6 +158,7 @@ packages:
     purl: "pkg:pypi/six@1.14.0"
     declared_licenses:
     - "MIT"
+    - "MIT License"
     declared_licenses_processed:
       spdx_expression: "MIT"
     description: "Python 2 and 3 compatibility utilities"

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -3,7 +3,7 @@ project:
   id: "PIP::Example-App-requirements:2.4.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/pip/requirements.txt"
   declared_licenses:
-  - "MIT"
+  - "MIT License"
   declared_licenses_processed:
     spdx_expression: "MIT"
   vcs:
@@ -34,6 +34,7 @@ packages:
     purl: "pkg:pypi/Flask@1.0"
     declared_licenses:
     - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "A simple framework for building complex web applications."
@@ -64,6 +65,7 @@ packages:
     purl: "pkg:pypi/Jinja2@2.10.1"
     declared_licenses:
     - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "A small but fast and easy to use stand-alone template engine written\
@@ -95,6 +97,7 @@ packages:
     purl: "pkg:pypi/MarkupSafe@1.0"
     declared_licenses:
     - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "Implements a XML/HTML/XHTML Markup safe string for Python"
@@ -124,7 +127,7 @@ packages:
     id: "PyPI::Werkzeug:0.15.3"
     purl: "pkg:pypi/Werkzeug@0.15.3"
     declared_licenses:
-    - "BSD"
+    - "BSD License"
     - "BSD-3-Clause"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
@@ -155,7 +158,7 @@ packages:
     id: "PyPI::click:6.7"
     purl: "pkg:pypi/click@6.7"
     declared_licenses:
-    - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "A simple wrapper around optparse for powerful command line utilities."
@@ -185,7 +188,7 @@ packages:
     id: "PyPI::itsdangerous:0.24"
     purl: "pkg:pypi/itsdangerous@0.24"
     declared_licenses:
-    - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "Various helpers to pass trusted data to untrusted environments and\

--- a/analyzer/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
@@ -32,6 +32,7 @@ packages:
     purl: "pkg:pypi/Flask@1.0"
     declared_licenses:
     - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "A simple framework for building complex web applications."
@@ -62,6 +63,7 @@ packages:
     purl: "pkg:pypi/Jinja2@2.10.1"
     declared_licenses:
     - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "A small but fast and easy to use stand-alone template engine written\
@@ -93,6 +95,7 @@ packages:
     purl: "pkg:pypi/MarkupSafe@1.0"
     declared_licenses:
     - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "Implements a XML/HTML/XHTML Markup safe string for Python"
@@ -122,7 +125,7 @@ packages:
     id: "PyPI::Werkzeug:0.15.3"
     purl: "pkg:pypi/Werkzeug@0.15.3"
     declared_licenses:
-    - "BSD"
+    - "BSD License"
     - "BSD-3-Clause"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
@@ -153,7 +156,7 @@ packages:
     id: "PyPI::click:6.7"
     purl: "pkg:pypi/click@6.7"
     declared_licenses:
-    - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "A simple wrapper around optparse for powerful command line utilities."
@@ -183,7 +186,7 @@ packages:
     id: "PyPI::itsdangerous:0.24"
     purl: "pkg:pypi/itsdangerous@0.24"
     declared_licenses:
-    - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "Various helpers to pass trusted data to untrusted environments and\

--- a/analyzer/src/funTest/assets/projects/synthetic/python3-django-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/python3-django-expected-output.yml
@@ -28,6 +28,7 @@ packages:
     purl: "pkg:pypi/Django@2.2.10"
     declared_licenses:
     - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "A high-level Python Web framework that encourages rapid development\
@@ -59,6 +60,7 @@ packages:
     purl: "pkg:pypi/pytz@2019.3"
     declared_licenses:
     - "MIT"
+    - "MIT License"
     declared_licenses_processed:
       spdx_expression: "MIT"
     description: "World timezone definitions, modern and historical"
@@ -89,6 +91,7 @@ packages:
     purl: "pkg:pypi/sqlparse@0.3.1"
     declared_licenses:
     - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "Non-validating SQL parser"

--- a/analyzer/src/funTest/assets/projects/synthetic/python3-django-pipenv-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/python3-django-pipenv-expected-output.yml
@@ -27,6 +27,7 @@ packages:
     purl: "pkg:pypi/Django@2.1.11"
     declared_licenses:
     - "BSD"
+    - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
     description: "A high-level Python Web framework that encourages rapid development\
@@ -58,6 +59,7 @@ packages:
     purl: "pkg:pypi/pytz@2019.3"
     declared_licenses:
     - "MIT"
+    - "MIT License"
     declared_licenses_processed:
       spdx_expression: "MIT"
     description: "World timezone definitions, modern and historical"

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -484,14 +484,14 @@ class Pip(
 
         // Use the top-level license field as well as the license classifiers as the declared licenses.
         setOf(pkgInfo["license"]).mapNotNullTo(declaredLicenses) { license ->
-            license?.textValue()?.removeSuffix(" License")?.takeUnless { it.isBlank() || it == "UNKNOWN" }
+            license?.textValue()?.takeUnless { it.isBlank() || it == "UNKNOWN" }
         }
 
         // Example license classifier:
         // "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)"
         pkgInfo["classifiers"]?.mapNotNullTo(declaredLicenses) {
             val classifier = it.textValue().split(" :: ")
-            classifier.takeIf { it.first() == "License" }?.last()?.removeSuffix(" License")
+            classifier.takeIf { it.first() == "License" }?.last()
         }
 
         return declaredLicenses


### PR DESCRIPTION
Often the " License" suffix is part of the name of the license. Also, we
do not do this in any of the other package manager implementations, and
it is ORT's philosophy to capture the original metadata without
manipulating it.