### PR TITLE
docs: Fix evaluator output to point to a directory, not to a file

### DIFF
--- a/docs/config-file-curations-yml.md
+++ b/docs/config-file-curations-yml.md
@@ -81,7 +81,7 @@ _evaluator_:
 ```bash
 cli/build/install/ort/bin/ort evaluate
   -i [scanner-output-path]/scan-result.yml
-  -o [evaluator-output-path]/evaluator-result.yml
+  -o [evaluator-output-path]
   --output-formats YAML
   --license-configuration-file [ort-configuration-path]/licenses.yml
   --package-curations-file [ort-configuration-path]/curations.yml

--- a/docs/config-file-licenses-yml.md
+++ b/docs/config-file-licenses-yml.md
@@ -18,7 +18,7 @@ To use the `licenses.yml` file pass it to the `--license-configuration-file` opt
 ```bash
 cli/build/install/ort/bin/ort evaluate
   -i [scanner-output-path]/scan-result.yml
-  -o [evaluator-output-path]/evaluator-result.yml
+  -o [evaluator-output-path]
   --output-formats YAML
   --license-configuration-file [ort-configuration-path]/licenses.yml
   --package-curations-file [ort-configuration-path]/curations.yml

--- a/docs/config-file-package-configuration-yml.md
+++ b/docs/config-file-package-configuration-yml.md
@@ -72,7 +72,7 @@ To use a directory with configuration files for each *package id*, pass it to th
 ```bash
 cli/build/install/ort/bin/ort evaluate
   -i [scanner-output-path]/scan-result.yml
-  -o [evaluator-output-path]/evaluator-result.yml
+  -o [evaluator-output-path]
   --output-formats YAML
   --license-configuration-file [ort-configuration-path]/licenses.yml
   --package-curations-file [ort-configuration-path]/curations.yml
@@ -98,7 +98,7 @@ To use a single package configuration `.yml` file, pass it to the `--package-con
 ```bash
 cli/build/install/ort/bin/ort evaluate
   -i [scanner-output-path]/scan-result.yml
-  -o [evaluator-output-path]/evaluator-result.yml
+  -o [evaluator-output-path]
   --output-formats YAML
   --license-configuration-file [ort-configuration-path]/licenses.yml
   --package-curations-file [ort-configuration-path]/curations.yml

--- a/docs/file-rules-kts.md
+++ b/docs/file-rules-kts.md
@@ -17,7 +17,7 @@ To use the `rules.kts` file pass it to the `--rules-file` option of the _evaluat
 ```bash
 cli/build/install/ort/bin/ort evaluate \
   -i [scanner-output-path]/scan-result.yml
-  -o [evaluator-output-path]/evaluator-result.yml \
+  -o [evaluator-output-path] \
   --output-formats YAML \
   --license-configuration-file [ort-configuration-path]/licenses.yml \
   --package-curations-file [ort-configuration-path]/curations.yml  \


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>