### PR TITLE
MavenSupport: Do not fail on missing checksum

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -458,7 +458,8 @@ class MavenSupport(workspaceReader: WorkspaceReader) {
                 }
 
                 val downloadUrl = "${repository.url.trimEnd('/')}/$remoteLocation"
-                return RemoteArtifact(downloadUrl, Hash.create(actualChecksum, checksum.algorithm)).also {
+                val hash = if (actualChecksum.isBlank()) Hash.NONE else Hash.create(actualChecksum, checksum.algorithm)
+                return RemoteArtifact(downloadUrl, hash).also {
                     log.debug { "Writing remote artifact for '$artifact' to disk cache." }
                     remoteArtifactCache.write(artifact.toString(), yamlMapper.writeValueAsString(it))
                 }


### PR DESCRIPTION
If the checksum cannot be retrieved from the server the function falls
back to using an empty string instead. This was broken since eeea7ec,
because calling `Hash.create()` with an empty string will fail to verify
the checksum with a message like this:

java.lang.IllegalArgumentException: '' is not a SHA-1 hash.

Instead, check if the checksum is blank and use `Hash.NONE` in this
case.