### PR TITLE
spdx-utils: Implement the SPDX 2.2.1 document model

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -69,3 +69,8 @@ License: CC0-1.0
 Files: spdx-utils/src/main/resources/licenserefs/*
 Copyright: 2011-2020 SPDX Workgroup <spdx-legal@lists.spdx.org>
 License: CC0-1.0
+
+Files: spdx-utils/src/test/resources/spdx-spec-examples/*
+Copyright: 2011-2020 SPDX Workgroup <spdx-legal@lists.spdx.org>
+License: CC-BY-3.0
+

--- a/spdx-utils/build.gradle.kts
+++ b/spdx-utils/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
 
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
 }
 

--- a/spdx-utils/src/main/kotlin/SpdxModelSerializer.kt
+++ b/spdx-utils/src/main/kotlin/SpdxModelSerializer.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.spdx
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+
+object SpdxModelSerializer {
+    internal val jsonMapper: ObjectMapper = JsonMapper().apply(mapperConfig)
+
+    fun <T : Any> fromJson(json: String, clazz: Class<T>): T = jsonMapper.readValue(json, clazz)
+
+    fun toJson(obj: Any): String = jsonMapper.writeValueAsString(obj)
+
+    internal val yamlMapper: ObjectMapper = YAMLMapper().apply(mapperConfig)
+
+    fun <T : Any> fromYaml(yaml: String, clazz: Class<T>): T = yamlMapper.readValue(yaml, clazz)
+
+    fun toYaml(obj: Any): String = yamlMapper.writeValueAsString(obj)
+}
+
+private val mapperConfig: ObjectMapper.() -> Unit = {
+    registerKotlinModule()
+
+    registerModule(JavaTimeModule())
+    disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    enable(SerializationFeature.INDENT_OUTPUT)
+}

--- a/spdx-utils/src/main/kotlin/SpdxUtils.kt
+++ b/spdx-utils/src/main/kotlin/SpdxUtils.kt
@@ -29,6 +29,9 @@ import java.net.URL
 import java.security.MessageDigest
 import java.util.EnumSet
 
+import org.ossreviewtoolkit.spdx.model.SpdxConstants
+import org.ossreviewtoolkit.spdx.SpdxExpression.Strictness
+
 /**
  * A list of globs that match file names which are not license files but typically trigger false-positives.
  */
@@ -165,6 +168,19 @@ fun getLicenseTextReader(
         SpdxLicense.forId(id)?.let { { it.text } }
             ?: SpdxLicenseException.forId(id)?.takeIf { handleExceptions }?.let { { it.text } }
     }
+
+/**
+ * Return true if and only if this String can be successfully parsed to a [SpdxExpression].
+ */
+internal fun String.isSpdxExpression(): Boolean =
+    runCatching { SpdxExpression.parse(this, Strictness.ALLOW_DEPRECATED) }.isSuccess
+
+/**
+ * Return true if and only if this String can be successfully parsed to an [SpdxExpression] or if it equals
+ * [org.ossreviewtoolkit.spdx.model.SpdxConstants.NONE] or [org.ossreviewtoolkit.spdx.model.SpdxConstants.NOASSERTION].
+ */
+internal fun String.isSpdxExpressionOrNotPresent(): Boolean =
+    SpdxConstants.isNotPresent(this) || isSpdxExpression()
 
 private fun getLicenseTextResource(id: String): URL? =
     object {}.javaClass.getResource("/licenserefs/$id")

--- a/spdx-utils/src/main/kotlin/model/SpdxAnnotation.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxAnnotation.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.spdx.model
+
+import java.time.Instant
+
+/**
+ * An annotation which can relate to [SpdxDocument]s, [SpdxFile]s, or [SpdxPackage]s.
+ */
+data class SpdxAnnotation(
+    /**
+     * The creation date of this annotation.
+     */
+    val annotationDate: Instant,
+
+    /**
+     * The type of this annotation.
+     */
+    val annotationType: Type,
+
+    /**
+     * The person, organization or tool that has created this annotation. The value must be a single line of text in one
+     * of the following formats:
+     *
+     * 1. "Person: person name" or "Person: person name (email)"
+     * 2. "Organization: organization name" or "Organization: organization name (email)"
+     * 3. "Tool: tool identifier - version"
+     */
+    val annotator: String,
+
+    /**
+     * Comments from the [annotator].
+     */
+    val comment: String
+) {
+    enum class Type {
+        /**
+         * Type of annotation which does not fit in any of the pre-defined annotation types.
+         */
+        OTHER,
+
+        /**
+         * A Review represents an audit and signoff by an individual, organization
+         * or tool on the information for an SpdxElement.
+         */
+        REVIEW;
+    }
+
+    init {
+        require(annotator.isNotBlank()) { "The annotator must not be blank." }
+    }
+}

--- a/spdx-utils/src/main/kotlin/model/SpdxChecksum.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxChecksum.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.spdx.model
+
+/**
+ * Specifies checksum value and algorithm.
+ */
+data class SpdxChecksum(
+    /**
+     * The checksum algorithm.
+     */
+    val algorithm: Algorithm,
+
+    /**
+     * The lower case hexadecimal checksum value.
+     */
+    val checksumValue: String
+) {
+    companion object {
+        internal val HEX_SYMBOLS_REGEX = "^[0-9a-f]+$".toRegex()
+    }
+
+    enum class Algorithm(val checksumHexDigits: Int) {
+        MD2(32),
+        MD4(32),
+        MD5(32),
+        MD6(-1),
+        SHA1(40),
+        SHA224(56),
+        SHA256(64),
+        SHA384(96),
+        SHA512(128);
+    }
+
+    init {
+        require(checksumValue.isNotBlank()) { "The checksum value must not be blank." }
+
+        require(checksumValue.matches(HEX_SYMBOLS_REGEX)) {
+            "The checksum value must only contain lower case hexadecimal symbols."
+        }
+
+        require(algorithm.checksumHexDigits == -1 || checksumValue.length == algorithm.checksumHexDigits) {
+            "Expected a checksum value with ${algorithm.checksumHexDigits} hexadecimal symbols, but found " +
+                    "${checksumValue.length}."
+        }
+    }
+}

--- a/spdx-utils/src/main/kotlin/model/SpdxConstants.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxConstants.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.spdx.model
+
+object SpdxConstants {
+    /**
+     * Represents a not present value, which has been determined to actually be not present. This representation must
+     * not be used if [NOASSERTION] could be used instead.
+     */
+    const val NONE = "NONE"
+
+    /**
+     * Represents a not present value where any of the following cases applies:
+     *
+     * 1. no attempt was made to determine the information.
+     * 2. intentionally no information is provided, whereas no meaning should be derived from the absence of the
+     *    information.
+     */
+    const val NOASSERTION = "NOASSERTION"
+
+    internal fun isNotPresent(value: String) = value in setOf(NONE, NOASSERTION)
+}

