### PR TITLE
Add a way to pass report-format-specific options

### DIFF
--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -46,14 +46,14 @@ import org.ossreviewtoolkit.utils.safeMkdirs
 import java.io.File
 
 class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine dependencies of a software project.") {
+    private val allPackageManagersByName = PackageManager.ALL.associateBy { it.managerName.toUpperCase() }
+
     private val packageManagers by option(
         "--package-managers", "-m",
         help = "The list of package managers to activate."
     ).convert { name ->
-        // Map upper-cased package manager names to their instances.
-        val packageManagers = PackageManager.ALL.associateBy { it.managerName.toUpperCase() }
-        packageManagers[name.toUpperCase()]
-            ?: throw BadParameterValue("Package managers must be one or more of ${packageManagers.keys}.")
+        allPackageManagersByName[name.toUpperCase()]
+            ?: throw BadParameterValue("Package managers must be one or more of ${allPackageManagersByName.keys}.")
     }.split(",").default(PackageManager.ALL)
 
     private val inputDir by option(

--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -46,14 +46,14 @@ import org.ossreviewtoolkit.utils.safeMkdirs
 import java.io.File
 
 class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine dependencies of a software project.") {
-    private val packageManagersOption by option(
+    private val packageManagers by option(
         "--package-managers", "-m",
         help = "The list of package managers to activate."
-    ).convert { packageManagerName ->
+    ).convert { name ->
         // Map upper-cased package manager names to their instances.
         val packageManagers = PackageManager.ALL.associateBy { it.managerName.toUpperCase() }
-        packageManagers[packageManagerName.toUpperCase()]
-            ?: throw BadParameterValue("Package managers must be contained in ${packageManagers.keys}.")
+        packageManagers[name.toUpperCase()]
+            ?: throw BadParameterValue("Package managers must be one or more of ${packageManagers.keys}.")
     }.split(",").default(PackageManager.ALL)
 
     private val inputDir by option(
@@ -116,10 +116,10 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
             throw UsageError("None of the output files $existingOutputFiles must exist yet.", statusCode = 2)
         }
 
-        val packageManagers = packageManagersOption.distinct()
+        val distinctPackageManagers = packageManagers.distinct()
 
         println("The following package managers are activated:")
-        println("\t" + packageManagers.joinToString(", "))
+        println("\t" + distinctPackageManagers.joinToString(", "))
 
         val absoluteInputDir = inputDir.normalize()
         println("Analyzing project path:\n\t$absoluteInputDir")
@@ -137,7 +137,7 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
         )
 
         val ortResult = analyzer.analyze(
-            absoluteInputDir, packageManagers, curationProvider, repositoryConfigurationFile
+            absoluteInputDir, distinctPackageManagers, curationProvider, repositoryConfigurationFile
         )
 
         println("Found ${ortResult.getProjects().size} project(s) in total.")

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -88,14 +88,14 @@ class ReporterCommand : CliktCommand(
         .file(mustExist = false, canBeFile = false, canBeDir = true, mustBeWritable = false, mustBeReadable = false)
         .required()
 
-    private val reporters by option(
+    private val reportFormats by option(
         "--report-formats", "-f",
         help = "The list of report formats that will be generated."
-    ).convert { reporterName ->
+    ).convert { name ->
         // Map upper-cased reporter names to their instances.
         val reporters = Reporter.ALL.associateBy { it.reporterName.toUpperCase() }
-        reporters[reporterName.toUpperCase()]
-            ?: throw BadParameterValue("Reporters must be contained in ${reporters.keys}.")
+        reporters[name.toUpperCase()]
+            ?: throw BadParameterValue("Report formats must be one or more of ${reporters.keys}.")
     }.split(",").required()
 
     private val resolutionsFile by option(
@@ -142,7 +142,7 @@ class ReporterCommand : CliktCommand(
     override fun run() {
         val absoluteOutputDir = outputDir.normalize()
 
-        val reports = reporters.associateWith { reporter ->
+        val reports = reportFormats.associateWith { reporter ->
             File(absoluteOutputDir, reporter.defaultFilename)
         }
 

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -58,6 +58,8 @@ class ReporterCommand : CliktCommand(
     name = "report",
     help = "Present Analyzer and Scanner results in various formats."
 ) {
+    private val allReportersByName = Reporter.ALL.associateBy { it.reporterName.toUpperCase() }
+
     private val ortFile by option(
         "--ort-file", "-i",
         help = "The ORT result file to use."
@@ -92,10 +94,8 @@ class ReporterCommand : CliktCommand(
         "--report-formats", "-f",
         help = "The list of report formats that will be generated."
     ).convert { name ->
-        // Map upper-cased reporter names to their instances.
-        val reporters = Reporter.ALL.associateBy { it.reporterName.toUpperCase() }
-        reporters[name.toUpperCase()]
-            ?: throw BadParameterValue("Report formats must be one or more of ${reporters.keys}.")
+        allReportersByName[name.toUpperCase()]
+            ?: throw BadParameterValue("Report formats must be one or more of ${allReportersByName.keys}.")
     }.split(",").required()
 
     private val resolutionsFile by option(

--- a/reporter/src/main/kotlin/Reporter.kt
+++ b/reporter/src/main/kotlin/Reporter.kt
@@ -55,9 +55,9 @@ interface Reporter {
 
     /**
      * Generate a report for the provided [input] and write the result to the [outputStream]. If and how the [input]
-     * data is used depends on the specific reporter implementation.
+     * data is used depends on the specific reporter implementation, taking into account any format-specific [options].
      */
-    fun generateReport(outputStream: OutputStream, input: ReporterInput)
+    fun generateReport(outputStream: OutputStream, input: ReporterInput, options: Map<String, String> = emptyMap())
 }
 
 internal val PathExclude.description: String get() = joinNonBlank(reason.toString(), comment)

--- a/reporter/src/main/kotlin/reporters/AbstractNoticeReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AbstractNoticeReporter.kt
@@ -100,7 +100,8 @@ abstract class AbstractNoticeReporter : Reporter {
 
     override fun generateReport(
         outputStream: OutputStream,
-        input: ReporterInput
+        input: ReporterInput,
+        options: Map<String, String>
     ) {
         requireNotNull(input.ortResult.scanner) {
             "The provided ORT result file does not contain a scan result."

--- a/reporter/src/main/kotlin/reporters/AmazonOssAttributionBuilderReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AmazonOssAttributionBuilderReporter.kt
@@ -66,7 +66,7 @@ class AmazonOssAttributionBuilderReporter : Reporter {
         OkHttpClientHelper.buildClient()
     )
 
-    override fun generateReport(outputStream: OutputStream, input: ReporterInput) {
+    override fun generateReport(outputStream: OutputStream, input: ReporterInput, options: Map<String, String>) {
         // TODO: Allow to configure username and password via the config file; use the defaults for now.
         val credentials = Credentials.basic("admin", "admin")
 

--- a/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
+++ b/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
@@ -73,7 +73,7 @@ class CycloneDxReporter : Reporter {
             }
         }
 
-    override fun generateReport(outputStream: OutputStream, input: ReporterInput) {
+    override fun generateReport(outputStream: OutputStream, input: ReporterInput, options: Map<String, String>) {
         val ortResult = input.ortResult
         val bom = Bom().apply { serialNumber = "urn:uuid:${UUID.randomUUID()}" }
 

--- a/reporter/src/main/kotlin/reporters/EvaluatedModelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/EvaluatedModelReporter.kt
@@ -56,7 +56,7 @@ abstract class EvaluatedModelReporter(
     override val defaultFilename: String,
     private val serialize: EvaluatedModel.(Writer) -> Unit
 ) : Reporter {
-    override fun generateReport(outputStream: OutputStream, input: ReporterInput) {
+    override fun generateReport(outputStream: OutputStream, input: ReporterInput, options: Map<String, String>) {
         val start = System.currentTimeMillis()
         val evaluatedModel = EvaluatedModel.create(input)
         log.debug { "Generating evaluated model took ${System.currentTimeMillis() - start}ms" }

--- a/reporter/src/main/kotlin/reporters/ExcelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ExcelReporter.kt
@@ -84,7 +84,7 @@ class ExcelReporter : Reporter {
     override val reporterName = "Excel"
     override val defaultFilename = "scan-report.xlsx"
 
-    override fun generateReport(outputStream: OutputStream, input: ReporterInput) {
+    override fun generateReport(outputStream: OutputStream, input: ReporterInput, options: Map<String, String>) {
         val tabularScanRecord =
             ReportTableModelMapper(input.resolutionProvider, input.packageConfigurationProvider).mapToReportTableModel(
                 input.ortResult

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -56,7 +56,7 @@ class StaticHtmlReporter : Reporter {
     override val reporterName = "StaticHtml"
     override val defaultFilename = "scan-report.html"
 
-    override fun generateReport(outputStream: OutputStream, input: ReporterInput) {
+    override fun generateReport(outputStream: OutputStream, input: ReporterInput, options: Map<String, String>) {
         val tabularScanRecord =
             ReportTableModelMapper(input.resolutionProvider, input.packageConfigurationProvider).mapToReportTableModel(
                 input.ortResult

--- a/reporter/src/main/kotlin/reporters/WebAppReporter.kt
+++ b/reporter/src/main/kotlin/reporters/WebAppReporter.kt
@@ -31,7 +31,8 @@ class WebAppReporter : Reporter {
 
     override fun generateReport(
         outputStream: OutputStream,
-        input: ReporterInput
+        input: ReporterInput,
+        options: Map<String, String>
     ) {
         val template = javaClass.classLoader.getResource("scan-report-template.html").readText()
         val evaluatedModel = EvaluatedModel.create(input)


### PR DESCRIPTION
This will become useful once a report format takes options, e.g. for
custom styling.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>