### PR TITLE
NoticeByPackageReporter: Use the configured license file patterns

### DIFF
--- a/reporter/src/main/kotlin/reporters/NoticeByPackageReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeByPackageReporter.kt
@@ -139,7 +139,7 @@ class NoticeByPackageProcessor(input: ReporterInput) : AbstractNoticeReporter.No
             val licenseFileFindings = if (scanResult != null) {
                 val path = "${id.toPath()}/${scanResult.provenance.hash()}"
                 if (archiver.unarchive(archiveDir, path)) {
-                    getFindingsForLicenseFiles(scanResult, archiveDir, licenseFindingsMap)
+                    getFindingsForLicenseFiles(scanResult, archiveDir, archiver.patterns, licenseFindingsMap)
                 } else {
                     emptyMap()
                 }
@@ -224,9 +224,10 @@ class NoticeByPackageProcessor(input: ReporterInput) : AbstractNoticeReporter.No
     private fun getFindingsForLicenseFiles(
         scanResult: ScanResult,
         archiveDir: File,
+        licenseFilePatterns: List<String>,
         licenseFindingsMap: LicenseFindingsMap
     ): MutableMap<String, LicenseFindingsMap> {
-        val matcher = FileMatcher(LICENSE_FILENAMES)
+        val matcher = FileMatcher(licenseFilePatterns)
         val licenseFiles = mutableMapOf<String, LicenseFindingsMap>()
 
         archiveDir.walkTopDown().forEach { file ->


### PR DESCRIPTION
Use the license file patterns configured in the file archiver when
generating the notices. Otherwise license texts from archived files are
ignored if they do not match the default `LICENSE_FILENAMES`.

Fixes #2452.