### PR TITLE
ListCopyrightsCommand: Add an option for providing package configurations

### DIFF
--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -51,6 +51,7 @@ import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.collectLicenseFindings
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
+import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.CopyrightStatementsProcessor
 import org.ossreviewtoolkit.utils.safeMkdirs
@@ -236,12 +237,14 @@ internal data class ProcessedCopyrightStatement(
  */
 internal fun OrtResult.processAllCopyrightStatements(
     omitExcluded: Boolean = true,
-    copyrightGarbage: Set<String> = emptySet()
+    copyrightGarbage: Set<String> = emptySet(),
+    packageConfigurationProvider: PackageConfigurationProvider = SimplePackageConfigurationProvider()
 ): List<ProcessedCopyrightStatement> {
     val result = mutableListOf<ProcessedCopyrightStatement>()
+
     val processor = CopyrightStatementsProcessor()
 
-    collectLicenseFindings(omitExcluded = omitExcluded).forEach { (id, findings) ->
+    collectLicenseFindings(packageConfigurationProvider, omitExcluded = omitExcluded).forEach { (id, findings) ->
         findings.forEach innerForEach@{ (licenseFindings, pathExcludes) ->
             if (omitExcluded && pathExcludes.isNotEmpty()) return@innerForEach
 


### PR DESCRIPTION
This command does not show excluded copyright findings for projects, and as
of this change also for packages the excluded copyright findings are
omit.

Signed-off-by: Frank Viernau <frank.viernau@here.com>