### PR TITLE
Jeninsfile: Remove the config directory before cloning to it

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -218,6 +218,7 @@ pipeline {
                             VCS_REVISION_OPTION="--vcs-revision $ORT_CONFIG_VCS_REVISION"
                         fi
 
+                        rm -fr $ORT_DATA_DIR/config
                         /opt/ort/bin/ort $LOG_LEVEL download --project-url $ORT_CONFIG_VCS_URL $VCS_REVISION_OPTION -o $ORT_DATA_DIR/config
 
                         rm -f $HOME/.netrc


### PR DESCRIPTION
This is a fixup for bd08a98 as the ORT Downloader does not do
incremental fetches but wants to do a fresh clone.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>