### PR TITLE
VcsHost: Handle Subversion trunk URLs in toVcsInfo()

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -1300,8 +1300,8 @@ analyzer:
           path: ""
         vcs_processed:
           type: "Subversion"
-          url: "http://svn.apache.org/repos/asf/commons/proper/cli/trunk"
-          revision: ""
+          url: "http://svn.apache.org/repos/asf/commons/proper/cli"
+          revision: "trunk"
           path: ""
       curations: []
     - package:
@@ -1333,8 +1333,8 @@ analyzer:
           path: ""
         vcs_processed:
           type: "Subversion"
-          url: "http://svn.apache.org/repos/asf/commons/proper/codec/trunk"
-          revision: ""
+          url: "http://svn.apache.org/repos/asf/commons/proper/codec"
+          revision: "trunk"
           path: ""
       curations: []
     - package:
@@ -1426,8 +1426,8 @@ analyzer:
           path: ""
         vcs_processed:
           type: "Subversion"
-          url: "https://opencsv.svn.sourceforge.net/svnroot/opencsv/trunk"
-          revision: ""
+          url: "https://opencsv.svn.sourceforge.net/svnroot/opencsv"
+          revision: "trunk"
           path: ""
       curations: []
     - package:
@@ -1690,8 +1690,8 @@ analyzer:
           path: ""
         vcs_processed:
           type: "Subversion"
-          url: "http://svn.apache.org/repos/asf/commons/proper/collections/trunk"
-          revision: ""
+          url: "http://svn.apache.org/repos/asf/commons/proper/collections"
+          revision: "trunk"
           path: ""
       curations: []
     - package:
@@ -1786,8 +1786,8 @@ analyzer:
           path: ""
         vcs_processed:
           type: "Subversion"
-          url: "http://svn.apache.org/repos/asf/commons/proper/lang/trunk"
-          revision: ""
+          url: "http://svn.apache.org/repos/asf/commons/proper/lang"
+          revision: "trunk"
           path: ""
       curations: []
     - package:

--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -343,8 +343,8 @@ packages:
       path: ""
     vcs_processed:
       type: "Subversion"
-      url: "http://svn.apache.org/repos/asf/commons/proper/codec/trunk"
-      revision: ""
+      url: "http://svn.apache.org/repos/asf/commons/proper/codec"
+      revision: "trunk"
       path: ""
   curations: []
 - package:
@@ -657,8 +657,8 @@ packages:
       path: ""
     vcs_processed:
       type: "Subversion"
-      url: "http://svn.apache.org/repos/asf/commons/proper/lang/trunk"
-      revision: ""
+      url: "http://svn.apache.org/repos/asf/commons/proper/lang"
+      revision: "trunk"
       path: ""
   curations: []
 - package:


### PR DESCRIPTION
Similar to like already done for Subversion URLs to branches or tags,
also handle trunk URLs and split out "trunk" as the symbolic revision
name.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>