### PR TITLE
Use SPDX expressions instead of strings for handling licenses in most of the code

### DIFF
--- a/docs/examples/notice-pre-processor.kts
+++ b/docs/examples/notice-pre-processor.kts
@@ -34,14 +34,14 @@ val licensesWithSourceCodeOffer = licenseConfiguration
         .map { it.id }
         .toSet()
 
-val allLicenses = findings.values.flatMap { it.keys }.toSet()
+val allLicenses = findings.values.flatMap { it.keys.map { it.toSpdx() } }.toSet()
 
 findings = findings.mapValues { (_, licenseFindingsMap) ->
-    licenseFindingsMap.filter { (license, _) -> license in licensesIncludedInNotices }.toSortedMap()
+    licenseFindingsMap.filter { (license, _) -> license.toSpdx() in licensesIncludedInNotices }.toSortedMap()
 }
 
-val includedLicenses = findings.values.flatMap { it.keys }.toSet()
-val ignoredLicenses = (allLicenses - includedLicenses).toSortedSet()
+val includedLicenses = findings.values.flatMap { it.keys.map { it.toSpdx() } }.toSet()
+val ignoredLicenses = (allLicenses - includedLicenses).toSortedSet(compareBy { it.toString() })
 
 println("The following licenses are not added to the notice file because they are not configured to be included:\n" +
         "${ignoredLicenses.joinToString("\n")}")

--- a/docs/examples/rules.kts
+++ b/docs/examples/rules.kts
@@ -71,7 +71,10 @@ fun PackageRule.LicenseRule.isHandled() =
     object : RuleMatcher {
         override val description = "isHandled($license)"
 
-        override fun matches() = license in handledLicenses && !(license.contains("-exception") && !license.contains(" WITH "))
+        override fun matches() =
+            license in handledLicenses
+                    && !(license.toString().contains("-exception")
+                    && !license.toString().contains(" WITH "))
     }
 
 fun PackageRule.LicenseRule.isCopyleft() =

--- a/evaluator/src/main/kotlin/LicenseView.kt
+++ b/evaluator/src/main/kotlin/LicenseView.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.evaluator
 
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 
 /**
  * A [LicenseView] provides a custom view on the licenses that belong to a [Package]. It can be used to filter the
@@ -78,13 +79,16 @@ class LicenseView(vararg licenseSources: List<LicenseSource>) {
 
     private val licenseSources = licenseSources.toList()
 
-    fun licenses(pkg: Package, detectedLicenses: List<String>): List<Pair<String, LicenseSource>> {
-        val declaredLicenses = pkg.declaredLicensesProcessed.spdxExpression?.decompose().orEmpty().map { it.toString() }
-        val concludedLicenses = pkg.concludedLicense?.decompose().orEmpty().map { it.toString() }
+    fun licenses(
+        pkg: Package,
+        detectedLicenses: List<SpdxSingleLicenseExpression>
+    ): List<Pair<SpdxSingleLicenseExpression, LicenseSource>> {
+        val declaredLicenses = pkg.declaredLicensesProcessed.spdxExpression?.decompose().orEmpty()
+        val concludedLicenses = pkg.concludedLicense?.decompose().orEmpty()
 
         fun getLicenseForSources(
             sources: Collection<LicenseSource>
-        ): List<Pair<String, LicenseSource>> =
+        ): List<Pair<SpdxSingleLicenseExpression, LicenseSource>> =
             sources.flatMap { source ->
                 when (source) {
                     LicenseSource.DECLARED -> declaredLicenses

--- a/evaluator/src/main/kotlin/PackageRule.kt
+++ b/evaluator/src/main/kotlin/PackageRule.kt
@@ -29,7 +29,11 @@ import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.PathExclude
+import org.ossreviewtoolkit.spdx.SpdxExpression
 import org.ossreviewtoolkit.spdx.SpdxLicense
+import org.ossreviewtoolkit.spdx.SpdxLicenseIdExpression
+import org.ossreviewtoolkit.spdx.SpdxLicenseWithExceptionExpression
+import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 
 /**
  * A [Rule] to check a single [Package].
@@ -164,7 +168,7 @@ open class PackageRule(
         /**
          * The license to check.
          */
-        val license: String,
+        val license: SpdxSingleLicenseExpression,
 
         /**
          * The source of the license.
@@ -213,7 +217,11 @@ open class PackageRule(
             object : RuleMatcher {
                 override val description = "isSpdxLicense($license)"
 
-                override fun matches() = SpdxLicense.forId(license) != null
+                override fun matches() = when (license) {
+                    is SpdxLicenseIdExpression, is SpdxLicenseWithExceptionExpression ->
+                        license.isValid(SpdxExpression.Strictness.ALLOW_DEPRECATED)
+                    else -> false
+                }
             }
 
         fun issue(severity: Severity, message: String, howToFix: String) =

--- a/evaluator/src/main/kotlin/Rule.kt
+++ b/evaluator/src/main/kotlin/Rule.kt
@@ -24,6 +24,7 @@ import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.utils.log
 
 /**
@@ -113,7 +114,7 @@ abstract class Rule(
     fun issue(
         severity: Severity,
         pkgId: Identifier,
-        license: String?,
+        license: SpdxSingleLicenseExpression?,
         licenseSource: LicenseSource?,
         message: String,
         howToFix: String
@@ -132,19 +133,37 @@ abstract class Rule(
     /**
      * Add a [hint][Severity.HINT] to the list of [violations].
      */
-    fun hint(pkgId: Identifier, license: String?, licenseSource: LicenseSource?, message: String, howToFix: String) =
+    fun hint(
+        pkgId: Identifier,
+        license: SpdxSingleLicenseExpression?,
+        licenseSource: LicenseSource?,
+        message: String,
+        howToFix: String
+    ) =
         issue(Severity.HINT, pkgId, license, licenseSource, message, howToFix)
 
     /**
      * Add a [warning][Severity.WARNING] to the list of [violations].
      */
-    fun warning(pkgId: Identifier, license: String?, licenseSource: LicenseSource?, message: String, howToFix: String) =
+    fun warning(
+        pkgId: Identifier,
+        license: SpdxSingleLicenseExpression?,
+        licenseSource: LicenseSource?,
+        message: String,
+        howToFix: String
+    ) =
         issue(Severity.WARNING, pkgId, license, licenseSource, message, howToFix)
 
     /**
      * Add an [error][Severity.ERROR] to the list of [violations].
      */
