### PR TITLE
PackageManager: Fix the logger instance being used from inside an object

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -108,7 +108,7 @@ abstract class PackageManager(
             Files.walkFileTree(directory.toPath(), object : SimpleFileVisitor<Path>() {
                 override fun preVisitDirectory(dir: Path, attributes: BasicFileAttributes): FileVisitResult {
                     if (IGNORED_DIRECTORY_MATCHERS.any { it.matches(dir) }) {
-                        log.info { "Not analyzing directory '$dir' as it is hard-coded to be ignored." }
+                        PackageManager.log.info { "Not analyzing directory '$dir' as it is hard-coded to be ignored." }
                         return FileVisitResult.SKIP_SUBTREE
                     }
 


### PR DESCRIPTION
This changes the output

    [main] INFO  org.ossreviewtoolkit.analyzer.PackageManager$Companion$findManagedFiles$2 - Not analyzing directory

to

    [main] INFO  org.ossreviewtoolkit.analyzer.PackageManager - Not analyzing directory

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>