### PR TITLE
Add a declared license mapping for "The Apache 2.0 License"

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -357,6 +357,7 @@
 "Sun Public License": SPL-1.0
 "TMate Open Source License (with dual licensing option)": TMate
 "The (New) BSD License": BSD-3-Clause
+"The Apache 2.0 License": Apache-2.0
 "The Apache License": Apache-2.0
 "The Apache License, Version 2.0": Apache-2.0
 "The Apache Software Licence, Version 2.0": Apache-2.0


### PR DESCRIPTION
As found in [1].

[1] https://github.com/kotest/kotest/blob/v4.0.5/publish-mpp.gradle.kts#L68