### PR TITLE
Somewhat support the SPDX operators AND and WITH for detected licenses

### DIFF
--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -31,9 +31,9 @@ import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.options.split
 import com.github.ajalt.clikt.parameters.types.enum
 import com.github.ajalt.clikt.parameters.types.file
+
 import org.ossreviewtoolkit.helper.common.PackageConfigurationOption
 import org.ossreviewtoolkit.helper.common.createProvider
-
 import org.ossreviewtoolkit.helper.common.fetchScannedSources
 import org.ossreviewtoolkit.helper.common.getLicenseFindingsById
 import org.ossreviewtoolkit.helper.common.getPackageOrProject

--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -107,6 +107,12 @@ internal class ListLicensesCommand : CliktCommand(
         help = "Apply the license finding curations contained in the ORT result."
     ).flag()
 
+    private val decomposeLicenseExpressions by option(
+        "--decompose-license-expressions",
+        help = "Decompose SPDX license expressions into its single licenses components and list the findings for " +
+                "each single license separately."
+    ).flag()
+
     private val repositoryConfigurationFile by option(
         "--repository-configuration-file",
         help = "Override the repository configuration contained in the ORT result."
@@ -155,7 +161,12 @@ internal class ListLicensesCommand : CliktCommand(
         val violatedRulesByLicense = ortResult.getViolatedRulesByLicense(packageId, offendingSeverity)
 
         val findingsByProvenance = ortResult
-            .getLicenseFindingsById(packageId, packageConfigurationProvider, applyLicenseFindingCurations)
+            .getLicenseFindingsById(
+                packageId,
+                packageConfigurationProvider,
+                applyLicenseFindingCurations,
+                decomposeLicenseExpressions
+            )
             .mapValues { (provenance, locationsByLicense) ->
                 locationsByLicense.filter { (license, _) ->
                     !offendingOnly || violatedRulesByLicense.contains(license)

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -302,7 +302,7 @@ internal fun OrtResult.getLicenseFindingsById(
         scanResultContainer.results.forEach { scanResult ->
             val findingsForProvenance = result.getOrPut(scanResult.provenance) { mutableMapOf() }
 
-            val licenseFindings = scanResult.summary.licenseFindings.let {
+            scanResult.summary.licenseFindings.let {
                 if (applyCurations) {
                     FindingCurationMatcher().applyAll(it, getLicenseFindingsCurations(scanResult.provenance))
                 } else {
@@ -316,9 +316,7 @@ internal fun OrtResult.getLicenseFindingsById(
                 } else {
                     findings
                 }
-            }
-
-            licenseFindings.forEach {
+            }.forEach {
                 findingsForProvenance.getOrPut(it.license) { mutableSetOf() }.add(it.location)
             }
         }

--- a/model/src/test/kotlin/utils/LicenseResolverTest.kt
+++ b/model/src/test/kotlin/utils/LicenseResolverTest.kt
@@ -627,6 +627,26 @@ class LicenseResolverTest : WordSpec() {
 
                 result should containExactlyInAnyOrder("BSD-2-Clause")
             }
+
+            "decompose SPDX expressions into single licenses" {
+                val id = setupProject().id
+                setupScanResult(
+                    id, ProvenanceType.VCS, listOf(
+                        LicenseFinding(
+                            license = "GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause OR MIT",
+                            location = TextLocation("some/path", startLine = 1, endLine = 1)
+                        )
+                    )
+                )
+
+                val result = createResolver().getDetectedLicensesWithCopyrights(id).keys
+
+                result should containExactlyInAnyOrder(
+                    "GPL-2.0-only WITH Classpath-exception-2.0",
+                    "BSD-3-Clause",
+                    "MIT"
+                )
+            }
         }
     }
 }

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -22,10 +22,10 @@
   } ],
   "licenses" : [ {
     "_id" : 0,
-    "id" : "Apache-2.0 (multi-line)"
+    "id" : "LicenseRef-test-Apache-2.0-multi-line"
   }, {
     "_id" : 1,
-    "id" : "Apache-2.0 (single-line)"
+    "id" : "LicenseRef-test-Apache-2.0-single-line"
   }, {
     "_id" : 2,
     "id" : "Apache-2.0"
@@ -648,8 +648,8 @@
       },
       "detected" : {
         "Apache-2.0" : 1,
-        "Apache-2.0 (multi-line)" : 1,
-        "Apache-2.0 (single-line)" : 1,
+        "LicenseRef-test-Apache-2.0-multi-line" : 1,
+        "LicenseRef-test-Apache-2.0-single-line" : 1,
         "MIT" : 1
       }
     }

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -22,34 +22,34 @@
   } ],
   "licenses" : [ {
     "_id" : 0,
-    "id" : "GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause OR MIT"
+    "id" : "GPL-2.0-only WITH Classpath-exception-2.0"
   }, {
     "_id" : 1,
-    "id" : "LicenseRef-test-Apache-2.0-multi-line"
+    "id" : "BSD-3-Clause"
   }, {
     "_id" : 2,
-    "id" : "LicenseRef-test-Apache-2.0-single-line"
-  }, {
-    "_id" : 3,
-    "id" : "Apache-2.0"
-  }, {
-    "_id" : 4,
     "id" : "MIT"
   }, {
+    "_id" : 3,
+    "id" : "LicenseRef-test-Apache-2.0-multi-line"
+  }, {
+    "_id" : 4,
+    "id" : "LicenseRef-test-Apache-2.0-single-line"
+  }, {
     "_id" : 5,
-    "id" : "Eclipse Public License 1.0"
+    "id" : "Apache-2.0"
   }, {
     "_id" : 6,
-    "id" : "EPL-1.0"
+    "id" : "Eclipse Public License 1.0"
   }, {
     "_id" : 7,
-    "id" : "Apache License, Version 2.0"
+    "id" : "EPL-1.0"
   }, {
     "_id" : 8,
-    "id" : "New BSD License"
+    "id" : "Apache License, Version 2.0"
   }, {
     "_id" : 9,
-    "id" : "BSD-3-Clause"
+    "id" : "New BSD License"
   } ],
   "scopes" : [ {
     "_id" : 0,
@@ -185,7 +185,7 @@
     "definition_file_path" : "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle",
     "purl" : "pkg:gradle/org.ossreviewtoolkit.gradle.example/lib@1.0.0",
     "declared_licenses_processed" : { },
-    "detected_licenses" : [ 0, 1, 2 ],
+    "detected_licenses" : [ 0, 1, 2, 3, 4 ],
     "binary_artifact" : {
       "url" : "",
       "hash" : {
@@ -225,20 +225,34 @@
     }, {
       "type" : "LICENSE",
       "license" : 1,
+      "path" : "src/code.cpp",
+      "start_line" : 1,
+      "end_line" : 1,
+      "scan_result" : 0
+    }, {
+      "type" : "LICENSE",
+      "license" : 2,
+      "path" : "src/code.cpp",
+      "start_line" : 1,
+      "end_line" : 1,
+      "scan_result" : 0
+    }, {
+      "type" : "LICENSE",
+      "license" : 3,
       "path" : "build.gradle",
       "start_line" : 19,
       "end_line" : 20,
       "scan_result" : 0
     }, {
       "type" : "LICENSE",
-      "license" : 2,
+      "license" : 4,
       "path" : "build.gradle",
       "start_line" : 19,
       "end_line" : 19,
       "scan_result" : 0
     }, {
       "type" : "LICENSE",
-      "license" : 2,
+      "license" : 4,
       "path" : "build.gradle",
       "start_line" : 20,
       "end_line" : 20,
@@ -252,8 +266,8 @@
     "definition_file_path" : "project/build.gradle",
     "purl" : "pkg:gradle/org.ossreviewtoolkit/nested-fake-project@1.0.0",
     "declared_licenses_processed" : { },
-    "detected_licenses" : [ 3, 4 ],
-    "detected_excluded_licenses" : [ 4 ],
+    "detected_licenses" : [ 5, 2 ],
+    "detected_excluded_licenses" : [ 2 ],
     "binary_artifact" : {
       "url" : "",
       "hash" : {
@@ -293,7 +307,7 @@
       "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
-      "license" : 3,
+      "license" : 5,
       "path" : "file.java",
       "start_line" : 1,
       "end_line" : 2,
@@ -301,7 +315,7 @@
       "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
-      "license" : 3,
+      "license" : 5,
       "path" : "file.kt",
       "start_line" : 1,
       "end_line" : 2,
@@ -316,7 +330,7 @@
       "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
-      "license" : 4,
+      "license" : 2,
       "path" : "file1.java",
       "start_line" : 1,
       "end_line" : 2,
@@ -324,7 +338,7 @@
       "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
-      "license" : 4,
+      "license" : 2,
       "path" : "file2.java",
       "start_line" : 1,
       "end_line" : 2,
@@ -339,10 +353,10 @@
     "is_project" : false,
     "definition_file_path" : "",
     "purl" : "pkg:ant/junit/junit@4.12",
-    "declared_licenses" : [ 5 ],
+    "declared_licenses" : [ 6 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "EPL-1.0",
-      "mapped_licenses" : [ 6 ]
+      "mapped_licenses" : [ 7 ]
     },
     "description" : "JUnit is a unit testing framework for Java, created by Erich Gamma and Kent Beck.",
     "homepage_url" : "http://junit.org",
@@ -384,10 +398,10 @@
     "is_project" : false,
     "definition_file_path" : "",
     "purl" : "pkg:maven/org.apache.commons/commons-lang3@3.5",
-    "declared_licenses" : [ 7 ],
+    "declared_licenses" : [ 8 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "Apache-2.0",
-      "mapped_licenses" : [ 3 ]
+      "mapped_licenses" : [ 5 ]
     },
     "description" : "Apache Commons Lang, a package of Java utility classes for the\n  classes that are in java.lang's hierarchy, or are considered to be so\n  standard as to justify existence in java.lang.",
     "homepage_url" : "http://commons.apache.org/proper/commons-lang/",
@@ -428,10 +442,10 @@
     "is_project" : false,
     "definition_file_path" : "",
     "purl" : "pkg:maven/org.apache.commons/commons-text@1.1",
-    "declared_licenses" : [ 7 ],
+    "declared_licenses" : [ 8 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "Apache-2.0",
-      "mapped_licenses" : [ 3 ]
+      "mapped_licenses" : [ 5 ]
     },
     "description" : "Apache Commons Text is a library focused on algorithms working on strings.",
     "homepage_url" : "http://commons.apache.org/proper/commons-text/",
@@ -472,10 +486,10 @@
     "is_project" : false,
     "definition_file_path" : "",
     "purl" : "pkg:maven/org.hamcrest/hamcrest-core@1.3",
-    "declared_licenses" : [ 8 ],
+    "declared_licenses" : [ 9 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "BSD-3-Clause",
-      "mapped_licenses" : [ 9 ]
+      "mapped_licenses" : [ 1 ]
     },
     "description" : "This is the core API of hamcrest matcher framework to be used by third-party framework providers. This includes the a foundation set of matcher implementations for common operations.",
     "homepage_url" : "https://github.com/hamcrest/JavaHamcrest/hamcrest-core",
@@ -604,7 +618,7 @@
     "_id" : 0,
     "rule" : "rule 1",
     "pkg" : 2,
-    "license" : 6,
+    "license" : 7,
     "license_source" : "DETECTED",
     "severity" : "ERROR",
     "message" : "EPL-1.0 error",
@@ -613,7 +627,7 @@
     "_id" : 1,
     "rule" : "rule 2",
     "pkg" : 4,
-    "license" : 3,
+    "license" : 5,
     "license_source" : "DECLARED",
     "severity" : "HINT",
     "message" : "Apache-2.0 hint",
@@ -623,7 +637,7 @@
     "_id" : 2,
     "rule" : "rule 3",
     "pkg" : 5,
-    "license" : 9,
+    "license" : 1,
     "license_source" : "CONCLUDED",
     "severity" : "WARNING",
     "message" : "BSD-3-Clause warning",
@@ -653,19 +667,19 @@
     "licenses" : {
       "declared" : {
         "Apache-2.0" : 2,
-    "BSD-3-Clause" : 1,
-    "EPL-1.0" : 1
+        "BSD-3-Clause" : 1,
+        "EPL-1.0" : 1
+      },
+      "detected" : {
+        "Apache-2.0" : 1,
+        "GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause OR MIT" : 1,
+        "LicenseRef-test-Apache-2.0-multi-line" : 1,
+        "LicenseRef-test-Apache-2.0-single-line" : 1,
+        "MIT" : 1
+      }
+    }
   },
-  "detected" : {
-    "Apache-2.0" : 1,
-    "GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause OR MIT" : 1,
-    "LicenseRef-test-Apache-2.0-multi-line" : 1,
-    "LicenseRef-test-Apache-2.0-single-line" : 1,
-    "MIT" : 1
-  }
-}
-},
-"repository" : {
+  "repository" : {
     "vcs" : {
       "type" : "",
       "url" : "",

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -22,30 +22,33 @@
   } ],
   "licenses" : [ {
     "_id" : 0,
-    "id" : "LicenseRef-test-Apache-2.0-multi-line"
+    "id" : "GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause OR MIT"
   }, {
     "_id" : 1,
-    "id" : "LicenseRef-test-Apache-2.0-single-line"
+    "id" : "LicenseRef-test-Apache-2.0-multi-line"
   }, {
     "_id" : 2,
-    "id" : "Apache-2.0"
+    "id" : "LicenseRef-test-Apache-2.0-single-line"
   }, {
     "_id" : 3,
-    "id" : "MIT"
+    "id" : "Apache-2.0"
   }, {
     "_id" : 4,
-    "id" : "Eclipse Public License 1.0"
+    "id" : "MIT"
   }, {
     "_id" : 5,
-    "id" : "EPL-1.0"
+    "id" : "Eclipse Public License 1.0"
   }, {
     "_id" : 6,
-    "id" : "Apache License, Version 2.0"
+    "id" : "EPL-1.0"
   }, {
     "_id" : 7,
-    "id" : "New BSD License"
+    "id" : "Apache License, Version 2.0"
   }, {
     "_id" : 8,
+    "id" : "New BSD License"
+  }, {
+    "_id" : 9,
     "id" : "BSD-3-Clause"
   } ],
   "scopes" : [ {
@@ -182,7 +185,7 @@
     "definition_file_path" : "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle",
     "purl" : "pkg:gradle/org.ossreviewtoolkit.gradle.example/lib@1.0.0",
     "declared_licenses_processed" : { },
-    "detected_licenses" : [ 0, 1 ],
+    "detected_licenses" : [ 0, 1, 2 ],
     "binary_artifact" : {
       "url" : "",
       "hash" : {
@@ -215,20 +218,27 @@
     "findings" : [ {
       "type" : "LICENSE",
       "license" : 0,
+      "path" : "src/code.cpp",
+      "start_line" : 1,
+      "end_line" : 1,
+      "scan_result" : 0
+    }, {
+      "type" : "LICENSE",
+      "license" : 1,
       "path" : "build.gradle",
       "start_line" : 19,
       "end_line" : 20,
       "scan_result" : 0
     }, {
       "type" : "LICENSE",
-      "license" : 1,
+      "license" : 2,
       "path" : "build.gradle",
       "start_line" : 19,
       "end_line" : 19,
       "scan_result" : 0
     }, {
       "type" : "LICENSE",
-      "license" : 1,
+      "license" : 2,
       "path" : "build.gradle",
       "start_line" : 20,
       "end_line" : 20,
@@ -242,8 +252,8 @@
     "definition_file_path" : "project/build.gradle",
     "purl" : "pkg:gradle/org.ossreviewtoolkit/nested-fake-project@1.0.0",
     "declared_licenses_processed" : { },
-    "detected_licenses" : [ 2, 3 ],
-    "detected_excluded_licenses" : [ 3 ],
+    "detected_licenses" : [ 3, 4 ],
+    "detected_excluded_licenses" : [ 4 ],
     "binary_artifact" : {
       "url" : "",
       "hash" : {
@@ -283,7 +293,7 @@
       "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
-      "license" : 2,
+      "license" : 3,
       "path" : "file.java",
       "start_line" : 1,
       "end_line" : 2,
@@ -291,7 +301,7 @@
       "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
-      "license" : 2,
+      "license" : 3,
       "path" : "file.kt",
       "start_line" : 1,
       "end_line" : 2,
@@ -306,7 +316,7 @@
       "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
-      "license" : 3,
+      "license" : 4,
       "path" : "file1.java",
       "start_line" : 1,
       "end_line" : 2,
@@ -314,7 +324,7 @@
       "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
-      "license" : 3,
+      "license" : 4,
       "path" : "file2.java",
       "start_line" : 1,
       "end_line" : 2,
@@ -329,10 +339,10 @@
     "is_project" : false,
     "definition_file_path" : "",
     "purl" : "pkg:ant/junit/junit@4.12",
-    "declared_licenses" : [ 4 ],
+    "declared_licenses" : [ 5 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "EPL-1.0",
-      "mapped_licenses" : [ 5 ]
+      "mapped_licenses" : [ 6 ]
     },
     "description" : "JUnit is a unit testing framework for Java, created by Erich Gamma and Kent Beck.",
     "homepage_url" : "http://junit.org",
@@ -374,10 +384,10 @@
     "is_project" : false,
     "definition_file_path" : "",
     "purl" : "pkg:maven/org.apache.commons/commons-lang3@3.5",
-    "declared_licenses" : [ 6 ],
+    "declared_licenses" : [ 7 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "Apache-2.0",
-      "mapped_licenses" : [ 2 ]
+      "mapped_licenses" : [ 3 ]
     },
     "description" : "Apache Commons Lang, a package of Java utility classes for the\n  classes that are in java.lang's hierarchy, or are considered to be so\n  standard as to justify existence in java.lang.",
     "homepage_url" : "http://commons.apache.org/proper/commons-lang/",
@@ -418,10 +428,10 @@
     "is_project" : false,
     "definition_file_path" : "",
     "purl" : "pkg:maven/org.apache.commons/commons-text@1.1",
-    "declared_licenses" : [ 6 ],
+    "declared_licenses" : [ 7 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "Apache-2.0",
-      "mapped_licenses" : [ 2 ]
+      "mapped_licenses" : [ 3 ]
     },
     "description" : "Apache Commons Text is a library focused on algorithms working on strings.",
     "homepage_url" : "http://commons.apache.org/proper/commons-text/",
@@ -462,10 +472,10 @@
     "is_project" : false,
     "definition_file_path" : "",
     "purl" : "pkg:maven/org.hamcrest/hamcrest-core@1.3",
-    "declared_licenses" : [ 7 ],
+    "declared_licenses" : [ 8 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "BSD-3-Clause",
-      "mapped_licenses" : [ 8 ]
+      "mapped_licenses" : [ 9 ]
     },
     "description" : "This is the core API of hamcrest matcher framework to be used by third-party framework providers. This includes the a foundation set of matcher implementations for common operations.",
     "homepage_url" : "https://github.com/hamcrest/JavaHamcrest/hamcrest-core",
@@ -594,7 +604,7 @@
     "_id" : 0,
     "rule" : "rule 1",
     "pkg" : 2,
-    "license" : 5,
+    "license" : 6,
     "license_source" : "DETECTED",
     "severity" : "ERROR",
     "message" : "EPL-1.0 error",
@@ -603,7 +613,7 @@
     "_id" : 1,
     "rule" : "rule 2",
     "pkg" : 4,
-    "license" : 2,
+    "license" : 3,
     "license_source" : "DECLARED",
     "severity" : "HINT",
     "message" : "Apache-2.0 hint",
@@ -613,7 +623,7 @@
     "_id" : 2,
     "rule" : "rule 3",
     "pkg" : 5,
-    "license" : 8,
+    "license" : 9,
     "license_source" : "CONCLUDED",
     "severity" : "WARNING",
     "message" : "BSD-3-Clause warning",
@@ -643,18 +653,19 @@
     "licenses" : {
       "declared" : {
         "Apache-2.0" : 2,
-        "BSD-3-Clause" : 1,
-        "EPL-1.0" : 1
-      },
-      "detected" : {
-        "Apache-2.0" : 1,
-        "LicenseRef-test-Apache-2.0-multi-line" : 1,
-        "LicenseRef-test-Apache-2.0-single-line" : 1,
-        "MIT" : 1
-      }
-    }
+    "BSD-3-Clause" : 1,
+    "EPL-1.0" : 1
   },
-  "repository" : {
+  "detected" : {
+    "Apache-2.0" : 1,
+    "GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause OR MIT" : 1,
+    "LicenseRef-test-Apache-2.0-multi-line" : 1,
+    "LicenseRef-test-Apache-2.0-single-line" : 1,
+    "MIT" : 1
+  }
+}
+},
+"repository" : {
     "vcs" : {
       "type" : "",
       "url" : "",

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -672,10 +672,11 @@
       },
       "detected" : {
         "Apache-2.0" : 1,
-        "GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause OR MIT" : 1,
+        "BSD-3-Clause" : 1,
+        "GPL-2.0-only WITH Classpath-exception-2.0" : 1,
         "LicenseRef-test-Apache-2.0-multi-line" : 1,
         "LicenseRef-test-Apache-2.0-single-line" : 1,
-        "MIT" : 1
+        "MIT" : 2
       }
     }
   },

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -18,25 +18,25 @@ copyrights:
   statement: "Copyright (c) example authors."
 licenses:
 - _id: 0
-  id: "GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause OR MIT"
+  id: "GPL-2.0-only WITH Classpath-exception-2.0"
 - _id: 1
-  id: "LicenseRef-test-Apache-2.0-multi-line"
-- _id: 2
-  id: "LicenseRef-test-Apache-2.0-single-line"
-- _id: 3
-  id: "Apache-2.0"
-- _id: 4
-  id: "MIT"
-- _id: 5
-  id: "Eclipse Public License 1.0"
-- _id: 6
-  id: "EPL-1.0"
-- _id: 7
-  id: "Apache License, Version 2.0"
-- _id: 8
-  id: "New BSD License"
-- _id: 9
   id: "BSD-3-Clause"
+- _id: 2
+  id: "MIT"
+- _id: 3
+  id: "LicenseRef-test-Apache-2.0-multi-line"
+- _id: 4
+  id: "LicenseRef-test-Apache-2.0-single-line"
+- _id: 5
+  id: "Apache-2.0"
+- _id: 6
+  id: "Eclipse Public License 1.0"
+- _id: 7
+  id: "EPL-1.0"
+- _id: 8
+  id: "Apache License, Version 2.0"
+- _id: 9
+  id: "New BSD License"
 scopes:
 - _id: 0
   name: "compile"
@@ -150,6 +150,8 @@ packages:
   - 0
   - 1
   - 2
+  - 3
+  - 4
   binary_artifact:
     url: ""
     hash:
@@ -184,18 +186,30 @@ packages:
     scan_result: 0
   - type: "LICENSE"
     license: 1
+    path: "src/code.cpp"
+    start_line: 1
+    end_line: 1
+    scan_result: 0
+  - type: "LICENSE"
+    license: 2
+    path: "src/code.cpp"
+    start_line: 1
+    end_line: 1
+    scan_result: 0
+  - type: "LICENSE"
+    license: 3
     path: "build.gradle"
     start_line: 19
     end_line: 20
     scan_result: 0
   - type: "LICENSE"
-    license: 2
+    license: 4
     path: "build.gradle"
     start_line: 19
     end_line: 19
     scan_result: 0
   - type: "LICENSE"
-    license: 2
+    license: 4
     path: "build.gradle"
     start_line: 20
     end_line: 20
@@ -208,10 +222,10 @@ packages:
   purl: "pkg:gradle/org.ossreviewtoolkit/nested-fake-project@1.0.0"
   declared_licenses_processed: {}
   detected_licenses:
-  - 3
-  - 4
+  - 5
+  - 2
   detected_excluded_licenses:
-  - 4
+  - 2
   binary_artifact:
     url: ""
     hash:
@@ -247,7 +261,7 @@ packages:
     path_excludes:
     - 1
   - type: "LICENSE"
-    license: 3
+    license: 5
     path: "file.java"
     start_line: 1
     end_line: 2
@@ -255,7 +269,7 @@ packages:
     path_excludes:
     - 1
   - type: "LICENSE"
-    license: 3
+    license: 5
     path: "file.kt"
     start_line: 1
     end_line: 2
@@ -269,7 +283,7 @@ packages:
     path_excludes:
     - 1
   - type: "LICENSE"
-    license: 4
+    license: 2
     path: "file1.java"
     start_line: 1
     end_line: 2
@@ -277,7 +291,7 @@ packages:
     path_excludes:
     - 1
   - type: "LICENSE"
-    license: 4
+    license: 2
     path: "file2.java"
     start_line: 1
     end_line: 2
@@ -293,11 +307,11 @@ packages:
   definition_file_path: ""
   purl: "pkg:ant/junit/junit@4.12"
   declared_licenses:
-  - 5
+  - 6
   declared_licenses_processed:
     spdx_expression: "EPL-1.0"
     mapped_licenses:
-    - 6
+    - 7
   description: "JUnit is a unit testing framework for Java, created by Erich Gamma\
     \ and Kent Beck."
   homepage_url: "http://junit.org"
@@ -338,11 +352,11 @@ packages:
   definition_file_path: ""
   purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
   declared_licenses:
-  - 7
+  - 8
   declared_licenses_processed:
     spdx_expression: "Apache-2.0"
     mapped_licenses:
-    - 3
+    - 5
   description: "Apache Commons Lang, a package of Java utility classes for the\n \
     \ classes that are in java.lang's hierarchy, or are considered to be so\n  standard\
     \ as to justify existence in java.lang."
@@ -384,11 +398,11 @@ packages:
   definition_file_path: ""
   purl: "pkg:maven/org.apache.commons/commons-text@1.1"
   declared_licenses:
-  - 7
+  - 8
   declared_licenses_processed:
     spdx_expression: "Apache-2.0"
     mapped_licenses:
-    - 3
+    - 5
   description: "Apache Commons Text is a library focused on algorithms working on\
     \ strings."
   homepage_url: "http://commons.apache.org/proper/commons-text/"
@@ -429,11 +443,11 @@ packages:
   definition_file_path: ""
   purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
   declared_licenses:
-  - 8
+  - 9
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped_licenses:
-    - 9
+    - 1
   description: "This is the core API of hamcrest matcher framework to be used by third-party\
     \ framework providers. This includes the a foundation set of matcher implementations\
     \ for common operations."
@@ -549,7 +563,7 @@ rule_violations:
 - _id: 0
   rule: "rule 1"
   pkg: 2
-  license: 6
+  license: 7
   license_source: "DETECTED"
   severity: "ERROR"
   message: "EPL-1.0 error"
@@ -558,7 +572,7 @@ rule_violations:
 - _id: 1
   rule: "rule 2"
   pkg: 4
-  license: 3
+  license: 5
   license_source: "DECLARED"
   severity: "HINT"
   message: "Apache-2.0 hint"
@@ -569,7 +583,7 @@ rule_violations:
 - _id: 2
   rule: "rule 3"
   pkg: 5
-  license: 9
+  license: 1
   license_source: "CONCLUDED"
   severity: "WARNING"
   message: "BSD-3-Clause warning"

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -616,10 +616,11 @@ statistics:
       EPL-1.0: 1
     detected:
       Apache-2.0: 1
-      GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause OR MIT: 1
+      BSD-3-Clause: 1
+      GPL-2.0-only WITH Classpath-exception-2.0: 1
       LicenseRef-test-Apache-2.0-multi-line: 1
       LicenseRef-test-Apache-2.0-single-line: 1
-      MIT: 1
+      MIT: 2
 repository:
   vcs:
     type: ""

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -18,9 +18,9 @@ copyrights:
   statement: "Copyright (c) example authors."
 licenses:
 - _id: 0
-  id: "Apache-2.0 (multi-line)"
+  id: "LicenseRef-test-Apache-2.0-multi-line"
 - _id: 1
-  id: "Apache-2.0 (single-line)"
+  id: "LicenseRef-test-Apache-2.0-single-line"
 - _id: 2
   id: "Apache-2.0"
 - _id: 3
@@ -593,8 +593,8 @@ statistics:
       EPL-1.0: 1
     detected:
       Apache-2.0: 1
-      Apache-2.0 (multi-line): 1
-      Apache-2.0 (single-line): 1
+      LicenseRef-test-Apache-2.0-multi-line: 1
+      LicenseRef-test-Apache-2.0-single-line: 1
       MIT: 1
 repository:
   vcs:

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -18,22 +18,24 @@ copyrights:
   statement: "Copyright (c) example authors."
 licenses:
 - _id: 0
-  id: "LicenseRef-test-Apache-2.0-multi-line"
+  id: "GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause OR MIT"
 - _id: 1
-  id: "LicenseRef-test-Apache-2.0-single-line"
+  id: "LicenseRef-test-Apache-2.0-multi-line"
 - _id: 2
-  id: "Apache-2.0"
+  id: "LicenseRef-test-Apache-2.0-single-line"
 - _id: 3
-  id: "MIT"
+  id: "Apache-2.0"
 - _id: 4
-  id: "Eclipse Public License 1.0"
+  id: "MIT"
 - _id: 5
-  id: "EPL-1.0"
+  id: "Eclipse Public License 1.0"
 - _id: 6
-  id: "Apache License, Version 2.0"
+  id: "EPL-1.0"
 - _id: 7
-  id: "New BSD License"
+  id: "Apache License, Version 2.0"
 - _id: 8
+  id: "New BSD License"
+- _id: 9
   id: "BSD-3-Clause"
 scopes:
 - _id: 0
@@ -147,6 +149,7 @@ packages:
   detected_licenses:
   - 0
   - 1
+  - 2
   binary_artifact:
     url: ""
     hash:
@@ -175,18 +178,24 @@ packages:
   findings:
   - type: "LICENSE"
     license: 0
+    path: "src/code.cpp"
+    start_line: 1
+    end_line: 1
+    scan_result: 0
+  - type: "LICENSE"
+    license: 1
     path: "build.gradle"
     start_line: 19
     end_line: 20
     scan_result: 0
   - type: "LICENSE"
-    license: 1
+    license: 2
     path: "build.gradle"
     start_line: 19
     end_line: 19
     scan_result: 0
   - type: "LICENSE"
-    license: 1
+    license: 2
     path: "build.gradle"
     start_line: 20
     end_line: 20
@@ -199,10 +208,10 @@ packages:
   purl: "pkg:gradle/org.ossreviewtoolkit/nested-fake-project@1.0.0"
   declared_licenses_processed: {}
   detected_licenses:
-  - 2
   - 3
+  - 4
   detected_excluded_licenses:
-  - 3
+  - 4
   binary_artifact:
     url: ""
     hash:
@@ -238,7 +247,7 @@ packages:
     path_excludes:
     - 1
   - type: "LICENSE"
-    license: 2
+    license: 3
     path: "file.java"
     start_line: 1
     end_line: 2
@@ -246,7 +255,7 @@ packages:
     path_excludes:
     - 1
   - type: "LICENSE"
-    license: 2
+    license: 3
     path: "file.kt"
     start_line: 1
     end_line: 2
@@ -260,7 +269,7 @@ packages:
     path_excludes:
     - 1
   - type: "LICENSE"
-    license: 3
+    license: 4
     path: "file1.java"
     start_line: 1
     end_line: 2
@@ -268,7 +277,7 @@ packages:
     path_excludes:
     - 1
   - type: "LICENSE"
-    license: 3
+    license: 4
     path: "file2.java"
     start_line: 1
     end_line: 2
@@ -284,11 +293,11 @@ packages:
   definition_file_path: ""
   purl: "pkg:ant/junit/junit@4.12"
   declared_licenses:
-  - 4
+  - 5
   declared_licenses_processed:
     spdx_expression: "EPL-1.0"
     mapped_licenses:
-    - 5
+    - 6
   description: "JUnit is a unit testing framework for Java, created by Erich Gamma\
     \ and Kent Beck."
   homepage_url: "http://junit.org"
@@ -329,11 +338,11 @@ packages:
   definition_file_path: ""
   purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
   declared_licenses:
-  - 6
+  - 7
   declared_licenses_processed:
     spdx_expression: "Apache-2.0"
     mapped_licenses:
-    - 2
+    - 3
   description: "Apache Commons Lang, a package of Java utility classes for the\n \
     \ classes that are in java.lang's hierarchy, or are considered to be so\n  standard\
     \ as to justify existence in java.lang."
@@ -375,11 +384,11 @@ packages:
   definition_file_path: ""
   purl: "pkg:maven/org.apache.commons/commons-text@1.1"
   declared_licenses:
-  - 6
+  - 7
   declared_licenses_processed:
     spdx_expression: "Apache-2.0"
     mapped_licenses:
-    - 2
+    - 3
   description: "Apache Commons Text is a library focused on algorithms working on\
     \ strings."
   homepage_url: "http://commons.apache.org/proper/commons-text/"
@@ -420,11 +429,11 @@ packages:
   definition_file_path: ""
   purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
   declared_licenses:
-  - 7
+  - 8
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped_licenses:
-    - 8
+    - 9
   description: "This is the core API of hamcrest matcher framework to be used by third-party\
     \ framework providers. This includes the a foundation set of matcher implementations\
     \ for common operations."
@@ -540,7 +549,7 @@ rule_violations:
 - _id: 0
   rule: "rule 1"
   pkg: 2
-  license: 5
+  license: 6
   license_source: "DETECTED"
   severity: "ERROR"
   message: "EPL-1.0 error"
@@ -549,7 +558,7 @@ rule_violations:
 - _id: 1
   rule: "rule 2"
   pkg: 4
-  license: 2
+  license: 3
   license_source: "DECLARED"
   severity: "HINT"
   message: "Apache-2.0 hint"
@@ -560,7 +569,7 @@ rule_violations:
 - _id: 2
   rule: "rule 3"
   pkg: 5
-  license: 8
+  license: 9
   license_source: "CONCLUDED"
   severity: "WARNING"
   message: "BSD-3-Clause warning"
@@ -593,6 +602,7 @@ statistics:
       EPL-1.0: 1
     detected:
       Apache-2.0: 1
+      GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause OR MIT: 1
       LicenseRef-test-Apache-2.0-multi-line: 1
       LicenseRef-test-Apache-2.0-single-line: 1
       MIT: 1

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -571,9 +571,11 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
             <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-1">1</a></td><td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td><td></td><td><em>Detected Licenses:</em>
               <dl>
                 <dd>
-                  <div>GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause OR MIT (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
+                  <div>BSD-3-Clause (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
+                  <div>GPL-2.0-only WITH Classpath-exception-2.0 (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
                   <div>LicenseRef-test-Apache-2.0-multi-line (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle#L19-L20">link</a> to the location)</div>
                   <div>LicenseRef-test-Apache-2.0-single-line (exemplary <a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle#L19">link</a> to the first of 2 locations)</div>
+                  <div>MIT (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
                 </dd>
               </dl>
             </td><td>

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -571,6 +571,7 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
             <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-1">1</a></td><td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td><td></td><td><em>Detected Licenses:</em>
               <dl>
                 <dd>
+                  <div>GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause OR MIT (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
                   <div>LicenseRef-test-Apache-2.0-multi-line (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle#L19-L20">link</a> to the location)</div>
                   <div>LicenseRef-test-Apache-2.0-single-line (exemplary <a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle#L19">link</a> to the first of 2 locations)</div>
                 </dd>

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -571,8 +571,8 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
             <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-1">1</a></td><td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td><td></td><td><em>Detected Licenses:</em>
               <dl>
                 <dd>
-                  <div>Apache-2.0 (multi-line) (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle#L19-L20">link</a> to the location)</div>
-                  <div>Apache-2.0 (single-line) (exemplary <a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle#L19">link</a> to the first of 2 locations)</div>
+                  <div>LicenseRef-test-Apache-2.0-multi-line (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle#L19-L20">link</a> to the location)</div>
+                  <div>LicenseRef-test-Apache-2.0-single-line (exemplary <a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle#L19">link</a> to the first of 2 locations)</div>
                 </dd>
               </dl>
             </td><td>

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -276,6 +276,11 @@ scanner:
               - path: "fake_path"
                 start_line: 206
                 end_line: 206
+          - license: "GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause OR MIT"
+            locations:
+            - path: "src/code.cpp"
+              start_line: 1
+              end_line: 1
           issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "FileCounter"

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -255,17 +255,17 @@ scanner:
           end_time: "1970-01-01T00:00:00Z"
           file_count: 0
           license_findings:
-          - license: "Apache-2.0 (multi-line)"
+          - license: "LicenseRef-test-Apache-2.0-multi-line"
             locations:
             - path: "build.gradle"
               start_line: 19
               end_line: 20
-          - license: "Apache-2.0 (single-line)"
+          - license: "LicenseRef-test-Apache-2.0-single-line"
             locations:
             - path: "build.gradle"
               start_line: 19
               end_line: 19
-          - license: "Apache-2.0 (single-line)"
+          - license: "LicenseRef-test-Apache-2.0-single-line"
             locations:
             - path: "build.gradle"
               start_line: 20

--- a/spdx-utils/src/main/kotlin/SpdxExpression.kt
+++ b/spdx-utils/src/main/kotlin/SpdxExpression.kt
@@ -66,7 +66,7 @@ sealed class SpdxExpression {
          */
         @JsonCreator
         @JvmStatic
-        fun parse(expression: String) = parse(expression, Strictness.ALLOW_ANY)
+        fun parse(expression: String): SpdxExpression = parse(expression, Strictness.ALLOW_ANY)
 
         /**
          * Parse a string into an [SpdxExpression]. [strictness] defines whether only the syntax is checked


### PR DESCRIPTION
The changes enable the use of the SPDX AND operator in detected licenses and thus most importantly also in license finding curations. The SPDX OR operator is not supported yet, but is now handle like the AND operator and thus the handling becomes fully consistent with that for declared and concluded licenses.
