### PR TITLE
SimplePackageConfigurationProvider: Fix-up a filter condition

### DIFF
--- a/model/src/main/kotlin/utils/SimplePackageConfigurationProvider.kt
+++ b/model/src/main/kotlin/utils/SimplePackageConfigurationProvider.kt
@@ -40,7 +40,8 @@ class SimplePackageConfigurationProvider(
          * [Provenance].
          */
         fun forDirectory(directory: File): SimplePackageConfigurationProvider {
-            val entries = directory.walkBottomUp().filterTo(mutableListOf()) { !it.isHidden }
+            val entries = directory.walkBottomUp()
+                .filterTo(mutableListOf()) { !it.isHidden && it.isFile }
                 .map { it.readValue<PackageConfiguration>() }
 
             return SimplePackageConfigurationProvider(entries)


### PR DESCRIPTION
Trying to read a PackageConfiguration from a directory does not make
sense and results in an uncaught exception, thus adjust the filter
condition accordingly.

This is a fix-up of 596aebb.

Signed-off-by: Frank Viernau <frank.viernau@here.com>