### PR TITLE
FindingsMatcher: Fix-up a major performance regression

### DIFF
--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -154,7 +154,7 @@ class FindingsMatcher(
             val matchedFileFindings = matchFileFindings(licenses, copyrights)
 
             matchedFindings += matchedFileFindings
-            unmatchedCopyrights += copyrights.toSet() - matchedFindings.values.flatten()
+            unmatchedCopyrights += copyrights.toSet() - matchedFileFindings.values.flatten()
         }
 
         val rootLicenseFindings = getRootLicenseFindings(licenseFindings)


### PR DESCRIPTION
The line for computing the unmatched findings was changed by 7b04388 to
subtract the `matchedFindings` rather than the `matchedFileFindings`.
This does not have any effect on the correctness of the result but it
renders matchFindings() very slow.

The time to compute the reports for some larger OrtResult was increased
from about 2 minutes to about an hour. This change fixes that problem.

Signed-off-by: Frank Viernau <frank.viernau@here.com>