### PR TITLE
Reporter: Factor out the exclude description extension properties

### DIFF
--- a/reporter/src/main/kotlin/Reporter.kt
+++ b/reporter/src/main/kotlin/Reporter.kt
@@ -22,6 +22,9 @@ package org.ossreviewtoolkit.reporter
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.ScanRecord
+import org.ossreviewtoolkit.model.config.PathExclude
+import org.ossreviewtoolkit.model.config.ScopeExclude
+import org.ossreviewtoolkit.utils.joinNonBlank
 
 import java.io.OutputStream
 import java.util.ServiceLoader
@@ -56,3 +59,7 @@ interface Reporter {
      */
     fun generateReport(outputStream: OutputStream, input: ReporterInput)
 }
+
+internal val PathExclude.description: String get() = joinNonBlank(reason.toString(), comment)
+
+internal val ScopeExclude.description: String get() = joinNonBlank(reason.toString(), comment)

--- a/reporter/src/main/kotlin/reporters/ExcelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ExcelReporter.kt
@@ -25,15 +25,14 @@ import java.io.OutputStream
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.VcsInfo
-import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
+import org.ossreviewtoolkit.reporter.description
 import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.ProjectTable
 import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.SummaryTable
 import org.ossreviewtoolkit.reporter.utils.SCOPE_EXCLUDE_LIST_COMPARATOR
 import org.ossreviewtoolkit.reporter.utils.SCOPE_EXCLUDE_MAP_COMPARATOR
 import org.ossreviewtoolkit.utils.isValidUri
-import org.ossreviewtoolkit.utils.joinNonBlank
 
 import org.apache.poi.common.usermodel.HyperlinkType
 import org.apache.poi.ss.usermodel.BorderStyle
@@ -471,5 +470,3 @@ private fun RichTextString.limit(maxLength: Int = MAX_EXCEL_CELL_CONTENT_LENGTH)
 
 private fun String.limit(maxLength: Int = MAX_EXCEL_CELL_CONTENT_LENGTH) =
     takeIf { it.length <= maxLength } ?: "${take(maxLength - ELLIPSIS.length)}$ELLIPSIS"
-
-private val ScopeExclude.description: String get() = joinNonBlank(reason.toString(), comment)

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -25,19 +25,17 @@ import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.VcsInfo
-import org.ossreviewtoolkit.model.config.PathExclude
-import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
+import org.ossreviewtoolkit.reporter.description
 import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.IssueTable
 import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.ProjectTable
 import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.ResolvableIssue
 import org.ossreviewtoolkit.reporter.utils.SCOPE_EXCLUDE_LIST_COMPARATOR
 import org.ossreviewtoolkit.utils.ORT_FULL_NAME
 import org.ossreviewtoolkit.utils.isValidUrl
-import org.ossreviewtoolkit.utils.joinNonBlank
 import org.ossreviewtoolkit.utils.normalizeLineBreaks
 
 import com.vladsch.flexmark.html.HtmlRenderer
@@ -208,10 +206,6 @@ class StaticHtmlReporter : Reporter {
             }
         }
     }
-
-    private val PathExclude.description: String get() = joinNonBlank(reason.toString(), comment)
-
-    private val ScopeExclude.description: String get() = joinNonBlank(reason.toString(), comment)
 
     private fun DIV.evaluatorTable(ruleViolations: List<ReportTableModel.ResolvableViolation>) {
         val issues = ruleViolations.filterNot { it.isResolved }.groupBy { it.violation.severity }


### PR DESCRIPTION
Move the functions to the Reporter interface and thus de-duplicate one of
them.

Signed-off-by: Frank Viernau <frank.viernau@here.com>