### PR TITLE
Azure: Change the Gradle cache key for the Linux analyzer job

### DIFF
--- a/.azure-pipelines/LinuxAnalyzerTest.yml
+++ b/.azure-pipelines/LinuxAnalyzerTest.yml
@@ -67,9 +67,9 @@ jobs:
   # Gradle build cache, see: https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | analyzer-test | gradle-caches | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
+      key: '"$(Agent.OS)" | analyzer-test | gradle-caches | v2 | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
       restoreKeys: |
-        "$(Agent.OS)" | analyzer-test | gradle-caches
+        "$(Agent.OS)" | analyzer-test | gradle-caches | v2
       path: $(GRADLE_USER_HOME)/caches
     displayName: Cache Gradle Caches
 


### PR DESCRIPTION
The existing Gradle cache is >5GB which causes builds to fail with "No
space left on device". Because there is no way to clear an existing
cache, change the cache key to ensure a new cache is used [1].

A prior change in 427f166 should make sure that the cache does not grow
too large in future.

[1] https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#can-i-clear-a-cache