-    fun error(pkgId: Identifier, license: String?, licenseSource: LicenseSource?, message: String, howToFix: String) =
+    fun error(
+        pkgId: Identifier,
+        license: SpdxSingleLicenseExpression?,
+        licenseSource: LicenseSource?,
+        message: String,
+        howToFix: String
+    ) =
         issue(Severity.ERROR, pkgId, license, licenseSource, message, howToFix)
 
     /**

--- a/evaluator/src/main/resources/rules/no_gpl_declared.kts
+++ b/evaluator/src/main/resources/rules/no_gpl_declared.kts
@@ -27,7 +27,7 @@ fun PackageRule.LicenseRule.isGpl() =
     object : RuleMatcher {
         override val description = "isGpl($license)"
 
-        override fun matches() = license.contains("GPL")
+        override fun matches() = license.toString().contains("GPL")
     }
 
 // Define the rule set.

--- a/evaluator/src/test/kotlin/EvaluatorTest.kt
+++ b/evaluator/src/test/kotlin/EvaluatorTest.kt
@@ -19,17 +19,18 @@
 
 package org.ossreviewtoolkit.evaluator
 
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.haveSize
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
-
-import io.kotest.matchers.collections.beEmpty
-import io.kotest.matchers.collections.haveSize
-import io.kotest.matchers.should
-import io.kotest.matchers.shouldBe
-import io.kotest.core.spec.style.WordSpec
+import org.ossreviewtoolkit.spdx.toSpdx
 
 class EvaluatorTest : WordSpec() {
     private fun createEvaluator() = Evaluator(OrtResult.EMPTY, SimplePackageConfigurationProvider())
@@ -78,7 +79,7 @@ class EvaluatorTest : WordSpec() {
                     ruleViolations += RuleViolation(
                         rule = "rule 1",
                         pkg = Identifier("type:namespace:name:1.0"),
-                        license = "license 1",
+                        license = SpdxLicenseIdExpression("license-1"),
                         licenseSource = LicenseSource.DETECTED,
                         severity = Severity.ERROR,
                         message = "message 1",
@@ -88,7 +89,7 @@ class EvaluatorTest : WordSpec() {
                     ruleViolations += RuleViolation(
                         rule = "rule 2",
                         pkg = Identifier("type:namespace:name:2.0"),
-                        license = "license 2",
+                        license = SpdxLicenseIdExpression("license-2"),
                         licenseSource = LicenseSource.DECLARED,
                         severity = Severity.WARNING,
                         message = "message 2",
@@ -102,7 +103,7 @@ class EvaluatorTest : WordSpec() {
                 with(result.violations[0]) {
                     rule shouldBe "rule 1"
                     pkg shouldBe Identifier("type:namespace:name:1.0")
-                    license shouldBe "license 1"
+                    license shouldBe "license-1".toSpdx()
                     licenseSource shouldBe LicenseSource.DETECTED
                     severity shouldBe Severity.ERROR
                     message shouldBe "message 1"
@@ -112,7 +113,7 @@ class EvaluatorTest : WordSpec() {
                 with(result.violations[1]) {
                     rule shouldBe "rule 2"
                     pkg shouldBe Identifier("type:namespace:name:2.0")
-                    license shouldBe "license 2"
+                    license shouldBe "license-2".toSpdx()
                     licenseSource shouldBe LicenseSource.DECLARED
                     severity shouldBe Severity.WARNING
                     message shouldBe "message 2"

--- a/evaluator/src/test/kotlin/LicenseViewTest.kt
+++ b/evaluator/src/test/kotlin/LicenseViewTest.kt
@@ -19,12 +19,13 @@
 
 package org.ossreviewtoolkit.evaluator
 
-import org.ossreviewtoolkit.model.LicenseSource
-
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.should
+
+import org.ossreviewtoolkit.model.LicenseSource
+import org.ossreviewtoolkit.spdx.toSpdx
 
 class LicenseViewTest : WordSpec({
     "All" should {
@@ -34,51 +35,51 @@ class LicenseViewTest : WordSpec({
             view.licenses(packageWithoutLicense, emptyList()) should beEmpty()
 
             view.licenses(packageWithoutLicense, detectedLicenses) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.DETECTED),
-                Pair("LicenseRef-b", LicenseSource.DETECTED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
             )
 
             view.licenses(packageWithOnlyConcludedLicense, emptyList()) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
 
             view.licenses(packageWithOnlyConcludedLicense, detectedLicenses) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-a", LicenseSource.DETECTED),
-                Pair("LicenseRef-b", LicenseSource.DETECTED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
             )
 
             view.licenses(packageWithOnlyDeclaredLicense, emptyList()) should containExactlyInAnyOrder(
-                Pair("Apache-2.0", LicenseSource.DECLARED),
-                Pair("MIT", LicenseSource.DECLARED)
+                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
             )
 
             view.licenses(packageWithOnlyDeclaredLicense, detectedLicenses) should containExactlyInAnyOrder(
-                Pair("Apache-2.0", LicenseSource.DECLARED),
-                Pair("MIT", LicenseSource.DECLARED),
-                Pair("LicenseRef-a", LicenseSource.DETECTED),
-                Pair("LicenseRef-b", LicenseSource.DETECTED)
+                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                Pair("MIT".toSpdx(), LicenseSource.DECLARED),
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
             )
 
             view.licenses(packageWithConcludedAndDeclaredLicense, emptyList()) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED),
-                Pair("Apache-2.0", LicenseSource.DECLARED),
-                Pair("MIT", LicenseSource.DECLARED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
             )
 
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED),
-                Pair("Apache-2.0", LicenseSource.DECLARED),
-                Pair("MIT", LicenseSource.DECLARED),
-                Pair("LicenseRef-a", LicenseSource.DETECTED),
-                Pair("LicenseRef-b", LicenseSource.DETECTED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                Pair("MIT".toSpdx(), LicenseSource.DECLARED),
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
             )
         }
     }
@@ -96,58 +97,58 @@ class LicenseViewTest : WordSpec({
                 packageWithoutLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.DETECTED),
-                Pair("LicenseRef-b", LicenseSource.DETECTED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
             )
 
             view.licenses(
                 packageWithOnlyConcludedLicense,
                 emptyList()
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
 
             view.licenses(
                 packageWithOnlyConcludedLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
 
             view.licenses(
                 packageWithOnlyDeclaredLicense,
                 emptyList()
             ) should containExactlyInAnyOrder(
-                Pair("Apache-2.0", LicenseSource.DECLARED),
-                Pair("MIT", LicenseSource.DECLARED)
+                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
             )
 
             view.licenses(
                 packageWithOnlyDeclaredLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("Apache-2.0", LicenseSource.DECLARED),
-                Pair("MIT", LicenseSource.DECLARED),
-                Pair("LicenseRef-a", LicenseSource.DETECTED),
-                Pair("LicenseRef-b", LicenseSource.DETECTED)
+                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                Pair("MIT".toSpdx(), LicenseSource.DECLARED),
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
             )
 
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 emptyList()
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
 
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
         }
     }
@@ -165,56 +166,56 @@ class LicenseViewTest : WordSpec({
                 packageWithoutLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.DETECTED),
-                Pair("LicenseRef-b", LicenseSource.DETECTED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
             )
 
             view.licenses(
                 packageWithOnlyConcludedLicense,
                 emptyList()
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
 
             view.licenses(
                 packageWithOnlyConcludedLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
 
             view.licenses(
                 packageWithOnlyDeclaredLicense,
                 emptyList()
             ) should containExactlyInAnyOrder(
-                Pair("Apache-2.0", LicenseSource.DECLARED),
-                Pair("MIT", LicenseSource.DECLARED)
+                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
             )
 
             view.licenses(
                 packageWithOnlyDeclaredLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("Apache-2.0", LicenseSource.DECLARED),
-                Pair("MIT", LicenseSource.DECLARED)
+                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
             )
 
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 emptyList()
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
 
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
         }
     }
@@ -231,24 +232,24 @@ class LicenseViewTest : WordSpec({
                 packageWithoutLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.DETECTED),
-                Pair("LicenseRef-b", LicenseSource.DETECTED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
             )
 
             view.licenses(
                 packageWithOnlyConcludedLicense,
                 emptyList()
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
 
             view.licenses(
                 packageWithOnlyConcludedLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
 
             view.licenses(
@@ -260,24 +261,24 @@ class LicenseViewTest : WordSpec({
                 packageWithOnlyDeclaredLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.DETECTED),
-                Pair("LicenseRef-b", LicenseSource.DETECTED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
             )
 
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 emptyList()
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
 
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
         }
     }
@@ -299,16 +300,16 @@ class LicenseViewTest : WordSpec({
                 packageWithOnlyConcludedLicense,
                 emptyList()
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
 
             view.licenses(
                 packageWithOnlyConcludedLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
 
             view.licenses(
@@ -325,16 +326,16 @@ class LicenseViewTest : WordSpec({
                 packageWithConcludedAndDeclaredLicense,
                 emptyList()
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
 
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b", LicenseSource.CONCLUDED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
             )
         }
     }
@@ -367,32 +368,32 @@ class LicenseViewTest : WordSpec({
                 packageWithOnlyDeclaredLicense,
                 emptyList()
             ) should containExactlyInAnyOrder(
-                Pair("Apache-2.0", LicenseSource.DECLARED),
-                Pair("MIT", LicenseSource.DECLARED)
+                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
             )
 
             view.licenses(
                 packageWithOnlyDeclaredLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("Apache-2.0", LicenseSource.DECLARED),
-                Pair("MIT", LicenseSource.DECLARED)
+                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
             )
 
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 emptyList()
             ) should containExactlyInAnyOrder(
-                Pair("Apache-2.0", LicenseSource.DECLARED),
-                Pair("MIT", LicenseSource.DECLARED)
+                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
             )
 
             view.licenses(
                 packageWithConcludedAndDeclaredLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("Apache-2.0", LicenseSource.DECLARED),
-                Pair("MIT", LicenseSource.DECLARED)
+                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
             )
         }
     }
@@ -410,8 +411,8 @@ class LicenseViewTest : WordSpec({
                 packageWithoutLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.DETECTED),
-                Pair("LicenseRef-b", LicenseSource.DETECTED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
             )
 
             view.licenses(
@@ -423,8 +424,8 @@ class LicenseViewTest : WordSpec({
                 packageWithOnlyConcludedLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.DETECTED),
-                Pair("LicenseRef-b", LicenseSource.DETECTED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
             )
 
             view.licenses(
@@ -436,8 +437,8 @@ class LicenseViewTest : WordSpec({
                 packageWithOnlyDeclaredLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.DETECTED),
-                Pair("LicenseRef-b", LicenseSource.DETECTED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
             )
 
             view.licenses(
@@ -449,8 +450,8 @@ class LicenseViewTest : WordSpec({
                 packageWithConcludedAndDeclaredLicense,
                 detectedLicenses
             ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a", LicenseSource.DETECTED),
-                Pair("LicenseRef-b", LicenseSource.DETECTED)
+                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
             )
         }
     }

--- a/evaluator/src/test/kotlin/PackageRuleTest.kt
+++ b/evaluator/src/test/kotlin/PackageRuleTest.kt
@@ -19,10 +19,11 @@
 
 package org.ossreviewtoolkit.evaluator
 
-import org.ossreviewtoolkit.model.LicenseSource
-
-import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.model.LicenseSource
+import org.ossreviewtoolkit.spdx.SpdxLicenseIdExpression
 
 class PackageRuleTest : WordSpec() {
     private val ruleSet = RuleSet(ortResult)
@@ -109,7 +110,9 @@ class PackageRuleTest : WordSpec() {
         "isSpdxLicense()" should {
             "return true if the license is an SPDX license" {
                 PackageRule(ruleSet, "test", packageWithoutLicense, emptyList(), emptyList()).apply {
-                    val licenseRule = LicenseRule("test", "Apache-2.0", LicenseSource.DECLARED, emptyMap())
+                    val licenseRule = LicenseRule(
+                        "test", SpdxLicenseIdExpression("Apache-2.0"), LicenseSource.DECLARED, emptyMap()
+                    )
                     val matcher = licenseRule.isSpdxLicense()
 
                     matcher.matches() shouldBe true
@@ -118,7 +121,9 @@ class PackageRuleTest : WordSpec() {
 
             "return false if the license is not an SPDX license" {
                 PackageRule(ruleSet, "test", packageWithoutLicense, emptyList(), emptyList()).apply {
-                    val licenseRule = LicenseRule("test", "invalid", LicenseSource.DECLARED, emptyMap())
+                    val licenseRule = LicenseRule(
+                        "test", SpdxLicenseIdExpression("invalid"), LicenseSource.DECLARED, emptyMap()
+                    )
                     val matcher = licenseRule.isSpdxLicense()
 
                     matcher.matches() shouldBe false

--- a/evaluator/src/test/kotlin/RuleTest.kt
+++ b/evaluator/src/test/kotlin/RuleTest.kt
@@ -19,19 +19,20 @@
 
 package org.ossreviewtoolkit.evaluator
 
-import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.LicenseSource
-import org.ossreviewtoolkit.model.Severity
-
+import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.kotest.core.spec.style.WordSpec
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.LicenseSource
+import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.spdx.SpdxLicenseIdExpression
 
 class RuleTest : WordSpec() {
     private val ruleSet = RuleSet(ortResult)
     private val id = Identifier("type:namespace:name:version")
-    private val license = "license"
+    private val license = SpdxLicenseIdExpression("license")
     private val licenseSource = LicenseSource.DECLARED
     private val message = "violation message"
     private val howToFix = "how to fix"

--- a/evaluator/src/test/kotlin/TestData.kt
+++ b/evaluator/src/test/kotlin/TestData.kt
@@ -41,17 +41,21 @@ import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.config.PathExcludeReason
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.spdx.SpdxLicenseReferenceExpression
 import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
 
 val concludedLicense = "LicenseRef-a AND LicenseRef-b".toSpdx()
 val declaredLicenses = sortedSetOf("Apache-2.0", "MIT")
 val declaredLicensesProcessed = DeclaredLicenseProcessor.process(declaredLicenses)
-val detectedLicenses = listOf("LicenseRef-a", "LicenseRef-b")
+val detectedLicenses = listOf(
+    SpdxLicenseReferenceExpression("LicenseRef-a"),
+    SpdxLicenseReferenceExpression("LicenseRef-b")
+)
 
 val licenseFindings = listOf(
-    LicenseFindings("LicenseRef-a", sortedSetOf(), sortedSetOf()),
-    LicenseFindings("LicenseRef-b", sortedSetOf(), sortedSetOf())
+    LicenseFindings(SpdxLicenseReferenceExpression("LicenseRef-a"), sortedSetOf(), sortedSetOf()),
+    LicenseFindings(SpdxLicenseReferenceExpression("LicenseRef-b"), sortedSetOf(), sortedSetOf())
 )
 
 val packageExcluded = Package.EMPTY.copy(

--- a/helper-cli/src/main/kotlin/commands/ListCopyrightsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListCopyrightsCommand.kt
@@ -94,7 +94,7 @@ internal class ListCopyrightsCommand : CliktCommand(
             copyrightGarbage = copyrightGarbage.items,
             packageConfigurationProvider = packageConfigurationProvider
         ).filter { packageId == null || it.packageId == packageId }
-            .filter { licenseId == null || it.licenseId == licenseId }
+            .filter { licenseId == null || it.license.toString() == licenseId }
             .groupBy({ it.statement }, { it.rawStatements })
             .mapValues { it.value.flatten().toSortedSet() }
 

--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -45,6 +45,7 @@ import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.utils.expandTilde
 
 import java.io.File
@@ -216,7 +217,7 @@ private fun Collection<TextLocationGroup>.assignReferenceNameAndSort(): List<Pai
         }
 }
 
-private fun Map<String, List<TextLocationGroup>>.writeValueAsString(
+private fun Map<SpdxSingleLicenseExpression, List<TextLocationGroup>>.writeValueAsString(
     isPathExcluded: (String) -> Boolean,
     provenanceIndex: Int,
     includeLicenseTexts: Boolean = true

--- a/model/src/main/kotlin/LicenseFinding.kt
+++ b/model/src/main/kotlin/LicenseFinding.kt
@@ -19,14 +19,20 @@
 
 package org.ossreviewtoolkit.model
 
+import org.ossreviewtoolkit.model.config.LicenseFindingCuration
+import org.ossreviewtoolkit.spdx.SpdxExpression
+import org.ossreviewtoolkit.spdx.toSpdx
+
 /**
- * A class representing a single license finding.
+ * A class representing a license finding. License findings can point to single licenses or to complex
+ * [SpdxExpression]s, depending on the capabilities of the used license scanner. [LicenseFindingCuration]s can also be
+ * used to create findings with complex expressions.
  */
 data class LicenseFinding(
     /**
-     * The SPDX license identifier corresponding to the license found.
+     * The found SPDX expression.
      */
-    val license: String,
+    val license: SpdxExpression,
 
     /**
      * The text location where the license was found.
@@ -34,8 +40,10 @@ data class LicenseFinding(
     val location: TextLocation
 ) : Comparable<LicenseFinding> {
     companion object {
-        private val COMPARATOR = compareBy(LicenseFinding::license).thenBy(LicenseFinding::location)
+        private val COMPARATOR = compareBy<LicenseFinding> { it.license.toString() }.thenBy(LicenseFinding::location)
     }
+
+    constructor(license: String, location: TextLocation) : this(license.toSpdx(), location)
 
     override fun compareTo(other: LicenseFinding) = COMPARATOR.compare(this, other)
 }

--- a/model/src/main/kotlin/LicenseFindings.kt
+++ b/model/src/main/kotlin/LicenseFindings.kt
@@ -19,11 +19,12 @@
 
 package org.ossreviewtoolkit.model
 
-import org.ossreviewtoolkit.model.config.CopyrightGarbage
-import org.ossreviewtoolkit.utils.CopyrightStatementsProcessor
-
 import java.util.SortedMap
 import java.util.SortedSet
+
+import org.ossreviewtoolkit.model.config.CopyrightGarbage
+import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
+import org.ossreviewtoolkit.utils.CopyrightStatementsProcessor
 
 /**
  * A map that associates licenses with their belonging copyrights. This is provided mostly for convenience as creating
@@ -78,12 +79,12 @@ fun Collection<LicenseFindingsMap>.merge() =
  * found.
  */
 data class LicenseFindings(
-    val license: String,
+    val license: SpdxSingleLicenseExpression,
     val locations: SortedSet<TextLocation>,
     val copyrights: SortedSet<CopyrightFindings>
 ) : Comparable<LicenseFindings> {
     companion object {
-        private val COMPARATOR = compareBy(LicenseFindings::license)
+        private val COMPARATOR = compareBy<LicenseFindings> { it.license.toString() }
                 .thenBy(TextLocation.SORTED_SET_COMPARATOR, LicenseFindings::locations)
                 .thenBy(CopyrightFindings.SORTED_SET_COMPARATOR, LicenseFindings::copyrights)
     }

--- a/model/src/main/kotlin/RuleViolation.kt
+++ b/model/src/main/kotlin/RuleViolation.kt
@@ -19,6 +19,8 @@
 
 package org.ossreviewtoolkit.model
 
+import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
+
 data class RuleViolation(
     /**
      * The identifier of the rule that found this violation.
@@ -33,7 +35,7 @@ data class RuleViolation(
     /**
      * The name of the license that caused this rule violation. Can be null if the rule does not work on licenses.
      */
-    val license: String?,
+    val license: SpdxSingleLicenseExpression?,
 
     /**
      * The [source][LicenseSource] of the [license]. Can be null if the rule does not work on licenses.

--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.Instant
 import java.util.SortedSet
 
+import org.ossreviewtoolkit.spdx.SpdxExpression
+
 /**
  * A short summary of the scan results.
  */
@@ -73,5 +75,5 @@ data class ScanSummary(
     val issues: List<OrtIssue> = emptyList()
 ) {
     @get:JsonIgnore
-    val licenses: Set<String> = licenseFindings.mapTo(mutableSetOf()) { it.license }
+    val licenses: Set<SpdxExpression> = licenseFindings.mapTo(mutableSetOf()) { it.license }
 }

--- a/model/src/main/kotlin/config/LicenseFindingCuration.kt
+++ b/model/src/main/kotlin/config/LicenseFindingCuration.kt
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.util.StdConverter
 
+import org.ossreviewtoolkit.spdx.SpdxExpression
+
 /**
  * A curation for license findings.
  */
@@ -55,13 +57,13 @@ data class LicenseFindingCuration(
      * [detectedLicense] or if [detectedLicense] is null.
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    val detectedLicense: String? = null,
+    val detectedLicense: SpdxExpression? = null,
 
     /**
      * The concluded license as SPDX expression or [org.ossreviewtoolkit.spdx.SpdxLicense.NONE] for no license,
      * see https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60.
      */
-    val concludedLicense: String,
+    val concludedLicense: SpdxExpression,
 
     /**
      * The reason why the curation was made, out of a predefined choice.
@@ -80,12 +82,6 @@ data class LicenseFindingCuration(
         }
         require(lineCount == null || lineCount >= 0) {
             "The value for line count must not be negative."
-        }
-        require(detectedLicense == null || detectedLicense.isNotBlank()) {
-            "The detected license must either be omitted or not be blank."
-        }
-        require(concludedLicense.isNotBlank()) {
-            "The concluded license must not be blank."
         }
     }
 }

--- a/model/src/main/kotlin/licenses/License.kt
+++ b/model/src/main/kotlin/licenses/License.kt
@@ -23,17 +23,16 @@ import com.fasterxml.jackson.annotation.JsonInclude
 
 import java.util.SortedSet
 
-import org.ossreviewtoolkit.spdx.toSpdx
+import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 
 /**
  * A class for configuring meta data for a specific license referred to by a SPDX license identifier.
  */
 data class License(
     /**
-     * The SPDX identifier of this [License]. The value has to be either a compound expression of one license with an
-     * exception or no compound expression at all.
+     * The [SpdxSingleLicenseExpression] of this [License].
      */
-    val id: String,
+    val id: SpdxSingleLicenseExpression,
 
     /**
      * The identifiers of the [LicenseSet]s this license is assigned to.
@@ -50,10 +49,4 @@ data class License(
      * Defines whether a source code offer should be made for this license.
      */
     val includeSourceCodeOfferInNoticeFile: Boolean
-) {
-    init {
-        require(id.toSpdx().licenses().size == 1) {
-            "The id '$id' contains multiple licenses which is not allowed."
-        }
-    }
-}
+)

--- a/model/src/main/kotlin/licenses/LicenseConfiguration.kt
+++ b/model/src/main/kotlin/licenses/LicenseConfiguration.kt
@@ -47,7 +47,7 @@ data class LicenseConfiguration(
         }
         licenses.groupBy { it.id }.values.filter { it.size > 1 }.let { groups ->
             require(groups.isEmpty()) {
-                "Found multiple license entries with the same Id: ${groups.joinToString { it.first().id }}."
+                "Found multiple license entries with the same Id: ${groups.joinToString { it.first().id.toString() }}."
             }
         }
     }

--- a/model/src/main/kotlin/utils/FindingCurationMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingCurationMatcher.kt
@@ -61,7 +61,7 @@ class FindingCurationMatcher {
      */
     fun apply(finding: LicenseFinding, curation: LicenseFindingCuration): LicenseFinding? =
         if (!matches(finding, curation)) finding
-        else if (curation.concludedLicense == SpdxLicense.NONE) null
+        else if (curation.concludedLicense.toString() == SpdxLicense.NONE) null
         else finding.copy(license = curation.concludedLicense)
 
     /**

--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -182,16 +182,17 @@ class FindingsMatcher(
             Set<LicenseFindings> {
         val result = matchFindings(licenseFindings.toSet(), copyrightFindings.toSet())
 
-        return result.matchedFindings.entries.groupBy { it.key.license }.mapTo(mutableSetOf()) { (license, findings) ->
-            val locations = findings.mapTo(sortedSetOf()) { it.key.location }
+        return result.matchedFindings.entries.groupBy { it.key.license }
+            .flatMapTo(mutableSetOf()) { (license, findings) ->
+                val locations = findings.mapTo(sortedSetOf()) { it.key.location }
 
-            val copyrights = findings.flatMap { it.value }.groupBy { it.statement }
-                .mapTo(sortedSetOf()) { (statement, findings) ->
-                    CopyrightFindings(statement, findings.mapTo(sortedSetOf()) { it.location })
-                }
+                val copyrights = findings.flatMap { it.value }.groupBy { it.statement }
+                    .mapTo(sortedSetOf()) { (statement, findings) ->
+                        CopyrightFindings(statement, findings.mapTo(sortedSetOf()) { it.location })
+                    }
 
-            LicenseFindings(license, locations, copyrights)
-        }
+                license.decompose().map { LicenseFindings(it, locations, copyrights) }
+            }
     }
 }
 

--- a/model/src/main/kotlin/utils/LicenseResolver.kt
+++ b/model/src/main/kotlin/utils/LicenseResolver.kt
@@ -28,7 +28,6 @@ import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.PathExclude
-import org.ossreviewtoolkit.spdx.toSpdx
 
 internal class LicenseResolver(
     private val ortResult: OrtResult,
@@ -45,7 +44,7 @@ internal class LicenseResolver(
             .associateWith { id -> collectLicenseFindings(id).toMutableMap() }
 
     fun getDetectedLicensesForId(id: Identifier): SortedSet<String> =
-        collectLicenseFindings(id).keys.mapTo(sortedSetOf()) { it.license }
+        collectLicenseFindings(id).keys.mapTo(sortedSetOf()) { it.license.toString() }
 
     private fun getPathExcludes(id: Identifier, provenance: Provenance): List<PathExclude> =
         if (ortResult.isProject(id)) {
@@ -81,7 +80,7 @@ internal class LicenseResolver(
             val curatedLicenseFindings = curationMatcher.applyAll(rawLicenseFindings, curations)
                 .mapNotNullTo(mutableSetOf()) { it.curatedFinding }
             val decomposedFindings = curatedLicenseFindings.flatMap { finding ->
-                finding.license.toSpdx().decompose().map { finding.copy(license = it.toString()) }
+                finding.license.decompose().map { finding.copy(license = it) }
             }
             val matchedFindings = findingsMatcher.match(decomposedFindings, copyrightFindings).toSortedSet()
 
@@ -110,7 +109,7 @@ internal class LicenseResolver(
             .filter { (_, excludes) -> !omitExcluded || excludes.isEmpty() }
             .map { (findings, _) -> findings }
             .associateBy(
-                { it.license },
+                { it.license.toString() },
                 { it.copyrights.mapTo(mutableSetOf()) { it.statement } }
             )
 }

--- a/model/src/test/assets/expected-scan-results.yml
+++ b/model/src/test/assets/expected-scan-results.yml
@@ -18,12 +18,12 @@ results:
     file_count: 1
     package_verification_code: "packageVerificationCode"
     licenses:
-    - license: "license 1.1"
+    - license: "license-1.1"
       location:
         path: "path 1.1"
         start_line: 1
         end_line: 1
-    - license: "license 1.2"
+    - license: "license-1.2"
       location:
         path: "path 1.2"
         start_line: 1
@@ -67,12 +67,12 @@ results:
     file_count: 2
     package_verification_code: "packageVerificationCode"
     licenses:
-    - license: "license 2.1"
+    - license: "license-2.1"
       location:
         path: "path/to/file"
         start_line: 1
         end_line: 2
-    - license: "license 2.2"
+    - license: "license-2.2"
       location:
         path: "path/to/another/file"
         start_line: 3

--- a/model/src/test/kotlin/ScanResultContainerTest.kt
+++ b/model/src/test/kotlin/ScanResultContainerTest.kt
@@ -65,11 +65,11 @@ class ScanResultContainerTest : WordSpec() {
         "packageVerificationCode",
         sortedSetOf(
             LicenseFinding(
-                "license 1.1",
+                "license-1.1",
                 TextLocation("path 1.1", 1, 1)
             ),
             LicenseFinding(
-                "license 1.2",
+                "license-1.2",
                 TextLocation("path 1.2", 1, 2)
             )
         ),
@@ -92,12 +92,12 @@ class ScanResultContainerTest : WordSpec() {
         "packageVerificationCode",
         sortedSetOf(
             LicenseFinding(
-                "license 2.1",
+                "license-2.1",
                 TextLocation("path/to/file", 1, 2)
 
             ),
             LicenseFinding(
-                "license 2.2",
+                "license-2.2",
                 TextLocation("path/to/another/file", 3, 4)
             )
         ),

--- a/model/src/test/kotlin/utils/FindingCurationMatcherTest.kt
+++ b/model/src/test/kotlin/utils/FindingCurationMatcherTest.kt
@@ -33,6 +33,7 @@ import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.LicenseFindingCurationReason.INCORRECT
 import org.ossreviewtoolkit.model.licenses.LicenseFindingCurationResult
 import org.ossreviewtoolkit.spdx.SpdxLicense
+import org.ossreviewtoolkit.spdx.toSpdx
 
 class FindingCurationMatcherTest : WordSpec() {
     private val matcher = FindingCurationMatcher()
@@ -53,15 +54,15 @@ class FindingCurationMatcherTest : WordSpec() {
         path: String,
         startLines: List<Int>,
         lineCount: Int?,
-        concludedLicense: String = "concluded_license_${Random.nextInt()}",
+        concludedLicense: String = "concluded-license-${Random.nextInt()}",
         comment: String = "comment_${Random.nextInt()}"
     ) {
         curation = LicenseFindingCuration(
             path = path,
             startLines = startLines,
             lineCount = lineCount,
-            detectedLicense = license,
-            concludedLicense = concludedLicense,
+            detectedLicense = license?.toSpdx(),
+            concludedLicense = concludedLicense.toSpdx(),
             reason = INCORRECT,
             comment = comment
         )
@@ -180,7 +181,7 @@ class FindingCurationMatcherTest : WordSpec() {
 
                 val curatedFinding = matcher.apply(finding, curation)!!
 
-                curatedFinding.license shouldBe "Apache-2.0"
+                curatedFinding.license shouldBe "Apache-2.0".toSpdx()
                 curatedFinding.location shouldBe finding.location
             }
         }
@@ -204,7 +205,7 @@ class FindingCurationMatcherTest : WordSpec() {
             "return the original finding" {
                 setupFinding(license = "MIT", path = "a/path", startLine = 8, endLine = 13)
                 setupCuration(
-                    license = "Non matching license",
+                    license = "Non-matching-license",
                     path = "**",
                     startLines = emptyList(),
                     lineCount = null,
@@ -238,21 +239,21 @@ class FindingCurationMatcherTest : WordSpec() {
                 val curations = listOf(
                     LicenseFindingCuration(
                         path = "some/path",
-                        detectedLicense = "MIT",
+                        detectedLicense = "MIT".toSpdx(),
                         reason = INCORRECT,
-                        concludedLicense = "Apache-2.0"
+                        concludedLicense = "Apache-2.0".toSpdx()
                     ),
                     LicenseFindingCuration(
                         path = "another/path",
-                        detectedLicense = "MIT",
+                        detectedLicense = "MIT".toSpdx(),
                         reason = INCORRECT,
-                        concludedLicense = "BSD-3-Clause"
+                        concludedLicense = "BSD-3-Clause".toSpdx()
                     ),
                     LicenseFindingCuration(
                         path = "one/more/path",
-                        detectedLicense = "MIT",
+                        detectedLicense = "MIT".toSpdx(),
                         reason = INCORRECT,
-                        concludedLicense = SpdxLicense.NONE
+                        concludedLicense = SpdxLicense.NONE.toSpdx()
                     )
                 )
 
@@ -299,15 +300,15 @@ class FindingCurationMatcherTest : WordSpec() {
                 val curations = listOf(
                     LicenseFindingCuration(
                         path = "some/path",
-                        detectedLicense = "MIT",
+                        detectedLicense = "MIT".toSpdx(),
                         reason = INCORRECT,
-                        concludedLicense = "MIT-old-style"
+                        concludedLicense = "MIT-old-style".toSpdx()
                     ),
                     LicenseFindingCuration(
                         path = "some/path",
-                        detectedLicense = "MIT",
+                        detectedLicense = "MIT".toSpdx(),
                         reason = INCORRECT,
-                        concludedLicense = "Apache-2.0"
+                        concludedLicense = "Apache-2.0".toSpdx()
                     )
                 )
 

--- a/model/src/test/kotlin/utils/LicenseResolverTest.kt
+++ b/model/src/test/kotlin/utils/LicenseResolverTest.kt
@@ -56,6 +56,7 @@ import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.config.PathExcludeReason
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.config.VcsMatcher
+import org.ossreviewtoolkit.spdx.toSpdx
 
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
@@ -228,7 +229,7 @@ class LicenseResolverTest : WordSpec() {
 
         val licenseFindingCurations = config.licenseFindingCurations + LicenseFindingCuration(
             path = path,
-            concludedLicense = concludedLicense,
+            concludedLicense = concludedLicense.toSpdx(),
             reason = LicenseFindingCurationReason.INCORRECT
         )
 
@@ -257,7 +258,7 @@ class LicenseResolverTest : WordSpec() {
     private fun setupRepositoryLicenseFindingCuration(path: String, concludedLicense: String) {
         val licenseFindingCuration = LicenseFindingCuration(
             path = path,
-            concludedLicense = concludedLicense,
+            concludedLicense = concludedLicense.toSpdx(),
             reason = LicenseFindingCurationReason.INCORRECT
         )
 

--- a/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
@@ -40,7 +40,6 @@ import org.ossreviewtoolkit.model.utils.FindingsMatcher
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.utils.StatisticsCalculator
-import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.ProcessedDeclaredLicense
 
 /**
@@ -330,7 +329,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     private fun addRuleViolation(ruleViolation: RuleViolation) {
         val resolutions = addResolutions(ruleViolation)
         val pkg = packages.getValue(ruleViolation.pkg)
-        val license = ruleViolation.license?.let { licenses.addIfRequired(LicenseId(it)) }
+        val license = ruleViolation.license?.let { licenses.addIfRequired(LicenseId(it.toString())) }
 
         val evaluatedViolation = EvaluatedRuleViolation(
             rule = ruleViolation.rule,
@@ -533,7 +532,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         val curatedFindings = curationsMatcher.applyAll(scanResult.summary.licenseFindings, licenseFindingCurations)
             .mapNotNullTo(mutableSetOf()) { it.curatedFinding }
         val decomposedFindings = curatedFindings.flatMap { finding ->
-            finding.license.toSpdx().decompose().map { finding.copy(license = it.toString()) }
+            finding.license.decompose().map { finding.copy(license = it) }
         }
         val matchedFindings = findingsMatcher.match(decomposedFindings, scanResult.summary.copyrightFindings)
 
@@ -558,7 +557,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
                 }
             }
 
-            val actualLicense = licenses.addIfRequired(LicenseId(licenseFindings.license))
+            val actualLicense = licenses.addIfRequired(LicenseId(licenseFindings.license.toString()))
 
             licenseFindings.locations.forEach { location ->
                 val evaluatedPathExcludes = pathExcludes.filter { it.matches(location.getRelativePathToRoot(id)) }

--- a/reporter/src/main/kotlin/reporters/AbstractNoticeReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AbstractNoticeReporter.kt
@@ -151,7 +151,10 @@ abstract class AbstractNoticeReporter : Reporter {
         val detectedLicenses = ortResult.collectLicenseFindings(packageConfigurationProvider, omitExcluded = true)
             .mapValues { (_, findings) ->
                 findings.filter { it.value.isEmpty() }.keys.associate { licenseFindings ->
-                    Pair(licenseFindings.license, licenseFindings.copyrights.map { it.statement }.toMutableSet())
+                    Pair(
+                        licenseFindings.license.toString(),
+                        licenseFindings.copyrights.map { it.statement }.toMutableSet()
+                    )
                 }.toSortedMap()
             }.toMutableMap()
 

--- a/reporter/src/main/kotlin/reporters/AntennaAttributionDocumentReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AntennaAttributionDocumentReporter.kt
@@ -128,7 +128,7 @@ class AntennaAttributionDocumentReporter : Reporter {
         licenseFindings: Map<Identifier, Map<LicenseFindings, List<PathExclude>>>
     ) =
         licenseFindings.getOrDefault(id, emptyMap())
-            .filter { licenses.contains(it.key.license) }
+            .filter { licenses.contains(it.key.license.toString()) }
             .flatMap { it.key.copyrights }
             .joinToString("\n") { it.statement }
 

--- a/reporter/src/main/kotlin/reporters/NoticeByPackageReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeByPackageReporter.kt
@@ -275,7 +275,7 @@ class NoticeByPackageProcessor(input: ReporterInput) : AbstractNoticeReporter.No
         return scanResult.summary.licenseFindings.filter {
             it.location.path == relativePath.toString()
         }.mapTo(mutableSetOf()) {
-            it.license
+            it.license.toString()
         }
     }
 }

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -570,7 +570,7 @@ class StaticHtmlReporter : Reporter {
 
                                 if (excludes.isEmpty()) {
                                     div {
-                                        +finding.license
+                                        +finding.license.toString()
                                         if (permalink != null) {
                                             val count = finding.locations.size
                                             if (count > 1) {

--- a/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
@@ -67,7 +67,7 @@ class ReportTableModelMapper(
             { it.violation.severity },
             { it.violation.rule },
             { it.violation.pkg },
-            { it.violation.license },
+            { it.violation.license.toString() },
             { it.violation.message },
             { it.resolutionDescription }
         )
@@ -135,7 +135,7 @@ class ReportTableModelMapper(
 
                 val concludedLicense = ortResult.getConcludedLicensesForId(id)
                 val declaredLicenses = ortResult.getDeclaredLicensesForId(id)
-                val detectedLicenses = licenseFindings[id]?.toSortedMap(compareBy { it.license }) ?: sortedMapOf()
+                val detectedLicenses = licenseFindings[id].orEmpty().toSortedMap(compareBy { it.license.toString() })
 
                 val analyzerIssues = projectIssues[id].orEmpty() + analyzerResult.issues[id].orEmpty() +
                         analyzerIssuesForPackages[id].orEmpty()
@@ -168,7 +168,7 @@ class ReportTableModelMapper(
                         scopes = sortedMapOf(project.id to row.scopes),
                         concludedLicenses = row.concludedLicense?.let { setOf(it) }.orEmpty(),
                         declaredLicenses = row.declaredLicenses,
-                        detectedLicenses = row.detectedLicenses.mapTo(sortedSetOf()) { it.key.license },
+                        detectedLicenses = row.detectedLicenses.mapTo(sortedSetOf()) { it.key.license.toString() },
                         analyzerIssues = if (nonExcludedAnalyzerIssues.isNotEmpty()) {
                             sortedMapOf(project.id to nonExcludedAnalyzerIssues)
                         } else {

--- a/reporter/src/main/kotlin/utils/StatisticsCalculator.kt
+++ b/reporter/src/main/kotlin/utils/StatisticsCalculator.kt
@@ -127,7 +127,7 @@ internal class StatisticsCalculator {
         }
 
         val packageLicenses = ortResult.collectLicenseFindings().mapValues { (_, findingsMap) ->
-            findingsMap.mapTo(mutableSetOf()) { it.key.license }
+            findingsMap.mapTo(mutableSetOf()) { it.key.license.toString() }
         }
 
         val detectedLicenses = packageLicenses.flatMap { it.value }.groupingBy { it }.eachCount().toSortedMap()

--- a/scanner/src/funTest/kotlin/scanners/AbstractScannerTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/AbstractScannerTest.kt
@@ -19,23 +19,23 @@
 
 package org.ossreviewtoolkit.scanner.scanners
 
-import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.scanner.LocalScanner
-import org.ossreviewtoolkit.utils.ORT_NAME
-import org.ossreviewtoolkit.utils.safeDeleteRecursively
-
-import io.kotest.core.spec.Spec
 import io.kotest.core.Tag
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
+import io.kotest.inspectors.forAll
 import io.kotest.matchers.file.shouldNotStartWithPath
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.kotest.core.spec.style.StringSpec
-import io.kotest.inspectors.forAll
 
 import java.io.File
-import java.util.TreeSet
+
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.scanner.LocalScanner
+import org.ossreviewtoolkit.spdx.SpdxExpression
+import org.ossreviewtoolkit.utils.ORT_NAME
+import org.ossreviewtoolkit.utils.safeDeleteRecursively
 
 abstract class AbstractScannerTest(testTags: Set<Tag> = emptySet()) : StringSpec() {
     protected val config = ScannerConfiguration()
@@ -48,8 +48,8 @@ abstract class AbstractScannerTest(testTags: Set<Tag> = emptySet()) : StringSpec
     private lateinit var outputDir: File
 
     abstract val scanner: LocalScanner
-    abstract val expectedFileLicenses: TreeSet<String>
-    abstract val expectedDirectoryLicenses: TreeSet<String>
+    abstract val expectedFileLicenses: Set<SpdxExpression>
+    abstract val expectedDirectoryLicenses: Set<SpdxExpression>
 
     override fun beforeSpec(spec: Spec) {
         super.beforeSpec(spec)

--- a/scanner/src/funTest/kotlin/scanners/AskalonoScannerTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/AskalonoScannerTest.kt
@@ -19,8 +19,10 @@
 
 package org.ossreviewtoolkit.scanner.scanners
 
+import org.ossreviewtoolkit.spdx.toSpdx
+
 class AskalonoScannerTest : AbstractScannerTest() {
     override val scanner = Askalono("Askalono", config)
-    override val expectedFileLicenses = sortedSetOf("Apache-2.0")
-    override val expectedDirectoryLicenses = sortedSetOf("Apache-2.0")
+    override val expectedFileLicenses = setOf("Apache-2.0".toSpdx())
+    override val expectedDirectoryLicenses = setOf("Apache-2.0".toSpdx())
 }

--- a/scanner/src/funTest/kotlin/scanners/BoyterLcScannerTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/BoyterLcScannerTest.kt
@@ -19,8 +19,10 @@
 
 package org.ossreviewtoolkit.scanner.scanners
 
+import org.ossreviewtoolkit.spdx.toSpdx
+
 class BoyterLcScannerTest : AbstractScannerTest() {
     override val scanner = BoyterLc("BoyterLc", config)
-    override val expectedFileLicenses = sortedSetOf("Apache-2.0", "ECL-2.0")
-    override val expectedDirectoryLicenses = sortedSetOf("Apache-2.0", "ECL-2.0")
+    override val expectedFileLicenses = setOf("Apache-2.0".toSpdx(), "ECL-2.0".toSpdx())
+    override val expectedDirectoryLicenses = setOf("Apache-2.0".toSpdx(), "ECL-2.0".toSpdx())
 }

--- a/scanner/src/funTest/kotlin/scanners/LicenseeScannerTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/LicenseeScannerTest.kt
@@ -19,10 +19,11 @@
 
 package org.ossreviewtoolkit.scanner.scanners
 
+import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 
 class LicenseeScannerTest : AbstractScannerTest(setOf(ExpensiveTag)) {
     override val scanner = Licensee("Licensee", config)
-    override val expectedFileLicenses = sortedSetOf("Apache-2.0")
-    override val expectedDirectoryLicenses = sortedSetOf("Apache-2.0")
+    override val expectedFileLicenses = setOf("Apache-2.0".toSpdx())
+    override val expectedDirectoryLicenses = setOf("Apache-2.0".toSpdx())
 }

--- a/scanner/src/funTest/kotlin/scanners/ScanCodeScannerTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/ScanCodeScannerTest.kt
@@ -19,11 +19,12 @@
 
 package org.ossreviewtoolkit.scanner.scanners
 
+import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 import org.ossreviewtoolkit.utils.test.ScanCodeTag
 
 class ScanCodeScannerTest : AbstractScannerTest(setOf(ExpensiveTag, ScanCodeTag)) {
     override val scanner = ScanCode("ScanCode", config)
-    override val expectedFileLicenses = sortedSetOf("Apache-2.0")
-    override val expectedDirectoryLicenses = sortedSetOf("Apache-2.0")
+    override val expectedFileLicenses = setOf("Apache-2.0".toSpdx())
+    override val expectedDirectoryLicenses = setOf("Apache-2.0".toSpdx())
 }

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageTest.kt
@@ -110,8 +110,8 @@ abstract class AbstractStorageTest : StringSpec() {
         1,
         "packageVerificationCode",
         sortedSetOf(
-            LicenseFinding("license 1.1", DUMMY_TEXT_LOCATION),
-            LicenseFinding("license 1.2", DUMMY_TEXT_LOCATION)
+            LicenseFinding("license-1.1", DUMMY_TEXT_LOCATION),
+            LicenseFinding("license-1.2", DUMMY_TEXT_LOCATION)
         ),
         sortedSetOf(),
         mutableListOf(error1, error2)

--- a/spdx-utils/src/main/kotlin/SpdxExpression.kt
+++ b/spdx-utils/src/main/kotlin/SpdxExpression.kt
@@ -267,7 +267,18 @@ class SpdxCompoundExpression(
  * An SPDX expression that contains only a single license with an optional exception. Can be
  * [SpdxLicenseWithExceptionExpression] or any subtype of [SpdxSimpleExpression].
  */
-sealed class SpdxSingleLicenseExpression : SpdxExpression()
+sealed class SpdxSingleLicenseExpression : SpdxExpression() {
+    companion object {
+        /**
+         * Parse a string into an [SpdxSingleLicenseExpression]. Throws an [SpdxException] if the string cannot be
+         * parsed. Throws a [ClassCastException] if the string is an [SpdxCompoundExpression].
+         */
+        @JsonCreator
+        @JvmStatic
+        fun parse(expression: String): SpdxSingleLicenseExpression =
+            SpdxExpression.parse(expression) as SpdxSingleLicenseExpression
+    }
+}
 
 /**
  * An SPDX expression that contains a [license] with an [exception].


### PR DESCRIPTION
Refactor most of the code to use `SpdxExpression` or
`SpdxSingleLicenseExpression` instead of strings for handling licenses.

This refactoring is a done in a single large commit, because much of the
code depends on each other and it was therefore easier to change it all
in one go.

Most model classes that contain properties for licenses are changed to
use SPDX expressions, except if they are supposed to contain license
strings that might not be valid SPDX expressions, for example
`Package.declaredLicenses`.

Probably the most important change was that now `LicenseFinding.license`
is an `SpdxExpression`. This properly expresses that this field can
contain multiple licenses. Currently this is only possible if license
finding curations are used, in future also scanners like `ScanCode`
might create findings that are SPDX expressions instead of single
licenses. This is important for implementing license choices later on.

Some helper functions like `OrtResult.getDetectedLicensesForId()` are
still returning licenses as strings to not further increase the size of
this commit, this will be addressed in later commits.

Several tests used license strings that were not valid SPDX license
identifiers, those are changed to be valid (e.g. "license 1" was changed
to "license-1").

This is a breaking change for existing rules.kts and
notice-pre-processor.kts files, those need to be updated to properly
work with SPDX expressions instead of strings. The files in
"docs/examples" are updated accordingly in this commit.