### PR TITLE
GradleIntegrationTest: Upgrade Gradle to 6.2.0

### DIFF
--- a/analyzer/src/funTest/kotlin/integration/GradleIntegrationTest.kt
+++ b/analyzer/src/funTest/kotlin/integration/GradleIntegrationTest.kt
@@ -53,17 +53,16 @@ class GradleIntegrationTest : AbstractIntegrationSpec() {
     override val expectedManagedFiles by lazy {
         // The Gradle project contains far too many definition files to list them all here. Use this tests to double
         // check that all of them are found, and that they are assigned to the correct package manager.
-        val gradleBuildFilenames = listOf("build.gradle", "build.gradle.kts")
-        val gradleSettingsFilenames = listOf("settings.gradle", "settings.gradle.kts")
-        val gradleFilenames = gradleBuildFilenames + gradleSettingsFilenames
+        val gradleFilenames = listOf("build.gradle", "build.gradle.kts", "settings.gradle", "settings.gradle.kts")
 
         val gradleFiles = downloadResult.downloadDirectory.walkTopDown().filter {
             it.name in gradleFilenames
         }.toMutableList()
 
-        // "settings" files should only be considered if there is no "build" file in the same directory.
+        // In each directory only the first file contained in gradleFiles is used.
         gradleFiles.removeAll { file ->
-            file.name in gradleSettingsFilenames && gradleBuildFilenames.any { file.resolveSibling(it) in gradleFiles }
+            val preferentialGradleFilenames = gradleFilenames.subList(0, gradleFilenames.indexOf(file.name))
+            preferentialGradleFilenames.any { file.resolveSibling(it) in gradleFiles }
         }
 
         val pomFiles = downloadResult.downloadDirectory.walkTopDown().filter { it.name == "pom.xml" }.toList()

--- a/analyzer/src/funTest/kotlin/integration/GradleIntegrationTest.kt
+++ b/analyzer/src/funTest/kotlin/integration/GradleIntegrationTest.kt
@@ -36,7 +36,7 @@ class GradleIntegrationTest : AbstractIntegrationSpec() {
             type = "Maven",
             namespace = "org.gradle",
             name = "Gradle",
-            version = "4.4.0"
+            version = "6.3.0"
         ),
         declaredLicenses = sortedSetOf(),
         description = "",
@@ -46,7 +46,7 @@ class GradleIntegrationTest : AbstractIntegrationSpec() {
         vcs = VcsInfo(
             type = VcsType.GIT,
             url = "https://github.com/gradle/gradle.git",
-            revision = "v4.4.0"
+            revision = "v6.3.0"
         )
     )
 


### PR DESCRIPTION
The Gradle wrapper of the previously used version 4.4.0 is not
compatible with Java 11. The new version now has a directory which
contains both a "build.gradle" and a "build.gradle.kts", adjust the
logic to get the `expectedManagedFiles` accordingly.