### PR TITLE
gitattributes: Checkout ScanCode samples with Unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@ gradlew						text eol=lf
 # Use Unix line endings for expected test results for consistency across platforms.
 */src/*/assets/**/*expected*.yml		text eol=lf
 reporter/src/funTest/assets/*-expected-*	text eol=lf
+scanner/src/test/assets/*.json			text eol=lf
 
 # Use Unix line endings for JavaScript source code to avoid problems with eslint.
 reporter-web-app/**/*.js			text eol=lf


### PR DESCRIPTION
Otherwise the ScanCodeTest can fail on Windows, because the calculated
package verification code depnds on the line endings.