### PR TITLE
Tests: Improve shouldContainExactlyInAnyOrder assertions

### DIFF
--- a/downloader/src/funTest/kotlin/vcs/GitWorkingTreeTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitWorkingTreeTest.kt
@@ -86,7 +86,9 @@ class GitWorkingTreeTest : StringSpec() {
         }
 
         "Git correctly lists remote branches" {
-            val expectedBranches = listOf(
+            val workingTree = git.getWorkingTree(zipContentDir)
+
+            workingTree.listRemoteBranches() shouldContainExactlyInAnyOrder listOf(
                 "debug-test-failures",
                 "drop-py2.6",
                 "fixing-test-setups",
@@ -95,13 +97,12 @@ class GitWorkingTreeTest : StringSpec() {
                 "reverse-mode",
                 "v2beta"
             )
-
-            val workingTree = git.getWorkingTree(zipContentDir)
-            workingTree.listRemoteBranches() shouldContainExactlyInAnyOrder expectedBranches
         }
 
         "Git correctly lists remote tags" {
-            val expectedTags = listOf(
+            val workingTree = git.getWorkingTree(zipContentDir)
+
+            workingTree.listRemoteTags() shouldContainExactlyInAnyOrder listOf(
                 "0.10.0",
                 "0.10.1",
                 "0.11.0",
@@ -116,9 +117,6 @@ class GitWorkingTreeTest : StringSpec() {
                 "0.8.0",
                 "0.9.0"
             )
-
-            val workingTree = git.getWorkingTree(zipContentDir)
-            workingTree.listRemoteTags() shouldContainExactlyInAnyOrder expectedTags
         }
 
         "Git correctly lists submodules" {

--- a/downloader/src/funTest/kotlin/vcs/GitWorkingTreeTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitWorkingTreeTest.kt
@@ -27,10 +27,11 @@ import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.unpack
 
 import io.kotest.core.spec.Spec
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.should
 
 import java.io.File
 
@@ -88,7 +89,7 @@ class GitWorkingTreeTest : StringSpec() {
         "Git correctly lists remote branches" {
             val workingTree = git.getWorkingTree(zipContentDir)
 
-            workingTree.listRemoteBranches() shouldContainExactlyInAnyOrder listOf(
+            workingTree.listRemoteBranches() should containExactlyInAnyOrder(
                 "debug-test-failures",
                 "drop-py2.6",
                 "fixing-test-setups",
@@ -102,7 +103,7 @@ class GitWorkingTreeTest : StringSpec() {
         "Git correctly lists remote tags" {
             val workingTree = git.getWorkingTree(zipContentDir)
 
-            workingTree.listRemoteTags() shouldContainExactlyInAnyOrder listOf(
+            workingTree.listRemoteTags() should containExactlyInAnyOrder(
                 "0.10.0",
                 "0.10.1",
                 "0.11.0",

--- a/evaluator/src/test/kotlin/LicenseViewTest.kt
+++ b/evaluator/src/test/kotlin/LicenseViewTest.kt
@@ -21,9 +21,10 @@ package org.ossreviewtoolkit.evaluator
 
 import org.ossreviewtoolkit.model.LicenseSource
 
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.should
 
 class LicenseViewTest : WordSpec({
     "All" should {
@@ -32,36 +33,36 @@ class LicenseViewTest : WordSpec({
 
             view.licenses(packageWithoutLicense, emptyList()) shouldBe emptyList()
 
-            view.licenses(packageWithoutLicense, detectedLicenses) shouldContainExactlyInAnyOrder listOf(
+            view.licenses(packageWithoutLicense, detectedLicenses) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.DETECTED),
                 Pair("LicenseRef-b", LicenseSource.DETECTED)
             )
 
-            view.licenses(packageWithOnlyConcludedLicense, emptyList()) shouldContainExactlyInAnyOrder listOf(
+            view.licenses(packageWithOnlyConcludedLicense, emptyList()) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
 
-            view.licenses(packageWithOnlyConcludedLicense, detectedLicenses) shouldContainExactlyInAnyOrder listOf(
+            view.licenses(packageWithOnlyConcludedLicense, detectedLicenses) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-a", LicenseSource.DETECTED),
                 Pair("LicenseRef-b", LicenseSource.DETECTED)
             )
 
-            view.licenses(packageWithOnlyDeclaredLicense, emptyList()) shouldContainExactlyInAnyOrder listOf(
+            view.licenses(packageWithOnlyDeclaredLicense, emptyList()) should containExactlyInAnyOrder(
                 Pair("license-a", LicenseSource.DECLARED),
                 Pair("license-b", LicenseSource.DECLARED)
             )
 
-            view.licenses(packageWithOnlyDeclaredLicense, detectedLicenses) shouldContainExactlyInAnyOrder listOf(
+            view.licenses(packageWithOnlyDeclaredLicense, detectedLicenses) should containExactlyInAnyOrder(
                 Pair("license-a", LicenseSource.DECLARED),
                 Pair("license-b", LicenseSource.DECLARED),
                 Pair("LicenseRef-a", LicenseSource.DETECTED),
                 Pair("LicenseRef-b", LicenseSource.DETECTED)
             )
 
-            view.licenses(packageWithConcludedAndDeclaredLicense, emptyList()) shouldContainExactlyInAnyOrder listOf(
+            view.licenses(packageWithConcludedAndDeclaredLicense, emptyList()) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED),
                 Pair("license-a", LicenseSource.DECLARED),
@@ -71,7 +72,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED),
                 Pair("license-a", LicenseSource.DECLARED),
@@ -94,7 +95,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithoutLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.DETECTED),
                 Pair("LicenseRef-b", LicenseSource.DETECTED)
             )
@@ -102,7 +103,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyConcludedLicense,
                 emptyList()
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
@@ -110,7 +111,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyConcludedLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
@@ -118,7 +119,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyDeclaredLicense,
                 emptyList()
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("license-a", LicenseSource.DECLARED),
                 Pair("license-b", LicenseSource.DECLARED)
             )
@@ -126,7 +127,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyDeclaredLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("license-a", LicenseSource.DECLARED),
                 Pair("license-b", LicenseSource.DECLARED),
                 Pair("LicenseRef-a", LicenseSource.DETECTED),
@@ -136,7 +137,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 emptyList()
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
@@ -144,7 +145,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
@@ -163,7 +164,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithoutLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.DETECTED),
                 Pair("LicenseRef-b", LicenseSource.DETECTED)
             )
@@ -171,7 +172,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyConcludedLicense,
                 emptyList()
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
@@ -179,7 +180,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyConcludedLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
@@ -187,7 +188,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyDeclaredLicense,
                 emptyList()
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("license-a", LicenseSource.DECLARED),
                 Pair("license-b", LicenseSource.DECLARED)
             )
@@ -195,7 +196,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyDeclaredLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("license-a", LicenseSource.DECLARED),
                 Pair("license-b", LicenseSource.DECLARED)
             )
@@ -203,7 +204,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 emptyList()
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
@@ -211,7 +212,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
@@ -229,7 +230,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithoutLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.DETECTED),
                 Pair("LicenseRef-b", LicenseSource.DETECTED)
             )
@@ -237,7 +238,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyConcludedLicense,
                 emptyList()
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
@@ -245,7 +246,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyConcludedLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
@@ -258,7 +259,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyDeclaredLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.DETECTED),
                 Pair("LicenseRef-b", LicenseSource.DETECTED)
             )
@@ -266,7 +267,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 emptyList()
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
@@ -274,7 +275,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
@@ -297,7 +298,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyConcludedLicense,
                 emptyList()
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
@@ -305,7 +306,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyConcludedLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
@@ -323,7 +324,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 emptyList()
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
@@ -331,7 +332,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.CONCLUDED),
                 Pair("LicenseRef-b", LicenseSource.CONCLUDED)
             )
@@ -365,7 +366,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyDeclaredLicense,
                 emptyList()
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("license-a", LicenseSource.DECLARED),
                 Pair("license-b", LicenseSource.DECLARED)
             )
@@ -373,7 +374,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyDeclaredLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("license-a", LicenseSource.DECLARED),
                 Pair("license-b", LicenseSource.DECLARED)
             )
@@ -381,7 +382,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 emptyList()
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("license-a", LicenseSource.DECLARED),
                 Pair("license-b", LicenseSource.DECLARED)
             )
@@ -389,7 +390,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("license-a", LicenseSource.DECLARED),
                 Pair("license-b", LicenseSource.DECLARED)
             )
@@ -408,7 +409,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithoutLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.DETECTED),
                 Pair("LicenseRef-b", LicenseSource.DETECTED)
             )
