### PR TITLE
FormatRepositoryConfigurationCommand: Fix-up an argument name

### DIFF
--- a/helper-cli/src/main/kotlin/commands/FormatRepositoryConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/FormatRepositoryConfigurationCommand.kt
@@ -35,7 +35,7 @@ internal class FormatRepositoryConfigurationCommand : CliktCommand(
             "written to the given repository configuration file."
 ) {
     private val repositoryConfigurationFile by argument(
-        "--repository-configuration-file",
+        "repository-configuration-file",
         help = "The repository configuration file to be formatted."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)


### PR DESCRIPTION
The double hyphen prefix are commonly used for options but not for
arguments.

Signed-off-by: Frank Viernau <frank.viernau@here.com>