### PR TITLE
AnalyzerCommand: Support reading package curations from the config directory

### DIFF
--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -40,6 +40,7 @@ import org.ossreviewtoolkit.model.OutputFormat
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.mapper
 import org.ossreviewtoolkit.utils.expandTilde
+import org.ossreviewtoolkit.utils.getOrtDataDirectory
 import org.ossreviewtoolkit.utils.safeMkdirs
 
 import java.io.File
@@ -126,9 +127,11 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
         val analyzerConfig = AnalyzerConfiguration(ignoreToolVersions, allowDynamicVersions)
         val analyzer = Analyzer(analyzerConfig)
 
+        val globalPackageCurationsFile = getOrtDataDirectory().resolve("config/curations.yml")
         val curationProvider = FallbackPackageCurationProvider(
             listOfNotNull(
                 packageCurationsFile?.let { FilePackageCurationProvider(it) },
+                globalPackageCurationsFile.takeIf { it.isFile }?.let { FilePackageCurationProvider(it) },
                 ClearlyDefinedPackageCurationProvider().takeIf { useClearlyDefinedCurations }
             )
         )


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>