### PR TITLE
tests: Turn forEach() into forAll() where applicable

### DIFF
--- a/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
+++ b/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
@@ -40,6 +40,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.inspectors.forAll
 
 import java.io.File
 
@@ -101,7 +102,7 @@ abstract class AbstractIntegrationSpec : StringSpec() {
             val managedFiles = PackageManager.findManagedFiles(downloadResult.downloadDirectory)
 
             managedFiles.size shouldBe expectedManagedFiles.size
-            managedFiles.forEach { (manager, files) ->
+            managedFiles.entries.forAll { (manager, files) ->
                 println("Verifying definition files for $manager.")
 
                 // The keys in expected and actual maps of definition files are different instances of package manager
@@ -117,13 +118,13 @@ abstract class AbstractIntegrationSpec : StringSpec() {
         }
 
         "Analyzer creates one non-empty result per definition file".config(tags = setOf(ExpensiveTag)) {
-            managedFilesForTest.forEach { (manager, files) ->
+            managedFilesForTest.entries.forAll { (manager, files) ->
                 println("Resolving $manager dependencies in $files.")
                 val results = manager.create(USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(files)
 
                 results.size shouldBe files.size
-                results.values.forEach { result ->
+                results.values.forAll { result ->
                     VersionControlSystem.forType(result.project.vcsProcessed.type) shouldBe
                             VersionControlSystem.forType(pkg.vcs.type)
                     result.project.vcsProcessed.url shouldBe pkg.vcs.url

--- a/analyzer/src/test/kotlin/managers/utils/NodeSupportTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/NodeSupportTest.kt
@@ -31,6 +31,7 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.inspectors.forAll
 
 import java.io.File
 
@@ -169,7 +170,7 @@ class NodeSupportTest : WordSpec() {
                             to "https://gitlab.com/another/repo.git"
                 )
 
-                packages.forEach { (actualUrl, expectedUrl) ->
+                packages.entries.forAll { (actualUrl, expectedUrl) ->
                     expandNpmShortcutURL(actualUrl) shouldBe expectedUrl
                 }
             }
@@ -184,7 +185,7 @@ class NodeSupportTest : WordSpec() {
                             to "github.com/improbable-eng/grpc-web"
                 )
 
-                packages.forEach { (actualUrl, expectedUrl) ->
+                packages.entries.forAll { (actualUrl, expectedUrl) ->
                     expandNpmShortcutURL(actualUrl) shouldBe expectedUrl
                 }
             }

--- a/model/src/test/kotlin/IdentifierTest.kt
+++ b/model/src/test/kotlin/IdentifierTest.kt
@@ -27,6 +27,7 @@ import io.kotest.matchers.string.shouldNotStartWith
 import io.kotest.matchers.string.shouldStartWith
 import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.inspectors.forAll
 
 class IdentifierTest : WordSpec({
     "String representations" should {
@@ -42,7 +43,7 @@ class IdentifierTest : WordSpec({
                         to "manager::name:version"
             )
 
-            mapping.forEach { (identifier, stringRepresentation) ->
+            mapping.entries.forAll { (identifier, stringRepresentation) ->
                 identifier.toCoordinates() shouldBe stringRepresentation
             }
         }
@@ -59,7 +60,7 @@ class IdentifierTest : WordSpec({
                         to Identifier("manager", "", "name", "version")
             )
 
-            mapping.forEach { (stringRepresentation, identifier) ->
+            mapping.entries.forAll { (stringRepresentation, identifier) ->
                 Identifier(stringRepresentation) shouldBe identifier
             }
         }

--- a/scanner/src/funTest/kotlin/scanners/AbstractScannerTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/AbstractScannerTest.kt
@@ -32,6 +32,7 @@ import io.kotest.matchers.file.shouldNotStartWithPath
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.inspectors.forAll
 
 import java.io.File
 import java.util.TreeSet
@@ -82,7 +83,7 @@ abstract class AbstractScannerTest(testTags: Set<Tag> = emptySet()) : StringSpec
             summary shouldNotBe null
             summary!!.fileCount shouldBe 1
             summary.licenses shouldBe expectedFileLicenses
-            summary.licenseFindings.forEach {
+            summary.licenseFindings.forAll {
                 File(it.location.path) shouldNotStartWithPath inputDir
             }
         }
@@ -94,7 +95,7 @@ abstract class AbstractScannerTest(testTags: Set<Tag> = emptySet()) : StringSpec
             summary shouldNotBe null
             summary!!.fileCount shouldBe commonlyDetectedFiles.size
             summary.licenses shouldBe expectedDirectoryLicenses
-            summary.licenseFindings.forEach {
+            summary.licenseFindings.forAll {
                 File(it.location.path) shouldNotStartWithPath inputDir
             }
         }

--- a/utils/src/test/kotlin/DeclaredLicenseProcessorTest.kt
+++ b/utils/src/test/kotlin/DeclaredLicenseProcessorTest.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.utils
 
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -40,7 +41,7 @@ class DeclaredLicenseProcessorTest : StringSpec() {
 
     init {
         "Declared licenses can be processed" {
-            declaredLicenses.forEach { declaredLicense ->
+            declaredLicenses.forAll { declaredLicense ->
                 val processedLicense = DeclaredLicenseProcessor.process(declaredLicense)
 
                 // Include the declared license in the comparison to see where a failure comes from.
@@ -59,7 +60,7 @@ class DeclaredLicenseProcessorTest : StringSpec() {
         }
 
         "Licenses are not mapped to deprecated SPDX licenses" {
-            declaredLicenses.forEach { declaredLicense ->
+            declaredLicenses.forAll { declaredLicense ->
                 val processedLicense = DeclaredLicenseProcessor.process(declaredLicense)
 
                 processedLicense shouldNotBe null

--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.utils
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.inspectors.forAll
 
 import java.io.File
 import java.nio.file.Paths
@@ -261,7 +262,7 @@ class UtilsTest : WordSpec({
                         to "https://github.com/DefinitelyTyped/DefinitelyTyped.git"
             )
 
-            packages.forEach { (actualUrl, expectedUrl) ->
+            packages.entries.forAll { (actualUrl, expectedUrl) ->
                 normalizeVcsUrl(actualUrl) shouldBe expectedUrl
             }
         }
@@ -276,7 +277,7 @@ class UtilsTest : WordSpec({
                         to "ssh://user@gerrit.server.com:29418/parent/project"
             )
 
-            packages.forEach { (actualUrl, expectedUrl) ->
+            packages.entries.forAll { (actualUrl, expectedUrl) ->
                 normalizeVcsUrl(actualUrl) shouldBe expectedUrl
             }
         }
@@ -287,7 +288,7 @@ class UtilsTest : WordSpec({
                         to "https://github.com/leanovate/play-mockws.git"
             )
 
-            packages.forEach { (actualUrl, expectedUrl) ->
+            packages.entries.forAll { (actualUrl, expectedUrl) ->
                 normalizeVcsUrl(actualUrl) shouldBe expectedUrl
             }
         }
@@ -300,7 +301,7 @@ class UtilsTest : WordSpec({
                         to "https://github.com/isaacs/inherits.git"
             )
 
-            packages.forEach { (actualUrl, expectedUrl) ->
+            packages.entries.forAll { (actualUrl, expectedUrl) ->
                 normalizeVcsUrl(actualUrl) shouldBe expectedUrl
             }
         }
@@ -313,7 +314,7 @@ class UtilsTest : WordSpec({
                         to "ssh://git@github.com/heremaps/here-aaa-java-sdk.git"
             )
 
-            packages.forEach { (actualUrl, expectedUrl) ->
+            packages.entries.forAll { (actualUrl, expectedUrl) ->
                 normalizeVcsUrl(actualUrl) shouldBe expectedUrl
             }
         }
@@ -326,7 +327,7 @@ class UtilsTest : WordSpec({
                         to "https://github.com/isaacs/inherits.git"
             )
 
-            packages.forEach { (actualUrl, expectedUrl) ->
+            packages.entries.forAll { (actualUrl, expectedUrl) ->
                 normalizeVcsUrl(actualUrl) shouldBe expectedUrl
             }
         }
@@ -354,7 +355,7 @@ class UtilsTest : WordSpec({
                         to "file://${userRoot}absolute/path/to/local/dir"
             )
 
-            packages.forEach { (actualUrl, expectedUrl) ->
+            packages.entries.forAll { (actualUrl, expectedUrl) ->
                 normalizeVcsUrl(actualUrl) shouldBe expectedUrl
             }
         }
@@ -367,7 +368,7 @@ class UtilsTest : WordSpec({
                         to "https://github.com/netty/netty.git/netty-buffer"
             )
 
-            packages.forEach { (actualUrl, expectedUrl) ->
+            packages.entries.forAll { (actualUrl, expectedUrl) ->
                 normalizeVcsUrl(actualUrl) shouldBe expectedUrl
             }
         }
@@ -378,7 +379,7 @@ class UtilsTest : WordSpec({
                         to "svn+ssh://svn.code.sf.net/p/stddecimal/code/trunk"
             )
 
-            packages.forEach { (actualUrl, expectedUrl) ->
+            packages.entries.forAll { (actualUrl, expectedUrl) ->
                 normalizeVcsUrl(actualUrl) shouldBe expectedUrl
             }
         }
@@ -391,7 +392,7 @@ class UtilsTest : WordSpec({
                         to "https://github.com/hacksparrow/node-easyimage.git"
             )
 
-            packages.forEach { (actualUrl, expectedUrl) ->
+            packages.entries.forAll { (actualUrl, expectedUrl) ->
                 normalizeVcsUrl(actualUrl) shouldBe expectedUrl
             }
         }


### PR DESCRIPTION
This leads to nicer output in case of assertion failures and ensures
that the loops are continued in case an assertion fails inside of the
loop.

Signed-off-by: Frank Viernau <frank.viernau@here.com>