### PR TITLE
reporter: Add a test for the AntennaAttributionDocumentReporter

### DIFF
--- a/reporter/src/funTest/kotlin/reporters/AntennaAttributionDocumentReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/AntennaAttributionDocumentReporterTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.reporter.reporters
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.reporter.ReporterInput
+import org.ossreviewtoolkit.utils.ORT_NAME
+import org.ossreviewtoolkit.utils.test.readOrtResult
+
+class AntennaAttributionDocumentReporterTest : WordSpec({
+    "AntennaAttributionDocumentReporter" should {
+        "successfully generate the PDF output" {
+            val ortResult = readOrtResult(
+                "../scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml"
+            )
+
+            val actualReport = generateReport(ortResult)
+
+            actualReport.size shouldBe 53797
+        }
+    }
+})
+
+private fun generateReport(ortResult: OrtResult): ByteArray {
+    val outputDir = createTempDir(
+        ORT_NAME, AntennaAttributionDocumentReporterTest::class.simpleName
+    ).apply { deleteOnExit() }
+
+    return AntennaAttributionDocumentReporter().generateReport(ReporterInput(ortResult), outputDir).single().readBytes()
+}

--- a/reporter/src/main/kotlin/reporters/AntennaAttributionDocumentReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AntennaAttributionDocumentReporter.kt
@@ -116,10 +116,11 @@ class AntennaAttributionDocumentReporter : Reporter {
 
         // Antenna keeps around temporary files in its working directory, so we cannot just use our output directory as
         // its working directory, but have to copy the file we are interested in.
-        documentFile.copyTo(outputDir.resolve(reportFilename))
+        val outputFile = outputDir.resolve(reportFilename)
+        documentFile.copyTo(outputFile)
         workingDir.safeDeleteRecursively()
 
-        return listOf(documentFile)
+        return listOf(outputFile)
     }
 
     private fun createCopyrightStatement(


### PR DESCRIPTION
The AntennaAttributionDocumentReporterTest tests only the size of the
generated report and uses for this the scanners test result.
