### PR TITLE
DeclaredLicenseProcessor: Record how declared licenses are mapped

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -31,6 +31,8 @@ analyzer:
       - "Mozilla Public License 2.0"
       declared_licenses_processed:
         spdx_expression: "MPL-2.0"
+        mapped:
+          Mozilla Public License 2.0: "MPL-2.0"
       vcs:
         type: "Git"
         url: "git@github.com:soc/directories-jvm.git"
@@ -75,6 +77,8 @@ analyzer:
         - "Two-clause BSD-style license"
         declared_licenses_processed:
           spdx_expression: "BSD-2-Clause"
+          mapped:
+            Two-clause BSD-style license: "BSD-2-Clause"
         description: "An implementation of sbt's test interface for JUnit 4"
         homepage_url: "http://github.com/sbt/junit-interface/"
         binary_artifact:
@@ -105,6 +109,8 @@ analyzer:
         - "Eclipse Public License 1.0"
         declared_licenses_processed:
           spdx_expression: "EPL-1.0"
+          mapped:
+            Eclipse Public License 1.0: "EPL-1.0"
         description: "JUnit is a unit testing framework for Java, created by Erich\
           \ Gamma and Kent Beck."
         homepage_url: "http://junit.org"
@@ -136,6 +142,8 @@ analyzer:
         - "New BSD License"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            New BSD License: "BSD-3-Clause"
         description: "This is the core API of hamcrest matcher framework to be used\
           \ by third-party framework providers. This includes the a foundation set\
           \ of matcher implementations for common operations."
@@ -168,6 +176,8 @@ analyzer:
         - "BSD"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD: "BSD-3-Clause"
         description: "Uniform test interface to Scala/Java test frameworks (specs,\
           \ ScalaCheck, ScalaTest, JUnit and other)"
         homepage_url: "http://www.scala-sbt.org"

--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -36,6 +36,9 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD: "BSD-3-Clause"
+        BSD License: "BSD-3-Clause"
     description: "A microframework based on Werkzeug, Jinja2 and good intentions"
     homepage_url: "http://github.com/pallets/flask/"
     binary_artifact:
@@ -67,6 +70,9 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD: "BSD-3-Clause"
+        BSD License: "BSD-3-Clause"
     description: "A small but fast and easy to use stand-alone template engine written\
       \ in pure python."
     homepage_url: "http://jinja.pocoo.org/"
@@ -99,6 +105,8 @@ packages:
     - "BSD-3-Clause"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD License: "BSD-3-Clause"
     description: "Safely add untrusted strings to HTML/XML markup."
     homepage_url: "https://palletsprojects.com/p/markupsafe/"
     binary_artifact:
@@ -130,6 +138,8 @@ packages:
     - "BSD-3-Clause"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD License: "BSD-3-Clause"
     description: "The comprehensive WSGI web application library."
     homepage_url: "https://palletsprojects.com/p/werkzeug/"
     binary_artifact:
@@ -161,6 +171,8 @@ packages:
     - "BSD-3-Clause"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD License: "BSD-3-Clause"
     description: "Composable command line interface toolkit"
     homepage_url: "https://palletsprojects.com/p/click/"
     binary_artifact:
@@ -192,6 +204,8 @@ packages:
     - "MIT License"
     declared_licenses_processed:
       spdx_expression: "MIT"
+      mapped:
+        MIT License: "MIT"
     description: "WSGI HTTP Server for UNIX"
     homepage_url: "http://gunicorn.org"
     binary_artifact:
@@ -223,6 +237,9 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD: "BSD-3-Clause"
+        BSD License: "BSD-3-Clause"
     description: "Various helpers to pass data to untrusted environments and back."
     homepage_url: "https://palletsprojects.com/p/itsdangerous/"
     binary_artifact:

--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -84,6 +84,8 @@ analyzer:
       - "Apache License, Version 2.0"
       declared_licenses_processed:
         spdx_expression: "Apache-2.0"
+        mapped:
+          Apache License, Version 2.0: "Apache-2.0"
       vcs:
         type: "Git"
         url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
@@ -118,6 +120,8 @@ analyzer:
       - "The Apache Software License, Version 2.0"
       declared_licenses_processed:
         spdx_expression: "Apache-2.0"
+        mapped:
+          The Apache Software License, Version 2.0: "Apache-2.0"
       vcs:
         type: "Git"
         url: "ssh://git@github.com:spdx/tools.git"
@@ -938,6 +942,8 @@ analyzer:
         - "BSD License"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD License: "BSD-3-Clause"
         description: "A framework for constructing recognizers, compilers,\n    and\
           \ translators from grammatical descriptions containing\n    Java, C#, C++,\
           \ or Python actions."
@@ -970,6 +976,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "Core annotations used for value types, used by Jackson data\
           \ binding package."
         homepage_url: "http://github.com/FasterXML/jackson"
@@ -1001,6 +1009,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "Core Jackson processing abstractions (aka Streaming API), implementation\
           \ for JSON"
         homepage_url: "https://github.com/FasterXML/jackson-core"
@@ -1032,6 +1042,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "General data-binding functionality for Jackson: works on core\
           \ streaming API"
         homepage_url: "http://github.com/FasterXML/jackson"
@@ -1063,6 +1075,8 @@ analyzer:
         - "MIT License"
         declared_licenses_processed:
           spdx_expression: "MIT"
+          mapped:
+            MIT License: "MIT"
         description: "Persistent (immutable) collection library"
         homepage_url: "https://github.com/andrewoma/dexx"
         binary_artifact:
@@ -1093,6 +1107,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "Java 7+ toolkit to quickly develop RFC 4627 JSON compatible\
           \ applications."
         homepage_url: "https://cliftonlabs.github.io/json-simple/"
@@ -1124,6 +1140,8 @@ analyzer:
         - "Revised BSD License"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            Revised BSD License: "BSD-3-Clause"
         description: "Json-LD core implementation"
         homepage_url: "http://github.com/jsonld-java/jsonld-java/jsonld-java/"
         binary_artifact:
@@ -1154,6 +1172,8 @@ analyzer:
         - "Apache License 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License 2.0: "Apache-2.0"
         description: "Implementation of mustache.js for Java"
         homepage_url: "http://github.com/spullara/mustache.java"
         binary_artifact:
@@ -1184,6 +1204,8 @@ analyzer:
         - "BSD License"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD License: "BSD-3-Clause"
         description: "Implementation of various mathematical curves that define themselves\
           \ over a set of control points. The API is written in Java. The curves supported\
           \ are: Bezier, B-Spline, Cardinal Spline, Catmull-Rom Spline, Lagrange,\
@@ -1217,6 +1239,8 @@ analyzer:
         - "Apache 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache 2.0: "Apache-2.0"
         description: "Gson JSON library"
         homepage_url: "https://github.com/google/gson/gson"
         binary_artifact:
@@ -1247,6 +1271,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "Guava is a suite of core and expanded libraries that include\n\
           \    utility classes, google's collections, io classes, and much\n    much\
           \ more.\n\n    Guava has only one code dependency - javax.annotation,\n\
@@ -1280,6 +1306,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Apache Commons CLI provides a simple API for presenting, processing\
           \ and validating a command line interface."
         homepage_url: "http://commons.apache.org/proper/commons-cli/"
@@ -1311,6 +1339,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "The Apache Commons Codec package contains simple encoder and\
           \ decoders for\n     various formats such as Base64 and Hexadecimal.  In\
           \ addition to these\n     widely used encoders and decoders, the codec package\
@@ -1344,6 +1374,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "The Apache Commons IO library contains utility classes, stream\
           \ implementations, file filters,\nfile comparators, endian transformation\
           \ classes, and much more."
@@ -1376,6 +1408,8 @@ analyzer:
         - "Eclipse Public License 1.0"
         declared_licenses_processed:
           spdx_expression: "EPL-1.0"
+          mapped:
+            Eclipse Public License 1.0: "EPL-1.0"
         description: "JUnit is a unit testing framework for Java, created by Erich\
           \ Gamma and Kent Beck."
         homepage_url: "http://junit.org"
@@ -1407,6 +1441,8 @@ analyzer:
         - "Apache 2"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache 2: "Apache-2.0"
         description: "A simple library for reading and writing CSV in Java"
         homepage_url: "http://opencsv.sf.net"
         binary_artifact:
@@ -1437,6 +1473,8 @@ analyzer:
         - "Mozilla Public License Version 1.0"
         declared_licenses_processed:
           spdx_expression: "MPL-1.0"
+          mapped:
+            Mozilla Public License Version 1.0: "MPL-1.0"
         description: "Saxon support library for third-party object model DOM"
         homepage_url: "http://saxon.sf.net"
         binary_artifact:
@@ -1467,6 +1505,8 @@ analyzer:
         - "Mozilla Public License Version 1.0"
         declared_licenses_processed:
           spdx_expression: "MPL-1.0"
+          mapped:
+            Mozilla Public License Version 1.0: "MPL-1.0"
         description: "The XSLT and XQuery Processor"
         homepage_url: "http://saxon.sf.net"
         binary_artifact:
@@ -1498,6 +1538,9 @@ analyzer:
         - "The MIT License"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause AND MIT"
+          mapped:
+            The (New) BSD License: "BSD-3-Clause"
+            The MIT License: "MIT"
         description: "The Validator.nu HTML Parser is an implementation of the HTML5\
           \ parsing algorithm in Java for applications. The parser is designed to\
           \ work as a drop-in replacement for the XML parser in applications that\
@@ -1532,6 +1575,8 @@ analyzer:
         - "BSD licence"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD licence: "BSD-3-Clause"
         description: "StringTemplate is a java template engine for generating source\
           \ code,\nweb pages, emails, or any other formatted text output.\n\nStringTemplate\
           \ is particularly good at multi-targeted code generators,\nmultiple site\
@@ -1630,6 +1675,8 @@ analyzer:
         - "BSD licence"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD licence: "BSD-3-Clause"
         description: "StringTemplate is a java template engine for generating source\
           \ code,\nweb pages, emails, or any other formatted text output.\n\nStringTemplate\
           \ is particularly good at multi-targeted code generators,\nmultiple site\
@@ -1670,6 +1717,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "The Apache Commons Collections package contains types that extend\
           \ and augment the Java Collections Framework."
         homepage_url: "http://commons.apache.org/proper/commons-collections/"
@@ -1701,6 +1750,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Apache Commons Compress software defines an API for working\
           \ with\ncompression and archive formats.  These include: bzip2, gzip, pack200,\n\
           lzma, xz, Snappy, traditional Unix Compress, DEFLATE, DEFLATE64, LZ4,\n\
@@ -1734,6 +1785,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "The Apache Commons CSV library provides a simple interface for\
           \ reading and writing\nCSV files of various types."
         homepage_url: "http://commons.apache.org/proper/commons-csv/"
@@ -1765,6 +1818,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "Commons Lang, a package of Java utility classes for the\n  classes\
           \ that are in java.lang's hierarchy, or are considered to be so\n  standard\
           \ as to justify existence in java.lang."
@@ -1797,6 +1852,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Apache Commons Lang, a package of Java utility classes for the\n\
           \  classes that are in java.lang's hierarchy, or are considered to be so\n\
           \  standard as to justify existence in java.lang."
@@ -1829,6 +1886,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Apache HttpComponents HttpClient - Cache"
         homepage_url: "http://hc.apache.org/httpcomponents-client"
         binary_artifact:
@@ -1859,6 +1918,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Apache HttpComponents Client"
         homepage_url: "http://hc.apache.org/httpcomponents-client"
         binary_artifact:
@@ -1889,6 +1950,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Apache HttpComponents Core (blocking I/O)"
         homepage_url: "http://hc.apache.org/httpcomponents-core-ga"
         binary_artifact:
@@ -1919,6 +1982,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "A POM artifact that references all the standard Jena Libraries\
           \ with a single dependency."
         homepage_url: "http://jena.apache.org/apache-jena-libs/"
@@ -1950,6 +2015,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "ARQ is a SPARQL 1.1 query engine for Apache Jena"
         homepage_url: "http://jena.apache.org/jena-arq/"
         binary_artifact:
@@ -1980,6 +2047,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "This module contains non-RDF library code and the common system\
           \ runtime."
         homepage_url: "http://jena.apache.org/jena-base/"
@@ -2011,6 +2080,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "Jena is a Java framework for building Semantic Web applications.\
           \ It provides a programmatic environment for RDF, RDFS and OWL, SPARQL and\
           \ includes a rule-based inference engine."
@@ -2043,6 +2114,8 @@ analyzer:
         - "Apache License 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License 2.0: "Apache-2.0"
         description: "The Apache Software Foundation provides support for the Apache\
           \ community of open-source software projects.\n    The Apache projects are\
           \ characterized by a collaborative, consensus based development process,\
@@ -2079,6 +2152,8 @@ analyzer:
         - "Apache License 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License 2.0: "Apache-2.0"
         description: "The Apache Software Foundation provides support for the Apache\
           \ community of open-source software projects.\n    The Apache projects are\
           \ characterized by a collaborative, consensus based development process,\
@@ -2115,6 +2190,8 @@ analyzer:
         - "Apache License 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License 2.0: "Apache-2.0"
         description: "The Apache Software Foundation provides support for the Apache\
           \ community of open-source software projects.\n    The Apache projects are\
           \ characterized by a collaborative, consensus based development process,\
@@ -2151,6 +2228,8 @@ analyzer:
         - "Apache License 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License 2.0: "Apache-2.0"
         description: "The Apache Software Foundation provides support for the Apache\
           \ community of open-source software projects.\n    The Apache projects are\
           \ characterized by a collaborative, consensus based development process,\
@@ -2187,6 +2266,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "The IRI module provides an implementation of the IRI and URI\
           \ specifications (RFC 3987 and 3986) which are used across Jena in order\
           \ to comply with relevant W3C specifications for RDF and SPARQL which require\
