### PR TITLE
SPDX expression improvements

### DIFF
--- a/spdx-utils/src/main/kotlin/SpdxExpression.kt
+++ b/spdx-utils/src/main/kotlin/SpdxExpression.kt
@@ -141,6 +141,20 @@ sealed class SpdxExpression {
         runCatching { validate(strictness) }.isSuccess
 
     /**
+     * Return true if [choice] is a valid license choice for this SPDX expression. This can only be the case, if
+     * [choice] does not offer a license choice itself and if the [licenses][SpdxSingleLicenseExpression] contained in
+     * [choice] match any of the [valid license choices][validChoices].
+     */
+    fun isValidChoice(choice: SpdxExpression): Boolean {
+        if (choice.offersChoice()) return false
+
+        val chosenLicenses = choice.decompose()
+        return validChoices().any { validChoice ->
+            validChoice.decompose() == chosenLicenses
+        }
+    }
+
+    /**
      * Return true if this expression offers a license choice. This can only be true if this expression contains the
      * [OR operator][SpdxOperator.OR].
      */

--- a/spdx-utils/src/main/kotlin/SpdxExpression.kt
+++ b/spdx-utils/src/main/kotlin/SpdxExpression.kt
@@ -141,6 +141,12 @@ sealed class SpdxExpression {
         runCatching { validate(strictness) }.isSuccess
 
     /**
+     * Return true if this expression offers a license choice. This can only be true if this expression contains the
+     * [OR operator][SpdxOperator.OR].
+     */
+    open fun offersChoice(): Boolean = false
+
+    /**
      * Concatenate [this][SpdxExpression] and [other] using [SpdxOperator.AND].
      */
     infix fun and(other: SpdxExpression) = SpdxCompoundExpression(this, SpdxOperator.AND, other)
@@ -215,6 +221,12 @@ data class SpdxCompoundExpression(
 
                 validChoicesLeft + validChoicesRight
             }
+        }
+
+    override fun offersChoice(): Boolean =
+        when (operator) {
+            SpdxOperator.OR -> true
+            SpdxOperator.AND -> left.offersChoice() || right.offersChoice()
         }
 
     override fun toString(): String {

--- a/spdx-utils/src/main/kotlin/SpdxExpression.kt
+++ b/spdx-utils/src/main/kotlin/SpdxExpression.kt
@@ -145,14 +145,7 @@ sealed class SpdxExpression {
      * [choice] does not offer a license choice itself and if the [licenses][SpdxSingleLicenseExpression] contained in
      * [choice] match any of the [valid license choices][validChoices].
      */
-    fun isValidChoice(choice: SpdxExpression): Boolean {
-        if (choice.offersChoice()) return false
-
-        val chosenLicenses = choice.decompose()
-        return validChoices().any { validChoice ->
-            validChoice.decompose() == chosenLicenses
-        }
-    }
+    fun isValidChoice(choice: SpdxExpression): Boolean = !choice.offersChoice() && choice in validChoices()
 
     /**
      * Return true if this expression offers a license choice. This can only be true if this expression contains the

--- a/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
@@ -250,7 +250,7 @@ class SpdxExpressionTest : WordSpec() {
             }
         }
 
-        "decompose" should {
+        "decompose()" should {
             fun String.decompose() = parse().decompose().map { it.toString() }
 
             "not split-up compound expressions with a WITH operator" {

--- a/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
@@ -31,6 +31,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.should
 
 class SpdxExpressionTest : WordSpec() {
@@ -319,6 +320,20 @@ class SpdxExpressionTest : WordSpec() {
                 val dnf = "((a AND (c AND d)) OR (a AND (c AND e))) OR ((b AND (c AND d)) OR (b AND (c AND e)))".parse()
 
                 spdxExpression.disjunctiveNormalForm() shouldBe dnf
+            }
+        }
+
+        "validChoices()" should {
+            "list the valid choices for a complex expression" {
+                val spdxExpression = "(a OR b) AND (c AND (d OR e))".parse()
+                val choices = listOf(
+                    "a AND (c AND d)",
+                    "a AND (c AND e)",
+                    "b AND (c AND d)",
+                    "b AND (c AND e)"
+                ).map { it.parse() }
+
+                spdxExpression.validChoices() shouldContainExactlyInAnyOrder choices
             }
         }
     }

--- a/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
@@ -336,5 +336,20 @@ class SpdxExpressionTest : WordSpec() {
                 spdxExpression.validChoices() shouldContainExactlyInAnyOrder choices
             }
         }
+
+        "offersChoice()" should {
+            "return true if the expression contains the OR operator" {
+                "a OR b".parse().offersChoice() shouldBe true
+                "a AND b OR c".parse().offersChoice() shouldBe true
+                "a OR b AND c".parse().offersChoice() shouldBe true
+                "a AND b AND c OR d".parse().offersChoice() shouldBe true
+            }
+
+            "return false if the expression does not contain the OR operator" {
+                "a".parse().offersChoice() shouldBe false
+                "a AND b".parse().offersChoice() shouldBe false
+                "a AND b AND c".parse().offersChoice() shouldBe false
+            }
+        }
     }
 }

--- a/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
@@ -296,45 +296,32 @@ class SpdxExpressionTest : WordSpec() {
             }
 
             "correctly convert an OR on the left side of an AND expression" {
-                val spdxExpression = "(a OR b) AND c".parse()
-                val dnf = "(a AND c) OR (b AND c)".parse()
-
-                spdxExpression.disjunctiveNormalForm() shouldBe dnf
+                "(a OR b) AND c".parse().disjunctiveNormalForm() shouldBe "(a AND c) OR (b AND c)".parse()
             }
 
             "correctly convert an OR on the right side of an AND expression" {
-                val spdxExpression = "a AND (b OR c)".parse()
-                val dnf = "(a AND b) OR (a AND c)".parse()
-
-                spdxExpression.disjunctiveNormalForm() shouldBe dnf
+                "a AND (b OR c)".parse().disjunctiveNormalForm() shouldBe "(a AND b) OR (a AND c)".parse()
             }
 
             "correctly convert ORs on both sides of an AND expression" {
-                val spdxExpression = "(a OR b) AND (c OR d)".parse()
-                val dnf = "(a AND c) OR (a AND d) OR (b AND c) OR (b AND d)".parse()
-
-                spdxExpression.disjunctiveNormalForm() shouldBe dnf
+                "(a OR b) AND (c OR d)".parse().disjunctiveNormalForm() shouldBe
+                        "(a AND c) OR (a AND d) OR (b AND c) OR (b AND d)".parse()
             }
 
             "correctly convert a complex expression" {
-                val spdxExpression = "(a OR b) AND c AND (d OR e)".parse()
-                val dnf = "(a AND c AND d) OR (a AND c AND e) OR (b AND c AND d) OR (b AND c AND e)".parse()
-
-                spdxExpression.disjunctiveNormalForm() shouldBe dnf
+                "(a OR b) AND c AND (d OR e)".parse().disjunctiveNormalForm() shouldBe
+                        "(a AND c AND d) OR (a AND c AND e) OR (b AND c AND d) OR (b AND c AND e)".parse()
             }
         }
 
         "validChoices()" should {
             "list the valid choices for a complex expression" {
-                val spdxExpression = "(a OR b) AND c AND (d OR e)".parse()
-                val choices = listOf(
+                "(a OR b) AND c AND (d OR e)".parse().validChoices() shouldContainExactlyInAnyOrder listOf(
                     "a AND c AND d",
                     "a AND c AND e",
                     "b AND c AND d",
                     "b AND c AND e"
                 ).map { it.parse() }
-
-                spdxExpression.validChoices() shouldContainExactlyInAnyOrder choices
             }
         }
 

--- a/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
@@ -33,6 +33,7 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldNotBe
 
 class SpdxExpressionTest : WordSpec() {
     private val yamlMapper = YAMLMapper()
@@ -379,6 +380,41 @@ class SpdxExpressionTest : WordSpec() {
                 spdxExpression.isValidChoice("a AND b AND c".parse()) shouldBe false
                 spdxExpression.isValidChoice("a AND b AND d".parse()) shouldBe false
                 spdxExpression.isValidChoice("a AND b AND c AND d".parse()) shouldBe false
+            }
+        }
+
+        "equals()" should {
+            "return true for semantically equal expressions" {
+                "a".parse() shouldBe "a".parse()
+                "a".parse() shouldBe "a AND a".parse()
+                "a AND a".parse() shouldBe "a".parse()
+                "a".parse() shouldBe "a OR a".parse()
+                "a OR a".parse() shouldBe "a".parse()
+                "a+".parse() shouldBe "a+".parse()
+                "a WITH b".parse() shouldBe "a WITH b".parse()
+                "a AND b".parse() shouldBe "b AND a".parse()
+                "a AND (b OR c)".parse() shouldBe "(a AND b) OR (a AND c)".parse()
+            }
+
+            "return false for semantically different expressions" {
+                "a".parse() shouldNotBe "b".parse()
+                "a AND b".parse() shouldNotBe "a OR b".parse()
+                "a OR b".parse() shouldNotBe "a AND b".parse()
+                "a".parse() shouldNotBe "a WITH b".parse()
+                "a".parse() shouldNotBe "a OR b".parse()
+                "a".parse() shouldNotBe "a AND b".parse()
+                "a".parse() shouldNotBe "a+".parse()
+            }
+        }
+
+        "hashCode()" should {
+            "return the same hashcode for equal expressions" {
+                "a".parse().hashCode() shouldBe "a".parse().hashCode()
+                "a".parse().hashCode() shouldBe "a AND a".parse().hashCode()
+                "a".parse().hashCode() shouldBe "a AND a AND a".parse().hashCode()
+                "a AND b".parse().hashCode() shouldBe "b AND a".parse().hashCode()
+                "a OR b".parse().hashCode() shouldBe "b OR a".parse().hashCode()
+                "a AND (b OR c)".parse().hashCode() shouldBe "(a AND b) OR (a AND c)".parse().hashCode()
             }
         }
     }

--- a/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
@@ -351,5 +351,35 @@ class SpdxExpressionTest : WordSpec() {
                 "a AND b AND c".parse().offersChoice() shouldBe false
             }
         }
+
+        "isValidChoice()" should {
+            "return true if a choice is valid" {
+                val spdxExpression = "(a OR b) AND (c AND (d OR e))".parse()
+
+                spdxExpression.isValidChoice("a AND c AND d".parse()) shouldBe true
+                spdxExpression.isValidChoice("a AND d AND c".parse()) shouldBe true
+                spdxExpression.isValidChoice("c AND a AND d".parse()) shouldBe true
+                spdxExpression.isValidChoice("c AND d AND a".parse()) shouldBe true
+                spdxExpression.isValidChoice("d AND a AND c".parse()) shouldBe true
+                spdxExpression.isValidChoice("d AND c AND a".parse()) shouldBe true
+
+                spdxExpression.isValidChoice("a AND c AND e".parse()) shouldBe true
+                spdxExpression.isValidChoice("b AND c AND d".parse()) shouldBe true
+                spdxExpression.isValidChoice("b AND c AND e".parse()) shouldBe true
+            }
+
+            "return false if a choice is invalid" {
+                val spdxExpression = "(a OR b) AND (c AND (d OR e))".parse()
+
+                spdxExpression.isValidChoice("a".parse()) shouldBe false
+                spdxExpression.isValidChoice("a AND b".parse()) shouldBe false
+                spdxExpression.isValidChoice("a AND c".parse()) shouldBe false
+                spdxExpression.isValidChoice("a AND d".parse()) shouldBe false
+                spdxExpression.isValidChoice("a AND e".parse()) shouldBe false
+                spdxExpression.isValidChoice("a AND b AND c".parse()) shouldBe false
+                spdxExpression.isValidChoice("a AND b AND d".parse()) shouldBe false
+                spdxExpression.isValidChoice("a AND b AND c AND d".parse()) shouldBe false
+            }
+        }
     }
 }

--- a/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
@@ -311,14 +311,14 @@ class SpdxExpressionTest : WordSpec() {
 
             "correctly convert ORs on both sides of an AND expression" {
                 val spdxExpression = "(a OR b) AND (c OR d)".parse()
-                val dnf = "((a AND c) OR (a AND d)) OR ((b AND c) OR (b AND d))".parse()
+                val dnf = "(a AND c) OR (a AND d) OR (b AND c) OR (b AND d)".parse()
 
                 spdxExpression.disjunctiveNormalForm() shouldBe dnf
             }
 
             "correctly convert a complex expression" {
-                val spdxExpression = "(a OR b) AND (c AND (d OR e))".parse()
-                val dnf = "((a AND (c AND d)) OR (a AND (c AND e))) OR ((b AND (c AND d)) OR (b AND (c AND e)))".parse()
+                val spdxExpression = "(a OR b) AND c AND (d OR e)".parse()
+                val dnf = "(a AND c AND d) OR (a AND c AND e) OR (b AND c AND d) OR (b AND c AND e)".parse()
 
                 spdxExpression.disjunctiveNormalForm() shouldBe dnf
             }
@@ -326,12 +326,12 @@ class SpdxExpressionTest : WordSpec() {
 
         "validChoices()" should {
             "list the valid choices for a complex expression" {
-                val spdxExpression = "(a OR b) AND (c AND (d OR e))".parse()
+                val spdxExpression = "(a OR b) AND c AND (d OR e)".parse()
                 val choices = listOf(
-                    "a AND (c AND d)",
-                    "a AND (c AND e)",
-                    "b AND (c AND d)",
-                    "b AND (c AND e)"
+                    "a AND c AND d",
+                    "a AND c AND e",
+                    "b AND c AND d",
+                    "b AND c AND e"
                 ).map { it.parse() }
 
                 spdxExpression.validChoices() shouldContainExactlyInAnyOrder choices
@@ -355,7 +355,7 @@ class SpdxExpressionTest : WordSpec() {
 
         "isValidChoice()" should {
             "return true if a choice is valid" {
-                val spdxExpression = "(a OR b) AND (c AND (d OR e))".parse()
+                val spdxExpression = "(a OR b) AND c AND (d OR e)".parse()
 
                 spdxExpression.isValidChoice("a AND c AND d".parse()) shouldBe true
                 spdxExpression.isValidChoice("a AND d AND c".parse()) shouldBe true
@@ -370,7 +370,7 @@ class SpdxExpressionTest : WordSpec() {
             }
 
             "return false if a choice is invalid" {
-                val spdxExpression = "(a OR b) AND (c AND (d OR e))".parse()
+                val spdxExpression = "(a OR b) AND c AND (d OR e)".parse()
 
                 spdxExpression.isValidChoice("a".parse()) shouldBe false
                 spdxExpression.isValidChoice("a AND b".parse()) shouldBe false

--- a/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
@@ -294,5 +294,43 @@ class SpdxExpressionTest : WordSpec() {
                     )
             }
         }
+
+        "disjunctiveNormalForm()" should {
+            "not change an expression already in DNF" {
+                val spdxExpression = SpdxExpression.parse("(a AND b) OR (c AND d)")
+
+                spdxExpression.disjunctiveNormalForm() shouldBe spdxExpression
+            }
+
+            "correctly convert an OR on the left side of an AND expression" {
+                val spdxExpression = SpdxExpression.parse("(a OR b) AND c")
+                val dnf = SpdxExpression.parse("(a AND c) OR (b AND c)")
+
+                spdxExpression.disjunctiveNormalForm() shouldBe dnf
+            }
+
+            "correctly convert an OR on the right side of an AND expression" {
+                val spdxExpression = SpdxExpression.parse("a AND (b OR c)")
+                val dnf = SpdxExpression.parse("(a AND b) OR (a AND c)")
+
+                spdxExpression.disjunctiveNormalForm() shouldBe dnf
+            }
+
+            "correctly convert ORs on both sides of an AND expression" {
+                val spdxExpression = SpdxExpression.parse("(a OR b) AND (c OR d)")
+                val dnf = SpdxExpression.parse("((a AND c) OR (a AND d)) OR ((b AND c) OR (b AND d))")
+
+                spdxExpression.disjunctiveNormalForm() shouldBe dnf
+            }
+
+            "correctly convert a complex expression" {
+                val spdxExpression = SpdxExpression.parse("(a OR b) AND (c AND (d OR e))")
+                val dnf = SpdxExpression.parse(
+                    "((a AND (c AND d)) OR (a AND (c AND e))) OR ((b AND (c AND d)) OR (b AND (c AND e)))"
+                )
+
+                spdxExpression.disjunctiveNormalForm() shouldBe dnf
+            }
+        }
     }
 }


### PR DESCRIPTION
Various improvements of SPDX expressions as preparation for implementing license choices. The core of this is the implementation of a function to convert an SPDX expression to the disjunctive normal form, which allows to easily implement some other functions. See the commit messages for details.