### PR TITLE
Gradle: Upgrade the detekt plugin to version 1.8.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-detektPluginVersion = 1.7.4
+detektPluginVersion = 1.8.0
 dokkaPluginVersion = 0.10.1
 ideaExtPluginVersion = 0.6.1
 kotlinPluginVersion = 1.3.72


### PR DESCRIPTION
See https://github.com/arturbosch/detekt/releases/tag/v1.8.0.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>