### PR TITLE
analyzer: Remove initial log statements when resolving dependencies

### DIFF
--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -40,7 +40,6 @@ import org.ossreviewtoolkit.utils.CommandLineTool
 import org.ossreviewtoolkit.utils.Os
 import org.ossreviewtoolkit.utils.fieldNamesOrEmpty
 import org.ossreviewtoolkit.utils.fieldsOrEmpty
-import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.stashDirectories
 import org.ossreviewtoolkit.utils.textValueOrEmpty
 
@@ -217,8 +216,6 @@ class Bower(
     override fun beforeResolution(definitionFiles: List<File>) = checkVersion(analyzerConfig.ignoreToolVersions)
 
     override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
-        log.info { "Resolving dependencies for: '$definitionFile'" }
-
         val workingDir = definitionFile.parentFile
 
         stashDirectories(File(workingDir, "bower_components")).use {

--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -227,8 +227,6 @@ class Cargo(
     }
 
     override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
-        log.info { "Resolving dependencies for: '$definitionFile'" }
-
         // Get the project name and version. If one of them is missing return null, because this is a workspace
         // definition file that does not contain a project.
         val pkgDefinition = Toml().read(definitionFile)

--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -98,8 +98,6 @@ class Conan(
      * Primary method for resolving dependencies from [definitionFile].
      */
     override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
-        log.info { "Resolving dependencies for: '$definitionFile'" }
-
         val conanHome = getUserHomeDirectory().resolve(".conan")
 
         stashDirectories(File(conanHome.resolve("data").path)).use {


### PR DESCRIPTION
There already is logging for this in the caller.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>