### PR TITLE
Fix AppVeyor builds after migration to new org

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -52,18 +52,18 @@ install:
   - echo extension_dir=ext>>php.ini
   - echo extension=php_mbstring.dll>>php.ini
   - echo extension=php_openssl.dll>>php.ini
-  - cd %APPVEYOR_BUILD_FOLDER%
+  - cd "%APPVEYOR_BUILD_FOLDER%"
   - cinst dep --version %GO_DEP_VERSION% -y
   - refreshenv
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy cvs"
-  - set PATH=%PATH%;C:\msys64\usr\bin # For CVS.
-  - set PATH=C:\Ruby25\bin;%PATH% # For licensee.
+  - set "PATH=%PATH%;C:\msys64\usr\bin" # For CVS.
+  - set "PATH=C:\Ruby25\bin;%PATH%" # For licensee.
   # Install git-repo.
   - ps: Start-FileDownload 'https://storage.googleapis.com/git-repo-downloads/repo' -FileName "$env:PROGRAMFILES\Git\usr\bin\repo"
   # Install the Android SDK.
   - ps: Start-FileDownload "https://dl.google.com/android/repository/sdk-tools-windows-$env:ANDROID_SDK_VERSION.zip"
-  - 7z x sdk-tools-windows-%ANDROID_SDK_VERSION%.zip -o%ANDROID_HOME% > nul
-  - yes | %ANDROID_HOME%\tools\bin\sdkmanager.bat platform-tools
+  - 7z x sdk-tools-windows-%ANDROID_SDK_VERSION%.zip -o"%ANDROID_HOME%" > nul
+  - yes | "%ANDROID_HOME%\tools\bin\sdkmanager.bat" platform-tools
   # Install Flutter.
   - ps: Start-FileDownload "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_$env:FLUTTER_VERSION.zip"
   - 7z x flutter_windows_%FLUTTER_VERSION%.zip -oC:\ > nul
@@ -78,8 +78,8 @@ install:
 
 # Do something useful here to override the default MSBuild (which would fail otherwise).
 build_script:
-  - if not exist %HOME%\.gradle mkdir %HOME%\.gradle
-  - echo org.gradle.java.home=C:/Program Files/Java/jdk9>>%HOME%\.gradle\gradle.properties
+  - if not exist "%HOME%\.gradle" mkdir "%HOME%\.gradle"
+  - echo org.gradle.java.home=C:/Program Files/Java/jdk9>>"%HOME%\.gradle\gradle.properties"
   - gradlew --stacktrace detekt
 
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,8 +2,6 @@ skip_branch_with_pr: true
 
 environment:
   HOME: $(HOMEDRIVE)$(HOMEPATH)
-  ANDROID_HOME: C:\android-sdk
-  ANDROID_SDK_VERSION: 3859397
   BOWER_VERSION: 1.8.8
   COMPOSER_VERSION: 4.8.0
   CONAN_VERSION: 1.18.0
@@ -60,10 +58,6 @@ install:
   - set "PATH=C:\Ruby25\bin;%PATH%" # For licensee.
   # Install git-repo.
   - ps: Start-FileDownload 'https://storage.googleapis.com/git-repo-downloads/repo' -FileName "$env:PROGRAMFILES\Git\usr\bin\repo"
-  # Install the Android SDK.
-  - ps: Start-FileDownload "https://dl.google.com/android/repository/sdk-tools-windows-$env:ANDROID_SDK_VERSION.zip"
-  - 7z x sdk-tools-windows-%ANDROID_SDK_VERSION%.zip -o"%ANDROID_HOME%" > nul
-  - yes | "%ANDROID_HOME%\tools\bin\sdkmanager.bat" platform-tools
   # Install Flutter.
   - ps: Start-FileDownload "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_$env:FLUTTER_VERSION.zip"
   - 7z x flutter_windows_%FLUTTER_VERSION%.zip -oC:\ > nul

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -73,7 +73,7 @@ install:
 # Do something useful here to override the default MSBuild (which would fail otherwise).
 build_script:
   - if not exist "%HOME%\.gradle" mkdir "%HOME%\.gradle"
-  - echo org.gradle.java.home=C:/Program Files/Java/jdk9>>"%HOME%\.gradle\gradle.properties"
+  - echo org.gradle.java.home=C:/Program Files/Java/jdk11>>"%HOME%\.gradle\gradle.properties"
   - gradlew --stacktrace detekt
 
 test_script:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 &nbsp;
 
-| Linux (OpenJDK 10)             | Windows (Oracle JDK 9)          | JitPack (OpenJDK 8)             |
+| Linux (OpenJDK 10)             | Windows (Oracle JDK 11)         | JitPack (OpenJDK 8)             |
 | :----------------------------- | :------------------------------ | :------------------------------ |
 | [![Linux build status][1]][2]  | [![Windows build status][3]][4] | [![JitPack build status][5]][6] |
 | [![Linux code coverage][7]][8] |                                 |                                 |

--- a/analyzer/src/funTest/kotlin/managers/GoModTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoModTest.kt
@@ -19,14 +19,6 @@
 
 package org.ossreviewtoolkit.analyzer.managers
 
-import org.ossreviewtoolkit.downloader.VersionControlSystem
-import org.ossreviewtoolkit.model.yamlMapper
-import org.ossreviewtoolkit.utils.normalizeVcsUrl
-import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
-import org.ossreviewtoolkit.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
-import org.ossreviewtoolkit.utils.test.USER_DIR
-import org.ossreviewtoolkit.utils.test.patchExpectedResult
-
 import io.kotlintest.matchers.beEmpty
 import io.kotlintest.should
 import io.kotlintest.shouldBe
@@ -35,6 +27,15 @@ import io.kotlintest.specs.StringSpec
 
 import java.io.File
 
+import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.model.yamlMapper
+import org.ossreviewtoolkit.utils.Os
+import org.ossreviewtoolkit.utils.normalizeVcsUrl
+import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+import org.ossreviewtoolkit.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
+import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.patchExpectedResult
+
 class GoModTest : StringSpec() {
     private val projectDir = File("src/funTest/assets/projects/synthetic/gomod").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
@@ -42,7 +43,7 @@ class GoModTest : StringSpec() {
     private val vcsRevision = vcsDir.getRevision()
 
     init {
-        "Project dependencies are detected correctly" {
+        "Project dependencies are detected correctly".config(enabled = !Os.isWindows) {
             val definitionFile = File(projectDir, "go.mod")
             val vcsPath = vcsDir.getPathToRoot(projectDir)
             val expectedResult = patchExpectedResult(


### PR DESCRIPTION
Looks like the migration implicitly made use use newer / different AppVeyor base images.

Please have a look at the individual commit messages for the details.