### PR TITLE
analyzer: Allow multiple projects per definition file

### DIFF
--- a/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
+++ b/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
@@ -124,7 +124,7 @@ abstract class AbstractIntegrationSpec : StringSpec() {
                     .resolveDependencies(files)
 
                 results.size shouldBe files.size
-                results.values.forAll { result ->
+                results.values.flatten().forAll { result ->
                     VersionControlSystem.forType(result.project.vcsProcessed.type) shouldBe
                             VersionControlSystem.forType(pkg.vcs.type)
                     result.project.vcsProcessed.url shouldBe pkg.vcs.url

--- a/analyzer/src/funTest/kotlin/managers/Extensions.kt
+++ b/analyzer/src/funTest/kotlin/managers/Extensions.kt
@@ -19,6 +19,8 @@
 
 package org.ossreviewtoolkit.analyzer.managers
 
+import io.kotest.matchers.collections.haveSize
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldNotBe
 
 import java.io.File
@@ -32,5 +34,6 @@ fun Any?.toYaml() = yamlMapper.writeValueAsString(this)!!
 fun PackageManager.resolveSingleProject(definitionFile: File): ProjectAnalyzerResult =
     resolveDependencies(listOf(definitionFile))[definitionFile].let { result ->
         result shouldNotBe null
-        result!!
+        result!! should haveSize(1)
+        result.single()
     }

--- a/analyzer/src/funTest/kotlin/managers/MavenTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/MavenTest.kt
@@ -30,6 +30,9 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.haveSize
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldNotBe
 
 import java.io.File
 
@@ -63,7 +66,9 @@ class MavenTest : StringSpec() {
             // of transitive dependencies would not work.
             val result = createMaven().resolveDependencies(listOf(pomFileCore, pomFileResources))[pomFileCore]
 
-            result.toYaml() shouldBe expectedResult
+            result shouldNotBe null
+            result!! should haveSize(1)
+            result.single().toYaml() shouldBe expectedResult
         }
 
         "Root project dependencies are detected correctly" {
@@ -93,7 +98,9 @@ class MavenTest : StringSpec() {
             // not work.
             val result = createMaven().resolveDependencies(listOf(pomFileApp, pomFileLib))[pomFileApp]
 
-            result.toYaml() shouldBe expectedResult
+            result shouldNotBe null
+            result!! should haveSize(1)
+            result.single().toYaml() shouldBe expectedResult
         }
 
         "External dependencies are detected correctly" {

--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -215,7 +215,7 @@ class Bower(
 
     override fun beforeResolution(definitionFiles: List<File>) = checkVersion(analyzerConfig.ignoreToolVersions)
 
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
 
         stashDirectories(File(workingDir, "bower_components")).use {
@@ -243,9 +243,11 @@ class Bower(
                 scopes = sortedSetOf(dependenciesScope, devDependenciesScope)
             )
 
-            return ProjectAnalyzerResult(
-                project = project,
-                packages = packages.mapTo(sortedSetOf()) { it.value.toCuratedPackage() }
+            return listOf(
+                ProjectAnalyzerResult(
+                    project = project,
+                    packages = packages.mapTo(sortedSetOf()) { it.value.toCuratedPackage() }
+                )
             )
         }
     }

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -91,7 +91,7 @@ class Bundler(
         // fixed versions to be sure to get consistent results.
         checkVersion(analyzerConfig.ignoreToolVersions)
 
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
 
         stashDirectories(File(workingDir, "vendor")).use {
@@ -119,7 +119,13 @@ class Bundler(
                 scopes = scopes.toSortedSet()
             )
 
-            return ProjectAnalyzerResult(project, packages.mapTo(sortedSetOf()) { it.toCuratedPackage() }, issues)
+            return listOf(
+                ProjectAnalyzerResult(
+                    project = project,
+                    packages = packages.mapTo(sortedSetOf()) { it.toCuratedPackage() },
+                    issues = issues
+                )
+            )
         }
     }
 

--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -226,12 +226,12 @@ class Cargo(
         return null
     }
 
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         // Get the project name and version. If one of them is missing return null, because this is a workspace
         // definition file that does not contain a project.
         val pkgDefinition = Toml().read(definitionFile)
-        val projectName = pkgDefinition.getString("package.name") ?: return null
-        val projectVersion = pkgDefinition.getString("package.version") ?: return null
+        val projectName = pkgDefinition.getString("package.name") ?: return emptyList()
+        val projectVersion = pkgDefinition.getString("package.version") ?: return emptyList()
 
         val workingDir = definitionFile.parentFile
         val metadataJson = runMetadata(workingDir)
@@ -290,6 +290,11 @@ class Cargo(
             .map { it.value.toCuratedPackage() }
             .toSortedSet()
 
-        return ProjectAnalyzerResult(project, nonProjectPackages)
+        return listOf(
+            ProjectAnalyzerResult(
+                project = project,
+                packages = nonProjectPackages
+            )
+        )
     }
 }

--- a/analyzer/src/main/kotlin/managers/CocoaPods.kt
+++ b/analyzer/src/main/kotlin/managers/CocoaPods.kt
@@ -46,7 +46,7 @@ class CocoaPods(
         ) = CocoaPods(managerName, analysisRoot, analyzerConfig, repoConfig)
     }
 
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
     }
 }

--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -97,7 +97,7 @@ class Conan(
     /**
      * Primary method for resolving dependencies from [definitionFile].
      */
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val conanHome = getUserHomeDirectory().resolve(".conan")
 
         stashDirectories(File(conanHome.resolve("data").path)).use {
@@ -121,21 +121,23 @@ class Conan(
 
             val projectPackage = extractProjectPackage(rootNode, definitionFile, workingDir)
 
-            return ProjectAnalyzerResult(
-                project = Project(
-                    id = projectPackage.id,
-                    definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
-                    declaredLicenses = projectPackage.declaredLicenses,
-                    vcs = projectPackage.vcs,
-                    vcsProcessed = processProjectVcs(
-                        workingDir,
-                        projectPackage.vcs,
-                        projectPackage.homepageUrl
+            return listOf(
+                ProjectAnalyzerResult(
+                    project = Project(
+                        id = projectPackage.id,
+                        definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+                        declaredLicenses = projectPackage.declaredLicenses,
+                        vcs = projectPackage.vcs,
+                        vcsProcessed = processProjectVcs(
+                            workingDir,
+                            projectPackage.vcs,
+                            projectPackage.homepageUrl
+                        ),
+                        homepageUrl = projectPackage.homepageUrl,
+                        scopes = sortedSetOf(dependenciesScope, devDependenciesScope)
                     ),
-                    homepageUrl = projectPackage.homepageUrl,
-                    scopes = sortedSetOf(dependenciesScope, devDependenciesScope)
-                ),
-                packages = packages.map { it.value.toCuratedPackage() }.toSortedSet()
+                    packages = packages.map { it.value.toCuratedPackage() }.toSortedSet()
+                )
             )
         }
     }

--- a/analyzer/src/main/kotlin/managers/DotNet.kt
+++ b/analyzer/src/main/kotlin/managers/DotNet.kt
@@ -88,6 +88,6 @@ class DotNet(
         ) = DotNet(managerName, analysisRoot, analyzerConfig, repoConfig)
     }
 
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? =
-        resolveDotNetDependencies(definitionFile, DotNetPackageReferenceMapper())
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> =
+        listOfNotNull(resolveDotNetDependencies(definitionFile, DotNetPackageReferenceMapper()))
 }

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -91,7 +91,7 @@ class GoDep(
     override fun transformVersion(output: String) =
         output.lineSequence().first { it.contains("version") }.substringAfter(':').trim().removePrefix("v")
 
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val projectDir = resolveProjectRoot(definitionFile)
         val projectVcs = processProjectVcs(projectDir)
         val gopath = createTempDir(ORT_NAME, "${projectDir.name}-gopath")
@@ -160,22 +160,24 @@ class GoDep(
         // TODO Keeping this between scans would speed things up considerably.
         gopath.safeDeleteRecursively(force = true)
 
-        return ProjectAnalyzerResult(
-            project = Project(
-                id = Identifier(
-                    type = managerName,
-                    namespace = "",
-                    name = projectName,
-                    version = projectVcs.revision
+        return listOf(
+            ProjectAnalyzerResult(
+                project = Project(
+                    id = Identifier(
+                        type = managerName,
+                        namespace = "",
+                        name = projectName,
+                        version = projectVcs.revision
+                    ),
+                    definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+                    declaredLicenses = sortedSetOf(),
+                    vcs = VcsInfo.EMPTY,
+                    vcsProcessed = projectVcs,
+                    homepageUrl = "",
+                    scopes = sortedSetOf(scope)
                 ),
-                definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
-                declaredLicenses = sortedSetOf(),
-                vcs = VcsInfo.EMPTY,
-                vcsProcessed = projectVcs,
-                homepageUrl = "",
-                scopes = sortedSetOf(scope)
-            ),
-            packages = packages.mapTo(sortedSetOf()) { it.toCuratedPackage() }
+                packages = packages.mapTo(sortedSetOf()) { it.toCuratedPackage() }
+            )
         )
     }
 

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -85,7 +85,7 @@ class GoMod(
                 .contains("vendor")
         }
 
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val projectDir = definitionFile.parentFile
 
         stashDirectories(File(projectDir, "vendor")).use {
@@ -114,22 +114,24 @@ class GoMod(
                 )
             )
 
-            return ProjectAnalyzerResult(
-                project = Project(
-                    id = Identifier(
-                        type = managerName,
-                        namespace = "",
-                        name = projectName,
-                        version = projectVcs.revision
+            return listOf(
+                ProjectAnalyzerResult(
+                    project = Project(
+                        id = Identifier(
+                            type = managerName,
+                            namespace = "",
+                            name = projectName,
+                            version = projectVcs.revision
+                        ),
+                        definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+                        declaredLicenses = sortedSetOf(), // Go mod doesn't support declared licenses.
+                        vcs = projectVcs,
+                        vcsProcessed = projectVcs,
+                        homepageUrl = "",
+                        scopes = scopes
                     ),
-                    definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
-                    declaredLicenses = sortedSetOf(), // Go mod doesn't support declared licenses.
-                    vcs = projectVcs,
-                    vcsProcessed = projectVcs,
-                    homepageUrl = "",
-                    scopes = scopes
-                ),
-                packages = packages.mapTo(sortedSetOf()) { it.toCuratedPackage() }
+                    packages = packages.mapTo(sortedSetOf()) { it.toCuratedPackage() }
+                )
             )
         }
     }

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -124,7 +124,7 @@ class Gradle(
 
     private val maven = MavenSupport(GradleCacheReader())
 
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val gradleSystemProperties = mutableListOf<Pair<String, String>>()
 
         // Usually, the Gradle wrapper's Java code handles applying system properties defined in a Gradle properties
@@ -244,10 +244,12 @@ class Gradle(
                     createAndLogIssue(source = managerName, message = it, severity = Severity.WARNING)
                 }
 
-                ProjectAnalyzerResult(
-                    project,
-                    packages.values.mapTo(sortedSetOf()) { it.toCuratedPackage() },
-                    issues
+                listOf(
+                    ProjectAnalyzerResult(
+                        project,
+                        packages.values.mapTo(sortedSetOf()) { it.toCuratedPackage() },
+                        issues
+                    )
                 )
             }
         }

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -126,7 +126,7 @@ class Maven(
         }
     }
 
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
         val projectBuildingResult = mvn.buildMavenProject(definitionFile)
         val mavenProject = projectBuildingResult.project
@@ -171,7 +171,12 @@ class Maven(
             scopes = scopes.values.toSortedSet()
         )
 
-        return ProjectAnalyzerResult(project, packages.values.mapTo(sortedSetOf()) { it.toCuratedPackage() })
+        return listOf(
+            ProjectAnalyzerResult(
+                project = project,
+                packages = packages.values.mapTo(sortedSetOf()) { it.toCuratedPackage() }
+            )
+        )
     }
 
     private fun parseDependency(node: DependencyNode, packages: MutableMap<String, Package>): PackageReference {

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -118,7 +118,7 @@ open class Npm(
         ortProxySelector.removeProxyOrigin(managerName)
     }
 
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
 
         stashDirectories(File(workingDir, "node_modules")).use {
@@ -140,9 +140,12 @@ open class Npm(
 
             // TODO: add support for peerDependencies and bundledDependencies.
 
-            return parseProject(
-                definitionFile, sortedSetOf(dependenciesScope, devDependenciesScope),
-                packages.values.toSortedSet()
+            return listOf(
+                parseProject(
+                    definitionFile,
+                    sortedSetOf(dependenciesScope, devDependenciesScope),
+                    packages.values.toSortedSet()
+                )
             )
         }
     }

--- a/analyzer/src/main/kotlin/managers/NuGet.kt
+++ b/analyzer/src/main/kotlin/managers/NuGet.kt
@@ -84,6 +84,6 @@ class NuGet(
         ) = NuGet(managerName, analysisRoot, analyzerConfig, repoConfig)
     }
 
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? =
-        resolveDotNetDependencies(definitionFile, NuGetPackageReferenceMapper())
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> =
+        listOfNotNull(resolveDotNetDependencies(definitionFile, NuGetPackageReferenceMapper()))
 }

--- a/analyzer/src/main/kotlin/managers/PhpComposer.kt
+++ b/analyzer/src/main/kotlin/managers/PhpComposer.kt
@@ -118,7 +118,7 @@ class PhpComposer(
         checkVersion(analyzerConfig.ignoreToolVersions)
     }
 
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
 
         stashDirectories(File(workingDir, "vendor")).use {
@@ -156,7 +156,12 @@ class PhpComposer(
 
             val project = parseProject(definitionFile, scopes)
 
-            return ProjectAnalyzerResult(project, packages.values.mapTo(sortedSetOf()) { it.toCuratedPackage() })
+            return listOf(
+                ProjectAnalyzerResult(
+                    project = project,
+                    packages = packages.values.mapTo(sortedSetOf()) { it.toCuratedPackage() }
+                )
+            )
         }
     }
 

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -224,7 +224,7 @@ class Pip(
         VirtualEnv.checkVersion(analyzerConfig.ignoreToolVersions)
 
     @Suppress("LongMethod")
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         // For an overview, dependency resolution involves the following steps:
         // 1. Install dependencies via pip (inside a virtualenv, for isolation from globally installed packages).
         // 2. Get meta-data about the local project via pydep (only for setup.py-based projects).
@@ -446,7 +446,12 @@ class Pip(
         // Remove the virtualenv by simply deleting the directory.
         virtualEnvDir.safeDeleteRecursively()
 
-        return ProjectAnalyzerResult(project, packages.mapTo(sortedSetOf()) { it.toCuratedPackage() })
+        return listOf(
+            ProjectAnalyzerResult(
+                project = project,
+                packages = packages.mapTo(sortedSetOf()) { it.toCuratedPackage() }
+            )
+        )
     }
 
     private fun getBinaryArtifact(pkg: Package, releaseNode: ArrayNode): RemoteArtifact {

--- a/analyzer/src/main/kotlin/managers/Pipenv.kt
+++ b/analyzer/src/main/kotlin/managers/Pipenv.kt
@@ -59,7 +59,7 @@ class Pipenv(
 
     override fun beforeResolution(definitionFiles: List<File>) = checkVersion(analyzerConfig.ignoreToolVersions)
 
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         // For an overview, dependency resolution involves the following steps:
         // 1. Generate "requirements.txt" file with `pipenv` command
         // 2. Use existing "Pip" PackageManager to do the actual dependency resolution

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -83,7 +83,7 @@ class Stack(
 
     override fun beforeResolution(definitionFiles: List<File>) = checkVersion(analyzerConfig.ignoreToolVersions)
 
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
 
         // Parse project information from the *.cabal file.
@@ -173,7 +173,12 @@ class Stack(
             scopes = scopes
         )
 
-        return ProjectAnalyzerResult(project, allPackages.values.mapTo(sortedSetOf()) { it.toCuratedPackage() })
+        return listOf(
+            ProjectAnalyzerResult(
+                project = project,
+                packages = allPackages.values.mapTo(sortedSetOf()) { it.toCuratedPackage() }
+            )
+        )
     }
 
     private fun buildDependencyTree(

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -58,7 +58,7 @@ class Unmanaged(
      *
      * @param definitionFile The directory containing the unmanaged project.
      */
-    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+    override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val vcsInfo = VersionControlSystem.getCloneInfo(definitionFile)
 
         val id = when {
@@ -112,6 +112,11 @@ class Unmanaged(
             scopes = sortedSetOf()
         )
 
-        return ProjectAnalyzerResult(project, sortedSetOf())
+        return listOf(
+            ProjectAnalyzerResult(
+                project = project,
+                packages = sortedSetOf()
+            )
+        )
     }
 }


### PR DESCRIPTION
Change the signature of `PackageManager.resolveDependencies` to allow
multiple projects per definition file. This is required for package
managers that allow defining multiple projects in a single definition
file, like Gradle or SBT.

This commit only changes the API, support for actually detekting
multiple projects in a single definition file will be added later.