### PR TITLE
New license API

### DIFF
--- a/model/src/main/kotlin/licenses/DefaultLicenseInfoProvider.kt
+++ b/model/src/main/kotlin/licenses/DefaultLicenseInfoProvider.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.licenses
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.OrtResult
+
+/**
+ * The default [LicenseInfoProvider] that collects license information from an [ortResult].
+ */
+class DefaultLicenseInfoProvider(val ortResult: OrtResult) : LicenseInfoProvider {
+    private val licenseInfo: ConcurrentMap<Identifier, LicenseInfo> = ConcurrentHashMap()
+
+    override fun get(id: Identifier) = licenseInfo.getOrPut(id) { createLicenseInfo(id) }
+
+    private fun createLicenseInfo(id: Identifier): LicenseInfo {
+        require(id in ortResult.getProjectAndPackageIds()) {
+            "The ORT result does not contain a project or package with id '${id.toCoordinates()}'."
+        }
+
+        return LicenseInfo(
+            id = id,
+            concludedLicenseInfo = createConcludedLicenseInfo(id),
+            declaredLicenseInfo = createDeclaredLicenseInfo(id),
+            detectedLicenseInfo = createDetectedLicenseInfo(id)
+        )
+    }
+
+    private fun createConcludedLicenseInfo(id: Identifier): ConcludedLicenseInfo =
+        ortResult.getPackage(id)?.let { curatedPkg ->
+            ConcludedLicenseInfo(
+                concludedLicense = curatedPkg.pkg.concludedLicense,
+                appliedCurations = curatedPkg.curations.filter { it.curation.concludedLicense != null }
+            )
+        } ?: ConcludedLicenseInfo(concludedLicense = null, appliedCurations = emptyList())
+
+    private fun createDeclaredLicenseInfo(id: Identifier): DeclaredLicenseInfo =
+        ortResult.getProject(id)?.let { project ->
+            DeclaredLicenseInfo(
+                licenses = project.declaredLicenses,
+                processed = project.declaredLicensesProcessed,
+                appliedCurations = emptyList()
+            )
+        } ?: ortResult.getPackage(id)?.let { curatedPkg ->
+            DeclaredLicenseInfo(
+                licenses = curatedPkg.pkg.declaredLicenses,
+                processed = curatedPkg.pkg.declaredLicensesProcessed,
+                appliedCurations = curatedPkg.curations.filter { it.curation.declaredLicenses != null }
+            )
+        } ?: throw IllegalArgumentException(
+            "The ORT result does not contain a project or package with id '${id.toCoordinates()}'."
+        )
+
+    private fun createDetectedLicenseInfo(id: Identifier): DetectedLicenseInfo {
+        val findings = mutableListOf<Findings>()
+
+        ortResult.getScanResultsForId(id).forEach { scanResult ->
+            findings += Findings(
+                provenance = scanResult.provenance,
+                licenses = scanResult.summary.licenseFindings,
+                copyrights = scanResult.summary.copyrightFindings
+            )
+        }
+
+        return DetectedLicenseInfo(findings)
+    }
+}

--- a/model/src/main/kotlin/licenses/LicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfo.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.licenses
+
+import org.ossreviewtoolkit.model.CopyrightFinding
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.PackageCurationResult
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.spdx.SpdxExpression
+import org.ossreviewtoolkit.utils.ProcessedDeclaredLicense
+
+/**
+ * This class contains all license information about a package or project.
+ */
+data class LicenseInfo(
+    /**
+     * The identifier of the package or project.
+     */
+    val id: Identifier,
+
+    /**
+     * Information about the declared license.
+     */
+    val declaredLicenseInfo: DeclaredLicenseInfo,
+
+    /**
+     * Information about the detected license.
+     */
+    val detectedLicenseInfo: DetectedLicenseInfo,
+
+    /**
+     * Information about the concluded license.
+     */
+    val concludedLicenseInfo: ConcludedLicenseInfo
+)
+
+/**
+ * Information about the concluded license of a package or project.
+ */
+data class ConcludedLicenseInfo(
+    /**
+     * The concluded license, or null if no license was concluded.
+     */
+    val concludedLicense: SpdxExpression?,
+
+    /**
+     * The list of [PackageCurationResult]s that modified the concluded license.
+     */
+    val appliedCurations: List<PackageCurationResult>
+)
+
+/**
+ * Information about the declared license of a package or project.
+ */
+data class DeclaredLicenseInfo(
+    /**
+     * The unmodified set of declared licenses.
+     */
+    val licenses: Set<String>,
+
+    /**
+     * The processed declared license.
+     */
+    val processed: ProcessedDeclaredLicense,
+
+    /**
+     * The list of [PackageCurationResult]s that modified the declared license.
+     */
+    val appliedCurations: List<PackageCurationResult>
+)
+
+/**
+ * Information about the detected licenses of a package or project.
+ */
+data class DetectedLicenseInfo(
+    /**
+     * The list of all [Findings].
+     */
+    val findings: List<Findings>
+)
+
+/**
+ * A collection of [license][licenses] and [copyright][copyrights] findings detected in the source code located at
+ * [provenance].
+ */
+data class Findings(
+    /**
+     * The [Provenance] of the scanned source code.
+     */
+    val provenance: Provenance,
+
+    /**
+     * The set of all license findings.
+     */
+    val licenses: Set<LicenseFinding>,
+
+    /**
+     * The set of all copyright findings.
+     */
+    val copyrights: Set<CopyrightFinding>
+)

