### PR TITLE
reporter: Add a very basic SpdxDocumentReporter

### DIFF
--- a/analyzer/src/funTest/kotlin/managers/NpmTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmTest.kt
@@ -48,7 +48,7 @@ class NpmTest : WordSpec() {
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                     File(projectsDir.parentFile, "npm-expected-output.yml"),
-                    custom = Pair("npm-project", "npm-${workingDir.name}"),
+                    custom = mapOf("npm-project" to "npm-${workingDir.name}"),
                     definitionFilePath = "$vcsPath/package.json",
                     url = normalizeVcsUrl(vcsUrl),
                     revision = vcsRevision,
@@ -66,7 +66,7 @@ class NpmTest : WordSpec() {
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                     File(projectsDir.parentFile, "npm-expected-output.yml"),
-                    custom = Pair("npm-project", "npm-${workingDir.name}"),
+                    custom = mapOf("npm-project" to "npm-${workingDir.name}"),
                     definitionFilePath = "$vcsPath/package.json",
                     url = normalizeVcsUrl(vcsUrl),
                     revision = vcsRevision,
@@ -84,7 +84,7 @@ class NpmTest : WordSpec() {
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                     File(projectsDir.parentFile, "npm-expected-output-no-lockfile.yml"),
-                    custom = Pair("npm-project", "npm-${workingDir.name}"),
+                    custom = mapOf("npm-project" to "npm-${workingDir.name}"),
                     definitionFilePath = "$vcsPath/package.json",
                     url = normalizeVcsUrl(vcsUrl),
                     revision = vcsRevision,
@@ -102,7 +102,7 @@ class NpmTest : WordSpec() {
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                     File(projectsDir.parentFile, "npm-expected-output.yml"),
-                    custom = Pair("npm-project", "npm-${workingDir.name}"),
+                    custom = mapOf("npm-project" to "npm-${workingDir.name}"),
                     definitionFilePath = "$vcsPath/package.json",
                     url = normalizeVcsUrl(vcsUrl),
                     revision = vcsRevision,

--- a/analyzer/src/funTest/kotlin/managers/PubTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PubTest.kt
@@ -57,7 +57,7 @@ class PubTest : WordSpec() {
                     val vcsPath = vcsDir.getPathToRoot(workingDir)
                     val expectedResult = patchExpectedResult(
                         expectedResultFile,
-                        custom = Pair("pub-project", "pub-${workingDir.name}"),
+                        custom = mapOf("pub-project" to "pub-${workingDir.name}"),
                         definitionFilePath = "$vcsPath/pubspec.yaml",
                         url = normalizeVcsUrl(vcsUrl),
                         revision = vcsRevision,
@@ -79,7 +79,7 @@ class PubTest : WordSpec() {
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                     expectedResultFile,
-                    custom = Pair("pub-project", "pub-${workingDir.name}"),
+                    custom = mapOf("pub-project" to "pub-${workingDir.name}"),
                     definitionFilePath = "$vcsPath/pubspec.yaml",
                     url = normalizeVcsUrl(vcsUrl),
                     revision = vcsRevision,
@@ -98,7 +98,7 @@ class PubTest : WordSpec() {
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                     expectedResultFile,
-                    custom = Pair("pub-project", "pub-${workingDir.name}"),
+                    custom = mapOf("pub-project" to "pub-${workingDir.name}"),
                     definitionFilePath = "$vcsPath/pubspec.yaml",
                     url = normalizeVcsUrl(vcsUrl),
                     revision = vcsRevision,

--- a/analyzer/src/funTest/kotlin/managers/YarnTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/YarnTest.kt
@@ -45,7 +45,7 @@ class YarnTest : WordSpec() {
             url = normalizeVcsUrl(vcsUrl),
             revision = vcsRevision,
             path = vcsPath,
-            custom = "<REPLACE_RAW_URL>" to vcsUrl
+            custom = mapOf("<REPLACE_RAW_URL>" to vcsUrl)
         )
     }
 

--- a/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
+++ b/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
@@ -1,0 +1,14 @@
+{
+  "SPDXID" : "SPDXRef-<REPLACE_UUID>",
+  "spdxVersion" : "SPDX-2.2.1",
+  "creationInfo" : {
+    "comment" : "some creation info comment",
+    "created" : "<REPLACE_CREATION_DATE_AND_TIME>",
+    "creators" : [ "Tool: OSS Review Toolkit - <REPLACE_ORT_VERSION>" ],
+    "licenseListVersion" : "<REPLACE_LICENSE_LIST_VERSION>"
+  },
+  "name" : "some document name",
+  "dataLicense" : "CC0-1.0",
+  "comment" : "some document comment",
+  "documentNamespace" : "spdx://<REPLACE_UUID>"
+}

--- a/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
+++ b/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
@@ -1,0 +1,13 @@
+---
+SPDXID: "SPDXRef-<REPLACE_UUID>"
+spdxVersion: "SPDX-2.2.1"
+creationInfo:
+  comment: "some creation info comment"
+  created: "<REPLACE_CREATION_DATE_AND_TIME>"
+  creators:
+  - "Tool: OSS Review Toolkit - <REPLACE_ORT_VERSION>"
+  licenseListVersion: "<REPLACE_LICENSE_LIST_VERSION>"
+name: "some document name"
+dataLicense: "CC0-1.0"
+comment: "some document comment"
+documentNamespace: "spdx://<REPLACE_UUID>"

--- a/reporter/src/funTest/kotlin/reporters/SpdxDocumentReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/SpdxDocumentReporterTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.reporter.reporters
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import java.io.File
+
+import org.ossreviewtoolkit.model.Environment
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.reporter.ReporterInput
+import org.ossreviewtoolkit.reporter.reporters.SpdxDocumentReporter.FileFormat
+import org.ossreviewtoolkit.spdx.SpdxLicense
+import org.ossreviewtoolkit.spdx.SpdxModelSerializer.fromJson
+import org.ossreviewtoolkit.spdx.SpdxModelSerializer.fromYaml
+import org.ossreviewtoolkit.spdx.model.SpdxDocument
+import org.ossreviewtoolkit.utils.ORT_NAME
+import org.ossreviewtoolkit.utils.normalizeLineBreaks
+import org.ossreviewtoolkit.utils.test.patchExpectedResult
+import org.ossreviewtoolkit.utils.test.readOrtResult
+
+class SpdxDocumentReporterTest : WordSpec({
+    "SpdxDocumentReporter" should {
+        "create the expected JSON SPDX document" {
+            val ortResult = readOrtResult("src/funTest/assets/static-html-reporter-test-input.yml")
+
+            val jsonSpdxDocument = generateReport(ortResult, FileFormat.JSON)
+
+            jsonSpdxDocument shouldBe patchExpectedResult(
+                "src/funTest/assets/spdx-document-reporter-expected-output.spdx.json",
+                fromJson(jsonSpdxDocument, SpdxDocument::class.java)
+            )
+        }
+
+        "create the expected YAML SPDX document" {
+            val ortResult = readOrtResult("src/funTest/assets/static-html-reporter-test-input.yml")
+
+            val yamlSpdxDocument = generateReport(ortResult, FileFormat.YAML)
+
+            yamlSpdxDocument shouldBe patchExpectedResult(
+                "src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml",
+                fromYaml(yamlSpdxDocument, SpdxDocument::class.java)
+            )
+        }
+    }
+})
+
+private fun generateReport(ortResult: OrtResult, format: FileFormat): String {
+    val input = ReporterInput(ortResult)
+
+    val outputDir = createTempDir(ORT_NAME, SpdxDocumentReporterTest::class.simpleName).apply { deleteOnExit() }
+
+    val reportOptions = mapOf(
+        SpdxDocumentReporter.CREATION_INFO_COMMENT to "some creation info comment",
+        SpdxDocumentReporter.DOCUMENT_COMMENT to "some document comment",
+        SpdxDocumentReporter.DOCUMENT_NAME to "some document name",
+        SpdxDocumentReporter.OUTPUT_FILE_FORMATS to format.toString()
+    )
+
+    return SpdxDocumentReporter().generateReport(input, outputDir, reportOptions).single().readText()
+        .normalizeLineBreaks()
+}
+
+private fun patchExpectedResult(expectedResultFile: String, actualSpdxDocument: SpdxDocument): String =
+    patchExpectedResult(
+        File(expectedResultFile),
+        mapOf(
+            "<REPLACE_LICENSE_LIST_VERSION>" to SpdxLicense.LICENSE_LIST_VERSION.substringBefore("-"),
+            "<REPLACE_ORT_VERSION>" to Environment().ortVersion,
+            "<REPLACE_CREATION_DATE_AND_TIME>" to actualSpdxDocument.creationInfo.created.toString(),
+            "<REPLACE_UUID>" to actualSpdxDocument.spdxId.substringAfter("SPDXRef-")
+        )
+    )

--- a/reporter/src/funTest/kotlin/reporters/StaticHtmlReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/StaticHtmlReporterTest.kt
@@ -49,7 +49,7 @@ class StaticHtmlReporterTest : WordSpec({
 
             val expectedReport = patchExpectedResult(
                 File("src/funTest/assets/static-html-reporter-test-expected-output.html"),
-                "<REPLACE_ORT_VERSION>" to Environment().ortVersion
+                mapOf("<REPLACE_ORT_VERSION>" to Environment().ortVersion)
             )
 
             actualReport shouldBe expectedReport

--- a/reporter/src/main/kotlin/reporters/SpdxDocumentReporter.kt
+++ b/reporter/src/main/kotlin/reporters/SpdxDocumentReporter.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.reporter.reporters
+
+import java.io.File
+
+import org.ossreviewtoolkit.reporter.Reporter
+import org.ossreviewtoolkit.reporter.ReporterInput
+import org.ossreviewtoolkit.reporter.utils.SpdxDocumentModelMapper
+import org.ossreviewtoolkit.spdx.SpdxModelSerializer
+
+/**
+ * Creates YAML and JSON SPDX documents. The option keys [CREATION_INFO_COMMENT], [DOCUMENT_COMMENT] and [DOCUMENT_NAME]
+ * can be provided to [generateReport] to inject the corresponding values as meta-data into the produced [SpdxDocument].
+ * The option key [OUTPUT_FILE_FORMATS] specifies a comma separated list of [FileFormat]s, whereas [FileFormat.values]
+ * is used by default.
+ */
+class SpdxDocumentReporter : Reporter {
+    companion object {
+        const val CREATION_INFO_COMMENT = "creationInfo.comment"
+        const val DOCUMENT_COMMENT = "document.comment"
+        const val DOCUMENT_NAME = "document.name"
+        const val OUTPUT_FILE_FORMATS = "output.file.formats"
+
+        private const val DOCUMENT_NAME_DEFAULT_VALUE = "Unnamed document"
+    }
+
+    enum class FileFormat(val reportFilename: String) {
+        JSON("document.spdx.json"),
+        YAML("document.spdx.yml")
+    }
+
+    override val reporterName = "SpdxDocument"
+
+    override fun generateReport(
+        input: ReporterInput,
+        outputDir: File,
+        options: Map<String, String>
+    ): List<File> {
+        val outputFileFormats = options[OUTPUT_FILE_FORMATS]
+            ?.split(",")
+            ?.map { FileFormat.valueOf(it.toUpperCase()) }
+            ?.distinct()
+            ?: enumValues<FileFormat>().asList()
+
+        val params = SpdxDocumentModelMapper.SpdxDocumentParams(
+            documentName = options.getOrDefault(DOCUMENT_NAME, DOCUMENT_NAME_DEFAULT_VALUE),
+            documentComment = options.getOrDefault(DOCUMENT_COMMENT, ""),
+            creationInfoComment = options.getOrDefault(CREATION_INFO_COMMENT, "")
+        )
+
+        val spdxDocument = SpdxDocumentModelMapper.map(input.ortResult, params)
+
+        return outputFileFormats.map { fileFormat ->
+            val serializedDocument = when (fileFormat) {
+                FileFormat.JSON -> SpdxModelSerializer.toJson(spdxDocument)
+                FileFormat.YAML -> SpdxModelSerializer.toYaml(spdxDocument)
+            }
+
+            outputDir.resolve(fileFormat.reportFilename).apply {
+                bufferedWriter().use { it.write(serializedDocument) }
+            }
+        }
+    }
+}

--- a/reporter/src/main/kotlin/utils/SpdxDocumentModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/SpdxDocumentModelMapper.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.reporter.utils
+
+import java.time.Instant
+import java.util.UUID
+
+import org.ossreviewtoolkit.model.Environment
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.spdx.SpdxLicense
+import org.ossreviewtoolkit.spdx.model.SpdxCreationInfo
+import org.ossreviewtoolkit.spdx.model.SpdxDocument
+import org.ossreviewtoolkit.utils.ORT_FULL_NAME
+
+/**
+ * A class for mapping [OrtResult]s to [SpdxDocument]s.
+ */
+object SpdxDocumentModelMapper {
+    fun map(@Suppress("UNUSED_PARAMETER") ortResult: OrtResult, params: SpdxDocumentParams): SpdxDocument {
+        val documentUuid = UUID.randomUUID()
+
+        return SpdxDocument(
+            spdxId = "SPDXRef-$documentUuid",
+            creationInfo = SpdxCreationInfo(
+                created = Instant.now(),
+                comment = params.creationInfoComment,
+                creators = listOf("Tool: $ORT_FULL_NAME - ${Environment().ortVersion}"),
+                licenseListVersion = SpdxLicense.LICENSE_LIST_VERSION.substringBefore("-")
+            ),
+            documentNamespace = "spdx://$documentUuid",
+            name = params.documentName,
+            comment = params.documentComment
+        )
+    }
+
+    data class SpdxDocumentParams(
+        val documentName: String,
+        val documentComment: String,
+        val creationInfoComment: String
+    )
+}

--- a/reporter/src/main/resources/META-INF/services/org.ossreviewtoolkit.reporter.Reporter
+++ b/reporter/src/main/resources/META-INF/services/org.ossreviewtoolkit.reporter.Reporter
@@ -6,5 +6,6 @@ org.ossreviewtoolkit.reporter.reporters.EvaluatedModelYamlReporter
 org.ossreviewtoolkit.reporter.reporters.ExcelReporter
 org.ossreviewtoolkit.reporter.reporters.NoticeByPackageReporter
 org.ossreviewtoolkit.reporter.reporters.NoticeSummaryReporter
+org.ossreviewtoolkit.reporter.reporters.SpdxDocumentReporter
 org.ossreviewtoolkit.reporter.reporters.StaticHtmlReporter
 org.ossreviewtoolkit.reporter.reporters.WebAppReporter

--- a/test-utils/src/main/kotlin/Utils.kt
+++ b/test-utils/src/main/kotlin/Utils.kt
@@ -43,18 +43,14 @@ private val START_AND_END_TIME_REGEX = Regex("((start|end)_time): \".*\"")
 private val TIMESTAMP_REGEX = Regex("(timestamp): \".*\"")
 
 fun patchExpectedResult(
-    result: File, custom: Pair<String, String>? = null, definitionFilePath: String? = null,
+    result: File, custom: Map<String, String> = emptyMap(), definitionFilePath: String? = null,
     url: String? = null, revision: String? = null, path: String? = null,
     urlProcessed: String? = null
 ): String {
-    fun String.replaceIfNotNull(strings: Pair<String, String>?) =
-        if (strings != null) replace(strings.first, strings.second) else this
-
     fun String.replaceIfNotNull(oldValue: String, newValue: String?) =
         if (newValue != null) replace(oldValue, newValue) else this
 
-    return result.readText()
-        .replaceIfNotNull(custom)
+    return custom.entries.fold(result.readText()) { text, entry -> text.replaceIfNotNull(entry.key, entry.value) }
         .replaceIfNotNull("<REPLACE_JAVA>", System.getProperty("java.version"))
         .replaceIfNotNull("<REPLACE_OS>", System.getProperty("os.name"))
         .replaceIfNotNull("<REPLACE_DEFINITION_FILE_PATH>", definitionFilePath)


### PR DESCRIPTION
Add an initial SPDX document reporter which for now only creates the
document header. Logic for serializing additional data will be added
incrementally in following changes.

Signed-off-by: Frank Viernau <frank.viernau@here.com>