--- a/spdx-utils/src/main/kotlin/model/SpdxCreationInfo.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxCreationInfo.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.spdx.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+import java.time.Instant
+
+/**
+ * Meta data corresponding to a [SpdxDocument].
+ */
+data class SpdxCreationInfo(
+    /**
+     * A general comment about the creation of the [SpdxDocument] or any other relevant comment not included in
+     * the other fields.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val comment: String = "",
+
+    /**
+     * The date and time the [SpdxDocument] was created.
+     */
+    val created: Instant,
+
+    /**
+     * The list of subjects who created the related [SpdxDocument]. At least one must be provided. The format equals the
+     * one for [SpdxAnnotation.annotator].
+     */
+    val creators: List<String> = emptyList(),
+
+    /**
+     * The version of SPDX license list (https://spdx.org/licenses/) used in the related [SpdxDocument].
+     * Data Format: "M.N"
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val licenseListVersion: String = ""
+
+) {
+    init {
+        require(creators.isNotEmpty()) { "Creators must contain at least one entry, but was empty." }
+    }
+}

--- a/spdx-utils/src/main/kotlin/model/SpdxDocument.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxDocument.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.spdx.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+private const val SPDX_VERSION = "SPDX-2.2.1"
+private const val DATA_LICENSE = "CC0-1.0"
+
+/**
+ * An SPDX document as specified by https://github.com/spdx/spdx-spec/tree/development/v2.2.1/chapters and
+ * https://github.com/spdx/spdx-spec/blob/development/v2.2.1/examples/ in revision 947271b.
+ */
+data class SpdxDocument(
+    /**
+     * Identifier of this [SpdxDocument] which may be referenced in relationships by other files, packages internally
+     * and documents externally.
+     *
+     * TODO: Introduce a dedicated type.
+     */
+    @JsonProperty("SPDXID")
+    val spdxId: String,
+
+    /**
+     * The SPDX version of this document, must equal [SPDX_VERSION].
+     */
+    val spdxVersion: String = SPDX_VERSION,
+
+    /**
+     * Information about the creation of this document.
+     */
+    val creationInfo: SpdxCreationInfo,
+
+    /**
+     * The name of this [SpdxDocument] as a single line.
+     */
+    val name: String,
+
+    /**
+     * The data license of this document, must equal [DATA_LICENSE].
+     */
+    val dataLicense: String = DATA_LICENSE,
+
+    /**
+     * A comment towards the consumers of this [SpdxDocument] as multi-line text.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val comment: String = "",
+
+    /**
+     * A listing of any external [SpdxDocument] referenced from within this [SpdxDocument].
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val externalDocumentRefs: List<SpdxExternalDocumentReference> = emptyList(),
+
+    /**
+     * Information about any licenses which are not on the SPDX license list.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val hasExtractedLicensingInfos: List<SpdxExtractedLicenseInfo> = emptyList(),
+
+    /**
+     * The [SpdxAnnotation]s for the [SpdxDocument]..
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val annotations: List<SpdxAnnotation> = emptyList(),
+
+    /**
+     * A unique absolute Uniform Resource Identifier (URI) as specified in RFC-3986, with the following
+     * exceptions:
+     *
+     *  - The SPDX Document URI cannot contain a URI "part" (e.g. the # delimiter), since the # is used to uniquely
+     *    identify SPDX element identifiers. The URI must contain a scheme (e.g. https:).
+     *  - The URI must be unique for the SPDX document including the specific version of the SPDX document. If the SPDX
+     *    document is updated, thereby creating a new version, a new URI for the updated document must be used. There
+     *    can only be one URI for an SPDX document and only one SPDX document for a given URI.
+     */
+    val documentNamespace: String,
+
+    /**
+     * All SPDX identifiers of all packages and files contained in [packages] and [files].
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val documentDescribes: List<String> = emptyList(),
+
+    /**
+     * All packages described in this [SpdxDocument].
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val packages: List<SpdxPackage> = emptyList(),
+
+    /**
+     * All files described in this [SpdxDocument].
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val files: List<SpdxFile> = emptyList(),
+
+    /**
+     * All snippets described in this [SpdxDocument].
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val snippets: List<SpdxSnippet> = emptyList(),
+
+    /**
+     * All relationships described in this [SpdxDocument].
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val relationships: List<SpdxRelationship> = emptyList()
+) {
+    init {
+        require(spdxId.isNotBlank()) { "The SPDX-Id must not be blank." }
+
+        require(spdxVersion.isNotBlank()) { "The SPDX version must not be blank." }
+
+        require(name.isNotBlank()) { "The name must not be blank." }
+
+        require(dataLicense.isNotBlank()) { "The data license must not be blank." }
+
+        require(documentNamespace.isNotBlank()) { "The document namespace must not be blank." }
+    }
+}

--- a/spdx-utils/src/main/kotlin/model/SpdxExternalDocumentReference.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxExternalDocumentReference.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.spdx.model
+
+/**
+ * [SpdxExternalDocumentReference]s are used by [SpdxDocument]s to list all external documents which are referenced from
+ * that particular [SpdxDocument].
+ */
+data class SpdxExternalDocumentReference(
+    /**
+     * The identifier referencing the external [SpdxDocument] in the format: "DocumentRef-${id-string}"
+     */
+    val externalDocumentId: String,
+
+    /**
+     * The checksum corresponding to the external [SpdxDocument] referenced by this [SpdxExternalDocumentReference].
+     */
+    val checksum: SpdxChecksum,
+
+    /**
+     * The SPDX Document URI of the external [SpdxDocument] referenced by this [SpdxExternalDocumentReference].
+     */
+    val spdxDocument: String
+) {
+    init {
+        require(externalDocumentId.isNotBlank()) { "The external document Id must not be blank." }
+
+        require(spdxDocument.isNotBlank()) { "The SPDX document must not be blank." }
+    }
+}

--- a/spdx-utils/src/main/kotlin/model/SpdxExternalReference.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxExternalReference.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.spdx.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonValue
+
+/**
+ *  References an external source of additional information, metadata, enumerations, asset identifiers, or downloadable
+ *  content believed to be relevant to the Package.
+ */
+class SpdxExternalReference(
+    /**
+     * Human-readable information about the purpose and target of the reference.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val comment: String = "",
+
+    /**
+     * The category of this reference which corresponds to the [referenceType].
+     */
+    val referenceCategory: Category,
+
+    /**
+     *  The unique string with no spaces necessary to access the package-specific information, metadata, or content
+     *  within the target location. The format of the locator is subject to constraints defined by the [referenceType].
+     */
+    val referenceLocator: String,
+
+    /**
+     * The references type as specified by
+     * https://github.com/spdx/spdx-spec/blob/master/chapters/appendix-VI-external-repository-identifiers.md.
+     *
+     * TODO: Introduce an enum for the reference type values.
+     */
+    val referenceType: String
+) {
+    enum class Category(
+        @JsonValue
+        private val serializedName: String
+    ) {
+        SECURITY("SECURITY"),
+        PACKAGE_MANAGER("PACKAGE-MANAGER"),
+        PERSISTENT_ID("PERSISTENT-ID"),
+        OTHER("OTHER");
+    }
+
+    init {
+        require(referenceLocator.isNotBlank()) { "The referenceLocator must not be blank." }
+
+        require(referenceType.isNotBlank()) { "The referenceType must not be blank." }
+    }
+}

--- a/spdx-utils/src/main/kotlin/model/SpdxExtractedLicenseInfo.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxExtractedLicenseInfo.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.spdx.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+/**
+ * This class holds information about any license not on the SPDX license list.
+ *
+ * Note: The above specification says that several fields are mandatory only if the license is not on the SPDX license
+ * list and at the same time says that instances of this class should only be created for licenses not on the SPDX
+ * license list. Thus make the respective fields unconditionally mandatory in order to address both of the mentioned
+ * constraints.
+ */
+data class SpdxExtractedLicenseInfo(
+    /**
+     * A general comment about the license referred to by [licenseId].
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val comment: String = "",
+
+    /**
+     * The actual text of the license reference extracted from the package or file that is associated with the License
+     * Identifier to aid in future analysis.
+     */
+    val extractedText: String,
+
+    /**
+     * A locally unique identifier for a license that is not on the SPDX License List.
+     */
+    val licenseId: String,
+
+    /**
+     * The common name for the license referred to by [licenseId].
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val name: String = "",
+
+    /**
+     * A list of URLs pointing to the official source of the license referred to by [licenseId].
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val seeAlsos: List<String> = emptyList()
+) {
+    init {
+        require(extractedText.isNotBlank()) { "The extracted text must not be blank." }
+
+        require(licenseId.isNotBlank()) { "The license Id must not be blank." }
+    }
+}

--- a/spdx-utils/src/main/kotlin/model/SpdxFile.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxFile.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.spdx.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+import org.ossreviewtoolkit.spdx.isSpdxExpressionOrNotPresent
+
+/**
+ * Provides important meta-data about a particular file of a software package.
+ */
+@JsonIgnoreProperties("ranges") // TODO: Implement ranges which is broken in the specification examples.
+data class SpdxFile(
+    /**
+     * A unique identifies this [SpdxFile] within a SPDX document.
+     */
+    @JsonProperty("SPDXID")
+    val spdxId: String,
+
+    /**
+     * The [SpdxAnnotation]s for the file.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val annotations: List<SpdxAnnotation> = emptyList(),
+
+    /**
+     * Checksums of the file, must contain at least one entry using [SpdxChecksum.Algorithm.SHA1].
+     */
+    val checksums: List<SpdxChecksum>,
+
+    /**
+     * A general comment about the file.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val comment: String = "",
+
+    /**
+     * A text relating to a copyright notice, even if not complete. To represent a not present value
+     * [SpdxConstants.NONE] or [SpdxConstants.NOASSERTION] must be used.
+     */
+    val copyrightText: String,
+
+    /**
+     * The list of contributors which contributed to the file. Contributors could include names of copyright holders
+     * and/or authors who may not be copyright holders, yet contributed to the file content.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val fileContributors: List<String> = emptyList(),
+
+    /**
+     * This field is deprecated since SPDX 2.0 in favor of [SpdxDocument.relationships].
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val fileDependencies: List<String> = emptyList(),
+
+    /**
+     * The name of the file.
+     */
+    @JsonProperty("fileName")
+    val filename: String,
+
+    /**
+     * The types of the file.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val fileTypes: List<Type> = emptyList(),
+
+    /**
+     * Any relevant background references or analysis that went in to arriving at the concluded License for the file.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val licenseComments: String = "",
+
+    /**
+     * The concluded license for the file as SPDX expression. To represent a not present value [SpdxConstants.NONE] or
+     * [SpdxConstants.NOASSERTION] must be used.
+     */
+    val licenseConcluded: String,
+
+    /**
+     * The license information found in this file. To represent a not present value [SpdxConstants.NONE] or
+     * [SpdxConstants.NOASSERTION] must be used.
+     */
+    val licenseInfoInFiles: List<String>,
+
+    /**
+     * License notices or other such related notices found in the file. This may include copyright statements.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val noticeText: String = ""
+) {
+    enum class Type {
+        /**
+         * The file is associated with a specific application type (MIME type of application e.g. .exe).
+         */
+        APPLICATION,
+
+        /**
+         * Indicates the file is an archive file.
+         */
+        ARCHIVE,
+
+        /**
+         * The file is associated with an audio file (MIME type of audio, e.g. .mp3).
+         */
+        AUDIO,
+
+        /**
+         * Indicates the file is not a text file.
+         */
+        BINARY,
+
+        /**
+         * The file serves as documentation.
+         */
+        DOCUMENTATION,
+
+        /**
+         * The file is associated with an picture image file (MIME type of image, e.g. .jpg, .gif).
+         */
+        IMAGE,
+
+        /**
+         * Indicates the file is not a source, archive or binary file.
+         */
+        OTHER,
+
+        /**
+         * Indicates the file is a source code file.
+         */
+        SOURCE,
+
+        /**
+         * The file is an SPDX document.
+         */
+        SPDX,
+
+        /**
+         * The file is a human readable text file (MIME type of text).
+         */
+        TEXT,
+
+        /**
+         * The file is associated with a video file (MIME type of video, e.g. .avi, .mkv, .mp4)
+         */
+        VIDEO;
+    }
+
+    init {
+        require(checksums.any { it.algorithm == SpdxChecksum.Algorithm.SHA1 }) {
+            "At least one SHA1 checksum must be provided."
+        }
+
+        require(copyrightText.isNotBlank()) { "The copyright text must not be blank." }
+
+        require(filename.isNotBlank()) { "The filename must not be blank." }
+
+        require(licenseConcluded.isSpdxExpressionOrNotPresent()) {
+            "The license concluded must be either an SpdxExpression, 'NONE' or 'NOASSERTION', but was " +
+                "$licenseConcluded."
+        }
+
+        // TODO: The check for [licenseInfoInFiles] can be made more strict, but the SPDX specification is not exact
+        // enough yet to do this safely.
+        licenseInfoInFiles.filterNot { it.isSpdxExpressionOrNotPresent() }.let {
+            require(it.isEmpty()) {
+                "The entries in licenseInfoInFiles must each be either an SpdxExpression, 'NONE' or 'NOASSERTION', " +
+                    "but found ${it.joinToString()}."
+            }
+        }
+    }
+}

--- a/spdx-utils/src/main/kotlin/model/SpdxPackage.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxPackage.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.spdx.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+import org.ossreviewtoolkit.spdx.isSpdxExpressionOrNotPresent
+
+/**
+ * Describes a software package.
+ */
+data class SpdxPackage(
+    /**
+     * A unique identifier for this [SpdxPackage] within a SPDX document.
+     */
+    @JsonProperty("SPDXID")
+    val spdxId: String,
+
+    /**
+     * The [SpdxAnnotation]s for the package.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val annotations: List<SpdxAnnotation> = emptyList(),
+
+    /**
+     * Acknowledgements for the package that may be required to be communicated in some contexts. This is not meant to
+     * include the package's actual complete license text, and may include copyright notices. The SPDX data creator
+     * may use this field to record other acknowledgements, such as particular clauses from license texts, which may be
+     * necessary or desirable to reproduce.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val attributionTexts: List<String> = emptyList(),
+
+    /**
+     * Checksums of the package.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val checksums: List<SpdxChecksum> = emptyList(),
+
+    /**
+     * Any general comments about the package.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val comment: String = "",
+
+    /**
+     * A text relating to a copyright notice, even if not complete. To represent a not present value
+     * [SpdxConstants.NONE] or [SpdxConstants.NOASSERTION] must be used.
+     */
+    val copyrightText: String,
+
+    /**
+     * A more detailed description of the package as opposed to [summary], which may be an extract from the package.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val description: String = "",
+
+    /**
+     * The download location as URL. To represent a not present value [SpdxConstants.NONE] or
+     * [SpdxConstants.NOASSERTION] must be used.
+     */
+    val downloadLocation: String,
+
+    /**
+     * References to external sources of additional information.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val externalRefs: List<SpdxExternalReference> = emptyList(),
+
+    /**
+     * Indicates whether the files contents of the package have been used for the creation of the associated
+     * [SpdxDocument].
+     */
+    val filesAnalyzed: Boolean = true,
+
+    /**
+     * The Spdx references to the files belonging to the package in the format "SPDXRef-${id-string}".
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val hasFiles: List<String> = emptyList(),
+
+    /**
+     * The homepage URL. To represent a not present value [SpdxConstants.NONE] or [SpdxConstants.NOASSERTION] must be
+     * used.
+     */
+    val homepage: String,
+
+    /**
+     * Any relevant background references or analysis that went in to arriving at the concluded License for the package.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val licenseComments: String = "",
+
+    /*
+     * The concluded license for the package as SPDX expression. To represent a not present value [SpdxConstants.NONE]
+     * or [SpdxConstants.NOASSERTION] must be used.
+     */
+    val licenseConcluded: String,
+
+    /**
+     * The declared license for the package as SPDX expression. To represent a not present value [SpdxConstants.NONE] or
+     * [SpdxConstants.NOASSERTION] must be used.
+     */
+    val licenseDeclared: String,
+
+    /**
+     * The license information found in the package as SPDX expression. To represent a not present value
+     * [SpdxConstants.NONE] or [SpdxConstants.NOASSERTION] must be used.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val licenseInfoFromFiles: List<String> = emptyList(),
+
+    /**
+     * The name of the package.
+     */
+    val name: String,
+
+    /**
+     * Identifies from where or whom the package originally came. The value must be a single line text in one of the
+     * following formats:
+     *
+     * 1. "Person: person name" or "Person: person name (email)"
+     * 2. "Organization: organization name" or "Organization: organization name (email)"
+     *
+     * TODO: Introduce a data type for above subjects.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val originator: String = "",
+
+    /**
+     * The actual file name of the package, or path of the directory being treated as a package.
+     */
+    @JsonProperty("packageFileName")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val packageFilename: String = "",
+
+    /**
+     * The [SpdxPackageVerificationCode] for the package.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val packageVerificationCode: SpdxPackageVerificationCode? = null,
+
+    /**
+     * Any relevant background information or additional comments about the origin of the package.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val sourceInfo: String = "",
+
+    /**
+     * A short description of the package.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val summary: String = "",
+
+    /**
+     * The distribution source for the package. The value must be a single line of text in one of the following formats:
+     *
+     * 1. "Person: person name" or "Person: person name (email)"
+     * 2. "Organization: organization name" or "Organization: organization name (email)"
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val supplier: String = "",
+
+    /**
+     * The version of the package.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val versionInfo: String = ""
+) {
+    init {
+        require(spdxId.isNotBlank()) { "The SPDX-Id must not be blank." }
+
+        require(copyrightText.isNotBlank()) { "The copyright text must not be blank." }
+
+        require(downloadLocation.isNotBlank()) { "The download location must not be blank." }
+
+        require(name.isNotBlank()) { "The name must not be blank." }
+
+        require(homepage.isNotBlank()) { "The homepage must not be blank." }
+
+        // TODO: The check for [licenseInfoFromFiles] can be made more strict, but the SPDX specification is not exact
+        // enough yet to do this safely.
+        licenseInfoFromFiles.filterNot { it.isSpdxExpressionOrNotPresent() }.let {
+            require(it.isEmpty()) {
+                "The entries in licenseInfoFromFiles must each be either an SpdxExpression, 'NONE' or 'NOASSERTION', " +
+                        "but found ${it.joinToString()}."
+            }
+        }
+    }
+}

--- a/spdx-utils/src/main/kotlin/model/SpdxPackageVerificationCode.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxPackageVerificationCode.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.spdx.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+/**
+ * A unique identifier based on the file contents of a package.
+ */
+data class SpdxPackageVerificationCode(
+    /**
+     * The list of file excluded from the package verification code calculation.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val packageVerificationCodeExcludedFiles: List<String> = emptyList(),
+
+    /**
+     * The package verification code value in lower case hexadecimal representation.
+     */
+    val packageVerificationCodeValue: String
+) {
+    init {
+        require(packageVerificationCodeValue.matches(SpdxChecksum.HEX_SYMBOLS_REGEX)) {
+            "The checksum value must only contain lower case hexadecimal digits."
+        }
+
+        require(SpdxChecksum.Algorithm.SHA1.checksumHexDigits == packageVerificationCodeValue.length) {
+            "Expected a checksum value with ${SpdxChecksum.Algorithm.SHA1.checksumHexDigits} hexadecimal digits, but " +
+                    "found ${packageVerificationCodeValue.length}."
+        }
+    }
+}

--- a/spdx-utils/src/main/kotlin/model/SpdxRelationship.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxRelationship.kt
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.spdx.model
+
+/**
+ * A relationship between two SPDX documents, packages or files.
+ */
+data class SpdxRelationship(
+    /**
+     * The source element of this directed relationship.
+     */
+    val spdxElementId: String,
+
+    /**
+     * The target element of this directed relationship.
+     */
+    val relatedSpdxElement: String,
+
+    /**
+     * The type of this relationship.
+     */
+    val relationshipType: Type
+) {
+    enum class Type {
+        /**
+         * Is to be used when (current) SPDXRef-DOCUMENT amends the SPDX information in SPDXRef-B.
+         */
+        AMENDS,
+
+        /**
+         * Is to be used when SPDXRef-A is an ancestor (same lineage but pre-dates) of SPDXRef-B.
+         */
+        ANCESTOR_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is a build dependency of SPDXRef-B.
+         */
+        BUILD_DEPENDENCY_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is used to build SPDXRef-B.
+         */
+        BUILD_TOOL_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is contained by SPDXRef-B.
+         */
+        CONTAINED_BY,
+
+        /**
+         * Is to be used when SPDXRef-A contains SPDXRef-B.
+         */
+        CONTAINS,
+
+        /**
+         * Is to be used when SPDXRef-A is an exact copy of SPDXRef-B.
+         */
+        COPY_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is a data file used in SPDXRef-B.
+         */
+        DATA_FILE_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is a manifest file that lists a set of dependencies for SPDXRef-B.
+         */
+        DEPENDENCY_MANIFEST_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is dependency of SPDXRef-B.
+         */
+        DEPENDENCY_OF,
+
+        /**
+         * Is to be used when SPDXRef-A depends on SPDXRef-B.
+         */
+        DEPENDS_ON,
+
+        /**
+         * Is to be used when SPDXRef-A is a descendant of (same lineage but postdates) SPDXRef-B.
+         */
+        DESCENDANT_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is described by SPDXREF-Document.
+         */
+        DESCRIBED_BY,
+
+        /**
+         * Is to be used when SPDXRef-DOCUMENT describes SPDXRef-A.
+         */
+        DESCRIBES,
+
+        /**
+         * Is to be used when SPDXRef-A is a development dependency of SPDXRef-B.
+         */
+        DEV_DEPENDENCY_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is used as a development tool for SPDXRef-B.
+         */
+        DEV_TOOL_OF,
+
+        /**
+         * Is to be used when distributing SPDXRef-A requires that SPDXRef-B also be distributed.
+         */
+        DISTRIBUTION_ARTIFACT,
+
+        /**
+         * Is to be used when SPDXRef-A provides documentation of SPDXRef-B.
+         */
+        DOCUMENTATION_OF,
+
+        /**
+         * Is to be used when SPDXRef-A dynamically links to SPDXRef-B.
+         */
+        DYNAMIC_LINK,
+
+        /**
+         * Is to be used when SPDXRef-A is an example of SPDXRef-B.
+         */
+        EXAMPLE_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is expanded from the archive SPDXRef-B.
+         */
+        EXPANDED_FROM_ARCHIVE,
+
+        /**
+         * Is to be used when SPDXRef-A is a file that was added to SPDXRef-B.
+         */
+        FILE_ADDED,
+
+        /**
+         * Is to be used when SPDXRef-A is a file that was deleted from SPDXRef-B.
+         */
+        FILE_DELETED,
+
+        /**
+         * Is to be used when SPDXRef-A is a file that was modified from SPDXRef-B.
+         */
+        FILE_MODIFIED,
+
+        /**
+         * Is to be used when SPDXRef-A was generated from SPDXRef-B.
+         */
+        GENERATED_FROM,
+
+        /**
+         * Is to be used when SPDXRef-A generates SPDXRef-B.
+         */
+        GENERATES,
+
+        /**
+         * Is to be used when SPDXRef-A has as a prerequisite SPDXRef-B.
+         */
+        HAS_PREREQUISITE,
+
+        /**
+         * Is to be used when SPDXRef-A is a metafile of SPDXRef-B.
+         */
+        METAFILE_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is an optional component of SPDXRef-B.
+         */
+        OPTIONAL_COMPONENT_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is an optional dependency of SPDXRef-B.
+         */
+        OPTIONAL_DEPENDENCY_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is used as a package as part of SPDXRef-B.
+         */
+        PACKAGE_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is a patch file that has been applied to SPDXRef-B.
+         */
+        PATCH_APPLIED,
+
+        /**
+         * Is to be used when SPDXRef-A is a patch file for (to be applied to) SPDXRef-B.
+         */
+        PATCH_FOR,
+
+        /**
+         * Is to be used when SPDXRef-A is a prerequisite for SPDXRef-B.
+         */
+        PREREQUISITE_FOR,
+
+        /**
+         * Is to be used when SPDXRef-A is a to be provided dependency of SPDXRef-B.
+         */
+        PROVIDED_DEPENDENCY_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is a dependency required for the execution of SPDXRef-B.
+         */
+        RUNTIME_DEPENDENCY_OF,
+
+        /**
+         * Is to be used when SPDXRef-A statically links to SPDXRef-B.
+         */
+        STATIC_LINK,
+
+        /**
+         * Is to be used when SPDXRef-A is a test case used in testing SPDXRef-B.
+         */
+        TEST_CASE_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is a test dependency of SPDXRef-B.
+         */
+        TEST_DEPENDENCY_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is used for testing SPDXRef-B.
+         */
+        TEST_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is used as a test tool for SPDXRef-B.
+         */
+        TEST_TOOL_OF,
+
+        /**
+         * Is to be used when SPDXRef-A is a variant of (same lineage but not clear which came first) SPDXRef-B.
+         */
+        VARIANT_OF;
+    }
+
+    init {
+        require(spdxElementId.isNotBlank()) {
+            "The SPDX element Id must not be blank."
+        }
+
+        require(relatedSpdxElement.isNotBlank()) {
+            "The related SPDX element must not be blank."
+        }
+    }
+}

--- a/spdx-utils/src/main/kotlin/model/SpdxSnippet.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxSnippet.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.spdx.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+import org.ossreviewtoolkit.spdx.isSpdxExpressionOrNotPresent
+
+/**
+ * A Snippet can be used when a file is known to have some content that has been included from another original source.
+ * It can be used to denote when a part of a file may have been originally created under another license.
+ */
+@JsonIgnoreProperties("ranges") // TODO: Implement ranges which is broken in the specification examples.
+data class SpdxSnippet(
+    /**
+     * The unique identifies of this [SpdxSnippet] within a SPDX document.
+     */
+    @JsonProperty("SPDXID")
+    val spdxId: String,
+
+    /**
+     * A general comment about the snippet.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val comment: String = "",
+
+    /**
+     * The copyright text containing the copyright holder of the snippet and the copyright dates if present
+     * respectively. Ideally this text is extracted from the actual snippet. To represent a not present value
+     * [SpdxConstants.NONE] or [SpdxConstants.NOASSERTION] must be used.
+     */
+    val copyrightText: String,
+
+    /**
+     * Any relevant background references or analysis that went in to arriving at the concluded License for the file.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val licenseComments: String = "",
+
+    /**
+     * The concluded license as SPDX expression. To represent a not present value [SpdxConstants.NONE] or
+     * [SpdxConstants.NOASSERTION] must be used.
+     */
+    val licenseConcluded: String,
+
+    /**
+     * The license information found in this file. To represent a not present value [SpdxConstants.NONE] or
+     * [SpdxConstants.NOASSERTION] must be used.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val licenseInfoInSnippets: List<String> = emptyList(),
+
+    /**
+     * A name for the snippet in a human convenient manner.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val name: String = "",
+
+    /**
+     * The SPDX reference referencing the document within the SpdxDocument containing the snippet.
+     */
+    val snippetFromFile: String
+) {
+    init {
+        require(copyrightText.isNotBlank()) {
+            "The copyright text must not be blank."
+        }
+
+        require(licenseConcluded.isSpdxExpressionOrNotPresent()) {
+            "The license concluded must be either an SpdxExpression, 'NONE' or 'NOASSERTION', but was " +
+                "$licenseConcluded."
+        }
+
+        // TODO: The check for [licenseInfoInSnippets] can be made more strict, but the SPDX specification is not exact
+        // enough yet to do this safely.
+        licenseInfoInSnippets.filterNot { it.isSpdxExpressionOrNotPresent() }.let { invalidEntries ->
+            require(invalidEntries.isEmpty()) {
+                "The entries in licenseInfoInSnippets must each be either an SpdxExpression, 'NONE' or " +
+                        "'NOASSERTION', but found ${invalidEntries.joinToString()}."
+            }
+        }
+
+        require(snippetFromFile.isNotBlank()) {
+            "The snippet from file must not be blank."
+        }
+    }
+}

--- a/spdx-utils/src/test/kotlin/SpdxDocumentModelTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxDocumentModelTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.spdx
+
+import com.fasterxml.jackson.databind.ObjectMapper
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.spdx.model.SpdxDocument
+
+private fun format(value: String, mapper: ObjectMapper): String =
+    mapper.readTree(value).let { node ->
+        mapper.writeValueAsString(node)
+    }
+
+private fun formatYaml(yaml: String): String = format(yaml, SpdxModelSerializer.yamlMapper)
+
+private fun formatJson(json: String): String = format(json, SpdxModelSerializer.jsonMapper)
+
+private fun readResourceAsText(resourceFile: String): String =
+    SpdxDocumentModelTest::class.java.getResource(resourceFile).readText()
+
+/**
+ * This test uses the following test assets copied from the SPDX 2.2.1 specification examples.
+ *
+ * 1. https://github.com/spdx/spdx-spec/blob/development/v2.2.1/examples/SPDXYAMLExample-2.2.spdx.yaml
+ * 2. https://github.com/spdx/spdx-spec/blob/development/v2.2.1/examples/SPDXJSONExample-v2.2.spdx.json
+ *
+ * The "*-no-ranges*" resource files have the 'ranges' property removed, which is actually broken in specification and
+ * thus impossible to implement.
+ */
+class SpdxDocumentModelTest : WordSpec({
+    "The official YAML example from the SPDX specification version 2.2" should {
+        "be deserializable" {
+            val yaml = readResourceAsText("/spdx-spec-examples/SPDXYAMLExample-2.2.spdx.yaml")
+
+            SpdxModelSerializer.fromYaml(yaml, SpdxDocument::class.java)
+        }
+    }
+
+    "The official YAML example without ranges from the SPDX specification version 2.2" should {
+        "have idempotent (de)-serialization" {
+            val yaml = readResourceAsText("/spdx-spec-examples/SPDXYAMLExample-2.2-no-ranges.spdx.yaml")
+
+            val document = SpdxModelSerializer.fromYaml(yaml, SpdxDocument::class.java)
+            val serializedYaml = SpdxModelSerializer.toYaml(document)
+
+            serializedYaml shouldBe formatYaml(yaml)
+        }
+    }
+
+    "The official JSON example from the SPDX specification version 2.2" should {
+        "be deserializable" {
+            val json = readResourceAsText("/spdx-spec-examples/SPDXJSONExample-v2.2.spdx.json")
+
+            SpdxModelSerializer.fromJson(json, SpdxDocument::class.java)
+        }
+    }
+
+    "The official JSON example without ranges from the SPDX specification version 2.2" should {
+        "have idempotent (de-)serialization" {
+            val json = readResourceAsText("/spdx-spec-examples/SPDXJSONExample-v2.2-no-ranges.spdx.json")
+
+            val document = SpdxModelSerializer.fromJson(json, SpdxDocument::class.java)
+            val serializedJson = SpdxModelSerializer.toJson(document)
+
+            serializedJson shouldBe formatJson(json)
+        }
+    }
+})

--- a/spdx-utils/src/test/resources/spdx-spec-examples/SPDXJSONExample-v2.2-no-ranges.spdx.json
+++ b/spdx-utils/src/test/resources/spdx-spec-examples/SPDXJSONExample-v2.2-no-ranges.spdx.json
@@ -1,0 +1,260 @@
+{
+  "SPDXID" : "SPDXRef-DOCUMENT",
+  "spdxVersion" : "SPDX-2.2",
+  "creationInfo" : {
+    "comment" : "This package has been shipped in source and binary form.\nThe binaries were created with gcc 4.5.1 and expect to link to\ncompatible system run time libraries.",
+    "created" : "2010-01-29T18:30:22Z",
+    "creators" : [ "Tool: LicenseFind-1.0", "Organization: ExampleCodeInspect ()", "Person: Jane Doe ()" ],
+    "licenseListVersion" : "3.9"
+  },
+  "name" : "SPDX-Tools-v2.0",
+  "dataLicense" : "CC0-1.0",
+  "comment" : "This document was created using SPDX 2.0 using licenses from the web site.",
+  "externalDocumentRefs" : [ {
+    "externalDocumentId" : "DocumentRef-spdx-tool-1.2",
+    "checksum" : {
+      "algorithm" : "SHA1",
+      "checksumValue" : "d6a770ba38583ed4bb4525bd96e50461655d2759"
+    },
+    "spdxDocument" : "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301"
+  } ],
+  "hasExtractedLicensingInfos" : [ {
+    "extractedText" : "\"THE BEER-WARE LICENSE\" (Revision 42):\nphk@FreeBSD.ORG wrote this file. As long as you retain this notice you\ncan do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a beer in return Poul-Henning Kamp  </\nLicenseName: Beer-Ware License (Version 42)\nLicenseCrossReference:  http://people.freebsd.org/~phk/\nLicenseComment: \nThe beerware license has a couple of other standard variants.",
+    "licenseId" : "LicenseRef-Beerware-4.2"
+  }, {
+    "extractedText" : "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n*/",
+    "licenseId" : "LicenseRef-4"
+  }, {
+    "comment" : "This is tye CyperNeko License",
+    "extractedText" : "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.",
+    "licenseId" : "LicenseRef-3",
+    "name" : "CyberNeko License",
+    "seeAlsos" : [ "http://people.apache.org/~andyc/neko/LICENSE", "http://justasample.url.com" ]
+  }, {
+    "extractedText" : "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n� Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.",
+    "licenseId" : "LicenseRef-2"
+  }, {
+    "extractedText" : "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n*/",
+    "licenseId" : "LicenseRef-1"
+  } ],
+  "annotations" : [ {
+    "annotationDate" : "2010-01-29T18:30:22Z",
+    "annotationType" : "OTHER",
+    "annotator" : "Person: Jane Doe ()",
+    "comment" : "Document level annotation"
+  }, {
+    "annotationDate" : "2011-03-13T00:00:00Z",
+    "annotationType" : "REVIEW",
+    "annotator" : "Person: Suzanne Reviewer",
+    "comment" : "Another example reviewer."
+  }, {
+    "annotationDate" : "2010-02-10T00:00:00Z",
+    "annotationType" : "REVIEW",
+    "annotator" : "Person: Joe Reviewer",
+    "comment" : "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses"
+  } ],
+  "documentNamespace" : "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301",
+  "documentDescribes" : [ "SPDXRef-File", "SPDXRef-Package" ],
+  "packages" : [ {
+    "SPDXID" : "SPDXRef-Package",
+    "annotations" : [ {
+      "annotationDate" : "2011-01-29T18:30:22Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Person: Package Commenter",
+      "comment" : "Package level annotation"
+    } ],
+    "attributionTexts" : [ "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually." ],
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "85ed0817af83a24ad8da68c2b5094de69833983c"
+    }, {
+      "algorithm" : "MD5",
+      "checksumValue" : "624c1abb3664f4b35547e7c73864ad24"
+    }, {
+      "algorithm" : "SHA256",
+      "checksumValue" : "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
+    } ],
+    "copyrightText" : "Copyright 2008-2010 John Smith",
+    "description" : "The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.",
+    "downloadLocation" : "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz",
+    "externalRefs" : [ {
+      "comment" : "This is the external ref for Acme",
+      "referenceCategory" : "OTHER",
+      "referenceLocator" : "acmecorp/acmenator/4.1.3-alpha",
+      "referenceType" : "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge"
+    }, {
+      "referenceCategory" : "SECURITY",
+      "referenceLocator" : "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*",
+      "referenceType" : "http://spdx.org/rdf/references/cpe23Type"
+    } ],
+    "filesAnalyzed" : true,
+    "hasFiles" : [ "SPDXRef-JenaLib", "SPDXRef-DoapSource", "SPDXRef-CommonsLangSrc" ],
+    "homepage" : "http://ftp.gnu.org/gnu/glibc",
+    "licenseComments" : "The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change.",
+    "licenseConcluded" : "(LGPL-2.0-only OR LicenseRef-3)",
+    "licenseDeclared" : "(LGPL-2.0-only AND LicenseRef-3)",
+    "licenseInfoFromFiles" : [ "GPL-2.0-only", "LicenseRef-2", "LicenseRef-1" ],
+    "name" : "glibc",
+    "originator" : "Organization: ExampleCodeInspect (contact@example.com)",
+    "packageFileName" : "glibc-2.11.1.tar.gz",
+    "packageVerificationCode" : {
+      "packageVerificationCodeExcludedFiles" : [ "./package.spdx" ],
+      "packageVerificationCodeValue" : "d6a770ba38583ed4bb4525bd96e50461655d2758"
+    },
+    "sourceInfo" : "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.",
+    "summary" : "GNU C library.",
+    "supplier" : "Person: Jane Doe (jane.doe@example.com)",
+    "versionInfo" : "2.11.1"
+  }, {
+    "SPDXID" : "SPDXRef-fromDoap-1",
+    "comment" : "This package was converted from a DOAP Project by the same name",
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "filesAnalyzed" : false,
+    "homepage" : "http://commons.apache.org/proper/commons-lang/",
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "Apache Commons Lang"
+  }, {
+    "SPDXID" : "SPDXRef-fromDoap-0",
+    "comment" : "This package was converted from a DOAP Project by the same name",
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "filesAnalyzed" : false,
+    "homepage" : "http://www.openjena.org/",
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "Jena"
+  }, {
+    "SPDXID" : "SPDXRef-Saxon",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "85ed0817af83a24ad8da68c2b5094de69833983c"
+    } ],
+    "copyrightText" : "Copyright Saxonica Ltd",
+    "description" : "The Saxon package is a collection of tools for processing XML documents.",
+    "downloadLocation" : "https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download",
+    "filesAnalyzed" : false,
+    "homepage" : "http://saxon.sourceforge.net/",
+    "licenseComments" : "Other versions available for a commercial license",
+    "licenseConcluded" : "MPL-1.0",
+    "licenseDeclared" : "MPL-1.0",
+    "name" : "Saxon",
+    "packageFileName" : "saxonB-8.8.zip",
+    "versionInfo" : "8.8"
+  } ],
+  "files" : [ {
+    "SPDXID" : "SPDXRef-DoapSource",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+    } ],
+    "copyrightText" : "Copyright 2010, 2011 Source Auditor Inc.",
+    "fileContributors" : [ "Protecode Inc.", "SPDX Technical Team Members", "Open Logic Inc.", "Source Auditor Inc.", "Black Duck Software In.c" ],
+    "fileDependencies" : [ "SPDXRef-JenaLib", "SPDXRef-CommonsLangSrc" ],
+    "fileName" : "./src/org/spdx/parser/DOAPProject.java",
+    "fileTypes" : [ "SOURCE" ],
+    "licenseConcluded" : "Apache-2.0",
+    "licenseInfoInFiles" : [ "Apache-2.0" ]
+  }, {
+    "SPDXID" : "SPDXRef-CommonsLangSrc",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+    } ],
+    "comment" : "This file is used by Jena",
+    "copyrightText" : "Copyright 2001-2011 The Apache Software Foundation",
+    "fileContributors" : [ "Apache Software Foundation" ],
+    "fileName" : "./lib-source/commons-lang3-3.1-sources.jar",
+    "fileTypes" : [ "ARCHIVE" ],
+    "licenseConcluded" : "Apache-2.0",
+    "licenseInfoInFiles" : [ "Apache-2.0" ],
+    "noticeText" : "Apache Commons Lang\nCopyright 2001-2011 The Apache Software Foundation\n\nThis product includes software developed by\nThe Apache Software Foundation (http://www.apache.org/).\n\nThis product includes software from the Spring Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())"
+  }, {
+    "SPDXID" : "SPDXRef-JenaLib",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+    } ],
+    "comment" : "This file belongs to Jena",
+    "copyrightText" : "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP",
+    "fileContributors" : [ "Apache Software Foundation", "Hewlett Packard Inc." ],
+    "fileDependencies" : [ "SPDXRef-CommonsLangSrc" ],
+    "fileName" : "./lib-source/jena-2.6.3-sources.jar",
+    "fileTypes" : [ "ARCHIVE" ],
+    "licenseComments" : "This license is used by Jena",
+    "licenseConcluded" : "LicenseRef-1",
+    "licenseInfoInFiles" : [ "LicenseRef-1" ]
+  }, {
+    "SPDXID" : "SPDXRef-File",
+    "annotations" : [ {
+      "annotationDate" : "2011-01-29T18:30:22Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Person: File Commenter",
+      "comment" : "File level annotation"
+    } ],
+    "checksums" : [ {
+      "algorithm" : "MD5",
+      "checksumValue" : "624c1abb3664f4b35547e7c73864ad24"
+    }, {
+      "algorithm" : "SHA1",
+      "checksumValue" : "d6a770ba38583ed4bb4525bd96e50461655d2758"
+    } ],
+    "comment" : "The concluded license was taken from the package level that the file was included in.\nThis information was found in the COPYING.txt file in the xyz directory.",
+    "copyrightText" : "Copyright 2008-2010 John Smith",
+    "fileContributors" : [ "The Regents of the University of California", "Modified by Paul Mundt lethal@linux-sh.org", "IBM Corporation" ],
+    "fileName" : "./package/foo.c",
+    "fileTypes" : [ "SOURCE" ],
+    "licenseComments" : "The concluded license was taken from the package level that the file was included in.",
+    "licenseConcluded" : "(LGPL-2.0-only OR LicenseRef-2)",
+    "licenseInfoInFiles" : [ "GPL-2.0-only", "LicenseRef-2" ],
+    "noticeText" : "Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the �Software�), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: \nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED �AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+  } ],
+  "snippets" : [ {
+    "SPDXID" : "SPDXRef-Snippet",
+    "comment" : "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0.",
+    "copyrightText" : "Copyright 2008-2010 John Smith",
+    "licenseComments" : "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.",
+    "licenseConcluded" : "GPL-2.0-only",
+    "licenseInfoInSnippets" : [ "GPL-2.0-only" ],
+    "name" : "from linux kernel",
+    "snippetFromFile" : "SPDXRef-DoapSource"
+  } ],
+  "relationships" : [ {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-File",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement",
+    "relationshipType" : "COPY_OF"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-Saxon",
+    "relationshipType" : "DYNAMIC_LINK"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-JenaLib",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-CommonsLangSrc",
+    "relatedSpdxElement" : "NOASSERTION",
+    "relationshipType" : "GENERATED_FROM"
+  }, {
+    "spdxElementId" : "SPDXRef-JenaLib",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-File",
+    "relatedSpdxElement" : "SPDXRef-fromDoap-0",
+    "relationshipType" : "GENERATED_FROM"
+  } ]
+}

