### PR TITLE
SpdxDeclaredLicenseMapping: Add an entry for `jsr-107-jcache-spec`

### DIFF
--- a/spdx-utils/src/main/kotlin/SpdxDeclaredLicenseMapping.kt
+++ b/spdx-utils/src/main/kotlin/SpdxDeclaredLicenseMapping.kt
@@ -371,6 +371,10 @@ object SpdxDeclaredLicenseMapping {
         "License Agreement For Open Source Computer Vision Library (3-clause BSD License)"
                 to BSD_3_CLAUSE.toExpression(),
         "lgplv2 or later" to LGPL_2_1_OR_LATER.toExpression(),
+        "JSR-000107 JCACHE 2.9 Public Review - Updated Specification License" to licenseRef(
+            "jsr-107-jcache-spec.LICENSE",
+            "scancode"
+        ),
         "MIT / http://rem.mit-license.org" to MIT.toExpression(),
         "MIT Licence" to MIT.toExpression(),
         "MIT License (http://opensource.org/licenses/MIT)" to MIT.toExpression(),


### PR DESCRIPTION
As found in [1], where the URL in the license tag points to [2], which
equals [3].

[1] https://repo.maven.apache.org/maven2/javax/cache/cache-api/1.0.0/cache-api-1.0.0.pom
[2] https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt
[3] https://github.com/nexB/scancode-toolkit/blob/v3.0.2/src/licensedcode/data/licenses/jsr-107-jcache-spec.LICENSE

Signed-off-by: Frank Viernau <frank.viernau@here.com>