### PR TITLE
EvaluatedModelMapper: Map all analyzer issues for packages

### DIFF
--- a/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
@@ -261,10 +261,17 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     }
 
     private fun addAnalyzerIssues(id: Identifier, pkg: EvaluatedPackage): List<EvaluatedOrtIssue> {
+        val result = mutableListOf<EvaluatedOrtIssue>()
+
         input.ortResult.analyzer?.result?.issues?.get(id)?.let { analyzerIssues ->
-            return addIssues(analyzerIssues, EvaluatedOrtIssueType.ANALYZER, pkg, null, null)
+            result += addIssues(analyzerIssues, EvaluatedOrtIssueType.ANALYZER, pkg, null, null)
         }
-        return emptyList()
+
+        input.ortResult.getPackage(id)?.let {
+            result += addIssues(it.pkg.collectIssues(), EvaluatedOrtIssueType.ANALYZER, pkg, null, null)
+        }
+
+        return result
     }
 
     private fun addRuleViolation(ruleViolation: RuleViolation) {


### PR DESCRIPTION
Previously Package.collectIssues() was never called by this model mapper
class. Thus only analyzer issues linked to PackageReferences were included
in the result while the ones linked to Packages were missing.

Include Package.collectIssues() into the result computation so that
the issues show-up in the WebApp report.

Signed-off-by: Frank Viernau <frank.viernau@here.com>