### PR TITLE
OrtResult: Speed-up getFilePathRelativeToAnalyzerRoot()

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -244,13 +244,17 @@ data class OrtResult(
     fun getDefinitionFilePathRelativeToAnalyzerRoot(project: Project) =
         getFilePathRelativeToAnalyzerRoot(project, project.definitionFilePath)
 
+    private val relativeProjectVcsPath: Map<Identifier, String?> by lazy {
+        getProjects().associateBy({ it.id }, { repository.getRelativePath(it.vcsProcessed) })
+    }
+
     /**
      * Return the path of a file contained in [project], relative to the analyzer root. If the project was checked out
      * from a VCS the analyzer root is the root of the working tree, if the project was not checked out from a VCS the
      * analyzer root is the input directory of the analyzer.
      */
     fun getFilePathRelativeToAnalyzerRoot(project: Project, path: String): String {
-        val vcsPath = repository.getRelativePath(project.vcsProcessed)
+        val vcsPath = relativeProjectVcsPath.getValue(project.id)
 
         requireNotNull(vcsPath) {
             "The ${project.vcsProcessed} of project '${project.id.toCoordinates()}' cannot be found in $repository."

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -102,7 +102,7 @@ class OrtResultTest : WordSpec({
                 AnalyzerRun(
                     environment = Environment(),
                     config = AnalyzerConfiguration(ignoreToolVersions = true, allowDynamicVersions = true),
-                    result = AnalyzerResult.EMPTY
+                    result = AnalyzerResult.EMPTY.copy(projects = sortedSetOf(project1, project2, project3))
                 )
             )
 
@@ -131,7 +131,7 @@ class OrtResultTest : WordSpec({
                 AnalyzerRun(
                     environment = Environment(),
                     config = AnalyzerConfiguration(ignoreToolVersions = true, allowDynamicVersions = true),
-                    result = AnalyzerResult.EMPTY
+                    result = AnalyzerResult.EMPTY.copy(projects = sortedSetOf(project))
                 )
             )
 

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -80,13 +80,13 @@ class OrtResultTest : WordSpec({
                 vcsProcessed = vcs.normalize()
             )
             val project2 = Project.EMPTY.copy(
-                id = Identifier("Gradle:org.ossreviewtoolkit:project1:1.0"),
+                id = Identifier("Gradle:org.ossreviewtoolkit:project2:1.0"),
                 definitionFilePath = "project2/build.gradle",
                 vcs = nestedVcs1,
                 vcsProcessed = nestedVcs1.normalize()
             )
             val project3 = Project.EMPTY.copy(
-                id = Identifier("Gradle:org.ossreviewtoolkit:project1:1.0"),
+                id = Identifier("Gradle:org.ossreviewtoolkit:project3:1.0"),
                 definitionFilePath = "project3/build.gradle",
                 vcs = nestedVcs2,
                 vcsProcessed = nestedVcs2.normalize()


### PR DESCRIPTION
When the OrtResult contains a large number of nested VCSes
Repository.getRelativePath() executes relatively slowly. In combination
with a large number of projects and packages in which case this function
gets called quite often this leads to terrible execution time.

For my real world example the evaluator took about 30 minutes while
computing the reports took around 3 hours. With this change it executes
altogether in less than two minutes again.

Signed-off-by: Frank Viernau <frank.viernau@here.com>