### PR TITLE
Replace Java's listFiles() with Kotlin's walk()

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -36,7 +36,6 @@ import org.ossreviewtoolkit.utils.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.showStackTrace
 
 import java.io.File
-import java.io.FileFilter
 import java.nio.file.FileSystems
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
@@ -122,7 +121,7 @@ abstract class PackageManager(
                         return FileVisitResult.SKIP_SUBTREE
                     }
 
-                    val filesInDir = dirAsFile.listFiles(FileFilter { it.isFile })
+                    val filesInDir = dirAsFile.walk().maxDepth(1).filter { it.isFile }.toList()
 
                     packageManagers.forEach { manager ->
                         // Create a list of lists of matching files per glob.

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -230,7 +230,7 @@ class Bundler(
     }
 
     private fun getGemspecFile(workingDir: File) =
-        workingDir.listFiles { file -> file.extension == "gemspec" }.firstOrNull()
+        workingDir.walk().maxDepth(1).filter { it.isFile && it.extension == "gemspec" }.firstOrNull()
 
     private fun installDependencies(workingDir: File) {
         requireLockfile(workingDir) { File(workingDir, "Gemfile.lock").isFile }

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.vdurmont.semver4j.Requirement
 
 import java.io.File
-import java.io.FileFilter
 import java.net.HttpURLConnection
 import java.net.URLEncoder
 import java.util.SortedSet
@@ -383,12 +382,12 @@ open class Npm(
         val nodeModulesDir = moduleDir.resolve("node_modules")
         if (!nodeModulesDir.isDirectory) return emptyList()
 
-        val searchDirs = nodeModulesDir.listFiles(FileFilter {
+        val searchDirs = nodeModulesDir.walk().maxDepth(1).filter {
             it.isDirectory && it.name.startsWith("@")
-        }) + nodeModulesDir
+        }.toList() + nodeModulesDir
 
         return searchDirs.flatMap { dir ->
-            dir.listFiles(FileFilter { it.isSymbolicLink() && it.isDirectory }).toList()
+            dir.walk().maxDepth(1).filter { it.isDirectory && it.isSymbolicLink() }.toList()
         }
     }
 

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -44,10 +44,8 @@ import com.paypal.digraph.parser.GraphParser
 import com.vdurmont.semver4j.Requirement
 
 import java.io.File
-import java.io.FileFilter
 import java.io.IOException
 import java.net.HttpURLConnection
-import java.nio.file.FileSystems
 import java.util.SortedSet
 
 import okhttp3.Request
@@ -87,11 +85,9 @@ class Stack(
         val workingDir = definitionFile.parentFile
 
         // Parse project information from the *.cabal file.
-        val cabalMatcher = FileSystems.getDefault().getPathMatcher("glob:**/*.cabal")
-
-        val cabalFiles = workingDir.listFiles(FileFilter {
-            cabalMatcher.matches(it.toPath())
-        })
+        val cabalFiles = workingDir.walk().filter {
+            it.isFile && it.extension == "cabal"
+        }.toList()
 
         val cabalFile = when (cabalFiles.size) {
             0 -> throw IOException("No *.cabal file found in '$workingDir'.")

--- a/cli/src/funTest/kotlin/ExamplesTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesTest.kt
@@ -25,7 +25,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.shouldNot
 
 import java.io.File
 import java.io.IOException
@@ -49,7 +49,8 @@ class ExamplesTest : StringSpec() {
 
     init {
         "Listing examples files succeeded" {
-            examplesDir.listFiles()?.also { exampleFiles = it.toMutableList() } shouldNotBe null
+            exampleFiles = examplesDir.walk().maxDepth(1).filter { it.isFile }.toMutableList()
+            exampleFiles shouldNot beEmpty()
         }
 
         "ort.yml examples are parsable" {

--- a/downloader/src/funTest/kotlin/vcs/GitRepoDownloadTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitRepoDownloadTest.kt
@@ -32,7 +32,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.StringSpec
 
 import java.io.File
-import java.io.FileFilter
 
 private const val REPO_URL = "https://github.com/oss-review-toolkit/ort-test-data-git-repo"
 private const val REPO_REV = "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
@@ -68,7 +67,7 @@ class GitRepoDownloadTest : StringSpec() {
                 "src"
             )
 
-            val actualSpdxFiles = spdxDir.listFiles(FileFilter { it.isDirectory }).map { it.name }.sorted()
+            val actualSpdxFiles = spdxDir.walk().maxDepth(1).filter { it.isDirectory }.map { it.name }.sorted()
 
             val submodulesDir = File(outputDir, "submodules")
             val expectedSubmodulesFiles = listOf(
@@ -77,7 +76,11 @@ class GitRepoDownloadTest : StringSpec() {
                 "test-data-npm"
             )
 
-            val actualSubmodulesFiles = submodulesDir.listFiles(FileFilter { it.isDirectory }).map { it.name }.sorted()
+            val actualSubmodulesFiles = submodulesDir.walk().maxDepth(1).filter {
+                it.isDirectory
+            }.map {
+                it.name
+            }.sorted()
 
             workingTree.isValid() shouldBe true
             workingTree.getInfo() shouldBe vcs

--- a/downloader/src/main/kotlin/vcs/Cvs.kt
+++ b/downloader/src/main/kotlin/vcs/Cvs.kt
@@ -138,7 +138,7 @@ class Cvs : VersionControlSystem(), CommandLineTool {
                     }.toMap().toSortedMap()
                 } finally {
                     // Clean the temporarily updated working tree again.
-                    workingDir.listFiles().forEach {
+                    workingDir.walk().maxDepth(1).forEach {
                         if (it.isDirectory) {
                             if (it.name != "CVS") it.safeDeleteRecursively()
                         } else {

--- a/reporter/src/main/kotlin/reporters/AntennaAttributionDocumentReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AntennaAttributionDocumentReporter.kt
@@ -118,7 +118,7 @@ class AntennaAttributionDocumentReporter : Reporter {
                     templateId = providedTemplateId
                 }
             } else if (templatePath.isDirectory) {
-                require(templatePath.listFiles().isNotEmpty()) {
+                require(templatePath.walk().maxDepth(1).filter { it.isFile }.any()) {
                     "The template path must point to a directory with template files if no template id is provided."
                 }
 

--- a/spdx-utils/build.gradle.kts
+++ b/spdx-utils/build.gradle.kts
@@ -26,7 +26,6 @@ import groovy.json.JsonSlurper
 
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 
-import java.io.FileFilter
 import java.io.FileNotFoundException
 import java.net.URL
 import java.time.Year
@@ -287,7 +286,7 @@ fun generateLicenseTextResources(description: String, ids: Map<String, LicenseMe
     val scanCodeLicensePath = "$buildDir/SvnExport/licenses/scancode-toolkit"
     val spdxIdToScanCodeKey = mutableMapOf<String, String>()
 
-    file(scanCodeLicensePath).listFiles(FileFilter { it.name.endsWith(".yml") }).forEach { file ->
+    file(scanCodeLicensePath).walk().maxDepth(1).filter { it.isFile && it.extension == "yml" }.forEach { file ->
         file.readLines().forEach { line ->
             val keyAndValue = line.split(Regex("^spdx_license_key:"), 2)
             if (keyAndValue.size == 2) {
@@ -357,9 +356,9 @@ val generateLicenseRefTextResources by tasks.registering {
             mkdirs()
         }
 
-        licensesDir.listFiles(FileFilter {
-            it.name.endsWith(".yml") && !it.name.endsWith("-exception.yml")
-        }).forEach { file ->
+        licensesDir.walk().maxDepth(1).filter {
+            it.isFile && it.extension == "yml" && !it.nameWithoutExtension.endsWith("-exception")
+        }.forEach { file ->
             val isSpdxLicense = file.readLines().any { it.startsWith("spdx_license_key: ") }
             if (!isSpdxLicense) {
                 // The base name of a ScanCode license YML file matches the ScanCode-internal license key.


### PR DESCRIPTION
To avoid "Unsafe use of a nullable receiver" inspection warnings, and to
reduce dependencies on the JVM.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>