### PR TITLE
NodeSupportTest: Also test parsing an unauthenticated proxy

### DIFF
--- a/analyzer/src/test/kotlin/managers/utils/NodeSupportTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/NodeSupportTest.kt
@@ -198,7 +198,11 @@ class NodeSupportTest : WordSpec() {
                 fun ProtocolProxyMap.mapSingleValuesToString() =
                     mapValues { (_, proxies) ->
                         val (proxy, authentication) = proxies.single()
-                        listOf(proxy.toString(), authentication?.userName, authentication?.password?.let { String(it) })
+                        listOfNotNull(
+                            proxy.toString(),
+                            authentication?.userName,
+                            authentication?.password?.let { String(it) }
+                        )
                     }
 
                 readProxySettingsFromNpmRc("""
@@ -233,8 +237,8 @@ class NodeSupportTest : WordSpec() {
                     https-proxy=host.tld
                     """.trimIndent()
                 ).mapSingleValuesToString() shouldBe mapOf(
-                    "http" to listOf("HTTP @ host.tld:8080", null, null),
-                    "https" to listOf("HTTP @ host.tld:8080", null, null)
+                    "http" to listOf("HTTP @ host.tld:8080"),
+                    "https" to listOf("HTTP @ host.tld:8080")
                 )
             }
 

--- a/analyzer/src/test/kotlin/managers/utils/NodeSupportTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/NodeSupportTest.kt
@@ -227,6 +227,15 @@ class NodeSupportTest : WordSpec() {
                     "http" to listOf("HTTP @ host.tld:8080", "user", "password"),
                     "https" to listOf("HTTP @ host.tld:8080", "user", "password")
                 )
+
+                readProxySettingsFromNpmRc("""
+                    proxy=host.tld
+                    https-proxy=host.tld
+                    """.trimIndent()
+                ).mapSingleValuesToString() shouldBe mapOf(
+                    "http" to listOf("HTTP @ host.tld:8080", null, null),
+                    "https" to listOf("HTTP @ host.tld:8080", null, null)
+                )
             }
 
             "ignore non-proxy URLs" {


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>