### PR TITLE
Dockerfile: Fix alphabetical sorting of libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,8 +83,8 @@ RUN \
         libffi-dev \
         libgmp-dev \
         libxext6 \
-        libxrender1 \
         libxi6 \
+        libxrender1 \
         libxtst6 \
         make \
         netbase \


### PR DESCRIPTION
This is a fixup for commit f192d99.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>