### PR TITLE
downloader: Fix a sub-directory walk to not contain the parent directory

### DIFF
--- a/downloader/src/funTest/kotlin/vcs/GitRepoDownloadTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitRepoDownloadTest.kt
@@ -67,7 +67,11 @@ class GitRepoDownloadTest : StringSpec() {
                 "src"
             )
 
-            val actualSpdxFiles = spdxDir.walk().maxDepth(1).filter { it.isDirectory }.map { it.name }.sorted()
+            val actualSpdxFiles = spdxDir.walk().maxDepth(1).filter {
+                it.isDirectory && it != spdxDir
+            }.map {
+                it.name
+            }.sorted()
 
             val submodulesDir = File(outputDir, "submodules")
             val expectedSubmodulesFiles = listOf(
@@ -77,7 +81,7 @@ class GitRepoDownloadTest : StringSpec() {
             )
 
             val actualSubmodulesFiles = submodulesDir.walk().maxDepth(1).filter {
-                it.isDirectory
+                it.isDirectory && it != submodulesDir
             }.map {
                 it.name
             }.sorted()

--- a/downloader/src/main/kotlin/vcs/Cvs.kt
+++ b/downloader/src/main/kotlin/vcs/Cvs.kt
@@ -140,7 +140,7 @@ class Cvs : VersionControlSystem(), CommandLineTool {
                     // Clean the temporarily updated working tree again.
                     workingDir.walk().maxDepth(1).forEach {
                         if (it.isDirectory) {
-                            if (it.name != "CVS") it.safeDeleteRecursively()
+                            if (it != workingDir && it.name != "CVS") it.safeDeleteRecursively()
                         } else {
                             it.delete()
                         }


### PR DESCRIPTION
As walk().maxDepth(1) includes the "." directory we need to explicitly
exclude it if we do not want to handle it. This is a fixup for a9451c6.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>