### PR TITLE
YarnTest: Fix the expected VCS URL in workspace packages

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces-expected-output.yml
@@ -80,7 +80,7 @@ packages:
         algorithm: ""
     vcs:
       type: "Git"
-      url: "<REPLACE_URL>"
+      url: "<REPLACE_RAW_URL>"
       revision: "<REPLACE_REVISION>"
       path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg2"
     vcs_processed:
@@ -170,7 +170,7 @@ packages:
         algorithm: ""
     vcs:
       type: "Git"
-      url: "<REPLACE_URL>"
+      url: "<REPLACE_RAW_URL>"
       revision: "<REPLACE_REVISION>"
       path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg1"
     vcs_processed:

--- a/analyzer/src/funTest/kotlin/managers/YarnTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/YarnTest.kt
@@ -45,7 +45,8 @@ class YarnTest : WordSpec() {
             definitionFilePath = "$vcsPath/package.json",
             url = normalizeVcsUrl(vcsUrl),
             revision = vcsRevision,
-            path = vcsPath
+            path = vcsPath,
+            custom = "<REPLACE_RAW_URL>" to vcsUrl
         )
     }
 


### PR DESCRIPTION
Before, the normalized VCS URL was used for the unprocessed and the
processed VCS URL of the workspace packages in the expected results.
This was wrong, because the URL is not normalized in the unprocessed VCS
info.