### PR TITLE
Identifier: Limit the split components to a maximum of 4

### DIFF
--- a/model/src/main/kotlin/Identifier.kt
+++ b/model/src/main/kotlin/Identifier.kt
@@ -76,7 +76,7 @@ data class Identifier(
      * three colon separators the missing values are assigned empty strings.
      */
     @JsonCreator
-    constructor(identifier: String) : this(identifier.split(':'))
+    constructor(identifier: String) : this(identifier.split(':', limit = 4))
 
     private val components = listOf(type, namespace, name, version)
 


### PR DESCRIPTION
So that the rest of a string will become part of the version instead of
being silently dropped.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>