### PR TITLE
downloader: Fix a jsch dependency issue in the generated Maven POM

### DIFF
--- a/downloader/build.gradle.kts
+++ b/downloader/build.gradle.kts
@@ -33,6 +33,14 @@ dependencies {
     implementation(project(":utils"))
 
     implementation("com.jcraft:jsch.agentproxy.jsch:$jSchAgentProxyVersion")
+
+    // Force the generated Maven POM to use the same version of "jsch" Gradle resolves the version conflict to.
+    implementation("com.jcraft:jsch") {
+        version {
+            strictly("0.1.55")
+        }
+    }
+
     implementation("org.eclipse.jgit:org.eclipse.jgit:$jgitVersion")
     implementation("org.tmatesoft.svnkit:svnkit:$svnkitVersion")
 }


### PR DESCRIPTION
While we are using jsch.agentproxy.jsch 0.0.7, even the currently latest
version 0.0.9 still depends on jsch 0.1.49. However, JGit requires jsch
version 0.1.55, which is what Gradle resolves to.

The generated POM only declares jsch.agentproxy.jsch 0.0.7, and Maven's
version conflict resolution (take the version that is closest to the
root) does *not* upgrade jsch 0.1.49 to version 0.1.55, which causes
problems with JGit on the consumer side. So manually stick the version
to 0.1.55 here.

Ideally, the dependency version could be customized in the Maven Publish
Plugin as described at [1], but doing so did not have any effect on the
generated POM when tested.

[1] https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:resolved_dependencies

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>