### PR TITLE
Jenkinsfile: Sort projects to make the root project the first

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -209,8 +209,15 @@ pipeline {
                 script {
                     try {
                         def result = readYaml file: 'analyzer/out/results/analyzer-result.yml'
-                        def rootProjectId = result.analyzer?.result?.projects?.getAt(0)?.id
-                        if (rootProjectId) {
+                        def projects = result.analyzer?.result?.projects
+
+                        if (projects) {
+                            // Determine the / a root project simply by sorting by path depth.
+                            def sortedProjects = projects.toSorted { it.definition_file_path.count("/") }
+
+                            // There is always at least one (unmanaged) project.
+                            def rootProjectId = sortedProjects.first().id
+
                             currentBuild.displayName += ": $rootProjectId"
                         }
                     } catch (IOException e) {


### PR DESCRIPTION
This makes using the id of the first project for the build description
(see 0366b45) more meaningful.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>