### PR TITLE
Tests: Improve shouldContainExactly assertions

### DIFF
--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -20,13 +20,13 @@
 package org.ossreviewtoolkit.model
 
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
-import io.kotest.matchers.collections.shouldContainExactly
 
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.string.shouldMatch
 
@@ -64,7 +64,7 @@ class OrtResultTest : WordSpec({
 
             ids should haveSize(9)
             idsWithoutSubProjects should haveSize(8)
-            actualIds shouldContainExactly listOf(Identifier("Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"))
+            actualIds should containExactly(Identifier("Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"))
         }
     }
 

--- a/model/src/test/kotlin/ScanResultContainerTest.kt
+++ b/model/src/test/kotlin/ScanResultContainerTest.kt
@@ -23,9 +23,10 @@ import com.fasterxml.jackson.module.kotlin.readValue
 
 import org.ossreviewtoolkit.utils.test.patchActualResult
 
-import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.should
 
 import java.io.File
 import java.time.Duration
@@ -141,7 +142,7 @@ class ScanResultContainerTest : WordSpec() {
                 val deprecatedScanResult = File("src/test/assets/deprecated-license-findings-scan-result.yml")
                     .readValue<ScanResultContainer>()
 
-                deprecatedScanResult.results[0].summary.copyrightFindings shouldContainExactly listOf(
+                deprecatedScanResult.results[0].summary.copyrightFindings should containExactly(
                     CopyrightFinding(
                         statement = "copyright 1",
                         location = TextLocation(path = "copyright path 1.1", startLine = 1, endLine = 1)
@@ -152,7 +153,7 @@ class ScanResultContainerTest : WordSpec() {
                     )
                 )
 
-                deprecatedScanResult.results[0].summary.licenseFindings shouldContainExactly listOf(
+                deprecatedScanResult.results[0].summary.licenseFindings should containExactly(
                     LicenseFinding(
                         license = "license 1.1",
                         location = TextLocation(path = "path 1.1", startLine = 1, endLine = 1)


### PR DESCRIPTION
Consistently use `should containExactly` instead of
`shouldContainExactly` if applicable as it saves the manual construction
of the expected collection, e.g. the listOf() call.

Note: The new syntax is unfortunately not applicable for maps and sets
with the current matchers API of kotest. At least for maps it seems
possible to extend the API upstream.

Signed-off-by: Frank Viernau <frank.viernau@here.com>