### PR TITLE
EvaluatedModel: Properly decompose the declared license

### DIFF
--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -37,18 +37,27 @@
     "id" : "LicenseRef-test-Apache-2.0-single-line"
   }, {
     "_id" : 5,
-    "id" : "Apache-2.0"
+    "id" : "GPL-3.0-only WITH GCC-exception-3.1 AND CC-BY-NC-3.0"
   }, {
     "_id" : 6,
-    "id" : "Eclipse Public License 1.0"
+    "id" : "GPL-3.0-only"
   }, {
     "_id" : 7,
-    "id" : "EPL-1.0"
+    "id" : "CC-BY-NC-3.0"
   }, {
     "_id" : 8,
-    "id" : "Apache License, Version 2.0"
+    "id" : "Apache-2.0"
   }, {
     "_id" : 9,
+    "id" : "Eclipse Public License 1.0"
+  }, {
+    "_id" : 10,
+    "id" : "EPL-1.0"
+  }, {
+    "_id" : 11,
+    "id" : "Apache License, Version 2.0"
+  }, {
+    "_id" : 12,
     "id" : "New BSD License"
   } ],
   "scopes" : [ {
@@ -265,8 +274,12 @@
     "is_project" : true,
     "definition_file_path" : "project/build.gradle",
     "purl" : "pkg:gradle/org.ossreviewtoolkit/nested-fake-project@1.0.0",
-    "declared_licenses_processed" : { },
-    "detected_licenses" : [ 5, 2 ],
+    "declared_licenses" : [ 5 ],
+    "declared_licenses_processed" : {
+      "spdx_expression" : "GPL-3.0-only WITH GCC-exception-3.1 AND CC-BY-NC-3.0",
+      "mapped_licenses" : [ 6, 7 ]
+    },
+    "detected_licenses" : [ 8, 2 ],
     "detected_excluded_licenses" : [ 2 ],
     "binary_artifact" : {
       "url" : "",
@@ -307,7 +320,7 @@
       "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
-      "license" : 5,
+      "license" : 8,
       "path" : "file.java",
       "start_line" : 1,
       "end_line" : 2,
@@ -315,7 +328,7 @@
       "path_excludes" : [ 1 ]
     }, {
       "type" : "LICENSE",
-      "license" : 5,
+      "license" : 8,
       "path" : "file.kt",
       "start_line" : 1,
       "end_line" : 2,
@@ -353,10 +366,10 @@
     "is_project" : false,
     "definition_file_path" : "",
     "purl" : "pkg:ant/junit/junit@4.12",
-    "declared_licenses" : [ 6 ],
+    "declared_licenses" : [ 9 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "EPL-1.0",
-      "mapped_licenses" : [ 7 ]
+      "mapped_licenses" : [ 10 ]
     },
     "description" : "JUnit is a unit testing framework for Java, created by Erich Gamma and Kent Beck.",
     "homepage_url" : "http://junit.org",
@@ -398,10 +411,10 @@
     "is_project" : false,
     "definition_file_path" : "",
     "purl" : "pkg:maven/org.apache.commons/commons-lang3@3.5",
-    "declared_licenses" : [ 8 ],
+    "declared_licenses" : [ 11 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "Apache-2.0",
-      "mapped_licenses" : [ 5 ]
+      "mapped_licenses" : [ 8 ]
     },
     "description" : "Apache Commons Lang, a package of Java utility classes for the\n  classes that are in java.lang's hierarchy, or are considered to be so\n  standard as to justify existence in java.lang.",
     "homepage_url" : "http://commons.apache.org/proper/commons-lang/",
@@ -442,10 +455,10 @@
     "is_project" : false,
     "definition_file_path" : "",
     "purl" : "pkg:maven/org.apache.commons/commons-text@1.1",
-    "declared_licenses" : [ 8 ],
+    "declared_licenses" : [ 11 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "Apache-2.0",
-      "mapped_licenses" : [ 5 ]
+      "mapped_licenses" : [ 8 ]
     },
     "description" : "Apache Commons Text is a library focused on algorithms working on strings.",
     "homepage_url" : "http://commons.apache.org/proper/commons-text/",
@@ -486,7 +499,7 @@
     "is_project" : false,
     "definition_file_path" : "",
     "purl" : "pkg:maven/org.hamcrest/hamcrest-core@1.3",
-    "declared_licenses" : [ 9 ],
+    "declared_licenses" : [ 12 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "BSD-3-Clause",
       "mapped_licenses" : [ 1 ]
@@ -618,7 +631,7 @@
     "_id" : 0,
     "rule" : "rule 1",
     "pkg" : 2,
-    "license" : 7,
+    "license" : 10,
     "license_source" : "DETECTED",
     "severity" : "ERROR",
     "message" : "EPL-1.0 error",
@@ -627,7 +640,7 @@
     "_id" : 1,
     "rule" : "rule 2",
     "pkg" : 4,
-    "license" : 5,
+    "license" : 8,
     "license_source" : "DECLARED",
     "severity" : "HINT",
     "message" : "Apache-2.0 hint",
@@ -668,7 +681,9 @@
       "declared" : {
         "Apache-2.0" : 2,
         "BSD-3-Clause" : 1,
-        "EPL-1.0" : 1
+        "CC-BY-NC-3.0" : 1,
+        "EPL-1.0" : 1,
+        "GPL-3.0-only WITH GCC-exception-3.1" : 1
       },
       "detected" : {
         "Apache-2.0" : 1,

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -40,7 +40,7 @@
     "id" : "GPL-3.0-only WITH GCC-exception-3.1 AND CC-BY-NC-3.0"
   }, {
     "_id" : 6,
-    "id" : "GPL-3.0-only"
+    "id" : "GPL-3.0-only WITH GCC-exception-3.1"
   }, {
     "_id" : 7,
     "id" : "CC-BY-NC-3.0"

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -30,7 +30,7 @@ licenses:
 - _id: 5
   id: "GPL-3.0-only WITH GCC-exception-3.1 AND CC-BY-NC-3.0"
 - _id: 6
-  id: "GPL-3.0-only"
+  id: "GPL-3.0-only WITH GCC-exception-3.1"
 - _id: 7
   id: "CC-BY-NC-3.0"
 - _id: 8

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -28,14 +28,20 @@ licenses:
 - _id: 4
   id: "LicenseRef-test-Apache-2.0-single-line"
 - _id: 5
-  id: "Apache-2.0"
+  id: "GPL-3.0-only WITH GCC-exception-3.1 AND CC-BY-NC-3.0"
 - _id: 6
-  id: "Eclipse Public License 1.0"
+  id: "GPL-3.0-only"
 - _id: 7
-  id: "EPL-1.0"
+  id: "CC-BY-NC-3.0"
 - _id: 8
-  id: "Apache License, Version 2.0"
+  id: "Apache-2.0"
 - _id: 9
+  id: "Eclipse Public License 1.0"
+- _id: 10
+  id: "EPL-1.0"
+- _id: 11
+  id: "Apache License, Version 2.0"
+- _id: 12
   id: "New BSD License"
 scopes:
 - _id: 0
@@ -220,9 +226,15 @@ packages:
   is_project: true
   definition_file_path: "project/build.gradle"
   purl: "pkg:gradle/org.ossreviewtoolkit/nested-fake-project@1.0.0"
-  declared_licenses_processed: {}
-  detected_licenses:
+  declared_licenses:
   - 5
+  declared_licenses_processed:
+    spdx_expression: "GPL-3.0-only WITH GCC-exception-3.1 AND CC-BY-NC-3.0"
+    mapped_licenses:
+    - 6
+    - 7
+  detected_licenses:
+  - 8
   - 2
   detected_excluded_licenses:
   - 2
@@ -261,7 +273,7 @@ packages:
     path_excludes:
     - 1
   - type: "LICENSE"
-    license: 5
+    license: 8
     path: "file.java"
     start_line: 1
     end_line: 2
@@ -269,7 +281,7 @@ packages:
     path_excludes:
     - 1
   - type: "LICENSE"
-    license: 5
+    license: 8
     path: "file.kt"
     start_line: 1
     end_line: 2
@@ -307,11 +319,11 @@ packages:
   definition_file_path: ""
   purl: "pkg:ant/junit/junit@4.12"
   declared_licenses:
-  - 6
+  - 9
   declared_licenses_processed:
     spdx_expression: "EPL-1.0"
     mapped_licenses:
-    - 7
+    - 10
   description: "JUnit is a unit testing framework for Java, created by Erich Gamma\
     \ and Kent Beck."
   homepage_url: "http://junit.org"
@@ -352,11 +364,11 @@ packages:
   definition_file_path: ""
   purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
   declared_licenses:
-  - 8
+  - 11
   declared_licenses_processed:
     spdx_expression: "Apache-2.0"
     mapped_licenses:
-    - 5
+    - 8
   description: "Apache Commons Lang, a package of Java utility classes for the\n \
     \ classes that are in java.lang's hierarchy, or are considered to be so\n  standard\
     \ as to justify existence in java.lang."
@@ -398,11 +410,11 @@ packages:
   definition_file_path: ""
   purl: "pkg:maven/org.apache.commons/commons-text@1.1"
   declared_licenses:
-  - 8
+  - 11
   declared_licenses_processed:
     spdx_expression: "Apache-2.0"
     mapped_licenses:
-    - 5
+    - 8
   description: "Apache Commons Text is a library focused on algorithms working on\
     \ strings."
   homepage_url: "http://commons.apache.org/proper/commons-text/"
@@ -443,7 +455,7 @@ packages:
   definition_file_path: ""
   purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
   declared_licenses:
-  - 9
+  - 12
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped_licenses:
@@ -563,7 +575,7 @@ rule_violations:
 - _id: 0
   rule: "rule 1"
   pkg: 2
-  license: 7
+  license: 10
   license_source: "DETECTED"
   severity: "ERROR"
   message: "EPL-1.0 error"
@@ -572,7 +584,7 @@ rule_violations:
 - _id: 1
   rule: "rule 2"
   pkg: 4
-  license: 5
+  license: 8
   license_source: "DECLARED"
   severity: "HINT"
   message: "Apache-2.0 hint"
@@ -613,7 +625,9 @@ statistics:
     declared:
       Apache-2.0: 2
       BSD-3-Clause: 1
+      CC-BY-NC-3.0: 1
       EPL-1.0: 1
+      GPL-3.0-only WITH GCC-exception-3.1: 1
     detected:
       Apache-2.0: 1
       BSD-3-Clause: 1

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -696,7 +696,14 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
         </thead>
         <tbody>
           <tr class="ort-success " id="Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0-pkg-1">
-            <td><a href="#Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0-pkg-1">1</a></td><td>Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0</td><td></td><td><em>Detected Licenses:</em>
+            <td><a href="#Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0-pkg-1">1</a></td><td>Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0</td><td></td><td><em>Declared Licenses:</em>
+              <dl>
+                <dd>
+                  <div>CC-BY-NC-3.0</div>
+                  <div>GPL-3.0-only WITH GCC-exception-3.1</div>
+                </dd>
+              </dl>
+              <em>Detected Licenses:</em>
               <dl>
                 <dd>
                   <div>Apache-2.0</div>

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -79,8 +79,8 @@ analyzer:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
     - id: "Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0"
       definition_file_path: "project/build.gradle"
-      declared_licenses: []
-      declared_licenses_processed: {}
+      declared_licenses:
+      - "GPL-3.0-only WITH GCC-exception-3.1 AND CC-BY-NC-3.0"
       vcs:
         type: ""
         url: ""

--- a/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
@@ -599,7 +599,9 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     private fun ProcessedDeclaredLicense.evaluate(): EvaluatedProcessedDeclaredLicense =
         EvaluatedProcessedDeclaredLicense(
             spdxExpression = spdxExpression,
-            mappedLicenses = spdxExpression?.licenses().orEmpty().map { licenses.addIfRequired(LicenseId(it)) },
+            mappedLicenses = spdxExpression?.decompose().orEmpty().map {
+                licenses.addIfRequired(LicenseId(it.toString()))
+            },
             unmappedLicenses = unmapped.map { licenses.addIfRequired(LicenseId(it)) }
         )
 

--- a/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
@@ -599,7 +599,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     private fun ProcessedDeclaredLicense.evaluate(): EvaluatedProcessedDeclaredLicense =
         EvaluatedProcessedDeclaredLicense(
             spdxExpression = spdxExpression,
-            mappedLicenses = spdxExpression?.licenses()?.map { licenses.addIfRequired(LicenseId(it)) }.orEmpty(),
+            mappedLicenses = spdxExpression?.licenses().orEmpty().map { licenses.addIfRequired(LicenseId(it)) },
             unmappedLicenses = unmapped.map { licenses.addIfRequired(LicenseId(it)) }
         )
 


### PR DESCRIPTION
The licenses array contains entries for declared licenses and detected licenses while only the entries for the detected licenses were actually decomposed. Use `decompose()` instead of `licenses()` also for deriving the entries for the declared licenses.