### PR TITLE
Reporters: Add package configuration handling to further reporters

### DIFF
--- a/reporter/src/main/kotlin/reporters/AmazonOssAttributionBuilderReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AmazonOssAttributionBuilderReporter.kt
@@ -116,7 +116,8 @@ class AmazonOssAttributionBuilderReporter : Reporter {
                 // URL passed into the Amazon Oss Attribution Builder needs to be reachable!
                 val pkgUrl = pkg.homepageUrl.takeUnless { it.isEmpty() } ?: "https://github.com/404"
 
-                val licensesWithCopyrights = input.ortResult.getDetectedLicensesWithCopyrights(pkg.id)
+                val licensesWithCopyrights =
+                    input.ortResult.getDetectedLicensesWithCopyrights(pkg.id, input.packageConfigurationProvider)
 
                 val allCopyrights = if (licensesWithCopyrights.isNotEmpty()) {
                     licensesWithCopyrights.values.reduce { acc, set -> acc + set }

--- a/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
+++ b/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
@@ -73,8 +73,9 @@ class CycloneDxReporter : Reporter {
                 rootProject.homepageUrl
             )
 
-            val licenseNames = ortResult.getDetectedLicensesForId(rootProject.id) +
-                    rootProject.declaredLicensesProcessed.allLicenses
+            val licenseNames = rootProject.declaredLicensesProcessed.allLicenses +
+                    ortResult.getDetectedLicensesForId(rootProject.id, input.packageConfigurationProvider)
+
             bom.addExternalReference(
                 ExternalReference.Type.LICENSE,
                 licenseNames.joinToString(", ")
@@ -113,7 +114,8 @@ class CycloneDxReporter : Reporter {
         ortResult.getPackages().forEach { (pkg, _) ->
             // TODO: We should actually use the concluded license expression here, but we first need a workflow to
             //       ensure it is being set.
-            val licenseNames = ortResult.getDetectedLicensesForId(pkg.id) + pkg.declaredLicensesProcessed.allLicenses
+            val licenseNames = pkg.declaredLicensesProcessed.allLicenses +
+                    ortResult.getDetectedLicensesForId(pkg.id, input.packageConfigurationProvider)
 
             val licenseObjects = licenseNames.map { licenseName ->
                 val spdxId = SpdxLicense.forId(licenseName)?.id


### PR DESCRIPTION
Recently 614feb1 added a command line option for providing package
confgurations. That change implemented the handling of the provided
configurations only for the static HTML report.

This change enables package configurations for all remaining reporters,
except for the evaluated model and thus the WebApp report. The
underlying features package configuration needs, namely license
finding curations and path excludes for license findings, are not
implemented yet in the evaluated model and should be added first.

Signed-off-by: Frank Viernau <frank.viernau@here.com>