### PR TITLE
spdx-utils: Copyright fixes

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -59,18 +59,18 @@ Copyright: 2013-2020 GitHub, Inc. and contributors <support@github.com>
 License: CC-BY-3.0
 
 Files: spdx-utils/src/main/resources/exceptions/*
-Copyright: 2011-2020 SPDX Workgroup <spdx-legal@lists.spdx.org>
+Copyright: 2010-2020 Linux Foundation and its Contributors
 License: CC0-1.0
 
 Files: spdx-utils/src/main/resources/licenses/*
-Copyright: 2011-2020 SPDX Workgroup <spdx-legal@lists.spdx.org>
+Copyright: 2010-2020 Linux Foundation and its Contributors
 License: CC0-1.0
 
 Files: spdx-utils/src/main/resources/licenserefs/*
-Copyright: 2011-2020 SPDX Workgroup <spdx-legal@lists.spdx.org>
+Copyright: 2010-2020 Linux Foundation and its Contributors
 License: CC0-1.0
 
 Files: spdx-utils/src/test/resources/spdx-spec-examples/*
-Copyright: 2011-2020 SPDX Workgroup <spdx-legal@lists.spdx.org>
+Copyright: 2010-2020 Linux Foundation and its Contributors
 License: CC-BY-3.0
 

--- a/spdx-utils/src/main/kotlin/SpdxModelSerializer.kt
+++ b/spdx-utils/src/main/kotlin/SpdxModelSerializer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spdx-utils/src/main/kotlin/model/SpdxAnnotation.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxAnnotation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spdx-utils/src/main/kotlin/model/SpdxChecksum.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxChecksum.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spdx-utils/src/main/kotlin/model/SpdxConstants.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxConstants.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spdx-utils/src/main/kotlin/model/SpdxCreationInfo.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxCreationInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spdx-utils/src/main/kotlin/model/SpdxDocument.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxDocument.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spdx-utils/src/main/kotlin/model/SpdxExternalDocumentReference.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxExternalDocumentReference.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spdx-utils/src/main/kotlin/model/SpdxExternalReference.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxExternalReference.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spdx-utils/src/main/kotlin/model/SpdxExtractedLicenseInfo.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxExtractedLicenseInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spdx-utils/src/main/kotlin/model/SpdxFile.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxFile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spdx-utils/src/main/kotlin/model/SpdxPackage.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxPackage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spdx-utils/src/main/kotlin/model/SpdxPackageVerificationCode.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxPackageVerificationCode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spdx-utils/src/main/kotlin/model/SpdxRelationship.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxRelationship.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spdx-utils/src/main/kotlin/model/SpdxSnippet.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxSnippet.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spdx-utils/src/test/kotlin/SpdxDocumentModelTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxDocumentModelTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fix-up the copyright years of the SPDX document model implementation as well as several REUSE file entries.