--- a/spdx-utils/src/test/resources/spdx-spec-examples/SPDXJSONExample-v2.2.spdx.json
+++ b/spdx-utils/src/test/resources/spdx-spec-examples/SPDXJSONExample-v2.2.spdx.json
@@ -1,0 +1,279 @@
+{
+  "SPDXID" : "SPDXRef-DOCUMENT",
+  "spdxVersion" : "SPDX-2.2",
+  "creationInfo" : {
+    "comment" : "This package has been shipped in source and binary form.\nThe binaries were created with gcc 4.5.1 and expect to link to\ncompatible system run time libraries.",
+    "created" : "2010-01-29T18:30:22Z",
+    "creators" : [ "Tool: LicenseFind-1.0", "Organization: ExampleCodeInspect ()", "Person: Jane Doe ()" ],
+    "licenseListVersion" : "3.9"
+  },
+  "name" : "SPDX-Tools-v2.0",
+  "dataLicense" : "CC0-1.0",
+  "comment" : "This document was created using SPDX 2.0 using licenses from the web site.",
+  "externalDocumentRefs" : [ {
+    "externalDocumentId" : "DocumentRef-spdx-tool-1.2",
+    "checksum" : {
+      "algorithm" : "SHA1",
+      "checksumValue" : "d6a770ba38583ed4bb4525bd96e50461655d2759"
+    },
+    "spdxDocument" : "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301"
+  } ],
+  "hasExtractedLicensingInfos" : [ {
+    "extractedText" : "\"THE BEER-WARE LICENSE\" (Revision 42):\nphk@FreeBSD.ORG wrote this file. As long as you retain this notice you\ncan do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a beer in return Poul-Henning Kamp  </\nLicenseName: Beer-Ware License (Version 42)\nLicenseCrossReference:  http://people.freebsd.org/~phk/\nLicenseComment: \nThe beerware license has a couple of other standard variants.",
+    "licenseId" : "LicenseRef-Beerware-4.2"
+  }, {
+    "extractedText" : "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n*/",
+    "licenseId" : "LicenseRef-4"
+  }, {
+    "comment" : "This is tye CyperNeko License",
+    "extractedText" : "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.",
+    "licenseId" : "LicenseRef-3",
+    "name" : "CyberNeko License",
+    "seeAlsos" : [ "http://people.apache.org/~andyc/neko/LICENSE", "http://justasample.url.com" ]
+  }, {
+    "extractedText" : "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n� Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.",
+    "licenseId" : "LicenseRef-2"
+  }, {
+    "extractedText" : "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n*/",
+    "licenseId" : "LicenseRef-1"
+  } ],
+  "annotations" : [ {
+    "annotationDate" : "2010-01-29T18:30:22Z",
+    "annotationType" : "OTHER",
+    "annotator" : "Person: Jane Doe ()",
+    "comment" : "Document level annotation"
+  }, {
+    "annotationDate" : "2011-03-13T00:00:00Z",
+    "annotationType" : "REVIEW",
+    "annotator" : "Person: Suzanne Reviewer",
+    "comment" : "Another example reviewer."
+  }, {
+    "annotationDate" : "2010-02-10T00:00:00Z",
+    "annotationType" : "REVIEW",
+    "annotator" : "Person: Joe Reviewer",
+    "comment" : "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses"
+  } ],
+  "documentNamespace" : "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301",
+  "documentDescribes" : [ "SPDXRef-File", "SPDXRef-Package" ],
+  "packages" : [ {
+    "SPDXID" : "SPDXRef-Package",
+    "annotations" : [ {
+      "annotationDate" : "2011-01-29T18:30:22Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Person: Package Commenter",
+      "comment" : "Package level annotation"
+    } ],
+    "attributionTexts" : [ "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually." ],
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "85ed0817af83a24ad8da68c2b5094de69833983c"
+    }, {
+      "algorithm" : "MD5",
+      "checksumValue" : "624c1abb3664f4b35547e7c73864ad24"
+    }, {
+      "algorithm" : "SHA256",
+      "checksumValue" : "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
+    } ],
+    "copyrightText" : "Copyright 2008-2010 John Smith",
+    "description" : "The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.",
+    "downloadLocation" : "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz",
+    "externalRefs" : [ {
+      "comment" : "This is the external ref for Acme",
+      "referenceCategory" : "OTHER",
+      "referenceLocator" : "acmecorp/acmenator/4.1.3-alpha",
+      "referenceType" : "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge"
+    }, {
+      "referenceCategory" : "SECURITY",
+      "referenceLocator" : "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*",
+      "referenceType" : "http://spdx.org/rdf/references/cpe23Type"
+    } ],
+    "filesAnalyzed" : true,
+    "hasFiles" : [ "SPDXRef-JenaLib", "SPDXRef-DoapSource", "SPDXRef-CommonsLangSrc" ],
+    "homepage" : "http://ftp.gnu.org/gnu/glibc",
+    "licenseComments" : "The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change.",
+    "licenseConcluded" : "(LGPL-2.0-only OR LicenseRef-3)",
+    "licenseDeclared" : "(LGPL-2.0-only AND LicenseRef-3)",
+    "licenseInfoFromFiles" : [ "GPL-2.0-only", "LicenseRef-2", "LicenseRef-1" ],
+    "name" : "glibc",
+    "originator" : "Organization: ExampleCodeInspect (contact@example.com)",
+    "packageFileName" : "glibc-2.11.1.tar.gz",
+    "packageVerificationCode" : {
+      "packageVerificationCodeExcludedFiles" : [ "./package.spdx" ],
+      "packageVerificationCodeValue" : "d6a770ba38583ed4bb4525bd96e50461655d2758"
+    },
+    "sourceInfo" : "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.",
+    "summary" : "GNU C library.",
+    "supplier" : "Person: Jane Doe (jane.doe@example.com)",
+    "versionInfo" : "2.11.1"
+  }, {
+    "SPDXID" : "SPDXRef-fromDoap-1",
+    "comment" : "This package was converted from a DOAP Project by the same name",
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "filesAnalyzed" : false,
+    "homepage" : "http://commons.apache.org/proper/commons-lang/",
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "Apache Commons Lang"
+  }, {
+    "SPDXID" : "SPDXRef-fromDoap-0",
+    "comment" : "This package was converted from a DOAP Project by the same name",
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "filesAnalyzed" : false,
+    "homepage" : "http://www.openjena.org/",
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "Jena"
+  }, {
+    "SPDXID" : "SPDXRef-Saxon",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "85ed0817af83a24ad8da68c2b5094de69833983c"
+    } ],
+    "copyrightText" : "Copyright Saxonica Ltd",
+    "description" : "The Saxon package is a collection of tools for processing XML documents.",
+    "downloadLocation" : "https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download",
+    "filesAnalyzed" : false,
+    "homepage" : "http://saxon.sourceforge.net/",
+    "licenseComments" : "Other versions available for a commercial license",
+    "licenseConcluded" : "MPL-1.0",
+    "licenseDeclared" : "MPL-1.0",
+    "name" : "Saxon",
+    "packageFileName" : "saxonB-8.8.zip",
+    "versionInfo" : "8.8"
+  } ],
+  "files" : [ {
+    "SPDXID" : "SPDXRef-DoapSource",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+    } ],
+    "copyrightText" : "Copyright 2010, 2011 Source Auditor Inc.",
+    "fileContributors" : [ "Protecode Inc.", "SPDX Technical Team Members", "Open Logic Inc.", "Source Auditor Inc.", "Black Duck Software In.c" ],
+    "fileDependencies" : [ "SPDXRef-JenaLib", "SPDXRef-CommonsLangSrc" ],
+    "fileName" : "./src/org/spdx/parser/DOAPProject.java",
+    "fileTypes" : [ "SOURCE" ],
+    "licenseConcluded" : "Apache-2.0",
+    "licenseInfoInFiles" : [ "Apache-2.0" ]
+  }, {
+    "SPDXID" : "SPDXRef-CommonsLangSrc",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+    } ],
+    "comment" : "This file is used by Jena",
+    "copyrightText" : "Copyright 2001-2011 The Apache Software Foundation",
+    "fileContributors" : [ "Apache Software Foundation" ],
+    "fileName" : "./lib-source/commons-lang3-3.1-sources.jar",
+    "fileTypes" : [ "ARCHIVE" ],
+    "licenseConcluded" : "Apache-2.0",
+    "licenseInfoInFiles" : [ "Apache-2.0" ],
+    "noticeText" : "Apache Commons Lang\nCopyright 2001-2011 The Apache Software Foundation\n\nThis product includes software developed by\nThe Apache Software Foundation (http://www.apache.org/).\n\nThis product includes software from the Spring Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())"
+  }, {
+    "SPDXID" : "SPDXRef-JenaLib",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+    } ],
+    "comment" : "This file belongs to Jena",
+    "copyrightText" : "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP",
+    "fileContributors" : [ "Apache Software Foundation", "Hewlett Packard Inc." ],
+    "fileDependencies" : [ "SPDXRef-CommonsLangSrc" ],
+    "fileName" : "./lib-source/jena-2.6.3-sources.jar",
+    "fileTypes" : [ "ARCHIVE" ],
+    "licenseComments" : "This license is used by Jena",
+    "licenseConcluded" : "LicenseRef-1",
+    "licenseInfoInFiles" : [ "LicenseRef-1" ]
+  }, {
+    "SPDXID" : "SPDXRef-File",
+    "annotations" : [ {
+      "annotationDate" : "2011-01-29T18:30:22Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Person: File Commenter",
+      "comment" : "File level annotation"
+    } ],
+    "checksums" : [ {
+      "algorithm" : "MD5",
+      "checksumValue" : "624c1abb3664f4b35547e7c73864ad24"
+    }, {
+      "algorithm" : "SHA1",
+      "checksumValue" : "d6a770ba38583ed4bb4525bd96e50461655d2758"
+    } ],
+    "comment" : "The concluded license was taken from the package level that the file was included in.\nThis information was found in the COPYING.txt file in the xyz directory.",
+    "copyrightText" : "Copyright 2008-2010 John Smith",
+    "fileContributors" : [ "The Regents of the University of California", "Modified by Paul Mundt lethal@linux-sh.org", "IBM Corporation" ],
+    "fileName" : "./package/foo.c",
+    "fileTypes" : [ "SOURCE" ],
+    "licenseComments" : "The concluded license was taken from the package level that the file was included in.",
+    "licenseConcluded" : "(LGPL-2.0-only OR LicenseRef-2)",
+    "licenseInfoInFiles" : [ "GPL-2.0-only", "LicenseRef-2" ],
+    "noticeText" : "Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the �Software�), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: \nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED �AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+  } ],
+  "snippets" : [ {
+    "SPDXID" : "SPDXRef-Snippet",
+    "comment" : "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0.",
+    "copyrightText" : "Copyright 2008-2010 John Smith",
+    "licenseComments" : "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.",
+    "licenseConcluded" : "GPL-2.0-only",
+    "licenseInfoInSnippets" : [ "GPL-2.0-only" ],
+    "name" : "from linux kernel",
+    "ranges" : [ {
+      "endPointer" : {
+        "lineNumber" : 23,
+        "reference" : "SPDXRef-DoapSource"
+      },
+      "startPointer" : {
+        "lineNumber" : 5,
+        "reference" : "SPDXRef-DoapSource"
+      }
+    }, {
+      "endPointer" : {
+        "offset" : 420,
+        "reference" : "SPDXRef-DoapSource"
+      },
+      "startPointer" : {
+        "offset" : 310,
+        "reference" : "SPDXRef-DoapSource"
+      }
+    } ],
+    "snippetFromFile" : "SPDXRef-DoapSource"
+  } ],
+  "relationships" : [ {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-File",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement",
+    "relationshipType" : "COPY_OF"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-Saxon",
+    "relationshipType" : "DYNAMIC_LINK"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-JenaLib",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-CommonsLangSrc",
+    "relatedSpdxElement" : "NOASSERTION",
+    "relationshipType" : "GENERATED_FROM"
+  }, {
+    "spdxElementId" : "SPDXRef-JenaLib",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-File",
+    "relatedSpdxElement" : "SPDXRef-fromDoap-0",
+    "relationshipType" : "GENERATED_FROM"
+  } ]
+}

