### PR TITLE
Utils: Let normalizeVcsUrl() append ".git" only for repository paths

### DIFF
--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -272,8 +272,10 @@ fun normalizeVcsUrl(vcsUrl: String): String {
     if (uri.host != null) {
         when {
             uri.host.endsWith("github.com") || uri.host.endsWith("gitlab.com") -> {
-                // Ensure the path ends in ".git".
-                val path = uri.path.takeIf { Regex("\\.git(/|$)") in it } ?: "${uri.path}.git"
+                // Ensure the path to a repository ends with ".git".
+                val path = uri.path.takeIf { path ->
+                    path.endsWith(".git") || path.count { it == '/' } != 2
+                } ?: "${uri.path}.git"
 
                 return if (uri.scheme == "ssh") {
                     // Ensure the generic "git" user name is specified.


### PR DESCRIPTION
Paths that point to sub-directories contained in the repository (but
that do not contain ".git/" in between) should not get ".git" appended.

For example, previously

    https://github.com/hamcrest/JavaHamcrest/hamcrest-core

was turned into

    https://github.com/hamcrest/JavaHamcrest/hamcrest-core.git

which is wrong.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>