### PR TITLE
LicenseResolver: Remove an obsolete code comment

### DIFF
--- a/model/src/main/kotlin/utils/LicenseResolver.kt
+++ b/model/src/main/kotlin/utils/LicenseResolver.kt
@@ -75,7 +75,6 @@ internal class LicenseResolver(
             matchedFindings.forEach { findings ->
                 val matchingExcludes = mutableSetOf<PathExclude>()
 
-                // Only license findings of projects can be excluded by path excludes.
                 val isExcluded = findings.locations.all { location ->
                     val path = location.getRelativePathToRoot(id)
                     pathExcludes.any { exclude ->


### PR DESCRIPTION
The comment has been made obsolete by eb0b346.

Signed-off-by: Frank Viernau <frank.viernau@here.com>