### PR TITLE
(helper-)cli: Make the -P option consistent across commands

### DIFF
--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -29,8 +29,8 @@ import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.pair
 import com.github.ajalt.clikt.parameters.options.switch
+import com.github.ajalt.clikt.parameters.options.unique
 import com.github.ajalt.clikt.parameters.options.versionOption
 import com.github.ajalt.clikt.parameters.types.file
 
@@ -71,7 +71,10 @@ class OrtMain : CliktCommand(name = ORT_NAME, epilog = "* denotes required optio
 
     private val stacktrace by option(help = "Print out the stacktrace for all exceptions.").flag()
 
-    private val configArguments by option("-P", help = "Allows to override configuration parameters.").pair().multiple()
+    private val configArguments by option("-P", help = "Allows to override configuration parameters.")
+        .convert { Pair(it.substringBefore("="), it.substringAfter("=", "")) }
+        .multiple()
+        .unique()
 
     private val env = Environment()
 

--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -71,8 +71,11 @@ class OrtMain : CliktCommand(name = ORT_NAME, epilog = "* denotes required optio
 
     private val stacktrace by option(help = "Print out the stacktrace for all exceptions.").flag()
 
-    private val configArguments by option("-P", help = "Allows to override configuration parameters.")
-        .convert { Pair(it.substringBefore("="), it.substringAfter("=", "")) }
+    private val configArguments by option(
+        "-P",
+        help = "Override a key-value pair in the configuration file. For example: " +
+                "-P scanner.postgresStorage.schema=testSchema"
+    ).convert { Pair(it.substringBefore("="), it.substringAfter("=", "")) }
         .multiple()
         .unique()
 


### PR DESCRIPTION
Change both implementation so that the `-P` option can now be provided
multiple times each time along with a key-value pair separated by a '=',
for example: `-P a=b -P c=d`.

Using a POSIX style short option, like `-Pa=b -Pc=d`, was the ultimate
goal which wasn't easily achievable as Clikt seems not to allow that in
case the parameter contains '='.

Signed-off-by: Frank Viernau <frank.viernau@here.com>