### PR TITLE
Add tests for the examples in the docs

### DIFF
--- a/cli/src/funTest/kotlin/ExamplesTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+import java.io.File
+import java.io.IOException
+
+import org.ossreviewtoolkit.evaluator.Evaluator
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.PackageCuration
+import org.ossreviewtoolkit.model.config.CopyrightGarbage
+import org.ossreviewtoolkit.model.config.RepositoryConfiguration
+import org.ossreviewtoolkit.model.config.Resolutions
+import org.ossreviewtoolkit.model.licenses.LicenseConfiguration
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
+import org.ossreviewtoolkit.reporter.reporters.AbstractNoticeReporter
+
+class ExamplesTest : StringSpec() {
+    private val examplesDir = File("../docs/examples")
+
+    init {
+        "ort.yml examples are parsable" {
+            examplesDir.listFiles { file ->
+                file.name.endsWith(".ort.yml")
+            }!!.forEach { file ->
+                withClue(file.name) {
+                    shouldNotThrow<IOException> {
+                        file.readValue<RepositoryConfiguration>()
+                    }
+                }
+            }
+        }
+
+        "copyright-garbage.yml can be deserialized" {
+            shouldNotThrow<IOException> {
+                examplesDir.resolve("copyright-garbage.yml").readValue<CopyrightGarbage>()
+            }
+        }
+
+        "curations.yml can be deserialized" {
+            shouldNotThrow<IOException> {
+                examplesDir.resolve("curations.yml").readValue<List<PackageCuration>>()
+            }
+        }
+
+        "licenses.yml can be deserialized" {
+            shouldNotThrow<IOException> {
+                examplesDir.resolve("licenses.yml").readValue<LicenseConfiguration>()
+            }
+        }
+
+        "notice-pre-processor.kts can be compiled" {
+            val model = AbstractNoticeReporter.NoticeReportModel(
+                headers = emptyList(),
+                headerWithoutLicenses = "",
+                headerWithLicenses = "",
+                findings = emptyMap(),
+                footers = emptyList()
+            )
+
+            val preProcessor = AbstractNoticeReporter.PreProcessor(
+                ortResult = OrtResult.EMPTY,
+                model = model,
+                copyrightGarbage = CopyrightGarbage(),
+                licenseConfiguration = LicenseConfiguration(),
+                packageConfigurationProvider = SimplePackageConfigurationProvider()
+            )
+
+            val script = examplesDir.resolve("notice-pre-processor.kts").readText()
+
+            preProcessor.checkSyntax(script) shouldBe true
+
+            // TODO: It should also be verified that the script works as expected.
+        }
+
+        "resolutions.yml can be deserialized" {
+            shouldNotThrow<IOException> {
+                examplesDir.resolve("resolutions.yml").readValue<Resolutions>()
+            }
+        }
+
+        "rules.kts can be compiled" {
+            val evaluator = Evaluator(
+                ortResult = OrtResult.EMPTY,
+                packageConfigurationProvider = SimplePackageConfigurationProvider(),
+                licenseConfiguration = LicenseConfiguration()
+            )
+
+            val script = examplesDir.resolve("rules.kts").readText()
+
+            evaluator.checkSyntax(script) shouldBe true
+
+            // TODO: It should also be verified that the script works as expected.
+        }
+    }
+}

--- a/docs/examples/go-dep.ort.yml
+++ b/docs/examples/go-dep.ort.yml
@@ -1,3 +1,3 @@
-excludes:
+excludes: {}
 # dep only has one scope named 'install' thus no default scope based
 # excludes can be defined.

--- a/docs/examples/pip.ort.yml
+++ b/docs/examples/pip.ort.yml
@@ -1,3 +1,3 @@
-excludes:
+excludes: {}
 # PIP only has one scope named 'install' thus no default scope based
 # excludes can be defined.

--- a/docs/examples/sbt.ort.yml
+++ b/docs/examples/sbt.ort.yml
@@ -4,5 +4,5 @@ excludes:
     reason: "PROVIDED_DEPENDENCY_OF"
     comment: "Packages provided at runtime by the JDK or container only."
   - pattern: "test"
-    reason: "TEST_DEPENDENCY_OFF"
+    reason: "TEST_DEPENDENCY_OF"
     comment: "Packages for testing only."

--- a/spdx-utils/src/main/kotlin/SpdxSimpleLicenseMapping.kt
+++ b/spdx-utils/src/main/kotlin/SpdxSimpleLicenseMapping.kt
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
  * A mapping from simple license names to valid SPDX license IDs. This mapping only contains license strings which *can*
  * be parsed by [SpdxExpression.parse] but have a corresponding valid SPDX license ID that should be used instead. When
  * mapping a name without any indication of a version to an ID with a version, the most commonly used version at the
- * time of writing is used. See [SpdxDeclaredLicenseMapping] for a mapping of unparseable license strings.
+ * time of writing is used. See [SpdxDeclaredLicenseMapping] for a mapping of unparsable license strings.
  */
 object SpdxSimpleLicenseMapping {
     /**


### PR DESCRIPTION
Add tests for the files in "docs/examples" to ensure that changes in ORT
do not break the examples. The test class is added to the "cli" module,
because this module depends on all other modules and therefore has
access to all required classes.