### PR TITLE
utils: Remove the now unused disjoint() function

### DIFF
--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -68,24 +68,6 @@ inline fun <reified T : Any> T.hasNonNullProperty() =
     T::class.memberProperties.asSequence().map { it.get(this) }.any { it != null }
 
 /**
- * Return the set of elements which are contained in at least two of the given collections, or an empty set if all
- * collections are disjoint.
- */
-fun <T> disjoint(c1: Collection<T>, c2: Collection<T>, vararg cN: Collection<T>): Set<T> {
-    val c = listOf(c1, c2, *cN)
-
-    val commonElements = mutableSetOf<T>()
-
-    for (a in c.indices) {
-        for (b in a + 1 until c.size) {
-            commonElements += c[a].intersect(c[b])
-        }
-    }
-
-    return commonElements
-}
-
-/**
  * Filter a list of [names] to include only those that likely belong to the given [version] of an optional [project].
  */
 fun filterVersionNames(version: String, names: List<String>, project: String? = null): List<String> {

--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -27,16 +27,6 @@ import java.io.File
 import java.nio.file.Paths
 
 class UtilsTest : WordSpec({
-    "disjoint" should {
-        "return an empty set for collections that have no common elements" {
-            disjoint(setOf(1), setOf(2), setOf(3)) shouldBe emptySet()
-        }
-
-        "return the set of common elements for collections that have common elements" {
-            disjoint(setOf(1, 2), setOf(2, 3), setOf(3, 4)) shouldBe setOf(2, 3)
-        }
-    }
-
     "filterVersionNames" should {
         "return an empty list for a blank version" {
             val names = listOf("dummy")


### PR DESCRIPTION
This used to be used in "rules.kts" but got replaced by a neat
"groupBy { it }" trick by now.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>