@@ -2220,6 +2301,8 @@ analyzer:
         - "Apache 2.0 License"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache 2.0 License: "Apache-2.0"
         description: "RDF Connection"
         homepage_url: "http://jena.apache.org/jena-rdfconnection/"
         binary_artifact:
@@ -2250,6 +2333,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "This module shades Google's Guava.\n    Direct use can lead\
           \ to versioning problems \n    as some systems are dependent on specific\n\
           \    versions of guava. \n    This module uses the Shade plugin to \n  \
@@ -2283,6 +2368,8 @@ analyzer:
         - "Apache License 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License 2.0: "Apache-2.0"
         description: "The Apache Software Foundation provides support for the Apache\
           \ community of open-source software projects.\n    The Apache projects are\
           \ characterized by a collaborative, consensus based development process,\
@@ -2319,6 +2406,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "TDB is a storage subsystem for Jena and ARQ, it is a native\
           \ triple store providing persisent disk based storage of triples/quads."
         homepage_url: "http://jena.apache.org/jena-tdb/"
@@ -2350,6 +2439,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "The Apache Log4j API"
         homepage_url: "https://logging.apache.org/log4j/2.x/log4j-api/"
         binary_artifact:
@@ -2380,6 +2471,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "The Apache Log4j Implementation"
         homepage_url: "https://logging.apache.org/log4j/2.x/log4j-core/"
         binary_artifact:
@@ -2410,6 +2503,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "The Apache Log4j SLF4J API binding to Log4j 2 Core"
         homepage_url: "https://logging.apache.org/log4j/2.x/log4j-slf4j-impl/"
         binary_artifact:
@@ -2440,6 +2535,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "Apache POI - Java API To Access Microsoft Format Files"
         homepage_url: "http://poi.apache.org/"
         binary_artifact:
@@ -2470,6 +2567,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "Apache POI - Java API To Access Microsoft Format Files"
         homepage_url: "http://poi.apache.org/"
         binary_artifact:
@@ -2500,6 +2599,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "Apache POI - Java API To Access Microsoft Format Files"
         homepage_url: "http://poi.apache.org/"
         binary_artifact:
@@ -2530,6 +2631,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "Thrift is a software framework for scalable cross-language services\
           \ development."
         homepage_url: "http://thrift.apache.org"
@@ -2561,6 +2664,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "XmlBeans main jar"
         homepage_url: "http://xmlbeans.apache.org"
         binary_artifact:
@@ -2591,6 +2696,8 @@ analyzer:
         - "The Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache License, Version 2.0: "Apache-2.0"
         description: "@API Guardian"
         homepage_url: "https://github.com/apiguardian-team/apiguardian"
         binary_artifact:
@@ -2621,6 +2728,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Rich and fluent assertions for testing for Java"
         homepage_url: "http://assertj.org/assertj-core"
         binary_artifact:
@@ -2651,6 +2760,8 @@ analyzer:
         - "New BSD License"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            New BSD License: "BSD-3-Clause"
         description: "This is the core API of hamcrest matcher framework to be used\
           \ by third-party framework providers. This includes the a foundation set\
           \ of matcher implementations for common operations."
@@ -2683,6 +2794,8 @@ analyzer:
         - "The MIT License"
         declared_licenses_processed:
           spdx_expression: "MIT"
+          mapped:
+            The MIT License: "MIT"
         description: "jsoup HTML parser"
         homepage_url: "http://jsoup.org/"
         binary_artifact:
@@ -2713,6 +2826,8 @@ analyzer:
         - "Eclipse Public License v2.0"
         declared_licenses_processed:
           spdx_expression: "EPL-2.0"
+          mapped:
+            Eclipse Public License v2.0: "EPL-2.0"
         description: "Module \"junit-jupiter-api\" of JUnit 5."
         homepage_url: "http://junit.org/junit5/"
         binary_artifact:
@@ -2743,6 +2858,8 @@ analyzer:
         - "Eclipse Public License v2.0"
         declared_licenses_processed:
           spdx_expression: "EPL-2.0"
+          mapped:
+            Eclipse Public License v2.0: "EPL-2.0"
         description: "Module \"junit-jupiter-engine\" of JUnit 5."
         homepage_url: "http://junit.org/junit5/"
         binary_artifact:
@@ -2773,6 +2890,8 @@ analyzer:
         - "Eclipse Public License v2.0"
         declared_licenses_processed:
           spdx_expression: "EPL-2.0"
+          mapped:
+            Eclipse Public License v2.0: "EPL-2.0"
         description: "Module \"junit-jupiter-params\" of JUnit 5."
         homepage_url: "http://junit.org/junit5/"
         binary_artifact:
@@ -2803,6 +2922,8 @@ analyzer:
         - "Eclipse Public License v2.0"
         declared_licenses_processed:
           spdx_expression: "EPL-2.0"
+          mapped:
+            Eclipse Public License v2.0: "EPL-2.0"
         description: "Module \"junit-platform-commons\" of JUnit 5."
         homepage_url: "http://junit.org/junit5/"
         binary_artifact:
@@ -2833,6 +2954,8 @@ analyzer:
         - "Eclipse Public License v2.0"
         declared_licenses_processed:
           spdx_expression: "EPL-2.0"
+          mapped:
+            Eclipse Public License v2.0: "EPL-2.0"
         description: "Module \"junit-platform-engine\" of JUnit 5."
         homepage_url: "http://junit.org/junit5/"
         binary_artifact:
@@ -2863,6 +2986,8 @@ analyzer:
         - "Eclipse Public License v2.0"
         declared_licenses_processed:
           spdx_expression: "EPL-2.0"
+          mapped:
+            Eclipse Public License v2.0: "EPL-2.0"
         description: "Module \"junit-platform-launcher\" of JUnit 5."
         homepage_url: "http://junit.org/junit5/"
         binary_artifact:
@@ -2893,6 +3018,8 @@ analyzer:
         - "The Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache License, Version 2.0: "Apache-2.0"
         description: "Open Test Alliance for the JVM"
         homepage_url: "https://github.com/ota4j-team/opentest4j"
         binary_artifact:
@@ -2923,6 +3050,8 @@ analyzer:
         - "MIT License"
         declared_licenses_processed:
           spdx_expression: "MIT"
+          mapped:
+            MIT License: "MIT"
         description: "JCL 1.2 implemented over SLF4J"
         homepage_url: "http://www.slf4j.org"
         binary_artifact:
@@ -2953,6 +3082,8 @@ analyzer:
         - "MIT License"
         declared_licenses_processed:
           spdx_expression: "MIT"
+          mapped:
+            MIT License: "MIT"
         description: "The slf4j API"
         homepage_url: "http://www.slf4j.org"
         binary_artifact:
@@ -2983,6 +3114,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "StAX API is the standard java XML processing API defined by\
           \ JSR-173"
         homepage_url: "http://stax.codehaus.org/"
@@ -4045,6 +4178,8 @@ analyzer:
         - "BSD-like"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD-like: "BSD-3-Clause"
         description: "a CSS selector compiler/engine"
         homepage_url: "https://github.com/fb55/css-select#readme"
         binary_artifact:
@@ -4700,6 +4835,8 @@ analyzer:
         - "BSD-like"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD-like: "BSD-3-Clause"
         description: "Encode & decode XML/HTML entities with ease"
         homepage_url: "https://github.com/fb55/node-entities"
         binary_artifact:
@@ -4730,6 +4867,8 @@ analyzer:
         - "BSD-like"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD-like: "BSD-3-Clause"
         description: "Encode & decode XML/HTML entities with ease"
         homepage_url: "https://github.com/fb55/node-entities"
         binary_artifact:
@@ -4972,6 +5111,8 @@ analyzer:
         - "BSD"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD: "BSD-3-Clause"
         description: "ECMAScript JS AST traversal functions"
         homepage_url: "https://github.com/estools/estraverse"
         binary_artifact:
@@ -5002,6 +5143,8 @@ analyzer:
         - "BSD"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD: "BSD-3-Clause"
         description: "utility box for ECMAScript language tools"
         homepage_url: "https://github.com/estools/esutils"
         binary_artifact:
@@ -6367,6 +6510,9 @@ analyzer:
         - "BSD"
         declared_licenses_processed:
           spdx_expression: "AFL-2.1 AND BSD-3-Clause"
+          mapped:
+            AFLv2.1: "AFL-2.1"
+            BSD: "BSD-3-Clause"
         description: "JSON Schema validation and specifications"
         homepage_url: "https://github.com/kriszyp/json-schema#readme"
         binary_artifact:
@@ -7090,6 +7236,8 @@ analyzer:
         - "MIT/X11"
         declared_licenses_processed:
           spdx_expression: "MIT OR X11"
+          mapped:
+            MIT/X11: "MIT OR X11"
         description: "Light-weight option parsing with an argv hash. No optstrings\
           \ attached."
         homepage_url: "https://github.com/substack/node-optimist"
@@ -7909,6 +8057,8 @@ analyzer:
         - "BSD*"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD*: "BSD-3-Clause"
         description: "Portable Unix shell commands for Node.js"
         homepage_url: "http://github.com/arturadib/shelljs"
         binary_artifact:
@@ -7939,6 +8089,8 @@ analyzer:
         - "BSD"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD: "BSD-3-Clause"
         description: "Generates and consumes source maps"
         homepage_url: "https://github.com/mozilla/source-map"
         binary_artifact:

--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -73,6 +73,8 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD License: "BSD-3-Clause"
     description: "A framework for constructing recognizers, compilers,\n    and translators\
       \ from grammatical descriptions containing\n    Java, C#, C++, or Python actions."
     homepage_url: "http://www.antlr.org/"
@@ -104,6 +106,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Library for introspecting types with full generic information\n\
       \        including resolving of field and method types."
     homepage_url: "http://github.com/cowtowncoder/java-classmate"
@@ -135,6 +139,8 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD License: "BSD-3-Clause"
     description: "Implementation of various mathematical curves that define themselves\
       \ over a set of control points. The API is written in Java. The curves supported\
       \ are: Bezier, B-Spline, Cardinal Spline, Catmull-Rom Spline, Lagrange, Natural\
@@ -168,6 +174,8 @@ packages:
     - "MPL 2.0 or EPL 1.0"
     declared_licenses_processed:
       spdx_expression: "MPL-2.0 OR EPL-1.0"
+      mapped:
+        MPL 2.0 or EPL 1.0: "MPL-2.0 OR EPL-1.0"
     description: "H2 Database Engine"
     homepage_url: "http://www.h2database.com"
     binary_artifact:
@@ -199,6 +207,9 @@ packages:
     - "GNU Lesser General Public License, Version 2.1"
     declared_licenses_processed:
       spdx_expression: "EPL-1.0 AND LGPL-2.1-only"
+      mapped:
+        Eclipse Public License, Version 1.0: "EPL-1.0"
+        GNU Lesser General Public License, Version 2.1: "LGPL-2.1-only"
     description: "a JDBC Connection pooling / Statement caching library"
     homepage_url: "https://github.com/swaldman/c3p0"
     binary_artifact:
@@ -230,6 +241,9 @@ packages:
     - "GNU Lesser General Public License, Version 2.1"
     declared_licenses_processed:
       spdx_expression: "EPL-1.0 AND LGPL-2.1-only"
+      mapped:
+        Eclipse Public License, Version 1.0: "EPL-1.0"
+        GNU Lesser General Public License, Version 2.1: "LGPL-2.1-only"
     description: "mchange-commons-java"
     homepage_url: "https://github.com/swaldman/mchange-commons-java"
     binary_artifact:
@@ -260,6 +274,8 @@ packages:
     - "BSD style"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD style: "BSD-3-Clause"
     description: "XStream extension for Hibernate 3/4 to untie Java objects from Hibernate."
     homepage_url: "http://x-stream.github.io/xstream-hibernate"
     binary_artifact:
@@ -290,6 +306,8 @@ packages:
     - "BSD style"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD style: "BSD-3-Clause"
     description: "XStream is a serialization library from Java objects to XML and\
       \ back."
     homepage_url: "http://x-stream.github.io/xstream"
@@ -321,6 +339,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "The Apache Commons Codec package contains simple encoder and decoders\
       \ for\n     various formats such as Base64 and Hexadecimal.  In addition to\
       \ these\n     widely used encoders and decoders, the codec package also maintains\
@@ -382,6 +402,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Netty is an asynchronous event-driven network application framework\
       \ for\n    rapid development of maintainable high performance protocol servers\
       \ and\n    clients."
@@ -414,6 +436,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Netty is an asynchronous event-driven network application framework\
       \ for\n    rapid development of maintainable high performance protocol servers\
       \ and\n    clients."
@@ -446,6 +470,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Netty is an asynchronous event-driven network application framework\
       \ for\n    rapid development of maintainable high performance protocol servers\
       \ and\n    clients."
