### PR TITLE
EvaluatedModel: Apply path excludes to license and copyright findings

### DIFF
--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -4,6 +4,11 @@
     "pattern" : "sub/module/project/build.gradle",
     "reason" : "EXAMPLE_OF",
     "comment" : "The project is an example."
+  }, {
+    "_id" : 1,
+    "pattern" : "**.java",
+    "reason" : "EXAMPLE_OF",
+    "comment" : "These are example files."
   } ],
   "scope_excludes" : [ {
     "_id" : 0,
@@ -306,14 +311,16 @@
       "path" : "file.java",
       "start_line" : 1,
       "end_line" : 1,
-      "scan_result" : 1
+      "scan_result" : 1,
+      "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
       "license" : 2,
       "path" : "file.java",
       "start_line" : 1,
       "end_line" : 2,
-      "scan_result" : 1
+      "scan_result" : 1,
+      "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
       "license" : 2,
@@ -327,21 +334,24 @@
       "path" : "file1.java",
       "start_line" : 1,
       "end_line" : 1,
-      "scan_result" : 1
+      "scan_result" : 1,
+      "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
       "license" : 3,
       "path" : "file1.java",
       "start_line" : 1,
       "end_line" : 2,
-      "scan_result" : 1
+      "scan_result" : 1,
+      "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
       "license" : 3,
       "path" : "file2.java",
       "start_line" : 1,
       "end_line" : 2,
-      "scan_result" : 1
+      "scan_result" : 1,
+      "path_excludes" : [ 1 ]
     } ],
     "is_excluded" : true,
     "path_excludes" : [ 0 ],
