### PR TITLE
Pip: Allow requirements.txt to be prefixed

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -158,7 +158,7 @@ class Pip(
     repoConfig: RepositoryConfiguration
 ) : PackageManager(name, analysisRoot, analyzerConfig, repoConfig), CommandLineTool {
     class Factory : AbstractPackageManagerFactory<Pip>("PIP") {
-        override val globsForDefinitionFiles = listOf("requirements*.txt", "setup.py")
+        override val globsForDefinitionFiles = listOf("*requirements*.txt", "setup.py")
 
         override fun create(
             analysisRoot: File,


### PR DESCRIPTION
Some developers use 'dev_requirements.txt' as name for the file defining Python dependencies used only for development.

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>