--- a/spdx-utils/src/test/resources/spdx-spec-examples/SPDXYAMLExample-2.2-no-ranges.spdx.yaml
+++ b/spdx-utils/src/test/resources/spdx-spec-examples/SPDXYAMLExample-2.2-no-ranges.spdx.yaml
@@ -1,0 +1,377 @@
+---
+SPDXID: "SPDXRef-DOCUMENT"
+spdxVersion: "SPDX-2.2"
+creationInfo:
+  comment: "This package has been shipped in source and binary form.\nThe binaries\
+    \ were created with gcc 4.5.1 and expect to link to\ncompatible system run time\
+    \ libraries."
+  created: "2010-01-29T18:30:22Z"
+  creators:
+    - "Tool: LicenseFind-1.0"
+    - "Organization: ExampleCodeInspect ()"
+    - "Person: Jane Doe ()"
+  licenseListVersion: "3.9"
+name: "SPDX-Tools-v2.0"
+dataLicense: "CC0-1.0"
+comment: "This document was created using SPDX 2.0 using licenses from the web site."
+externalDocumentRefs:
+  - externalDocumentId: "DocumentRef-spdx-tool-1.2"
+    checksum:
+      algorithm: "SHA1"
+      checksumValue: "d6a770ba38583ed4bb4525bd96e50461655d2759"
+    spdxDocument: "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301"
+hasExtractedLicensingInfos:
+  - extractedText: "\"THE BEER-WARE LICENSE\" (Revision 42):\nphk@FreeBSD.ORG wrote\
+    \ this file. As long as you retain this notice you\ncan do whatever you want with\
+    \ this stuff. If we meet some day, and you think this stuff is worth it, you can\
+    \ buy me a beer in return Poul-Henning Kamp  </\nLicenseName: Beer-Ware License\
+    \ (Version 42)\nLicenseCrossReference:  http://people.freebsd.org/~phk/\nLicenseComment:\
+    \ \nThe beerware license has a couple of other standard variants."
+    licenseId: "LicenseRef-Beerware-4.2"
+  - extractedText: "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n\
+    \ *\n * Redistribution and use in source and binary forms, with or without\n *\
+    \ modification, are permitted provided that the following conditions\n * are met:\n\
+    \ * 1. Redistributions of source code must retain the above copyright\n *    notice,\
+    \ this list of conditions and the following disclaimer.\n * 2. Redistributions\
+    \ in binary form must reproduce the above copyright\n *    notice, this list of\
+    \ conditions and the following disclaimer in the\n *    documentation and/or other\
+    \ materials provided with the distribution.\n * 3. The name of the author may\
+    \ not be used to endorse or promote products\n *    derived from this software\
+    \ without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED\
+    \ BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING,\
+    \ BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS\
+    \ FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE\
+    \ LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\
+    \ DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS\
+    \ OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\
+    \ CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\
+    \ OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE\
+    \ USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\
+    */"
+    licenseId: "LicenseRef-4"
+  - comment: "This is tye CyperNeko License"
+    extractedText: "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright\
+    \ 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source\
+    \ and binary forms, with or without\nmodification, are permitted provided that\
+    \ the following conditions\nare met:\n\n1. Redistributions of source code must\
+    \ retain the above copyright\n   notice, this list of conditions and the following\
+    \ disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n\
+    \   notice, this list of conditions and the following disclaimer in\n   the documentation\
+    \ and/or other materials provided with the\n   distribution.\n\n3. The end-user\
+    \ documentation included with the redistribution,\n   if any, must include the\
+    \ following acknowledgment:  \n     \"This product includes software developed\
+    \ by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software\
+    \ itself,\n   if and wherever such third-party acknowledgments normally appear.\n\
+    \n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n  \
+    \ or promote products derived from this software without prior \n   written permission.\
+    \ For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products\
+    \ derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\"\
+    \ appear in their name, without prior written\n   permission of the author.\n\n\
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES,\
+    \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND\
+    \ FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR\
+    \ OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,\
+    \ EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT\
+    \ \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS\
+    \ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT,\
+    \ STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY\
+    \ WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF\
+    \ SUCH DAMAGE."
+    licenseId: "LicenseRef-3"
+    name: "CyberNeko License"
+    seeAlsos:
+      - "http://people.apache.org/~andyc/neko/LICENSE"
+      - "http://justasample.url.com"
+  - extractedText: "This package includes the GRDDL parser developed by Hewlett Packard\
+    \ under the following license:\n� Copyright 2007 Hewlett-Packard Development Company,\
+    \ LP\n\nRedistribution and use in source and binary forms, with or without modification,\
+    \ are permitted provided that the following conditions are met: \n\nRedistributions\
+    \ of source code must retain the above copyright notice, this list of conditions\
+    \ and the following disclaimer. \nRedistributions in binary form must reproduce\
+    \ the above copyright notice, this list of conditions and the following disclaimer\
+    \ in the documentation and/or other materials provided with the distribution.\
+    \ \nThe name of the author may not be used to endorse or promote products derived\
+    \ from this software without specific prior written permission. \nTHIS SOFTWARE\
+    \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,\
+    \ BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\
+    \ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE\
+    \ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES\
+    \ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;\
+    \ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND\
+    \ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING\
+    \ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,\
+    \ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    licenseId: "LicenseRef-2"
+  - extractedText: "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,\
+    \ 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n\
+    \ *\n * Redistribution and use in source and binary forms, with or without\n *\
+    \ modification, are permitted provided that the following conditions\n * are met:\n\
+    \ * 1. Redistributions of source code must retain the above copyright\n *    notice,\
+    \ this list of conditions and the following disclaimer.\n * 2. Redistributions\
+    \ in binary form must reproduce the above copyright\n *    notice, this list of\
+    \ conditions and the following disclaimer in the\n *    documentation and/or other\
+    \ materials provided with the distribution.\n * 3. The name of the author may\
+    \ not be used to endorse or promote products\n *    derived from this software\
+    \ without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED\
+    \ BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING,\
+    \ BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS\
+    \ FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE\
+    \ LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\
+    \ DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS\
+    \ OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\
+    \ CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\
+    \ OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE\
+    \ USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\
+    */"
+    licenseId: "LicenseRef-1"
+annotations:
+  - annotationDate: "2011-03-13T00:00:00Z"
+    annotationType: "REVIEW"
+    annotator: "Person: Suzanne Reviewer"
+    comment: "Another example reviewer."
+  - annotationDate: "2010-02-10T00:00:00Z"
+    annotationType: "REVIEW"
+    annotator: "Person: Joe Reviewer"
+    comment: "This is just an example.  Some of the non-standard licenses look like\
+    \ they are actually BSD 3 clause licenses"
+  - annotationDate: "2010-01-29T18:30:22Z"
+    annotationType: "OTHER"
+    annotator: "Person: Jane Doe ()"
+    comment: "Document level annotation"
+documentNamespace: "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301"
+documentDescribes:
+  - "SPDXRef-Package"
+  - "SPDXRef-File"
+packages:
+  - SPDXID: "SPDXRef-Package"
+    annotations:
+      - annotationDate: "2011-01-29T18:30:22Z"
+        annotationType: "OTHER"
+        annotator: "Person: Package Commenter"
+        comment: "Package level annotation"
+    attributionTexts:
+      - "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions,\
+    \ and LICENSES for notices about a few contributions that require these additional\
+    \ notices to be distributed.  License copyright years may be listed using range\
+    \ notation, e.g., 1996-2015, indicating that every year in the range, inclusive,\
+    \ is a copyrightable year that would otherwise be listed individually."
+    checksums:
+      - algorithm: "MD5"
+        checksumValue: "624c1abb3664f4b35547e7c73864ad24"
+      - algorithm: "SHA256"
+        checksumValue: "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
+      - algorithm: "SHA1"
+        checksumValue: "85ed0817af83a24ad8da68c2b5094de69833983c"
+    copyrightText: "Copyright 2008-2010 John Smith"
+    description: "The GNU C Library defines functions that are specified by the ISO\
+    \ C standard, as well as additional features specific to POSIX and other derivatives\
+    \ of the Unix operating system, and extensions specific to GNU systems."
+    downloadLocation: "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz"
+    externalRefs:
+      - comment: "This is the external ref for Acme"
+        referenceCategory: "OTHER"
+        referenceLocator: "acmecorp/acmenator/4.1.3-alpha"
+        referenceType: "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge"
+      - referenceCategory: "SECURITY"
+        referenceLocator: "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*"
+        referenceType: "http://spdx.org/rdf/references/cpe23Type"
+    filesAnalyzed: true
+    hasFiles:
+      - "SPDXRef-JenaLib"
+      - "SPDXRef-DoapSource"
+      - "SPDXRef-CommonsLangSrc"
+    homepage: "http://ftp.gnu.org/gnu/glibc"
+    licenseComments: "The license for this project changed with the release of version\
+    \ x.y.  The version of the project included here post-dates the license change."
+    licenseConcluded: "(LGPL-2.0-only OR LicenseRef-3)"
+    licenseDeclared: "(LGPL-2.0-only AND LicenseRef-3)"
+    licenseInfoFromFiles:
+      - "GPL-2.0-only"
+      - "LicenseRef-2"
+      - "LicenseRef-1"
+    name: "glibc"
+    originator: "Organization: ExampleCodeInspect (contact@example.com)"
+    packageFileName: "glibc-2.11.1.tar.gz"
+    packageVerificationCode:
+      packageVerificationCodeExcludedFiles:
+        - "./package.spdx"
+      packageVerificationCodeValue: "d6a770ba38583ed4bb4525bd96e50461655d2758"
+    sourceInfo: "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git."
+    summary: "GNU C library."
+    supplier: "Person: Jane Doe (jane.doe@example.com)"
+    versionInfo: "2.11.1"
+  - SPDXID: "SPDXRef-fromDoap-1"
+    comment: "This package was converted from a DOAP Project by the same name"
+    copyrightText: "NOASSERTION"
+    downloadLocation: "NOASSERTION"
+    filesAnalyzed: false
+    homepage: "http://commons.apache.org/proper/commons-lang/"
+    licenseConcluded: "NOASSERTION"
+    licenseDeclared: "NOASSERTION"
+    name: "Apache Commons Lang"
+  - SPDXID: "SPDXRef-fromDoap-0"
+    comment: "This package was converted from a DOAP Project by the same name"
+    copyrightText: "NOASSERTION"
+    downloadLocation: "NOASSERTION"
+    filesAnalyzed: false
+    homepage: "http://www.openjena.org/"
+    licenseConcluded: "NOASSERTION"
+    licenseDeclared: "NOASSERTION"
+    name: "Jena"
+  - SPDXID: "SPDXRef-Saxon"
+    checksums:
+      - algorithm: "SHA1"
+        checksumValue: "85ed0817af83a24ad8da68c2b5094de69833983c"
+    copyrightText: "Copyright Saxonica Ltd"
+    description: "The Saxon package is a collection of tools for processing XML documents."
+    downloadLocation: "https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download"
+    filesAnalyzed: false
+    homepage: "http://saxon.sourceforge.net/"
+    licenseComments: "Other versions available for a commercial license"
+    licenseConcluded: "MPL-1.0"
+    licenseDeclared: "MPL-1.0"
+    name: "Saxon"
+    packageFileName: "saxonB-8.8.zip"
+    versionInfo: "8.8"
+files:
+  - SPDXID: "SPDXRef-DoapSource"
+    checksums:
+      - algorithm: "SHA1"
+        checksumValue: "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+    copyrightText: "Copyright 2010, 2011 Source Auditor Inc."
+    fileContributors:
+      - "Protecode Inc."
+      - "SPDX Technical Team Members"
+      - "Open Logic Inc."
+      - "Source Auditor Inc."
+      - "Black Duck Software In.c"
+    fileDependencies:
+      - "SPDXRef-JenaLib"
+      - "SPDXRef-CommonsLangSrc"
+    fileName: "./src/org/spdx/parser/DOAPProject.java"
+    fileTypes:
+      - "SOURCE"
+    licenseConcluded: "Apache-2.0"
+    licenseInfoInFiles:
+      - "Apache-2.0"
+  - SPDXID: "SPDXRef-CommonsLangSrc"
+    checksums:
+      - algorithm: "SHA1"
+        checksumValue: "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+    comment: "This file is used by Jena"
+    copyrightText: "Copyright 2001-2011 The Apache Software Foundation"
+    fileContributors:
+      - "Apache Software Foundation"
+    fileName: "./lib-source/commons-lang3-3.1-sources.jar"
+    fileTypes:
+      - "ARCHIVE"
+    licenseConcluded: "Apache-2.0"
+    licenseInfoInFiles:
+      - "Apache-2.0"
+    noticeText: "Apache Commons Lang\nCopyright 2001-2011 The Apache Software Foundation\n\
+    \nThis product includes software developed by\nThe Apache Software Foundation\
+    \ (http://www.apache.org/).\n\nThis product includes software from the Spring\
+    \ Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())"
+  - SPDXID: "SPDXRef-JenaLib"
+    checksums:
+      - algorithm: "SHA1"
+        checksumValue: "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+    comment: "This file belongs to Jena"
+    copyrightText: "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008,\
+    \ 2009 Hewlett-Packard Development Company, LP"
+    fileContributors:
+      - "Apache Software Foundation"
+      - "Hewlett Packard Inc."
+    fileDependencies:
+      - "SPDXRef-CommonsLangSrc"
+    fileName: "./lib-source/jena-2.6.3-sources.jar"
+    fileTypes:
+      - "ARCHIVE"
+    licenseComments: "This license is used by Jena"
+    licenseConcluded: "LicenseRef-1"
+    licenseInfoInFiles:
+      - "LicenseRef-1"
+  - SPDXID: "SPDXRef-File"
+    annotations:
+      - annotationDate: "2011-01-29T18:30:22Z"
+        annotationType: "OTHER"
+        annotator: "Person: File Commenter"
+        comment: "File level annotation"
+    checksums:
+      - algorithm: "MD5"
+        checksumValue: "624c1abb3664f4b35547e7c73864ad24"
+      - algorithm: "SHA1"
+        checksumValue: "d6a770ba38583ed4bb4525bd96e50461655d2758"
+    comment: "The concluded license was taken from the package level that the file was\
+    \ included in.\nThis information was found in the COPYING.txt file in the xyz\
+    \ directory."
+    copyrightText: "Copyright 2008-2010 John Smith"
+    fileContributors:
+      - "The Regents of the University of California"
+      - "Modified by Paul Mundt lethal@linux-sh.org"
+      - "IBM Corporation"
+    fileName: "./package/foo.c"
+    fileTypes:
+      - "SOURCE"
+    licenseComments: "The concluded license was taken from the package level that the\
+    \ file was included in."
+    licenseConcluded: "(LGPL-2.0-only OR LicenseRef-2)"
+    licenseInfoInFiles:
+      - "GPL-2.0-only"
+      - "LicenseRef-2"
+    noticeText: "Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com\n\nPermission is\
+    \ hereby granted, free of charge, to any person obtaining a copy of this software\
+    \ and associated documentation files (the �Software�), to deal in the Software\
+    \ without restriction, including without limitation the rights to use, copy, modify,\
+    \ merge, publish, distribute, sublicense, and/or sell copies of the Software,\
+    \ and to permit persons to whom the Software is furnished to do so, subject to\
+    \ the following conditions: \nThe above copyright notice and this permission notice\
+    \ shall be included in all copies or substantial portions of the Software.\n\n\
+    THE SOFTWARE IS PROVIDED �AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,\
+    \ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR\
+    \ A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR\
+    \ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER\
+    \ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\
+    \ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+snippets:
+  - SPDXID: "SPDXRef-Snippet"
+    comment: "This snippet was identified as significant and highlighted in this Apache-2.0\
+    \ file, when a commercial scanner identified it as being derived from file foo.c\
+    \ in package xyz which is licensed under GPL-2.0."
+    copyrightText: "Copyright 2008-2010 John Smith"
+    licenseComments: "The concluded license was taken from package xyz, from which the\
+    \ snippet was copied into the current file. The concluded license information\
+    \ was found in the COPYING.txt file in package xyz."
+    licenseConcluded: "GPL-2.0-only"
+    licenseInfoInSnippets:
+      - "GPL-2.0-only"
+    name: "from linux kernel"
+    snippetFromFile: "SPDXRef-DoapSource"
+relationships:
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement"
+    relationshipType: "COPY_OF"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "DESCRIBES"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "CONTAINS"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-File"
+    relationshipType: "DESCRIBES"
+  - spdxElementId: "SPDXRef-Package"
+    relatedSpdxElement: "SPDXRef-Saxon"
+    relationshipType: "DYNAMIC_LINK"
+  - spdxElementId: "SPDXRef-Package"
+    relatedSpdxElement: "SPDXRef-JenaLib"
+    relationshipType: "CONTAINS"
+  - spdxElementId: "SPDXRef-CommonsLangSrc"
+    relatedSpdxElement: "NOASSERTION"
+    relationshipType: "GENERATED_FROM"
+  - spdxElementId: "SPDXRef-JenaLib"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "CONTAINS"
+  - spdxElementId: "SPDXRef-File"
+    relatedSpdxElement: "SPDXRef-fromDoap-0"
+    relationshipType: "GENERATED_FROM"

