### PR TITLE
GenerateScopeExcludesCommand: Fix-up the reason for `kapt*` scopes

### DIFF
--- a/helper-cli/src/main/kotlin/commands/GenerateScopeExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateScopeExcludesCommand.kt
@@ -140,7 +140,7 @@ private fun getScopeExcludesForPackageManager(packageManagerName: String): List<
             ),
             ScopeExclude(
                 pattern = "kapt.*",
-                reason = ScopeExcludeReason.PROVIDED_DEPENDENCY_OF,
+                reason = ScopeExcludeReason.BUILD_DEPENDENCY_OF,
                 comment = "Packages to process code annotations only."
             ),
             ScopeExclude(


### PR DESCRIPTION
Signed-off-by: Frank Viernau <frank.viernau@here.com>