### PR TITLE
helper-cli: Handle package configurations

### DIFF
--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -147,7 +147,7 @@ internal class ListLicensesCommand : CliktCommand(
         val violatedRulesByLicense = ortResult.getViolatedRulesByLicense(packageId, Severity.ERROR)
 
         val findingsByProvenance = ortResult
-            .getLicenseFindingsById(packageId, applyLicenseFindingCurations)
+            .getLicenseFindingsById(packageId, packageConfigurationProvider, applyLicenseFindingCurations)
             .mapValues { (provenance, locationsByLicense) ->
                 locationsByLicense.filter { (license, _) ->
                     !onlyOffending || violatedRulesByLicense.contains(license)

--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -158,7 +158,7 @@ internal class ListLicensesCommand : CliktCommand(
                     }
                 }.mapValues { (_, locations) ->
                     locations.groupByText(sourcesDir)
-                }
+                }.filter { (_, locations) -> locations.isNotEmpty() }
             }
 
         buildString {

--- a/helper-cli/src/main/kotlin/common/PackageConfigurationOption.kt
+++ b/helper-cli/src/main/kotlin/common/PackageConfigurationOption.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.common
+
+import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
+import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
+
+internal sealed class PackageConfigurationOption {
+    data class Dir(val value: java.io.File) : PackageConfigurationOption()
+    data class File(val value: java.io.File) : PackageConfigurationOption()
+}
+
+internal fun PackageConfigurationOption?.createProvider(): PackageConfigurationProvider =
+    when (this) {
+        is PackageConfigurationOption.Dir -> SimplePackageConfigurationProvider.forDirectory(value)
+        is PackageConfigurationOption.File -> SimplePackageConfigurationProvider.forFile(value)
+        null -> SimplePackageConfigurationProvider()
+    }


### PR DESCRIPTION
Note: The code of `ListLicensesCommand` is a bit redunant with `LicenseResolver` or rather `OrtResult.collectLicenseFindings()`. This redundancy is intentionally `kept for now` in order not to introduce an additional caller of `collectLicenseFindings()` since the return type of that function needs to be refactored. Adding an additional caller would make that more difficult.