### PR TITLE
spdx-utils: Fix all broken references from kDoc to SpdxConstants

### DIFF
--- a/spdx-utils/src/main/kotlin/model/SpdxFile.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxFile.kt
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
+import org.ossreviewtoolkit.spdx.SpdxConstants
 import org.ossreviewtoolkit.spdx.isSpdxExpressionOrNotPresent
 
 /**

--- a/spdx-utils/src/main/kotlin/model/SpdxPackage.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxPackage.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.spdx.model
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
+import org.ossreviewtoolkit.spdx.SpdxConstants
 import org.ossreviewtoolkit.spdx.isSpdxExpressionOrNotPresent
 
 /**

--- a/spdx-utils/src/main/kotlin/model/SpdxSnippet.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxSnippet.kt
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
+import org.ossreviewtoolkit.spdx.SpdxConstants
 import org.ossreviewtoolkit.spdx.isSpdxExpressionOrNotPresent
 
 /**


### PR DESCRIPTION
This is a fix-up for 4b2354d.

Signed-off-by: Frank Viernau <frank.viernau@here.com>