### PR TITLE
LocalFileStorageConfiguration: Enable compression by default

### DIFF
--- a/model/src/main/kotlin/config/LocalFileStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/LocalFileStorageConfiguration.kt
@@ -32,7 +32,7 @@ data class LocalFileStorageConfiguration(
     val directory: File,
 
     /**
-     * Whether to use compression for storing files or not.
+     * Whether to use compression for storing files or not. Defaults to true.
      */
-    val compression: Boolean
+    val compression: Boolean = true
 )


### PR DESCRIPTION
Providing a default value for the compression allows to configure the
local file storage by only setting the directory.