### PR TITLE
detekt: Disable ktlint's NoUnusedImports rule

### DIFF
--- a/.detekt.yml
+++ b/.detekt.yml
@@ -25,6 +25,8 @@ formatting:
     active: false
   MaximumLineLength:
     active: false
+  NoUnusedImports:
+    active: false
   NoWildcardImports:
     active: false
   ParameterListWrapping:


### PR DESCRIPTION
In favor of detekt's built-in UnusedImports rule.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>