@@ -478,6 +504,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Netty is an asynchronous event-driven network application framework\
       \ for\n    rapid development of maintainable high performance protocol servers\
       \ and\n    clients."
@@ -510,6 +538,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Netty is an asynchronous event-driven network application framework\
       \ for\n    rapid development of maintainable high performance protocol servers\
       \ and\n    clients."
@@ -542,6 +572,8 @@ packages:
     - "Eclipse Public License 1.0"
     declared_licenses_processed:
       spdx_expression: "EPL-1.0"
+      mapped:
+        Eclipse Public License 1.0: "EPL-1.0"
     description: "JUnit is a unit testing framework for Java, created by Erich Gamma\
       \ and Kent Beck."
     homepage_url: "http://junit.org"
@@ -573,6 +605,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Apache Log4j 1.2"
     homepage_url: "http://logging.apache.org/log4j/1.2/"
     binary_artifact:
@@ -604,6 +638,9 @@ packages:
     - "Public Domain"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause AND LicenseRef-scancode-public-domain-disclaimer"
+      mapped:
+        BSD style: "BSD-3-Clause"
+        Public Domain: "LicenseRef-scancode-public-domain-disclaimer"
     description: "kXML is a small XML pull parser, specially designed for constrained\
       \ environments such as Applets, Personal Java or MIDP devices. In contrast to\
       \ kXML 1, kXML 2 is based on the common XML pull API."
@@ -636,6 +673,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Lang, a package of Java utility classes for the\n\
       \  classes that are in java.lang's hierarchy, or are considered to be so\n \
       \ standard as to justify existence in java.lang."
@@ -668,6 +707,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Apache POI - Java API To Access Microsoft Format Files"
     homepage_url: "http://poi.apache.org/"
     binary_artifact:
@@ -698,6 +739,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Apache POI - Java API To Access Microsoft Format Files"
     homepage_url: "http://poi.apache.org/"
     binary_artifact:
@@ -728,6 +771,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Apache POI - Java API To Access Microsoft Format Files"
     homepage_url: "http://poi.apache.org/"
     binary_artifact:
@@ -758,6 +803,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "XmlBeans main jar"
     homepage_url: "http://xmlbeans.apache.org"
     binary_artifact:
@@ -788,6 +835,8 @@ packages:
     - "New BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        New BSD License: "BSD-3-Clause"
     description: "A self-contained hamcrest jar containing all of the sub-modules\
       \ in a single artifact."
     homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-all"
@@ -819,6 +868,8 @@ packages:
     - "GNU Lesser General Public License"
     declared_licenses_processed:
       spdx_expression: "LGPL-2.1-only"
+      mapped:
+        GNU Lesser General Public License: "LGPL-2.1-only"
     description: "Common reflection code used in support of annotation processing"
     homepage_url: "http://hibernate.org"
     binary_artifact:
@@ -850,6 +901,9 @@ packages:
     - "Eclipse Public License (EPL), Version 1.0"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause AND EPL-1.0"
+      mapped:
+        Eclipse Distribution License (EDL), Version 1.0: "BSD-3-Clause"
+        Eclipse Public License (EPL), Version 1.0: "EPL-1.0"
     description: "Clean-room definition of JPA APIs intended for use in developing\
       \ Hibernate JPA implementation.  See README.md for details"
     homepage_url: "http://hibernate.org"
@@ -881,6 +935,8 @@ packages:
     - "GNU Lesser General Public License"
     declared_licenses_processed:
       spdx_expression: "LGPL-2.1-only"
+      mapped:
+        GNU Lesser General Public License: "LGPL-2.1-only"
     description: "Integration for c3p0 Connection pooling into Hibernate O/RM"
     homepage_url: "http://hibernate.org"
     binary_artifact:
@@ -911,6 +967,8 @@ packages:
     - "GNU Lesser General Public License"
     declared_licenses_processed:
       spdx_expression: "LGPL-2.1-only"
+      mapped:
+        GNU Lesser General Public License: "LGPL-2.1-only"
     description: "The core O/RM functionality as provided by Hibernate"
     homepage_url: "http://hibernate.org"
     binary_artifact:
@@ -941,6 +999,8 @@ packages:
     - "HSQLDB License, a BSD open source license"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        HSQLDB License, a BSD open source license: "BSD-3-Clause"
     description: "HSQLDB - Lightweight 100% Java SQL Database Engine"
     homepage_url: "http://hsqldb.org"
     binary_artifact:
@@ -973,6 +1033,10 @@ packages:
     - "MPL 1.1"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0 AND LGPL-2.1-only AND MPL-1.1"
+      mapped:
+        Apache License 2.0: "Apache-2.0"
+        LGPL 2.1: "LGPL-2.1-only"
+        MPL 1.1: "MPL-1.1"
     description: "Javassist (JAVA programming ASSISTant) makes Java bytecode manipulation\n\
       \    simple.  It is a class library for editing bytecodes in Java."
     homepage_url: "http://www.javassist.org/"
@@ -1004,6 +1068,8 @@ packages:
     - "Apache License, version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, version 2.0: "Apache-2.0"
     description: "The JBoss Logging Framework"
     homepage_url: "http://www.jboss.org"
     binary_artifact:
@@ -1035,6 +1101,10 @@ packages:
     - "GNU General Public License, Version 2 with the Classpath Exception"
     declared_licenses_processed:
       spdx_expression: "CDDL-1.0 AND GPL-2.0-only WITH Classpath-exception-2.0"
+      mapped:
+        Common Development and Distribution License: "CDDL-1.0"
+        GNU General Public License, Version 2 with the Classpath Exception: "GPL-2.0-only\
+          \ WITH Classpath-exception-2.0"
     description: "The Java Transaction 1.2 API classes"
     homepage_url: "http://www.jboss.org/jboss-transaction-api_1.2_spec"
     binary_artifact:
@@ -1065,6 +1135,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Parent POM for JBoss projects. Provides default project build configuration."
     homepage_url: "http://www.jboss.org/jandex"
     binary_artifact:
@@ -1095,6 +1167,8 @@ packages:
     - "MIT License"
     declared_licenses_processed:
       spdx_expression: "MIT"
+      mapped:
+        MIT License: "MIT"
     description: "The slf4j API"
     homepage_url: "http://www.slf4j.org"
     binary_artifact:
@@ -1125,6 +1199,8 @@ packages:
     - "MIT License"
     declared_licenses_processed:
       spdx_expression: "MIT"
+      mapped:
+        MIT License: "MIT"
     description: "SLF4J LOG4J-12 Binding"
     homepage_url: "http://www.slf4j.org"
     binary_artifact:

--- a/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
@@ -28,6 +28,8 @@ packages:
     - "Eclipse Public License 1.0"
     declared_licenses_processed:
       spdx_expression: "EPL-1.0"
+      mapped:
+        Eclipse Public License 1.0: "EPL-1.0"
     description: "JUnit is a unit testing framework for Java, created by Erich Gamma\
       \ and Kent Beck."
     homepage_url: "http://junit.org"
@@ -59,6 +61,8 @@ packages:
     - "New BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        New BSD License: "BSD-3-Clause"
     description: "A self-contained hamcrest jar containing all of the sub-modules\
       \ in a single artifact."
     homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-all"

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-cli.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-cli.yml
@@ -239,6 +239,8 @@ packages:
     - "The Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
     description: "Kotlin Compiler (embeddable)"
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
@@ -269,6 +271,8 @@ packages:
     - "The Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
     description: "Kotlin Full Reflection Library"
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
@@ -299,6 +303,8 @@ packages:
     - "The Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
     description: "Kotlin Script Runtime"
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
@@ -329,6 +335,8 @@ packages:
     - "The Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
     description: "Kotlin Scripting Compiler Plugin for embeddable compiler"
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
@@ -359,6 +367,8 @@ packages:
     - "The Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
     description: "Kotlin Common Standard Library"
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
@@ -389,6 +399,8 @@ packages:
     - "The Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
     description: "Kotlin Standard Library for JVM"
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
@@ -419,6 +431,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "A set of annotations used for code inspection support and code documentation."
     homepage_url: "http://www.jetbrains.org"
     binary_artifact:

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-core.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-core.yml
@@ -148,6 +148,8 @@ packages:
     - "The Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
     description: "Kotlin Compiler (embeddable)"
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
@@ -178,6 +180,8 @@ packages:
     - "The Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
     description: "Kotlin Full Reflection Library"
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
@@ -208,6 +212,8 @@ packages:
     - "The Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
     description: "Kotlin Script Runtime"
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
@@ -238,6 +244,8 @@ packages:
     - "The Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
     description: "Kotlin Scripting Compiler Plugin for embeddable compiler"
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
@@ -268,6 +276,8 @@ packages:
     - "The Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
     description: "Kotlin Common Standard Library"
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
@@ -298,6 +308,8 @@ packages:
     - "The Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
     description: "Kotlin Standard Library for JVM"
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
@@ -328,6 +340,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "A set of annotations used for code inspection support and code documentation."
     homepage_url: "http://www.jetbrains.org"
     binary_artifact:

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-root.yml
@@ -49,6 +49,8 @@ packages:
     - "The Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
     description: "Kotlin Common Standard Library"
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
@@ -79,6 +81,8 @@ packages:
     - "The Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
     description: "Kotlin Standard Library for JVM"
     homepage_url: "https://kotlinlang.org/"
     binary_artifact:
@@ -109,6 +113,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "A set of annotations used for code inspection support and code documentation."
     homepage_url: "http://www.jetbrains.org"
     binary_artifact:

--- a/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output-win32.yml
+++ b/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output-win32.yml
@@ -6,6 +6,8 @@ project:
   - "BSD3"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD3: "BSD-3-Clause"
   vcs:
     type: "Git"
     url: "https://github.com/advancedtelematic/quickcheck-state-machine"
@@ -1061,6 +1063,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "In mathematics, a semigroup is an algebraic structure consisting\
       \ of a set together with an associative binary operation. A semigroup generalizes\
       \ a monoid in that there might not exist an identity element. It also (originally)\
@@ -1176,6 +1180,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package includes backported versions of types that were added\n\
       to transformers in transformers 0.3, 0.4, and 0.5 for users who need strict\n\
       transformers 0.2 or 0.3 compatibility to run on old versions of the\nplatform,\
@@ -1211,6 +1217,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package provides a higher-level interface over\nthreads, in\
       \ which an @Async a@ is a concurrent\nthread that will eventually deliver a\
       \ value of\ntype @a@.  The package provides ways to create\n@Async@ computations,\
@@ -1249,6 +1257,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Software Transactional Memory, or STM, is an abstraction for\nconcurrent\
       \ communication. The main benefits of STM are\n/composability/ and /modularity/.\
       \ That is, using STM you can write\nconcurrent abstractions that can be easily\
@@ -1284,6 +1294,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Contravariant functors."
     homepage_url: "http://github.com/ekmett/contravariant/"
     binary_artifact:
@@ -1314,6 +1326,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Extensible optionally-pure exceptions."
     homepage_url: "http://github.com/ekmett/exceptions/"
     binary_artifact:
