### PR TITLE
Reporter: Initial implementation for AntennaAttributionDocumentReporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ designed to support multiple output formats.
 Currently, the following report formats are supported (reporter names are case-insensitive):
 
 * [Amazon OSS Attribution Builder](https://github.com/amzn/oss-attribution-builder) document (*experimental*, `-f AmazonOssAttributionBuilder`)
+* [Antenna Attribution Document (PDF)](https://github.com/eclipse/antenna) (`-f AntennaAttributionDocument`)
 * [CycloneDX](https://cyclonedx.org/) BOM (`-f CycloneDx`)
 * [Excel](https://products.office.com/excel) sheet (`-f Excel`)
 * [NOTICE](http://www.apache.org/dev/licensing-howto.html) file in two variants

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
  * Copyright (C) 2019 Bosch Software Innovations GmbH
+ * Copyright (C) 2020 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,6 +83,26 @@ repositories {
 
         filter {
             includeGroup("org.gradle")
+        }
+    }
+
+    exclusiveContent {
+        forRepository {
+            maven("https://download.eclipse.org/antenna/releases/")
+        }
+
+        filter {
+            includeGroup("org.eclipse.sw360.antenna")
+        }
+    }
+
+    exclusiveContent {
+        forRepository {
+            maven("https://jitpack.io/")
+        }
+
+        filter {
+            includeGroup("com.github.ralfstuckert.pdfbox-layout")
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 # Copyright (C) 2017-2019 HERE Europe B.V.
 # Copyright (C) 2019 Bosch Software Innovations GmbH
+# Copyright (C) 2020 Bosch.IO GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,6 +25,7 @@ reckonPluginVersion = 0.12.0
 svntoolsPluginVersion = 2.2.1
 versionsPluginVersion = 0.28.0
 
+antennaVersion = 1.0.0-weekly-2020-23
 antlrVersion = 4.8-1
 apachePoiSchemasVersion = 1.4
 apachePoiVersion = 3.17

--- a/reporter/build.gradle.kts
+++ b/reporter/build.gradle.kts
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
  * Copyright (C) 2019 Bosch Software Innovations GmbH
+ * Copyright (C) 2020 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +19,7 @@
  * License-Filename: LICENSE
  */
 
+val antennaVersion: String by project
 val apachePoiVersion: String by project
 val apachePoiSchemasVersion: String by project
 val cyclonedxCoreJavaVersion: String by project
@@ -60,6 +62,26 @@ repositories {
             includeGroup("bad.robot")
         }
     }
+
+    exclusiveContent {
+        forRepository {
+            maven("https://download.eclipse.org/antenna/releases/")
+        }
+
+        filter {
+            includeGroup("org.eclipse.sw360.antenna")
+        }
+    }
+
+    exclusiveContent {
+        forRepository {
+            maven("https://jitpack.io")
+        }
+
+        filter {
+            includeGroup("com.github.ralfstuckert.pdfbox-layout")
+        }
+    }
 }
 
 dependencies {
@@ -76,6 +98,8 @@ dependencies {
     implementation("org.apache.poi:ooxml-schemas:$apachePoiSchemasVersion")
     implementation("org.apache.poi:poi-ooxml:$apachePoiVersion")
     implementation("org.cyclonedx:cyclonedx-core-java:$cyclonedxCoreJavaVersion")
+    implementation("org.eclipse.sw360.antenna:attribution-document-core:$antennaVersion")
+    implementation("org.eclipse.sw360.antenna:attribution-document-basic-bundle:$antennaVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:$kotlinxHtmlVersion")
 
     // This is required to not depend on the version of Apache Xalan bundled with the JDK. Otherwise the formatting of

--- a/reporter/src/main/kotlin/reporters/AntennaAttributionDocumentReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AntennaAttributionDocumentReporter.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.reporter.reporters
+
+import java.io.File
+import java.io.OutputStream
+import java.net.URL
+import java.net.URLClassLoader
+import java.util.SortedSet
+
+import org.eclipse.sw360.antenna.attribution.document.core.AttributionDocumentGeneratorImpl
+import org.eclipse.sw360.antenna.attribution.document.core.DocumentValues
+import org.eclipse.sw360.antenna.attribution.document.core.model.LicenseInfo
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.LicenseFindings
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.config.PathExclude
+import org.ossreviewtoolkit.model.utils.collectLicenseFindings
+import org.ossreviewtoolkit.model.utils.getDetectedLicensesForId
+import org.ossreviewtoolkit.reporter.LicenseTextProvider
+import org.ossreviewtoolkit.reporter.Reporter
+import org.ossreviewtoolkit.reporter.ReporterInput
+import org.ossreviewtoolkit.reporter.utils.AttributionDocumentPdfModel
+import org.ossreviewtoolkit.spdx.SpdxLicense
+import org.ossreviewtoolkit.utils.safeDeleteRecursively
+import org.ossreviewtoolkit.utils.toHexString
+
+private const val DEFAULT_TEMPLATE_ID = "basic-pdf-template"
+private const val TEMPLATE_ID = "template.id"
+private const val TEMPLATE_PATH = "template.path"
+
+class AntennaAttributionDocumentReporter : Reporter {
+    override val reporterName = "AntennaAttributionDocument"
+    override val defaultFilename = "attribution-document.pdf"
+
+    override fun generateReport(outputStream: OutputStream, input: ReporterInput, options: Map<String, String>) {
+        val ortResult = input.ortResult
+        val licenseFindings = ortResult.collectLicenseFindings(input.packageConfigurationProvider, omitExcluded = true)
+        val artifacts = ortResult.getPackages().map { (pkg, _) ->
+            val licenses = collectLicenses(pkg.id, ortResult)
+            AttributionDocumentPdfModel(
+                purl = pkg.purl,
+                binaryFilename = pkg.binaryArtifact.takeUnless { it.url.isEmpty() }?.let { File(it.url).name },
+                declaredLicenses = licenses.map { createLicenseInfo(it, input.licenseTextProvider) },
+                copyrightStatements = createCopyrightStatement(pkg.id, licenses, licenseFindings)
+            )
+        }.toList()
+
+        val rootProject = input.ortResult.getProjects().singleOrNull()
+
+        // TODO: Add support for multiple projects.
+        requireNotNull(rootProject) {
+            "The $reporterName currently only supports ORT results with a single project."
+        }
+
+        val projectCopyright = createCopyrightStatement(
+            rootProject.id,
+            collectLicenses(rootProject.id, ortResult),
+            licenseFindings
+        )
+
+        // Use the default template unless a custom template is provided via the options.
+        var templateId = DEFAULT_TEMPLATE_ID
+        options[TEMPLATE_ID]?.let { id ->
+            options[TEMPLATE_PATH]?.let { path ->
+                templateId = id
+                addTemplateToClasspath(File(path).toURI().toURL())
+            }
+        }
+
+        val workingDir = createTempDir()
+        val documentFile = AttributionDocumentGeneratorImpl(
+            defaultFilename,
+            workingDir,
+            templateId,
+            DocumentValues(rootProject.id.name, rootProject.id.version, projectCopyright)
+        ).generate(artifacts)
+
+        if (documentFile.isFile) {
+            documentFile.inputStream().use {
+                it.copyTo(outputStream)
+            }
+        }
+
+        workingDir.safeDeleteRecursively()
+    }
+
+    private fun createCopyrightStatement(
+        id: Identifier,
+        licenses: SortedSet<String>,
+        licenseFindings: Map<Identifier, Map<LicenseFindings, List<PathExclude>>>
+    ) =
+        licenseFindings.getOrDefault(id, emptyMap())
+            .filter { licenses.contains(it.key.license) }
+            .flatMap { it.key.copyrights }
+            .joinToString("\n") { it.statement }
+
+    private fun addTemplateToClasspath(url: URL) {
+        val addURL = URLClassLoader::class.java.getDeclaredMethod("addURL", URL::class.java)
+        addURL.isAccessible = true
+        addURL.invoke(ClassLoader.getSystemClassLoader(), url)
+    }
+
+    private fun collectLicenses(id: Identifier, ortResult: OrtResult): SortedSet<String> {
+        val concludedLicense = ortResult.getConcludedLicensesForId(id)?.licenses() ?: emptyList()
+        val declaredLicense = ortResult.getDeclaredLicensesForId(id)
+        val detectedLicense = ortResult.getDetectedLicensesForId(id)
+
+        return if (concludedLicense.isNotEmpty()) {
+            concludedLicense.toSortedSet()
+        } else {
+            (declaredLicense + detectedLicense).toSortedSet()
+        }
+    }
+
+    private fun createLicenseInfo(
+        licenseId: String,
+        licenseTextProvider: LicenseTextProvider
+    ) =
+        LicenseInfo(
+            // Generate a key that is used as the license anchor in the PDF. A valid key consists of numbers and letters
+            // only, any special characters are invalid.
+            licenseId.toByteArray().toHexString(),
+            // Replace tabs with spaces to work around an issue where the chosen font does not provide a (horizontal)
+            // tab character, which otherwise causes something like:
+            //
+            //     IllegalArgumentException: U+0009 ('controlHT') is not available in this font Times-Roman encoding:
+            //     WinAnsiEncoding
+            licenseTextProvider.getLicenseText(licenseId)?.replace("\t", "    ") ?: "No license text found.",
+            licenseId,
+            SpdxLicense.forId(licenseId)?.fullName ?: licenseId
+        )
+}

--- a/reporter/src/main/kotlin/utils/AttributionDocumentPdfModel.kt
+++ b/reporter/src/main/kotlin/utils/AttributionDocumentPdfModel.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.reporter.utils
+
+import org.eclipse.sw360.antenna.attribution.document.core.model.ArtifactAndLicense
+import org.eclipse.sw360.antenna.attribution.document.core.model.LicenseInfo
+
+import java.util.Optional
+
+data class AttributionDocumentPdfModel(
+    val purl: String,
+    val binaryFilename: String?,
+    val declaredLicenses: List<LicenseInfo>,
+    val copyrightStatements: String
+) : ArtifactAndLicense {
+    override fun getFilename() = binaryFilename
+
+    override fun getPurl() = Optional.of(purl)
+
+    override fun getLicenses() = declaredLicenses
+
+    override fun getCopyrightStatement() = Optional.of(copyrightStatements)
+}

--- a/reporter/src/main/resources/META-INF/services/org.ossreviewtoolkit.reporter.Reporter
+++ b/reporter/src/main/resources/META-INF/services/org.ossreviewtoolkit.reporter.Reporter
@@ -1,4 +1,5 @@
 org.ossreviewtoolkit.reporter.reporters.AmazonOssAttributionBuilderReporter
+org.ossreviewtoolkit.reporter.reporters.AntennaAttributionDocumentReporter
 org.ossreviewtoolkit.reporter.reporters.CycloneDxReporter
 org.ossreviewtoolkit.reporter.reporters.EvaluatedModelJsonReporter
 org.ossreviewtoolkit.reporter.reporters.EvaluatedModelYamlReporter


### PR DESCRIPTION
This PR adds a new reporter that creates attribution documents in PDF format by leveraging the Eclipse Antenna project, see https://github.com/eclipse/antenna. 

Resolves #2599.

Signed-off-by: Onur Demirci <onur.demirci@bosch.io>