### PR TITLE
Pip: Prevent returning 'OSI Approved' as declared license

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -490,7 +490,7 @@ class Pip(
         // "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)"
         pkgInfo["classifiers"]?.mapNotNullTo(declaredLicenses) {
             val classifier = it.textValue().split(" :: ")
-            classifier.takeIf { it.first() == "License" }?.last()
+            classifier.takeIf { it.first() == "License" }?.last()?.takeUnless { it == "OSI Approved" }
         }
 
         return declaredLicenses


### PR DESCRIPTION
As some libraries use the classifier 'License :: OSI Approved'.

Signed-off-by: Frank Viernau <frank.viernau@here.com>