### PR TITLE
PackageManagerTest: Move the class one package level up

### DIFF
--- a/analyzer/src/test/kotlin/PackageManagerTest.kt
+++ b/analyzer/src/test/kotlin/PackageManagerTest.kt
@@ -17,15 +17,15 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.analyzer.managers
-
-import org.ossreviewtoolkit.analyzer.PackageManager
+package org.ossreviewtoolkit.analyzer
 
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.WordSpec
 
 import java.io.File
+
+import org.ossreviewtoolkit.analyzer.managers.*
 
 class PackageManagerTest : WordSpec({
     val projectDir = File("src/funTest/assets/projects/synthetic/all-managers").absoluteFile


### PR DESCRIPTION
To match the location of the tested PackageManager class.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>