@@ -1344,6 +1358,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package provides methods for fully evaluating data structures\n\
       (\\\"deep evaluation\\\"). Deep evaluation is often used for adding\nstrictness\
       \ to a program, e.g. in order to force pending exceptions,\nremove space leaks,\
@@ -1415,6 +1431,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Monad classes using functional dependencies, with instances\nfor\
       \ various monad transformers, inspired by the paper\n/Functional Programming\
       \ with Overloading and Higher-Order Polymorphism/,\nby Mark P Jones, in /Advanced\
@@ -1448,6 +1466,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Per Conor McBride, the Newtype typeclass represents the packing\
       \ and unpacking of a newtype,\nand allows you to operate under that newtype\
       \ with functions such as ala.\nGenerics support was added in version 0.4, making\
@@ -1482,6 +1502,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A portable library of functor and monad transformers, inspired by\n\
       the paper \\\"Functional Programming with Overloading and Higher-Order\nPolymorphism\\\
       \", by Mark P Jones,\nin /Advanced School of Functional Programming/, 1995\n\
@@ -1583,6 +1605,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "An inductive representation of manipulating graph data structures.\n\
       \nOriginal website can be found at <http://web.engr.oregonstate.edu/~erwig/fgl/haskell>."
     homepage_url: ""
@@ -1614,6 +1638,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "In addition to providing the \"Data.Array\" module\n<http://www.haskell.org/onlinereport/haskell2010/haskellch14.html\
       \ as specified in the Haskell 2010 Language Report>,\nthis package also defines\
       \ the classes 'IArray' of\nimmutable arrays and 'MArray' of arrays mutable within\
@@ -1647,6 +1673,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package contains efficient general-purpose implementations\n\
       of various immutable container types including sets, maps, sequences,\ntrees,\
       \ and graphs.\n\nFor a walkthrough of what this package provides with examples\
@@ -1682,6 +1710,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "An efficient implementation of Int-indexed arrays (both mutable\n\
       and immutable), with a powerful loop optimisation framework .\n\nIt is structured\
       \ as follows:\n\n[\"Data.Vector\"] Boxed vectors of arbitrary types.\n\n[\"\
@@ -1721,6 +1751,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Efficient, pure binary serialisation using lazy ByteStrings.\nHaskell\
       \ values may be encoded to and from binary formats,\nwritten to disk as binary,\
       \ or sent over the network.\nThe format used can be automatically generated,\
@@ -1756,6 +1788,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Haskell 98 phantom types to avoid unsafely passing dummy arguments."
     homepage_url: "http://github.com/ekmett/tagged"
     binary_artifact:
@@ -1786,6 +1820,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Common diff algorithm works on list structures:\n\n@\ndiff :: Eq\
       \ a => [a] -> [a] -> [Edit a]\n@\n\nThis package works on trees.\n\n@\ntreeDiff\
       \ :: Eq a => Tree a -> Tree a -> Edit (EditTree a)\n@\n\nThis package also provides\
@@ -1825,6 +1861,8 @@ packages:
     - "BSD2"
     declared_licenses_processed:
       spdx_expression: "BSD-2-Clause"
+      mapped:
+        BSD2: "BSD-2-Clause"
     description: "An efficient packed, immutable Unicode text type (both strict and\n\
       lazy), with a powerful loop fusion optimization framework.\n\nThe 'Text' type\
       \ represents Unicode character strings, in a time and\nspace-efficient manner.\
@@ -1870,6 +1908,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "MemoTrie provides a basis for memoized functions over some domains,\n\
       using tries.  It's based on ideas from Ralf Hinze and code from\nSpencer Janssen.\
       \ Generic support thanks to Sam Boosalis.\n\nProject wiki page: <http://haskell.org/haskellwiki/MemoTrie>\n\
@@ -1903,6 +1943,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package contains state variables, which are references in the\
       \ IO monad,\nlike IORefs or parts of the OpenGL state."
     homepage_url: "https://github.com/haskell-opengl/StateVar"
@@ -1934,6 +1976,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "An efficient compact, immutable byte string type (both strict and\
       \ lazy)\nsuitable for binary or 8-bit character data.\n\nThe 'ByteString' type\
       \ represents sequences of bytes or 8-bit characters.\nIt is suitable for high\
@@ -1985,6 +2029,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Fast unicode character sets based on complemented PATRICIA tries"
     homepage_url: "http://github.com/ekmett/charset"
     binary_artifact:
@@ -2015,6 +2061,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Difference lists are a list-like type supporting O(1) append. This\
       \ is\nparticularly useful for efficient logging and pretty printing (e.g. with\
       \ the\nWriter monad), where list append quickly becomes too expensive."
@@ -2047,6 +2095,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package defines a class, 'Hashable', for types that\ncan be\
       \ converted to a hash value.  This class\nexists for the benefit of hashing-based\
       \ data\nstructures.  The package provides instances for\nbasic types and a way\
@@ -2080,6 +2130,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package provides various primitive memory-related operations."
     homepage_url: "https://github.com/haskell/primitive"
     binary_artifact:
@@ -2110,6 +2162,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "\"Data.Scientific\" provides the number type 'Scientific'. Scientific\
       \ numbers are\narbitrary precision and space efficient. They are represented\
       \ using\n<http://en.wikipedia.org/wiki/Scientific_notation scientific notation>.\n\
@@ -2158,6 +2212,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Implementation of n-ary sums and n-ary products.\n\nThe module \"\
       Data.SOP\" is the main module of this library and contains\nmore detailed documentation.\n\
       \nThe main use case of this package is to serve as the core of\n@<https://hackage.haskell.org/package/generics-sop\
@@ -2193,6 +2249,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Efficient hashing-based container types.  The containers have been\n\
       optimized for performance critical use, both in terms of large data\nquantities\
       \ and high speed.\n\nThe declared cost of each operation is either worst-case\
@@ -2226,6 +2284,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This library contains type definitions for Universally Unique Identifiers\n\
       and basic conversion functions.\n\nSee <http://en.wikipedia.org/wiki/UUID> for\
       \ the general idea."
@@ -2258,6 +2318,8 @@ packages:
     - "BSD2"
     declared_licenses_processed:
       spdx_expression: "BSD-2-Clause"
+      mapped:
+        BSD2: "BSD-2-Clause"
     description: "Happy is a parser generator for Haskell.  Given a grammar\nspecification\
       \ in BNF, Happy generates Haskell code to parse the\ngrammar.  Happy works in\
       \ a similar way to the @yacc@ tool for C."
@@ -2323,6 +2385,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "The Haskell Common Architecture for Building Applications and\n\
       Libraries: a framework defining a common interface for authors to more\neasily\
       \ build their Haskell applications in a portable way.\n\nThe Haskell Cabal is\
@@ -2388,6 +2452,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A library to support the definition of generic functions.\nDatatypes\
       \ are viewed in a uniform, structured way:\nthe choice between constructors\
       \ is represented using an n-ary\nsum, and the arguments of each constructor\
@@ -2434,6 +2500,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This library provides bindings for the Dot language used by the\n\
       Graphviz (<http://graphviz.org/>) suite of programs for visualising\ngraphs,\
       \ as well as functions to call those programs.\n\nMain features of the graphviz\
@@ -2477,6 +2545,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A fully compliant Haskell 98 lexer."
     homepage_url: "https://github.com/yav/haskell-lexer"
     binary_artifact:
@@ -2507,6 +2577,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A collection of various methods for splitting\nlists into parts,\
       \ akin to the \\\"split\\\" function\nfound in several mainstream languages.\
       \ Here is\nits tale:\n\nOnce upon a time the standard \"Data.List\" module\n\
@@ -2581,6 +2653,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Matrix library. Basic operations and some algorithms.\n\nTo get\
       \ the library update your cabal package list (if needed) with @cabal update@\
       \ and\nthen use @cabal install matrix@, assuming that you already have Cabal\
@@ -2616,6 +2690,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package provides the low-level implementation of the standard\n\
       'Integer' type based on the\n<http://gmplib.org/ GNU Multiple Precision Arithmetic\
       \ Library (GMP)>.\n\nThis package provides access to the internal representation\
@@ -2680,6 +2756,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Parsec is designed from scratch as an industrial-strength parser\n\
       library.  It is simple, safe, well documented (on the package\nhomepage), has\
       \ extensive libraries, good error messages,\nand is fast.  It is defined as\
@@ -2749,6 +2827,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A binding to part of the Win32 library."
     homepage_url: "https://github.com/haskell/win32"
     binary_artifact:
@@ -2779,6 +2859,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Functions for creating temporary files and directories."
     homepage_url: "https://github.com/feuerbach/temporary"
     binary_artifact:
@@ -2809,6 +2891,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This library provides a basic set of operations for manipulating\
       \ files and\ndirectories in a portable way."
     homepage_url: ""
@@ -2840,6 +2924,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package provides functionality for manipulating @FilePath@\
       \ values, and is shipped with both <https://www.haskell.org/ghc/ GHC> and the\
       \ <https://www.haskell.org/platform/ Haskell Platform>. It provides three modules:\n\
@@ -2878,6 +2964,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "MinTTY is a Windows-specific terminal emulator for the\nwidely used\
       \ Cygwin and MSYS projects, which provide\nUnix-like environments for Windows.\
       \ MinTTY consoles behave\ndifferently from native Windows consoles (such as\n\
@@ -2919,6 +3007,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package contains libraries for dealing with system processes.\n\
       \nThe typed-process package is a more recent take on a process API,\nwhich uses\
       \ this package internally. It features better binary\nsupport, easier concurrency,\
@@ -2952,6 +3042,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package provides a basic random number generation\nlibrary,\
       \ including the ability to split random number\ngenerators."
     homepage_url: ""
@@ -2983,6 +3075,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Pure Haskell implementation of SplitMix described in\n\nGuy L. Steele,\
       \ Jr., Doug Lea, and Christine H. Flood. 2014.\nFast splittable pseudorandom\
       \ number generators. In Proceedings\nof the 2014 ACM International Conference\
@@ -3027,6 +3121,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package contains wrapped name module for time-format locale\
       \ between old-locale and time-1.5."
     homepage_url: "https://github.com/khibino/haskell-time-locale-compat"
@@ -3058,6 +3154,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package provides modules containing facilities for manipulating\n\
       Haskell source code using Template Haskell.\n\nSee <http://www.haskell.org/haskellwiki/Template_Haskell>\
       \ for more\ninformation."
@@ -3090,6 +3188,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "QuickCheck is a library for random testing of program properties.\n\
       The programmer provides a specification of the program, in the form of\nproperties\
       \ which functions should satisfy, and QuickCheck then tests that the\nproperties\
@@ -3135,6 +3235,8 @@ packages:
     - "BSD2"
     declared_licenses_processed:
       spdx_expression: "BSD-2-Clause"
+      mapped:
+        BSD2: "BSD-2-Clause"
     description: "Please see the README on GitHub at <https://github.com/advancedtelematic/markov-chain-usage-model#readme>"
     homepage_url: "https://github.com/advancedtelematic/markov-chain-usage-model#readme"
     binary_artifact:
@@ -3165,6 +3267,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A fast parser combinator library, aimed particularly at dealing\n\
       efficiently with network protocols and complicated text/binary\nfile formats."
     homepage_url: "https://github.com/bos/attoparsec"
@@ -3196,6 +3300,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This library provides convenient combinators for working with and\
       \ building parsing combinator libraries.\n\nGiven a few simple instances, e.g.\
       \ for the class 'Text.Parser.Combinators.Parsing' in \"Text.Parser.Combinators.Parsing\"\
@@ -3230,6 +3336,8 @@ packages:
     - "LGPL"
     declared_licenses_processed:
       spdx_expression: "LGPL-2.0-or-later"
+      mapped:
+        LGPL: "LGPL-2.0-or-later"
     description: "This version, 1.12.1 is a Non-Maintainer Upload (NMU). Report issues\
       \ to the Hackage Trustees issue tracker.\n\nA variety of alternative parser\
       \ combinator libraries, including\nthe original HuttonMeijer set.  The Poly\
@@ -3266,6 +3374,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A JSON parsing and encoding library optimized for ease of use\n\
       and high performance.\n\nTo get started, see the documentation for the @Data.Aeson@\
       \ module\nbelow.\n\n(A note on naming: in Greek mythology, Aeson was the father\
@@ -3334,6 +3444,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package contains a pretty-printing library, a set of API's\n\
       that provides a way to easily print out text in a consistent\nformat of your\
       \ choosing. This is useful for compilers and related\ntools.\n\nThis library\
@@ -3398,6 +3510,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A clone of wl-pprint for use with the text library."
     homepage_url: ""
     binary_artifact:
@@ -3428,6 +3542,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A time library"
     homepage_url: "https://github.com/haskell/time"
     binary_artifact:
@@ -3458,6 +3574,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This is a pretty printing library based on Wadler's paper [\"A Prettier\
       \ Printer\"](https://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf).\
       \ It has been enhanced with support for ANSI terminal colored output using the\
@@ -3491,6 +3609,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "ANSI terminal support for Haskell: allows cursor movement,\nscreen\
       \ clearing, color output, showing or hiding the\ncursor, and changing the title.\
       \ Works on UNIX and Windows."

--- a/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output.yml
@@ -6,6 +6,8 @@ project:
   - "BSD3"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD3: "BSD-3-Clause"
   vcs:
     type: "Git"
     url: "https://github.com/advancedtelematic/quickcheck-state-machine"
@@ -1048,6 +1050,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "In mathematics, a semigroup is an algebraic structure consisting\
       \ of a set together with an associative binary operation. A semigroup generalizes\
       \ a monoid in that there might not exist an identity element. It also (originally)\
@@ -1163,6 +1167,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package includes backported versions of types that were added\n\
       to transformers in transformers 0.3, 0.4, and 0.5 for users who need strict\n\
       transformers 0.2 or 0.3 compatibility to run on old versions of the\nplatform,\
@@ -1198,6 +1204,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package provides a higher-level interface over\nthreads, in\
       \ which an @Async a@ is a concurrent\nthread that will eventually deliver a\
       \ value of\ntype @a@.  The package provides ways to create\n@Async@ computations,\
@@ -1236,6 +1244,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Software Transactional Memory, or STM, is an abstraction for\nconcurrent\
       \ communication. The main benefits of STM are\n/composability/ and /modularity/.\
       \ That is, using STM you can write\nconcurrent abstractions that can be easily\
@@ -1271,6 +1281,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Contravariant functors."
     homepage_url: "http://github.com/ekmett/contravariant/"
     binary_artifact:
@@ -1301,6 +1313,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Extensible optionally-pure exceptions."
     homepage_url: "http://github.com/ekmett/exceptions/"
     binary_artifact:
@@ -1331,6 +1345,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package provides methods for fully evaluating data structures\n\
       (\\\"deep evaluation\\\"). Deep evaluation is often used for adding\nstrictness\
       \ to a program, e.g. in order to force pending exceptions,\nremove space leaks,\
@@ -1402,6 +1418,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Monad classes using functional dependencies, with instances\nfor\
       \ various monad transformers, inspired by the paper\n/Functional Programming\
       \ with Overloading and Higher-Order Polymorphism/,\nby Mark P Jones, in /Advanced\
@@ -1435,6 +1453,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Per Conor McBride, the Newtype typeclass represents the packing\
       \ and unpacking of a newtype,\nand allows you to operate under that newtype\
       \ with functions such as ala.\nGenerics support was added in version 0.4, making\
@@ -1469,6 +1489,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A portable library of functor and monad transformers, inspired by\n\
       the paper \\\"Functional Programming with Overloading and Higher-Order\nPolymorphism\\\
       \", by Mark P Jones,\nin /Advanced School of Functional Programming/, 1995\n\
@@ -1570,6 +1592,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "An inductive representation of manipulating graph data structures.\n\
       \nOriginal website can be found at <http://web.engr.oregonstate.edu/~erwig/fgl/haskell>."
     homepage_url: ""
@@ -1601,6 +1625,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "In addition to providing the \"Data.Array\" module\n<http://www.haskell.org/onlinereport/haskell2010/haskellch14.html\
       \ as specified in the Haskell 2010 Language Report>,\nthis package also defines\
       \ the classes 'IArray' of\nimmutable arrays and 'MArray' of arrays mutable within\
@@ -1634,6 +1660,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package contains efficient general-purpose implementations\n\
       of various immutable container types including sets, maps, sequences,\ntrees,\
       \ and graphs.\n\nFor a walkthrough of what this package provides with examples\
@@ -1669,6 +1697,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "An efficient implementation of Int-indexed arrays (both mutable\n\
       and immutable), with a powerful loop optimisation framework .\n\nIt is structured\
       \ as follows:\n\n[\"Data.Vector\"] Boxed vectors of arbitrary types.\n\n[\"\
@@ -1708,6 +1738,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Efficient, pure binary serialisation using lazy ByteStrings.\nHaskell\
       \ values may be encoded to and from binary formats,\nwritten to disk as binary,\
       \ or sent over the network.\nThe format used can be automatically generated,\
@@ -1743,6 +1775,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Haskell 98 phantom types to avoid unsafely passing dummy arguments."
     homepage_url: "http://github.com/ekmett/tagged"
     binary_artifact:
@@ -1773,6 +1807,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Common diff algorithm works on list structures:\n\n@\ndiff :: Eq\
       \ a => [a] -> [a] -> [Edit a]\n@\n\nThis package works on trees.\n\n@\ntreeDiff\
       \ :: Eq a => Tree a -> Tree a -> Edit (EditTree a)\n@\n\nThis package also provides\
@@ -1812,6 +1848,8 @@ packages:
     - "BSD2"
     declared_licenses_processed:
       spdx_expression: "BSD-2-Clause"
+      mapped:
+        BSD2: "BSD-2-Clause"
     description: "An efficient packed, immutable Unicode text type (both strict and\n\
       lazy), with a powerful loop fusion optimization framework.\n\nThe 'Text' type\
       \ represents Unicode character strings, in a time and\nspace-efficient manner.\
@@ -1857,6 +1895,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "MemoTrie provides a basis for memoized functions over some domains,\n\
       using tries.  It's based on ideas from Ralf Hinze and code from\nSpencer Janssen.\
       \ Generic support thanks to Sam Boosalis.\n\nProject wiki page: <http://haskell.org/haskellwiki/MemoTrie>\n\
@@ -1890,6 +1930,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package contains state variables, which are references in the\
       \ IO monad,\nlike IORefs or parts of the OpenGL state."
     homepage_url: "https://github.com/haskell-opengl/StateVar"
@@ -1921,6 +1963,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "An efficient compact, immutable byte string type (both strict and\
       \ lazy)\nsuitable for binary or 8-bit character data.\n\nThe 'ByteString' type\
       \ represents sequences of bytes or 8-bit characters.\nIt is suitable for high\
@@ -1972,6 +2016,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Fast unicode character sets based on complemented PATRICIA tries"
     homepage_url: "http://github.com/ekmett/charset"
     binary_artifact:
@@ -2002,6 +2048,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Difference lists are a list-like type supporting O(1) append. This\
       \ is\nparticularly useful for efficient logging and pretty printing (e.g. with\
       \ the\nWriter monad), where list append quickly becomes too expensive."
@@ -2034,6 +2082,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package defines a class, 'Hashable', for types that\ncan be\
       \ converted to a hash value.  This class\nexists for the benefit of hashing-based\
       \ data\nstructures.  The package provides instances for\nbasic types and a way\
@@ -2067,6 +2117,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package provides various primitive memory-related operations."
     homepage_url: "https://github.com/haskell/primitive"
     binary_artifact:
@@ -2097,6 +2149,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "\"Data.Scientific\" provides the number type 'Scientific'. Scientific\
       \ numbers are\narbitrary precision and space efficient. They are represented\
       \ using\n<http://en.wikipedia.org/wiki/Scientific_notation scientific notation>.\n\
@@ -2145,6 +2199,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Implementation of n-ary sums and n-ary products.\n\nThe module \"\
       Data.SOP\" is the main module of this library and contains\nmore detailed documentation.\n\
       \nThe main use case of this package is to serve as the core of\n@<https://hackage.haskell.org/package/generics-sop\
@@ -2180,6 +2236,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Efficient hashing-based container types.  The containers have been\n\
       optimized for performance critical use, both in terms of large data\nquantities\
       \ and high speed.\n\nThe declared cost of each operation is either worst-case\
@@ -2213,6 +2271,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This library contains type definitions for Universally Unique Identifiers\n\
       and basic conversion functions.\n\nSee <http://en.wikipedia.org/wiki/UUID> for\
       \ the general idea."
@@ -2245,6 +2305,8 @@ packages:
     - "BSD2"
     declared_licenses_processed:
       spdx_expression: "BSD-2-Clause"
+      mapped:
+        BSD2: "BSD-2-Clause"
     description: "Happy is a parser generator for Haskell.  Given a grammar\nspecification\
       \ in BNF, Happy generates Haskell code to parse the\ngrammar.  Happy works in\
       \ a similar way to the @yacc@ tool for C."
@@ -2310,6 +2372,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "The Haskell Common Architecture for Building Applications and\n\
       Libraries: a framework defining a common interface for authors to more\neasily\
       \ build their Haskell applications in a portable way.\n\nThe Haskell Cabal is\
@@ -2375,6 +2439,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A library to support the definition of generic functions.\nDatatypes\
       \ are viewed in a uniform, structured way:\nthe choice between constructors\
       \ is represented using an n-ary\nsum, and the arguments of each constructor\
@@ -2421,6 +2487,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This library provides bindings for the Dot language used by the\n\
       Graphviz (<http://graphviz.org/>) suite of programs for visualising\ngraphs,\
       \ as well as functions to call those programs.\n\nMain features of the graphviz\
@@ -2464,6 +2532,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A fully compliant Haskell 98 lexer."
     homepage_url: "https://github.com/yav/haskell-lexer"
     binary_artifact:
@@ -2494,6 +2564,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A collection of various methods for splitting\nlists into parts,\
       \ akin to the \\\"split\\\" function\nfound in several mainstream languages.\
       \ Here is\nits tale:\n\nOnce upon a time the standard \"Data.List\" module\n\
@@ -2568,6 +2640,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Matrix library. Basic operations and some algorithms.\n\nTo get\
       \ the library update your cabal package list (if needed) with @cabal update@\
       \ and\nthen use @cabal install matrix@, assuming that you already have Cabal\
@@ -2603,6 +2677,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package provides the low-level implementation of the standard\n\
       'Integer' type based on the\n<http://gmplib.org/ GNU Multiple Precision Arithmetic\
       \ Library (GMP)>.\n\nThis package provides access to the internal representation\
@@ -2667,6 +2743,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Parsec is designed from scratch as an industrial-strength parser\n\
       library.  It is simple, safe, well documented (on the package\nhomepage), has\
       \ extensive libraries, good error messages,\nand is fast.  It is defined as\
@@ -2736,6 +2814,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Functions for creating temporary files and directories."
     homepage_url: "https://github.com/feuerbach/temporary"
     binary_artifact:
@@ -2766,6 +2846,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This library provides a basic set of operations for manipulating\
       \ files and\ndirectories in a portable way."
     homepage_url: ""
@@ -2797,6 +2879,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package provides functionality for manipulating @FilePath@\
       \ values, and is shipped with both <https://www.haskell.org/ghc/ GHC> and the\
       \ <https://www.haskell.org/platform/ Haskell Platform>. It provides three modules:\n\
@@ -2835,6 +2919,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package contains libraries for dealing with system processes.\n\
       \nThe typed-process package is a more recent take on a process API,\nwhich uses\
       \ this package internally. It features better binary\nsupport, easier concurrency,\
@@ -2868,6 +2954,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package provides a basic random number generation\nlibrary,\
       \ including the ability to split random number\ngenerators."
     homepage_url: ""
@@ -2899,6 +2987,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "Pure Haskell implementation of SplitMix described in\n\nGuy L. Steele,\
       \ Jr., Doug Lea, and Christine H. Flood. 2014.\nFast splittable pseudorandom\
       \ number generators. In Proceedings\nof the 2014 ACM International Conference\
@@ -2943,6 +3033,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package contains wrapped name module for time-format locale\
       \ between old-locale and time-1.5."
     homepage_url: "https://github.com/khibino/haskell-time-locale-compat"
@@ -2974,6 +3066,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package gives you access to the set of operating system\nservices\
       \ standardised by\n<http://pubs.opengroup.org/onlinepubs/9699919799/ POSIX.1-2008>\n\
       (or the IEEE Portable Operating System Interface for Computing\nEnvironments\
@@ -3007,6 +3101,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package provides modules containing facilities for manipulating\n\
       Haskell source code using Template Haskell.\n\nSee <http://www.haskell.org/haskellwiki/Template_Haskell>\
       \ for more\ninformation."
@@ -3039,6 +3135,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "QuickCheck is a library for random testing of program properties.\n\
       The programmer provides a specification of the program, in the form of\nproperties\
       \ which functions should satisfy, and QuickCheck then tests that the\nproperties\
@@ -3084,6 +3182,8 @@ packages:
     - "BSD2"
     declared_licenses_processed:
       spdx_expression: "BSD-2-Clause"
+      mapped:
+        BSD2: "BSD-2-Clause"
     description: "Please see the README on GitHub at <https://github.com/advancedtelematic/markov-chain-usage-model#readme>"
     homepage_url: "https://github.com/advancedtelematic/markov-chain-usage-model#readme"
     binary_artifact:
@@ -3114,6 +3214,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A fast parser combinator library, aimed particularly at dealing\n\
       efficiently with network protocols and complicated text/binary\nfile formats."
     homepage_url: "https://github.com/bos/attoparsec"
@@ -3145,6 +3247,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This library provides convenient combinators for working with and\
       \ building parsing combinator libraries.\n\nGiven a few simple instances, e.g.\
       \ for the class 'Text.Parser.Combinators.Parsing' in \"Text.Parser.Combinators.Parsing\"\
@@ -3179,6 +3283,8 @@ packages:
     - "LGPL"
     declared_licenses_processed:
       spdx_expression: "LGPL-2.0-or-later"
+      mapped:
+        LGPL: "LGPL-2.0-or-later"
     description: "This version, 1.12.1 is a Non-Maintainer Upload (NMU). Report issues\
       \ to the Hackage Trustees issue tracker.\n\nA variety of alternative parser\
       \ combinator libraries, including\nthe original HuttonMeijer set.  The Poly\
@@ -3215,6 +3321,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A JSON parsing and encoding library optimized for ease of use\n\
       and high performance.\n\nTo get started, see the documentation for the @Data.Aeson@\
       \ module\nbelow.\n\n(A note on naming: in Greek mythology, Aeson was the father\
@@ -3283,6 +3391,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This package contains a pretty-printing library, a set of API's\n\
       that provides a way to easily print out text in a consistent\nformat of your\
       \ choosing. This is useful for compilers and related\ntools.\n\nThis library\
@@ -3347,6 +3457,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A clone of wl-pprint for use with the text library."
     homepage_url: ""
     binary_artifact:
@@ -3377,6 +3489,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "A time library"
     homepage_url: "https://github.com/haskell/time"
     binary_artifact:
@@ -3407,6 +3521,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "This is a pretty printing library based on Wadler's paper [\"A Prettier\
       \ Printer\"](https://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf).\
       \ It has been enhanced with support for ANSI terminal colored output using the\
@@ -3440,6 +3556,8 @@ packages:
     - "BSD3"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD3: "BSD-3-Clause"
     description: "ANSI terminal support for Haskell: allows cursor movement,\nscreen\
       \ clearing, color output, showing or hiding the\ncursor, and changing the title.\
       \ Works on UNIX and Windows."

--- a/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
@@ -239,6 +239,9 @@ analyzer:
         - "GNU Lesser General Public License"
         declared_licenses_processed:
           spdx_expression: "EPL-1.0 AND LGPL-2.1-only"
+          mapped:
+            Eclipse Public License - v 1.0: "EPL-1.0"
+            GNU Lesser General Public License: "LGPL-2.1-only"
         description: "logback-classic module"
         homepage_url: "http://logback.qos.ch/logback-classic"
         binary_artifact:
@@ -270,6 +273,9 @@ analyzer:
         - "GNU Lesser General Public License"
         declared_licenses_processed:
           spdx_expression: "EPL-1.0 AND LGPL-2.1-only"
+          mapped:
+            Eclipse Public License - v 1.0: "EPL-1.0"
+            GNU Lesser General Public License: "LGPL-2.1-only"
         description: "logback-core module"
         homepage_url: "http://logback.qos.ch/logback-core"
         binary_artifact:
@@ -300,6 +306,8 @@ analyzer:
         - "Apache 2"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache 2: "Apache-2.0"
         description: "core"
         homepage_url: "https://github.com/milessabin/shapeless"
         binary_artifact:
@@ -330,6 +338,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "Core annotations used for value types, used by Jackson data\
           \ binding package."
         homepage_url: "http://github.com/FasterXML/jackson"
@@ -361,6 +371,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "Core Jackson abstractions, basic JSON streaming API implementation"
         homepage_url: "https://github.com/FasterXML/jackson-core"
         binary_artifact:
@@ -391,6 +403,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "General data-binding functionality for Jackson: works on core\
           \ streaming API"
         homepage_url: "http://github.com/FasterXML/jackson"
@@ -482,6 +496,8 @@ analyzer:
         - "Mozilla Public License, version 2.0"
         declared_licenses_processed:
           spdx_expression: "MPL-2.0"
+          mapped:
+            Mozilla Public License, version 2.0: "MPL-2.0"
         description: "pureconfig-macros"
         homepage_url: "https://github.com/pureconfig/pureconfig"
         binary_artifact:
@@ -512,6 +528,8 @@ analyzer:
         - "Mozilla Public License, version 2.0"
         declared_licenses_processed:
           spdx_expression: "MPL-2.0"
+          mapped:
+            Mozilla Public License, version 2.0: "MPL-2.0"
         description: "pureconfig"
         homepage_url: "https://github.com/pureconfig/pureconfig"
         binary_artifact:
@@ -542,6 +560,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "akka-actor"
         homepage_url: "http://akka.io/"
         binary_artifact:
@@ -572,6 +592,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "akka-stream"
         homepage_url: "http://akka.io/"
         binary_artifact:
@@ -602,6 +624,8 @@ analyzer:
         - "Apache 2.0 License"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache 2.0 License: "Apache-2.0"
         description: "scala-logging"
         homepage_url: "https://github.com/typesafehub/scala-logging"
         binary_artifact:
@@ -632,6 +656,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "config"
         homepage_url: "https://github.com/typesafehub/config"
         binary_artifact:
@@ -662,6 +688,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "ssl-config-core"
         homepage_url: "https://github.com/typesafehub/ssl-config"
         binary_artifact:
@@ -693,6 +721,9 @@ analyzer:
         - "MIT License"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0 AND MIT"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+            MIT License: "MIT"
         description: "Logback encoder which will output events as Logstash-compatible\
           \ JSON"
         homepage_url: "https://github.com/logstash/logstash-logback-encoder"
@@ -724,6 +755,8 @@ analyzer:
         - "CC0"
         declared_licenses_processed:
           spdx_expression: "CC0-1.0"
+          mapped:
+            CC0: "CC0-1.0"
         description: "A Protocol for Asynchronous Non-Blocking Data Sequence"
         homepage_url: "http://www.reactive-streams.org/"
         binary_artifact:
@@ -754,6 +787,8 @@ analyzer:
         - "BSD 3-clause"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-clause: "BSD-3-Clause"
         description: "scala-java8-compat"
         homepage_url: "http://www.scala-lang.org/"
         binary_artifact:
@@ -784,6 +819,8 @@ analyzer:
         - "BSD 3-clause"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-clause: "BSD-3-Clause"
         description: "scala-parser-combinators"
         homepage_url: "http://www.scala-lang.org/"
         binary_artifact:
@@ -814,6 +851,8 @@ analyzer:
         - "BSD 3-clause"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-clause: "BSD-3-Clause"
         description: "scala-xml"
         homepage_url: "http://www.scala-lang.org/"
         binary_artifact:
@@ -844,6 +883,8 @@ analyzer:
         - "BSD 3-Clause"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-Clause: "BSD-3-Clause"
         description: "Compiler for the Scala Programming Language"
         homepage_url: "http://www.scala-lang.org/"
         binary_artifact:
@@ -874,6 +915,8 @@ analyzer:
         - "BSD 3-Clause"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-Clause: "BSD-3-Clause"
         description: "Standard library for the Scala Programming Language"
         homepage_url: "http://www.scala-lang.org/"
         binary_artifact:
@@ -904,6 +947,8 @@ analyzer:
         - "BSD 3-Clause"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-Clause: "BSD-3-Clause"
         description: "Compiler for the Scala Programming Language"
         homepage_url: "http://www.scala-lang.org/"
         binary_artifact:
@@ -934,6 +979,8 @@ analyzer:
         - "BSD"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD: "BSD-3-Clause"
         description: "Uniform test interface to Scala/Java test frameworks (specs,\
           \ ScalaCheck, ScalaTest, JUnit and other)"
         homepage_url: "http://www.scala-sbt.org"
@@ -965,6 +1012,8 @@ analyzer:
         - "BSD-style"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD-style: "BSD-3-Clause"
         description: "scalacheck"
         homepage_url: "http://www.scalacheck.org"
         binary_artifact:
@@ -995,6 +1044,8 @@ analyzer:
         - "the Apache License, ASL Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            the Apache License, ASL Version 2.0: "Apache-2.0"
         description: "scalactic"
         homepage_url: "http://www.scalatest.org"
         binary_artifact:
@@ -1025,6 +1076,8 @@ analyzer:
         - "the Apache License, ASL Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            the Apache License, ASL Version 2.0: "Apache-2.0"
         description: "scalatest"
         homepage_url: "http://www.scalatest.org"
         binary_artifact:
@@ -1055,6 +1108,8 @@ analyzer:
         - "BSD-style"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD-style: "BSD-3-Clause"
         description: "scalaz-core"
         homepage_url: "http://scalaz.org"
         binary_artifact:
@@ -1085,6 +1140,8 @@ analyzer:
         - "MIT License"
         declared_licenses_processed:
           spdx_expression: "MIT"
+          mapped:
+            MIT License: "MIT"
         description: "JCL 1.2 implemented over SLF4J"
         homepage_url: "http://www.slf4j.org"
         binary_artifact:
@@ -1115,6 +1172,8 @@ analyzer:
         - "MIT License"
         declared_licenses_processed:
           spdx_expression: "MIT"
+          mapped:
+            MIT License: "MIT"
         description: "The slf4j API"
         homepage_url: "http://www.slf4j.org"
         binary_artifact:
@@ -1145,6 +1204,8 @@ analyzer:
         - "Apache 2"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache 2: "Apache-2.0"
         description: "core"
         homepage_url: "https://github.com/milessabin/macro-compat"
         binary_artifact:

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -7,6 +7,8 @@ project:
   - "Apache-2.0"
   declared_licenses_processed:
     spdx_expression: "Apache-2.0"
+    mapped:
+      Apache Software License: "Apache-2.0"
   vcs:
     type: ""
     url: ""
@@ -39,6 +41,9 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD: "BSD-3-Clause"
+        BSD License: "BSD-3-Clause"
     description: "An ISO 8601 date/time/duration parser and formatter"
     homepage_url: "https://github.com/gweis/isodate/"
     binary_artifact:
@@ -69,6 +74,8 @@ packages:
     - "BSD"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD: "BSD-3-Clause"
     description: "Python Lex & Yacc"
     homepage_url: "http://www.dabeaz.com/ply/"
     binary_artifact:
@@ -99,6 +106,8 @@ packages:
     - "MIT License"
     declared_licenses_processed:
       spdx_expression: "MIT"
+      mapped:
+        MIT License: "MIT"
     description: "Python parsing module"
     homepage_url: "https://github.com/pyparsing/pyparsing/"
     binary_artifact:
@@ -130,6 +139,8 @@ packages:
     - "BSD-3-Clause"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD License: "BSD-3-Clause"
     description: "RDFLib is a Python library for working with RDF, a simple yet powerful\
       \ language for representing information."
     homepage_url: "https://github.com/RDFLib/rdflib"
@@ -162,6 +173,8 @@ packages:
     - "MIT License"
     declared_licenses_processed:
       spdx_expression: "MIT"
+      mapped:
+        MIT License: "MIT"
     description: "Python 2 and 3 compatibility utilities"
     homepage_url: "https://github.com/benjaminp/six"
     binary_artifact:

--- a/analyzer/src/funTest/assets/projects/synthetic/bower-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bower-expected-output.yml
@@ -65,6 +65,8 @@ packages:
     - "http://polymer.github.io/LICENSE.txt"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        http://polymer.github.io/LICENSE.txt: "BSD-3-Clause"
     description: ""
     homepage_url: "https://github.com/Polymer/polymer"
     binary_artifact:

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
@@ -86,6 +86,8 @@ packages:
     - "MIT"
     declared_licenses_processed:
       spdx_expression: "Artistic-2.0 AND GPL-2.0-or-later AND MIT"
+      mapped:
+        GPL-2.0+: "GPL-2.0-or-later"
     description: "Diff::LCS computes the difference between two Enumerable sequences\
       \ using the\nMcIlroy-Hunt longest common subsequence (LCS) algorithm. It includes\
       \ utilities\nto create a simple HTML diff output format and a standard diff-like\

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
@@ -47,6 +47,8 @@ packages:
     - "MIT"
     declared_licenses_processed:
       spdx_expression: "Artistic-2.0 AND GPL-2.0-or-later AND MIT"
+      mapped:
+        GPL-2.0+: "GPL-2.0-or-later"
     description: "Diff::LCS computes the difference between two Enumerable sequences\
       \ using the\nMcIlroy-Hunt longest common subsequence (LCS) algorithm. It includes\
       \ utilities\nto create a simple HTML diff output format and a standard diff-like\

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -416,6 +416,8 @@ analyzer:
         - "Eclipse Public License 1.0"
         declared_licenses_processed:
           spdx_expression: "EPL-1.0"
+          mapped:
+            Eclipse Public License 1.0: "EPL-1.0"
         description: "JUnit is a unit testing framework for Java, created by Erich\
           \ Gamma and Kent Beck."
         homepage_url: "http://junit.org"
@@ -447,6 +449,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Apache Commons Lang, a package of Java utility classes for the\n\
           \  classes that are in java.lang's hierarchy, or are considered to be so\n\
           \  standard as to justify existence in java.lang."
@@ -479,6 +483,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Apache Commons Text is a library focused on algorithms working\
           \ on strings."
         homepage_url: "http://commons.apache.org/proper/commons-text/"
@@ -510,6 +516,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "Apache Struts 2"
         homepage_url: "http://struts.apache.org/struts2-assembly/"
         binary_artifact:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -416,6 +416,8 @@ analyzer:
         - "Eclipse Public License 1.0"
         declared_licenses_processed:
           spdx_expression: "EPL-1.0"
+          mapped:
+            Eclipse Public License 1.0: "EPL-1.0"
         description: "JUnit is a unit testing framework for Java, created by Erich\
           \ Gamma and Kent Beck."
         homepage_url: "http://junit.org"
@@ -447,6 +449,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Apache Commons Lang, a package of Java utility classes for the\n\
           \  classes that are in java.lang's hierarchy, or are considered to be so\n\
           \  standard as to justify existence in java.lang."
@@ -479,6 +483,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Apache Commons Text is a library focused on algorithms working\
           \ on strings."
         homepage_url: "http://commons.apache.org/proper/commons-text/"
@@ -510,6 +516,8 @@ analyzer:
         - "The Apache Software License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
         description: "Apache Struts 2"
         homepage_url: "http://struts.apache.org/struts2-assembly/"
         binary_artifact:
@@ -540,6 +548,8 @@ analyzer:
         - "New BSD License"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            New BSD License: "BSD-3-Clause"
         description: "This is the core API of hamcrest matcher framework to be used\
           \ by third-party framework providers. This includes the a foundation set\
           \ of matcher implementations for common operations."

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
@@ -462,6 +462,8 @@ packages:
     - "Apache 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache 2.0: "Apache-2.0"
     description: "An HTTP+HTTP/2 client for Android and Java applications"
     homepage_url: "https://github.com/square/okhttp/okhttp"
     binary_artifact:
@@ -492,6 +494,8 @@ packages:
     - "Apache 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache 2.0: "Apache-2.0"
     description: "A modern I/O API for Java"
     homepage_url: "https://github.com/square/okio/okio"
     binary_artifact:
@@ -522,6 +526,8 @@ packages:
     - "Eclipse Public License 1.0"
     declared_licenses_processed:
       spdx_expression: "EPL-1.0"
+      mapped:
+        Eclipse Public License 1.0: "EPL-1.0"
     description: "JUnit is a unit testing framework for Java, created by Erich Gamma\
       \ and Kent Beck."
     homepage_url: "http://junit.org"
@@ -553,6 +559,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Compress software defines an API for working with\n\
       compression and archive formats.  These include: bzip2, gzip, pack200,\nlzma,\
       \ xz, Snappy, traditional Unix Compress, DEFLATE, DEFLATE64, LZ4,\nBrotli, Zstandard\
@@ -586,6 +594,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Lang, a package of Java utility classes for the\n\
       \  classes that are in java.lang's hierarchy, or are considered to be so\n \
       \ standard as to justify existence in java.lang."
@@ -618,6 +628,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Text is a library focused on algorithms working on\
       \ strings."
     homepage_url: "http://commons.apache.org/proper/commons-text/"
@@ -649,6 +661,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Text is a library focused on algorithms working on\
       \ strings."
     homepage_url: "http://commons.apache.org/proper/commons-text/"
@@ -680,6 +694,8 @@ packages:
     - "New BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        New BSD License: "BSD-3-Clause"
     description: "This is the core API of hamcrest matcher framework to be used by\
       \ third-party framework providers. This includes the a foundation set of matcher\
       \ implementations for common operations."

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
@@ -178,6 +178,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Compress software defines an API for working with\n\
       compression and archive formats.  These include: bzip2, gzip, pack200,\nlzma,\
       \ xz, Snappy, traditional Unix Compress, DEFLATE, DEFLATE64, LZ4,\nBrotli, Zstandard\
@@ -211,6 +213,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Lang, a package of Java utility classes for the\n\
       \  classes that are in java.lang's hierarchy, or are considered to be so\n \
       \ standard as to justify existence in java.lang."
@@ -243,6 +247,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Text is a library focused on algorithms working on\
       \ strings."
     homepage_url: "http://commons.apache.org/proper/commons-text/"
@@ -274,6 +280,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Text is a library focused on algorithms working on\
       \ strings."
     homepage_url: "http://commons.apache.org/proper/commons-text/"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -115,6 +115,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Lang, a package of Java utility classes for the\n\
       \  classes that are in java.lang's hierarchy, or are considered to be so\n \
       \ standard as to justify existence in java.lang."
@@ -147,6 +149,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Text is a library focused on algorithms working on\
       \ strings."
     homepage_url: "http://commons.apache.org/proper/commons-text/"
@@ -178,6 +182,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Apache Struts 2"
     homepage_url: "http://struts.apache.org/struts2-assembly/"
     binary_artifact:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -100,6 +100,8 @@ packages:
     - "Eclipse Public License 1.0"
     declared_licenses_processed:
       spdx_expression: "EPL-1.0"
+      mapped:
+        Eclipse Public License 1.0: "EPL-1.0"
     description: "JUnit is a unit testing framework for Java, created by Erich Gamma\
       \ and Kent Beck."
     homepage_url: "http://junit.org"
@@ -131,6 +133,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Lang, a package of Java utility classes for the\n\
       \  classes that are in java.lang's hierarchy, or are considered to be so\n \
       \ standard as to justify existence in java.lang."
@@ -163,6 +167,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Text is a library focused on algorithms working on\
       \ strings."
     homepage_url: "http://commons.apache.org/proper/commons-text/"
@@ -194,6 +200,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Apache Struts 2"
     homepage_url: "http://struts.apache.org/struts2-assembly/"
     binary_artifact:
@@ -224,6 +232,8 @@ packages:
     - "New BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        New BSD License: "BSD-3-Clause"
     description: "This is the core API of hamcrest matcher framework to be used by\
       \ third-party framework providers. This includes the a foundation set of matcher\
       \ implementations for common operations."

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
@@ -113,6 +113,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Lang, a package of Java utility classes for the\n\
       \  classes that are in java.lang's hierarchy, or are considered to be so\n \
       \ standard as to justify existence in java.lang."
@@ -145,6 +147,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Text is a library focused on algorithms working on\
       \ strings."
     homepage_url: "http://commons.apache.org/proper/commons-text/"
@@ -176,6 +180,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Apache Struts 2"
     homepage_url: "http://struts.apache.org/struts2-assembly/"
     binary_artifact:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
@@ -78,6 +78,8 @@ packages:
     - "Eclipse Public License 1.0"
     declared_licenses_processed:
       spdx_expression: "EPL-1.0"
+      mapped:
+        Eclipse Public License 1.0: "EPL-1.0"
     description: "JUnit is a unit testing framework for Java, created by Erich Gamma\
       \ and Kent Beck."
     homepage_url: "http://junit.org"
@@ -109,6 +111,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Lang, a package of Java utility classes for the\n\
       \  classes that are in java.lang's hierarchy, or are considered to be so\n \
       \ standard as to justify existence in java.lang."
@@ -141,6 +145,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Text is a library focused on algorithms working on\
       \ strings."
     homepage_url: "http://commons.apache.org/proper/commons-text/"
@@ -172,6 +178,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Apache Struts 2"
     homepage_url: "http://struts.apache.org/struts2-assembly/"
     binary_artifact:
@@ -202,6 +210,8 @@ packages:
     - "New BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        New BSD License: "BSD-3-Clause"
     description: "This is the core API of hamcrest matcher framework to be used by\
       \ third-party framework providers. This includes the a foundation set of matcher\
       \ implementations for common operations."

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
@@ -6,6 +6,8 @@ project:
   - "Apache License, Version 2.0"
   declared_licenses_processed:
     spdx_expression: "Apache-2.0"
+    mapped:
+      Apache License, Version 2.0: "Apache-2.0"
   vcs:
     type: ""
     url: ""
@@ -36,6 +38,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Beam provides a simple, Java-based interface\n  for processing\
       \ virtually any size data. This artifact includes the parent POM\n  for other\
       \ Beam artifacts."
@@ -68,6 +72,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Lang, a package of Java utility classes for the\n\
       \  classes that are in java.lang's hierarchy, or are considered to be so\n \
       \ standard as to justify existence in java.lang."
@@ -100,6 +106,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Text is a library focused on algorithms working on\
       \ strings."
     homepage_url: "http://commons.apache.org/proper/commons-text/"
@@ -131,6 +139,8 @@ packages:
     - "MIT License"
     declared_licenses_processed:
       spdx_expression: "MIT"
+      mapped:
+        MIT License: "MIT"
     description: ""
     homepage_url: "http://jenkins-ci.org/version-number/"
     binary_artifact:

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
@@ -6,6 +6,8 @@ project:
   - "Apache License, Version 2.0"
   declared_licenses_processed:
     spdx_expression: "Apache-2.0"
+    mapped:
+      Apache License, Version 2.0: "Apache-2.0"
   vcs:
     type: ""
     url: ""
@@ -36,6 +38,8 @@ packages:
     - "Common Public License Version 1.0"
     declared_licenses_processed:
       spdx_expression: "CPL-1.0"
+      mapped:
+        Common Public License Version 1.0: "CPL-1.0"
     description: "JUnit is a regression testing framework written by Erich Gamma and\
       \ Kent Beck. It is used by the developer who implements unit tests in Java."
     homepage_url: "http://junit.org"
@@ -67,6 +71,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Beam provides a simple, Java-based interface\n  for processing\
       \ virtually any size data. This artifact includes the parent POM\n  for other\
       \ Beam artifacts."
@@ -99,6 +105,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Lang, a package of Java utility classes for the\n\
       \  classes that are in java.lang's hierarchy, or are considered to be so\n \
       \ standard as to justify existence in java.lang."
@@ -131,6 +139,8 @@ packages:
     - "Apache License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
     description: "Apache Commons Text is a library focused on algorithms working on\
       \ strings."
     homepage_url: "http://commons.apache.org/proper/commons-text/"
@@ -162,6 +172,8 @@ packages:
     - "MIT License"
     declared_licenses_processed:
       spdx_expression: "MIT"
+      mapped:
+        MIT License: "MIT"
     description: ""
     homepage_url: "http://jenkins-ci.org/version-number/"
     binary_artifact:

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
@@ -6,6 +6,8 @@ project:
   - "Apache License, Version 2.0"
   declared_licenses_processed:
     spdx_expression: "Apache-2.0"
+    mapped:
+      Apache License, Version 2.0: "Apache-2.0"
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
@@ -6,6 +6,8 @@ project:
   - "Apache License, Version 2.0"
   declared_licenses_processed:
     spdx_expression: "Apache-2.0"
+    mapped:
+      Apache License, Version 2.0: "Apache-2.0"
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -4134,6 +4134,8 @@ packages:
     - "BSD"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD: "BSD-3-Clause"
     description: "utility box for ECMAScript language tools"
     homepage_url: "https://github.com/estools/esutils"
     binary_artifact:

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
@@ -297,6 +297,8 @@ packages:
     - "BSD-like"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD-like: "BSD-3-Clause"
     description: "a CSS selector compiler/engine"
     homepage_url: "https://github.com/fb55/css-select#readme"
     binary_artifact:

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -6,6 +6,8 @@ project:
   - "MIT License"
   declared_licenses_processed:
     spdx_expression: "MIT"
+    mapped:
+      MIT License: "MIT"
   vcs:
     type: ""
     url: ""
@@ -37,6 +39,9 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD: "BSD-3-Clause"
+        BSD License: "BSD-3-Clause"
     description: "A simple framework for building complex web applications."
     homepage_url: "https://www.palletsprojects.com/p/flask/"
     binary_artifact:
@@ -68,6 +73,9 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD: "BSD-3-Clause"
+        BSD License: "BSD-3-Clause"
     description: "A small but fast and easy to use stand-alone template engine written\
       \ in pure python."
     homepage_url: "http://jinja.pocoo.org/"
@@ -100,6 +108,9 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD: "BSD-3-Clause"
+        BSD License: "BSD-3-Clause"
     description: "Implements a XML/HTML/XHTML Markup safe string for Python"
     homepage_url: "http://github.com/pallets/markupsafe"
     binary_artifact:
@@ -131,6 +142,8 @@ packages:
     - "BSD-3-Clause"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD License: "BSD-3-Clause"
     description: "The comprehensive WSGI web application library."
     homepage_url: "https://palletsprojects.com/p/werkzeug/"
     binary_artifact:
@@ -161,6 +174,8 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD License: "BSD-3-Clause"
     description: "A simple wrapper around optparse for powerful command line utilities."
     homepage_url: "http://github.com/mitsuhiko/click"
     binary_artifact:
@@ -191,6 +206,8 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD License: "BSD-3-Clause"
     description: "Various helpers to pass trusted data to untrusted environments and\
       \ back."
     homepage_url: "http://github.com/mitsuhiko/itsdangerous"

--- a/analyzer/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
@@ -35,6 +35,9 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD: "BSD-3-Clause"
+        BSD License: "BSD-3-Clause"
     description: "A simple framework for building complex web applications."
     homepage_url: "https://www.palletsprojects.com/p/flask/"
     binary_artifact:
@@ -66,6 +69,9 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD: "BSD-3-Clause"
+        BSD License: "BSD-3-Clause"
     description: "A small but fast and easy to use stand-alone template engine written\
       \ in pure python."
     homepage_url: "http://jinja.pocoo.org/"
@@ -98,6 +104,9 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD: "BSD-3-Clause"
+        BSD License: "BSD-3-Clause"
     description: "Implements a XML/HTML/XHTML Markup safe string for Python"
     homepage_url: "http://github.com/pallets/markupsafe"
     binary_artifact:
@@ -129,6 +138,8 @@ packages:
     - "BSD-3-Clause"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD License: "BSD-3-Clause"
     description: "The comprehensive WSGI web application library."
     homepage_url: "https://palletsprojects.com/p/werkzeug/"
     binary_artifact:
@@ -159,6 +170,8 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD License: "BSD-3-Clause"
     description: "A simple wrapper around optparse for powerful command line utilities."
     homepage_url: "http://github.com/mitsuhiko/click"
     binary_artifact:
@@ -189,6 +202,8 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD License: "BSD-3-Clause"
     description: "Various helpers to pass trusted data to untrusted environments and\
       \ back."
     homepage_url: "http://github.com/mitsuhiko/itsdangerous"

--- a/analyzer/src/funTest/assets/projects/synthetic/pub-expected-output-project-with-flutter.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pub-expected-output-project-with-flutter.yml
@@ -11243,6 +11243,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -11276,6 +11278,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -11309,6 +11313,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Android Arch-Common"
     homepage_url: "https://developer.android.com/topic/libraries/architecture/index.html"
     binary_artifact:
@@ -11339,6 +11345,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Android Arch-Runtime"
     homepage_url: "https://developer.android.com/topic/libraries/architecture/index.html"
     binary_artifact:
@@ -11369,6 +11377,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -11402,6 +11412,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Android Support Custom Tabs"
     homepage_url: "http://developer.android.com/tools/extras/support-library.html"
     binary_artifact:
@@ -11432,6 +11444,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Android Support CardView v7"
     homepage_url: "http://developer.android.com/tools/extras/support-library.html"
     binary_artifact:
@@ -11462,6 +11476,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Standalone efficient collections."
     homepage_url: "http://developer.android.com/tools/extras/support-library.html"
     binary_artifact:
@@ -11492,6 +11508,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -11525,6 +11543,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -11558,6 +11578,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -11591,6 +11613,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -11624,6 +11648,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -11657,6 +11683,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -11690,6 +11718,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -11723,6 +11753,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -11756,6 +11788,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -11789,6 +11823,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -11822,6 +11858,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -11855,6 +11893,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Android Lifecycle-Common"
     homepage_url: "https://developer.android.com/topic/libraries/architecture/index.html"
     binary_artifact:
@@ -11885,6 +11925,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Android Lifecycle LiveData Core"
     homepage_url: "https://developer.android.com/topic/libraries/architecture/index.html"
     binary_artifact:
@@ -11915,6 +11957,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Android Lifecycle LiveData"
     homepage_url: "https://developer.android.com/topic/libraries/architecture/index.html"
     binary_artifact:
@@ -11945,6 +11989,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Android Lifecycle Runtime"
     homepage_url: "https://developer.android.com/topic/libraries/architecture/index.html"
     binary_artifact:
@@ -11975,6 +12021,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Android Lifecycle ViewModel"
     homepage_url: "https://developer.android.com/topic/libraries/architecture/index.html"
     binary_artifact:
@@ -12005,6 +12053,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -12038,6 +12088,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -12071,6 +12123,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -12104,6 +12158,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -12137,6 +12193,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -12170,6 +12228,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -12203,6 +12263,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Android Support AnimatedVectorDrawable"
     homepage_url: "http://developer.android.com/tools/extras/support-library.html"
     binary_artifact:
@@ -12233,6 +12295,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Android Support VectorDrawable"
     homepage_url: "http://developer.android.com/tools/extras/support-library.html"
     binary_artifact:
@@ -12263,6 +12327,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Provides a stable but relatively compact binary serialization format\
       \ that can be passed across processes or persisted safely."
     homepage_url: "http://developer.android.com/tools/extras/support-library.html"
@@ -12294,6 +12360,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "The Support Library is a static library that you can add to your\
       \ Android application in order to use APIs that are either not available for\
       \ older platform versions or utility APIs that aren't a part of the framework\
@@ -12575,6 +12643,8 @@ packages:
     - "The Apache Software License, Version 2.0"
     declared_licenses_processed:
       spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
     description: "Core barcode encoding/decoding library"
     homepage_url: "https://github.com/zxing/zxing/core"
     binary_artifact:
@@ -12605,6 +12675,8 @@ packages:
     - "BSD 2-Clause License"
     declared_licenses_processed:
       spdx_expression: "BSD-2-Clause"
+      mapped:
+        BSD 2-Clause License: "BSD-2-Clause"
     description: "Bolts is a collection of low-level libraries designed to make developing\
       \ mobile apps easier."
     homepage_url: "https://github.com/BoltsFramework/Bolts-Android"
@@ -12636,6 +12708,8 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD License: "BSD-3-Clause"
     description: "Bolts is a collection of low-level libraries designed to make developing\
       \ mobile apps easier."
     homepage_url: "https://github.com/BoltsFramework/Bolts-Android"
@@ -12667,6 +12741,8 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD License: "BSD-3-Clause"
     description: "Bolts is a collection of low-level libraries designed to make developing\
       \ mobile apps easier."
     homepage_url: "https://github.com/BoltsFramework/Bolts-Android"

--- a/analyzer/src/funTest/assets/projects/synthetic/python3-django-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/python3-django-expected-output.yml
@@ -31,6 +31,9 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD: "BSD-3-Clause"
+        BSD License: "BSD-3-Clause"
     description: "A high-level Python Web framework that encourages rapid development\
       \ and clean, pragmatic design."
     homepage_url: "https://www.djangoproject.com/"
@@ -63,6 +66,8 @@ packages:
     - "MIT License"
     declared_licenses_processed:
       spdx_expression: "MIT"
+      mapped:
+        MIT License: "MIT"
     description: "World timezone definitions, modern and historical"
     homepage_url: "http://pythonhosted.org/pytz"
     binary_artifact:
@@ -94,6 +99,9 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD: "BSD-3-Clause"
+        BSD License: "BSD-3-Clause"
     description: "Non-validating SQL parser"
     homepage_url: "https://github.com/andialbrecht/sqlparse"
     binary_artifact:

--- a/analyzer/src/funTest/assets/projects/synthetic/python3-django-pipenv-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/python3-django-pipenv-expected-output.yml
@@ -30,6 +30,9 @@ packages:
     - "BSD License"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD: "BSD-3-Clause"
+        BSD License: "BSD-3-Clause"
     description: "A high-level Python Web framework that encourages rapid development\
       \ and clean, pragmatic design."
     homepage_url: "https://www.djangoproject.com/"
@@ -62,6 +65,8 @@ packages:
     - "MIT License"
     declared_licenses_processed:
       spdx_expression: "MIT"
+      mapped:
+        MIT License: "MIT"
     description: "World timezone definitions, modern and historical"
     homepage_url: "http://pythonhosted.org/pytz"
     binary_artifact:

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
@@ -297,6 +297,8 @@ packages:
     - "BSD-like"
     declared_licenses_processed:
       spdx_expression: "BSD-3-Clause"
+      mapped:
+        BSD-like: "BSD-3-Clause"
     description: "a CSS selector compiler/engine"
     homepage_url: "https://github.com/fb55/css-select#readme"
     binary_artifact:

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -101,6 +101,8 @@ analyzer:
         - "Eclipse Public License 1.0"
         declared_licenses_processed:
           spdx_expression: "EPL-1.0"
+          mapped:
+            Eclipse Public License 1.0: "EPL-1.0"
         description: "JUnit is a unit testing framework for Java, created by Erich\
           \ Gamma and Kent Beck."
         homepage_url: "http://junit.org"
@@ -132,6 +134,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Apache Commons Lang, a package of Java utility classes for the\n\
           \  classes that are in java.lang's hierarchy, or are considered to be so\n\
           \  standard as to justify existence in java.lang."
@@ -164,6 +168,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Apache Commons Text is a library focused on algorithms working\
           \ on strings."
         homepage_url: "http://commons.apache.org/proper/commons-text/"
@@ -195,6 +201,8 @@ analyzer:
         - "New BSD License"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            New BSD License: "BSD-3-Clause"
         description: "This is the core API of hamcrest matcher framework to be used\
           \ by third-party framework providers. This includes the a foundation set\
           \ of matcher implementations for common operations."

--- a/scanner/src/funTest/assets/analyzer-result.yml
+++ b/scanner/src/funTest/assets/analyzer-result.yml
@@ -56,19 +56,26 @@ analyzer:
     packages:
     - package:
         id: "Maven:junit:junit:4.12"
+        purl: "pkg:maven/junit/junit@4.12"
         declared_licenses:
         - "Eclipse Public License 1.0"
+        declared_licenses_processed:
+          spdx_expression: "EPL-1.0"
+          mapped:
+            Eclipse Public License 1.0: "EPL-1.0"
         description: "JUnit is a unit testing framework for Java, created by Erich\
           \ Gamma and Kent Beck."
         homepage_url: "http://junit.org"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
-          hash: "2973d150c0dc1fefe998f834810d68f278ea58ec"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-          hash: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: ""
@@ -82,20 +89,27 @@ analyzer:
       curations: []
     - package:
         id: "Maven:org.apache.commons:commons-lang3:3.5"
+        purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
         declared_licenses:
         - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Apache Commons Lang, a package of Java utility classes for the\n\
           \  classes that are in java.lang's hierarchy, or are considered to be so\n\
           \  standard as to justify existence in java.lang."
         homepage_url: "http://commons.apache.org/proper/commons-lang/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
-          hash: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-          hash: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: ""
@@ -109,19 +123,26 @@ analyzer:
       curations: []
     - package:
         id: "Maven:org.apache.commons:commons-text:1.1"
+        purl: "pkg:maven/org.apache.commons/commons-text@1.1"
         declared_licenses:
         - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Apache Commons Text is a library focused on algorithms working\
           \ on strings."
         homepage_url: "http://commons.apache.org/proper/commons-text/"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
-          hash: "c336bf600f44b88af356c8a85eef4af822b06a4d"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-          hash: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: ""
@@ -135,20 +156,27 @@ analyzer:
       curations: []
     - package:
         id: "Maven:org.hamcrest:hamcrest-core:1.3"
+        purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
         declared_licenses:
         - "New BSD License"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            New BSD License: "BSD-3-Clause"
         description: "This is the core API of hamcrest matcher framework to be used\
           \ by third-party framework providers. This includes the a foundation set\
           \ of matcher implementations for common operations."
         homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
         binary_artifact:
           url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
-          hash: "42a25dc3219429f0e5d060061f71acb49bf010a0"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+            algorithm: "SHA-1"
         source_artifact:
           url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-          hash: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+            algorithm: "SHA-1"
         vcs:
           type: ""
           url: ""

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -62,6 +62,8 @@ analyzer:
         - "Eclipse Public License 1.0"
         declared_licenses_processed:
           spdx_expression: "EPL-1.0"
+          mapped:
+            Eclipse Public License 1.0: "EPL-1.0"
         description: "JUnit is a unit testing framework for Java, created by Erich\
           \ Gamma and Kent Beck."
         homepage_url: "http://junit.org"
@@ -93,6 +95,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Apache Commons Lang, a package of Java utility classes for the\n\
           \  classes that are in java.lang's hierarchy, or are considered to be so\n\
           \  standard as to justify existence in java.lang."
@@ -125,6 +129,8 @@ analyzer:
         - "Apache License, Version 2.0"
         declared_licenses_processed:
           spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
         description: "Apache Commons Text is a library focused on algorithms working\
           \ on strings."
         homepage_url: "http://commons.apache.org/proper/commons-text/"
@@ -156,6 +162,8 @@ analyzer:
         - "New BSD License"
         declared_licenses_processed:
           spdx_expression: "BSD-3-Clause"
+          mapped:
+            New BSD License: "BSD-3-Clause"
         description: "This is the core API of hamcrest matcher framework to be used\
           \ by third-party framework providers. This includes the a foundation set\
           \ of matcher implementations for common operations."

--- a/utils/src/main/kotlin/DeclaredLicenseProcessor.kt
+++ b/utils/src/main/kotlin/DeclaredLicenseProcessor.kt
@@ -67,15 +67,22 @@ object DeclaredLicenseProcessor {
     }
 
     fun process(declaredLicenses: Collection<String>): ProcessedDeclaredLicense {
-        val processedLicenses = mutableSetOf<SpdxExpression>()
+        val processedLicenses = mutableMapOf<String, SpdxExpression>()
         val unmapped = mutableListOf<String>()
 
-        declaredLicenses.forEach { declaredLicense ->
-            process(declaredLicense)?.let { processedLicenses += it } ?: run { unmapped += declaredLicense }
+        declaredLicenses.distinct().forEach { declaredLicense ->
+            process(declaredLicense)?.let {
+                processedLicenses[declaredLicense] = it
+            } ?: run { unmapped += declaredLicense }
         }
 
-        val spdxExpression = processedLicenses.takeUnless { it.isEmpty() }?.reduce { left, right -> left and right }
-        return ProcessedDeclaredLicense(spdxExpression, unmapped)
+        val spdxExpression = processedLicenses.values.distinct().takeUnless { it.isEmpty() }
+            ?.reduce { left, right -> left and right }
+        val mapped = processedLicenses.filterNot { (key, value) ->
+            key.removeSurrounding("(", ")") == value.toString()
+        }
+
+        return ProcessedDeclaredLicense(spdxExpression, mapped, unmapped)
     }
 
     private fun parseLicense(declaredLicense: String) =
@@ -95,6 +102,13 @@ data class ProcessedDeclaredLicense(
     val spdxExpression: SpdxExpression?,
 
     /**
+     * A map from the original declared license strings to the SPDX expressions they were mapped to. If the original
+     * declared license string and the processed declared license are identical they are not contained in this map.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val mapped: Map<String, SpdxExpression> = emptyMap(),
+
+    /**
      * Declared licenses that could not be mapped to an SPDX expression.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -104,6 +118,7 @@ data class ProcessedDeclaredLicense(
         @JvmField
         val EMPTY = ProcessedDeclaredLicense(
             spdxExpression = null,
+            mapped = emptyMap(),
             unmapped = emptyList()
         )
     }

--- a/utils/src/test/kotlin/DeclaredLicenseProcessorTest.kt
+++ b/utils/src/test/kotlin/DeclaredLicenseProcessorTest.kt
@@ -23,6 +23,8 @@ import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.maps.beEmpty
+import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -30,8 +32,10 @@ import io.kotest.matchers.shouldNotBe
 import org.ossreviewtoolkit.spdx.SpdxDeclaredLicenseMapping
 import org.ossreviewtoolkit.spdx.SpdxException
 import org.ossreviewtoolkit.spdx.SpdxExpression
+import org.ossreviewtoolkit.spdx.SpdxLicense
 import org.ossreviewtoolkit.spdx.SpdxLicenseAliasMapping
 import org.ossreviewtoolkit.spdx.SpdxLicenseIdExpression
+import org.ossreviewtoolkit.spdx.toExpression
 
 class DeclaredLicenseProcessorTest : StringSpec() {
     /**
@@ -56,6 +60,10 @@ class DeclaredLicenseProcessorTest : StringSpec() {
             val processedLicenses = DeclaredLicenseProcessor.process(declaredLicenses)
 
             processedLicenses.spdxExpression shouldBe SpdxLicenseIdExpression("Apache-2.0")
+            processedLicenses.mapped shouldContainExactly (mapOf(
+                "Apache2" to SpdxLicense.APACHE_2_0.toExpression(),
+                "Apache-2" to SpdxLicense.APACHE_2_0.toExpression()
+            ))
             processedLicenses.unmapped shouldBe emptyList()
         }
 
@@ -92,6 +100,7 @@ class DeclaredLicenseProcessorTest : StringSpec() {
             val processedLicenses = DeclaredLicenseProcessor.process(declaredLicenses)
 
             processedLicenses.spdxExpression shouldBe SpdxLicenseIdExpression("Apache-2.0")
+            processedLicenses.mapped should beEmpty()
             processedLicenses.unmapped should containExactly("invalid")
         }
     }


### PR DESCRIPTION
Add a map to the `ProcessedDeclaredLicense` that records for each
declared license string to which SPDX expression it was mapped.

This improves transparency on how ORT creates it's results, helps with
debugging declared license mappings, and can later be shown in the
reports.