--- a/spdx-utils/src/test/resources/spdx-spec-examples/SPDXYAMLExample-2.2.spdx.yaml
+++ b/spdx-utils/src/test/resources/spdx-spec-examples/SPDXYAMLExample-2.2.spdx.yaml
@@ -1,0 +1,390 @@
+---
+SPDXID: "SPDXRef-DOCUMENT"
+spdxVersion: "SPDX-2.2"
+creationInfo:
+  comment: "This package has been shipped in source and binary form.\nThe binaries\
+    \ were created with gcc 4.5.1 and expect to link to\ncompatible system run time\
+    \ libraries."
+  created: "2010-01-29T18:30:22Z"
+  creators:
+    - "Tool: LicenseFind-1.0"
+    - "Organization: ExampleCodeInspect ()"
+    - "Person: Jane Doe ()"
+  licenseListVersion: "3.9"
+name: "SPDX-Tools-v2.0"
+dataLicense: "CC0-1.0"
+comment: "This document was created using SPDX 2.0 using licenses from the web site."
+externalDocumentRefs:
+  - externalDocumentId: "DocumentRef-spdx-tool-1.2"
+    checksum:
+      algorithm: "SHA1"
+      checksumValue: "d6a770ba38583ed4bb4525bd96e50461655d2759"
+    spdxDocument: "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301"
+hasExtractedLicensingInfos:
+  - extractedText: "\"THE BEER-WARE LICENSE\" (Revision 42):\nphk@FreeBSD.ORG wrote\
+    \ this file. As long as you retain this notice you\ncan do whatever you want with\
+    \ this stuff. If we meet some day, and you think this stuff is worth it, you can\
+    \ buy me a beer in return Poul-Henning Kamp  </\nLicenseName: Beer-Ware License\
+    \ (Version 42)\nLicenseCrossReference:  http://people.freebsd.org/~phk/\nLicenseComment:\
+    \ \nThe beerware license has a couple of other standard variants."
+    licenseId: "LicenseRef-Beerware-4.2"
+  - extractedText: "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n\
+    \ *\n * Redistribution and use in source and binary forms, with or without\n *\
+    \ modification, are permitted provided that the following conditions\n * are met:\n\
+    \ * 1. Redistributions of source code must retain the above copyright\n *    notice,\
+    \ this list of conditions and the following disclaimer.\n * 2. Redistributions\
+    \ in binary form must reproduce the above copyright\n *    notice, this list of\
+    \ conditions and the following disclaimer in the\n *    documentation and/or other\
+    \ materials provided with the distribution.\n * 3. The name of the author may\
+    \ not be used to endorse or promote products\n *    derived from this software\
+    \ without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED\
+    \ BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING,\
+    \ BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS\
+    \ FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE\
+    \ LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\
+    \ DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS\
+    \ OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\
+    \ CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\
+    \ OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE\
+    \ USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\
+    */"
+    licenseId: "LicenseRef-4"
+  - comment: "This is tye CyperNeko License"
+    extractedText: "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright\
+    \ 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source\
+    \ and binary forms, with or without\nmodification, are permitted provided that\
+    \ the following conditions\nare met:\n\n1. Redistributions of source code must\
+    \ retain the above copyright\n   notice, this list of conditions and the following\
+    \ disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n\
+    \   notice, this list of conditions and the following disclaimer in\n   the documentation\
+    \ and/or other materials provided with the\n   distribution.\n\n3. The end-user\
+    \ documentation included with the redistribution,\n   if any, must include the\
+    \ following acknowledgment:  \n     \"This product includes software developed\
+    \ by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software\
+    \ itself,\n   if and wherever such third-party acknowledgments normally appear.\n\
+    \n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n  \
+    \ or promote products derived from this software without prior \n   written permission.\
+    \ For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products\
+    \ derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\"\
+    \ appear in their name, without prior written\n   permission of the author.\n\n\
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES,\
+    \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND\
+    \ FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR\
+    \ OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,\
+    \ EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT\
+    \ \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS\
+    \ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT,\
+    \ STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY\
+    \ WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF\
+    \ SUCH DAMAGE."
+    licenseId: "LicenseRef-3"
+    name: "CyberNeko License"
+    seeAlsos:
+      - "http://people.apache.org/~andyc/neko/LICENSE"
+      - "http://justasample.url.com"
+  - extractedText: "This package includes the GRDDL parser developed by Hewlett Packard\
+    \ under the following license:\n� Copyright 2007 Hewlett-Packard Development Company,\
+    \ LP\n\nRedistribution and use in source and binary forms, with or without modification,\
+    \ are permitted provided that the following conditions are met: \n\nRedistributions\
+    \ of source code must retain the above copyright notice, this list of conditions\
+    \ and the following disclaimer. \nRedistributions in binary form must reproduce\
+    \ the above copyright notice, this list of conditions and the following disclaimer\
+    \ in the documentation and/or other materials provided with the distribution.\
+    \ \nThe name of the author may not be used to endorse or promote products derived\
+    \ from this software without specific prior written permission. \nTHIS SOFTWARE\
+    \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,\
+    \ BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\
+    \ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE\
+    \ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES\
+    \ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;\
+    \ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND\
+    \ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING\
+    \ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,\
+    \ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    licenseId: "LicenseRef-2"
+  - extractedText: "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,\
+    \ 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n\
+    \ *\n * Redistribution and use in source and binary forms, with or without\n *\
+    \ modification, are permitted provided that the following conditions\n * are met:\n\
+    \ * 1. Redistributions of source code must retain the above copyright\n *    notice,\
+    \ this list of conditions and the following disclaimer.\n * 2. Redistributions\
+    \ in binary form must reproduce the above copyright\n *    notice, this list of\
+    \ conditions and the following disclaimer in the\n *    documentation and/or other\
+    \ materials provided with the distribution.\n * 3. The name of the author may\
+    \ not be used to endorse or promote products\n *    derived from this software\
+    \ without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED\
+    \ BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING,\
+    \ BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS\
+    \ FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE\
+    \ LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\
+    \ DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS\
+    \ OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\
+    \ CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\
+    \ OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE\
+    \ USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\
+    */"
+    licenseId: "LicenseRef-1"
+annotations:
+  - annotationDate: "2011-03-13T00:00:00Z"
+    annotationType: "REVIEW"
+    annotator: "Person: Suzanne Reviewer"
+    comment: "Another example reviewer."
+  - annotationDate: "2010-02-10T00:00:00Z"
+    annotationType: "REVIEW"
+    annotator: "Person: Joe Reviewer"
+    comment: "This is just an example.  Some of the non-standard licenses look like\
+    \ they are actually BSD 3 clause licenses"
+  - annotationDate: "2010-01-29T18:30:22Z"
+    annotationType: "OTHER"
+    annotator: "Person: Jane Doe ()"
+    comment: "Document level annotation"
+documentNamespace: "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301"
+documentDescribes:
+  - "SPDXRef-Package"
+  - "SPDXRef-File"
+packages:
+  - SPDXID: "SPDXRef-Package"
+    annotations:
+      - annotationDate: "2011-01-29T18:30:22Z"
+        annotationType: "OTHER"
+        annotator: "Person: Package Commenter"
+        comment: "Package level annotation"
+    attributionTexts:
+      - "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions,\
+    \ and LICENSES for notices about a few contributions that require these additional\
+    \ notices to be distributed.  License copyright years may be listed using range\
+    \ notation, e.g., 1996-2015, indicating that every year in the range, inclusive,\
+    \ is a copyrightable year that would otherwise be listed individually."
+    checksums:
+      - algorithm: "MD5"
+        checksumValue: "624c1abb3664f4b35547e7c73864ad24"
+      - algorithm: "SHA256"
+        checksumValue: "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
+      - algorithm: "SHA1"
+        checksumValue: "85ed0817af83a24ad8da68c2b5094de69833983c"
+    copyrightText: "Copyright 2008-2010 John Smith"
+    description: "The GNU C Library defines functions that are specified by the ISO\
+    \ C standard, as well as additional features specific to POSIX and other derivatives\
+    \ of the Unix operating system, and extensions specific to GNU systems."
+    downloadLocation: "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz"
+    externalRefs:
+      - comment: "This is the external ref for Acme"
+        referenceCategory: "OTHER"
+        referenceLocator: "acmecorp/acmenator/4.1.3-alpha"
+        referenceType: "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge"
+      - referenceCategory: "SECURITY"
+        referenceLocator: "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*"
+        referenceType: "http://spdx.org/rdf/references/cpe23Type"
+    filesAnalyzed: true
+    hasFiles:
+      - "SPDXRef-JenaLib"
+      - "SPDXRef-DoapSource"
+      - "SPDXRef-CommonsLangSrc"
+    homepage: "http://ftp.gnu.org/gnu/glibc"
+    licenseComments: "The license for this project changed with the release of version\
+    \ x.y.  The version of the project included here post-dates the license change."
+    licenseConcluded: "(LGPL-2.0-only OR LicenseRef-3)"
+    licenseDeclared: "(LGPL-2.0-only AND LicenseRef-3)"
+    licenseInfoFromFiles:
+      - "GPL-2.0-only"
+      - "LicenseRef-2"
+      - "LicenseRef-1"
+    name: "glibc"
+    originator: "Organization: ExampleCodeInspect (contact@example.com)"
+    packageFileName: "glibc-2.11.1.tar.gz"
+    packageVerificationCode:
+      packageVerificationCodeExcludedFiles:
+        - "./package.spdx"
+      packageVerificationCodeValue: "d6a770ba38583ed4bb4525bd96e50461655d2758"
+    sourceInfo: "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git."
+    summary: "GNU C library."
+    supplier: "Person: Jane Doe (jane.doe@example.com)"
+    versionInfo: "2.11.1"
+  - SPDXID: "SPDXRef-fromDoap-1"
+    comment: "This package was converted from a DOAP Project by the same name"
+    copyrightText: "NOASSERTION"
+    downloadLocation: "NOASSERTION"
+    filesAnalyzed: false
+    homepage: "http://commons.apache.org/proper/commons-lang/"
+    licenseConcluded: "NOASSERTION"
+    licenseDeclared: "NOASSERTION"
+    name: "Apache Commons Lang"
+  - SPDXID: "SPDXRef-fromDoap-0"
+    comment: "This package was converted from a DOAP Project by the same name"
+    copyrightText: "NOASSERTION"
+    downloadLocation: "NOASSERTION"
+    filesAnalyzed: false
+    homepage: "http://www.openjena.org/"
+    licenseConcluded: "NOASSERTION"
+    licenseDeclared: "NOASSERTION"
+    name: "Jena"
+  - SPDXID: "SPDXRef-Saxon"
+    checksums:
+      - algorithm: "SHA1"
+        checksumValue: "85ed0817af83a24ad8da68c2b5094de69833983c"
+    copyrightText: "Copyright Saxonica Ltd"
+    description: "The Saxon package is a collection of tools for processing XML documents."
+    downloadLocation: "https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download"
+    filesAnalyzed: false
+    homepage: "http://saxon.sourceforge.net/"
+    licenseComments: "Other versions available for a commercial license"
+    licenseConcluded: "MPL-1.0"
+    licenseDeclared: "MPL-1.0"
+    name: "Saxon"
+    packageFileName: "saxonB-8.8.zip"
+    versionInfo: "8.8"
+files:
+  - SPDXID: "SPDXRef-DoapSource"
+    checksums:
+      - algorithm: "SHA1"
+        checksumValue: "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+    copyrightText: "Copyright 2010, 2011 Source Auditor Inc."
+    fileContributors:
+      - "Protecode Inc."
+      - "SPDX Technical Team Members"
+      - "Open Logic Inc."
+      - "Source Auditor Inc."
+      - "Black Duck Software In.c"
+    fileDependencies:
+      - "SPDXRef-JenaLib"
+      - "SPDXRef-CommonsLangSrc"
+    fileName: "./src/org/spdx/parser/DOAPProject.java"
+    fileTypes:
+      - "SOURCE"
+    licenseConcluded: "Apache-2.0"
+    licenseInfoInFiles:
+      - "Apache-2.0"
+  - SPDXID: "SPDXRef-CommonsLangSrc"
+    checksums:
+      - algorithm: "SHA1"
+        checksumValue: "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+    comment: "This file is used by Jena"
+    copyrightText: "Copyright 2001-2011 The Apache Software Foundation"
+    fileContributors:
+      - "Apache Software Foundation"
+    fileName: "./lib-source/commons-lang3-3.1-sources.jar"
+    fileTypes:
+      - "ARCHIVE"
+    licenseConcluded: "Apache-2.0"
+    licenseInfoInFiles:
+      - "Apache-2.0"
+    noticeText: "Apache Commons Lang\nCopyright 2001-2011 The Apache Software Foundation\n\
+    \nThis product includes software developed by\nThe Apache Software Foundation\
+    \ (http://www.apache.org/).\n\nThis product includes software from the Spring\
+    \ Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())"
+  - SPDXID: "SPDXRef-JenaLib"
+    checksums:
+      - algorithm: "SHA1"
+        checksumValue: "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+    comment: "This file belongs to Jena"
+    copyrightText: "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008,\
+    \ 2009 Hewlett-Packard Development Company, LP"
+    fileContributors:
+      - "Apache Software Foundation"
+      - "Hewlett Packard Inc."
+    fileDependencies:
+      - "SPDXRef-CommonsLangSrc"
+    fileName: "./lib-source/jena-2.6.3-sources.jar"
+    fileTypes:
+      - "ARCHIVE"
+    licenseComments: "This license is used by Jena"
+    licenseConcluded: "LicenseRef-1"
+    licenseInfoInFiles:
+      - "LicenseRef-1"
+  - SPDXID: "SPDXRef-File"
+    annotations:
+      - annotationDate: "2011-01-29T18:30:22Z"
+        annotationType: "OTHER"
+        annotator: "Person: File Commenter"
+        comment: "File level annotation"
+    checksums:
+      - algorithm: "MD5"
+        checksumValue: "624c1abb3664f4b35547e7c73864ad24"
+      - algorithm: "SHA1"
+        checksumValue: "d6a770ba38583ed4bb4525bd96e50461655d2758"
+    comment: "The concluded license was taken from the package level that the file was\
+    \ included in.\nThis information was found in the COPYING.txt file in the xyz\
+    \ directory."
+    copyrightText: "Copyright 2008-2010 John Smith"
+    fileContributors:
+      - "The Regents of the University of California"
+      - "Modified by Paul Mundt lethal@linux-sh.org"
+      - "IBM Corporation"
+    fileName: "./package/foo.c"
+    fileTypes:
+      - "SOURCE"
+    licenseComments: "The concluded license was taken from the package level that the\
+    \ file was included in."
+    licenseConcluded: "(LGPL-2.0-only OR LicenseRef-2)"
+    licenseInfoInFiles:
+      - "GPL-2.0-only"
+      - "LicenseRef-2"
+    noticeText: "Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com\n\nPermission is\
+    \ hereby granted, free of charge, to any person obtaining a copy of this software\
+    \ and associated documentation files (the �Software�), to deal in the Software\
+    \ without restriction, including without limitation the rights to use, copy, modify,\
+    \ merge, publish, distribute, sublicense, and/or sell copies of the Software,\
+    \ and to permit persons to whom the Software is furnished to do so, subject to\
+    \ the following conditions: \nThe above copyright notice and this permission notice\
+    \ shall be included in all copies or substantial portions of the Software.\n\n\
+    THE SOFTWARE IS PROVIDED �AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,\
+    \ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR\
+    \ A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR\
+    \ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER\
+    \ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\
+    \ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+snippets:
+  - SPDXID: "SPDXRef-Snippet"
+    comment: "This snippet was identified as significant and highlighted in this Apache-2.0\
+    \ file, when a commercial scanner identified it as being derived from file foo.c\
+    \ in package xyz which is licensed under GPL-2.0."
+    copyrightText: "Copyright 2008-2010 John Smith"
+    licenseComments: "The concluded license was taken from package xyz, from which the\
+    \ snippet was copied into the current file. The concluded license information\
+    \ was found in the COPYING.txt file in package xyz."
+    licenseConcluded: "GPL-2.0-only"
+    licenseInfoInSnippets:
+      - "GPL-2.0-only"
+    name: "from linux kernel"
+    ranges:
+      - endPointer:
+          offset: 420
+          reference: "SPDXRef-DoapSource"
+        startPointer:
+          offset: 310
+          reference: "SPDXRef-DoapSource"
+      - endPointer:
+          lineNumber: 23
+          reference: "SPDXRef-DoapSource"
+        startPointer:
+          lineNumber: 5
+          reference: "SPDXRef-DoapSource"
+    snippetFromFile: "SPDXRef-DoapSource"
+relationships:
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement"
+    relationshipType: "COPY_OF"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "DESCRIBES"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "CONTAINS"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-File"
+    relationshipType: "DESCRIBES"
+  - spdxElementId: "SPDXRef-Package"
+    relatedSpdxElement: "SPDXRef-Saxon"
+    relationshipType: "DYNAMIC_LINK"
+  - spdxElementId: "SPDXRef-Package"
+    relatedSpdxElement: "SPDXRef-JenaLib"
+    relationshipType: "CONTAINS"
+  - spdxElementId: "SPDXRef-CommonsLangSrc"
+    relatedSpdxElement: "NOASSERTION"
+    relationshipType: "GENERATED_FROM"
+  - spdxElementId: "SPDXRef-JenaLib"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "CONTAINS"
+  - spdxElementId: "SPDXRef-File"
+    relatedSpdxElement: "SPDXRef-fromDoap-0"
+    relationshipType: "GENERATED_FROM"


### PR DESCRIPTION
This change adds the model classes for SPDX documents for SPDX version
2.2.1 and supports serialization and deserialization of JSON and YAML
SPDX document files. All properties are supported except for 'ranges'
which are not properly specified yet [1], and thus cannot be implemented yet.

There is some design flexibility regarding how strong the typing is for
the respective properties, e.g. a propery could use a String or a
dedicated type. This change does not implement the strongest possible
typing for both, fault tollerance and most importantly to limit the
scope of this first iteration. Adding a dedicated type for SPDX IDs or
references are good candidates for future improvements.

The SPDX specification [2] is targeting mainly RDF and thus does not
provide enough information to derive the actual JSON or YAML format.
To fill the gap the examples [3] are taken as referrence additionally.

The tests proof that the JSON and YAML examples are (apart from the
mentioned ranges property) fully implemented, e.g.
`serialize(deserialize(example)) == example` holds.

[1] https://github.com/spdx/spdx-spec/issues/412
[2] https://github.com/spdx/spdx-spec/tree/development/v2.2.1/chapters
[3] https://github.com/spdx/spdx-spec/tree/development/v2.2.1/examples

Signed-off-by: Frank Viernau <frank.viernau@here.com>