### PR TITLE
GoDepTest: Lock dependency versions of the godeps test project

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/godep/godeps/Godeps/Godeps.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/godep/godeps/Godeps/Godeps.json
@@ -6,6 +6,10 @@
     {
       "ImportPath": "github.com/mattn/go-isatty",
       "Rev": "7b513a986450394f7bbf1476909911b3aa3a55ce"
+    },
+    {
+      "ImportPath": "golang.org/x/sys",
+      "Rev": "8d3cce7afc34617998104db7c4b58c2de9e77215"
     }
   ]
 }


### PR DESCRIPTION
Add golang.org/x/sys to the Godeps.json file to avoid having to do
repeated updates of the expected results.