### PR TITLE
(Path|Scope)Exclude: Make the comment optional

### DIFF
--- a/docs/config-file-ort-yml.md
+++ b/docs/config-file-ort-yml.md
@@ -42,7 +42,7 @@ To be able to show why a part is excluded, each exclude must include an explanat
 The explanation consists of:
 
 * `reason` -- must be selected from a predefined list of options.
-* `comment` -- free text that provides an additional explanation.
+* `comment` -- free text that provides an optional explanation.
 
 ### Excluding Paths
 

--- a/model/src/main/kotlin/config/PathExclude.kt
+++ b/model/src/main/kotlin/config/PathExclude.kt
@@ -19,6 +19,8 @@
 
 package org.ossreviewtoolkit.model.config
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
 import java.nio.file.FileSystems
 import java.nio.file.Paths
 
@@ -41,7 +43,8 @@ data class PathExclude(
     /**
      * A comment to further explain why the [reason] is applicable here.
      */
-    val comment: String
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val comment: String = ""
 ) {
     private val glob by lazy { FileSystems.getDefault().getPathMatcher("glob:$pattern") }
 

--- a/model/src/main/kotlin/config/ScopeExclude.kt
+++ b/model/src/main/kotlin/config/ScopeExclude.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.model.config
 
 import com.fasterxml.jackson.annotation.JsonAlias
+import com.fasterxml.jackson.annotation.JsonInclude
 
 /**
  * Defines a scope that should be excluded.
@@ -39,7 +40,8 @@ data class ScopeExclude(
     /**
      * A comment to further explain why the [reason] is applicable here.
      */
-    val comment: String
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val comment: String = ""
 ) {
     private val regex by lazy { Regex(pattern) }
 

--- a/reporter/src/main/kotlin/reporters/ExcelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ExcelReporter.kt
@@ -33,6 +33,7 @@ import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.SummaryTable
 import org.ossreviewtoolkit.reporter.utils.SCOPE_EXCLUDE_LIST_COMPARATOR
 import org.ossreviewtoolkit.reporter.utils.SCOPE_EXCLUDE_MAP_COMPARATOR
 import org.ossreviewtoolkit.utils.isValidUri
+import org.ossreviewtoolkit.utils.joinNonBlank
 
 import org.apache.poi.common.usermodel.HyperlinkType
 import org.apache.poi.ss.usermodel.BorderStyle
@@ -471,10 +472,4 @@ private fun RichTextString.limit(maxLength: Int = MAX_EXCEL_CELL_CONTENT_LENGTH)
 private fun String.limit(maxLength: Int = MAX_EXCEL_CELL_CONTENT_LENGTH) =
     takeIf { it.length <= maxLength } ?: "${take(maxLength - ELLIPSIS.length)}$ELLIPSIS"
 
-private val ScopeExclude.description: String get() =
-    buildString {
-        append(reason)
-        if (comment.isNotBlank()) {
-            append(" - ").append(comment)
-        }
-    }
+private val ScopeExclude.description: String get() = joinNonBlank(reason.toString(), comment)

--- a/reporter/src/main/kotlin/reporters/ExcelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ExcelReporter.kt
@@ -25,6 +25,7 @@ import java.io.OutputStream
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.ProjectTable
@@ -228,7 +229,7 @@ class ExcelReporter : Reporter {
 
                         excludes.forEach { exclude ->
                             scopesText.append(
-                                "    Excluded: ${exclude.reason} - ${exclude.comment}\n",
+                                "    Excluded: ${exclude.description}\n",
                                 excludedFont
                             )
                         }
@@ -313,7 +314,7 @@ class ExcelReporter : Reporter {
                     scopesText.append("$scope\n", if (excludes.isNotEmpty()) excludedFont else font)
 
                     excludes.forEach { exclude ->
-                        scopesText.append("  Excluded: ${exclude.reason} - ${exclude.comment}\n", excludedFont)
+                        scopesText.append("  Excluded: ${exclude.description}\n", excludedFont)
                     }
                 }
 
@@ -469,3 +470,11 @@ private fun RichTextString.limit(maxLength: Int = MAX_EXCEL_CELL_CONTENT_LENGTH)
 
 private fun String.limit(maxLength: Int = MAX_EXCEL_CELL_CONTENT_LENGTH) =
     takeIf { it.length <= maxLength } ?: "${take(maxLength - ELLIPSIS.length)}$ELLIPSIS"
+
+private val ScopeExclude.description: String get() =
+    buildString {
+        append(reason)
+        if (comment.isNotBlank()) {
+            append(" - ").append(comment)
+        }
+    }

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -37,6 +37,7 @@ import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.ResolvableIssue
 import org.ossreviewtoolkit.reporter.utils.SCOPE_EXCLUDE_LIST_COMPARATOR
 import org.ossreviewtoolkit.utils.ORT_FULL_NAME
 import org.ossreviewtoolkit.utils.isValidUrl
+import org.ossreviewtoolkit.utils.joinNonBlank
 import org.ossreviewtoolkit.utils.normalizeLineBreaks
 
 import com.vladsch.flexmark.html.HtmlRenderer
@@ -208,21 +209,9 @@ class StaticHtmlReporter : Reporter {
         }
     }
 
-    private val PathExclude.description: String get() =
-        buildString {
-            append(reason)
-            if (comment.isNotBlank()) {
-                append(" - ").append(comment)
-            }
-        }
+    private val PathExclude.description: String get() = joinNonBlank(reason.toString(), comment)
 
-    private val ScopeExclude.description: String get() =
-        buildString {
-            append(reason)
-            if (comment.isNotBlank()) {
-                append(" - ").append(comment)
-            }
-        }
+    private val ScopeExclude.description: String get() = joinNonBlank(reason.toString(), comment)
 
     private fun DIV.evaluatorTable(ruleViolations: List<ReportTableModel.ResolvableViolation>) {
         val issues = ruleViolations.filterNot { it.isResolved }.groupBy { it.violation.severity }

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -38,6 +38,7 @@ import org.ossreviewtoolkit.reporter.utils.SCOPE_EXCLUDE_LIST_COMPARATOR
 import org.ossreviewtoolkit.utils.ORT_FULL_NAME
 import org.ossreviewtoolkit.utils.isValidUrl
 import org.ossreviewtoolkit.utils.normalizeLineBreaks
+
 import com.vladsch.flexmark.html.HtmlRenderer
 import com.vladsch.flexmark.parser.Parser
 

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -25,6 +25,8 @@ import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.config.PathExclude
+import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.reporter.Reporter
@@ -190,7 +192,7 @@ class StaticHtmlReporter : Reporter {
                         if (projectTable.isExcluded()) {
                             projectTable.pathExcludes.forEach { exclude ->
                                 +" "
-                                div("ort-reason") { +"Excluded: ${exclude.reason} - ${exclude.comment}" }
+                                div("ort-reason") { +"Excluded: ${exclude.description}" }
                             }
                         }
                     }
@@ -204,6 +206,22 @@ class StaticHtmlReporter : Reporter {
             }
         }
     }
