### PR TITLE
rebase: Add the missing fetch-depth of 0

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Checkout Action
       uses: actions/checkout@master
+      with:
+        fetch-depth: 0
     - name: Rebase Action
       uses: docker://cirrusactions/rebase:latest
       env:


### PR DESCRIPTION
See https://github.com/cirrus-actions/rebase#installation, otherwise the
base to rebase onto is wrong (the root commit).

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>