### PR TITLE
Dockerfile: Allow proxies to tamper with Bintray's SSL certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ ENV \
 RUN \
     apt-get update && \
     apt-get install -y --no-install-recommends gnupg && \
+    echo 'Acquire::https::dl.bintray.com::Verify-Peer "false";' | tee -a /etc/apt/apt.conf.d/00sbt && \
     echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
     curl -ksS "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key adv --import - && \
     apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,10 @@ RUN \
         lib32stdc++6 \
         libffi-dev \
         libgmp-dev \
+        libxext6 \
+        libxrender1 \
+        libxi6 \
+        libxtst6 \
         make \
         netbase \
         openssh-client \


### PR DESCRIPTION
This is again needed for corporate proxy support to be able to install
sbt from Bintray.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>