### PR TITLE
ListLicensesCommand: Output the resolved revision

### DIFF
--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -288,5 +288,5 @@ private fun Provenance.writeValueAsString(): String =
     sourceArtifact?.let {
         "url=${it.url}, hash=${it.hash.value}"
     } ?: vcsInfo?.let {
-        "type=${it.type}, url=${it.url}, path=${it.path}, revision=${it.revision}"
+        "type=${it.type}, url=${it.url}, path=${it.path}, revision=${it.resolvedRevision}"
     } ?: throw IllegalArgumentException("Provenance must have either a non-null source artifact or VCS info.")


### PR DESCRIPTION
Instead of the revision, because this usually is the more interresting
value.

Signed-off-by: Frank Viernau <frank.viernau@here.com>