@@ -421,7 +422,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyConcludedLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.DETECTED),
                 Pair("LicenseRef-b", LicenseSource.DETECTED)
             )
@@ -434,7 +435,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithOnlyDeclaredLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.DETECTED),
                 Pair("LicenseRef-b", LicenseSource.DETECTED)
             )
@@ -447,7 +448,7 @@ class LicenseViewTest : WordSpec({
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 detectedLicenses
-            ) shouldContainExactlyInAnyOrder listOf(
+            ) should containExactlyInAnyOrder(
                 Pair("LicenseRef-a", LicenseSource.DETECTED),
                 Pair("LicenseRef-b", LicenseSource.DETECTED)
             )

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -21,13 +21,13 @@ package org.ossreviewtoolkit.model
 
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.string.shouldMatch
 
 import java.io.File
@@ -46,7 +46,7 @@ class OrtResultTest : WordSpec({
             val id = Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
             val dependencies = ortResult.collectDependencies(id, 1).map { it.toCoordinates() }
 
-            dependencies shouldContainExactlyInAnyOrder listOf(
+            dependencies should containExactlyInAnyOrder(
                 "Maven:com.typesafe.akka:akka-actor_2.12:2.5.6",
                 "Maven:com.typesafe:ssl-config-core_2.12:0.2.2",
                 "Maven:org.reactivestreams:reactive-streams:1.0.1"

--- a/model/src/test/kotlin/ProjectTest.kt
+++ b/model/src/test/kotlin/ProjectTest.kt
@@ -20,10 +20,10 @@
 package org.ossreviewtoolkit.model
 
 import io.kotest.matchers.collections.beEmpty
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 
 import java.io.File
 import java.time.Instant
@@ -40,7 +40,7 @@ class ProjectTest : WordSpec({
 
             val dependencies = project.collectDependencies().map { it.toCoordinates() }
 
-            dependencies shouldContainExactlyInAnyOrder listOf(
+            dependencies should containExactlyInAnyOrder(
                 "Maven:junit:junit:4.12",
                 "Maven:org.apache.commons:commons-lang3:3.5",
                 "Maven:org.apache.commons:commons-text:1.1",
@@ -62,7 +62,7 @@ class ProjectTest : WordSpec({
 
             val dependencies = project.collectDependencies(maxDepth = 1).map { it.toCoordinates() }
 
-            dependencies shouldContainExactlyInAnyOrder listOf(
+            dependencies should containExactlyInAnyOrder(
                 "Maven:junit:junit:4.12",
                 "Maven:org.apache.commons:commons-text:1.1",
                 "Maven:org.apache.struts:struts2-assembly:2.5.14.1"

--- a/model/src/test/kotlin/utils/FindingCurationMatcherTest.kt
+++ b/model/src/test/kotlin/utils/FindingCurationMatcherTest.kt
@@ -25,9 +25,10 @@ import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.LicenseFindingCurationReason.INCORRECT
 
 import io.kotest.core.spec.IsolationMode
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.should
 
 import kotlin.random.Random
 
@@ -245,7 +246,7 @@ class FindingCurationMatcherTest : WordSpec() {
 
                 val result = matcher.applyAll(findings, curations)
 
-                result shouldContainExactlyInAnyOrder listOf(
+                result should containExactlyInAnyOrder(
                     LicenseFinding(
                         license = "Apache-2.0",
                         location = TextLocation(path = "some/path", startLine = 1, endLine = 1)
@@ -287,7 +288,7 @@ class FindingCurationMatcherTest : WordSpec() {
 
                 val result = matcher.applyAll(findings, curations)
 
-                result shouldContainExactlyInAnyOrder listOf(
+                result should containExactlyInAnyOrder(
                     LicenseFinding(
                         license = "MIT-old-style",
                         location = TextLocation(path = "some/path", startLine = 1, endLine = 1)

--- a/model/src/test/kotlin/utils/FindingsMatcherTest.kt
+++ b/model/src/test/kotlin/utils/FindingsMatcherTest.kt
@@ -29,10 +29,10 @@ import org.ossreviewtoolkit.utils.FileMatcher
 
 import io.kotest.core.spec.IsolationMode
 import io.kotest.matchers.collections.beEmpty
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 
 import kotlin.random.Random
 
@@ -86,8 +86,8 @@ class FindingsMatcherTest : WordSpec() {
 
                 result.size shouldBe 1
                 val findings = result.getFindings("some id")
-                findings.locations.map { it.path } shouldContainExactlyInAnyOrder listOf(NESTED_LICENSE_FILE_A)
-                findings.copyrights.map { it.statement } shouldContainExactlyInAnyOrder listOf("some stmt")
+                findings.locations.map { it.path } should containExactlyInAnyOrder(NESTED_LICENSE_FILE_A)
+                findings.copyrights.map { it.statement } should containExactlyInAnyOrder("some stmt")
             }
         }
 
@@ -136,16 +136,15 @@ class FindingsMatcherTest : WordSpec() {
 
                 result.size shouldBe 2
                 result.flatMap { it.copyrights.filter { it.statement == "stmt 1" } } should beEmpty()
-                result.getFindings("license nearby").copyrights.map { it.statement } shouldContainExactlyInAnyOrder
-                        listOf(
-                            "stmt 8",
-                            "stmt 10",
-                            "stmt 11",
-                            "stmt 12",
-                            "stmt 13",
-                            "stmt 14",
-                            "stmt 15"
-                        )
+                result.getFindings("license nearby").copyrights.map { it.statement } should containExactlyInAnyOrder(
+                    "stmt 8",
+                    "stmt 10",
+                    "stmt 11",
+                    "stmt 12",
+                    "stmt 13",
+                    "stmt 14",
+                    "stmt 15"
+                )
             }
         }
 
@@ -199,11 +198,10 @@ class FindingsMatcherTest : WordSpec() {
 
                 val result = matcher.match(licenseFindings, copyrightFindings)
 
-                result.getFindings("license nearby")
-                    .copyrights.map { it.statement } shouldContainExactlyInAnyOrder listOf(
-                        "statement2",
-                        "statement3"
-                    )
+                result.getFindings("license nearby").copyrights.map { it.statement } should containExactlyInAnyOrder(
+                    "statement2",
+                    "statement3"
+                )
                 result.getFindings("license far away").copyrights should beEmpty()
             }
         }

--- a/scanner/src/test/kotlin/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/ScanCodeTest.kt
@@ -174,8 +174,8 @@ class ScanCodeTest : WordSpec({
     }
 
     "generateSummary()" should {
-        // TODO: minimize this test case.
         "properly summarize the license findings for ScanCode 2.2.1" {
+            // TODO: minimize this test case.
             val resultFile = File("src/test/assets/esprima-2.7.3_scancode-2.2.1.json")
             val result = scanner.getRawResult(resultFile)
 

--- a/scanner/src/test/kotlin/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/ScanCodeTest.kt
@@ -176,7 +176,15 @@ class ScanCodeTest : WordSpec({
     "generateSummary()" should {
         // TODO: minimize this test case.
         "properly summarize the license findings for ScanCode 2.2.1" {
-            val expectedLicenseFindings = listOf(
+            val resultFile = File("src/test/assets/esprima-2.7.3_scancode-2.2.1.json")
+            val result = scanner.getRawResult(resultFile)
+
+            // The "scanPath" argument should point to the path that was scanned, but as the scanned files are
+            // not available here anymore, instead pass the "resultFile" to test the calculation of the package
+            // verification code on an arbitrary file.
+            val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
+
+            summary.licenseFindings shouldContainExactlyInAnyOrder listOf(
                 LicenseFinding(
                     license = "BSD-2-Clause",
                     location = TextLocation(path = "LICENSE.BSD", startLine = 3, endLine = 21)
@@ -546,7 +554,10 @@ class ScanCodeTest : WordSpec({
                     location = TextLocation(path = "test/3rdparty/underscore-1.5.2.js", startLine = 4, endLine = 4)
                 )
             )
+        }
 
+        "properly summarize the copyright findings for ScanCode 2.2.1" {
+            // TODO: minimize this test case
             val resultFile = File("src/test/assets/esprima-2.7.3_scancode-2.2.1.json")
             val result = scanner.getRawResult(resultFile)
 
@@ -555,12 +566,7 @@ class ScanCodeTest : WordSpec({
             // verification code on an arbitrary file.
             val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
 
-            summary.licenseFindings shouldContainExactlyInAnyOrder expectedLicenseFindings
-        }
-
-        "properly summarize the copyright findings for ScanCode 2.2.1" {
-            // TODO: minimize this test case
-            val expectedCopyrightFindings = listOf(
+            summary.copyrightFindings shouldContainExactlyInAnyOrder listOf(
                 CopyrightFinding(
                     statement = "(c) 2007-2008 Steven Levithan",
                     location = TextLocation(path = "test/3rdparty/mootools-1.4.5.js", startLine = 1881, endLine = 1883)
@@ -736,16 +742,6 @@ class ScanCodeTest : WordSpec({
                     location = TextLocation(path = "test/3rdparty/benchmark.js", startLine = 2, endLine = 6)
                 )
             )
-
-            val resultFile = File("src/test/assets/esprima-2.7.3_scancode-2.2.1.json")
-            val result = scanner.getRawResult(resultFile)
-
-            // The "scanPath" argument should point to the path that was scanned, but as the scanned files are
-            // not available here anymore, instead pass the "resultFile" to test the calculation of the package
-            // verification code on an arbitrary file.
-            val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
-
-            summary.copyrightFindings shouldContainExactlyInAnyOrder expectedCopyrightFindings
         }
 
         "properly summarize license findings for ScanCode 2.9.7" {

--- a/scanner/src/test/kotlin/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/ScanCodeTest.kt
@@ -26,7 +26,7 @@ import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.scanners.ScanCode
 
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -184,7 +184,7 @@ class ScanCodeTest : WordSpec({
             // verification code on an arbitrary file.
             val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
 
-            summary.licenseFindings shouldContainExactlyInAnyOrder listOf(
+            summary.licenseFindings should containExactlyInAnyOrder(
                 LicenseFinding(
                     license = "BSD-2-Clause",
                     location = TextLocation(path = "LICENSE.BSD", startLine = 3, endLine = 21)
@@ -566,7 +566,7 @@ class ScanCodeTest : WordSpec({
             // verification code on an arbitrary file.
             val summary = scanner.generateSummary(Instant.now(), Instant.now(), resultFile, result)
 
-            summary.copyrightFindings shouldContainExactlyInAnyOrder listOf(
+            summary.copyrightFindings should containExactlyInAnyOrder(
                 CopyrightFinding(
                     statement = "(c) 2007-2008 Steven Levithan",
                     location = TextLocation(path = "test/3rdparty/mootools-1.4.5.js", startLine = 1881, endLine = 1883)
@@ -757,7 +757,7 @@ class ScanCodeTest : WordSpec({
 
             actualFindings.distinctBy { it.license } should haveSize(1)
             actualFindings should haveSize(517)
-            actualFindings.toList().subList(0, 10).map { it.location } shouldContainExactlyInAnyOrder listOf(
+            actualFindings.toList().subList(0, 10).map { it.location } should containExactlyInAnyOrder(
                 TextLocation("com/amazonaws/AbortedException.java", 4, 13),
                 TextLocation("com/amazonaws/AmazonClientException.java", 4, 13),
                 TextLocation("com/amazonaws/AmazonServiceException.java", 4, 13),
@@ -782,7 +782,7 @@ class ScanCodeTest : WordSpec({
                 .generateSummary(Instant.now(), Instant.now(), resultFile, result)
                 .copyrightFindings
 
-            actualFindings.map { it.statement }.distinct() shouldContainExactlyInAnyOrder listOf(
+            actualFindings.map { it.statement }.distinct() should containExactlyInAnyOrder(
                 "Copyright (c) 2016 Amazon.com, Inc.",
                 "Copyright (c) 2016. Amazon.com, Inc.",
                 "Copyright 2010-2017 Amazon.com, Inc.",

--- a/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
@@ -27,10 +27,11 @@ import org.ossreviewtoolkit.spdx.SpdxLicense.*
 import org.ossreviewtoolkit.spdx.SpdxLicenseException.*
 
 import io.kotest.assertions.assertSoftly
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.should
 
 class SpdxExpressionTest : WordSpec() {
     private val yamlMapper = YAMLMapper()
@@ -273,27 +274,24 @@ class SpdxExpressionTest : WordSpec() {
             fun String.decompose() = SpdxExpression.parse(this).decompose().map { it.toString() }
 
             "not split-up compound expressions with a WITH operator" {
-                "GPL-2.0-or-later WITH Classpath-exception-2.0".decompose() shouldContainExactlyInAnyOrder listOf(
+                "GPL-2.0-or-later WITH Classpath-exception-2.0".decompose() should containExactlyInAnyOrder(
                     "GPL-2.0-or-later WITH Classpath-exception-2.0"
                 )
             }
 
             "split-up compound expressions with AND or OR operator but not ones with WITH operator" {
-                "GPL-2.0-or-later WITH Classpath-exception-2.0 AND MIT"
-                    .decompose() shouldContainExactlyInAnyOrder
-                        listOf(
-                            "GPL-2.0-or-later WITH Classpath-exception-2.0",
-                            "MIT"
-                        )
+                "GPL-2.0-or-later WITH Classpath-exception-2.0 AND MIT".decompose() should containExactlyInAnyOrder(
+                    "GPL-2.0-or-later WITH Classpath-exception-2.0",
+                    "MIT"
+                )
             }
 
             "work with LicenseRef-* identifiers" {
                 "LicenseRef-gpl-2.0-custom WITH Classpath-exception-2.0 AND LicenseRef-scancode-commercial-license"
-                    .decompose() shouldContainExactlyInAnyOrder
-                        listOf(
-                            "LicenseRef-gpl-2.0-custom WITH Classpath-exception-2.0",
-                            "LicenseRef-scancode-commercial-license"
-                        )
+                    .decompose() should containExactlyInAnyOrder(
+                        "LicenseRef-gpl-2.0-custom WITH Classpath-exception-2.0",
+                        "LicenseRef-scancode-commercial-license"
+                    )
             }
 
             "return distinct strings" {
@@ -303,10 +301,10 @@ class SpdxExpressionTest : WordSpec() {
 
             "not merge license-exception pairs with single matching licenses" {
                 "GPL-2.0-or-later WITH Classpath-exception-2.0 AND GPL-2.0-or-later"
-                    .decompose() shouldContainExactlyInAnyOrder listOf(
-                    "GPL-2.0-or-later WITH Classpath-exception-2.0",
-                    "GPL-2.0-or-later"
-                )
+                    .decompose() should containExactlyInAnyOrder(
+                        "GPL-2.0-or-later WITH Classpath-exception-2.0",
+                        "GPL-2.0-or-later"
+                    )
             }
         }
     }


### PR DESCRIPTION
Note: If this PR should get accepted a similar change for `shouldContainExactly` should be implemented.