### PR TITLE
reporter: Remove the defaultFilename from the interface

### DIFF
--- a/reporter/src/main/kotlin/Reporter.kt
+++ b/reporter/src/main/kotlin/Reporter.kt
@@ -49,11 +49,6 @@ interface Reporter {
     val reporterName: String
 
     /**
-     * The default output filename to use with this reporter format.
-     */
-    val defaultFilename: String
-
-    /**
      * Generate a report for the provided [input] and write the generated file(s) to the [outputDir]. If and how the
      * [input] data is used depends on the specific reporter implementation, taking into account any format-specific
      * [options]. The list of generated report files is returned.

--- a/reporter/src/main/kotlin/reporters/AbstractNoticeReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AbstractNoticeReporter.kt
@@ -98,6 +98,8 @@ abstract class AbstractNoticeReporter : Reporter {
         abstract fun process(model: NoticeReportModel): List<() -> String>
     }
 
+    protected abstract val noticeFilename: String
+
     override fun generateReport(
         input: ReporterInput,
         outputDir: File,
@@ -130,7 +132,7 @@ abstract class AbstractNoticeReporter : Reporter {
 
         val processor = createProcessor(input)
         val notices = processor.process(preProcessedModel)
-        val outputFile = outputDir.resolve(defaultFilename)
+        val outputFile = outputDir.resolve(noticeFilename)
 
         outputFile.bufferedWriter().use { writer ->
             notices.forEach {

--- a/reporter/src/main/kotlin/reporters/AntennaAttributionDocumentReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AntennaAttributionDocumentReporter.kt
@@ -48,8 +48,8 @@ private const val TEMPLATE_PATH = "template.path"
 
 class AntennaAttributionDocumentReporter : Reporter {
     override val reporterName = "AntennaAttributionDocument"
-    override val defaultFilename = "attribution-document.pdf"
 
+    private val reportFilename = "attribution-document.pdf"
     private val originalClassLoader = Thread.currentThread().contextClassLoader
 
     override fun generateReport(
@@ -105,7 +105,7 @@ class AntennaAttributionDocumentReporter : Reporter {
 
         val documentFile = try {
             AttributionDocumentGeneratorImpl(
-                defaultFilename,
+                reportFilename,
                 workingDir,
                 templateId,
                 DocumentValues(rootProject.id.name, rootProject.id.version, projectCopyright)
@@ -116,7 +116,7 @@ class AntennaAttributionDocumentReporter : Reporter {
 
         // Antenna keeps around temporary files in its working directory, so we cannot just use our output directory as
         // its working directory, but have to copy the file we are interested in.
-        documentFile.copyTo(outputDir.resolve(defaultFilename))
+        documentFile.copyTo(outputDir.resolve(reportFilename))
         workingDir.safeDeleteRecursively()
 
         return listOf(documentFile)

--- a/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
+++ b/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
@@ -41,7 +41,8 @@ import org.ossreviewtoolkit.spdx.SpdxLicense
 
 class CycloneDxReporter : Reporter {
     override val reporterName = "CycloneDx"
-    override val defaultFilename = "bom.xml"
+
+    private val reportFilename = "bom.xml"
 
     private fun Bom.addExternalReference(type: ExternalReference.Type, url: String, comment: String? = null) {
         if (url.isBlank()) return
@@ -176,7 +177,7 @@ class CycloneDxReporter : Reporter {
         }
 
         val bomGenerator = BomGeneratorFactory.create(CycloneDxSchema.Version.VERSION_11, bom).apply { generate() }
-        val outputFile = outputDir.resolve(defaultFilename)
+        val outputFile = outputDir.resolve(reportFilename)
 
         outputFile.bufferedWriter().use {
             it.write(bomGenerator.toXmlString())

--- a/reporter/src/main/kotlin/reporters/EvaluatedModelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/EvaluatedModelReporter.kt
@@ -36,7 +36,7 @@ private fun EvaluatedModel.toJson(writer: Writer) = toJson(writer, prettyPrint =
  */
 class EvaluatedModelJsonReporter : EvaluatedModelReporter(
     reporterName = "EvaluatedModelJson",
-    defaultFilename = "evaluated-model.json",
+    reportFilename = "evaluated-model.json",
     serialize = EvaluatedModel::toJson
 )
 
@@ -45,7 +45,7 @@ class EvaluatedModelJsonReporter : EvaluatedModelReporter(
  */
 class EvaluatedModelYamlReporter : EvaluatedModelReporter(
     reporterName = "EvaluatedModelYaml",
-    defaultFilename = "evaluated-model.yml",
+    reportFilename = "evaluated-model.yml",
     serialize = EvaluatedModel::toYaml
 )
 
@@ -55,7 +55,7 @@ class EvaluatedModelYamlReporter : EvaluatedModelReporter(
  */
 abstract class EvaluatedModelReporter(
     override val reporterName: String,
-    override val defaultFilename: String,
+    private val reportFilename: String,
     private val serialize: EvaluatedModel.(Writer) -> Unit
 ) : Reporter {
     override fun generateReport(
@@ -67,7 +67,7 @@ abstract class EvaluatedModelReporter(
 
         log.debug { "Generating evaluated model took ${evaluatedModel.duration.inMilliseconds}ms." }
 
-        val outputFile = outputDir.resolve(defaultFilename)
+        val outputFile = outputDir.resolve(reportFilename)
 
         outputFile.bufferedWriter().use {
             evaluatedModel.value.serialize(it)

--- a/reporter/src/main/kotlin/reporters/ExcelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ExcelReporter.kt
@@ -61,6 +61,10 @@ import org.ossreviewtoolkit.utils.isValidUri
  * dependencies.
  */
 class ExcelReporter : Reporter {
+    override val reporterName = "Excel"
+
+    private val reportFilename = "scan-report.xlsx"
+
     private val defaultColumns = 5
 
     private val borderColor = XSSFColor(Color(211, 211, 211))
@@ -82,9 +86,6 @@ class ExcelReporter : Reporter {
     private lateinit var excludedFont: XSSFFont
 
     private lateinit var creationHelper: CreationHelper
-
-    override val reporterName = "Excel"
-    override val defaultFilename = "scan-report.xlsx"
 
     override fun generateReport(
         input: ReporterInput,
@@ -166,7 +167,7 @@ class ExcelReporter : Reporter {
             )
         }
 
-        val outputFile = outputDir.resolve(defaultFilename)
+        val outputFile = outputDir.resolve(reportFilename)
 
         outputFile.outputStream().use {
             workbook.write(it)

--- a/reporter/src/main/kotlin/reporters/NoticeByPackageReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeByPackageReporter.kt
@@ -50,7 +50,7 @@ import java.nio.file.Path
  */
 class NoticeByPackageReporter : AbstractNoticeReporter() {
     override val reporterName = "NoticeByPackage"
-    override val defaultFilename = "NOTICE_BY_PACKAGE"
+    override val noticeFilename = "NOTICE_BY_PACKAGE"
 
     override fun createProcessor(input: ReporterInput): NoticeProcessor = NoticeByPackageProcessor(input)
 }

--- a/reporter/src/main/kotlin/reporters/NoticeSummaryReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeSummaryReporter.kt
@@ -30,7 +30,7 @@ import org.ossreviewtoolkit.utils.log
  */
 class NoticeSummaryReporter : AbstractNoticeReporter() {
     override val reporterName = "NoticeSummary"
-    override val defaultFilename = "NOTICE_SUMMARY"
+    override val noticeFilename = "NOTICE_SUMMARY"
 
     override fun createProcessor(input: ReporterInput): NoticeProcessor = NoticeSummaryProcessor(input)
 }

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -54,10 +54,10 @@ import org.ossreviewtoolkit.utils.normalizeLineBreaks
 
 @Suppress("LargeClass")
 class StaticHtmlReporter : Reporter {
-    private val css = javaClass.getResource("/static-html-reporter.css").readText()
-
     override val reporterName = "StaticHtml"
-    override val defaultFilename = "scan-report.html"
+
+    private val reportFilename = "scan-report.html"
+    private val css = javaClass.getResource("/static-html-reporter.css").readText()
 
     override fun generateReport(
         input: ReporterInput,
@@ -72,7 +72,7 @@ class StaticHtmlReporter : Reporter {
         )
 
         val html = renderHtml(tabularScanRecord)
-        val outputFile = outputDir.resolve(defaultFilename)
+        val outputFile = outputDir.resolve(reportFilename)
 
         outputFile.bufferedWriter().use {
             it.write(html)

--- a/reporter/src/main/kotlin/reporters/WebAppReporter.kt
+++ b/reporter/src/main/kotlin/reporters/WebAppReporter.kt
@@ -27,7 +27,8 @@ import org.ossreviewtoolkit.reporter.model.EvaluatedModel
 
 class WebAppReporter : Reporter {
     override val reporterName = "WebApp"
-    override val defaultFilename = "scan-report-web-app.html"
+
+    private val reportFilename = "scan-report-web-app.html"
 
     override fun generateReport(
         input: ReporterInput,
@@ -42,7 +43,7 @@ class WebAppReporter : Reporter {
         val prefix = template.substring(0, index)
         val suffix = template.substring(index + placeholder.length, template.length)
 
-        val outputFile = outputDir.resolve(defaultFilename)
+        val outputFile = outputDir.resolve(reportFilename)
 
         outputFile.bufferedWriter().use {
             it.write(prefix)


### PR DESCRIPTION
With possibly multiple files being created now, enforing this property
for all reporters does not make sense anymore.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>