### PR TITLE
CI: Do not cache .ort/utils/cache

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,7 +25,6 @@ cache:
   - $(HOME)\.ort\analyzer\cache
   - $(HOME)\.ort\downloader\cache
   - $(HOME)\.ort\scanner\cache
-  - $(HOME)\.ort\utils\cache
 
 clone_depth: 50
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ cache:
     - $HOME/.ort/analyzer/cache/
     - $HOME/.ort/downloader/cache/
     - $HOME/.ort/scanner/cache/
-    - $HOME/.ort/utils/cache/
 
 env:
   global:


### PR DESCRIPTION
The utils module does not create a cache folder during the tests. This
leads to a warning on AppVeyor [1].

[1] https://ci.appveyor.com/project/oss-review-toolkit/ort/builds/32408723?fullLog=true#L4391