### PR TITLE
model: Add a result class for applying license finding curations

### DIFF
--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -302,11 +302,12 @@ internal fun OrtResult.getLicenseFindingsById(
         scanResultContainer.results.forEach { scanResult ->
             val findingsForProvenance = result.getOrPut(scanResult.provenance) { mutableMapOf() }
 
-            scanResult.summary.licenseFindings.let {
+            scanResult.summary.licenseFindings.let { findings ->
                 if (applyCurations) {
-                    FindingCurationMatcher().applyAll(it, getLicenseFindingsCurations(scanResult.provenance))
+                    FindingCurationMatcher().applyAll(findings, getLicenseFindingsCurations(scanResult.provenance))
+                        .mapNotNull { it.curatedFinding }.distinct()
                 } else {
-                    it
+                    findings
                 }
             }.let { findings ->
                 if (decomposeLicenseExpressions) {

--- a/model/src/main/kotlin/licenses/LicenseFindingCurationResult.kt
+++ b/model/src/main/kotlin/licenses/LicenseFindingCurationResult.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.licenses
+
+import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.config.LicenseFindingCuration
+import org.ossreviewtoolkit.spdx.SpdxLicense
+
+/**
+ * A [curated license finding][curatedFinding] created by applying [LicenseFindingCuration]s.
+ */
+data class LicenseFindingCurationResult(
+    /**
+     * The curated license finding, or null, if the [concluded license][LicenseFindingCuration.concluded] is
+     * [SpdxLicense.NONE].
+     */
+    val curatedFinding: LicenseFinding?,
+
+    /**
+     * All pairs of original license findings and applied curation that were resolved to the [curatedFinding].
+     */
+    val originalFindings: List<Pair<LicenseFinding, LicenseFindingCuration>>
+)

--- a/model/src/main/kotlin/utils/LicenseResolver.kt
+++ b/model/src/main/kotlin/utils/LicenseResolver.kt
@@ -79,6 +79,7 @@ internal class LicenseResolver(
             }
 
             val curatedLicenseFindings = curationMatcher.applyAll(rawLicenseFindings, curations)
+                .mapNotNullTo(mutableSetOf()) { it.curatedFinding }
             val decomposedFindings = curatedLicenseFindings.flatMap { finding ->
                 SpdxExpression.parse(finding.license).decompose().map { finding.copy(license = it.toString()) }
             }

--- a/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
@@ -531,6 +531,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         val pathExcludes = getPathExcludes(id, scanResult.provenance)
         val licenseFindingCurations = getLicenseFindingCurations(id, scanResult.provenance)
         val curatedFindings = curationsMatcher.applyAll(scanResult.summary.licenseFindings, licenseFindingCurations)
+            .mapNotNullTo(mutableSetOf()) { it.curatedFinding }
         val decomposedFindings = curatedFindings.flatMap { finding ->
             SpdxExpression.parse(finding.license).decompose().map { finding.copy(license = it.toString()) }
         }


### PR DESCRIPTION
Add a result class that is returned by the `FindingCurationMatcher`,
instead of only returning a list of resulting license findings. This
allows to track the original findings and the license finding curations
which resulted in the curated findings.

This is useful for visualizing applied license finding curations in the
reporters to help users to see the effect of license finding curations,
and to debug issues with license finding curations.

It will also be used by a new license resolver in a later commit.