### PR TITLE
Gradle: Eventually show stdout and stderr of the analyzed build

### DIFF
--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -46,6 +46,7 @@ import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.showStackTrace
 import org.ossreviewtoolkit.utils.temporaryProperties
 
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.Properties
 import java.util.concurrent.TimeUnit
@@ -163,17 +164,37 @@ class Gradle(
             gradleConnector.daemonMaxIdleTime(10, TimeUnit.SECONDS)
         }
 
-        val gradleConnection = gradleConnector.forProjectDirectory(definitionFile.parentFile).connect()
+        val projectDir = definitionFile.parentFile
+        val gradleConnection = gradleConnector.forProjectDirectory(projectDir).connect()
 
         return temporaryProperties(*gradleSystemProperties.toTypedArray()) {
             gradleConnection.use { connection ->
                 val initScriptFile = File.createTempFile("init", ".gradle")
                 initScriptFile.writeBytes(javaClass.getResource("/scripts/init.gradle").readBytes())
 
+                val stdout = ByteArrayOutputStream()
+                val stderr = ByteArrayOutputStream()
+
                 val dependencyTreeModel = connection
                     .model(DependencyTreeModel::class.java)
+                    .setStandardOutput(stdout)
+                    .setStandardError(stderr)
                     .withArguments("--init-script", initScriptFile.path)
                     .get()
+
+                if (stdout.size() > 0) {
+                    log.debug {
+                        "Analyzing the project in '$projectDir' produced standard output:\n" +
+                                stdout.toString().prependIndent("\t")
+                    }
+                }
+
+                if (stderr.size() > 0) {
+                    log.warn {
+                        "Analyzing the project in '$projectDir' produced error output:\n" +
+                                stderr.toString().prependIndent("\t")
+                    }
+                }
 
                 if (!initScriptFile.delete()) {
                     log.warn { "Init script file '$initScriptFile' could not be deleted." }


### PR DESCRIPTION
If the ORT Analyzer is run with "--debug", show standard output of the
analyzed Gradle project in ORT's debug log.

Show error output of the analyzed Gradle project in ORT's warning log.

This eases debugging of issues with the analysis of Gradle projects.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>