### PR TITLE
MavenSupport: Treat Subversion tag names as revisions

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -956,13 +956,13 @@ packages:
     vcs:
       type: "Subversion"
       url: "http://svn.code.sf.net/p/hsqldb/svn/base/"
-      revision: ""
-      path: "tags/2.4.0"
+      revision: "tags/2.4.0"
+      path: ""
     vcs_processed:
       type: "Subversion"
       url: "http://svn.code.sf.net/p/hsqldb/svn/base"
-      revision: ""
-      path: "tags/2.4.0"
+      revision: "tags/2.4.0"
+      path: ""
   curations: []
 - package:
     id: "Maven:org.javassist:javassist:3.20.0-GA"

--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -203,9 +203,8 @@ class MavenSupport(workspaceReader: WorkspaceReader) {
                         }
 
                         type == "svn" -> {
-                            // With Subversion, a tag actually is a path and not a symbolic revision.
-                            val path = tag.takeIf { it.isEmpty() } ?: "tags/$tag"
-                            VcsInfo(type = VcsType.SUBVERSION, url = url, revision = "", path = path)
+                            val revision = tag.takeIf { it.isEmpty() } ?: "tags/$tag"
+                            VcsInfo(type = VcsType.SUBVERSION, url = url, revision = revision)
                         }
 
                         url.startsWith("//") -> {


### PR DESCRIPTION
This is a fixup for 103a3c1.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>