@@ -743,12 +753,7 @@
     },
     "config" : {
       "excludes" : {
-        "paths" : [ 0, {
-          "_id" : 1,
-          "pattern" : "**.java",
-          "reason" : "EXAMPLE_OF",
-          "comment" : "These are example files."
-        } ],
+        "paths" : [ 0, 1 ],
         "scopes" : [ 0 ]
       },
       "resolutions" : {

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -272,6 +272,7 @@
       "unmapped_licenses" : [ ]
     },
     "detected_licenses" : [ 2, 3 ],
+    "detected_excluded_licenses" : [ 3 ],
     "description" : "",
     "homepage_url" : "",
     "binary_artifact" : {

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -4,6 +4,10 @@ path_excludes:
   pattern: "sub/module/project/build.gradle"
   reason: "EXAMPLE_OF"
   comment: "The project is an example."
+- _id: 1
+  pattern: "**.java"
+  reason: "EXAMPLE_OF"
+  comment: "These are example files."
 scope_excludes:
 - _id: 0
   pattern: "testCompile"
@@ -260,12 +264,16 @@ packages:
     start_line: 1
     end_line: 1
     scan_result: 1
+    path_excludes:
+    - 1
   - type: "LICENSE"
     license: 2
     path: "file.java"
     start_line: 1
     end_line: 2
     scan_result: 1
+    path_excludes:
+    - 1
   - type: "LICENSE"
     license: 2
     path: "file.kt"
@@ -278,18 +286,24 @@ packages:
     start_line: 1
     end_line: 1
     scan_result: 1
+    path_excludes:
+    - 1
   - type: "LICENSE"
     license: 3
     path: "file1.java"
     start_line: 1
     end_line: 2
     scan_result: 1
+    path_excludes:
+    - 1
   - type: "LICENSE"
     license: 3
     path: "file2.java"
     start_line: 1
     end_line: 2
     scan_result: 1
+    path_excludes:
+    - 1
   is_excluded: true
   path_excludes:
   - 0
@@ -676,10 +690,7 @@ repository:
     excludes:
       paths:
       - 0
-      - _id: 1
-        pattern: "**.java"
-        reason: "EXAMPLE_OF"
-        comment: "These are example files."
+      - 1
       scopes:
       - 0
     resolutions:

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -228,6 +228,8 @@ packages:
   detected_licenses:
   - 2
   - 3
+  detected_excluded_licenses:
+  - 3
   description: ""
   homepage_url: ""
   binary_artifact:

--- a/reporter/src/main/kotlin/model/EvaluatedFinding.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedFinding.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.reporter.model
 import com.fasterxml.jackson.annotation.JsonInclude
 
 import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.config.PathExclude
 
 /**
  * The evaluated form of a [LicenseFinding] used by the [EvaluatedModel].
@@ -35,5 +36,7 @@ data class EvaluatedFinding(
     val path: String,
     val startLine: Int,
     val endLine: Int,
-    val scanResult: EvaluatedScanResult
+    val scanResult: EvaluatedScanResult,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val pathExcludes: List<PathExclude>
 )

--- a/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
@@ -228,8 +228,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         issues += addAnalyzerIssues(project.id, evaluatedPackage)
 
         input.ortResult.getScanResultsForId(project.id).mapTo(scanResults) { result ->
-            val licenseFindingCurations = getLicenseFindingCurations(project.id, result.provenance)
-            convertScanResult(result, findings, evaluatedPackage, licenseFindingCurations)
+            convertScanResult(result, findings, evaluatedPackage)
         }
 
         findings.filter { it.type == EvaluatedFindingType.LICENSE }.mapNotNullTo(detectedLicenses) { it.license }
@@ -280,8 +279,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         issues += addAnalyzerIssues(pkg.id, evaluatedPackage)
 
         input.ortResult.getScanResultsForId(pkg.id).mapTo(scanResults) { result ->
-            val licenseFindingCurations = getLicenseFindingCurations(pkg.id, result.provenance)
-            convertScanResult(result, findings, evaluatedPackage, licenseFindingCurations)
+            convertScanResult(result, findings, evaluatedPackage)
         }
 
         findings.filter { it.type == EvaluatedFindingType.LICENSE }.mapNotNullTo(detectedLicenses) { it.license }
@@ -323,8 +321,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     private fun convertScanResult(
         result: ScanResult,
         findings: MutableList<EvaluatedFinding>,
-        pkg: EvaluatedPackage,
-        licenseFindingCurations: Collection<LicenseFindingCuration>
+        pkg: EvaluatedPackage
     ): EvaluatedScanResult {
         val issues = mutableListOf<EvaluatedOrtIssue>()
 
@@ -348,7 +345,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             null
         )
 
-        addLicensesAndCopyrights(result, actualScanResult, findings, licenseFindingCurations)
+        addLicensesAndCopyrights(pkg.id, result, actualScanResult, findings)
 
         return actualScanResult
     }
@@ -500,11 +497,12 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     }
 
     private fun addLicensesAndCopyrights(
+        id: Identifier,
         scanResult: ScanResult,
         evaluatedScanResult: EvaluatedScanResult,
-        findings: MutableList<EvaluatedFinding>,
-        licenseFindingCurations: Collection<LicenseFindingCuration>
+        findings: MutableList<EvaluatedFinding>
     ) {
+        val licenseFindingCurations = getLicenseFindingCurations(id, scanResult.provenance)
         val curatedFindings = curationsMatcher.applyAll(scanResult.summary.licenseFindings, licenseFindingCurations)
         val matchedFindings = findingsMatcher.match(curatedFindings, scanResult.summary.copyrightFindings)
 

--- a/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
@@ -27,7 +27,6 @@ import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.ScanResult
-import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.IssueResolution
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
@@ -342,7 +341,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             null
         )
 
-        addLicensesAndCopyrights(result.summary, actualScanResult, findings, licenseFindingCurations)
+        addLicensesAndCopyrights(result, actualScanResult, findings, licenseFindingCurations)
 
         return actualScanResult
     }
@@ -494,13 +493,13 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     }
 
     private fun addLicensesAndCopyrights(
-        summary: ScanSummary,
-        scanResult: EvaluatedScanResult,
+        scanResult: ScanResult,
+        evaluatedScanResult: EvaluatedScanResult,
         findings: MutableList<EvaluatedFinding>,
         licenseFindingCurations: Collection<LicenseFindingCuration>
     ) {
-        val curatedFindings = curationsMatcher.applyAll(summary.licenseFindings, licenseFindingCurations)
-        val matchedFindings = findingsMatcher.match(curatedFindings, summary.copyrightFindings)
+        val curatedFindings = curationsMatcher.applyAll(scanResult.summary.licenseFindings, licenseFindingCurations)
+        val matchedFindings = findingsMatcher.match(curatedFindings, scanResult.summary.copyrightFindings)
 
         matchedFindings.forEach { licenseFindings ->
             licenseFindings.copyrights.forEach { copyrightFinding ->
@@ -514,7 +513,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
                         path = location.path,
                         startLine = location.startLine,
                         endLine = location.endLine,
-                        scanResult = scanResult
+                        scanResult = evaluatedScanResult
                     )
                 }
             }
@@ -529,7 +528,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
                     path = location.path,
                     startLine = location.startLine,
                     endLine = location.endLine,
-                    scanResult = scanResult
+                    scanResult = evaluatedScanResult
                 )
             }
         }

--- a/reporter/src/main/kotlin/model/EvaluatedPackage.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedPackage.kt
@@ -44,6 +44,8 @@ data class EvaluatedPackage(
     val declaredLicenses: List<LicenseId>,
     val declaredLicensesProcessed: EvaluatedProcessedDeclaredLicense,
     val detectedLicenses: Set<LicenseId>,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val detectedExcludedLicenses: Set<LicenseId>,
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val concludedLicense: SpdxExpression? = null,
     val description: String,


### PR DESCRIPTION
The changes adjust the `evaluated model` so that path excludes handling for license and copyright findings can be implemented in the `Web App`. In particular the only `first matching` path exclude is added  to each `EvaluatedFinding`, e.g. not adding all matching excludes to keep the size small and for simplicity in the code using this model.