### PR TITLE
Reduce indentation in tests by passing init as a lambda

### DIFF
--- a/analyzer/src/test/kotlin/curation/ClearlyDefinedPackageCurationProviderTest.kt
+++ b/analyzer/src/test/kotlin/curation/ClearlyDefinedPackageCurationProviderTest.kt
@@ -27,16 +27,14 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.StringSpec
 
-class ClearlyDefinedPackageCurationProviderTest : StringSpec() {
-    init {
-        "Provider can read curations from development server" {
-            val provider = ClearlyDefinedPackageCurationProvider(Server.DEVELOPMENT)
+class ClearlyDefinedPackageCurationProviderTest : StringSpec({
+    "Provider can read curations from development server" {
+        val provider = ClearlyDefinedPackageCurationProvider(Server.DEVELOPMENT)
 
-            val identifier = Identifier("NPM", "@nestjs", "platform-express", "6.2.3")
-            val curations = provider.getCurationsFor(identifier)
+        val identifier = Identifier("NPM", "@nestjs", "platform-express", "6.2.3")
+        val curations = provider.getCurationsFor(identifier)
 
-            curations should haveSize(1)
-            curations.first().data.declaredLicenses shouldBe sortedSetOf("Apache-1.0")
-        }
+        curations should haveSize(1)
+        curations.first().data.declaredLicenses shouldBe sortedSetOf("Apache-1.0")
     }
-}
+})

--- a/model/src/test/kotlin/AnalyzerRunTest.kt
+++ b/model/src/test/kotlin/AnalyzerRunTest.kt
@@ -26,50 +26,48 @@ import io.kotest.core.spec.style.StringSpec
 
 import java.time.Instant
 
-class AnalyzerRunTest : StringSpec() {
-    init {
-        "AnalyzerRun without timestamps can be deserialized" {
-            val yaml = """
-                ---
-                environment:
-                  os: "Linux"
-                  tool_versions: {}
-                config:
-                  ignore_tool_versions: false
-                  allow_dynamic_versions: false
-                result:
-                  projects: []
-                  packages: []
-                  has_issues: false
-            """.trimIndent()
+class AnalyzerRunTest : StringSpec({
+    "AnalyzerRun without timestamps can be deserialized" {
+        val yaml = """
+            ---
+            environment:
+              os: "Linux"
+              tool_versions: {}
+            config:
+              ignore_tool_versions: false
+              allow_dynamic_versions: false
+            result:
+              projects: []
+              packages: []
+              has_issues: false
+        """.trimIndent()
 
-            val analyzerRun = yamlMapper.readValue<AnalyzerRun>(yaml)
+        val analyzerRun = yamlMapper.readValue<AnalyzerRun>(yaml)
 
-            analyzerRun.startTime shouldBe Instant.EPOCH
-            analyzerRun.endTime shouldBe Instant.EPOCH
-        }
-
-        "AnalyzerRun with timestamps can be deserialized" {
-            val yaml = """
-                ---
-                start_time: "1970-01-01T00:00:10Z"
-                end_time: "1970-01-01T00:00:20Z"
-                environment:
-                  os: "Linux"
-                  tool_versions: {}
-                config:
-                  ignore_tool_versions: false
-                  allow_dynamic_versions: false
-                result:
-                  projects: []
-                  packages: []
-                  has_issues: false
-            """.trimIndent()
-
-            val analyzerRun = yamlMapper.readValue<AnalyzerRun>(yaml)
-
-            analyzerRun.startTime shouldBe Instant.ofEpochSecond(10)
-            analyzerRun.endTime shouldBe Instant.ofEpochSecond(20)
-        }
+        analyzerRun.startTime shouldBe Instant.EPOCH
+        analyzerRun.endTime shouldBe Instant.EPOCH
     }
-}
+
+    "AnalyzerRun with timestamps can be deserialized" {
+        val yaml = """
+            ---
+            start_time: "1970-01-01T00:00:10Z"
+            end_time: "1970-01-01T00:00:20Z"
+            environment:
+              os: "Linux"
+              tool_versions: {}
+            config:
+              ignore_tool_versions: false
+              allow_dynamic_versions: false
+            result:
+              projects: []
+              packages: []
+              has_issues: false
+        """.trimIndent()
+
+        val analyzerRun = yamlMapper.readValue<AnalyzerRun>(yaml)
+
+        analyzerRun.startTime shouldBe Instant.ofEpochSecond(10)
+        analyzerRun.endTime shouldBe Instant.ofEpochSecond(20)
+    }
+})

--- a/model/src/test/kotlin/EvaluatorRunTest.kt
+++ b/model/src/test/kotlin/EvaluatorRunTest.kt
@@ -26,32 +26,30 @@ import io.kotest.core.spec.style.StringSpec
 
 import java.time.Instant
 
-class EvaluatorRunTest : StringSpec() {
-    init {
-        "EvaluatorRun without timestamps can be deserialized" {
-            val yaml = """
-                ---
-                violations: []
-            """.trimIndent()
+class EvaluatorRunTest : StringSpec({
+    "EvaluatorRun without timestamps can be deserialized" {
+        val yaml = """
+            ---
+            violations: []
+        """.trimIndent()
 
-            val evaluatorRun = yamlMapper.readValue<EvaluatorRun>(yaml)
+        val evaluatorRun = yamlMapper.readValue<EvaluatorRun>(yaml)
 
-            evaluatorRun.startTime shouldBe Instant.EPOCH
-            evaluatorRun.endTime shouldBe Instant.EPOCH
-        }
-
-        "EvaluatorRun with timestamps can be deserialized" {
-            val yaml = """
-                ---
-                start_time: "1970-01-01T00:00:10Z"
-                end_time: "1970-01-01T00:00:10Z"
-                violations: []
-            """.trimIndent()
-
-            val evaluatorRun = yamlMapper.readValue<EvaluatorRun>(yaml)
-
-            evaluatorRun.startTime shouldBe Instant.ofEpochSecond(10)
-            evaluatorRun.endTime shouldBe Instant.ofEpochSecond(10)
-        }
+        evaluatorRun.startTime shouldBe Instant.EPOCH
+        evaluatorRun.endTime shouldBe Instant.EPOCH
     }
-}
+
+    "EvaluatorRun with timestamps can be deserialized" {
+        val yaml = """
+            ---
+            start_time: "1970-01-01T00:00:10Z"
+            end_time: "1970-01-01T00:00:10Z"
+            violations: []
+        """.trimIndent()
+
+        val evaluatorRun = yamlMapper.readValue<EvaluatorRun>(yaml)
+
+        evaluatorRun.startTime shouldBe Instant.ofEpochSecond(10)
+        evaluatorRun.endTime shouldBe Instant.ofEpochSecond(10)
+    }
+})

--- a/model/src/test/kotlin/PackageTest.kt
+++ b/model/src/test/kotlin/PackageTest.kt
@@ -23,82 +23,80 @@ import io.kotest.matchers.shouldBe
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 
-class PackageTest : StringSpec() {
-    init {
-        "diff throws an exception if the identifiers are not equals" {
-            val pkg = Package.EMPTY.copy(id = Identifier("type1", "namespace1", "name1", "version1"))
-            val other = Package.EMPTY.copy(id = Identifier("type2", "namespace2", "name2", "version2"))
+class PackageTest : StringSpec({
+    "diff throws an exception if the identifiers are not equals" {
+        val pkg = Package.EMPTY.copy(id = Identifier("type1", "namespace1", "name1", "version1"))
+        val other = Package.EMPTY.copy(id = Identifier("type2", "namespace2", "name2", "version2"))
 
-            shouldThrow<IllegalArgumentException> {
-                pkg.diff(other)
-            }
-        }
-
-        "diff result contains all changed values" {
-            val pkg = Package(
-                id = Identifier(
-                    type = "type",
-                    namespace = "namespace",
-                    name = "name",
-                    version = "version"
-                ),
-                declaredLicenses = sortedSetOf("declared license"),
-                description = "description",
-                homepageUrl = "homepageUrl",
-                binaryArtifact = RemoteArtifact("url", Hash.create("hash")),
-                sourceArtifact = RemoteArtifact("url", Hash.create("hash")),
-                vcs = VcsInfo(VcsType("type"), "url", "revision")
-            )
-
-            val other = Package(
-                id = Identifier(
-                    type = "type",
-                    namespace = "namespace",
-                    name = "name",
-                    version = "version"
-                ),
-                declaredLicenses = sortedSetOf("other declared license"),
-                description = "other description",
-                homepageUrl = "other homepageUrl",
-                binaryArtifact = RemoteArtifact("other url", Hash.create("other hash")),
-                sourceArtifact = RemoteArtifact("other url", Hash.create("other hash")),
-                vcs = VcsInfo(VcsType("other type"), "other url", "other revision")
-            )
-
-            val diff = pkg.diff(other)
-
-            diff.binaryArtifact shouldBe pkg.binaryArtifact
-            diff.comment shouldBe null
-            diff.declaredLicenses shouldBe pkg.declaredLicenses
-            diff.homepageUrl shouldBe pkg.homepageUrl
-            diff.sourceArtifact shouldBe pkg.sourceArtifact
-            diff.vcs shouldBe pkg.vcs.toCuration()
-        }
-
-        "diff result does not contain unchanged values" {
-            val pkg = Package(
-                id = Identifier(
-                    type = "type",
-                    namespace = "namespace",
-                    name = "name",
-                    version = "version"
-                ),
-                declaredLicenses = sortedSetOf("declared license"),
-                description = "description",
-                homepageUrl = "homepageUrl",
-                binaryArtifact = RemoteArtifact("url", Hash.create("hash")),
-                sourceArtifact = RemoteArtifact("url", Hash.create("hash")),
-                vcs = VcsInfo(VcsType("type"), "url", "revision")
-            )
-
-            val diff = pkg.diff(pkg)
-
-            diff.binaryArtifact shouldBe null
-            diff.comment shouldBe null
-            diff.declaredLicenses shouldBe null
-            diff.homepageUrl shouldBe null
-            diff.sourceArtifact shouldBe null
-            diff.vcs shouldBe null
+        shouldThrow<IllegalArgumentException> {
+            pkg.diff(other)
         }
     }
-}
+
+    "diff result contains all changed values" {
+        val pkg = Package(
+            id = Identifier(
+                type = "type",
+                namespace = "namespace",
+                name = "name",
+                version = "version"
+            ),
+            declaredLicenses = sortedSetOf("declared license"),
+            description = "description",
+            homepageUrl = "homepageUrl",
+            binaryArtifact = RemoteArtifact("url", Hash.create("hash")),
+            sourceArtifact = RemoteArtifact("url", Hash.create("hash")),
+            vcs = VcsInfo(VcsType("type"), "url", "revision")
+        )
+
+        val other = Package(
+            id = Identifier(
+                type = "type",
+                namespace = "namespace",
+                name = "name",
+                version = "version"
+            ),
+            declaredLicenses = sortedSetOf("other declared license"),
+            description = "other description",
+            homepageUrl = "other homepageUrl",
+            binaryArtifact = RemoteArtifact("other url", Hash.create("other hash")),
+            sourceArtifact = RemoteArtifact("other url", Hash.create("other hash")),
+            vcs = VcsInfo(VcsType("other type"), "other url", "other revision")
+        )
+
+        val diff = pkg.diff(other)
+
+        diff.binaryArtifact shouldBe pkg.binaryArtifact
+        diff.comment shouldBe null
+        diff.declaredLicenses shouldBe pkg.declaredLicenses
+        diff.homepageUrl shouldBe pkg.homepageUrl
+        diff.sourceArtifact shouldBe pkg.sourceArtifact
+        diff.vcs shouldBe pkg.vcs.toCuration()
+    }
+
+    "diff result does not contain unchanged values" {
+        val pkg = Package(
+            id = Identifier(
+                type = "type",
+                namespace = "namespace",
+                name = "name",
+                version = "version"
+            ),
+            declaredLicenses = sortedSetOf("declared license"),
+            description = "description",
+            homepageUrl = "homepageUrl",
+            binaryArtifact = RemoteArtifact("url", Hash.create("hash")),
+            sourceArtifact = RemoteArtifact("url", Hash.create("hash")),
+            vcs = VcsInfo(VcsType("type"), "url", "revision")
+        )
+
+        val diff = pkg.diff(pkg)
+
+        diff.binaryArtifact shouldBe null
+        diff.comment shouldBe null
+        diff.declaredLicenses shouldBe null
+        diff.homepageUrl shouldBe null
+        diff.sourceArtifact shouldBe null
+        diff.vcs shouldBe null
+    }
+})

--- a/model/src/test/kotlin/ScannerRunTest.kt
+++ b/model/src/test/kotlin/ScannerRunTest.kt
@@ -26,52 +26,50 @@ import io.kotest.core.spec.style.StringSpec
 
 import java.time.Instant
 
-class ScannerRunTest : StringSpec() {
-    init {
-        "ScannerRun without timestamps can be deserialized" {
-            val yaml = """
-                ---
-                environment:
-                  os: "Linux"
-                  tool_versions: {}
-                config:
-                  scanner: null
-                results:
-                  scan_results: []
-                  storage_stats:
-                    num_reads: 0
-                    num_hits: 0
-                  has_issues: false
-            """.trimIndent()
+class ScannerRunTest : StringSpec({
+    "ScannerRun without timestamps can be deserialized" {
+        val yaml = """
+            ---
+            environment:
+              os: "Linux"
+              tool_versions: {}
+            config:
+              scanner: null
+            results:
+              scan_results: []
+              storage_stats:
+                num_reads: 0
+                num_hits: 0
+              has_issues: false
+        """.trimIndent()
 
-            val scannerRun = yamlMapper.readValue<ScannerRun>(yaml)
+        val scannerRun = yamlMapper.readValue<ScannerRun>(yaml)
 
-            scannerRun.startTime shouldBe Instant.EPOCH
-            scannerRun.endTime shouldBe Instant.EPOCH
-        }
-
-        "ScannerRun with timestamps can be deserialized" {
-            val yaml = """
-                ---
-                start_time: "1970-01-01T00:00:10Z"
-                end_time: "1970-01-01T00:00:10Z"
-                environment:
-                  os: "Linux"
-                  tool_versions: {}
-                config:
-                  scanner: null
-                results:
-                  scan_results: []
-                  storage_stats:
-                    num_reads: 0
-                    num_hits: 0
-                  has_issues: false
-            """.trimIndent()
-
-            val scannerRun = yamlMapper.readValue<ScannerRun>(yaml)
-
-            scannerRun.startTime shouldBe Instant.ofEpochSecond(10)
-            scannerRun.endTime shouldBe Instant.ofEpochSecond(10)
-        }
+        scannerRun.startTime shouldBe Instant.EPOCH
+        scannerRun.endTime shouldBe Instant.EPOCH
     }
-}
+
+    "ScannerRun with timestamps can be deserialized" {
+        val yaml = """
+            ---
+            start_time: "1970-01-01T00:00:10Z"
+            end_time: "1970-01-01T00:00:10Z"
+            environment:
+              os: "Linux"
+              tool_versions: {}
+            config:
+              scanner: null
+            results:
+              scan_results: []
+              storage_stats:
+                num_reads: 0
+                num_hits: 0
+              has_issues: false
+        """.trimIndent()
+
+        val scannerRun = yamlMapper.readValue<ScannerRun>(yaml)
+
+        scannerRun.startTime shouldBe Instant.ofEpochSecond(10)
+        scannerRun.endTime shouldBe Instant.ofEpochSecond(10)
+    }
+})

--- a/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
+++ b/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
@@ -29,80 +29,78 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.core.spec.style.WordSpec
 
-class RepositoryConfigurationTest : WordSpec() {
-    init {
-        "RepositoryConfiguration" should {
-            "deserialize to a path regex working with double star" {
-                val configuration = """
-                    excludes:
-                      paths:
-                      - pattern: "android/**build.gradle"
-                        reason: "BUILD_TOOL_OF"
-                        comment: "project comment"
-                    """.trimIndent()
+class RepositoryConfigurationTest : WordSpec({
+    "RepositoryConfiguration" should {
+        "deserialize to a path regex working with double star" {
+            val configuration = """
+                excludes:
+                  paths:
+                  - pattern: "android/**build.gradle"
+                    reason: "BUILD_TOOL_OF"
+                    comment: "project comment"
+                """.trimIndent()
 
-                val config = yamlMapper.readValue<RepositoryConfiguration>(configuration)
-                config.excludes.paths[0].matches("android/project1/build.gradle") shouldBe true
+            val config = yamlMapper.readValue<RepositoryConfiguration>(configuration)
+            config.excludes.paths[0].matches("android/project1/build.gradle") shouldBe true
+        }
+
+        "be deserializable" {
+            val configuration = """
+                excludes:
+                  paths:
+                  - pattern: "project1/path"
+                    reason: "BUILD_TOOL_OF"
+                    comment: "project comment"
+                  scopes:
+                  - name: "scope"
+                    reason: "TEST_DEPENDENCY_OF"
+                    comment: "scope comment"
+                resolutions:
+                  issues:
+                  - message: "message"
+                    reason: "CANT_FIX_ISSUE"
+                    comment: "issue comment"
+                  rule_violations:
+                  - message: "rule message"
+                    reason: "PATENT_GRANT_EXCEPTION"
+                    comment: "rule comment"
+                """.trimIndent()
+
+            val repositoryConfiguration = yamlMapper.readValue<RepositoryConfiguration>(configuration)
+
+            repositoryConfiguration shouldNotBe null
+
+            val paths = repositoryConfiguration.excludes.paths
+            paths should haveSize(1)
+
+            val path = paths[0]
+            path.pattern shouldBe "project1/path"
+            path.reason shouldBe PathExcludeReason.BUILD_TOOL_OF
+            path.comment shouldBe "project comment"
+
+            val scopes = repositoryConfiguration.excludes.scopes
+            scopes should haveSize(1)
+            with(scopes.first()) {
+                pattern shouldBe "scope"
+                reason shouldBe ScopeExcludeReason.TEST_DEPENDENCY_OF
+                comment shouldBe "scope comment"
             }
 
-            "be deserializable" {
-                val configuration = """
-                    excludes:
-                      paths:
-                      - pattern: "project1/path"
-                        reason: "BUILD_TOOL_OF"
-                        comment: "project comment"
-                      scopes:
-                      - name: "scope"
-                        reason: "TEST_DEPENDENCY_OF"
-                        comment: "scope comment"
-                    resolutions:
-                      issues:
-                      - message: "message"
-                        reason: "CANT_FIX_ISSUE"
-                        comment: "issue comment"
-                      rule_violations:
-                      - message: "rule message"
-                        reason: "PATENT_GRANT_EXCEPTION"
-                        comment: "rule comment"
-                    """.trimIndent()
+            val issues = repositoryConfiguration.resolutions.issues
+            issues should haveSize(1)
+            with(issues.first()) {
+                message shouldBe "message"
+                reason shouldBe IssueResolutionReason.CANT_FIX_ISSUE
+                comment shouldBe "issue comment"
+            }
 
-                val repositoryConfiguration = yamlMapper.readValue<RepositoryConfiguration>(configuration)
-
-                repositoryConfiguration shouldNotBe null
-
-                val paths = repositoryConfiguration.excludes.paths
-                paths should haveSize(1)
-
-                val path = paths[0]
-                path.pattern shouldBe "project1/path"
-                path.reason shouldBe PathExcludeReason.BUILD_TOOL_OF
-                path.comment shouldBe "project comment"
-
-                val scopes = repositoryConfiguration.excludes.scopes
-                scopes should haveSize(1)
-                with(scopes.first()) {
-                    pattern shouldBe "scope"
-                    reason shouldBe ScopeExcludeReason.TEST_DEPENDENCY_OF
-                    comment shouldBe "scope comment"
-                }
-
-                val issues = repositoryConfiguration.resolutions.issues
-                issues should haveSize(1)
-                with(issues.first()) {
-                    message shouldBe "message"
-                    reason shouldBe IssueResolutionReason.CANT_FIX_ISSUE
-                    comment shouldBe "issue comment"
-                }
-
-                val ruleViolations = repositoryConfiguration.resolutions.ruleViolations
-                ruleViolations should haveSize(1)
-                with(ruleViolations.first()) {
-                    message shouldBe "rule message"
-                    reason shouldBe RuleViolationResolutionReason.PATENT_GRANT_EXCEPTION
-                    comment shouldBe "rule comment"
-                }
+            val ruleViolations = repositoryConfiguration.resolutions.ruleViolations
+            ruleViolations should haveSize(1)
+            with(ruleViolations.first()) {
+                message shouldBe "rule message"
+                reason shouldBe RuleViolationResolutionReason.PATENT_GRANT_EXCEPTION
+                comment shouldBe "rule comment"
             }
         }
     }
-}
+})

--- a/spdx-utils/src/test/kotlin/SpdxExpressionLexerTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionLexerTest.kt
@@ -37,44 +37,42 @@ fun getTokensByTypeForExpression(expression: String): List<Pair<Int, String>> {
     return lexer.allTokens.map { it.type to it.text }
 }
 
-class SpdxExpressionLexerTest : WordSpec() {
-    init {
-        "SpdxExpressionLexer" should {
-            "create the correct tokens for a valid expression" {
-                val expression = "(license-1 AND OR license.2 WITH 0LiCeNsE-3+) and (or with license-4 license-.5(("
+class SpdxExpressionLexerTest : WordSpec({
+    "SpdxExpressionLexer" should {
+        "create the correct tokens for a valid expression" {
+            val expression = "(license-1 AND OR license.2 WITH 0LiCeNsE-3+) and (or with license-4 license-.5(("
 
-                val tokens = getTokensByTypeForExpression(expression)
+            val tokens = getTokensByTypeForExpression(expression)
 
-                tokens should containExactly(
-                    SpdxExpressionLexer.OPEN to "(",
-                    SpdxExpressionLexer.IDSTRING to "license-1",
-                    SpdxExpressionLexer.AND to "AND",
-                    SpdxExpressionLexer.OR to "OR",
-                    SpdxExpressionLexer.IDSTRING to "license.2",
-                    SpdxExpressionLexer.WITH to "WITH",
-                    SpdxExpressionLexer.IDSTRING to "0LiCeNsE-3",
-                    SpdxExpressionLexer.PLUS to "+",
-                    SpdxExpressionLexer.CLOSE to ")",
-                    SpdxExpressionLexer.AND to "and",
-                    SpdxExpressionLexer.OPEN to "(",
-                    SpdxExpressionLexer.OR to "or",
-                    SpdxExpressionLexer.WITH to "with",
-                    SpdxExpressionLexer.IDSTRING to "license-4",
-                    SpdxExpressionLexer.IDSTRING to "license-.5",
-                    SpdxExpressionLexer.OPEN to "(",
-                    SpdxExpressionLexer.OPEN to "("
-                )
+            tokens should containExactly(
+                SpdxExpressionLexer.OPEN to "(",
+                SpdxExpressionLexer.IDSTRING to "license-1",
+                SpdxExpressionLexer.AND to "AND",
+                SpdxExpressionLexer.OR to "OR",
+                SpdxExpressionLexer.IDSTRING to "license.2",
+                SpdxExpressionLexer.WITH to "WITH",
+                SpdxExpressionLexer.IDSTRING to "0LiCeNsE-3",
+                SpdxExpressionLexer.PLUS to "+",
+                SpdxExpressionLexer.CLOSE to ")",
+                SpdxExpressionLexer.AND to "and",
+                SpdxExpressionLexer.OPEN to "(",
+                SpdxExpressionLexer.OR to "or",
+                SpdxExpressionLexer.WITH to "with",
+                SpdxExpressionLexer.IDSTRING to "license-4",
+                SpdxExpressionLexer.IDSTRING to "license-.5",
+                SpdxExpressionLexer.OPEN to "(",
+                SpdxExpressionLexer.OPEN to "("
+            )
+        }
+
+        "fail for an invalid expression" {
+            val expression = "/"
+
+            val exception = shouldThrow<SpdxException> {
+                getTokensByTypeForExpression(expression)
             }
 
-            "fail for an invalid expression" {
-                val expression = "/"
-
-                val exception = shouldThrow<SpdxException> {
-                    getTokensByTypeForExpression(expression)
-                }
-
-                exception.message shouldBe "token recognition error at: '/'"
-            }
+            exception.message shouldBe "token recognition error at: '/'"
         }
     }
-}
+})

--- a/spdx-utils/src/test/kotlin/SpdxExpressionParserTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionParserTest.kt
@@ -23,187 +23,185 @@ import io.kotest.matchers.shouldBe
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 
-class SpdxExpressionParserTest : WordSpec() {
-    init {
-        "SpdxExpressionParser" should {
-            "parse a license id correctly" {
-                val actualExpression = SpdxExpression.parse("spdx.license-id")
-                val expectedExpression = SpdxLicenseIdExpression("spdx.license-id")
+class SpdxExpressionParserTest : WordSpec({
+    "SpdxExpressionParser" should {
+        "parse a license id correctly" {
+            val actualExpression = SpdxExpression.parse("spdx.license-id")
+            val expectedExpression = SpdxLicenseIdExpression("spdx.license-id")
 
-                actualExpression shouldBe expectedExpression
-            }
+            actualExpression shouldBe expectedExpression
+        }
 
-            "parse a license id starting with a digit correctly" {
-                val actualExpression = SpdxExpression.parse("0license")
-                val expectedExpression = SpdxLicenseIdExpression("0license")
+        "parse a license id starting with a digit correctly" {
+            val actualExpression = SpdxExpression.parse("0license")
+            val expectedExpression = SpdxLicenseIdExpression("0license")
 
-                actualExpression shouldBe expectedExpression
-            }
+            actualExpression shouldBe expectedExpression
+        }
 
-            "parse a license id with any later version correctly" {
-                val actualExpression = SpdxExpression.parse("license+")
-                val expectedExpression = SpdxLicenseIdExpression("license", orLaterVersion = true)
+        "parse a license id with any later version correctly" {
+            val actualExpression = SpdxExpression.parse("license+")
+            val expectedExpression = SpdxLicenseIdExpression("license", orLaterVersion = true)
 
-                actualExpression shouldBe expectedExpression
-            }
+            actualExpression shouldBe expectedExpression
+        }
 
-            "parse a document ref correctly" {
-                val actualExpression = SpdxExpression.parse("DocumentRef-document:LicenseRef-license")
-                val expectedExpression = SpdxLicenseReferenceExpression("DocumentRef-document:LicenseRef-license")
+        "parse a document ref correctly" {
+            val actualExpression = SpdxExpression.parse("DocumentRef-document:LicenseRef-license")
+            val expectedExpression = SpdxLicenseReferenceExpression("DocumentRef-document:LicenseRef-license")
 
-                actualExpression shouldBe expectedExpression
-            }
+            actualExpression shouldBe expectedExpression
+        }
 
-            "parse a license ref correctly" {
-                val actualExpression = SpdxExpression.parse("LicenseRef-license")
-                val expectedExpression = SpdxLicenseReferenceExpression("LicenseRef-license")
+        "parse a license ref correctly" {
+            val actualExpression = SpdxExpression.parse("LicenseRef-license")
+            val expectedExpression = SpdxLicenseReferenceExpression("LicenseRef-license")
 
-                actualExpression shouldBe expectedExpression
-            }
+            actualExpression shouldBe expectedExpression
+        }
 
-            "parse a complex expression correctly" {
-                val actualExpression = SpdxExpression.parse(
-                    "license1+ and ((license2 with exception1) OR license3+ AND license4 WITH exception2)"
-                )
-                val expectedExpression = SpdxCompoundExpression(
-                    SpdxLicenseIdExpression("license1", orLaterVersion = true),
-                    SpdxOperator.AND,
+        "parse a complex expression correctly" {
+            val actualExpression = SpdxExpression.parse(
+                "license1+ and ((license2 with exception1) OR license3+ AND license4 WITH exception2)"
+            )
+            val expectedExpression = SpdxCompoundExpression(
+                SpdxLicenseIdExpression("license1", orLaterVersion = true),
+                SpdxOperator.AND,
+                SpdxCompoundExpression(
+                    SpdxLicenseWithExceptionExpression(
+                        SpdxLicenseIdExpression("license2"),
+                        "exception1"
+                    ),
+                    SpdxOperator.OR,
                     SpdxCompoundExpression(
+                        SpdxLicenseIdExpression("license3", orLaterVersion = true),
+                        SpdxOperator.AND,
                         SpdxLicenseWithExceptionExpression(
-                            SpdxLicenseIdExpression("license2"),
-                            "exception1"
-                        ),
-                        SpdxOperator.OR,
-                        SpdxCompoundExpression(
-                            SpdxLicenseIdExpression("license3", orLaterVersion = true),
-                            SpdxOperator.AND,
-                            SpdxLicenseWithExceptionExpression(
-                                SpdxLicenseIdExpression("license4"),
-                                "exception2"
-                            )
+                            SpdxLicenseIdExpression("license4"),
+                            "exception2"
                         )
                     )
                 )
+            )
 
-                actualExpression shouldBe expectedExpression
-            }
+            actualExpression shouldBe expectedExpression
+        }
 
-            "bind + stronger than WITH" {
-                val actualExpression = SpdxExpression.parse("license+ WITH exception")
-                val expectedExpression = SpdxLicenseWithExceptionExpression(
-                    SpdxLicenseIdExpression("license", orLaterVersion = true),
+        "bind + stronger than WITH" {
+            val actualExpression = SpdxExpression.parse("license+ WITH exception")
+            val expectedExpression = SpdxLicenseWithExceptionExpression(
+                SpdxLicenseIdExpression("license", orLaterVersion = true),
+                "exception"
+            )
+
+            actualExpression shouldBe expectedExpression
+        }
+
+        "bind WITH stronger than AND" {
+            val actualExpression = SpdxExpression.parse("license1 AND license2 WITH exception")
+            val expectedExpression = SpdxCompoundExpression(
+                SpdxLicenseIdExpression("license1"),
+                SpdxOperator.AND,
+                SpdxLicenseWithExceptionExpression(
+                    SpdxLicenseIdExpression("license2"),
                     "exception"
                 )
+            )
 
-                actualExpression shouldBe expectedExpression
-            }
+            actualExpression shouldBe expectedExpression
+        }
 
-            "bind WITH stronger than AND" {
-                val actualExpression = SpdxExpression.parse("license1 AND license2 WITH exception")
-                val expectedExpression = SpdxCompoundExpression(
+        "bind AND stronger than OR" {
+            val actualExpression = SpdxExpression.parse("license1 OR license2 AND license3")
+            val expectedExpression = SpdxCompoundExpression(
+                SpdxLicenseIdExpression("license1"),
+                SpdxOperator.OR,
+                SpdxCompoundExpression(
+                    SpdxLicenseIdExpression("license2"),
+                    SpdxOperator.AND,
+                    SpdxLicenseIdExpression("license3")
+                )
+            )
+
+            actualExpression shouldBe expectedExpression
+        }
+
+        "bind the and operator left associative" {
+            val actualExpression = SpdxExpression.parse("license1 AND license2 AND license3")
+            val expectedExpression = SpdxCompoundExpression(
+                SpdxCompoundExpression(
                     SpdxLicenseIdExpression("license1"),
                     SpdxOperator.AND,
-                    SpdxLicenseWithExceptionExpression(
-                        SpdxLicenseIdExpression("license2"),
-                        "exception"
-                    )
-                )
+                    SpdxLicenseIdExpression("license2")
+                ),
+                SpdxOperator.AND,
+                SpdxLicenseIdExpression("license3")
+            )
 
-                actualExpression shouldBe expectedExpression
-            }
+            actualExpression shouldBe expectedExpression
+        }
 
-            "bind AND stronger than OR" {
-                val actualExpression = SpdxExpression.parse("license1 OR license2 AND license3")
-                val expectedExpression = SpdxCompoundExpression(
+        "bind the or operator left associative" {
+            val actualExpression = SpdxExpression.parse("license1 OR license2 OR license3")
+            val expectedExpression = SpdxCompoundExpression(
+                SpdxCompoundExpression(
                     SpdxLicenseIdExpression("license1"),
                     SpdxOperator.OR,
-                    SpdxCompoundExpression(
-                        SpdxLicenseIdExpression("license2"),
-                        SpdxOperator.AND,
-                        SpdxLicenseIdExpression("license3")
-                    )
-                )
+                    SpdxLicenseIdExpression("license2")
+                ),
+                SpdxOperator.OR,
+                SpdxLicenseIdExpression("license3")
+            )
 
-                actualExpression shouldBe expectedExpression
-            }
+            actualExpression shouldBe expectedExpression
+        }
 
-            "bind the and operator left associative" {
-                val actualExpression = SpdxExpression.parse("license1 AND license2 AND license3")
-                val expectedExpression = SpdxCompoundExpression(
-                    SpdxCompoundExpression(
-                        SpdxLicenseIdExpression("license1"),
-                        SpdxOperator.AND,
-                        SpdxLicenseIdExpression("license2")
-                    ),
-                    SpdxOperator.AND,
-                    SpdxLicenseIdExpression("license3")
-                )
-
-                actualExpression shouldBe expectedExpression
-            }
-
-            "bind the or operator left associative" {
-                val actualExpression = SpdxExpression.parse("license1 OR license2 OR license3")
-                val expectedExpression = SpdxCompoundExpression(
-                    SpdxCompoundExpression(
-                        SpdxLicenseIdExpression("license1"),
-                        SpdxOperator.OR,
-                        SpdxLicenseIdExpression("license2")
-                    ),
+        "respect parentheses for binding strength of operators" {
+            val actualExpression = SpdxExpression.parse("(license1 OR license2) AND license3")
+            val expectedExpression = SpdxCompoundExpression(
+                SpdxCompoundExpression(
+                    SpdxLicenseIdExpression("license1"),
                     SpdxOperator.OR,
-                    SpdxLicenseIdExpression("license3")
-                )
+                    SpdxLicenseIdExpression("license2")
+                ),
+                SpdxOperator.AND,
+                SpdxLicenseIdExpression("license3")
+            )
 
-                actualExpression shouldBe expectedExpression
+            actualExpression shouldBe expectedExpression
+        }
+
+        "fail if + is used in an exception expression" {
+            val exception = shouldThrow<SpdxException> {
+                SpdxExpression.parse("license WITH exception+")
             }
 
-            "respect parentheses for binding strength of operators" {
-                val actualExpression = SpdxExpression.parse("(license1 OR license2) AND license3")
-                val expectedExpression = SpdxCompoundExpression(
-                    SpdxCompoundExpression(
-                        SpdxLicenseIdExpression("license1"),
-                        SpdxOperator.OR,
-                        SpdxLicenseIdExpression("license2")
-                    ),
-                    SpdxOperator.AND,
-                    SpdxLicenseIdExpression("license3")
-                )
+            exception.message shouldBe "extraneous input '+' expecting <EOF>"
+        }
 
-                actualExpression shouldBe expectedExpression
+        "fail if a compound expression is used before WITH" {
+            val exception = shouldThrow<SpdxException> {
+                SpdxExpression.parse("(license1 AND license2) WITH exception")
             }
 
-            "fail if + is used in an exception expression" {
-                val exception = shouldThrow<SpdxException> {
-                    SpdxExpression.parse("license WITH exception+")
-                }
+            exception.message shouldBe "mismatched input 'WITH' expecting {AND, OR, ')', '+'}"
+        }
 
-                exception.message shouldBe "extraneous input '+' expecting <EOF>"
+        "fail on an invalid symbol" {
+            val exception = shouldThrow<SpdxException> {
+                SpdxExpression.parse("/")
             }
 
-            "fail if a compound expression is used before WITH" {
-                val exception = shouldThrow<SpdxException> {
-                    SpdxExpression.parse("(license1 AND license2) WITH exception")
-                }
+            exception.message shouldBe "token recognition error at: '/'"
+        }
 
-                exception.message shouldBe "mismatched input 'WITH' expecting {AND, OR, ')', '+'}"
+        "fail on a syntax error" {
+            val exception = shouldThrow<SpdxException> {
+                SpdxExpression.parse("((")
             }
 
-            "fail on an invalid symbol" {
-                val exception = shouldThrow<SpdxException> {
-                    SpdxExpression.parse("/")
-                }
-
-                exception.message shouldBe "token recognition error at: '/'"
-            }
-
-            "fail on a syntax error" {
-                val exception = shouldThrow<SpdxException> {
-                    SpdxExpression.parse("((")
-                }
-
-                exception.message shouldBe
-                        "mismatched input '<EOF>' expecting {'(', DOCUMENTREFERENCE, LICENSEREFERENCE, IDSTRING}"
-            }
+            exception.message shouldBe
+                    "mismatched input '<EOF>' expecting {'(', DOCUMENTREFERENCE, LICENSEREFERENCE, IDSTRING}"
         }
     }
-}
+})


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>