### PR TITLE
WorkingTree: Use a dedicated message for a blank version in guessRevisionName()

### DIFF
--- a/downloader/src/main/kotlin/WorkingTree.kt
+++ b/downloader/src/main/kotlin/WorkingTree.kt
@@ -88,6 +88,8 @@ abstract class WorkingTree(val workingDir: File, val vcsType: VcsType) {
      * @throws IOException If no or multiple matching revisions are found.
      */
     fun guessRevisionName(project: String, version: String): String {
+        if (version.isBlank()) throw IOException("Cannot guess a revision name from a blank version.")
+
         val versionNames = filterVersionNames(version, listRemoteTags(), project)
         return when {
             versionNames.isEmpty() ->


### PR DESCRIPTION
As

    No matching tag found for version ''. Please create a tag whose name contains the version.

reads a bit awkward, and the hint is also wrong.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>