### PR TITLE
PackageManager: Make processPackageVcs() validate URLs after splitting

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output-win32.yml
+++ b/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output-win32.yml
@@ -1541,10 +1541,10 @@ packages:
       revision: ""
       path: ""
     vcs_processed:
-      type: ""
-      url: ""
-      revision: ""
-      path: ""
+      type: "Git"
+      url: "https://github.com/fpco/unliftio.git"
+      revision: "master"
+      path: "unliftio-core"
   curations: []
 - package:
     id: "Hackage:Control:unliftio:0.2.10"
@@ -1571,10 +1571,10 @@ packages:
       revision: ""
       path: ""
     vcs_processed:
-      type: ""
-      url: ""
-      revision: ""
-      path: ""
+      type: "Git"
+      url: "https://github.com/fpco/unliftio.git"
+      revision: "master"
+      path: "unliftio"
   curations: []
 - package:
     id: "Hackage:Data Structures, Graphs:fgl:5.7.0.1"

--- a/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output.yml
@@ -1528,10 +1528,10 @@ packages:
       revision: ""
       path: ""
     vcs_processed:
-      type: ""
-      url: ""
-      revision: ""
-      path: ""
+      type: "Git"
+      url: "https://github.com/fpco/unliftio.git"
+      revision: "master"
+      path: "unliftio-core"
   curations: []
 - package:
     id: "Hackage:Control:unliftio:0.2.10"
@@ -1558,10 +1558,10 @@ packages:
       revision: ""
       path: ""
     vcs_processed:
-      type: ""
-      url: ""
-      revision: ""
-      path: ""
+      type: "Git"
+      url: "https://github.com/fpco/unliftio.git"
+      revision: "master"
+      path: "unliftio"
   curations: []
 - package:
     id: "Hackage:Data Structures, Graphs:fgl:5.7.0.1"

--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -241,7 +241,7 @@ class Bower(
                 definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                 declaredLicenses = projectPackage.declaredLicenses,
                 vcs = projectPackage.vcs,
-                vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, listOf(projectPackage.homepageUrl)),
+                vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, projectPackage.homepageUrl),
                 homepageUrl = projectPackage.homepageUrl,
                 scopes = sortedSetOf(dependenciesScope, devDependenciesScope)
             )

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -115,7 +115,7 @@ class Bundler(
                 definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
                 declaredLicenses = declaredLicenses.toSortedSet(),
                 vcs = VcsInfo.EMPTY,
-                vcsProcessed = processProjectVcs(workingDir, fallbackUrls = listOf(homepageUrl)),
+                vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY, homepageUrl),
                 homepageUrl = homepageUrl,
                 scopes = scopes.toSortedSet()
             )
@@ -169,7 +169,7 @@ class Bundler(
                     binaryArtifact = RemoteArtifact.EMPTY,
                     sourceArtifact = gemSpec.artifact,
                     vcs = gemSpec.vcs,
-                    vcsProcessed = processPackageVcs(gemSpec.vcs, listOf(gemSpec.homepageUrl))
+                    vcsProcessed = processPackageVcs(gemSpec.vcs, gemSpec.homepageUrl)
                 )
 
                 val transitiveDependencies = mutableSetOf<PackageReference>()

--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -282,7 +282,7 @@ class Cargo(
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
             declaredLicenses = projectPkg.declaredLicenses,
             vcs = projectPkg.vcs,
-            vcsProcessed = processProjectVcs(workingDir, projectPkg.vcs, listOf(homepageUrl)),
+            vcsProcessed = processProjectVcs(workingDir, projectPkg.vcs, homepageUrl),
             homepageUrl = homepageUrl,
             scopes = sortedSetOf(dependenciesScope, devDependenciesScope, buildDependenciesScope)
         )

--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -132,7 +132,7 @@ class Conan(
                     vcsProcessed = processProjectVcs(
                         workingDir,
                         projectPackage.vcs,
-                        listOf(projectPackage.homepageUrl)
+                        projectPackage.homepageUrl
                     ),
                     homepageUrl = projectPackage.homepageUrl,
                     scopes = sortedSetOf(dependenciesScope, devDependenciesScope)

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -154,7 +154,7 @@ class Maven(
 
         val browsableScmUrl = MavenSupport.getOriginalScm(mavenProject)?.url
         val homepageUrl = mavenProject.url
-        val vcsFallbackUrls = listOfNotNull(browsableScmUrl, homepageUrl)
+        val vcsFallbackUrls = listOfNotNull(browsableScmUrl, homepageUrl).toTypedArray()
 
         val project = Project(
             id = Identifier(
@@ -166,7 +166,7 @@ class Maven(
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
             declaredLicenses = MavenSupport.parseLicenses(mavenProject),
             vcs = vcsFromPackage,
-            vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, vcsFallbackUrls),
+            vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, *vcsFallbackUrls),
             homepageUrl = homepageUrl.orEmpty(),
             scopes = scopes.values.toSortedSet()
         )

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -308,7 +308,7 @@ open class Npm(
                     hash = hash
                 ),
                 vcs = vcsFromPackage,
-                vcsProcessed = processPackageVcs(vcsFromPackage, listOf(homepageUrl))
+                vcsProcessed = processPackageVcs(vcsFromPackage, homepageUrl)
             )
 
             require(module.id.name.isNotEmpty()) {
@@ -519,7 +519,7 @@ open class Npm(
             definitionFilePath = VersionControlSystem.getPathInfo(packageJson).path,
             declaredLicenses = declaredLicenses,
             vcs = vcsFromPackage,
-            vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, listOf(homepageUrl)),
+            vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, homepageUrl),
             homepageUrl = homepageUrl,
             scopes = scopes
         )

