### PR TITLE
commands: Add an option to specifiy a single package configuration file

### DIFF
--- a/cli/src/main/kotlin/utils/PackageConfigurationOption.kt
+++ b/cli/src/main/kotlin/utils/PackageConfigurationOption.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.utils
+
+import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
+import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
+
+internal sealed class PackageConfigurationOption {
+    data class Dir(val value: java.io.File) : PackageConfigurationOption()
+    data class File(val value: java.io.File) : PackageConfigurationOption()
+}
+
+internal fun PackageConfigurationOption?.createProvider(): PackageConfigurationProvider =
+    when (this) {
+        is PackageConfigurationOption.Dir -> SimplePackageConfigurationProvider.forDirectory(value)
+        is PackageConfigurationOption.File -> SimplePackageConfigurationProvider.forFile(value)
+        null -> SimplePackageConfigurationProvider()
+    }

--- a/model/src/main/kotlin/config/PackageConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageConfiguration.kt
@@ -38,12 +38,12 @@ data class PackageConfiguration(
     /**
      * The source artifact this configuration applies to.
      */
-    val sourceArtifactUrl: String?,
+    val sourceArtifactUrl: String? = null,
 
     /**
      * The vcs and revision this configuration applies to.
      */
-    val vcs: VcsMatcher?,
+    val vcs: VcsMatcher? = null,
 
     /**
      * Path excludes.

--- a/model/src/main/kotlin/utils/SimplePackageConfigurationProvider.kt
+++ b/model/src/main/kotlin/utils/SimplePackageConfigurationProvider.kt
@@ -47,6 +47,16 @@ class SimplePackageConfigurationProvider(
 
             return SimplePackageConfigurationProvider(entries)
         }
+
+        /**
+         * Return a [SimplePackageConfigurationProvider] which provides all [PackageConfiguration]s found in the given
+         * file. Throws if there is more than one configuration per [Identifier] and [Provenance].
+         */
+        fun forFile(file: File): SimplePackageConfigurationProvider {
+            val entries = file.readValue<List<PackageConfiguration>>()
+
+            return SimplePackageConfigurationProvider(entries)
+        }
     }
 
     private val configurationsById: Map<Identifier, List<PackageConfiguration>>

--- a/model/src/main/kotlin/utils/SimplePackageConfigurationProvider.kt
+++ b/model/src/main/kotlin/utils/SimplePackageConfigurationProvider.kt
@@ -37,9 +37,8 @@ class SimplePackageConfigurationProvider(
     companion object {
         /**
          * Return a [SimplePackageConfigurationProvider] which provides all [PackageConfiguration]s found recursively
-         * in the given [directory]. All non-hidden files within the given [directory] must be package curation files,
-         * and the [directory] must not contain multiple [PackageConfiguration]s matching the same [Identifier] and
-         * [Provenance].
+         * in the given [directory]. All non-hidden files within the given [directory] must be package curation files.
+         * Throws if there is more than one configuration per [Identifier] and [Provenance].
          */
         fun forDirectory(directory: File): SimplePackageConfigurationProvider {
             val entries = directory.walkBottomUp()

--- a/model/src/test/kotlin/SimplePackageConfigurationProviderTest.kt
+++ b/model/src/test/kotlin/SimplePackageConfigurationProviderTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import org.ossreviewtoolkit.model.config.PackageConfiguration
+import org.ossreviewtoolkit.model.config.VcsMatcher
+import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
+
+class SimplePackageConfigurationProviderTest : WordSpec({
+    "constructor" should {
+        "throw an exception provided multiple package configurations for same Id and source artifact provenance" {
+            val packageConfig = PackageConfiguration(
+                id = Identifier("type:group:name:version"),
+                sourceArtifactUrl = "https://some-host/some/path"
+            )
+            val configurations = listOf(packageConfig, packageConfig.copy())
+
+            shouldThrow<IllegalArgumentException> {
+                SimplePackageConfigurationProvider(configurations)
+            }
+        }
+
+        "throw an exception provided multiple package configurations for same Id and VCS provenance" {
+            val packageConfig = PackageConfiguration(
+                id = Identifier("type:group:name:version"),
+                vcs = VcsMatcher(
+                    type = VcsType.GIT,
+                    url = "https://some-host/some/path.git",
+                    revision = "0c1b2aec2812e4833bdca1028b5cb4b6"
+                )
+            )
+            val configurations = listOf(packageConfig, packageConfig.copy())
+
+            shouldThrow<IllegalArgumentException> {
+                SimplePackageConfigurationProvider(configurations)
+            }
+        }
+    }
+})


### PR DESCRIPTION
There is already an option to specify a package configuration directory
which is supposed to contain files each holding the configuration for a
single package.

This option allows specifying a single file holding a list of all package
configurations, and thus only a new representation is added to give some
flexibility to the user.

Signed-off-by: Frank Viernau <frank.viernau@here.com>