### PR TITLE
ClearlyDefinedUploadCommand: Rely on components getting implicitly harvested

### DIFF
--- a/cli/src/main/kotlin/commands/ClearlyDefinedUploadCommand.kt
+++ b/cli/src/main/kotlin/commands/ClearlyDefinedUploadCommand.kt
@@ -136,31 +136,16 @@ class ClearlyDefinedUploadCommand : CliktCommand(
             }
         }
 
-        val harvestableCurations = curationsByHarvestStatus[HarvestStatus.NOT_HARVESTED].orEmpty()
+        val unharvestedCurations = curationsByHarvestStatus[HarvestStatus.NOT_HARVESTED].orEmpty()
 
-        harvestableCurations.forEach { curation ->
+        unharvestedCurations.forEach { curation ->
             val webServerUrl = server.url.replaceFirst("dev-api.", "dev.").replaceFirst("api.", "")
             val definitionUrl = "$webServerUrl/definitions/${curationsToCoordinates[curation]}"
 
             println(
-                "Package '${curation.id.toCoordinates()}' has not been harvested yet, requesting it to be harvested. " +
+                "Package '${curation.id.toCoordinates()}' was not harvested until now, but harvesting was requested. " +
                         "Check $definitionUrl for the harvesting status."
             )
-        }
-
-        val harvestRequest = harvestableCurations.mapNotNull { curation ->
-            curationsToCoordinates[curation]?.let { coordinates ->
-                ClearlyDefinedService.HarvestRequest(
-                    tool = "package",
-                    coordinates = coordinates
-                )
-            }
-        }
-
-        if (requestHarvest(harvestRequest)) {
-            println("Requesting harvest of packages succeeded.")
-        } else {
-            println("Requesting harvest of packages failed.")
         }
 
         var error = false


### PR DESCRIPTION
As explained at [1] and visible in the code at [2], getting the
definitions already triggers the harvest of non-harvested components, so
omit requesting an explicit harvest again.

[1] https://github.com/oss-review-toolkit/ort/pull/2611#issuecomment-628744320
[2] https://github.com/clearlydefined/service/blob/4917725/business/definitionService.js#L212

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>