### PR TITLE
JenkinsFile: Amend the build's display name with the root project's id

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,10 @@ or
 
 A basic ORT pipeline (using the _analyzer_, _scanner_ and _reporter_) can easily be run on
 [Jenkins CI](https://jenkins.io/) by using the [Jenkinsfile](./Jenkinsfile) in a (declarative)
-[pipeline](https://jenkins.io/doc/book/pipeline/) job. The job accepts various parameters that are translated to ORT
-command line arguments. Additionally, one can trigger a downstream job which e.g. further processes scan results. Note
-that it is the downstream job's responsibility to copy any artifacts it needs from the upstream job.
+[pipeline](https://jenkins.io/doc/book/pipeline/) job. Please see the [Jenkinsfile](./Jenkinsfile) itself for
+documentation of the required Jenkins plugins. The job accepts various parameters that are translated to ORT command
+line arguments. Additionally, one can trigger a downstream job which e.g. further processes scan results. Note that it
+is the downstream job's responsibility to copy any artifacts it needs from the upstream job.
 
 ## Getting started
 


### PR DESCRIPTION
To quickly see e.g. in the build history which project was analyzed in
which build.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>