### PR TITLE
PackageConfiguration: Optionally match also the VCS path

### DIFF
--- a/model/src/main/kotlin/config/PackageConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageConfiguration.kt
@@ -83,12 +83,21 @@ data class PackageConfiguration(
 data class VcsMatcher(
     val type: VcsType,
     val url: String,
-    val revision: String
+    val revision: String,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val path: String? = null
 ) {
     init {
         require(url.isNotBlank() && revision.isNotBlank())
+
+        if (type == VcsType.GIT_REPO) {
+            require(!path.isNullOrBlank()) {
+                "Matching against Git-Repo VCS info requires a non-blank path."
+            }
+        }
     }
 
     fun matches(vcsInfo: VcsInfo): Boolean =
-        type == vcsInfo.type && url == vcsInfo.url && revision == vcsInfo.resolvedRevision
+        type == vcsInfo.type && url == vcsInfo.url && (path == null || path == vcsInfo.path) &&
+                revision == vcsInfo.resolvedRevision
 }


### PR DESCRIPTION
For some VCS types like Git it is not necessary to match the VCS path,
because the configuration entries are still valid if the VCS path was
changed. For Git-Repo the path denotes the Git-Repo manifest and thus
the path should be matched. Introduce an optional `path` property to
address that.

Signed-off-by: Frank Viernau <frank.viernau@here.com>