### PR TITLE
Support .netrc files as a way to authenticate HTTP(S) downloads

### DIFF
--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -74,22 +74,25 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
     private val projectNameOption by option(
         "--project-name",
         help = "The speaking name of the project to download. For use together with '--project-url'. Will be ignored " +
-                "if '--ort-file' is also specified."
+                "if '--ort-file' is also specified. (default: the last part of the project URL)"
     )
 
     private val vcsTypeOption by option(
         "--vcs-type",
-        help = "The VCS type if '--project-url' points to a VCS. Will be ignored if '--ort-file' is also specified."
+        help = "The VCS type if '--project-url' points to a VCS. Will be ignored if '--ort-file' is also specified. " +
+                "(default: the VCS type detected by querying the project URL)"
     )
 
     private val vcsRevisionOption by option(
         "--vcs-revision",
-        help = "The VCS revision if '--project-url' points to a VCS. Will be ignored if '--ort-file' is also specified."
+        help = "The VCS revision if '--project-url' points to a VCS. Will be ignored if '--ort-file' is also " +
+                "specified. (default: the VCS's default revision)"
     )
 
     private val vcsPath by option(
         "--vcs-path",
-        help = "The VCS path if '--project-url' points to a VCS. Will be ignored if '--ort-file' is also specified."
+        help = "The VCS path if '--project-url' points to a VCS. Will be ignored if '--ort-file' is also specified. " +
+                "(default: the empty root path)"
     ).default("")
 
     private val outputDir by option(

--- a/utils/src/test/kotlin/OrtAuthenticatorTest.kt
+++ b/utils/src/test/kotlin/OrtAuthenticatorTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.utils
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class OrtAuthenticatorTest : WordSpec({
+    "getNetrcAuthentication()" should {
+        "correctly parse single-line contents" {
+            val authentication = getNetrcAuthentication("""
+                machine github.com login foo password bar
+            """.trimIndent(), "github.com")
+
+            authentication shouldNotBe null
+            authentication!!.userName shouldBe "foo"
+            authentication.password shouldBe "bar".toCharArray()
+        }
+
+        "correctly parse multi-line contents" {
+            val authentication = getNetrcAuthentication("""
+                machine gitlab.com
+                login foo
+                password bar
+            """.trimIndent(), "gitlab.com")
+
+            authentication shouldNotBe null
+            authentication!!.userName shouldBe "foo"
+            authentication.password shouldBe "bar".toCharArray()
+        }
+
+        "recognize the default machine" {
+            val authentication = getNetrcAuthentication("""
+                machine github.com
+                login git
+                password hub
+                default login foo password bar
+            """.trimIndent(), "gitlab.com")
+
+            authentication shouldNotBe null
+            authentication!!.userName shouldBe "foo"
+            authentication.password shouldBe "bar".toCharArray()
+        }
+
+        "ignore superfluous statements" {
+            val authentication = getNetrcAuthentication("""
+                machine "# A funky way to add comments."
+                login funkyLogin
+                password funkyPassword
+                machine bitbucket.com
+                # This is a port.
+                port 433
+                password bar
+                login foo
+            """.trimIndent(), "bitbucket.com")
+
+            authentication shouldNotBe null
+            authentication!!.userName shouldBe "foo"
+            authentication.password shouldBe "bar".toCharArray()
+        }
+
+        "ignore irrelavant machines" {
+            val authentication = getNetrcAuthentication("""
+                machine bitbucket.com login foo password bar
+            """.trimIndent(), "github.com")
+
+            authentication shouldBe null
+        }
+    }
+})


### PR DESCRIPTION
This includes support for cloning private Git repos via HTTP(S). Please have a look at the individual commit messages for the details.