### PR TITLE
EvaluatedModel: Avoid an intermediate toList() conversion

### DIFF
--- a/reporter/src/main/kotlin/model/EvaluatedModel.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedModel.kt
@@ -160,12 +160,11 @@ data class EvaluatedModel(
      * Serialize this [EvaluatedModel] to JSON and write the output to the [writer], optionally
      * [pretty printed][prettyPrint].
      */
-    fun toJson(writer: Writer, prettyPrint: Boolean = true) {
+    fun toJson(writer: Writer, prettyPrint: Boolean = true) =
         when {
             prettyPrint -> JSON_MAPPER.writerWithDefaultPrettyPrinter()
             else -> JSON_MAPPER.writer()
         }.writeValue(writer, toSortedTree())
-    }
 
     /**
      * Serialize this [EvaluatedModel] to YAML and write the output to the [writer].

--- a/reporter/src/main/kotlin/model/EvaluatedModel.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedModel.kt
@@ -181,8 +181,7 @@ data class EvaluatedModel(
         tree.forEach { node ->
             if (node is ArrayNode) {
                 if (!node.isEmpty && node[0].has("_id")) {
-                    val sortedChildren =
-                        node.elements().asSequence().toList().sortedBy { it["_id"].intValue() }.toList()
+                    val sortedChildren = node.elements().asSequence().sortedBy { it["_id"].intValue() }.toList()
                     node.removeAll()
                     node.addAll(sortedChildren)
                 }


### PR DESCRIPTION
To potentially save some memory.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>