### PR TITLE
declared-license-mapping: Remove an entry for the JCache library

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -270,7 +270,6 @@
 "ISC/BSD License": ISC OR BSD-2-Clause
 "Indiana University Extreme! Lab Software License, vesion 1.1.1": LicenseRef-indiana-extreme-scancode
 "Individual BSD License": BSD-3-Clause
-"JSR-000107 JCACHE 2.9 Public Review - Updated Specification License": LicenseRef-scancode-jsr-107-jcache-spec.LICENSE
 "Jabber Open Source License": LicenseRef-scancode-josl-1.0
 "Jython Software License": Python-2.0
 "Kirkk.com BSD License": BSD-3-Clause


### PR DESCRIPTION
The license of this library changed several times while the declared
license string remained constant. That is, any mapping entry for this
declared license string is incorrect, and thus remove the existing one.

This reverts ed84d8c.

Signed-off-by: Frank Viernau <frank.viernau@here.com>