+
+    private val PathExclude.description: String get() =
+        buildString {
+            append(reason)
+            if (comment.isNotBlank()) {
+                append(" - ").append(comment)
+            }
+        }
+
+    private val ScopeExclude.description: String get() =
+        buildString {
+            append(reason)
+            if (comment.isNotBlank()) {
+                append(" - ").append(comment)
+            }
+        }
 
     private fun DIV.evaluatorTable(ruleViolations: List<ReportTableModel.ResolvableViolation>) {
         val issues = ruleViolations.filterNot { it.isResolved }.groupBy { it.violation.severity }
@@ -389,7 +407,7 @@ class StaticHtmlReporter : Reporter {
 
         table.pathExcludes.forEach { exclude ->
             p {
-                div("ort-reason") { +"${exclude.reason} - ${exclude.comment}" }
+                div("ort-reason") { +exclude.description }
             }
         }
 
@@ -476,7 +494,7 @@ class StaticHtmlReporter : Reporter {
                                     +" "
                                     div("ort-reason") {
                                         +"Excluded: "
-                                        +it.value.joinToString { "${it.reason} - ${it.comment}" }
+                                        +it.value.joinToString { "${it.description}" }
                                     }
                                 }
                             }
@@ -570,7 +588,7 @@ class StaticHtmlReporter : Reporter {
                                 } else {
                                     div("ort-excluded") {
                                         +"${finding.license} (Excluded: "
-                                        +excludes.joinToString { "${it.reason} - ${it.comment}" }
+                                        +excludes.joinToString { it.description }
                                         +")"
                                     }
                                 }

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -222,6 +222,12 @@ fun getOrtDataDirectory() =
     } ?: getUserHomeDirectory().resolve(".ort")
 
 /**
+ * Return the concatenated [strings] separated by [separator] whereas blank strings are omitted.
+ */
+fun joinNonBlank(vararg strings: String, separator: String = " - ") =
+    strings.filter { it.isNotBlank() }.joinToString(separator)
+
+/**
  * Normalize a string representing a [VCS URL][vcsUrl] to a common string form.
  */
 fun normalizeVcsUrl(vcsUrl: String): String {


### PR DESCRIPTION
Path and scope excludes can now be de-serialized also if no comment is
provided, which improves usability for cases in which no comment is
needed. Empty comments are not serialized anymore.

Signed-off-by: Frank Viernau <frank.viernau@here.com>