### PR TITLE
reporter: Move report tabel model classes to the utils package

### DIFF
--- a/reporter/src/main/kotlin/reporters/ExcelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ExcelReporter.kt
@@ -22,18 +22,6 @@ package org.ossreviewtoolkit.reporter.reporters
 import java.awt.Color
 import java.io.OutputStream
 
-import org.ossreviewtoolkit.model.AnalyzerResult
-import org.ossreviewtoolkit.model.OrtResult
-import org.ossreviewtoolkit.model.VcsInfo
-import org.ossreviewtoolkit.reporter.Reporter
-import org.ossreviewtoolkit.reporter.ReporterInput
-import org.ossreviewtoolkit.reporter.description
-import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.ProjectTable
-import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.SummaryTable
-import org.ossreviewtoolkit.reporter.utils.SCOPE_EXCLUDE_LIST_COMPARATOR
-import org.ossreviewtoolkit.reporter.utils.SCOPE_EXCLUDE_MAP_COMPARATOR
-import org.ossreviewtoolkit.utils.isValidUri
-
 import org.apache.poi.common.usermodel.HyperlinkType
 import org.apache.poi.ss.usermodel.BorderStyle
 import org.apache.poi.ss.usermodel.Cell
@@ -52,6 +40,20 @@ import org.apache.poi.xssf.usermodel.XSSFFont
 import org.apache.poi.xssf.usermodel.XSSFRichTextString
 import org.apache.poi.xssf.usermodel.XSSFSheet
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
+
+import org.ossreviewtoolkit.model.AnalyzerResult
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.reporter.Reporter
+import org.ossreviewtoolkit.reporter.ReporterInput
+import org.ossreviewtoolkit.reporter.description
+import org.ossreviewtoolkit.reporter.utils.ReportTableModel.ProjectTable
+import org.ossreviewtoolkit.reporter.utils.ReportTableModel.SummaryTable
+import org.ossreviewtoolkit.reporter.utils.ReportTableModelMapper
+import org.ossreviewtoolkit.reporter.utils.SCOPE_EXCLUDE_LIST_COMPARATOR
+import org.ossreviewtoolkit.reporter.utils.SCOPE_EXCLUDE_MAP_COMPARATOR
+import org.ossreviewtoolkit.reporter.utils.containsUnresolved
+import org.ossreviewtoolkit.utils.isValidUri
 
 /**
  * A [Reporter] that creates an Excel sheet report from an [OrtResult] in the Open XML XLSX format. It creates one sheet

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -19,6 +19,17 @@
 
 package org.ossreviewtoolkit.reporter.reporters
 
+import com.vladsch.flexmark.html.HtmlRenderer
+import com.vladsch.flexmark.parser.Parser
+
+import java.io.OutputStream
+import java.time.Instant
+
+import javax.xml.parsers.DocumentBuilderFactory
+
+import kotlinx.html.*
+import kotlinx.html.dom.*
+
 import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.model.Environment
 import org.ossreviewtoolkit.model.Project
@@ -30,24 +41,16 @@ import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.description
-import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.IssueTable
-import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.ProjectTable
-import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.ResolvableIssue
+import org.ossreviewtoolkit.reporter.utils.ReportTableModel
+import org.ossreviewtoolkit.reporter.utils.ReportTableModel.IssueTable
+import org.ossreviewtoolkit.reporter.utils.ReportTableModel.ProjectTable
+import org.ossreviewtoolkit.reporter.utils.ReportTableModel.ResolvableIssue
+import org.ossreviewtoolkit.reporter.utils.ReportTableModelMapper
 import org.ossreviewtoolkit.reporter.utils.SCOPE_EXCLUDE_LIST_COMPARATOR
+import org.ossreviewtoolkit.reporter.utils.containsUnresolved
 import org.ossreviewtoolkit.utils.ORT_FULL_NAME
 import org.ossreviewtoolkit.utils.isValidUrl
 import org.ossreviewtoolkit.utils.normalizeLineBreaks
-
-import com.vladsch.flexmark.html.HtmlRenderer
-import com.vladsch.flexmark.parser.Parser
-
-import java.io.OutputStream
-import java.time.Instant
-
-import javax.xml.parsers.DocumentBuilderFactory
-
-import kotlinx.html.*
-import kotlinx.html.dom.*
 
 @Suppress("LargeClass")
 class StaticHtmlReporter : Reporter {

--- a/reporter/src/main/kotlin/utils/ReportTableModel.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModel.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.reporter.reporters
+package org.ossreviewtoolkit.reporter.utils
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseFindings

--- a/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.reporter.reporters
+package org.ossreviewtoolkit.reporter.utils
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
@@ -31,13 +31,13 @@ import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.collectLicenseFindings
 import org.ossreviewtoolkit.reporter.ResolutionProvider
-import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.DependencyRow
-import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.IssueRow
-import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.IssueTable
-import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.ProjectTable
-import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.ResolvableIssue
-import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.SummaryRow
-import org.ossreviewtoolkit.reporter.reporters.ReportTableModel.SummaryTable
+import org.ossreviewtoolkit.reporter.utils.ReportTableModel.DependencyRow
+import org.ossreviewtoolkit.reporter.utils.ReportTableModel.IssueRow
+import org.ossreviewtoolkit.reporter.utils.ReportTableModel.IssueTable
+import org.ossreviewtoolkit.reporter.utils.ReportTableModel.ProjectTable
+import org.ossreviewtoolkit.reporter.utils.ReportTableModel.ResolvableIssue
+import org.ossreviewtoolkit.reporter.utils.ReportTableModel.SummaryRow
+import org.ossreviewtoolkit.reporter.utils.ReportTableModel.SummaryTable
 
 private fun Collection<ResolvableIssue>.filterUnresolved() = filter { !it.isResolved }
 


### PR DESCRIPTION
As they are not reporters themselves.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>