### PR TITLE
SpdxDeclaredLicenseMapping: Add 'BSD License 3'

### DIFF
--- a/spdx-utils/src/main/kotlin/SpdxDeclaredLicenseMapping.kt
+++ b/spdx-utils/src/main/kotlin/SpdxDeclaredLicenseMapping.kt
@@ -117,6 +117,7 @@ object SpdxDeclaredLicenseMapping {
         "BSD 4 Clause" to BSD_4_CLAUSE.toExpression(),
         "BSD Licence 3" to BSD_3_CLAUSE.toExpression(),
         "BSD License" to BSD_3_CLAUSE.toExpression(),
+        "BSD License 3" to BSD_3_CLAUSE.toExpression(),
         "BSD License for HSQL" to BSD_3_CLAUSE.toExpression(),
         "BSD New" to BSD_3_CLAUSE.toExpression(),
         "BSD New license" to BSD_3_CLAUSE.toExpression(),


### PR DESCRIPTION
Found in
https://github.com/hamcrest/JavaHamcrest/blob/60454d3c3e2eac8f3049dfbef2900a989a8b8624/build.gradle#L73.

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>