### PR TITLE
PackageConfiguration: Fix-up VcsMatcher.matches()

### DIFF
--- a/model/src/main/kotlin/config/PackageConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageConfiguration.kt
@@ -89,5 +89,6 @@ data class VcsMatcher(
         require(url.isNotBlank() && revision.isNotBlank())
     }
 
-    fun matches(vcsInfo: VcsInfo): Boolean = type == vcsInfo.type && url == vcsInfo.url && revision == vcsInfo.revision
+    fun matches(vcsInfo: VcsInfo): Boolean =
+        type == vcsInfo.type && url == vcsInfo.url && revision == vcsInfo.resolvedRevision
 }

--- a/model/src/test/kotlin/utils/LicenseResolverTest.kt
+++ b/model/src/test/kotlin/utils/LicenseResolverTest.kt
@@ -194,7 +194,7 @@ class LicenseResolverTest : WordSpec() {
 
     private fun setupPackage(): Package {
         val id = nextId.getAndIncrement().toString()
-        val vcsInfo = VcsInfo(type = VcsType.GIT, url = "ssh://some-host/$id.git", revision = id)
+        val vcsInfo = VcsInfo(type = VcsType.GIT, url = "ssh://some-host/$id.git", revision = id, resolvedRevision = id)
         val pkg = Package.EMPTY.copy(
             id = Identifier(id),
             sourceArtifact = RemoteArtifact("http://some-host/$id", Hash.NONE),

--- a/model/src/test/kotlin/utils/LicenseResolverTest.kt
+++ b/model/src/test/kotlin/utils/LicenseResolverTest.kt
@@ -194,7 +194,7 @@ class LicenseResolverTest : WordSpec() {
 
     private fun setupPackage(): Package {
         val id = nextId.getAndIncrement().toString()
-        val vcsInfo = VcsInfo(type = VcsType.GIT, url = "ssh://some-host/$id.git", revision = id, path = "")
+        val vcsInfo = VcsInfo(type = VcsType.GIT, url = "ssh://some-host/$id.git", revision = id)
         val pkg = Package.EMPTY.copy(
             id = Identifier(id),
             sourceArtifact = RemoteArtifact("http://some-host/$id", Hash.NONE),


### PR DESCRIPTION
One has to compare against `resolvedRevision` as just `revision` may be
a moving target, e.g. reference a branch head.

Signed-off-by: Frank Viernau <frank.viernau@here.com>