### PR TITLE
scanner: Improve logging when reading scan results

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -171,32 +171,35 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
 
                     async {
                         val result = try {
-                            log.info { "Queueing scan of '${pkg.id.toCoordinates()}' $packageIndex." }
-
                             val storedResults = withContext(storageDispatcher) {
                                 log.info {
-                                    "Trying to read stored scan results for ${pkg.id.toCoordinates()} in thread " +
-                                            "'${Thread.currentThread().name}' $packageIndex."
+                                    "Looking for stored scan results for ${pkg.id.toCoordinates()} and " +
+                                            "$scannerDetails $packageIndex."
                                 }
 
                                 readFromStorage(scannerDetails, pkg, outputDirectory)
                             }
 
                             if (storedResults.isNotEmpty()) {
-                                log.info { "Using stored scan result(s) for ${pkg.id.toCoordinates()} $packageIndex." }
+                                log.info {
+                                    "Found ${storedResults.size} stored scan result(s) for ${pkg.id.toCoordinates()} " +
+                                            "and $scannerDetails, not scanning the package again $packageIndex."
+                                }
 
                                 storedResults
                             } else {
                                 withContext(scanDispatcher) {
                                     log.info {
-                                        "No stored results found, scanning package ${pkg.id.toCoordinates()} in " +
-                                                "thread '${Thread.currentThread().name}' $packageIndex."
+                                        "No stored result found for ${pkg.id.toCoordinates()} and $scannerDetails, " +
+                                                "scanning package in thread '${Thread.currentThread().name}' " +
+                                                "$packageIndex."
                                     }
 
                                     listOf(
                                         scanPackage(scannerDetails, pkg, outputDirectory, downloadDirectory).also {
                                             log.info {
-                                                "Finished scanning ${pkg.id.toCoordinates()} $packageIndex."
+                                                "Finished scanning ${pkg.id.toCoordinates()} in thread " +
+                                                        "'${Thread.currentThread().name}' $packageIndex."
                                             }
                                         }
                                     )

--- a/scanner/src/main/kotlin/storages/FileBasedStorage.kt
+++ b/scanner/src/main/kotlin/storages/FileBasedStorage.kt
@@ -89,7 +89,7 @@ class FileBasedStorage(
         // Only keep scan results whose provenance information matches the package information.
         scanResults.retainAll { it.provenance.matches(pkg) }
         if (scanResults.isEmpty()) {
-            log.info {
+            log.debug {
                 "No stored scan results found for $pkg. The following entries with non-matching provenance have " +
                         "been ignored: ${scanResults.map { it.provenance }}"
             }
@@ -99,16 +99,11 @@ class FileBasedStorage(
         // Only keep scan results from compatible scanners.
         scanResults.retainAll { scannerDetails.isCompatible(it.scanner) }
         if (scanResults.isEmpty()) {
-            log.info {
+            log.debug {
                 "No stored scan results found for $scannerDetails. The following entries with incompatible scanners " +
                         "have been ignored: ${scanResults.map { it.scanner }}"
             }
             return Success(ScanResultContainer(pkg.id, scanResults))
-        }
-
-        log.info {
-            "Found ${scanResults.size} stored scan result(s) for ${pkg.id.toCoordinates()} that are compatible with " +
-                    "$scannerDetails."
         }
 
         return Success(ScanResultContainer(pkg.id, scanResults))
@@ -129,7 +124,7 @@ class FileBasedStorage(
         @Suppress("TooGenericExceptionCaught")
         return try {
             backend.write(path, input)
-            log.info { "Stored scan result for '${id.toCoordinates()}' at path '$path'." }
+            log.debug { "Stored scan result for '${id.toCoordinates()}' at path '$path'." }
             Success(Unit)
         } catch (e: Exception) {
             when (e) {
@@ -138,7 +133,7 @@ class FileBasedStorage(
 
                     val message = "Could not store scan result for '${id.toCoordinates()}' at path '$path': " +
                             e.collectMessagesAsString()
-                    log.info { message }
+                    log.warn { message }
 
                     Failure(message)
                 }


### PR DESCRIPTION
Remove log statements of little value, improve the wording of log
messages, prefer to log only once in the caller, and adjust log levels
where sensible.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>