### PR TITLE
reporter-web-app: Remove unprocessed licenses from Summary

### DIFF
--- a/reporter-web-app/src/components/SummaryView.js
+++ b/reporter-web-app/src/components/SummaryView.js
@@ -32,12 +32,12 @@ import LicenseStatsTable from './LicenseStatsTable';
 import RuleViolationsTable from './RuleViolationsTable';
 import {
     getOrtResult,
-    getSummaryDeclaredLicenses,
-    getSummaryDeclaredLicensesChart,
-    getSummaryDeclaredLicensesFilter,
-    getSummaryDetectedLicenses,
-    getSummaryDetectedLicensesChart,
-    getSummaryDetectedLicensesFilter,
+    getSummaryDeclaredLicensesProcessed,
+    getSummaryDeclaredLicensesProcessedChart,
+    getSummaryDeclaredLicensesProcessedFilter,
+    getSummaryDetectedLicensesProcessed,
+    getSummaryDetectedLicensesProcessedChart,
+    getSummaryDetectedLicensesProcessedFilter,
     getSummaryIssuesFilter,
     getSummaryRuleViolationsFilter,
     getSummaryViewShouldComponentUpdate
@@ -65,8 +65,8 @@ class SummaryView extends React.Component {
         store.dispatch({
             type: 'SUMMARY::CHANGE_DETECTED_LICENSES_TABLE',
             payload: {
-                detectedLicensesChart: extra.currentDataSource,
-                detectedLicensesFilter: {
+                detectedLicensesProcessedChart: extra.currentDataSource,
+                detectedLicensesProcessedFilter: {
                     filteredInfo: filters,
                     sortedInfo: sorter
                 }
@@ -103,20 +103,20 @@ class SummaryView extends React.Component {
 
     render() {
         const {
-            declaredLicensesChart,
-            declaredLicensesFilter,
-            declaredLicenseStats,
-            detectedLicensesChart,
-            detectedLicensesFilter,
-            detectedLicensesStats,
+            declaredLicensesProcessedChart,
+            declaredLicensesProcessedFilter,
+            declaredLicenseProcessedStats,
+            detectedLicensesProcessedChart,
+            detectedLicensesProcessedFilter,
+            detectedLicensesProcessedStats,
             issuesFilter,
             ruleViolationsFilter,
             webAppOrtResult
         } = this.props;
 
         const {
-            declaredLicenses,
-            detectedLicenses,
+            declaredLicensesProcessed,
+            detectedLicensesProcessed,
             issues,
             levels,
             packages,
@@ -200,14 +200,14 @@ class SummaryView extends React.Component {
                             </Item>
                             <Item>
                                 {
-                                    detectedLicenses.length === 0
+                                    detectedLicensesProcessed.length === 0
                                     && (
                                         <span>
                                             {' '}
                                             Detected
                                             {' '}
                                             <b>
-                                                {declaredLicenses.length}
+                                                {declaredLicensesProcessed.length}
                                             </b>
                                             {' '}
                                             declared licenses
@@ -215,19 +215,19 @@ class SummaryView extends React.Component {
                                     )
                                 }
                                 {
-                                    detectedLicenses.length !== 0
+                                    detectedLicensesProcessed.length !== 0
                                     && (
                                         <span>
                                             Detected
                                             {' '}
                                             <b>
-                                                {detectedLicenses.length}
+                                                {detectedLicensesProcessed.length}
                                             </b>
                                             {' '}
                                             licenses and
                                             {' '}
                                             <b>
-                                                {declaredLicenses.length}
+                                                {declaredLicensesProcessed.length}
                                             </b>
                                             {' '}
                                             declared licenses
@@ -394,13 +394,13 @@ class SummaryView extends React.Component {
                                         )
                                     }
                                     {
-                                        webAppOrtResult.hasDeclaredLicenses()
+                                        webAppOrtResult.hasDeclaredLicensesProcessed()
                                         && (
                                             <TabPane
                                                 tab={(
                                                     <span>
                                                         Declared Licenses (
-                                                        {declaredLicenses.length}
+                                                        {declaredLicensesProcessed.length}
                                                         )
                                                     </span>
                                                 )}
@@ -410,29 +410,29 @@ class SummaryView extends React.Component {
                                                     <Col xs={24} sm={24} md={24} lg={24} xl={9}>
                                                         <LicenseStatsTable
                                                             emptyText="No declared licenses"
-                                                            filter={declaredLicensesFilter}
-                                                            licenses={declaredLicenses}
-                                                            licenseStats={declaredLicenseStats}
+                                                            filter={declaredLicensesProcessedFilter}
+                                                            licenses={declaredLicensesProcessed}
+                                                            licenseStats={declaredLicenseProcessedStats}
                                                             onChange={
                                                                 SummaryView.onChangeDeclaredLicensesTable
                                                             }
                                                         />
                                                     </Col>
                                                     <Col xs={24} sm={24} md={24} lg={24} xl={15}>
-                                                        <LicenseChart licenses={declaredLicensesChart} />
+                                                        <LicenseChart licenses={declaredLicensesProcessedChart} />
                                                     </Col>
                                                 </Row>
                                             </TabPane>
                                         )
                                     }
                                     {
-                                        webAppOrtResult.hasDetectedLicenses()
+                                        webAppOrtResult.hasDetectedLicensesProcessed()
                                         && (
                                             <TabPane
                                                 tab={(
                                                     <span>
                                                         Detected Licenses (
-                                                        {detectedLicenses.length}
+                                                        {detectedLicensesProcessed.length}
                                                         )
                                                     </span>
                                                 )}
@@ -442,14 +442,14 @@ class SummaryView extends React.Component {
                                                     <Col xs={24} sm={24} md={24} lg={24} xl={9}>
                                                         <LicenseStatsTable
                                                             emptyText="No detected licenses"
-                                                            filter={detectedLicensesFilter}
-                                                            licenses={detectedLicenses}
-                                                            licenseStats={detectedLicensesStats}
+                                                            filter={detectedLicensesProcessedFilter}
+                                                            licenses={detectedLicensesProcessed}
+                                                            licenseStats={detectedLicensesProcessedStats}
                                                             onChange={SummaryView.onChangeDetectedLicensesTable}
                                                         />
                                                     </Col>
                                                     <Col xs={24} sm={24} md={24} lg={24} xl={15}>
-                                                        <LicenseChart licenses={detectedLicensesChart} />
+                                                        <LicenseChart licenses={detectedLicensesProcessedChart} />
                                                     </Col>
                                                 </Row>
                                             </TabPane>
@@ -466,12 +466,12 @@ class SummaryView extends React.Component {
 }
 
 SummaryView.propTypes = {
-    declaredLicensesChart: PropTypes.array.isRequired,
-    declaredLicensesFilter: PropTypes.object.isRequired,
-    declaredLicenseStats: PropTypes.array.isRequired,
-    detectedLicensesChart: PropTypes.array.isRequired,
-    detectedLicensesFilter: PropTypes.object.isRequired,
-    detectedLicensesStats: PropTypes.array.isRequired,
+    declaredLicensesProcessedChart: PropTypes.array.isRequired,
+    declaredLicensesProcessedFilter: PropTypes.object.isRequired,
+    declaredLicenseProcessedStats: PropTypes.array.isRequired,
+    detectedLicensesProcessedChart: PropTypes.array.isRequired,
+    detectedLicensesProcessedFilter: PropTypes.object.isRequired,
+    detectedLicensesProcessedStats: PropTypes.array.isRequired,
     issuesFilter: PropTypes.object.isRequired,
     shouldComponentUpdate: PropTypes.bool.isRequired,
     ruleViolationsFilter: PropTypes.object.isRequired,
@@ -479,12 +479,12 @@ SummaryView.propTypes = {
 };
 
 const mapStateToProps = (state) => ({
-    declaredLicensesChart: getSummaryDeclaredLicensesChart(state),
-    declaredLicensesFilter: getSummaryDeclaredLicensesFilter(state),
-    declaredLicenseStats: getSummaryDeclaredLicenses(state),
-    detectedLicensesChart: getSummaryDetectedLicensesChart(state),
-    detectedLicensesFilter: getSummaryDetectedLicensesFilter(state),
-    detectedLicensesStats: getSummaryDetectedLicenses(state),
+    declaredLicensesProcessedChart: getSummaryDeclaredLicensesProcessedChart(state),
+    declaredLicensesProcessedFilter: getSummaryDeclaredLicensesProcessedFilter(state),
+    declaredLicenseProcessedStats: getSummaryDeclaredLicensesProcessed(state),
+    detectedLicensesProcessedChart: getSummaryDetectedLicensesProcessedChart(state),
+    detectedLicensesProcessedFilter: getSummaryDetectedLicensesProcessedFilter(state),
+    detectedLicensesProcessedStats: getSummaryDetectedLicensesProcessed(state),
     issuesFilter: getSummaryIssuesFilter(state),
     shouldComponentUpdate: getSummaryViewShouldComponentUpdate(state),
     ruleViolationsFilter: getSummaryRuleViolationsFilter(state),

--- a/reporter-web-app/src/models/WebAppOrtResult.js
+++ b/reporter-web-app/src/models/WebAppOrtResult.js
@@ -475,11 +475,7 @@ class WebAppOrtResult {
     }
 
     hasDeclaredLicenses() {
-        if (this.#declaredLicenses.length > 0) {
-            return true;
-        }
-
-        return false;
+        return this.#declaredLicenses.length > 0;
     }
 
     hasDeclaredLicensesProcessed() {
@@ -487,11 +483,7 @@ class WebAppOrtResult {
     }
 
     hasDetectedLicenses() {
-        if (this.#detectedLicenses.length > 0) {
-            return true;
-        }
-
-        return false;
+        return this.#detectedLicenses.length > 0;
     }
 
     hasDetectedLicensesProcessed() {
@@ -524,35 +516,19 @@ class WebAppOrtResult {
     }
 
     hasLevels() {
-        if (this.#levels.length > 0) {
-            return true;
-        }
-
-        return false;
+        return this.#levels.length > 0;
     }
 
     hasPathExcludes() {
-        if (this.#pathExcludes.length > 0) {
-            return true;
-        }
-
-        return false;
+        return this.#pathExcludes.length > 0;
     }
 
     hasScopes() {
-        if (this.#scopes.length > 0) {
-            return true;
-        }
-
-        return false;
+        return this.#scopes.length > 0;
     }
 
     hasScopeExcludes() {
-        if (this.#scopeExcludes.length > 0) {
-            return true;
-        }
-
-        return false;
+        return this.#scopeExcludes.length > 0;
     }
 
     hasRepositoryConfiguration() {

--- a/reporter-web-app/src/models/WebAppOrtResult.js
+++ b/reporter-web-app/src/models/WebAppOrtResult.js
@@ -39,6 +39,8 @@ class WebAppOrtResult {
 
     #declaredLicenses = [];
 
+    #declaredLicensesProcessed = [];
+
     #dependencyTrees = [];
 
     #treeNodesByPackageIndexMap;
@@ -46,6 +48,8 @@ class WebAppOrtResult {
     #treeNodesByKeyMap;
 
     #detectedLicenses = [];
+
+    #detectedLicensesProcessed = [];
 
     #issues = [];
 
@@ -189,7 +193,23 @@ class WebAppOrtResult {
             if (obj.statistics) {
                 const { statistics } = obj;
                 this.#statistics = new Statistics(statistics);
-                const { dependencyTree: { totalTreeDepth } } = this.#statistics;
+                const {
+                    dependencyTree: {
+                        totalTreeDepth
+                    },
+                    licenses: {
+                        declared,
+                        detected
+                    }
+                } = this.#statistics;
+
+                if (declared) {
+                    this.#declaredLicensesProcessed = [...declared.keys()];
+                }
+
+                if (detected) {
+                    this.#detectedLicensesProcessed = [...detected.keys()];
+                }
 
                 if (totalTreeDepth) {
                     for (let i = 0, len = totalTreeDepth; i < len; i++) {
@@ -302,6 +322,10 @@ class WebAppOrtResult {
         return this.#declaredLicenses;
     }
 
+    get declaredLicensesProcessed() {
+        return this.#declaredLicensesProcessed;
+    }
+
     get dependencyTrees() {
         return this.#dependencyTrees;
     }
@@ -316,6 +340,10 @@ class WebAppOrtResult {
 
     get detectedLicenses() {
         return this.#detectedLicenses;
+    }
+
+    get detectedLicensesProcessed() {
+        return this.#detectedLicensesProcessed;
     }
 
     get issues() {
@@ -454,12 +482,20 @@ class WebAppOrtResult {
         return false;
     }
 
+    hasDeclaredLicensesProcessed() {
+        return this.#declaredLicensesProcessed.length > 0;
+    }
+
     hasDetectedLicenses() {
         if (this.#detectedLicenses.length > 0) {
             return true;
         }
 
         return false;
+    }
+
+    hasDetectedLicensesProcessed() {
+        return this.#detectedLicensesProcessed.length > 0;
     }
 
     hasExcludes() {

--- a/reporter-web-app/src/models/WebAppPackage.js
+++ b/reporter-web-app/src/models/WebAppPackage.js
@@ -570,11 +570,8 @@ class WebAppPackage {
     }
 
     hasConcludedLicense() {
-        if (this.#concludedLicense) {
-            return this.#concludedLicense.length !== 0;
-        }
-
-        return false;
+        return this.#concludedLicense
+            && this.#concludedLicense.length !== 0;
     }
 
     hasDeclaredLicenses() {
@@ -582,27 +579,18 @@ class WebAppPackage {
     }
 
     hasDeclaredLicensesMapped() {
-        if (this.#declaredLicensesMapped) {
-            return this.#declaredLicensesMapped.size !== 0;
-        }
-
-        return false;
+        return this.#declaredLicensesMapped
+            && this.#declaredLicensesMapped.size !== 0;
     }
 
     hasDeclaredLicensesSpdxExpression() {
-        if (this.#declaredLicensesSpdxExpression) {
-            return this.#declaredLicensesSpdxExpression.length !== 0;
-        }
-
-        return false;
+        return this.#declaredLicensesSpdxExpression
+            && this.#declaredLicensesSpdxExpression.length !== 0;
     }
 
     hasDeclaredLicensesUnmapped() {
-        if (this.#declaredLicensesUnmapped) {
-            return this.#declaredLicensesUnmapped.size !== 0;
-        }
-
-        return false;
+        return this.#declaredLicensesUnmapped
+            && this.#declaredLicensesUnmapped.size !== 0;
     }
 
     hasDetectedLicenses() {
@@ -626,28 +614,16 @@ class WebAppPackage {
     }
 
     hasLicenses() {
-        if (this.declaredLicenses.size !== 0
-            || this.detectedLicenses.size !== 0) {
-            return true;
-        }
-
-        return false;
+        return this.declaredLicenses.size !== 0
+            || this.detectedLicenses.size !== 0;
     }
 
     hasPathExcludes() {
-        if (this.pathExcludeIndexes.size !== 0) {
-            return true;
-        }
-
-        return false;
+        return this.pathExcludeIndexes.size !== 0;
     }
 
     hasPaths() {
-        if (this.paths && this.paths.length > 0) {
-            return true;
-        }
-
-        return false;
+        return this.paths && this.paths.length > 0;
     }
 
     hasScopeIndex(val) {
@@ -655,19 +631,11 @@ class WebAppPackage {
     }
 
     hasScopeExcludes() {
-        if (this.scopeExcludeIndexes.size !== 0) {
-            return true;
-        }
-
-        return false;
+        return this.scopeExcludeIndexes.size !== 0;
     }
 
     hasScopes() {
-        if (this.scopes && this.scopes.length > 0) {
-            return true;
-        }
-
-        return false;
+        return this.scopes && this.scopes.length > 0;
     }
 
     hasRuleViolations() {

--- a/reporter-web-app/src/reducers/index.js
+++ b/reporter-web-app/src/reducers/index.js
@@ -28,12 +28,12 @@ const initState = {
     },
     summary: {
         declaredLicensesChart: [],
-        detectedLicensesChart: [],
+        detectedLicensesProcessedChart: [],
         declaredLicensesFilter: {
             filteredInfo: {},
             sortedInfo: {}
         },
-        detectedLicensesFilter: {
+        detectedLicensesProcessedFilter: {
             filteredInfo: {},
             sortedInfo: {}
         },
@@ -243,16 +243,16 @@ export default (state = initState, action) => {
     }
     case 'SUMMARY::CHANGE_DETECTED_LICENSES_TABLE': {
         const {
-            detectedLicensesChart,
-            detectedLicensesFilter
+            detectedLicensesProcessedChart,
+            detectedLicensesProcessedFilter
         } = action.payload;
 
         return {
             ...state,
             summary: {
                 ...state.summary,
-                detectedLicensesChart,
-                detectedLicensesFilter
+                detectedLicensesProcessedChart,
+                detectedLicensesProcessedFilter
             }
         };
     }

--- a/reporter-web-app/src/reducers/selectors.js
+++ b/reporter-web-app/src/reducers/selectors.js
@@ -69,7 +69,7 @@ export const getCustomDataAsFlatArray = memoizeOne(
 
 // ---- SummaryView selectors ----
 
-export const getSummaryDeclaredLicenses = memoizeOne(
+export const getSummaryDeclaredLicensesProcessed = memoizeOne(
     (state) => {
         const licenses = [];
         const webAppOrtResult = getOrtResult(state);
@@ -97,8 +97,8 @@ export const getSummaryDeclaredLicenses = memoizeOne(
     },
     hasOrtResultChanged
 );
-export const getSummaryDeclaredLicensesChart = (state) => {
-    const declaredLicenses = getSummaryDeclaredLicenses(state);
+export const getSummaryDeclaredLicensesProcessedChart = (state) => {
+    const declaredLicenses = getSummaryDeclaredLicensesProcessed(state);
 
     if (state.summary.declaredLicensesChart.length === 0 && declaredLicenses.length !== 0) {
         return declaredLicenses;
@@ -106,8 +106,8 @@ export const getSummaryDeclaredLicensesChart = (state) => {
 
     return state.summary.declaredLicensesChart;
 };
-export const getSummaryDeclaredLicensesFilter = (state) => state.summary.declaredLicensesFilter;
-export const getSummaryDetectedLicenses = memoizeOne(
+export const getSummaryDeclaredLicensesProcessedFilter = (state) => state.summary.declaredLicensesFilter;
+export const getSummaryDetectedLicensesProcessed = memoizeOne(
     (state) => {
         const licenses = [];
         const webAppOrtResult = getOrtResult(state);
@@ -135,16 +135,16 @@ export const getSummaryDetectedLicenses = memoizeOne(
     },
     hasOrtResultChanged
 );
-export const getSummaryDetectedLicensesChart = (state) => {
-    const detectedLicenses = getSummaryDetectedLicenses(state);
+export const getSummaryDetectedLicensesProcessedChart = (state) => {
+    const detectedLicenses = getSummaryDetectedLicensesProcessed(state);
 
-    if (state.summary.detectedLicensesChart.length === 0 && detectedLicenses.length !== 0) {
+    if (state.summary.detectedLicensesProcessedChart.length === 0 && detectedLicenses.length !== 0) {
         return detectedLicenses;
     }
 
-    return state.summary.detectedLicensesChart;
+    return state.summary.detectedLicensesProcessedChart;
 };
-export const getSummaryDetectedLicensesFilter = (state) => state.summary.detectedLicensesFilter;
+export const getSummaryDetectedLicensesProcessedFilter = (state) => state.summary.detectedLicensesProcessedFilter;
 export const getSummaryIssuesFilter = (state) => state.summary.issuesFilter;
 export const getSummaryRuleViolationsFilter = (state) => state.summary.ruleViolationsFilter;
 


### PR DESCRIPTION
Fix the Summary tab to only show processed/de-duplicated licenses names and numbers
instead of a mix of processed and unprocessed declared and detected licenses.

Prior to this change it could happen that the Summary license table
showed X number of licenses rows while the row count number showed Y.

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>