### PR TITLE
model: Sort projects by type and then by definition file

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
@@ -25,6 +25,25 @@ analyzer:
     allow_dynamic_versions: false
   result:
     projects:
+    - id: "SBT:com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT"
+      definition_file_path: "target/scala-2.12/sbt-multi-project-example_2.12-0.1-SNAPSHOT.pom"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        path: ""
+      homepage_url: ""
+      scopes:
+      - name: "compile"
+        dependencies:
+        - id: "Maven:org.scala-lang:scala-library:2.12.3"
     - id: "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
       definition_file_path: "common/target/scala-2.12/common_2.12-0.1-SNAPSHOT.pom"
       declared_licenses: []
@@ -195,25 +214,6 @@ analyzer:
           - id: "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
           - id: "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
           - id: "Maven:org.scalactic:scalactic_2.12:3.0.4"
-    - id: "SBT:com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT"
-      definition_file_path: "target/scala-2.12/sbt-multi-project-example_2.12-0.1-SNAPSHOT.pom"
-      declared_licenses: []
-      declared_licenses_processed: {}
-      vcs:
-        type: ""
-        url: ""
-        revision: ""
-        path: ""
-      vcs_processed:
-        type: "Git"
-        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
-        path: ""
-      homepage_url: ""
-      scopes:
-      - name: "compile"
-        dependencies:
-        - id: "Maven:org.scala-lang:scala-library:2.12.3"
     - id: "Unmanaged::sbt-multi-project-example:31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
       definition_file_path: ""
       declared_licenses: []

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -94,6 +94,11 @@ data class Project(
             homepageUrl = "",
             scopes = sortedSetOf()
         )
+
+        private val PATH_STRING_COMPARATOR = compareBy<String>({ path -> path.count { it == '/' } }, { it })
+        private val COMPARARTOR = compareBy<Project> { it.id.type }
+            .thenBy(PATH_STRING_COMPARATOR) { it.definitionFilePath }
+            .thenBy { it.id }
     }
 
     /**
@@ -153,9 +158,10 @@ data class Project(
         }
 
     /**
-     * A comparison function to sort projects by their identifier.
+     * A comparison function to sort projects by their type, then by definition file depth / path, and finally by their
+     * full id.
      */
