### PR TITLE
NoticeByPackageReporter: Rewrite code a bit to avoid explicit typing

### DIFF
--- a/reporter/src/main/kotlin/reporters/NoticeByPackageReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeByPackageReporter.kt
@@ -136,16 +136,12 @@ class NoticeByPackageProcessor(input: ReporterInput) : AbstractNoticeReporter.No
             val scanResult = input.ortResult.getScanResultsForId(id).firstOrNull()
             val archiveDir = createTempDir(ORT_NAME, "notice").also { it.deleteOnExit() }
 
-            val licenseFileFindings = if (scanResult != null) {
+            val licenseFileFindings = scanResult?.let {
                 val path = "${id.toPath()}/${scanResult.provenance.hash()}"
-                if (archiver.unarchive(archiveDir, path)) {
+                archiver.unarchive(archiveDir, path).takeIf { it }?.let {
                     getFindingsForLicenseFiles(scanResult, archiveDir, archiver.patterns, licenseFindingsMap)
-                } else {
-                    emptyMap()
                 }
-            } else {
-                emptyMap<String, LicenseFindingsMap>()
-            }
+            }.orEmpty()
 
             addLicenseFileFindings(licenseFileFindings, archiveDir)
 


### PR DESCRIPTION
Change the code to functional style so we can avoid the explicit typing
and returning of an empty map in two different branches.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>