--- a/model/src/main/kotlin/licenses/LicenseInfoProvider.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoProvider.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.licenses
+
+import org.ossreviewtoolkit.model.Identifier
+
+/**
+ * A provider for [LicenseInfo]s.
+ */
+interface LicenseInfoProvider {
+    /**
+     * Get the [LicenseInfo] for the project or package identified by [id].
+     * @throws IllegalArgumentException if no project or package with [id] can be found.
+     */
+    fun get(id: Identifier): LicenseInfo
+}

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.licenses
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+
+import org.ossreviewtoolkit.model.CopyrightFinding
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.LicenseSource
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.utils.FindingsMatcher
+import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
+
+class LicenseInfoResolver(val provider: LicenseInfoProvider) {
+    private val resolvedLicenseInfo: ConcurrentMap<Identifier, ResolvedLicenseInfo> = ConcurrentHashMap()
+
+    /**
+     * Get the [ResolvedLicenseInfo] for the project or package identified by [id].
+     * TODO: Add options to filter output, e.g. "filter excluded findings".
+     */
+    fun resolveLicenseInfo(id: Identifier) = resolvedLicenseInfo.getOrPut(id) { createLicenseInfo(id) }
+
+    private fun createLicenseInfo(id: Identifier): ResolvedLicenseInfo {
+        val licenseInfo = provider.get(id)
+
+        val concludedLicenses = licenseInfo.concludedLicenseInfo.concludedLicense?.decompose().orEmpty()
+        val declaredLicenses = licenseInfo.declaredLicenseInfo.processed.spdxExpression?.decompose().orEmpty()
+        val detectedLicenses = licenseInfo.detectedLicenseInfo.findings.flatMapTo(mutableSetOf()) { findings ->
+            findings.licenses.flatMap { it.license.decompose() }
+        }
+
+        val resolvedLicenses = mutableMapOf<SpdxSingleLicenseExpression, ResolvedLicenseBuilder>()
+
+        fun SpdxSingleLicenseExpression.builder() =
+            resolvedLicenses.getOrPut(this) { ResolvedLicenseBuilder(this) }
+
+        // Handle concluded licenses.
+        concludedLicenses.forEach { license ->
+            license.builder().sources += LicenseSource.CONCLUDED
+        }
+
+        // Handle declared licenses.
+        declaredLicenses.forEach { license ->
+            license.builder().apply {
+                sources += LicenseSource.DECLARED
+
+                originalDeclaredLicenses.addAll(
+                    licenseInfo.declaredLicenseInfo.processed.mapped.filterValues { it == license }.keys
+                )
+            }
+        }
+
+        // Handle detected licenses.
+        val unmatchedCopyrights = mutableMapOf<Provenance, MutableSet<CopyrightFinding>>()
+        val resolvedLocations = resolveLocations(licenseInfo.detectedLicenseInfo, unmatchedCopyrights)
+
+        detectedLicenses.forEach { license ->
+            license.builder().apply {
+                sources += LicenseSource.DETECTED
+                resolvedLocations[license]?.let { locations.addAll(it) }
+            }
+        }
+
+        return ResolvedLicenseInfo(id, resolvedLicenses.values.map { it.build() }, unmatchedCopyrights)
+    }
+
+    private fun resolveLocations(
+        detectedLicenseInfo: DetectedLicenseInfo,
+        unmatchedCopyrights: MutableMap<Provenance, MutableSet<CopyrightFinding>>
+    ): Map<SpdxSingleLicenseExpression, Set<ResolvedLicenseLocation>> {
+        val resolvedLocations = mutableMapOf<SpdxSingleLicenseExpression, MutableSet<ResolvedLicenseLocation>>()
+
+        detectedLicenseInfo.findings.forEach { findings ->
+            // TODO: Add copyrights.
+            // TODO: Filter copyright garbage.
+            // TODO: Process copyright statements.
+            // TODO: Apply license finding curations.
+            // TODO: Apply path excludes.
+            val matchResult = FindingsMatcher().matchFindings(findings.licenses, findings.copyrights)
+            matchResult.matchedFindings.forEach { (licenseFinding, _) ->
+                licenseFinding.license.decompose().forEach { singleLicense ->
+                    resolvedLocations.getOrPut(singleLicense) { mutableSetOf() } += ResolvedLicenseLocation(
+                        findings.provenance,
+                        licenseFinding.location.path,
+                        licenseFinding.location.startLine,
+                        licenseFinding.location.endLine,
+                        appliedCuration = null,
+                        matchingPathExcludes = emptyList(),
+                        copyrights = emptySet()
+                    )
+                }
+            }
+
+            unmatchedCopyrights.getOrPut(findings.provenance) { mutableSetOf() } += matchResult.unmatchedCopyrights
+        }
+
+        return resolvedLocations
+    }
+}
+
+private class ResolvedLicenseBuilder(val license: SpdxSingleLicenseExpression) {
+    val sources = mutableSetOf<LicenseSource>()
+    var originalDeclaredLicenses = mutableSetOf<String>()
+    var locations = mutableSetOf<ResolvedLicenseLocation>()
+
+    fun build() = ResolvedLicense(license, sources, originalDeclaredLicenses, locations)
+}

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -89,13 +89,20 @@ class LicenseInfoResolver(val provider: LicenseInfoProvider) {
         val resolvedLocations = mutableMapOf<SpdxSingleLicenseExpression, MutableSet<ResolvedLicenseLocation>>()
 
         detectedLicenseInfo.findings.forEach { findings ->
-            // TODO: Add copyrights.
-            // TODO: Filter copyright garbage.
-            // TODO: Process copyright statements.
             // TODO: Apply license finding curations.
             // TODO: Apply path excludes.
             val matchResult = FindingsMatcher().matchFindings(findings.licenses, findings.copyrights)
-            matchResult.matchedFindings.forEach { (licenseFinding, _) ->
+            matchResult.matchedFindings.forEach { (licenseFinding, copyrightFindings) ->
+                val resolvedCopyrightFindings = copyrightFindings.mapTo(mutableSetOf()) { copyrightFinding->
+                    // TODO: Filter copyright garbage.
+                    // TODO: Process copyright statements (and keep original statements).
+                    ResolvedCopyrightFinding(
+                        statement = copyrightFinding.statement,
+                        originalStatements = emptySet(),
+                        locations = setOf(copyrightFinding.location)
+                    )
+                }
+
                 licenseFinding.license.decompose().forEach { singleLicense ->
                     resolvedLocations.getOrPut(singleLicense) { mutableSetOf() } += ResolvedLicenseLocation(
                         findings.provenance,
@@ -104,7 +111,7 @@ class LicenseInfoResolver(val provider: LicenseInfoProvider) {
                         licenseFinding.location.endLine,
                         appliedCuration = null,
                         matchingPathExcludes = emptyList(),
-                        copyrights = emptySet()
+                        copyrights = resolvedCopyrightFindings
                     )
                 }
             }

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -111,9 +111,7 @@ class LicenseInfoResolver(
                 licenseFinding.license.decompose().forEach { singleLicense ->
                     resolvedLocations.getOrPut(singleLicense) { mutableSetOf() } += ResolvedLicenseLocation(
                         findings.provenance,
-                        licenseFinding.location.path,
-                        licenseFinding.location.startLine,
-                        licenseFinding.location.endLine,
+                        licenseFinding.location,
                         appliedCuration = null,
                         matchingPathExcludes = emptyList(),
                         copyrights = resolvedCopyrightFindings.toSet()

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -130,7 +130,12 @@ class LicenseInfoResolver(
         processedCopyrightStatements: Map<String, Set<String>>
     ): List<ResolvedCopyright> {
         val resolvedCopyrightFindings = copyrightFindings.map {
-            ResolvedCopyrightFinding(it.statement, it.location, isGarbage = it.statement in copyrightGarbage.items)
+            ResolvedCopyrightFinding(
+                it.statement,
+                it.location,
+                matchingPathExcludes = emptyList(),
+                isGarbage = it.statement in copyrightGarbage.items
+            )
         }
 
         return processedCopyrightStatements.mapValues { (_, originalStatements) ->

--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -142,6 +142,11 @@ data class ResolvedCopyrightFinding(
     val location: TextLocation,
 
     /**
+     * All [PathExclude]s matching this [location].
+     */
+    val matchingPathExcludes: List<PathExclude>,
+
+    /**
      * True, if this [statement] is contained in the [CopyrightGarbage] used during resolution.
      */
     val isGarbage: Boolean

--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.licenses
+
+import org.ossreviewtoolkit.model.CopyrightFinding
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.LicenseSource
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.model.config.LicenseFindingCuration
+import org.ossreviewtoolkit.model.config.PathExclude
+import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
+import org.ossreviewtoolkit.utils.CopyrightStatementsProcessor
+import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
+
+/**
+ * Resolved license information about a package (or project).
+ */
+data class ResolvedLicenseInfo(
+    /**
+     * The identifier of the package (or project).
+     */
+    val id: Identifier,
+
+    /**
+     * The list of [ResolvedLicense]s for this package (or project).
+     */
+    val licenses: List<ResolvedLicense>,
+
+    val unmatchedCopyrights: Map<Provenance, Set<CopyrightFinding>>
+) : Iterable<ResolvedLicense> by licenses {
+    operator fun get(license: SpdxSingleLicenseExpression): ResolvedLicense? = find { it.license == license }
+}
+
+/**
+ * Resolved information for a single license.
+ */
+data class ResolvedLicense(
+    /**
+     * The license.
+     */
+    val license: SpdxSingleLicenseExpression,
+
+    /**
+     * The sources where this license was found.
+     */
+    val sources: Set<LicenseSource>,
+
+    /**
+     * The list of original declared license that were [processed][DeclaredLicenseProcessor] to this [license], or an
+     * empty list, if this [license] was not modified during processing.
+     */
+    val originalDeclaredLicenses: Set<String>,
+
+    /**
+     * All text locations where this license was found.
+     */
+    val locations: Set<ResolvedLicenseLocation>
+)
+
+/**
+ * A resolved text location.
+ */
+data class ResolvedLicenseLocation(
+    /**
+     * The provenance of the file.
+     */
+    val provenance: Provenance,
+
+    /**
+     * The path of the file.
+     */
+    val path: String,
+
+    /**
+     * The start line of the text location.
+     */
+    val startLine: Int,
+
+    /**
+     * The end line of the text location.
+     */
+    val endLine: Int,
+
+    /**
+     * The applied [LicenseFindingCuration], or null if none were applied.
+     */
+    val appliedCuration: LicenseFindingCuration?,
+
+    /**
+     * All matching [PathExclude]s matching this [path].
+     */
+    val matchingPathExcludes: List<PathExclude>,
+
+    /**
+     * All copyright findings associated to this license location.
+     */
+    val copyrights: Set<ResolvedCopyrightFinding>
+)
+
+/**
+ * A resolved copyright finding.
+ */
+data class ResolvedCopyrightFinding(
+    /**
+     * The resolved copyright statement.
+     */
+    val statement: String,
+
+    /**
+     * The original copyright statements, if this statement was created by the [CopyrightStatementsProcessor].
+     */
+    val originalStatements: Set<String>,
+
+    /**
+     * All text locations where this copyright was found.
+     */
+    val locations: Set<TextLocation>
+)

--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -24,6 +24,7 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
@@ -112,7 +113,28 @@ data class ResolvedLicenseLocation(
     /**
      * All copyright findings associated to this license location.
      */
-    val copyrights: Set<ResolvedCopyrightFinding>
+    val copyrights: Set<ResolvedCopyright>
+)
+
+/**
+ * A resolved copyright.
+ */
+data class ResolvedCopyright(
+    /**
+     * The resolved copyright statement.
+     */
+    val statement: String,
+
+    /**
+     * The resolved findings for this copyright. The statements in the findings can be different to [statement] if they
+     * were processed by the [CopyrightStatementsProcessor].
+     */
+    val findings: Set<ResolvedCopyrightFinding>,
+
+    /**
+     * True, if this [statement] is contained in the [CopyrightGarbage] used during resolution.
+     */
+    val isGarbage: Boolean
 )
 
 /**
@@ -120,17 +142,17 @@ data class ResolvedLicenseLocation(
  */
 data class ResolvedCopyrightFinding(
     /**
-     * The resolved copyright statement.
+     * The copyright statement.
      */
     val statement: String,
 
     /**
-     * The original copyright statements, if this statement was created by the [CopyrightStatementsProcessor].
+     * The location where this copyright was found.
      */
-    val originalStatements: Set<String>,
+    val location: TextLocation,
 
     /**
-     * All text locations where this copyright was found.
+     * True, if this [statement] is contained in the [CopyrightGarbage] used during resolution.
      */
-    val locations: Set<TextLocation>
+    val isGarbage: Boolean
 )

--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -86,19 +86,9 @@ data class ResolvedLicenseLocation(
     val provenance: Provenance,
 
     /**
-     * The path of the file.
+     * The text location.
      */
-    val path: String,
-
-    /**
-     * The start line of the text location.
-     */
-    val startLine: Int,
-
-    /**
-     * The end line of the text location.
-     */
-    val endLine: Int,
+    val location: TextLocation,
 
     /**
      * The applied [LicenseFindingCuration], or null if none were applied.
@@ -106,7 +96,7 @@ data class ResolvedLicenseLocation(
     val appliedCuration: LicenseFindingCuration?,
 
     /**
-     * All matching [PathExclude]s matching this [path].
+     * All [PathExclude]s matching this [location].
      */
     val matchingPathExcludes: List<PathExclude>,
 

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -23,6 +23,8 @@ import io.kotest.assertions.show.show
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -30,16 +32,23 @@ import io.kotest.matchers.shouldBe
 import java.lang.IllegalArgumentException
 
 import org.ossreviewtoolkit.model.CopyrightFinding
+import org.ossreviewtoolkit.model.Hash
+import org.ossreviewtoolkit.model.HashAlgorithm
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
+import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.PathExclude
+import org.ossreviewtoolkit.model.config.PathExcludeReason
+import org.ossreviewtoolkit.model.config.VcsMatcher
+import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
 import org.ossreviewtoolkit.spdx.SpdxExpression
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
@@ -47,9 +56,8 @@ import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
 class LicenseInfoResolverTest : WordSpec() {
     init {
         val pkgId = Identifier("Gradle:org.ossreviewtoolkit:ort:1.0.0")
-        val provenance = Provenance(
-            vcsInfo = VcsInfo(VcsType.GIT, "https://github.com/oss-review-toolkit/ort.git", "master")
-        )
+        val vcsInfo = VcsInfo(VcsType.GIT, "https://github.com/oss-review-toolkit/ort.git", "master", "master")
+        val provenance = Provenance(vcsInfo = vcsInfo)
 
         "resolveLicenseInfo()" should {
             "resolve declared licenses" {
@@ -233,7 +241,8 @@ class LicenseInfoResolverTest : WordSpec() {
                     )
                 )
 
-                val resolver = createResolver(data, setOf("(c) 2009-2010 Holder 1", "(c) 2009 Holder 1"))
+                val resolver =
+                    createResolver(data, copyrightGarbage = setOf("(c) 2009-2010 Holder 1", "(c) 2009 Holder 1"))
 
                 val result = resolver.resolveLicenseInfo(pkgId)
 
@@ -247,13 +256,114 @@ class LicenseInfoResolverTest : WordSpec() {
                     "(c) 2010 Holder 2" to false
                 )
             }
+
+            "apply path excludes" {
+                val sourceArtifact = RemoteArtifact(
+                    url = "http://example.com",
+                    hash = Hash("", HashAlgorithm.NONE)
+                )
+                val sourceArtifactProvenance = Provenance(
+                    sourceArtifact = sourceArtifact
+                )
+
+                val data = listOf(
+                    createLicenseInfo(
+                        id = pkgId,
+                        detectedLicenses = listOf(
+                            Findings(
+                                provenance = provenance,
+                                licenses = mapOf(
+                                    "Apache-2.0" to listOf(
+                                        TextLocation("LICENSE", 1, 1),
+                                        TextLocation("a/b", 1, 1)
+                                    )
+                                ).toFindingsSet(),
+                                copyrights = setOf(
+                                    CopyrightFinding("(c) 2010 Holder", TextLocation("LICENSE", 1, 1)),
+                                    CopyrightFinding("(c) 2010 Holder", TextLocation("a/b", 1, 1))
+                                )
+                            ),
+                            Findings(
+                                provenance = sourceArtifactProvenance,
+                                licenses = mapOf(
+                                    "Apache-2.0" to listOf(
+                                        TextLocation("LICENSE", 1, 1),
+                                        TextLocation("a/b", 1, 1)
+                                    )
+                                ).toFindingsSet(),
+                                copyrights = setOf(
+                                    CopyrightFinding("(c) 2010 Holder", TextLocation("LICENSE", 1, 1)),
+                                    CopyrightFinding("(c) 2010 Holder", TextLocation("a/b", 1, 1))
+                                )
+                            )
+                        )
+                    )
+                )
+
+                val sourceArtifactPathExclude = PathExclude(
+                    pattern = "LICENSE",
+                    reason = PathExcludeReason.OTHER
+                )
+                val vcsPathExclude = PathExclude(
+                    pattern = "a/b",
+                    reason = PathExcludeReason.OTHER
+                )
+
+                val packageConfigs = listOf(
+                    PackageConfiguration(
+                        id = pkgId,
+                        sourceArtifactUrl = sourceArtifact.url,
+                        pathExcludes = listOf(sourceArtifactPathExclude)
+                    ),
+                    PackageConfiguration(
+                        id = pkgId,
+                        vcs = VcsMatcher(vcsInfo.type, vcsInfo.url, vcsInfo.revision),
+                        pathExcludes = listOf(vcsPathExclude)
+                    )
+                )
+
+                val resolver = createResolver(data, packageConfigs = packageConfigs)
+
+                val result = resolver.resolveLicenseInfo(pkgId)
+
+                result.pathExcludesForLicense(
+                    "Apache-2.0", provenance, TextLocation("LICENSE", 1, 1)
+                ) should beEmpty()
+                result.pathExcludesForLicense(
+                    "Apache-2.0", provenance, TextLocation("a/b", 1, 1)
+                ) should containExactly(vcsPathExclude)
+                result.pathExcludesForLicense(
+                    "Apache-2.0", sourceArtifactProvenance, TextLocation("LICENSE", 1, 1)
+                ) should containExactly(sourceArtifactPathExclude)
+                result.pathExcludesForLicense(
+                    "Apache-2.0", sourceArtifactProvenance, TextLocation("a/b", 1, 1)
+                ) should beEmpty()
+
+                result.pathExcludesForCopyright(
+                    "(c) 2010 Holder", provenance, TextLocation("LICENSE", 1, 1)
+                ) should beEmpty()
+                result.pathExcludesForCopyright(
+                    "(c) 2010 Holder", provenance, TextLocation("a/b", 1, 1)
+                ) should containExactly(vcsPathExclude)
+                result.pathExcludesForCopyright(
+                    "(c) 2010 Holder", sourceArtifactProvenance, TextLocation("LICENSE", 1, 1)
+                ) should containExactly(sourceArtifactPathExclude)
+                result.pathExcludesForCopyright(
+                    "(c) 2010 Holder", sourceArtifactProvenance, TextLocation("a/b", 1, 1)
+                ) should beEmpty()
+            }
         }
     }
 
     private fun createResolver(
         data: List<LicenseInfo>,
+        packageConfigs: List<PackageConfiguration> = emptyList(),
         copyrightGarbage: Set<String> = emptySet()
-    ) = LicenseInfoResolver(data.toProvider(), CopyrightGarbage(copyrightGarbage.toSortedSet()))
+    ) = LicenseInfoResolver(
+        data.toProvider(),
+        SimplePackageConfigurationProvider(packageConfigs),
+        CopyrightGarbage(copyrightGarbage.toSortedSet())
+    )
 
     private fun createLicenseInfo(
         id: Identifier,
@@ -445,3 +555,18 @@ fun containLocationForLicense(
             "ResolvedLicenseInfo should not contain location ${expectedLocation.show().value} for $license"
         )
     }
+
+fun ResolvedLicenseInfo.pathExcludesForLicense(license: String, provenance: Provenance, location: TextLocation) =
+    find { it.license == SpdxSingleLicenseExpression.parse(license) }
+        ?.locations
+        ?.find { it.provenance == provenance && it.location == location }
+        ?.matchingPathExcludes
+        ?.toSet().orEmpty()
+
+fun ResolvedLicenseInfo.pathExcludesForCopyright(copyright: String, provenance: Provenance, location: TextLocation) =
+    flatMap { license -> license.locations.filter { it.provenance == provenance } }
+        .flatMap { it.copyrights }
+        .flatMap { it.findings }
+        .find { it.statement == copyright && it.location == location }
+        ?.matchingPathExcludes
+        ?.toSet().orEmpty()

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -110,10 +110,16 @@ class LicenseInfoResolverTest : WordSpec() {
                     startLine = 1,
                     endLine = 1,
                     copyrights = setOf(
-                        ResolvedCopyrightFinding(
-                            "Copyright Apache-2.0",
-                            emptySet(),
-                            locations = setOf(TextLocation("LICENSE", 1, 1))
+                        ResolvedCopyright(
+                            statement = "Copyright Apache-2.0",
+                            findings = setOf(
+                                ResolvedCopyrightFinding(
+                                    statement = "Copyright Apache-2.0",
+                                    location = TextLocation("LICENSE", 1, 1),
+                                    isGarbage = false
+                                )
+                            ),
+                            isGarbage = false
                         )
                     )
                 )
@@ -132,10 +138,16 @@ class LicenseInfoResolverTest : WordSpec() {
                     startLine = 31,
                     endLine = 31,
                     copyrights = setOf(
-                        ResolvedCopyrightFinding(
-                            "Copyright MIT",
-                            emptySet(),
-                            locations = setOf(TextLocation("LICENSE", 31, 31))
+                        ResolvedCopyright(
+                            statement = "Copyright MIT",
+                            findings = setOf(
+                                ResolvedCopyrightFinding(
+                                    statement = "Copyright MIT",
+                                    location = TextLocation("LICENSE", 31, 31),
+                                    isGarbage = false
+                                )
+                            ),
+                            isGarbage = false
                         )
                     )
                 )
@@ -193,18 +205,32 @@ class LicenseInfoResolverTest : WordSpec() {
                 val result = resolver.resolveLicenseInfo(pkgId)
 
                 result should containCopyrightsExactly(
-                    ResolvedCopyrightFinding(
+                    ResolvedCopyright(
                         statement = "(c) 2009-2010 Holder 1",
-                        originalStatements = setOf("(c) 2009 Holder 1", "(c) 2010 Holder 1"),
-                        locations = setOf(
-                            TextLocation("LICENSE", 1, 1),
-                            TextLocation("LICENSE", 2, 2)
-                        )
+                        findings = setOf(
+                            ResolvedCopyrightFinding(
+                                statement = "(c) 2009 Holder 1",
+                                location = TextLocation("LICENSE", 1, 1),
+                                isGarbage = false
+                            ),
+                            ResolvedCopyrightFinding(
+                                statement = "(c) 2010 Holder 1",
+                                location = TextLocation("LICENSE", 2, 2),
+                                isGarbage = false
+                            )
+                        ),
+                        isGarbage = false
                     ),
-                    ResolvedCopyrightFinding(
+                    ResolvedCopyright(
                         statement = "(c) 2010 Holder 2",
-                        originalStatements = emptySet(),
-                        locations = setOf(TextLocation("LICENSE", 3, 3))
+                        findings = setOf(
+                            ResolvedCopyrightFinding(
+                                statement = "(c) 2010 Holder 2",
+                                location = TextLocation("LICENSE", 3, 3),
+                                isGarbage = false
+                            )
+                        ),
+                        isGarbage = false
                     )
                 )
             }
@@ -268,7 +294,7 @@ fun containNoCopyrights(): Matcher<ResolvedLicenseInfo?> =
         )
     }
 
-fun containCopyrightsExactly(vararg copyrights: ResolvedCopyrightFinding): Matcher<ResolvedLicenseInfo?> =
+fun containCopyrightsExactly(vararg copyrights: ResolvedCopyright): Matcher<ResolvedLicenseInfo?> =
     neverNullMatcher { value ->
         val expected = copyrights.toSet()
         val actual = value.flatMapTo(mutableSetOf()) { license -> license.locations.flatMap { it.copyrights } }
@@ -326,7 +352,7 @@ fun containLocationForLicense(
     endLine: Int,
     appliedCuration: LicenseFindingCuration? = null,
     matchingPathExcludes: List<PathExclude> = emptyList(),
-    copyrights: Set<ResolvedCopyrightFinding> = emptySet()
+    copyrights: Set<ResolvedCopyright> = emptySet()
 ): Matcher<ResolvedLicenseInfo?> =
     neverNullMatcher { value ->
         val expectedLocation =

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -115,6 +115,7 @@ class LicenseInfoResolverTest : WordSpec() {
                                 ResolvedCopyrightFinding(
                                     statement = "Copyright Apache-2.0",
                                     location = TextLocation("LICENSE", 1, 1),
+                                    matchingPathExcludes = emptyList(),
                                     isGarbage = false
                                 )
                             ),
@@ -139,6 +140,7 @@ class LicenseInfoResolverTest : WordSpec() {
                                 ResolvedCopyrightFinding(
                                     statement = "Copyright MIT",
                                     location = TextLocation("LICENSE", 31, 31),
+                                    matchingPathExcludes = emptyList(),
                                     isGarbage = false
                                 )
                             ),

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -63,13 +63,13 @@ class LicenseInfoResolverTest : WordSpec() {
 
         "resolveLicenseInfo()" should {
             "resolve declared licenses" {
-                val data = listOf(
+                val licenseInfos = listOf(
                     createLicenseInfo(
                         id = pkgId,
                         declaredLicenses = setOf("Apache-2.0 WITH LLVM-exception", "MIT")
                     )
                 )
-                val resolver = createResolver(data)
+                val resolver = createResolver(licenseInfos)
 
                 val result = resolver.resolveLicenseInfo(pkgId)
 
@@ -81,7 +81,7 @@ class LicenseInfoResolverTest : WordSpec() {
             }
 
             "resolve detected licenses" {
-                val data = listOf(
+                val licenseInfos = listOf(
                     createLicenseInfo(
                         id = pkgId,
                         detectedLicenses = listOf(
@@ -106,7 +106,7 @@ class LicenseInfoResolverTest : WordSpec() {
                     )
                 )
 
-                val resolver = createResolver(data)
+                val resolver = createResolver(licenseInfos)
 
                 val result = resolver.resolveLicenseInfo(pkgId)
 
@@ -166,13 +166,13 @@ class LicenseInfoResolverTest : WordSpec() {
             }
 
             "resolve concluded licenses" {
-                val data = listOf(
+                val licenseInfos = listOf(
                     createLicenseInfo(
                         id = pkgId,
                         concludedLicense = SpdxExpression.parse("Apache-2.0 WITH LLVM-exception AND MIT")
                     )
                 )
-                val resolver = createResolver(data)
+                val resolver = createResolver(licenseInfos)
 
                 val result = resolver.resolveLicenseInfo(pkgId)
 
@@ -184,7 +184,7 @@ class LicenseInfoResolverTest : WordSpec() {
             }
 
             "process copyright statements" {
-                val data = listOf(
+                val licenseInfos = listOf(
                     createLicenseInfo(
                         id = pkgId,
                         detectedLicenses = listOf(
@@ -205,7 +205,7 @@ class LicenseInfoResolverTest : WordSpec() {
                     )
                 )
 
-                val resolver = createResolver(data)
+                val resolver = createResolver(licenseInfos)
 
                 val result = resolver.resolveLicenseInfo(pkgId)
 
@@ -222,7 +222,7 @@ class LicenseInfoResolverTest : WordSpec() {
             }
 
             "mark copyright garbage as garbage" {
-                val data = listOf(
+                val licenseInfos = listOf(
                     createLicenseInfo(
                         id = pkgId,
                         detectedLicenses = listOf(
@@ -243,8 +243,10 @@ class LicenseInfoResolverTest : WordSpec() {
                     )
                 )
 
-                val resolver =
-                    createResolver(data, copyrightGarbage = setOf("(c) 2009-2010 Holder 1", "(c) 2009 Holder 1"))
+                val resolver = createResolver(
+                    licenseInfos,
+                    copyrightGarbage = setOf("(c) 2009-2010 Holder 1", "(c) 2009 Holder 1")
+                )
 
                 val result = resolver.resolveLicenseInfo(pkgId)
 
@@ -268,7 +270,7 @@ class LicenseInfoResolverTest : WordSpec() {
                     sourceArtifact = sourceArtifact
                 )
 
-                val data = listOf(
+                val licenseInfos = listOf(
                     createLicenseInfo(
                         id = pkgId,
                         detectedLicenses = listOf(
@@ -324,7 +326,7 @@ class LicenseInfoResolverTest : WordSpec() {
                     )
                 )
 
-                val resolver = createResolver(data, packageConfigs = packageConfigs)
+                val resolver = createResolver(licenseInfos, packageConfigs = packageConfigs)
 
                 val result = resolver.resolveLicenseInfo(pkgId)
 
@@ -356,7 +358,7 @@ class LicenseInfoResolverTest : WordSpec() {
             }
 
             "apply license finding curations" {
-                val data = listOf(
+                val licenseInfos = listOf(
                     createLicenseInfo(
                         id = pkgId,
                         detectedLicenses = listOf(
@@ -390,7 +392,7 @@ class LicenseInfoResolverTest : WordSpec() {
                     )
                 )
 
-                val resolver = createResolver(data, packageConfigs = packageConfigs)
+                val resolver = createResolver(licenseInfos, packageConfigs = packageConfigs)
 
                 val result = resolver.resolveLicenseInfo(pkgId)
 

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -107,9 +107,7 @@ class LicenseInfoResolverTest : WordSpec() {
                 result should containLocationForLicense(
                     license = "Apache-2.0 WITH LLVM-exception",
                     provenance = provenance,
-                    path = "LICENSE",
-                    startLine = 1,
-                    endLine = 1,
+                    location = TextLocation("LICENSE", 1, 1),
                     copyrights = setOf(
                         ResolvedCopyright(
                             statement = "Copyright Apache-2.0",
@@ -127,17 +125,13 @@ class LicenseInfoResolverTest : WordSpec() {
                 result should containLocationForLicense(
                     license = "Apache-2.0 WITH LLVM-exception",
                     provenance = provenance,
-                    path = "LICENSE",
-                    startLine = 21,
-                    endLine = 21
+                    location = TextLocation("LICENSE", 21, 21)
                 )
                 result should containNumberOfLocationsForLicense("MIT", 2)
                 result should containLocationForLicense(
                     license = "MIT",
                     provenance = provenance,
-                    path = "LICENSE",
-                    startLine = 31,
-                    endLine = 31,
+                    location = TextLocation("LICENSE", 31, 31),
                     copyrights = setOf(
                         ResolvedCopyright(
                             statement = "Copyright MIT",
@@ -155,9 +149,7 @@ class LicenseInfoResolverTest : WordSpec() {
                 result should containLocationForLicense(
                     license = "MIT",
                     provenance = provenance,
-                    path = "LICENSE",
-                    startLine = 41,
-                    endLine = 41
+                    location = TextLocation("LICENSE", 41, 41)
                 )
             }
 
@@ -426,9 +418,7 @@ fun containNumberOfLocationsForLicense(license: String, count: Int): Matcher<Res
 fun containLocationForLicense(
     license: String,
     provenance: Provenance,
-    path: String,
-    startLine: Int,
-    endLine: Int,
+    location: TextLocation,
     appliedCuration: LicenseFindingCuration? = null,
     matchingPathExcludes: List<PathExclude> = emptyList(),
     copyrights: Set<ResolvedCopyright> = emptySet()
@@ -437,9 +427,7 @@ fun containLocationForLicense(
         val expectedLocation =
             ResolvedLicenseLocation(
                 provenance,
-                path,
-                startLine,
-                endLine,
+                location,
                 appliedCuration,
                 matchingPathExcludes,
                 copyrights

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.licenses
+
+import io.kotest.assertions.show.show
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.neverNullMatcher
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import java.lang.IllegalArgumentException
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.LicenseSource
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.config.LicenseFindingCuration
+import org.ossreviewtoolkit.model.config.PathExclude
+import org.ossreviewtoolkit.spdx.SpdxExpression
+import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
+import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
+
+class LicenseInfoResolverTest : WordSpec() {
+    init {
+        val pkgId = Identifier("Gradle:org.ossreviewtoolkit:ort:1.0.0")
+        val provenance = Provenance(
+            vcsInfo = VcsInfo(VcsType.GIT, "https://github.com/oss-review-toolkit/ort.git", "master")
+        )
+
+        "resolveLicenseInfo()" should {
+            "resolve declared licenses" {
+                val data = listOf(
+                    createLicenseInfo(
+                        id = pkgId,
+                        declaredLicenses = setOf("Apache-2.0 WITH LLVM-exception", "MIT")
+                    )
+                )
+                val resolver = LicenseInfoResolver(data.toProvider())
+
+                val result = resolver.resolveLicenseInfo(pkgId)
+
+                result.id shouldBe pkgId
+                result should containOnlyLicenseSources(LicenseSource.DECLARED)
+                result should containLicensesExactly("Apache-2.0 WITH LLVM-exception", "MIT")
+                result should containNoLicenseLocations()
+                result should containNoCopyrights()
+            }
+
+            "resolve detected licenses" {
+                val data = listOf(
+                    createLicenseInfo(
+                        id = pkgId,
+                        detectedLicenses = listOf(
+                            Findings(
+                                provenance = provenance,
+                                licenses = mapOf(
+                                    "Apache-2.0 WITH LLVM-exception" to listOf(
+                                        TextLocation("LICENSE", 1, 1),
+                                        TextLocation("LICENSE", 2, 2)
+                                    ),
+                                    "MIT" to listOf(
+                                        TextLocation("LICENSE", 3, 3),
+                                        TextLocation("LICENSE", 4, 4)
+                                    )
+                                ).toFindingsSet(),
+                                copyrights = emptySet()
+                            )
+                        )
+                    )
+                )
+
+                val resolver = LicenseInfoResolver(data.toProvider())
+
+                val result = resolver.resolveLicenseInfo(pkgId)
+
+                result.id shouldBe pkgId
+                result should containOnlyLicenseSources(LicenseSource.DETECTED)
+                result should containLicensesExactly("Apache-2.0 WITH LLVM-exception", "MIT")
+                result should containNumberOfLocationsForLicense("Apache-2.0 WITH LLVM-exception", 2)
+                result should containLocationForLicense("Apache-2.0 WITH LLVM-exception", provenance, "LICENSE", 1, 1)
+                result should containLocationForLicense("Apache-2.0 WITH LLVM-exception", provenance, "LICENSE", 2, 2)
+                result should containNumberOfLocationsForLicense("MIT", 2)
+                result should containLocationForLicense("MIT", provenance, "LICENSE", 3, 3)
+                result should containLocationForLicense("MIT", provenance, "LICENSE", 4, 4)
+                result should containNoCopyrights()
+            }
+
+            "resolve concluded licenses" {
+                val data = listOf(
+                    createLicenseInfo(
+                        id = pkgId,
+                        concludedLicense = SpdxExpression.parse("Apache-2.0 WITH LLVM-exception AND MIT")
+                    )
+                )
+                val resolver = LicenseInfoResolver(data.toProvider())
+
+                val result = resolver.resolveLicenseInfo(pkgId)
+
+                result.id shouldBe pkgId
+                result should containOnlyLicenseSources(LicenseSource.CONCLUDED)
+                result should containLicensesExactly("Apache-2.0 WITH LLVM-exception", "MIT")
+                result should containNoLicenseLocations()
+                result should containNoCopyrights()
+            }
+        }
+    }
+
+    private fun createLicenseInfo(
+        id: Identifier,
+        declaredLicenses: Set<String> = emptySet(),
+        detectedLicenses: List<Findings> = emptyList(),
+        concludedLicense: SpdxExpression? = null
+    ) =
+        LicenseInfo(
+            id = id,
+            declaredLicenseInfo = DeclaredLicenseInfo(
+                licenses = declaredLicenses,
+                processed = DeclaredLicenseProcessor.process(declaredLicenses),
+                appliedCurations = emptyList()
+            ),
+            detectedLicenseInfo = DetectedLicenseInfo(
+                findings = detectedLicenses
+            ),
+            concludedLicenseInfo = ConcludedLicenseInfo(
+                concludedLicense = concludedLicense,
+                appliedCurations = emptyList()
+            )
+        )
+}
+
+private class SimpleLicenseInfoProvider(val licenseInfo: Map<Identifier, LicenseInfo>) : LicenseInfoProvider {
+    override fun get(id: Identifier) =
+        licenseInfo[id] ?: throw IllegalArgumentException("No license info for '${id.toCoordinates()}' available.")
+}
+
+private fun List<LicenseInfo>.toProvider() = SimpleLicenseInfoProvider(associateBy { it.id })
+
+private fun Map<String, List<TextLocation>>.toFindingsSet(): Set<LicenseFinding> =
+    flatMap { (license, locations) ->
+        locations.map { LicenseFinding(license, it) }
+    }.toSet()
+
+fun containNoLicenseLocations(): Matcher<ResolvedLicenseInfo?> =
+    neverNullMatcher { value ->
+        val locations = value.flatMap { it.locations }
+
+        MatcherResult(
+            locations.isEmpty(),
+            "ResolvedLicenseInfo should not contain license locations, but has ${locations.show().value}",
+            "ResolvedLicenseInfo should contain license locations, but has none"
+        )
+    }
+
+fun containNoCopyrights(): Matcher<ResolvedLicenseInfo?> =
+    neverNullMatcher { value ->
+        val copyrights = value.flatMap { license -> license.locations.flatMap { it.copyrights } }
+
+        MatcherResult(
+            copyrights.isEmpty(),
+            "ResolvedLicenseInfo should not contain copyrights, but has ${copyrights.show().value}",
+            "ResolvedLicenseInfo should contain copyrights, but has none"
+        )
+    }
+
+fun containOnlyLicenseSources(vararg licenseSources: LicenseSource): Matcher<ResolvedLicenseInfo?> =
+    neverNullMatcher { value ->
+        val expected = licenseSources.toSet()
+        val actual = value.flatMap { it.sources }.toSet()
+
+        MatcherResult(
+            expected == actual,
+            "ResolvedLicenseInfo should contain only license sources ${expected.show().value}, but has " +
+                    actual.show().value,
+            "ResolvedLicenseInfo should not only contain license source ${expected.show().value}"
+        )
+    }
+
+fun containLicensesExactly(vararg licenses: String): Matcher<ResolvedLicenseInfo?> =
+    neverNullMatcher { value ->
+        val expected = licenses.map { SpdxExpression.parse(it) as SpdxSingleLicenseExpression }.toSet()
+        val actual = value.map { it.license }.toSet()
+
+        MatcherResult(
+            expected == actual,
+            "ResolvedLicenseInfo should contain exactly licenses ${expected.show().value}, but has " +
+                    actual.show().value,
+            "ResolvedLicenseInfo should not contain exactly ${expected.show().value}"
+        )
+    }
+
+fun containNumberOfLocationsForLicense(license: String, count: Int): Matcher<ResolvedLicenseInfo?> =
+    neverNullMatcher { value ->
+        val actualCount = value[SpdxSingleLicenseExpression.parse(license)]?.locations?.size ?: 0
+
+        MatcherResult(
+            count == actualCount,
+            "ResolvedLicenseInfo should contain $count locations for $license, but has $actualCount",
+            "ResolvedLicenseInfo should not contain $count locations for $license"
+        )
+    }
+
+fun containLocationForLicense(
+    license: String,
+    provenance: Provenance,
+    path: String,
+    startLine: Int,
+    endLine: Int,
+    appliedCuration: LicenseFindingCuration? = null,
+    matchingPathExcludes: List<PathExclude> = emptyList(),
+    copyrights: Set<ResolvedCopyrightFinding> = emptySet()
+): Matcher<ResolvedLicenseInfo?> =
+    neverNullMatcher { value ->
+        val expectedLocation =
+            ResolvedLicenseLocation(
+                provenance,
+                path,
+                startLine,
+                endLine,
+                appliedCuration,
+                matchingPathExcludes,
+                copyrights
+            )
+        val locations = value[SpdxSingleLicenseExpression.parse(license)]?.locations.orEmpty()
+
+        val contained = expectedLocation in locations
+
+        MatcherResult(
+            contained,
+            "ResolvedLicenseInfo should contain location ${expectedLocation.show().value} for $license",
+            "ResolvedLicenseInfo should not contain location ${expectedLocation.show().value} for $license"
+        )
+    }


### PR DESCRIPTION
A new license API for ORT. The idea is to bundle the code that processes concluded, declared, and detected licenses in a single place, and to provide an API that will be used by all places in ORT working with those licenses, to make the license related code more consistent.

Please see the commit messages for details.