-    override fun compareTo(other: Project) = id.compareTo(other.id)
+    override fun compareTo(other: Project) = COMPARARTOR.compare(this, other)
 
     /**
      * Return whether the package identified by [id] is contained as a (transitive) dependency in this project.

--- a/model/src/test/kotlin/ProjectTest.kt
+++ b/model/src/test/kotlin/ProjectTest.kt
@@ -23,6 +23,7 @@ import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 
 import java.io.File
@@ -34,6 +35,35 @@ private fun readAnalyzerResult(analyzerResultFilename: String): Project =
         .readValue<ProjectAnalyzerResult>().project
 
 class ProjectTest : WordSpec({
+    "Projects" should {
+        "be sorted by type" {
+            val npmProject = Project.EMPTY.copy(id = Identifier.EMPTY.copy(type = "NPM"))
+            val mavenProject = Project.EMPTY.copy(id = Identifier.EMPTY.copy(type = "Maven"))
+
+            val sortedProjects = listOf(npmProject, mavenProject).sorted()
+
+            sortedProjects should containExactly(mavenProject, npmProject)
+        }
+    }
+
+    "Projects of the same type" should {
+        "be sorted by definition file depth" {
+            val nestedProject = Project.EMPTY.copy(
+                id = Identifier("Maven", "GroupA", "Artifact", "1.0.0"),
+                definitionFilePath = "nested/pom.xml"
+            )
+
+            val rootProject = Project.EMPTY.copy(
+                id = Identifier("Maven", "GroupB", "Artifact", "1.0.0"),
+                definitionFilePath = "pom.xml"
+            )
+
+            val sortedProjects = listOf(nestedProject, rootProject).sorted()
+
+            sortedProjects should containExactly(rootProject, nestedProject)
+        }
+    }
+
     "collectDependencies" should {
         "get all dependencies by default" {
             val project = readAnalyzerResult("gradle-expected-output-lib.yml")

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -22,16 +22,16 @@
   } ],
   "licenses" : [ {
     "_id" : 0,
-    "id" : "Apache-2.0 (multi-line)"
-  }, {
-    "_id" : 1,
-    "id" : "Apache-2.0 (single-line)"
-  }, {
-    "_id" : 2,
     "id" : "Apache-2.0"
   }, {
-    "_id" : 3,
+    "_id" : 1,
     "id" : "MIT"
+  }, {
+    "_id" : 2,
+    "id" : "Apache-2.0 (multi-line)"
+  }, {
+    "_id" : 3,
+    "id" : "Apache-2.0 (single-line)"
   }, {
     "_id" : 4,
     "id" : "Eclipse Public License 1.0"
@@ -82,24 +82,9 @@
     "end_time" : "1970-01-01T00:00:00Z",
     "file_count" : 0,
     "package_verification_code" : "",
-    "issues" : [ 0 ]
-  }, {
-    "_id" : 1,
-    "provenance" : {
-      "download_time" : "1970-01-01T00:00:00Z"
-    },
-    "scanner" : {
-      "name" : "FakeScanner",
-      "version" : "1.0",
-      "configuration" : ""
-    },
-    "start_time" : "1970-01-01T00:00:00Z",
-    "end_time" : "1970-01-01T00:00:00Z",
-    "file_count" : 0,
-    "package_verification_code" : "",
     "issues" : [ ]
   }, {
-    "_id" : 2,
+    "_id" : 1,
     "provenance" : {
       "download_time" : "1970-01-01T00:00:00Z",
       "source_artifact" : {
@@ -121,7 +106,7 @@
     "package_verification_code" : "",
     "issues" : [ ]
   }, {
-    "_id" : 3,
+    "_id" : 2,
     "provenance" : {
       "download_time" : "1970-01-01T00:00:00Z",
       "source_artifact" : {
@@ -143,7 +128,7 @@
     "package_verification_code" : "",
     "issues" : [ ]
   }, {
-    "_id" : 4,
+    "_id" : 3,
     "provenance" : {
       "download_time" : "1970-01-01T00:00:00Z",
       "source_artifact" : {
@@ -165,7 +150,7 @@
     "package_verification_code" : "",
     "issues" : [ ]
   }, {
-    "_id" : 5,
+    "_id" : 4,
     "provenance" : {
       "download_time" : "1970-01-01T00:00:00Z",
       "source_artifact" : {
@@ -199,7 +184,7 @@
       "mapped_licenses" : [ ],
       "unmapped_licenses" : [ ]
     },
-    "detected_licenses" : [ 0, 1 ],
+    "detected_licenses" : [ 2, 3 ],
     "description" : "",
     "homepage_url" : "",
     "binary_artifact" : {
@@ -235,21 +220,21 @@
     "scan_results" : [ 0 ],
     "findings" : [ {
       "type" : "LICENSE",
-      "license" : 0,
+      "license" : 2,
       "path" : "build.gradle",
       "start_line" : 19,
       "end_line" : 20,
       "scan_result" : 0
     }, {
       "type" : "LICENSE",
-      "license" : 1,
+      "license" : 3,
       "path" : "build.gradle",
       "start_line" : 19,
       "end_line" : 19,
       "scan_result" : 0
     }, {
       "type" : "LICENSE",
-      "license" : 1,
+      "license" : 3,
       "path" : "build.gradle",
       "start_line" : 20,
       "end_line" : 20,
@@ -271,8 +256,8 @@
       "mapped_licenses" : [ ],
       "unmapped_licenses" : [ ]
     },
-    "detected_licenses" : [ 2, 3 ],
-    "detected_excluded_licenses" : [ 3 ],
+    "detected_licenses" : [ 0, 1 ],
+    "detected_excluded_licenses" : [ 1 ],
     "description" : "",
     "homepage_url" : "",
     "binary_artifact" : {
@@ -305,53 +290,53 @@
     "paths" : [ ],
     "levels" : [ 0 ],
     "scopes" : [ ],
-    "scan_results" : [ 1 ],
+    "scan_results" : [ 0 ],
     "findings" : [ {
       "type" : "COPYRIGHT",
       "copyright" : 0,
       "path" : "file.java",
       "start_line" : 1,
       "end_line" : 1,
-      "scan_result" : 1,
+      "scan_result" : 0,
       "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
-      "license" : 2,
+      "license" : 0,
       "path" : "file.java",
       "start_line" : 1,
       "end_line" : 2,
-      "scan_result" : 1,
+      "scan_result" : 0,
       "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
-      "license" : 2,
+      "license" : 0,
       "path" : "file.kt",
       "start_line" : 1,
       "end_line" : 2,
-      "scan_result" : 1
+      "scan_result" : 0
     }, {
       "type" : "COPYRIGHT",
       "copyright" : 0,
       "path" : "file1.java",
       "start_line" : 1,
       "end_line" : 1,
-      "scan_result" : 1,
+      "scan_result" : 0,
       "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
-      "license" : 3,
+      "license" : 1,
       "path" : "file1.java",
       "start_line" : 1,
       "end_line" : 2,
-      "scan_result" : 1,
+      "scan_result" : 0,
       "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
-      "license" : 3,
+      "license" : 1,
       "path" : "file2.java",
       "start_line" : 1,
       "end_line" : 2,
-      "scan_result" : 1,
+      "scan_result" : 0,
       "path_excludes" : [ 1 ]
     } ],
     "is_excluded" : true,
@@ -403,7 +388,7 @@
     "paths" : [ 0 ],
     "levels" : [ 0 ],
     "scopes" : [ 1 ],
-    "scan_results" : [ 2 ],
+    "scan_results" : [ 1 ],
     "findings" : [ ],
     "is_excluded" : true,
     "path_excludes" : [ ],
@@ -418,7 +403,7 @@
     "declared_licenses" : [ 6 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "Apache-2.0",
-      "mapped_licenses" : [ 2 ],
+      "mapped_licenses" : [ 0 ],
       "unmapped_licenses" : [ ]
     },
     "detected_licenses" : [ ],
@@ -454,7 +439,7 @@
     "paths" : [ 1, 2 ],
     "levels" : [ 1 ],
     "scopes" : [ 0, 1 ],
-    "scan_results" : [ 3 ],
+    "scan_results" : [ 2 ],
     "findings" : [ ],
     "is_excluded" : false,
     "path_excludes" : [ ],
@@ -469,7 +454,7 @@
     "declared_licenses" : [ 6 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "Apache-2.0",
-      "mapped_licenses" : [ 2 ],
+      "mapped_licenses" : [ 0 ],
       "unmapped_licenses" : [ ]
     },
     "detected_licenses" : [ ],
@@ -505,7 +490,7 @@
     "paths" : [ 3, 4 ],
     "levels" : [ 0 ],
     "scopes" : [ 0, 1 ],
-    "scan_results" : [ 4 ],
+    "scan_results" : [ 3 ],
     "findings" : [ ],
     "is_excluded" : false,
     "path_excludes" : [ ],
@@ -556,7 +541,7 @@
     "paths" : [ 5 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
-    "scan_results" : [ 5 ],
+    "scan_results" : [ 4 ],
     "findings" : [ ],
     "is_excluded" : true,
     "path_excludes" : [ ],
@@ -602,52 +587,52 @@
   } ],
   "dependency_trees" : [ {
     "key" : 0,
+    "pkg" : 1,
+    "path_excludes" : [ 0 ],
+    "children" : [ ]
+  }, {
+    "key" : 1,
     "pkg" : 0,
     "children" : [ {
-      "key" : 1,
+      "key" : 2,
       "scope" : 0,
       "children" : [ {
-        "key" : 2,
+        "key" : 3,
         "linkage" : "DYNAMIC",
         "pkg" : 4,
         "children" : [ {
-          "key" : 3,
+          "key" : 4,
           "linkage" : "DYNAMIC",
           "pkg" : 3,
           "children" : [ ]
         } ]
       } ]
     }, {
-      "key" : 4,
+      "key" : 5,
       "scope" : 1,
       "scope_excludes" : [ 0 ],
       "children" : [ {
-        "key" : 5,
+        "key" : 6,
         "linkage" : "DYNAMIC",
         "pkg" : 2,
         "children" : [ {
-          "key" : 6,
+          "key" : 7,
           "linkage" : "DYNAMIC",
           "pkg" : 5,
           "children" : [ ]
         } ]
       }, {
-        "key" : 7,
+        "key" : 8,
         "linkage" : "DYNAMIC",
         "pkg" : 4,
         "children" : [ {
-          "key" : 8,
+          "key" : 9,
           "linkage" : "DYNAMIC",
           "pkg" : 3,
           "children" : [ ]
         } ]
       } ]
     } ]
-  }, {
-    "key" : 9,
-    "pkg" : 1,
-    "path_excludes" : [ 0 ],
-    "children" : [ ]
   } ],
   "rule_violation_resolutions" : [ {
     "_id" : 0,
@@ -669,7 +654,7 @@
     "_id" : 1,
     "rule" : "rule 2",
     "pkg" : 4,
-    "license" : 2,
+    "license" : 0,
     "license_source" : "DECLARED",
     "severity" : "HINT",
     "message" : "Apache-2.0 hint",

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -18,13 +18,13 @@ copyrights:
   statement: "Copyright (c) example authors."
 licenses:
 - _id: 0
-  id: "Apache-2.0 (multi-line)"
-- _id: 1
-  id: "Apache-2.0 (single-line)"
-- _id: 2
   id: "Apache-2.0"
-- _id: 3
+- _id: 1
   id: "MIT"
+- _id: 2
+  id: "Apache-2.0 (multi-line)"
+- _id: 3
+  id: "Apache-2.0 (single-line)"
 - _id: 4
   id: "Eclipse Public License 1.0"
 - _id: 5
@@ -67,21 +67,8 @@ scan_results:
   end_time: "1970-01-01T00:00:00Z"
   file_count: 0
   package_verification_code: ""
-  issues:
-  - 0
-- _id: 1
-  provenance:
-    download_time: "1970-01-01T00:00:00Z"
-  scanner:
-    name: "FakeScanner"
-    version: "1.0"
-    configuration: ""
-  start_time: "1970-01-01T00:00:00Z"
-  end_time: "1970-01-01T00:00:00Z"
-  file_count: 0
-  package_verification_code: ""
   issues: []
-- _id: 2
+- _id: 1
   provenance:
     download_time: "1970-01-01T00:00:00Z"
     source_artifact:
@@ -98,7 +85,7 @@ scan_results:
   file_count: 234
   package_verification_code: ""
   issues: []
-- _id: 3
+- _id: 2
   provenance:
     download_time: "1970-01-01T00:00:00Z"
     source_artifact:
@@ -115,7 +102,7 @@ scan_results:
   file_count: 168
   package_verification_code: ""
   issues: []
-- _id: 4
+- _id: 3
   provenance:
     download_time: "1970-01-01T00:00:00Z"
     source_artifact:
@@ -132,7 +119,7 @@ scan_results:
   file_count: 80
   package_verification_code: ""
   issues: []
-- _id: 5
+- _id: 4
   provenance:
     download_time: "1970-01-01T00:00:00Z"
     source_artifact:
@@ -161,8 +148,8 @@ packages:
     mapped_licenses: []
     unmapped_licenses: []
   detected_licenses:
-  - 0
-  - 1
+  - 2
+  - 3
   description: ""
   homepage_url: ""
   binary_artifact:
@@ -194,19 +181,19 @@ packages:
   - 0
   findings:
   - type: "LICENSE"
-    license: 0
+    license: 2
     path: "build.gradle"
     start_line: 19
     end_line: 20
     scan_result: 0
   - type: "LICENSE"
-    license: 1
+    license: 3
     path: "build.gradle"
     start_line: 19
     end_line: 19
     scan_result: 0
   - type: "LICENSE"
-    license: 1
+    license: 3
     path: "build.gradle"
     start_line: 20
     end_line: 20
@@ -226,10 +213,10 @@ packages:
     mapped_licenses: []
     unmapped_licenses: []
   detected_licenses:
-  - 2
-  - 3
+  - 0
+  - 1
   detected_excluded_licenses:
-  - 3
+  - 1
   description: ""
   homepage_url: ""
   binary_artifact:
@@ -258,52 +245,52 @@ packages:
   - 0
   scopes: []
   scan_results:
-  - 1
+  - 0
   findings:
   - type: "COPYRIGHT"
     copyright: 0
     path: "file.java"
     start_line: 1
     end_line: 1
-    scan_result: 1
+    scan_result: 0
     path_excludes:
     - 1
   - type: "LICENSE"
-    license: 2
+    license: 0
     path: "file.java"
     start_line: 1
     end_line: 2
-    scan_result: 1
+    scan_result: 0
     path_excludes:
     - 1
   - type: "LICENSE"
-    license: 2
+    license: 0
     path: "file.kt"
     start_line: 1
     end_line: 2
-    scan_result: 1
+    scan_result: 0
   - type: "COPYRIGHT"
     copyright: 0
     path: "file1.java"
     start_line: 1
     end_line: 1
-    scan_result: 1
+    scan_result: 0
     path_excludes:
     - 1
   - type: "LICENSE"
-    license: 3
+    license: 1
     path: "file1.java"
     start_line: 1
     end_line: 2
-    scan_result: 1
+    scan_result: 0
     path_excludes:
     - 1
   - type: "LICENSE"
-    license: 3
+    license: 1
     path: "file2.java"
     start_line: 1
     end_line: 2
-    scan_result: 1
+    scan_result: 0
     path_excludes:
     - 1
   is_excluded: true
@@ -355,7 +342,7 @@ packages:
   scopes:
   - 1
   scan_results:
-  - 2
+  - 1
   findings: []
   is_excluded: true
   path_excludes: []
@@ -372,7 +359,7 @@ packages:
   declared_licenses_processed:
     spdx_expression: "Apache-2.0"
     mapped_licenses:
-    - 2
+    - 0
     unmapped_licenses: []
   detected_licenses: []
   description: "Apache Commons Lang, a package of Java utility classes for the\n \
@@ -409,7 +396,7 @@ packages:
   - 0
   - 1
   scan_results:
-  - 3
+  - 2
   findings: []
   is_excluded: false
   path_excludes: []
@@ -425,7 +412,7 @@ packages:
   declared_licenses_processed:
     spdx_expression: "Apache-2.0"
     mapped_licenses:
-    - 2
+    - 0
     unmapped_licenses: []
   detected_licenses: []
   description: "Apache Commons Text is a library focused on algorithms working on\
@@ -461,7 +448,7 @@ packages:
   - 0
   - 1
   scan_results:
-  - 4
+  - 3
   findings: []
   is_excluded: false
   path_excludes: []
@@ -512,7 +499,7 @@ packages:
   scopes:
   - 1
   scan_results:
-  - 5
+  - 4
   findings: []
   is_excluded: true
   path_excludes: []
@@ -555,45 +542,45 @@ paths:
   - 2
 dependency_trees:
 - key: 0
-  pkg: 0
-  children:
-  - key: 1
-    scope: 0
-    children:
-    - key: 2
-      linkage: "DYNAMIC"
-      pkg: 4
-      children:
-      - key: 3
-        linkage: "DYNAMIC"
-        pkg: 3
-        children: []
-  - key: 4
-    scope: 1
-    scope_excludes:
-    - 0
-    children:
-    - key: 5
-      linkage: "DYNAMIC"
-      pkg: 2
-      children:
-      - key: 6
-        linkage: "DYNAMIC"
-        pkg: 5
-        children: []
-    - key: 7
-      linkage: "DYNAMIC"
-      pkg: 4
-      children:
-      - key: 8
-        linkage: "DYNAMIC"
-        pkg: 3
-        children: []
-- key: 9
   pkg: 1
   path_excludes:
   - 0
   children: []
+- key: 1
+  pkg: 0
+  children:
+  - key: 2
+    scope: 0
+    children:
+    - key: 3
+      linkage: "DYNAMIC"
+      pkg: 4
+      children:
+      - key: 4
+        linkage: "DYNAMIC"
+        pkg: 3
+        children: []
+  - key: 5
+    scope: 1
+    scope_excludes:
+    - 0
+    children:
+    - key: 6
+      linkage: "DYNAMIC"
+      pkg: 2
+      children:
+      - key: 7
+        linkage: "DYNAMIC"
+        pkg: 5
+        children: []
+    - key: 8
+      linkage: "DYNAMIC"
+      pkg: 4
+      children:
+      - key: 9
+        linkage: "DYNAMIC"
+        pkg: 3
+        children: []
 rule_violation_resolutions:
 - _id: 0
   message: "Apache-2.0 hint"
@@ -613,7 +600,7 @@ rule_violations:
 - _id: 1
   rule: "rule 2"
   pkg: 4
-  license: 2
+  license: 0
   license_source: "DECLARED"
   severity: "HINT"
   message: "Apache-2.0 hint"

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -434,11 +434,11 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
           <a href="#issue-summary">Issue Summary (1 errors, 0 warnings, 0 hints to resolve)</a>
         </li>
         <li>
-          <a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a>
-        </li>
-        <li>
           <a href="#Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0">Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0 <div class="ort-reason">Excluded: EXAMPLE_OF - The project is an example.</div>
           </a>
+        </li>
+        <li>
+          <a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a>
         </li>
         <li>
           <a href="#repository-configuration">Repository Configuration</a>
@@ -537,6 +537,53 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
                   <p></p>
                 </li>
               </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h2 id="Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0">Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0 (sub/module/project/build.gradle)</h2>
+      <h3>Project is Excluded</h3>
+      <p>The project is excluded for the following reason(s):</p>
+      <p>
+        <div class="ort-reason">EXAMPLE_OF - The project is an example.</div>
+      </p>
+      <h3 class="ort-excluded">VCS Information</h3>
+      <table class="ort-report-metadata ort-excluded">
+        <tbody>
+          <tr>
+            <td>Type</td><td>Git</td>
+          </tr>
+          <tr>
+            <td>URL</td><td>https://example.com/git</td>
+          </tr>
+          <tr>
+            <td>Path</td><td>project</td>
+          </tr>
+          <tr>
+            <td>Revision</td><td></td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 class="ort-excluded">Packages</h3>
+      <table class="ort-report-table ort-packages ort-excluded">
+        <thead>
+          <tr>
+            <th>#</th><th>Package</th><th>Scopes</th><th>Licenses</th><th>Analyzer Issues</th><th>Scanner Issues</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="ort-success " id="Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0-pkg-1">
+            <td><a href="#Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0-pkg-1">1</a></td><td>Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0</td><td></td><td><em>Detected Licenses:</em>
+              <dl>
+                <dd>
+                  <div>Apache-2.0</div>
+                  <div class="ort-excluded">MIT (Excluded: EXAMPLE_OF - These are example files.)</div>
+                </dd>
+              </dl>
+            </td><td>
+              <ul></ul>
+            </td><td>
+              <ul></ul>
             </td>
           </tr>
         </tbody>
@@ -651,53 +698,6 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
               <dl>
                 <dd>
                   <div>BSD-3-Clause</div>
-                </dd>
-              </dl>
-            </td><td>
-              <ul></ul>
-            </td><td>
-              <ul></ul>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <h2 id="Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0">Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0 (sub/module/project/build.gradle)</h2>
-      <h3>Project is Excluded</h3>
-      <p>The project is excluded for the following reason(s):</p>
-      <p>
-        <div class="ort-reason">EXAMPLE_OF - The project is an example.</div>
-      </p>
-      <h3 class="ort-excluded">VCS Information</h3>
-      <table class="ort-report-metadata ort-excluded">
-        <tbody>
-          <tr>
-            <td>Type</td><td>Git</td>
-          </tr>
-          <tr>
-            <td>URL</td><td>https://example.com/git</td>
-          </tr>
-          <tr>
-            <td>Path</td><td>project</td>
-          </tr>
-          <tr>
-            <td>Revision</td><td></td>
-          </tr>
-        </tbody>
-      </table>
-      <h3 class="ort-excluded">Packages</h3>
-      <table class="ort-report-table ort-packages ort-excluded">
-        <thead>
-          <tr>
-            <th>#</th><th>Package</th><th>Scopes</th><th>Licenses</th><th>Analyzer Issues</th><th>Scanner Issues</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr class="ort-success " id="Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0-pkg-1">
-            <td><a href="#Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0-pkg-1">1</a></td><td>Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0</td><td></td><td><em>Detected Licenses:</em>
-              <dl>
-                <dd>
-                  <div>Apache-2.0</div>
-                  <div class="ort-excluded">MIT (Excluded: EXAMPLE_OF - These are example files.)</div>
                 </dd>
               </dl>
             </td><td>


### PR DESCRIPTION
Instead of sorting projects by their full id, only sort by type, and
then by definition file depth / path. This causes root projects to
appear first in the result file, which makes using the id of the first
entry as part of the Jenkins build description (see 0366b45) more
meaningful.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>