### PR TITLE
CI: Enable simple multi-line-diffs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,9 +72,9 @@ build_script:
 
 test_script:
   - if "%APPVEYOR_SCHEDULED_BUILD%"=="True" (
-      gradlew --stacktrace dokkaJar test funTest
+      gradlew --stacktrace -Dkotest.assertions.multi-line-diff=simple dokkaJar test funTest
     ) else (
-      gradlew --stacktrace -Dkotest.tags.exclude=ExpensiveTag test funTest
+      gradlew --stacktrace -Dkotest.assertions.multi-line-diff=simple -Dkotest.tags.exclude=ExpensiveTag test funTest
     )
 
 after_test:

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,9 +84,9 @@ script:
   - set -o pipefail
   - ./gradlew --stacktrace detekt
   - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-      ./gradlew --stacktrace -Dkotest.tags.exclude=ScanCodeTag test funTest jacocoReport | tee log.txt;
+      ./gradlew --stacktrace -Dkotest.assertions.multi-line-diff=simple -Dkotest.tags.exclude=ScanCodeTag test funTest jacocoReport | tee log.txt;
     else
-      ./gradlew --scan --stacktrace -Dkotest.tags.exclude=ExpensiveTag test funTest jacocoReport | tee log.txt;
+      ./gradlew --scan --stacktrace -Dkotest.assertions.multi-line-diff=simple -Dkotest.tags.exclude=ExpensiveTag test funTest jacocoReport | tee log.txt;
     fi
   - if grep -A1 ".+Test.+STARTED$" log.txt | grep -q "^:"; then
       echo "Some tests seemingly have been aborted.";


### PR DESCRIPTION
Set `-Dkotest.assertions.multi-line-diff=simple` when running tests on
CI, because the condensed diffs often do not show the required
information to find out why a test failed. Printing the full diffs at
least allows to copy the output and do a local diff.