--- a/analyzer/src/main/kotlin/managers/PhpComposer.kt
+++ b/analyzer/src/main/kotlin/managers/PhpComposer.kt
@@ -234,7 +234,7 @@ class PhpComposer(
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
             declaredLicenses = parseDeclaredLicenses(json),
             vcs = vcs,
-            vcsProcessed = processProjectVcs(definitionFile.parentFile, vcs, listOf(homepageUrl)),
+            vcsProcessed = processProjectVcs(definitionFile.parentFile, vcs, homepageUrl),
             homepageUrl = homepageUrl,
             scopes = scopes
         )
@@ -269,7 +269,7 @@ class PhpComposer(
                     binaryArtifact = RemoteArtifact.EMPTY,
                     sourceArtifact = parseArtifact(pkgInfo),
                     vcs = vcsFromPackage,
-                    vcsProcessed = processPackageVcs(vcsFromPackage, listOf(homepageUrl))
+                    vcsProcessed = processPackageVcs(vcsFromPackage, homepageUrl)
                 )
             }
         }

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -406,7 +406,7 @@ class Pip(
                                 pkg.sourceArtifact
                             },
                             vcs = pkg.vcs,
-                            vcsProcessed = processPackageVcs(pkg.vcs, listOf(pkgHomepage))
+                            vcsProcessed = processPackageVcs(pkg.vcs, pkgHomepage)
                         )
                     } ?: run {
                         log.warn {
@@ -439,7 +439,7 @@ class Pip(
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
             declaredLicenses = declaredLicenses,
             vcs = VcsInfo.EMPTY,
-            vcsProcessed = processProjectVcs(workingDir, fallbackUrls = listOf(setupHomepage)),
+            vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY, setupHomepage),
             homepageUrl = setupHomepage,
             scopes = scopes
         )

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -369,7 +369,7 @@ class Pub(
             // Pub does not declare any licenses in the pubspec files, therefore we keep this empty.
             declaredLicenses = sortedSetOf(),
             vcs = vcs,
-            vcsProcessed = processProjectVcs(definitionFile.parentFile, vcs, listOf(homepageUrl)),
+            vcsProcessed = processProjectVcs(definitionFile.parentFile, vcs, homepageUrl),
             homepageUrl = homepageUrl,
             scopes = scopes
         )
@@ -441,7 +441,7 @@ class Pub(
                     // Pub does not create source artifacts, therefore use any empty artifact.
                     sourceArtifact = RemoteArtifact.EMPTY,
                     vcs = vcsFromPackage,
-                    vcsProcessed = processPackageVcs(vcsFromPackage, listOf(homepageUrl))
+                    vcsProcessed = processPackageVcs(vcsFromPackage, homepageUrl)
                 )
             }
         }

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -169,7 +169,7 @@ class Stack(
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
             declaredLicenses = projectPackage.declaredLicenses,
             vcs = projectPackage.vcs,
-            vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, listOf(projectPackage.homepageUrl)),
+            vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, projectPackage.homepageUrl),
             homepageUrl = projectPackage.homepageUrl,
             scopes = scopes
         )
@@ -355,7 +355,7 @@ class Stack(
             binaryArtifact = RemoteArtifact.EMPTY,
             sourceArtifact = artifact,
             vcs = vcs,
-            vcsProcessed = processPackageVcs(vcs, listOf(homepageUrl))
+            vcsProcessed = processPackageVcs(vcs, homepageUrl)
         )
     }
 }

--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -570,11 +570,11 @@ class MavenSupport(workspaceReader: WorkspaceReader) {
 
         val browsableScmUrl = MavenSupport.getOriginalScm(mavenProject)?.url
         val homepageUrl = mavenProject.url
-        val vcsFallbackUrls = listOfNotNull(browsableScmUrl, homepageUrl)
+        val vcsFallbackUrls = listOfNotNull(browsableScmUrl, homepageUrl).toTypedArray()
 
         val vcsProcessed = localDirectory?.let {
-            PackageManager.processProjectVcs(it, vcsFromPackage, vcsFallbackUrls)
-        } ?: PackageManager.processPackageVcs(vcsFromPackage, vcsFallbackUrls)
+            PackageManager.processProjectVcs(it, vcsFromPackage, *vcsFallbackUrls)
+        } ?: PackageManager.processPackageVcs(vcsFromPackage, *vcsFallbackUrls)
 
         return Package(
             id = Identifier(


### PR DESCRIPTION
Previously, VersionControlSystem.forUrl() was called before splitting
the URL into any contained VCS information via VcsHost.toVcsInfo(). That
did not really make sense, as URLs like e.g.

    https://github.com/fpco/unliftio/tree/master/unliftio

only become valid after they have been split. So change the function to
first split, and then check whether the URL is applicable for any
supported VCS implementation.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>