### PR TITLE
rules.kts: Remove 'HERE' in rule name

### DIFF
--- a/docs/examples/rules.kts
+++ b/docs/examples/rules.kts
@@ -140,7 +140,7 @@ val ruleSet = ruleSet(ortResult, packageConfigurationProvider) {
             error(message, howToFixDefault())
         }
 
-        licenseRule("COPYLEFT_LIMITED_IN_HERE_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_OR_DETECTED) {
+        licenseRule("COPYLEFT_LIMITED_IN_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_OR_DETECTED) {
             require {
                 -isExcluded()
                 +isCopyleftLimited()


### PR DESCRIPTION
Presence of 'HERE' in rule name was a left-over from HERE's rules.kts
which was the base for ORT's example rules.kts.

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>