### PR TITLE
Revert "Identifier: Limit the split components to a maximum of 4"

### DIFF
--- a/model/src/main/kotlin/Identifier.kt
+++ b/model/src/main/kotlin/Identifier.kt
@@ -76,7 +76,7 @@ data class Identifier(
      * three colon separators the missing values are assigned empty strings.
      */
     @JsonCreator
-    constructor(identifier: String) : this(identifier.split(':', limit = 4))
+    constructor(identifier: String) : this(identifier.split(':'))
 
     private val components = listOf(type, namespace, name, version)
 


### PR DESCRIPTION
This reverts commit d3178ffa1bfb303d7141b80beb067cc080ee4b48.

Revert as commit causes ORT to throw ValueInstantiationException.

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>