### PR TITLE
Revert "CuratedPackage: Serialize the curations property only if not …

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/dart-http-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/dart-http-expected-output.yml
@@ -113,6 +113,7 @@ packages:
       url: "https://github.com/dart-lang/sdk.git"
       revision: "master"
       path: "pkg/analyzer"
+  curations: []
 - package:
     id: "Pub:args:args:1.5.2"
     purl: "pkg:pub/args/args@1.5.2"
@@ -141,6 +142,7 @@ packages:
       url: "https://github.com/dart-lang/args.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:async:async:2.3.0"
     purl: "pkg:pub/async/async@2.3.0"
@@ -168,6 +170,7 @@ packages:
       url: "https://github.com/dart-lang/async.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:boolean_selector:boolean_selector:1.0.5"
     purl: "pkg:pub/boolean_selector/boolean_selector@1.0.5"
@@ -196,6 +199,7 @@ packages:
       url: "https://github.com/dart-lang/boolean_selector.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:charcode:charcode:1.1.2"
     purl: "pkg:pub/charcode/charcode@1.1.2"
@@ -226,6 +230,7 @@ packages:
       url: "https://github.com/dart-lang/charcode.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:collection:collection:1.14.11"
     purl: "pkg:pub/collection/collection@1.14.11"
@@ -253,6 +258,7 @@ packages:
       url: "https://github.com/dart-lang/collection.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:convert:convert:2.1.1"
     purl: "pkg:pub/convert/convert@2.1.1"
@@ -280,6 +286,7 @@ packages:
       url: "https://github.com/dart-lang/convert.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:crypto:crypto:2.1.1+1"
     purl: "pkg:pub/crypto/crypto@2.1.1%2B1"
@@ -307,6 +314,7 @@ packages:
       url: "https://github.com/dart-lang/crypto.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:csslib:csslib:0.16.1"
     purl: "pkg:pub/csslib/csslib@0.16.1"
@@ -334,6 +342,7 @@ packages:
       url: "https://github.com/dart-lang/csslib.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:front_end:front_end:0.1.20"
     purl: "pkg:pub/front_end/front_end@0.1.20"
@@ -361,6 +370,7 @@ packages:
       url: "https://github.com/dart-lang/sdk.git"
       revision: "master"
       path: "pkg/front_end"
+  curations: []
 - package:
     id: "Pub:glob:glob:1.1.7"
     purl: "pkg:pub/glob/glob@1.1.7"
@@ -388,6 +398,7 @@ packages:
       url: "https://github.com/dart-lang/glob.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:html:html:0.14.0+2"
     purl: "pkg:pub/html/html@0.14.0%2B2"
@@ -415,6 +426,7 @@ packages:
       url: "https://github.com/dart-lang/html.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:http_multi_server:http_multi_server:2.1.0"
     purl: "pkg:pub/http_multi_server/http_multi_server@2.1.0"
@@ -443,6 +455,7 @@ packages:
       url: "https://github.com/dart-lang/http_multi_server.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:http_parser:http_parser:3.1.3"
     purl: "pkg:pub/http_parser/http_parser@3.1.3"
@@ -471,6 +484,7 @@ packages:
       url: "https://github.com/dart-lang/http_parser.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:io:io:0.3.3"
     purl: "pkg:pub/io/io@0.3.3"
@@ -498,6 +512,7 @@ packages:
       url: "https://github.com/dart-lang/io.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:js:js:0.6.1+1"
     purl: "pkg:pub/js/js@0.6.1%2B1"
@@ -525,6 +540,7 @@ packages:
       url: "https://github.com/dart-lang/sdk.git"
       revision: "master"
       path: "pkg/js"
+  curations: []
 - package:
     id: "Pub:kernel:kernel:0.3.20"
     purl: "pkg:pub/kernel/kernel@0.3.20"
@@ -552,6 +568,7 @@ packages:
       url: "https://github.com/dart-lang/sdk.git"
       revision: "master"
       path: "pkg/kernel"
+  curations: []
 - package:
     id: "Pub:matcher:matcher:0.12.5"
     purl: "pkg:pub/matcher/matcher@0.12.5"
@@ -581,6 +598,7 @@ packages:
       url: "https://github.com/dart-lang/matcher.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:meta:meta:1.1.7"
     purl: "pkg:pub/meta/meta@1.1.7"
@@ -610,6 +628,7 @@ packages:
       url: "https://github.com/dart-lang/sdk.git"
       revision: "master"
       path: "pkg/meta"
+  curations: []
 - package:
     id: "Pub:mime:mime:0.9.6+3"
     purl: "pkg:pub/mime/mime@0.9.6%2B3"
@@ -638,6 +657,7 @@ packages:
       url: "https://github.com/dart-lang/mime.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:multi_server_socket:multi_server_socket:1.0.2"
     purl: "pkg:pub/multi_server_socket/multi_server_socket@1.0.2"
@@ -665,6 +685,7 @@ packages:
       url: "https://github.com/dart-lang/multi_server_socket.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:node_preamble:node_preamble:1.4.6"
     purl: "pkg:pub/node_preamble/node_preamble@1.4.6"
@@ -692,6 +713,7 @@ packages:
       url: "https://github.com/mbullington/node_preamble.dart.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:package_config:package_config:1.0.5"
     purl: "pkg:pub/package_config/package_config@1.0.5"
@@ -719,6 +741,7 @@ packages:
       url: "https://github.com/dart-lang/package_config.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:package_resolver:package_resolver:1.0.10"
     purl: "pkg:pub/package_resolver/package_resolver@1.0.10"
@@ -746,6 +769,7 @@ packages:
       url: "https://github.com/dart-lang/package_resolver.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:path:path:1.6.4"
     purl: "pkg:pub/path/path@1.6.4"
@@ -775,6 +799,7 @@ packages:
       url: "https://github.com/dart-lang/path.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:pedantic:pedantic:1.8.0+1"
     purl: "pkg:pub/pedantic/pedantic@1.8.0%2B1"
@@ -802,6 +827,7 @@ packages:
       url: "https://github.com/dart-lang/pedantic.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:pool:pool:1.4.0"
     purl: "pkg:pub/pool/pool@1.4.0"
@@ -830,6 +856,7 @@ packages:
       url: "https://github.com/dart-lang/pool.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:pub_semver:pub_semver:1.4.2"
     purl: "pkg:pub/pub_semver/pub_semver@1.4.2"
@@ -858,6 +885,7 @@ packages:
       url: "https://github.com/dart-lang/pub_semver.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:shelf:shelf:0.7.5"
     purl: "pkg:pub/shelf/shelf@0.7.5"
@@ -886,6 +914,7 @@ packages:
       url: "https://github.com/dart-lang/shelf.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:shelf_packages_handler:shelf_packages_handler:1.0.4"
     purl: "pkg:pub/shelf_packages_handler/shelf_packages_handler@1.0.4"
@@ -913,6 +942,7 @@ packages:
       url: "https://github.com/dart-lang/shelf_packages_handler.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:shelf_static:shelf_static:0.2.8"
     purl: "pkg:pub/shelf_static/shelf_static@0.2.8"
@@ -940,6 +970,7 @@ packages:
       url: "https://github.com/dart-lang/shelf_static.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:shelf_web_socket:shelf_web_socket:0.2.3"
     purl: "pkg:pub/shelf_web_socket/shelf_web_socket@0.2.3"
@@ -967,6 +998,7 @@ packages:
       url: "https://github.com/dart-lang/shelf_web_socket.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:source_map_stack_trace:source_map_stack_trace:1.1.5"
     purl: "pkg:pub/source_map_stack_trace/source_map_stack_trace@1.1.5"
@@ -994,6 +1026,7 @@ packages:
       url: "https://github.com/dart-lang/source_map_stack_trace.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:source_maps:source_maps:0.10.8"
     purl: "pkg:pub/source_maps/source_maps@0.10.8"
@@ -1021,6 +1054,7 @@ packages:
       url: "https://github.com/dart-lang/source_maps.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:source_span:source_span:1.5.5"
     purl: "pkg:pub/source_span/source_span@1.5.5"
@@ -1048,6 +1082,7 @@ packages:
       url: "https://github.com/dart-lang/source_span.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:stack_trace:stack_trace:1.9.3"
     purl: "pkg:pub/stack_trace/stack_trace@1.9.3"
@@ -1075,6 +1110,7 @@ packages:
       url: "https://github.com/dart-lang/stack_trace.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:stream_channel:stream_channel:2.0.0"
     purl: "pkg:pub/stream_channel/stream_channel@2.0.0"
@@ -1102,6 +1138,7 @@ packages:
       url: "https://github.com/dart-lang/stream_channel.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:stream_transform:stream_transform:0.0.19"
     purl: "pkg:pub/stream_transform/stream_transform@0.0.19"
@@ -1129,6 +1166,7 @@ packages:
       url: "https://github.com/dart-lang/stream_transform.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:string_scanner:string_scanner:1.0.5"
     purl: "pkg:pub/string_scanner/string_scanner@1.0.5"
@@ -1156,6 +1194,7 @@ packages:
       url: "https://github.com/dart-lang/string_scanner.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:term_glyph:term_glyph:1.1.0"
     purl: "pkg:pub/term_glyph/term_glyph@1.1.0"
@@ -1183,6 +1222,7 @@ packages:
       url: "https://github.com/dart-lang/term_glyph.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:test:test:1.6.5"
     purl: "pkg:pub/test/test@1.6.5"
@@ -1210,6 +1250,7 @@ packages:
       url: "https://github.com/dart-lang/test.git"
       revision: "master"
       path: "pkgs/test"
+  curations: []
 - package:
     id: "Pub:test_api:test_api:0.2.6"
     purl: "pkg:pub/test_api/test_api@0.2.6"
@@ -1237,6 +1278,7 @@ packages:
       url: "https://github.com/dart-lang/test.git"
       revision: "master"
       path: "pkgs/test_api"
+  curations: []
 - package:
     id: "Pub:test_core:test_core:0.2.7"
     purl: "pkg:pub/test_core/test_core@0.2.7"
@@ -1264,6 +1306,7 @@ packages:
       url: "https://github.com/dart-lang/test.git"
       revision: "master"
       path: "pkgs/test_core"
+  curations: []
 - package:
     id: "Pub:typed_data:typed_data:1.1.6"
     purl: "pkg:pub/typed_data/typed_data@1.1.6"
@@ -1291,6 +1334,7 @@ packages:
       url: "https://github.com/dart-lang/typed_data.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:vm_service_lib:vm_service_lib:3.22.2+1"
     purl: "pkg:pub/vm_service_lib/vm_service_lib@3.22.2%2B1"
@@ -1318,6 +1362,7 @@ packages:
       url: "https://github.com/dart-lang/vm_service_drivers.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:watcher:watcher:0.9.7+12"
     purl: "pkg:pub/watcher/watcher@0.9.7%2B12"
@@ -1346,6 +1391,7 @@ packages:
       url: "https://github.com/dart-lang/watcher.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:web_socket_channel:web_socket_channel:1.0.14"
     purl: "pkg:pub/web_socket_channel/web_socket_channel@1.0.14"
@@ -1375,6 +1421,7 @@ packages:
       url: "https://github.com/dart-lang/web_socket_channel.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:yaml:yaml:2.1.16"
     purl: "pkg:pub/yaml/yaml@2.1.16"
@@ -1402,3 +1449,4 @@ packages:
       url: "https://github.com/dart-lang/yaml.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -101,6 +101,7 @@ analyzer:
           url: "ssh://git@github.com/sbt/junit-interface.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:junit:junit:4.12"
         purl: "pkg:maven/junit/junit@4.12"
@@ -133,6 +134,7 @@ analyzer:
           url: "https://github.com/junit-team/junit.git"
           revision: "r4.12"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.hamcrest:hamcrest-core:1.3"
         purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
@@ -166,6 +168,7 @@ analyzer:
           url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.scala-sbt:test-interface:1.0"
         purl: "pkg:maven/org.scala-sbt/test-interface@1.0"
@@ -198,6 +201,7 @@ analyzer:
           url: "https://github.com/sbt/test-interface.git"
           revision: ""
           path: ""
+      curations: []
     has_issues: false
 scanner: null
 evaluator: null

--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -61,6 +61,7 @@ packages:
       url: "https://github.com/pallets/flask.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::Jinja2:2.8.1"
     purl: "pkg:pypi/Jinja2@2.8.1"
@@ -95,6 +96,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::MarkupSafe:1.1.1"
     purl: "pkg:pypi/MarkupSafe@1.1.1"
@@ -127,6 +129,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::Werkzeug:1.0.1"
     purl: "pkg:pypi/Werkzeug@1.0.1"
@@ -159,6 +162,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::click:7.1.2"
     purl: "pkg:pypi/click@7.1.2"
@@ -191,6 +195,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::gunicorn:19.6.0"
     purl: "pkg:pypi/gunicorn@19.6.0"
@@ -223,6 +228,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::itsdangerous:1.1.0"
     purl: "pkg:pypi/itsdangerous@1.1.0"
@@ -256,3 +262,4 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -420,6 +420,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:com.fasterxml.jackson.core:jackson-annotations:2.9.0"
         purl: "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.9.0"
@@ -452,6 +453,7 @@ analyzer:
           url: "ssh://git@github.com/FasterXML/jackson-annotations.git"
           revision: "jackson-annotations-2.9.0"
           path: ""
+      curations: []
     - package:
         id: "Maven:com.fasterxml.jackson.core:jackson-core:2.9.6"
         purl: "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.9.6"
@@ -484,6 +486,7 @@ analyzer:
           url: "ssh://git@github.com/FasterXML/jackson-core.git"
           revision: "jackson-core-2.9.6"
           path: ""
+      curations: []
     - package:
         id: "Maven:com.fasterxml.jackson.core:jackson-databind:2.9.6"
         purl: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.6"
@@ -516,6 +519,7 @@ analyzer:
           url: "ssh://git@github.com/FasterXML/jackson-databind.git"
           revision: "jackson-databind-2.9.6"
           path: ""
+      curations: []
     - package:
         id: "Maven:com.github.andrewoma.dexx:collection:0.7"
         purl: "pkg:maven/com.github.andrewoma.dexx/collection@0.7"
@@ -547,6 +551,7 @@ analyzer:
           url: "https://github.com/andrewoma/dexx.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:com.github.cliftonlabs:json-simple:2.3.1"
         purl: "pkg:maven/com.github.cliftonlabs/json-simple@2.3.1"
@@ -579,6 +584,7 @@ analyzer:
           url: "https://github.com/cliftonlabs/json-simple.git"
           revision: "json-simple-2.3.1"
           path: ""
+      curations: []
     - package:
         id: "Maven:com.github.jsonld-java:jsonld-java:0.12.1"
         purl: "pkg:maven/com.github.jsonld-java/jsonld-java@0.12.1"
@@ -610,6 +616,7 @@ analyzer:
           url: "ssh://git@github.com/jsonld-java/jsonld-java.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:com.github.spullara.mustache.java:compiler:0.7.9"
         purl: "pkg:maven/com.github.spullara.mustache.java/compiler@0.7.9"
@@ -641,6 +648,7 @@ analyzer:
           url: "https://github.com/spullara/mustache.java.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:com.github.virtuald:curvesapi:1.04"
         purl: "pkg:maven/com.github.virtuald/curvesapi@1.04"
@@ -675,6 +683,7 @@ analyzer:
           url: "https://github.com/virtuald/curvesapi.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:com.google.code.gson:gson:2.8.0"
         purl: "pkg:maven/com.google.code.gson/gson@2.8.0"
@@ -706,6 +715,7 @@ analyzer:
           url: "https://github.com/google/gson.git"
           revision: "gson-parent-2.8.0"
           path: ""
+      curations: []
     - package:
         id: "Maven:com.google.guava:guava:16.0.1"
         purl: "pkg:maven/com.google.guava/guava@16.0.1"
@@ -740,6 +750,7 @@ analyzer:
           url: "https://code.google.com/p/guava-libraries"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:commons-cli:commons-cli:1.4"
         purl: "pkg:maven/commons-cli/commons-cli@1.4"
@@ -772,6 +783,7 @@ analyzer:
           url: "http://svn.apache.org/repos/asf/commons/proper/cli"
           revision: "trunk"
           path: ""
+      curations: []
     - package:
         id: "Maven:commons-codec:commons-codec:1.10"
         purl: "pkg:maven/commons-codec/commons-codec@1.10"
@@ -806,6 +818,7 @@ analyzer:
           url: "http://svn.apache.org/repos/asf/commons/proper/codec"
           revision: "trunk"
           path: ""
+      curations: []
     - package:
         id: "Maven:commons-io:commons-io:2.6"
         purl: "pkg:maven/commons-io/commons-io@2.6"
@@ -839,6 +852,7 @@ analyzer:
           url: "http://git-wip-us.apache.org/repos/asf/commons-io.git"
           revision: "commons-io-2.6"
           path: ""
+      curations: []
     - package:
         id: "Maven:junit:junit:4.12"
         purl: "pkg:maven/junit/junit@4.12"
@@ -871,6 +885,7 @@ analyzer:
           url: "https://github.com/junit-team/junit.git"
           revision: "r4.12"
           path: ""
+      curations: []
     - package:
         id: "Maven:net.sf.opencsv:opencsv:2.3"
         purl: "pkg:maven/net.sf.opencsv/opencsv@2.3"
@@ -902,6 +917,7 @@ analyzer:
           url: "https://opencsv.svn.sourceforge.net/svnroot/opencsv"
           revision: "trunk"
           path: ""
+      curations: []
     - package:
         id: "Maven:net.sf.saxon:saxon-dom:8.7"
         purl: "pkg:maven/net.sf.saxon/saxon-dom@8.7"
@@ -933,6 +949,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:net.sf.saxon:saxon:8.7"
         purl: "pkg:maven/net.sf.saxon/saxon@8.7"
@@ -964,6 +981,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:nu.validator.htmlparser:htmlparser:1.4"
         purl: "pkg:maven/nu.validator.htmlparser/htmlparser@1.4"
@@ -1001,6 +1019,7 @@ analyzer:
           url: "http://hg.mozilla.org/projects/htmlparser"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.antlr:ST4:4.0.4"
         purl: "pkg:maven/org.antlr/ST4@4.0.4"
@@ -1042,6 +1061,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.antlr:antlr-runtime:3.4"
         purl: "pkg:maven/org.antlr/antlr-runtime@3.4"
@@ -1070,6 +1090,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.antlr:antlr:3.4"
         purl: "pkg:maven/org.antlr/antlr@3.4"
@@ -1098,6 +1119,7 @@ analyzer:
           url: "http://svn.sonatype.org/spice"
           revision: "tags/oss-parent-7"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.antlr:stringtemplate:3.2.1"
         purl: "pkg:maven/org.antlr/stringtemplate@3.2.1"
@@ -1139,6 +1161,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-collections4:4.1"
         purl: "pkg:maven/org.apache.commons/commons-collections4@4.1"
@@ -1171,6 +1194,7 @@ analyzer:
           url: "http://svn.apache.org/repos/asf/commons/proper/collections"
           revision: "trunk"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-compress:1.17"
         purl: "pkg:maven/org.apache.commons/commons-compress@1.17"
@@ -1205,6 +1229,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/commons-compress.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-csv:1.5"
         purl: "pkg:maven/org.apache.commons/commons-csv@1.5"
@@ -1237,6 +1262,7 @@ analyzer:
           url: "http://git-wip-us.apache.org/repos/asf/commons-csv.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-lang3:3.1"
         purl: "pkg:maven/org.apache.commons/commons-lang3@3.1"
@@ -1270,6 +1296,7 @@ analyzer:
           url: "http://svn.apache.org/repos/asf/commons/proper/lang"
           revision: "trunk"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-lang3:3.8.1"
         purl: "pkg:maven/org.apache.commons/commons-lang3@3.8.1"
@@ -1303,6 +1330,7 @@ analyzer:
           url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
           revision: "LANG_3_8_1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.httpcomponents:httpclient-cache:4.5.5"
         purl: "pkg:maven/org.apache.httpcomponents/httpclient-cache@4.5.5"
@@ -1334,6 +1362,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/httpcomponents-client.git"
           revision: "4.5.5"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.httpcomponents:httpclient:4.5.5"
         purl: "pkg:maven/org.apache.httpcomponents/httpclient@4.5.5"
@@ -1365,6 +1394,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/httpcomponents-client.git"
           revision: "4.5.5"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.httpcomponents:httpcore:4.4.9"
         purl: "pkg:maven/org.apache.httpcomponents/httpcore@4.4.9"
@@ -1396,6 +1426,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/httpcomponents-core.git"
           revision: "4.4.9"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.jena:apache-jena-libs:3.9.0"
         purl: "pkg:maven/org.apache.jena/apache-jena-libs@3.9.0"
@@ -1428,6 +1459,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
           revision: "jena-3.9.0-rc1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.jena:jena-arq:3.9.0"
         purl: "pkg:maven/org.apache.jena/jena-arq@3.9.0"
@@ -1459,6 +1491,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
           revision: "jena-3.9.0-rc1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.jena:jena-base:3.9.0"
         purl: "pkg:maven/org.apache.jena/jena-base@3.9.0"
@@ -1491,6 +1524,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
           revision: "jena-3.9.0-rc1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.jena:jena-core:3.9.0"
         purl: "pkg:maven/org.apache.jena/jena-core@3.9.0"
@@ -1524,6 +1558,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
           revision: "jena-3.9.0-rc1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.jena:jena-dboe-base:3.9.0"
         purl: "pkg:maven/org.apache.jena/jena-dboe-base@3.9.0"
@@ -1561,6 +1596,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
           revision: "jena-3.9.0-rc1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.jena:jena-dboe-index:3.9.0"
         purl: "pkg:maven/org.apache.jena/jena-dboe-index@3.9.0"
@@ -1598,6 +1634,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
           revision: "jena-3.9.0-rc1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.jena:jena-dboe-trans-data:3.9.0"
         purl: "pkg:maven/org.apache.jena/jena-dboe-trans-data@3.9.0"
@@ -1635,6 +1672,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
           revision: "jena-3.9.0-rc1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.jena:jena-dboe-transaction:3.9.0"
         purl: "pkg:maven/org.apache.jena/jena-dboe-transaction@3.9.0"
@@ -1672,6 +1710,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
           revision: "jena-3.9.0-rc1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.jena:jena-iri:3.9.0"
         purl: "pkg:maven/org.apache.jena/jena-iri@3.9.0"
@@ -1706,6 +1745,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
           revision: "jena-3.9.0-rc1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.jena:jena-rdfconnection:3.9.0"
         purl: "pkg:maven/org.apache.jena/jena-rdfconnection@3.9.0"
@@ -1737,6 +1777,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
           revision: "jena-3.9.0-rc1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.jena:jena-shaded-guava:3.9.0"
         purl: "pkg:maven/org.apache.jena/jena-shaded-guava@3.9.0"
@@ -1771,6 +1812,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
           revision: "jena-3.9.0-rc1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.jena:jena-tdb2:3.9.0"
         purl: "pkg:maven/org.apache.jena/jena-tdb2@3.9.0"
@@ -1808,6 +1850,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
           revision: "jena-3.9.0-rc1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.jena:jena-tdb:3.9.0"
         purl: "pkg:maven/org.apache.jena/jena-tdb@3.9.0"
@@ -1840,6 +1883,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
           revision: "jena-3.9.0-rc1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.logging.log4j:log4j-api:2.10.0"
         purl: "pkg:maven/org.apache.logging.log4j/log4j-api@2.10.0"
@@ -1871,6 +1915,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/logging-log4j2.git"
           revision: "log4j-2.10-rc1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.logging.log4j:log4j-core:2.10.0"
         purl: "pkg:maven/org.apache.logging.log4j/log4j-core@2.10.0"
@@ -1902,6 +1947,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/logging-log4j2.git"
           revision: "log4j-2.10-rc1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.logging.log4j:log4j-slf4j-impl:2.10.0"
         purl: "pkg:maven/org.apache.logging.log4j/log4j-slf4j-impl@2.10.0"
@@ -1933,6 +1979,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/logging-log4j2.git"
           revision: "log4j-2.10-rc1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.poi:poi-ooxml-schemas:3.15"
         purl: "pkg:maven/org.apache.poi/poi-ooxml-schemas@3.15"
@@ -1964,6 +2011,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.poi:poi-ooxml:3.15"
         purl: "pkg:maven/org.apache.poi/poi-ooxml@3.15"
@@ -1995,6 +2043,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.poi:poi:3.15"
         purl: "pkg:maven/org.apache.poi/poi@3.15"
@@ -2026,6 +2075,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.thrift:libthrift:0.10.0"
         purl: "pkg:maven/org.apache.thrift/libthrift@0.10.0"
@@ -2058,6 +2108,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/thrift.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.xmlbeans:xmlbeans:2.6.0"
         purl: "pkg:maven/org.apache.xmlbeans/xmlbeans@2.6.0"
@@ -2089,6 +2140,7 @@ analyzer:
           url: "https://svn.apache.org/repos/asf/xmlbeans"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apiguardian:apiguardian-api:1.0.0"
         purl: "pkg:maven/org.apiguardian/apiguardian-api@1.0.0"
@@ -2120,6 +2172,7 @@ analyzer:
           url: "https://github.com/apiguardian-team/apiguardian.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.assertj:assertj-core:3.11.1"
         purl: "pkg:maven/org.assertj/assertj-core@3.11.1"
@@ -2151,6 +2204,7 @@ analyzer:
           url: "ssh://git@github.com/joel-costigliola/assertj-core.git"
           revision: "assertj-core-3.11.1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.hamcrest:hamcrest-core:1.3"
         purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
@@ -2184,6 +2238,7 @@ analyzer:
           url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.jsoup:jsoup:1.7.2"
         purl: "pkg:maven/org.jsoup/jsoup@1.7.2"
@@ -2215,6 +2270,7 @@ analyzer:
           url: "https://github.com/jhy/jsoup.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.junit.jupiter:junit-jupiter-api:5.3.1"
         purl: "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.3.1"
@@ -2246,6 +2302,7 @@ analyzer:
           url: "https://github.com/junit-team/junit5.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.junit.jupiter:junit-jupiter-engine:5.3.1"
         purl: "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.3.1"
@@ -2277,6 +2334,7 @@ analyzer:
           url: "https://github.com/junit-team/junit5.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.junit.jupiter:junit-jupiter-params:5.3.1"
         purl: "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.3.1"
@@ -2308,6 +2366,7 @@ analyzer:
           url: "https://github.com/junit-team/junit5.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.junit.platform:junit-platform-commons:1.3.1"
         purl: "pkg:maven/org.junit.platform/junit-platform-commons@1.3.1"
@@ -2339,6 +2398,7 @@ analyzer:
           url: "https://github.com/junit-team/junit5.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.junit.platform:junit-platform-engine:1.3.1"
         purl: "pkg:maven/org.junit.platform/junit-platform-engine@1.3.1"
@@ -2370,6 +2430,7 @@ analyzer:
           url: "https://github.com/junit-team/junit5.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.junit.platform:junit-platform-launcher:1.3.1"
         purl: "pkg:maven/org.junit.platform/junit-platform-launcher@1.3.1"
@@ -2401,6 +2462,7 @@ analyzer:
           url: "https://github.com/junit-team/junit5.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.opentest4j:opentest4j:1.1.1"
         purl: "pkg:maven/org.opentest4j/opentest4j@1.1.1"
@@ -2432,6 +2494,7 @@ analyzer:
           url: "https://github.com/ota4j-team/opentest4j.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
         purl: "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.25"
@@ -2463,6 +2526,7 @@ analyzer:
           url: "ssh://git@github.com/qos-ch/slf4j.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.slf4j:slf4j-api:1.7.25"
         purl: "pkg:maven/org.slf4j/slf4j-api@1.7.25"
@@ -2494,6 +2558,7 @@ analyzer:
           url: "ssh://git@github.com/qos-ch/slf4j.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:stax:stax-api:1.0.1"
         purl: "pkg:maven/stax/stax-api@1.0.1"
@@ -2526,6 +2591,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "NPM::boolbase:1.0.0"
         purl: "pkg:npm/boolbase@1.0.0"
@@ -2555,6 +2621,7 @@ analyzer:
           url: "https://github.com/fb55/boolbase.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "NPM::cheerio:1.0.0-rc.1"
         purl: "pkg:npm/cheerio@1.0.0-rc.1"
@@ -2585,6 +2652,7 @@ analyzer:
           url: "https://github.com/cheeriojs/cheerio.git"
           revision: "f21ffef971826d1ba64ccbdf96adbc44964d30c5"
           path: ""
+      curations: []
     - package:
         id: "NPM::coffee-script:1.12.7"
         purl: "pkg:npm/coffee-script@1.12.7"
@@ -2614,6 +2682,7 @@ analyzer:
           url: "https://github.com/jashkenas/coffeescript.git"
           revision: "492111ccfb9b703b49a443c1aa68fb41dc8a2271"
           path: ""
+      curations: []
     - package:
         id: "NPM::cson-parser:1.3.5"
         purl: "pkg:npm/cson-parser@1.3.5"
@@ -2643,6 +2712,7 @@ analyzer:
           url: "ssh://git@github.com/groupon/cson-parser.git"
           revision: "fa37e04bc6c516eb76ef01df2d105a413c0253a0"
           path: ""
+      curations: []
     - package:
         id: "NPM::cson:4.1.0"
         purl: "pkg:npm/cson@4.1.0"
@@ -2673,6 +2743,7 @@ analyzer:
           url: "https://github.com/bevry/cson.git"
           revision: "0e913a90be66b2f29d2d75433b06ed52e83ba810"
           path: ""
+      curations: []
     - package:
         id: "NPM::css-select:1.2.0"
         purl: "pkg:npm/css-select@1.2.0"
@@ -2704,6 +2775,7 @@ analyzer:
           url: "https://github.com/fb55/css-select.git"
           revision: "09c405d8296bd97a660256604d8cdfb23fca47b6"
           path: ""
+      curations: []
     - package:
         id: "NPM::css-what:2.1.3"
         purl: "pkg:npm/css-what@2.1.3"
@@ -2733,6 +2805,7 @@ analyzer:
           url: "https://github.com/fb55/css-what.git"
           revision: "2db00ca221922c5b5131d798614aa043f2f6f80e"
           path: ""
+      curations: []
     - package:
         id: "NPM::deep-equal:0.2.2"
         purl: "pkg:npm/deep-equal@0.2.2"
@@ -2762,6 +2835,7 @@ analyzer:
           url: "https://github.com/substack/node-deep-equal.git"
           revision: "05cd26a25f0d7babf0c2758827b4dafec9d0582e"
           path: ""
+      curations: []
     - package:
         id: "NPM::defined:0.0.0"
         purl: "pkg:npm/defined@0.0.0"
@@ -2791,6 +2865,7 @@ analyzer:
           url: "https://github.com/substack/defined.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "NPM::dom-serializer:0.1.1"
         purl: "pkg:npm/dom-serializer@0.1.1"
@@ -2820,6 +2895,7 @@ analyzer:
           url: "https://github.com/cheeriojs/dom-renderer.git"
           revision: "1b9eb87c621a184b97467b03600b50d08e5a5086"
           path: ""
+      curations: []
     - package:
         id: "NPM::domelementtype:1.3.1"
         purl: "pkg:npm/domelementtype@1.3.1"
@@ -2849,6 +2925,7 @@ analyzer:
           url: "https://github.com/fb55/domelementtype.git"
           revision: "19b2491101a4de3679b59db8eb7fdd9aa0fbc60b"
           path: ""
+      curations: []
     - package:
         id: "NPM::domhandler:2.4.2"
         purl: "pkg:npm/domhandler@2.4.2"
@@ -2878,6 +2955,7 @@ analyzer:
           url: "https://github.com/fb55/DomHandler.git"
           revision: "045bd8d634dca30192fbd23fee0c530adc9c6f52"
           path: ""
+      curations: []
     - package:
         id: "NPM::domutils:1.5.1"
         purl: "pkg:npm/domutils@1.5.1"
@@ -2905,6 +2983,7 @@ analyzer:
           url: "https://github.com/FB55/domutils.git"
           revision: "7d4bd16cd36ffce62362ef91616806ea27e30d95"
           path: ""
+      curations: []
     - package:
         id: "NPM::eachr:3.2.0"
         purl: "pkg:npm/eachr@3.2.0"
@@ -2936,6 +3015,7 @@ analyzer:
           url: "ssh://git@github.com/bevry/eachr.git"
           revision: "57ef794d001c16fd906b2558137e8ea51c1f6330"
           path: ""
+      curations: []
     - package:
         id: "NPM::editions:1.3.4"
         purl: "pkg:npm/editions@1.3.4"
@@ -2966,6 +3046,7 @@ analyzer:
           url: "https://github.com/bevry/editions.git"
           revision: "5580800dc3935e988b7aa2cf8d571f3e9fa2d8f9"
           path: ""
+      curations: []
     - package:
         id: "NPM::editions:2.1.3"
         purl: "pkg:npm/editions@2.1.3"
@@ -2996,6 +3077,7 @@ analyzer:
           url: "https://github.com/bevry/editions.git"
           revision: "84f536320f7eff6385e867d9f5c1de0dfb92fa88"
           path: ""
+      curations: []
     - package:
         id: "NPM::entities:1.1.2"
         purl: "pkg:npm/entities@1.1.2"
@@ -3025,6 +3107,7 @@ analyzer:
           url: "https://github.com/fb55/entities.git"
           revision: "54a5717d85d886c4aafa2ac5ff83d8d3d730337c"
           path: ""
+      curations: []
     - package:
         id: "NPM::errlop:1.1.1"
         purl: "pkg:npm/errlop@1.1.1"
@@ -3055,6 +3138,7 @@ analyzer:
           url: "https://github.com/bevry/errlop.git"
           revision: "ca13727bd3a227cd937d104b3217d1cd778cc99b"
           path: ""
+      curations: []
     - package:
         id: "NPM::extract-opts:3.3.1"
         purl: "pkg:npm/extract-opts@3.3.1"
@@ -3085,6 +3169,7 @@ analyzer:
           url: "ssh://git@github.com/bevry/extract-opts.git"
           revision: "87e349bbf92a6f95d1ecc8b064a1631def105dc8"
           path: ""
+      curations: []
     - package:
         id: "NPM::glob:3.2.11"
         purl: "pkg:npm/glob@3.2.11"
@@ -3116,6 +3201,7 @@ analyzer:
           url: "https://github.com/isaacs/node-glob.git"
           revision: "73f57e99510582b2024b762305970ebcf9b70aa2"
           path: ""
+      curations: []
     - package:
         id: "NPM::graceful-fs:4.1.15"
         purl: "pkg:npm/graceful-fs@4.1.15"
@@ -3145,6 +3231,7 @@ analyzer:
           url: "https://github.com/isaacs/node-graceful-fs.git"
           revision: "26456e3deb4a5e85363e92f9015bcefd3b6b13ba"
           path: ""
+      curations: []
     - package:
         id: "NPM::htmlparser2:3.10.1"
         purl: "pkg:npm/htmlparser2@3.10.1"
@@ -3174,6 +3261,7 @@ analyzer:
           url: "https://github.com/fb55/htmlparser2.git"
           revision: "537bf2aeb56910d84d2c5aedb839dec678188a43"
           path: ""
+      curations: []
     - package:
         id: "NPM::inherits:2.0.3"
         purl: "pkg:npm/inherits@2.0.3"
@@ -3204,6 +3292,7 @@ analyzer:
           url: "https://github.com/isaacs/inherits.git"
           revision: "e05d0fb27c61a3ec687214f0476386b765364d5f"
           path: ""
+      curations: []
     - package:
         id: "NPM::lodash:4.17.11"
         purl: "pkg:npm/lodash@4.17.11"
@@ -3233,6 +3322,7 @@ analyzer:
           url: "https://github.com/lodash/lodash.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "NPM::lru-cache:2.7.3"
         purl: "pkg:npm/lru-cache@2.7.3"
@@ -3262,6 +3352,7 @@ analyzer:
           url: "https://github.com/isaacs/node-lru-cache.git"
           revision: "292048199f6d28b77fbe584279a1898e25e4c714"
           path: ""
+      curations: []
     - package:
         id: "NPM::minimatch:0.3.0"
         purl: "pkg:npm/minimatch@0.3.0"
@@ -3291,6 +3382,7 @@ analyzer:
           url: "https://github.com/isaacs/minimatch.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "NPM::nth-check:1.0.2"
         purl: "pkg:npm/nth-check@1.0.2"
@@ -3320,6 +3412,7 @@ analyzer:
           url: "https://github.com/fb55/nth-check.git"
           revision: "03a02587bbd126fafc3d2331ffef6ea5cb2f9b66"
           path: ""
+      curations: []
     - package:
         id: "NPM::object-inspect:0.4.0"
         purl: "pkg:npm/object-inspect@0.4.0"
@@ -3349,6 +3442,7 @@ analyzer:
           url: "https://github.com/substack/object-inspect.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "NPM::parse5:3.0.3"
         purl: "pkg:npm/parse5@3.0.3"
@@ -3379,6 +3473,7 @@ analyzer:
           url: "https://github.com/inikulin/parse5.git"
           revision: "723d782abee65aaab9c50f92e73ac2029ae853df"
           path: ""
+      curations: []
     - package:
         id: "NPM::readable-stream:3.2.0"
         purl: "pkg:npm/readable-stream@3.2.0"
@@ -3408,6 +3503,7 @@ analyzer:
           url: "https://github.com/nodejs/readable-stream.git"
           revision: "5b90ed2c1141fc41cb1f612eb88846473369298d"
           path: ""
+      curations: []
     - package:
         id: "NPM::requirefresh:2.2.0"
         purl: "pkg:npm/requirefresh@2.2.0"
@@ -3437,6 +3533,7 @@ analyzer:
           url: "https://github.com/bevry/requirefresh.git"
           revision: "f389cbc33b5891468bde8db479bc0f129b0fcc57"
           path: ""
+      curations: []
     - package:
         id: "NPM::resumer:0.0.0"
         purl: "pkg:npm/resumer@0.0.0"
@@ -3467,6 +3564,7 @@ analyzer:
           url: "https://github.com/substack/resumer.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "NPM::safe-buffer:5.1.2"
         purl: "pkg:npm/safe-buffer@5.1.2"
@@ -3496,6 +3594,7 @@ analyzer:
           url: "https://github.com/feross/safe-buffer.git"
           revision: "649435cc8e2d1f3ecdc7caf323f1cb1187307a16"
           path: ""
+      curations: []
     - package:
         id: "NPM::safefs:4.1.0"
         purl: "pkg:npm/safefs@4.1.0"
@@ -3526,6 +3625,7 @@ analyzer:
           url: "ssh://git@github.com/bevry/safefs.git"
           revision: "51d15eaa03e53aaedd3002dc67814355073e8a55"
           path: ""
+      curations: []
     - package:
         id: "NPM::semver:5.6.0"
         purl: "pkg:npm/semver@5.6.0"
@@ -3555,6 +3655,7 @@ analyzer:
           url: "https://github.com/npm/node-semver.git"
           revision: "46727afbe21b8d14641a0d1c4c7ee58bd053f922"
           path: ""
+      curations: []
     - package:
         id: "NPM::sigmund:1.0.1"
         purl: "pkg:npm/sigmund@1.0.1"
@@ -3584,6 +3685,7 @@ analyzer:
           url: "https://github.com/isaacs/sigmund.git"
           revision: "527f97aa5bb253d927348698c0cd3bb267d098c6"
           path: ""
+      curations: []
     - package:
         id: "NPM::string_decoder:1.2.0"
         purl: "pkg:npm/string_decoder@1.2.0"
@@ -3613,6 +3715,7 @@ analyzer:
           url: "https://github.com/nodejs/string_decoder.git"
           revision: "6e0a9286ed4497badebd4ec6a9a7a4d37793aae8"
           path: ""
+      curations: []
     - package:
         id: "NPM::tape:2.13.4"
         purl: "pkg:npm/tape@2.13.4"
@@ -3642,6 +3745,7 @@ analyzer:
           url: "https://github.com/substack/tape.git"
           revision: "17894caf61fbaa908bfc625a1119c16ab316afb6"
           path: ""
+      curations: []
     - package:
         id: "NPM::through:2.3.8"
         purl: "pkg:npm/through@2.3.8"
@@ -3671,6 +3775,7 @@ analyzer:
           url: "https://github.com/dominictarr/through.git"
           revision: "2c5a6f9a0cc54da759b6e10964f2081c358e49dc"
           path: ""
+      curations: []
     - package:
         id: "NPM::typechecker:4.7.0"
         purl: "pkg:npm/typechecker@4.7.0"
@@ -3701,6 +3806,7 @@ analyzer:
           url: "https://github.com/bevry/typechecker.git"
           revision: "69008d42927749d7e21cfe9816e478dd8d15ab88"
           path: ""
+      curations: []
     - package:
         id: "NPM::util-deprecate:1.0.2"
         purl: "pkg:npm/util-deprecate@1.0.2"
@@ -3730,6 +3836,7 @@ analyzer:
           url: "https://github.com/TooTallNate/util-deprecate.git"
           revision: "475fb6857cd23fafff20c1be846c1350abf8e6d4"
           path: ""
+      curations: []
     - package:
         id: "NPM:@types:node:11.9.6"
         purl: "pkg:npm/%40types/node@11.9.6"
@@ -3759,6 +3866,7 @@ analyzer:
           url: "https://github.com/DefinitelyTyped/DefinitelyTyped.git"
           revision: ""
           path: "types/node"
+      curations: []
     issues:
       'NPM::submodules/test-data-npm/long.js/package.json:':
       - timestamp: "1970-01-01T00:00:00Z"

--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -98,6 +98,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:com.fasterxml:classmate:1.3.0"
     purl: "pkg:maven/com.fasterxml/classmate@1.3.0"
@@ -130,6 +131,7 @@ packages:
       url: "ssh://git@github.com/cowtowncoder/java-classmate.git"
       revision: "classmate-1.3.0"
       path: ""
+  curations: []
 - package:
     id: "Maven:com.github.virtuald:curvesapi:1.03"
     purl: "pkg:maven/com.github.virtuald/curvesapi@1.03"
@@ -164,6 +166,7 @@ packages:
       url: "https://github.com/virtuald/curvesapi.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:com.h2database:h2:1.4.194"
     purl: "pkg:maven/com.h2database/h2@1.4.194"
@@ -195,6 +198,7 @@ packages:
       url: "https://github.com/h2database/h2database.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:com.mchange:c3p0:0.9.5.2"
     purl: "pkg:maven/com.mchange/c3p0@0.9.5.2"
@@ -228,6 +232,7 @@ packages:
       url: "ssh://git@github.com/swaldman/c3p0.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:com.mchange:mchange-commons-java:0.2.11"
     purl: "pkg:maven/com.mchange/mchange-commons-java@0.2.11"
@@ -261,6 +266,7 @@ packages:
       url: "ssh://git@github.com/swaldman/mchange-commons-java.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:com.thoughtworks.xstream:xstream-hibernate:1.4.9"
     purl: "pkg:maven/com.thoughtworks.xstream/xstream-hibernate@1.4.9"
@@ -292,6 +298,7 @@ packages:
       url: "https://github.com/x-stream/xstream.git"
       revision: "v-1.4.x"
       path: ""
+  curations: []
 - package:
     id: "Maven:com.thoughtworks.xstream:xstream:1.4.9"
     purl: "pkg:maven/com.thoughtworks.xstream/xstream@1.4.9"
@@ -324,6 +331,7 @@ packages:
       url: "https://github.com/x-stream/xstream.git"
       revision: "v-1.4.x"
       path: ""
+  curations: []
 - package:
     id: "Maven:commons-codec:commons-codec:1.10"
     purl: "pkg:maven/commons-codec/commons-codec@1.10"
@@ -358,6 +366,7 @@ packages:
       url: "http://svn.apache.org/repos/asf/commons/proper/codec"
       revision: "trunk"
       path: ""
+  curations: []
 - package:
     id: "Maven:dom4j:dom4j:1.6.1"
     purl: "pkg:maven/dom4j/dom4j@1.6.1"
@@ -385,6 +394,7 @@ packages:
       url: ":pserver:anonymous@cvs.sourceforge.net:/cvsroot/dom4j:dom4j"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:io.netty:netty-buffer:4.1.9.Final"
     purl: "pkg:maven/io.netty/netty-buffer@4.1.9.Final"
@@ -418,6 +428,7 @@ packages:
       url: "https://github.com/netty/netty.git"
       revision: "netty-4.1.9.Final"
       path: ""
+  curations: []
 - package:
     id: "Maven:io.netty:netty-codec:4.1.9.Final"
     purl: "pkg:maven/io.netty/netty-codec@4.1.9.Final"
@@ -451,6 +462,7 @@ packages:
       url: "https://github.com/netty/netty.git"
       revision: "netty-4.1.9.Final"
       path: ""
+  curations: []
 - package:
     id: "Maven:io.netty:netty-common:4.1.9.Final"
     purl: "pkg:maven/io.netty/netty-common@4.1.9.Final"
@@ -484,6 +496,7 @@ packages:
       url: "https://github.com/netty/netty.git"
       revision: "netty-4.1.9.Final"
       path: ""
+  curations: []
 - package:
     id: "Maven:io.netty:netty-resolver:4.1.9.Final"
     purl: "pkg:maven/io.netty/netty-resolver@4.1.9.Final"
@@ -517,6 +530,7 @@ packages:
       url: "https://github.com/netty/netty.git"
       revision: "netty-4.1.9.Final"
       path: ""
+  curations: []
 - package:
     id: "Maven:io.netty:netty-transport:4.1.9.Final"
     purl: "pkg:maven/io.netty/netty-transport@4.1.9.Final"
@@ -550,6 +564,7 @@ packages:
       url: "https://github.com/netty/netty.git"
       revision: "netty-4.1.9.Final"
       path: ""
+  curations: []
 - package:
     id: "Maven:junit:junit:4.12"
     purl: "pkg:maven/junit/junit@4.12"
@@ -582,6 +597,7 @@ packages:
       url: "https://github.com/junit-team/junit.git"
       revision: "r4.12"
       path: ""
+  curations: []
 - package:
     id: "Maven:log4j:log4j:1.2.17"
     purl: "pkg:maven/log4j/log4j@1.2.17"
@@ -613,6 +629,7 @@ packages:
       url: "http://svn.apache.org/repos/asf/logging/log4j"
       revision: "tags/v1_2_17_rc3"
       path: ""
+  curations: []
 - package:
     id: "Maven:net.sf.kxml:kxml2:2.3.0"
     purl: "pkg:maven/net.sf.kxml/kxml2@2.3.0"
@@ -648,6 +665,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-lang3:3.3.2"
     purl: "pkg:maven/org.apache.commons/commons-lang3@3.3.2"
@@ -681,6 +699,7 @@ packages:
       url: "http://svn.apache.org/repos/asf/commons/proper/lang"
       revision: "trunk"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.poi:poi-ooxml-schemas:3.14"
     purl: "pkg:maven/org.apache.poi/poi-ooxml-schemas@3.14"
@@ -712,6 +731,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.poi:poi-ooxml:3.14"
     purl: "pkg:maven/org.apache.poi/poi-ooxml@3.14"
@@ -743,6 +763,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.poi:poi:3.14"
     purl: "pkg:maven/org.apache.poi/poi@3.14"
@@ -774,6 +795,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.xmlbeans:xmlbeans:2.6.0"
     purl: "pkg:maven/org.apache.xmlbeans/xmlbeans@2.6.0"
@@ -805,6 +827,7 @@ packages:
       url: "https://svn.apache.org/repos/asf/xmlbeans"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.hamcrest:hamcrest-all:1.3"
     purl: "pkg:maven/org.hamcrest/hamcrest-all@1.3"
@@ -837,6 +860,7 @@ packages:
       url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.hibernate.common:hibernate-commons-annotations:5.0.1.Final"
     purl: "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.0.1.Final"
@@ -868,6 +892,7 @@ packages:
       url: "https://github.com/hibernate/hibernate-commons-annotations.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.0.Final"
     purl: "pkg:maven/org.hibernate.javax.persistence/hibernate-jpa-2.1-api@1.0.0.Final"
@@ -902,6 +927,7 @@ packages:
       url: "https://github.com/hibernate/hibernate-jpa-api.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.hibernate:hibernate-c3p0:5.2.10.Final"
     purl: "pkg:maven/org.hibernate/hibernate-c3p0@5.2.10.Final"
@@ -933,6 +959,7 @@ packages:
       url: "https://github.com/hibernate/hibernate-orm.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.hibernate:hibernate-core:5.2.10.Final"
     purl: "pkg:maven/org.hibernate/hibernate-core@5.2.10.Final"
@@ -964,6 +991,7 @@ packages:
       url: "https://github.com/hibernate/hibernate-orm.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.hsqldb:hsqldb:2.4.0"
     purl: "pkg:maven/org.hsqldb/hsqldb@2.4.0"
@@ -995,6 +1023,7 @@ packages:
       url: "http://svn.code.sf.net/p/hsqldb/svn/base"
       revision: "tags/2.4.0"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.javassist:javassist:3.20.0-GA"
     purl: "pkg:maven/org.javassist/javassist@3.20.0-GA"
@@ -1031,6 +1060,7 @@ packages:
       url: "ssh://git@github.com/jboss-javassist/javassist.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jboss.logging:jboss-logging:3.3.0.Final"
     purl: "pkg:maven/org.jboss.logging/jboss-logging@3.3.0.Final"
@@ -1062,6 +1092,7 @@ packages:
       url: "https://github.com/jboss-logging/jboss-logging.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:1.0.1.Final"
     purl: "pkg:maven/org.jboss.spec.javax.transaction/jboss-transaction-api_1.2_spec@1.0.1.Final"
@@ -1096,6 +1127,7 @@ packages:
       url: "ssh://git@github.com/jboss/jboss-transaction-api_spec.git"
       revision: "jboss-transaction-api_1.2_spec-1.0.1.Final"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jboss:jandex:2.0.3.Final"
     purl: "pkg:maven/org.jboss/jandex@2.0.3.Final"
@@ -1127,6 +1159,7 @@ packages:
       url: "ssh://git@github.com/jboss/jboss-parent-pom.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.slf4j:slf4j-api:1.7.21"
     purl: "pkg:maven/org.slf4j/slf4j-api@1.7.21"
@@ -1158,6 +1191,7 @@ packages:
       url: "ssh://git@github.com/qos-ch/slf4j.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.slf4j:slf4j-log4j12:1.7.21"
     purl: "pkg:maven/org.slf4j/slf4j-log4j12@1.7.21"
@@ -1189,3 +1223,4 @@ packages:
       url: "ssh://git@github.com/qos-ch/slf4j.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-expected-output.yml
@@ -53,6 +53,7 @@ packages:
       url: "https://github.com/junit-team/junit.git"
       revision: "r4.12"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.hamcrest:hamcrest-all:1.3"
     purl: "pkg:maven/org.hamcrest/hamcrest-all@1.3"
@@ -85,3 +86,4 @@ packages:
       url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-cli.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-cli.yml
@@ -263,6 +263,7 @@ packages:
       url: "https://github.com/JetBrains/kotlin.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
     purl: "pkg:maven/org.jetbrains.kotlin/kotlin-reflect@1.3.11"
@@ -294,6 +295,7 @@ packages:
       url: "https://github.com/JetBrains/kotlin.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
     purl: "pkg:maven/org.jetbrains.kotlin/kotlin-script-runtime@1.3.11"
@@ -325,6 +327,7 @@ packages:
       url: "https://github.com/JetBrains/kotlin.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
     purl: "pkg:maven/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable@1.3.11"
@@ -356,6 +359,7 @@ packages:
       url: "https://github.com/JetBrains/kotlin.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
     purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib-common@1.3.11"
@@ -387,6 +391,7 @@ packages:
       url: "https://github.com/JetBrains/kotlin.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
     purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@1.3.11"
@@ -418,6 +423,7 @@ packages:
       url: "https://github.com/JetBrains/kotlin.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jetbrains:annotations:13.0"
     purl: "pkg:maven/org.jetbrains/annotations@13.0"
@@ -449,3 +455,4 @@ packages:
       url: "https://github.com/JetBrains/intellij-community.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-core.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-core.yml
@@ -172,6 +172,7 @@ packages:
       url: "https://github.com/JetBrains/kotlin.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
     purl: "pkg:maven/org.jetbrains.kotlin/kotlin-reflect@1.3.11"
@@ -203,6 +204,7 @@ packages:
       url: "https://github.com/JetBrains/kotlin.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
     purl: "pkg:maven/org.jetbrains.kotlin/kotlin-script-runtime@1.3.11"
@@ -234,6 +236,7 @@ packages:
       url: "https://github.com/JetBrains/kotlin.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
     purl: "pkg:maven/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable@1.3.11"
@@ -265,6 +268,7 @@ packages:
       url: "https://github.com/JetBrains/kotlin.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
     purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib-common@1.3.11"
@@ -296,6 +300,7 @@ packages:
       url: "https://github.com/JetBrains/kotlin.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
     purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@1.3.11"
@@ -327,6 +332,7 @@ packages:
       url: "https://github.com/JetBrains/kotlin.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jetbrains:annotations:13.0"
     purl: "pkg:maven/org.jetbrains/annotations@13.0"
@@ -358,3 +364,4 @@ packages:
       url: "https://github.com/JetBrains/intellij-community.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-root.yml
@@ -73,6 +73,7 @@ packages:
       url: "https://github.com/JetBrains/kotlin.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
     purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@1.3.11"
@@ -104,6 +105,7 @@ packages:
       url: "https://github.com/JetBrains/kotlin.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jetbrains:annotations:13.0"
     purl: "pkg:maven/org.jetbrains/annotations@13.0"
@@ -135,3 +137,4 @@ packages:
       url: "https://github.com/JetBrains/intellij-community.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output-win32.yml
+++ b/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output-win32.yml
@@ -1091,6 +1091,7 @@ packages:
       url: "https://github.com/ekmett/semigroups.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Compatibility:base-compat:0.10.5"
     purl: "pkg:hackage/Compatibility/base-compat@0.10.5"
@@ -1135,6 +1136,7 @@ packages:
       url: "https://github.com/haskell-compat/base-compat.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Compatibility:base-orphans:0.8"
     purl: "pkg:hackage/Compatibility/base-orphans@0.8"
@@ -1170,6 +1172,7 @@ packages:
       url: "https://github.com/haskell-compat/base-orphans.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Compatibility:transformers-compat:0.6.2"
     purl: "pkg:hackage/Compatibility/transformers-compat@0.6.2"
@@ -1206,6 +1209,7 @@ packages:
       url: "https://github.com/ekmett/transformers-compat.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Concurrency:async:2.2.1"
     purl: "pkg:hackage/Concurrency/async@2.2.1"
@@ -1245,6 +1249,7 @@ packages:
       url: "https://github.com/simonmar/async.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Concurrency:stm:2.5.0.0"
     purl: "pkg:hackage/Concurrency/stm@2.5.0.0"
@@ -1281,6 +1286,7 @@ packages:
       url: "https://github.com/haskell/stm.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Control, Data:contravariant:1.5"
     purl: "pkg:hackage/Control%2C%20Data/contravariant@1.5"
@@ -1312,6 +1318,7 @@ packages:
       url: "https://github.com/ekmett/contravariant.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Control, Exceptions, Monad:exceptions:0.10.0"
     purl: "pkg:hackage/Control%2C%20Exceptions%2C%20Monad/exceptions@0.10.0"
@@ -1343,6 +1350,7 @@ packages:
       url: "https://github.com/ekmett/exceptions.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Control:deepseq:1.4.4.0"
     purl: "pkg:hackage/Control/deepseq@1.4.4.0"
@@ -1383,6 +1391,7 @@ packages:
       url: "https://github.com/haskell/deepseq.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Control:loop:0.3.0"
     purl: "pkg:hackage/Control/loop@0.3.0"
@@ -1414,6 +1423,7 @@ packages:
       url: "https://github.com/nh2/loop.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Control:mtl:2.2.2"
     purl: "pkg:hackage/Control/mtl@2.2.2"
@@ -1448,6 +1458,7 @@ packages:
       url: "https://github.com/haskell/mtl.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Control:newtype-generics:0.5.3"
     purl: "pkg:hackage/Control/newtype-generics@0.5.3"
@@ -1483,6 +1494,7 @@ packages:
       url: "https://github.com/sjakobi/newtype-generics.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Control:transformers:0.5.5.0"
     purl: "pkg:hackage/Control/transformers@0.5.5.0"
@@ -1525,6 +1537,7 @@ packages:
       url: "http://hub.darcs.net/ross/transformers"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Control:unliftio-core:0.1.2.0"
     purl: "pkg:hackage/Control/unliftio-core@0.1.2.0"
@@ -1554,6 +1567,7 @@ packages:
       url: "https://github.com/fpco/unliftio.git"
       revision: "master"
       path: "unliftio-core"
+  curations: []
 - package:
     id: "Hackage:Control:unliftio:0.2.10"
     purl: "pkg:hackage/Control/unliftio@0.2.10"
@@ -1583,6 +1597,7 @@ packages:
       url: "https://github.com/fpco/unliftio.git"
       revision: "master"
       path: "unliftio"
+  curations: []
 - package:
     id: "Hackage:Data Structures, Graphs:fgl:5.7.0.1"
     purl: "pkg:hackage/Data%20Structures%2C%20Graphs/fgl@5.7.0.1"
@@ -1615,6 +1630,7 @@ packages:
       url: "https://github.com/haskell/fgl.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data Structures:array:0.5.3.0"
     purl: "pkg:hackage/Data%20Structures/array@0.5.3.0"
@@ -1649,6 +1665,7 @@ packages:
       url: "http://git.haskell.org/packages/array.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data Structures:containers:0.6.0.1"
     purl: "pkg:hackage/Data%20Structures/containers@0.6.0.1"
@@ -1685,6 +1702,7 @@ packages:
       url: "https://github.com/haskell/containers.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data, Data Structures:vector:0.12.0.2"
     purl: "pkg:hackage/Data%2C%20Data%20Structures/vector@0.12.0.2"
@@ -1725,6 +1743,7 @@ packages:
       url: "https://github.com/haskell/vector.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data, Parsing:binary:0.8.6.0"
     purl: "pkg:hackage/Data%2C%20Parsing/binary@0.8.6.0"
@@ -1761,6 +1780,7 @@ packages:
       url: "https://github.com/kolmodin/binary.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data, Phantom Types:tagged:0.8.6"
     purl: "pkg:hackage/Data%2C%20Phantom%20Types/tagged@0.8.6"
@@ -1792,6 +1812,7 @@ packages:
       url: "https://github.com/ekmett/tagged.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data, Testing:tree-diff:0.0.2.1"
     purl: "pkg:hackage/Data%2C%20Testing/tree-diff@0.0.2.1"
@@ -1832,6 +1853,7 @@ packages:
       url: "https://github.com/phadej/tree-diff.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data, Text:text:1.2.3.1"
     purl: "pkg:hackage/Data%2C%20Text/text@1.2.3.1"
@@ -1878,6 +1900,7 @@ packages:
       url: "https://bitbucket.org/bos/text"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:MemoTrie:0.6.9"
     purl: "pkg:hackage/Data/MemoTrie@0.6.9"
@@ -1912,6 +1935,7 @@ packages:
       url: "https://github.com/conal/MemoTrie.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:StateVar:1.1.1.1"
     purl: "pkg:hackage/Data/StateVar@1.1.1.1"
@@ -1944,6 +1968,7 @@ packages:
       url: "https://github.com/haskell-opengl/StateVar.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:bytestring:0.10.8.2"
     purl: "pkg:hackage/Data/bytestring@0.10.8.2"
@@ -1996,6 +2021,7 @@ packages:
       url: "https://github.com/haskell/bytestring.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:charset:0.3.7.1"
     purl: "pkg:hackage/Data/charset@0.3.7.1"
@@ -2027,6 +2053,7 @@ packages:
       url: "https://github.com/ekmett/charset.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:dlist:0.8.0.5"
     purl: "pkg:hackage/Data/dlist@0.8.0.5"
@@ -2060,6 +2087,7 @@ packages:
       url: "https://github.com/spl/dlist.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:hashable:1.2.7.0"
     purl: "pkg:hackage/Data/hashable@1.2.7.0"
@@ -2094,6 +2122,7 @@ packages:
       url: "https://github.com/tibbe/hashable.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:primitive:0.6.4.0"
     purl: "pkg:hackage/Data/primitive@0.6.4.0"
@@ -2125,6 +2154,7 @@ packages:
       url: "https://github.com/haskell/primitive.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:scientific:0.3.6.2"
     purl: "pkg:hackage/Data/scientific@0.3.6.2"
@@ -2174,6 +2204,7 @@ packages:
       url: "https://github.com/basvandijk/scientific.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:sop-core:0.4.0.0"
     purl: "pkg:hackage/Data/sop-core@0.4.0.0"
@@ -2210,6 +2241,7 @@ packages:
       url: "https://github.com/well-typed/generics-sop.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:unordered-containers:0.2.9.0"
     purl: "pkg:hackage/Data/unordered-containers@0.2.9.0"
@@ -2244,6 +2276,7 @@ packages:
       url: "https://github.com/tibbe/unordered-containers.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:uuid-types:1.0.3"
     purl: "pkg:hackage/Data/uuid-types@1.0.3"
@@ -2277,6 +2310,7 @@ packages:
       url: "https://github.com/aslatter/uuid.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Development:happy:1.19.9"
     purl: "pkg:hackage/Development/happy@1.19.9"
@@ -2310,6 +2344,7 @@ packages:
       url: "https://github.com/simonmar/happy.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Development:th-abstraction:0.2.10.0"
     purl: "pkg:hackage/Development/th-abstraction@0.2.10.0"
@@ -2342,6 +2377,7 @@ packages:
       url: "https://github.com/glguy/th-abstraction.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Distribution:Cabal:2.4.1.0"
     purl: "pkg:hackage/Distribution/Cabal@2.4.1.0"
@@ -2377,6 +2413,7 @@ packages:
       url: "https://github.com/haskell/cabal.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:GHC:ghc-prim:0.5.3"
     purl: "pkg:hackage/GHC/ghc-prim@0.5.3"
@@ -2407,6 +2444,7 @@ packages:
       url: "http://git.haskell.org/ghc.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Generics:generics-sop:0.4.0.1"
     purl: "pkg:hackage/Generics/generics-sop@0.4.0.1"
@@ -2454,6 +2492,7 @@ packages:
       url: "https://github.com/well-typed/generics-sop.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Graphs, Graphics:graphviz:2999.20.0.3"
     purl: "pkg:hackage/Graphs%2C%20Graphics/graphviz@2999.20.0.3"
@@ -2498,6 +2537,7 @@ packages:
       url: "https://github.com/ivan-m/graphviz.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Language:haskell-lexer:1.0.2"
     purl: "pkg:hackage/Language/haskell-lexer@1.0.2"
@@ -2529,6 +2569,7 @@ packages:
       url: "https://github.com/yav/haskell-lexer.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:List:split:0.2.3.3"
     purl: "pkg:hackage/List/split@0.2.3.3"
@@ -2571,6 +2612,7 @@ packages:
       url: "https://github.com/byorgey/split.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Math, Algorithms, Number Theory:integer-logarithms:1.0.2.2"
     purl: "pkg:hackage/Math%2C%20Algorithms%2C%20Number%20Theory/integer-logarithms@1.0.2.2"
@@ -2603,6 +2645,7 @@ packages:
       url: "https://github.com/Bodigrim/integer-logarithms.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Math:matrix:0.3.6.1"
     purl: "pkg:hackage/Math/matrix@0.3.6.1"
@@ -2639,6 +2682,7 @@ packages:
       url: "https://github.com/Daniel-Diaz/matrix.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Numeric, Algebra:integer-gmp:1.0.2.0"
     purl: "pkg:hackage/Numeric%2C%20Algebra/integer-gmp@1.0.2.0"
@@ -2674,6 +2718,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Other:generic-data:0.3.0.0"
     purl: "pkg:hackage/Other/generic-data@0.3.0.0"
@@ -2703,6 +2748,7 @@ packages:
       url: "https://github.com/Lysxia/generic-data.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Parsing:parsec:3.1.13.0"
     purl: "pkg:hackage/Parsing/parsec@3.1.13.0"
@@ -2741,6 +2787,7 @@ packages:
       url: "https://github.com/hvr/parsec.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Prelude:base:4.12.0.0"
     purl: "pkg:hackage/Prelude/base@4.12.0.0"
@@ -2772,6 +2819,7 @@ packages:
       url: "http://git.haskell.org/ghc.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System, Graphics:Win32:2.6.1.0"
     purl: "pkg:hackage/System%2C%20Graphics/Win32@2.6.1.0"
@@ -2803,6 +2851,7 @@ packages:
       url: "https://github.com/haskell/win32.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System, Utils:temporary:1.3"
     purl: "pkg:hackage/System%2C%20Utils/temporary@1.3"
@@ -2834,6 +2883,7 @@ packages:
       url: "https://github.com/feuerbach/temporary.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System:directory:1.3.3.0"
     purl: "pkg:hackage/System/directory@1.3.3.0"
@@ -2866,6 +2916,7 @@ packages:
       url: "https://github.com/haskell/directory.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System:filepath:1.4.2.1"
     purl: "pkg:hackage/System/filepath@1.4.2.1"
@@ -2905,6 +2956,7 @@ packages:
       url: "https://github.com/haskell/filepath.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System:mintty:0.1.2"
     purl: "pkg:hackage/System/mintty@0.1.2"
@@ -2947,6 +2999,7 @@ packages:
       url: "https://github.com/RyanGlScott/mintty.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System:process:1.6.3.0"
     purl: "pkg:hackage/System/process@1.6.3.0"
@@ -2981,6 +3034,7 @@ packages:
       url: "https://github.com/haskell/process.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System:random:1.1"
     purl: "pkg:hackage/System/random@1.1"
@@ -3013,6 +3067,7 @@ packages:
       url: "http://git.haskell.org/packages/random.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System:splitmix:0.0.2"
     purl: "pkg:hackage/System/splitmix@0.0.2"
@@ -3058,6 +3113,7 @@ packages:
       url: "https://github.com/phadej/splitmix.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System:time-locale-compat:0.1.1.5"
     purl: "pkg:hackage/System/time-locale-compat@0.1.1.5"
@@ -3090,6 +3146,7 @@ packages:
       url: "https://bitbucket.org/khibino/haskell-time-locale-compat.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Template Haskell:template-haskell:2.14.0.0"
     purl: "pkg:hackage/Template%20Haskell/template-haskell@2.14.0.0"
@@ -3123,6 +3180,7 @@ packages:
       url: "http://git.haskell.org/ghc.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Testing:QuickCheck:2.13.1"
     purl: "pkg:hackage/Testing/QuickCheck@2.13.1"
@@ -3169,6 +3227,7 @@ packages:
       url: "https://github.com/nick8325/quickcheck.git"
       revision: "2.13.1"
       path: ""
+  curations: []
 - package:
     id: "Hackage:Testing:markov-chain-usage-model:0.0.0"
     purl: "pkg:hackage/Testing/markov-chain-usage-model@0.0.0"
@@ -3200,6 +3259,7 @@ packages:
       url: "https://github.com/advancedtelematic/markov-chain-usage-model.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Text, Parsing:attoparsec:0.13.2.2"
     purl: "pkg:hackage/Text%2C%20Parsing/attoparsec@0.13.2.2"
@@ -3232,6 +3292,7 @@ packages:
       url: "https://github.com/bos/attoparsec.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Text, Parsing:parsers:0.12.9"
     purl: "pkg:hackage/Text%2C%20Parsing/parsers@0.12.9"
@@ -3267,6 +3328,7 @@ packages:
       url: "https://github.com/ekmett/parsers.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Text, Parsing:polyparse:1.12.1"
     purl: "pkg:hackage/Text%2C%20Parsing/polyparse@1.12.1"
@@ -3304,6 +3366,7 @@ packages:
       url: "https://github.com/hackage-/malcolm-wallace-universe.git"
       revision: "1.12.1"
       path: ""
+  curations: []
 - package:
     id: "Hackage:Text, Web, JSON:aeson:1.4.2.0"
     purl: "pkg:hackage/Text%2C%20Web%2C%20JSON/aeson@1.4.2.0"
@@ -3338,6 +3401,7 @@ packages:
       url: "https://github.com/bos/aeson.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Text:pretty-show:1.9.5"
     purl: "pkg:hackage/Text/pretty-show@1.9.5"
@@ -3372,6 +3436,7 @@ packages:
       url: "https://github.com/yav/pretty-show.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Text:pretty:1.1.3.6"
     purl: "pkg:hackage/Text/pretty@1.1.3.6"
@@ -3407,6 +3472,7 @@ packages:
       url: "https://github.com/haskell/pretty.git"
       revision: "1.1.3.5"
       path: ""
+  curations: []
 - package:
     id: "Hackage:Text:show-combinators:0.1.0.0"
     purl: "pkg:hackage/Text/show-combinators@0.1.0.0"
@@ -3436,6 +3502,7 @@ packages:
       url: "https://github.com/Lysxia/show-combinators.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Text:wl-pprint-text:1.2.0.0"
     purl: "pkg:hackage/Text/wl-pprint-text@1.2.0.0"
@@ -3467,6 +3534,7 @@ packages:
       url: "https://github.com/ivan-m/wl-pprint-text.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Time:time:1.8.0.2"
     purl: "pkg:hackage/Time/time@1.8.0.2"
@@ -3498,6 +3566,7 @@ packages:
       url: "https://github.com/haskell/time.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:User Interfaces, Text:ansi-wl-pprint:0.6.8.2"
     purl: "pkg:hackage/User%20Interfaces%2C%20Text/ansi-wl-pprint@0.6.8.2"
@@ -3532,6 +3601,7 @@ packages:
       url: "https://github.com/ekmett/ansi-wl-pprint.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:User Interfaces:ansi-terminal:0.8.2"
     purl: "pkg:hackage/User%20Interfaces/ansi-terminal@0.8.2"
@@ -3565,6 +3635,7 @@ packages:
       url: "https://github.com/feuerbach/ansi-terminal.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:data, graphics:colour:2.3.4"
     purl: "pkg:hackage/data%2C%20graphics/colour@2.3.4"
@@ -3596,3 +3667,4 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/quickcheck-state-machine-expected-output.yml
@@ -1078,6 +1078,7 @@ packages:
       url: "https://github.com/ekmett/semigroups.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Compatibility:base-compat:0.10.5"
     purl: "pkg:hackage/Compatibility/base-compat@0.10.5"
@@ -1122,6 +1123,7 @@ packages:
       url: "https://github.com/haskell-compat/base-compat.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Compatibility:base-orphans:0.8"
     purl: "pkg:hackage/Compatibility/base-orphans@0.8"
@@ -1157,6 +1159,7 @@ packages:
       url: "https://github.com/haskell-compat/base-orphans.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Compatibility:transformers-compat:0.6.2"
     purl: "pkg:hackage/Compatibility/transformers-compat@0.6.2"
@@ -1193,6 +1196,7 @@ packages:
       url: "https://github.com/ekmett/transformers-compat.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Concurrency:async:2.2.1"
     purl: "pkg:hackage/Concurrency/async@2.2.1"
@@ -1232,6 +1236,7 @@ packages:
       url: "https://github.com/simonmar/async.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Concurrency:stm:2.5.0.0"
     purl: "pkg:hackage/Concurrency/stm@2.5.0.0"
@@ -1268,6 +1273,7 @@ packages:
       url: "https://github.com/haskell/stm.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Control, Data:contravariant:1.5"
     purl: "pkg:hackage/Control%2C%20Data/contravariant@1.5"
@@ -1299,6 +1305,7 @@ packages:
       url: "https://github.com/ekmett/contravariant.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Control, Exceptions, Monad:exceptions:0.10.0"
     purl: "pkg:hackage/Control%2C%20Exceptions%2C%20Monad/exceptions@0.10.0"
@@ -1330,6 +1337,7 @@ packages:
       url: "https://github.com/ekmett/exceptions.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Control:deepseq:1.4.4.0"
     purl: "pkg:hackage/Control/deepseq@1.4.4.0"
@@ -1370,6 +1378,7 @@ packages:
       url: "https://github.com/haskell/deepseq.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Control:loop:0.3.0"
     purl: "pkg:hackage/Control/loop@0.3.0"
@@ -1401,6 +1410,7 @@ packages:
       url: "https://github.com/nh2/loop.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Control:mtl:2.2.2"
     purl: "pkg:hackage/Control/mtl@2.2.2"
@@ -1435,6 +1445,7 @@ packages:
       url: "https://github.com/haskell/mtl.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Control:newtype-generics:0.5.3"
     purl: "pkg:hackage/Control/newtype-generics@0.5.3"
@@ -1470,6 +1481,7 @@ packages:
       url: "https://github.com/sjakobi/newtype-generics.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Control:transformers:0.5.5.0"
     purl: "pkg:hackage/Control/transformers@0.5.5.0"
@@ -1512,6 +1524,7 @@ packages:
       url: "http://hub.darcs.net/ross/transformers"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Control:unliftio-core:0.1.2.0"
     purl: "pkg:hackage/Control/unliftio-core@0.1.2.0"
@@ -1541,6 +1554,7 @@ packages:
       url: "https://github.com/fpco/unliftio.git"
       revision: "master"
       path: "unliftio-core"
+  curations: []
 - package:
     id: "Hackage:Control:unliftio:0.2.10"
     purl: "pkg:hackage/Control/unliftio@0.2.10"
@@ -1570,6 +1584,7 @@ packages:
       url: "https://github.com/fpco/unliftio.git"
       revision: "master"
       path: "unliftio"
+  curations: []
 - package:
     id: "Hackage:Data Structures, Graphs:fgl:5.7.0.1"
     purl: "pkg:hackage/Data%20Structures%2C%20Graphs/fgl@5.7.0.1"
@@ -1602,6 +1617,7 @@ packages:
       url: "https://github.com/haskell/fgl.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data Structures:array:0.5.3.0"
     purl: "pkg:hackage/Data%20Structures/array@0.5.3.0"
@@ -1636,6 +1652,7 @@ packages:
       url: "http://git.haskell.org/packages/array.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data Structures:containers:0.6.0.1"
     purl: "pkg:hackage/Data%20Structures/containers@0.6.0.1"
@@ -1672,6 +1689,7 @@ packages:
       url: "https://github.com/haskell/containers.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data, Data Structures:vector:0.12.0.2"
     purl: "pkg:hackage/Data%2C%20Data%20Structures/vector@0.12.0.2"
@@ -1712,6 +1730,7 @@ packages:
       url: "https://github.com/haskell/vector.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data, Parsing:binary:0.8.6.0"
     purl: "pkg:hackage/Data%2C%20Parsing/binary@0.8.6.0"
@@ -1748,6 +1767,7 @@ packages:
       url: "https://github.com/kolmodin/binary.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data, Phantom Types:tagged:0.8.6"
     purl: "pkg:hackage/Data%2C%20Phantom%20Types/tagged@0.8.6"
@@ -1779,6 +1799,7 @@ packages:
       url: "https://github.com/ekmett/tagged.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data, Testing:tree-diff:0.0.2.1"
     purl: "pkg:hackage/Data%2C%20Testing/tree-diff@0.0.2.1"
@@ -1819,6 +1840,7 @@ packages:
       url: "https://github.com/phadej/tree-diff.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data, Text:text:1.2.3.1"
     purl: "pkg:hackage/Data%2C%20Text/text@1.2.3.1"
@@ -1865,6 +1887,7 @@ packages:
       url: "https://bitbucket.org/bos/text"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:MemoTrie:0.6.9"
     purl: "pkg:hackage/Data/MemoTrie@0.6.9"
@@ -1899,6 +1922,7 @@ packages:
       url: "https://github.com/conal/MemoTrie.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:StateVar:1.1.1.1"
     purl: "pkg:hackage/Data/StateVar@1.1.1.1"
@@ -1931,6 +1955,7 @@ packages:
       url: "https://github.com/haskell-opengl/StateVar.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:bytestring:0.10.8.2"
     purl: "pkg:hackage/Data/bytestring@0.10.8.2"
@@ -1983,6 +2008,7 @@ packages:
       url: "https://github.com/haskell/bytestring.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:charset:0.3.7.1"
     purl: "pkg:hackage/Data/charset@0.3.7.1"
@@ -2014,6 +2040,7 @@ packages:
       url: "https://github.com/ekmett/charset.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:dlist:0.8.0.5"
     purl: "pkg:hackage/Data/dlist@0.8.0.5"
@@ -2047,6 +2074,7 @@ packages:
       url: "https://github.com/spl/dlist.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:hashable:1.2.7.0"
     purl: "pkg:hackage/Data/hashable@1.2.7.0"
@@ -2081,6 +2109,7 @@ packages:
       url: "https://github.com/tibbe/hashable.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:primitive:0.6.4.0"
     purl: "pkg:hackage/Data/primitive@0.6.4.0"
@@ -2112,6 +2141,7 @@ packages:
       url: "https://github.com/haskell/primitive.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:scientific:0.3.6.2"
     purl: "pkg:hackage/Data/scientific@0.3.6.2"
@@ -2161,6 +2191,7 @@ packages:
       url: "https://github.com/basvandijk/scientific.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:sop-core:0.4.0.0"
     purl: "pkg:hackage/Data/sop-core@0.4.0.0"
@@ -2197,6 +2228,7 @@ packages:
       url: "https://github.com/well-typed/generics-sop.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:unordered-containers:0.2.9.0"
     purl: "pkg:hackage/Data/unordered-containers@0.2.9.0"
@@ -2231,6 +2263,7 @@ packages:
       url: "https://github.com/tibbe/unordered-containers.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Data:uuid-types:1.0.3"
     purl: "pkg:hackage/Data/uuid-types@1.0.3"
@@ -2264,6 +2297,7 @@ packages:
       url: "https://github.com/aslatter/uuid.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Development:happy:1.19.9"
     purl: "pkg:hackage/Development/happy@1.19.9"
@@ -2297,6 +2331,7 @@ packages:
       url: "https://github.com/simonmar/happy.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Development:th-abstraction:0.2.10.0"
     purl: "pkg:hackage/Development/th-abstraction@0.2.10.0"
@@ -2329,6 +2364,7 @@ packages:
       url: "https://github.com/glguy/th-abstraction.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Distribution:Cabal:2.4.1.0"
     purl: "pkg:hackage/Distribution/Cabal@2.4.1.0"
@@ -2364,6 +2400,7 @@ packages:
       url: "https://github.com/haskell/cabal.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:GHC:ghc-prim:0.5.3"
     purl: "pkg:hackage/GHC/ghc-prim@0.5.3"
@@ -2394,6 +2431,7 @@ packages:
       url: "http://git.haskell.org/ghc.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Generics:generics-sop:0.4.0.1"
     purl: "pkg:hackage/Generics/generics-sop@0.4.0.1"
@@ -2441,6 +2479,7 @@ packages:
       url: "https://github.com/well-typed/generics-sop.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Graphs, Graphics:graphviz:2999.20.0.3"
     purl: "pkg:hackage/Graphs%2C%20Graphics/graphviz@2999.20.0.3"
@@ -2485,6 +2524,7 @@ packages:
       url: "https://github.com/ivan-m/graphviz.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Language:haskell-lexer:1.0.2"
     purl: "pkg:hackage/Language/haskell-lexer@1.0.2"
@@ -2516,6 +2556,7 @@ packages:
       url: "https://github.com/yav/haskell-lexer.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:List:split:0.2.3.3"
     purl: "pkg:hackage/List/split@0.2.3.3"
@@ -2558,6 +2599,7 @@ packages:
       url: "https://github.com/byorgey/split.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Math, Algorithms, Number Theory:integer-logarithms:1.0.2.2"
     purl: "pkg:hackage/Math%2C%20Algorithms%2C%20Number%20Theory/integer-logarithms@1.0.2.2"
@@ -2590,6 +2632,7 @@ packages:
       url: "https://github.com/Bodigrim/integer-logarithms.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Math:matrix:0.3.6.1"
     purl: "pkg:hackage/Math/matrix@0.3.6.1"
@@ -2626,6 +2669,7 @@ packages:
       url: "https://github.com/Daniel-Diaz/matrix.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Numeric, Algebra:integer-gmp:1.0.2.0"
     purl: "pkg:hackage/Numeric%2C%20Algebra/integer-gmp@1.0.2.0"
@@ -2661,6 +2705,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Other:generic-data:0.3.0.0"
     purl: "pkg:hackage/Other/generic-data@0.3.0.0"
@@ -2690,6 +2735,7 @@ packages:
       url: "https://github.com/Lysxia/generic-data.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Parsing:parsec:3.1.13.0"
     purl: "pkg:hackage/Parsing/parsec@3.1.13.0"
@@ -2728,6 +2774,7 @@ packages:
       url: "https://github.com/hvr/parsec.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Prelude:base:4.12.0.0"
     purl: "pkg:hackage/Prelude/base@4.12.0.0"
@@ -2759,6 +2806,7 @@ packages:
       url: "http://git.haskell.org/ghc.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System, Utils:temporary:1.3"
     purl: "pkg:hackage/System%2C%20Utils/temporary@1.3"
@@ -2790,6 +2838,7 @@ packages:
       url: "https://github.com/feuerbach/temporary.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System:directory:1.3.3.0"
     purl: "pkg:hackage/System/directory@1.3.3.0"
@@ -2822,6 +2871,7 @@ packages:
       url: "https://github.com/haskell/directory.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System:filepath:1.4.2.1"
     purl: "pkg:hackage/System/filepath@1.4.2.1"
@@ -2861,6 +2911,7 @@ packages:
       url: "https://github.com/haskell/filepath.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System:process:1.6.3.0"
     purl: "pkg:hackage/System/process@1.6.3.0"
@@ -2895,6 +2946,7 @@ packages:
       url: "https://github.com/haskell/process.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System:random:1.1"
     purl: "pkg:hackage/System/random@1.1"
@@ -2927,6 +2979,7 @@ packages:
       url: "http://git.haskell.org/packages/random.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System:splitmix:0.0.2"
     purl: "pkg:hackage/System/splitmix@0.0.2"
@@ -2972,6 +3025,7 @@ packages:
       url: "https://github.com/phadej/splitmix.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System:time-locale-compat:0.1.1.5"
     purl: "pkg:hackage/System/time-locale-compat@0.1.1.5"
@@ -3004,6 +3058,7 @@ packages:
       url: "https://bitbucket.org/khibino/haskell-time-locale-compat.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:System:unix:2.7.2.2"
     purl: "pkg:hackage/System/unix@2.7.2.2"
@@ -3038,6 +3093,7 @@ packages:
       url: "https://github.com/haskell/unix.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Template Haskell:template-haskell:2.14.0.0"
     purl: "pkg:hackage/Template%20Haskell/template-haskell@2.14.0.0"
@@ -3071,6 +3127,7 @@ packages:
       url: "http://git.haskell.org/ghc.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Testing:QuickCheck:2.13.1"
     purl: "pkg:hackage/Testing/QuickCheck@2.13.1"
@@ -3117,6 +3174,7 @@ packages:
       url: "https://github.com/nick8325/quickcheck.git"
       revision: "2.13.1"
       path: ""
+  curations: []
 - package:
     id: "Hackage:Testing:markov-chain-usage-model:0.0.0"
     purl: "pkg:hackage/Testing/markov-chain-usage-model@0.0.0"
@@ -3148,6 +3206,7 @@ packages:
       url: "https://github.com/advancedtelematic/markov-chain-usage-model.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Text, Parsing:attoparsec:0.13.2.2"
     purl: "pkg:hackage/Text%2C%20Parsing/attoparsec@0.13.2.2"
@@ -3180,6 +3239,7 @@ packages:
       url: "https://github.com/bos/attoparsec.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Text, Parsing:parsers:0.12.9"
     purl: "pkg:hackage/Text%2C%20Parsing/parsers@0.12.9"
@@ -3215,6 +3275,7 @@ packages:
       url: "https://github.com/ekmett/parsers.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Text, Parsing:polyparse:1.12.1"
     purl: "pkg:hackage/Text%2C%20Parsing/polyparse@1.12.1"
@@ -3252,6 +3313,7 @@ packages:
       url: "https://github.com/hackage-/malcolm-wallace-universe.git"
       revision: "1.12.1"
       path: ""
+  curations: []
 - package:
     id: "Hackage:Text, Web, JSON:aeson:1.4.2.0"
     purl: "pkg:hackage/Text%2C%20Web%2C%20JSON/aeson@1.4.2.0"
@@ -3286,6 +3348,7 @@ packages:
       url: "https://github.com/bos/aeson.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Text:pretty-show:1.9.5"
     purl: "pkg:hackage/Text/pretty-show@1.9.5"
@@ -3320,6 +3383,7 @@ packages:
       url: "https://github.com/yav/pretty-show.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Text:pretty:1.1.3.6"
     purl: "pkg:hackage/Text/pretty@1.1.3.6"
@@ -3355,6 +3419,7 @@ packages:
       url: "https://github.com/haskell/pretty.git"
       revision: "1.1.3.5"
       path: ""
+  curations: []
 - package:
     id: "Hackage:Text:show-combinators:0.1.0.0"
     purl: "pkg:hackage/Text/show-combinators@0.1.0.0"
@@ -3384,6 +3449,7 @@ packages:
       url: "https://github.com/Lysxia/show-combinators.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Text:wl-pprint-text:1.2.0.0"
     purl: "pkg:hackage/Text/wl-pprint-text@1.2.0.0"
@@ -3415,6 +3481,7 @@ packages:
       url: "https://github.com/ivan-m/wl-pprint-text.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:Time:time:1.8.0.2"
     purl: "pkg:hackage/Time/time@1.8.0.2"
@@ -3446,6 +3513,7 @@ packages:
       url: "https://github.com/haskell/time.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:User Interfaces, Text:ansi-wl-pprint:0.6.8.2"
     purl: "pkg:hackage/User%20Interfaces%2C%20Text/ansi-wl-pprint@0.6.8.2"
@@ -3480,6 +3548,7 @@ packages:
       url: "https://github.com/ekmett/ansi-wl-pprint.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:User Interfaces:ansi-terminal:0.8.2"
     purl: "pkg:hackage/User%20Interfaces/ansi-terminal@0.8.2"
@@ -3513,6 +3582,7 @@ packages:
       url: "https://github.com/feuerbach/ansi-terminal.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Hackage:data, graphics:colour:2.3.4"
     purl: "pkg:hackage/data%2C%20graphics/colour@2.3.4"
@@ -3544,3 +3614,4 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
@@ -264,6 +264,7 @@ analyzer:
           url: "ssh://git@github.com/ceki/logback.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:ch.qos.logback:logback-core:1.2.3"
         purl: "pkg:maven/ch.qos.logback/logback-core@1.2.3"
@@ -297,6 +298,7 @@ analyzer:
           url: "ssh://git@github.com/ceki/logback.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:com.chuusai:shapeless_2.12:2.3.2"
         purl: "pkg:maven/com.chuusai/shapeless_2.12@2.3.2"
@@ -328,6 +330,7 @@ analyzer:
           url: "ssh://git@github.com/milessabin/shapeless.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
         purl: "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.8.0"
@@ -360,6 +363,7 @@ analyzer:
           url: "ssh://git@github.com/FasterXML/jackson-annotations.git"
           revision: "jackson-annotations-2.8.0"
           path: ""
+      curations: []
     - package:
         id: "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
         purl: "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.8.9"
@@ -391,6 +395,7 @@ analyzer:
           url: "ssh://git@github.com/FasterXML/jackson-core.git"
           revision: "jackson-core-2.8.9"
           path: ""
+      curations: []
     - package:
         id: "Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9"
         purl: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.9"
@@ -423,6 +428,7 @@ analyzer:
           url: "ssh://git@github.com/FasterXML/jackson-databind.git"
           revision: "jackson-databind-2.8.9"
           path: ""
+      curations: []
     - package:
         id: "Maven:com.github.julien-truffaut:monocle-core_2.12:1.4.0"
         purl: "pkg:maven/com.github.julien-truffaut/monocle-core_2.12@1.4.0"
@@ -452,6 +458,7 @@ analyzer:
           url: "ssh://git@github.com/julien-truffaut/Monocle.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:com.github.julien-truffaut:monocle-macro_2.12:1.4.0"
         purl: "pkg:maven/com.github.julien-truffaut/monocle-macro_2.12@1.4.0"
@@ -481,6 +488,7 @@ analyzer:
           url: "ssh://git@github.com/julien-truffaut/Monocle.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:com.github.pureconfig:pureconfig-macros_2.12:0.8.0"
         purl: "pkg:maven/com.github.pureconfig/pureconfig-macros_2.12@0.8.0"
@@ -512,6 +520,7 @@ analyzer:
           url: "ssh://git@github.com/pureconfig/pureconfig.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:com.github.pureconfig:pureconfig_2.12:0.8.0"
         purl: "pkg:maven/com.github.pureconfig/pureconfig_2.12@0.8.0"
@@ -543,6 +552,7 @@ analyzer:
           url: "ssh://git@github.com/pureconfig/pureconfig.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"
         purl: "pkg:maven/com.typesafe.akka/akka-actor_2.12@2.5.6"
@@ -574,6 +584,7 @@ analyzer:
           url: "ssh://git@github.com/akka/akka.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"
         purl: "pkg:maven/com.typesafe.akka/akka-stream_2.12@2.5.6"
@@ -605,6 +616,7 @@ analyzer:
           url: "ssh://git@github.com/akka/akka.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2"
         purl: "pkg:maven/com.typesafe.scala-logging/scala-logging_2.12@3.7.2"
@@ -636,6 +648,7 @@ analyzer:
           url: "https://github.com/typesafehub/scala-logging.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:com.typesafe:config:1.3.1"
         purl: "pkg:maven/com.typesafe/config@1.3.1"
@@ -667,6 +680,7 @@ analyzer:
           url: "https://github.com/typesafehub/config.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:com.typesafe:ssl-config-core_2.12:0.2.2"
         purl: "pkg:maven/com.typesafe/ssl-config-core_2.12@0.2.2"
@@ -698,6 +712,7 @@ analyzer:
           url: "https://github.com/typesafehub/ssl-config.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:net.logstash.logback:logstash-logback-encoder:4.11"
         purl: "pkg:maven/net.logstash.logback/logstash-logback-encoder@4.11"
@@ -732,6 +747,7 @@ analyzer:
           url: "ssh://git@github.com/logstash/logstash-logback-encoder.git"
           revision: "logstash-logback-encoder-4.11"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.reactivestreams:reactive-streams:1.0.1"
         purl: "pkg:maven/org.reactivestreams/reactive-streams@1.0.1"
@@ -763,6 +779,7 @@ analyzer:
           url: "ssh://git@github.com/reactive-streams/reactive-streams.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0"
         purl: "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.12@0.8.0"
@@ -794,6 +811,7 @@ analyzer:
           url: "https://github.com/scala/scala-java8-compat.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
         purl: "pkg:maven/org.scala-lang.modules/scala-parser-combinators_2.12@1.0.4"
@@ -825,6 +843,7 @@ analyzer:
           url: "https://github.com/scala/scala-parser-combinators.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
         purl: "pkg:maven/org.scala-lang.modules/scala-xml_2.12@1.0.5"
@@ -856,6 +875,7 @@ analyzer:
           url: "https://github.com/scala/scala-xml.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.scala-lang:scala-compiler:2.12.3"
         purl: "pkg:maven/org.scala-lang/scala-compiler@2.12.3"
@@ -887,6 +907,7 @@ analyzer:
           url: "https://github.com/scala/scala.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.scala-lang:scala-library:2.12.3"
         purl: "pkg:maven/org.scala-lang/scala-library@2.12.3"
@@ -918,6 +939,7 @@ analyzer:
           url: "https://github.com/scala/scala.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.scala-lang:scala-reflect:2.12.2"
         purl: "pkg:maven/org.scala-lang/scala-reflect@2.12.2"
@@ -949,6 +971,7 @@ analyzer:
           url: "https://github.com/scala/scala.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.scala-sbt:test-interface:1.0"
         purl: "pkg:maven/org.scala-sbt/test-interface@1.0"
@@ -981,6 +1004,7 @@ analyzer:
           url: "https://github.com/sbt/test-interface.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.scalacheck:scalacheck_2.12:1.13.5"
         purl: "pkg:maven/org.scalacheck/scalacheck_2.12@1.13.5"
@@ -1012,6 +1036,7 @@ analyzer:
           url: "ssh://git@github.com/rickynils/scalacheck.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.scalactic:scalactic_2.12:3.0.4"
         purl: "pkg:maven/org.scalactic/scalactic_2.12@3.0.4"
@@ -1043,6 +1068,7 @@ analyzer:
           url: "ssh://git@github.com/scalatest/scalatest.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.scalatest:scalatest_2.12:3.0.4"
         purl: "pkg:maven/org.scalatest/scalatest_2.12@3.0.4"
@@ -1074,6 +1100,7 @@ analyzer:
           url: "ssh://git@github.com/scalatest/scalatest.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.scalaz:scalaz-core_2.12:7.2.8"
         purl: "pkg:maven/org.scalaz/scalaz-core_2.12@7.2.8"
@@ -1105,6 +1132,7 @@ analyzer:
           url: "ssh://git@github.com/scalaz/scalaz.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
         purl: "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.25"
@@ -1136,6 +1164,7 @@ analyzer:
           url: "ssh://git@github.com/qos-ch/slf4j.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.slf4j:slf4j-api:1.7.25"
         purl: "pkg:maven/org.slf4j/slf4j-api@1.7.25"
@@ -1167,6 +1196,7 @@ analyzer:
           url: "ssh://git@github.com/qos-ch/slf4j.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.typelevel:macro-compat_2.12:1.1.1"
         purl: "pkg:maven/org.typelevel/macro-compat_2.12@1.1.1"
@@ -1198,6 +1228,7 @@ analyzer:
           url: "ssh://git@github.com/milessabin/macro-compat.git"
           revision: ""
           path: ""
+      curations: []
     has_issues: false
 scanner: null
 evaluator: null

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -66,6 +66,7 @@ packages:
       url: "https://github.com/gweis/isodate.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::ply:3.11"
     purl: "pkg:pypi/ply@3.11"
@@ -97,6 +98,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::pyparsing:2.4.7"
     purl: "pkg:pypi/pyparsing@2.4.7"
@@ -128,6 +130,7 @@ packages:
       url: "https://github.com/pyparsing/pyparsing.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::rdflib:5.0.0"
     purl: "pkg:pypi/rdflib@5.0.0"
@@ -161,6 +164,7 @@ packages:
       url: "https://github.com/RDFLib/rdflib.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::six:1.15.0"
     purl: "pkg:pypi/six@1.15.0"
@@ -193,3 +197,4 @@ packages:
       url: "https://github.com/benjaminp/six.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/bower-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bower-expected-output.yml
@@ -57,6 +57,7 @@ packages:
       url: "https://github.com/jquery/jquery-dist.git"
       revision: "9e8ec3d10fad04748176144f108d7355662ae75e"
       path: ""
+  curations: []
 - package:
     id: "Bower::polymer:2.4.0"
     purl: "pkg:bower/polymer@2.4.0"
@@ -88,6 +89,7 @@ packages:
       url: "https://github.com/Polymer/polymer.git"
       revision: "a474d40c843e2b00a5c0cea818c36b1a89e2a66e"
       path: ""
+  curations: []
 - package:
     id: "Bower::shadycss:1.9.1"
     purl: "pkg:bower/shadycss@1.9.1"
@@ -115,6 +117,7 @@ packages:
       url: "https://github.com/webcomponents/shadycss.git"
       revision: "4665ae8da2b91198f7b4490d4285b3bb33d5ff06"
       path: ""
+  curations: []
 - package:
     id: "Bower::webcomponentsjs:1.3.3"
     purl: "pkg:bower/webcomponentsjs@1.3.3"
@@ -144,3 +147,4 @@ packages:
       url: "https://github.com/webcomponents/webcomponentsjs.git"
       revision: "0dc4cd2cb4233e0e63ee8bd3ee5db90035856933"
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
@@ -76,6 +76,7 @@ packages:
       url: "https://github.com/sporkmonger/addressable.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::diff-lcs:1.3"
     purl: "pkg:bundler/diff-lcs@1.3"
@@ -115,6 +116,7 @@ packages:
       url: "https://github.com/halostatue/diff-lcs.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::faraday:0.17.3"
     purl: "pkg:bundler/faraday@0.17.3"
@@ -144,6 +146,7 @@ packages:
       url: "https://github.com/lostisland/faraday.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::jwt:2.2.1"
     purl: "pkg:bundler/jwt@2.2.1"
@@ -174,6 +177,7 @@ packages:
       url: "https://github.com/jwt/ruby-jwt.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::multi_json:1.14.1"
     purl: "pkg:bundler/multi_json@1.14.1"
@@ -205,6 +209,7 @@ packages:
       url: "https://github.com/intridea/multi_json.git"
       revision: "v1.14.1"
       path: ""
+  curations: []
 - package:
     id: "Bundler::multipart-post:2.1.1"
     purl: "pkg:bundler/multipart-post@2.1.1"
@@ -236,6 +241,7 @@ packages:
       url: "https://github.com/nicksieger/multipart-post.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::public_suffix:4.0.5"
     purl: "pkg:bundler/public_suffix@4.0.5"
@@ -266,6 +272,7 @@ packages:
       url: "https://github.com/weppos/publicsuffix-ruby.git"
       revision: "v4.0.5"
       path: ""
+  curations: []
 - package:
     id: "Bundler::rack:2.2.3"
     purl: "pkg:bundler/rack@2.2.3"
@@ -298,6 +305,7 @@ packages:
       url: "https://github.com/rack/rack.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::rspec-core:3.7.1"
     purl: "pkg:bundler/rspec-core@3.7.1"
@@ -327,6 +335,7 @@ packages:
       url: "https://github.com/rspec/rspec-core.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::rspec-expectations:3.7.0"
     purl: "pkg:bundler/rspec-expectations@3.7.0"
@@ -357,6 +366,7 @@ packages:
       url: "https://github.com/rspec/rspec-expectations.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::rspec-mocks:3.7.0"
     purl: "pkg:bundler/rspec-mocks@3.7.0"
@@ -386,6 +396,7 @@ packages:
       url: "https://github.com/rspec/rspec-mocks.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::rspec-support:3.7.1"
     purl: "pkg:bundler/rspec-support@3.7.1"
@@ -415,6 +426,7 @@ packages:
       url: "https://github.com/rspec/rspec-support.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::rspec:3.7.0"
     purl: "pkg:bundler/rspec@3.7.0"
@@ -444,6 +456,7 @@ packages:
       url: "https://github.com/rspec/rspec.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::signet:0.8.1"
     purl: "pkg:bundler/signet@0.8.1"
@@ -473,3 +486,4 @@ packages:
       url: "https://github.com/google/signet.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
@@ -77,6 +77,7 @@ packages:
       url: "https://github.com/halostatue/diff-lcs.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::mini_portile2:2.4.0"
     purl: "pkg:bundler/mini_portile2@2.4.0"
@@ -108,6 +109,7 @@ packages:
       url: "https://github.com/flavorjones/mini_portile.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::nokogiri:1.10.8"
     purl: "pkg:bundler/nokogiri@1.10.8"
@@ -138,6 +140,7 @@ packages:
       url: "https://github.com/sparklemotion/nokogiri.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::rack:2.1.4"
     purl: "pkg:bundler/rack@2.1.4"
@@ -171,6 +174,7 @@ packages:
       url: "https://github.com/rack/rack.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::rspec-core:3.7.1"
     purl: "pkg:bundler/rspec-core@3.7.1"
@@ -200,6 +204,7 @@ packages:
       url: "https://github.com/rspec/rspec-core.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::rspec-expectations:3.7.0"
     purl: "pkg:bundler/rspec-expectations@3.7.0"
@@ -230,6 +235,7 @@ packages:
       url: "https://github.com/rspec/rspec-expectations.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::rspec-mocks:3.7.0"
     purl: "pkg:bundler/rspec-mocks@3.7.0"
@@ -259,6 +265,7 @@ packages:
       url: "https://github.com/rspec/rspec-mocks.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::rspec-support:3.7.1"
     purl: "pkg:bundler/rspec-support@3.7.1"
@@ -288,6 +295,7 @@ packages:
       url: "https://github.com/rspec/rspec-support.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Bundler::rspec:3.7.0"
     purl: "pkg:bundler/rspec@3.7.0"
@@ -317,3 +325,4 @@ packages:
       url: "https://github.com/rspec/rspec.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/cargo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/cargo-expected-output.yml
@@ -154,6 +154,7 @@ packages:
       url: "https://github.com/cuviper/autocfg.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::bitflags:1.1.0"
     purl: "pkg:cargo/bitflags@1.1.0"
@@ -184,6 +185,7 @@ packages:
       url: "https://github.com/bitflags/bitflags.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::cfg-if:0.1.9"
     purl: "pkg:cargo/cfg-if@0.1.9"
@@ -216,6 +218,7 @@ packages:
       url: "https://github.com/alexcrichton/cfg-if.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::cloudabi:0.0.3"
     purl: "pkg:cargo/cloudabi@0.0.3"
@@ -246,6 +249,7 @@ packages:
       url: "https://github.com/nuxinl/cloudabi.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::fuchsia-cprng:0.1.1"
     purl: "pkg:cargo/fuchsia-cprng@0.1.1"
@@ -274,6 +278,7 @@ packages:
       url: "https://fuchsia.googlesource.com/fuchsia/+/master/garnet/public/rust/fuchsia-cprng"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::libc:0.2.62"
     purl: "pkg:cargo/libc@0.2.62"
@@ -303,6 +308,7 @@ packages:
       url: "https://github.com/rust-lang/libc.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::rand:0.6.5"
     purl: "pkg:cargo/rand@0.6.5"
@@ -333,6 +339,7 @@ packages:
       url: "https://github.com/rust-random/rand.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::rand_chacha:0.1.1"
     purl: "pkg:cargo/rand_chacha@0.1.1"
@@ -363,6 +370,7 @@ packages:
       url: "https://github.com/rust-random/rand.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::rand_core:0.3.1"
     purl: "pkg:cargo/rand_core@0.3.1"
@@ -393,6 +401,7 @@ packages:
       url: "https://github.com/rust-random/rand.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::rand_core:0.4.2"
     purl: "pkg:cargo/rand_core@0.4.2"
@@ -423,6 +432,7 @@ packages:
       url: "https://github.com/rust-random/rand.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::rand_hc:0.1.0"
     purl: "pkg:cargo/rand_hc@0.1.0"
@@ -453,6 +463,7 @@ packages:
       url: "https://github.com/rust-random/rand.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::rand_isaac:0.1.1"
     purl: "pkg:cargo/rand_isaac@0.1.1"
@@ -483,6 +494,7 @@ packages:
       url: "https://github.com/rust-random/rand.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::rand_jitter:0.1.4"
     purl: "pkg:cargo/rand_jitter@0.1.4"
@@ -512,6 +524,7 @@ packages:
       url: "https://github.com/rust-random/rand.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::rand_os:0.1.3"
     purl: "pkg:cargo/rand_os@0.1.3"
@@ -542,6 +555,7 @@ packages:
       url: "https://github.com/rust-random/rand.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::rand_pcg:0.1.2"
     purl: "pkg:cargo/rand_pcg@0.1.2"
@@ -572,6 +586,7 @@ packages:
       url: "https://github.com/rust-random/rand.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::rand_xorshift:0.1.1"
     purl: "pkg:cargo/rand_xorshift@0.1.1"
@@ -602,6 +617,7 @@ packages:
       url: "https://github.com/rust-random/rand.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::rdrand:0.4.0"
     purl: "pkg:cargo/rdrand@0.4.0"
@@ -632,6 +648,7 @@ packages:
       url: "https://github.com/nagisa/rust_rdrand.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::spin:0.5.0"
     purl: "pkg:cargo/spin@0.5.0"
@@ -662,6 +679,7 @@ packages:
       url: "https://github.com/mvdnes/spin-rs.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::winapi-i686-pc-windows-gnu:0.4.0"
     purl: "pkg:cargo/winapi-i686-pc-windows-gnu@0.4.0"
@@ -693,6 +711,7 @@ packages:
       url: "https://github.com/retep998/winapi-rs.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::winapi-x86_64-pc-windows-gnu:0.4.0"
     purl: "pkg:cargo/winapi-x86_64-pc-windows-gnu@0.4.0"
@@ -724,6 +743,7 @@ packages:
       url: "https://github.com/retep998/winapi-rs.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::winapi:0.3.8"
     purl: "pkg:cargo/winapi@0.3.8"
@@ -754,3 +774,4 @@ packages:
       url: "https://github.com/retep998/winapi-rs.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate-client-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate-client-expected-output.yml
@@ -60,3 +60,4 @@ packages:
       url: "https://github.com/alexcrichton/cfg-if.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate-integration-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate-integration-expected-output.yml
@@ -55,3 +55,4 @@ packages:
       url: "https://github.com/mvdnes/spin-rs.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate-lib-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate-lib-expected-output.yml
@@ -67,6 +67,7 @@ packages:
       url: "https://github.com/alexcrichton/cfg-if.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::spin:0.4.10"
     purl: "pkg:cargo/spin@0.4.10"
@@ -97,6 +98,7 @@ packages:
       url: "https://github.com/mvdnes/spin-rs.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Cargo::spin:0.5.0"
     purl: "pkg:cargo/spin@0.5.0"
@@ -127,3 +129,4 @@ packages:
       url: "https://github.com/mvdnes/spin-rs.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-py.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-py.yml
@@ -58,6 +58,7 @@ packages:
       url: "https://github.com/conan-community/conan-openssl.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Conan::zlib:1.2.11"
     purl: "pkg:conan/zlib@1.2.11"
@@ -88,3 +89,4 @@ packages:
       url: "https://github.com/conan-community/conan-zlib.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-txt.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-txt.yml
@@ -53,6 +53,7 @@ packages:
       url: "https://github.com/bincrafters/conan-protobuf.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Conan::protoc_installer:3.6.1"
     purl: "pkg:conan/protoc_installer@3.6.1"
@@ -82,3 +83,4 @@ packages:
       url: "https://github.com/bincrafters/conan-protobuf.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
@@ -53,6 +53,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "nuget::Newtonsoft.Json:5.0.4"
     purl: "pkg:nuget/Newtonsoft.Json@5.0.4"
@@ -83,6 +84,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "nuget::WebGrease:1.5.2"
     purl: "pkg:nuget/WebGrease@1.5.2"
@@ -114,6 +116,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "nuget::jQuery:3.3.1"
     purl: "pkg:nuget/jQuery@3.3.1"
@@ -149,3 +152,4 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/glide-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/glide-expected-output.yml
@@ -50,6 +50,7 @@ packages:
       url: "https://github.com/mattn/go-isatty.git"
       revision: "7b513a986450394f7bbf1476909911b3aa3a55ce"
       path: ""
+  curations: []
 - package:
     id: "GoDep::golang.org/x/sys:05986578812163b26672dabd9b425240ae2bb0ad"
     purl: "pkg:godep/golang.org%2Fx%2Fsys@05986578812163b26672dabd9b425240ae2bb0ad"
@@ -77,3 +78,4 @@ packages:
       url: "https://go.googlesource.com/sys"
       revision: "05986578812163b26672dabd9b425240ae2bb0ad"
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/godep-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/godep-expected-output.yml
@@ -54,6 +54,7 @@ packages:
       url: "https://github.com/fatih/color.git"
       revision: "daf2830f2741ebb735b21709a520c5f37d642d85"
       path: ""
+  curations: []
 - package:
     id: "GoDep::github.com/mattn/go-colorable:v0.1.6"
     purl: "pkg:godep/github.com%2Fmattn%2Fgo-colorable@v0.1.6"
@@ -81,6 +82,7 @@ packages:
       url: "https://github.com/mattn/go-colorable.git"
       revision: "68e95eba382c972aafde02ead2cd2426a8a92480"
       path: ""
+  curations: []
 - package:
     id: "GoDep::github.com/mattn/go-isatty:v0.0.12"
     purl: "pkg:godep/github.com%2Fmattn%2Fgo-isatty@v0.0.12"
@@ -108,6 +110,7 @@ packages:
       url: "https://github.com/mattn/go-isatty.git"
       revision: "7b513a986450394f7bbf1476909911b3aa3a55ce"
       path: ""
+  curations: []
 - package:
     id: "GoDep::golang.org/x/sys:05986578812163b26672dabd9b425240ae2bb0ad"
     purl: "pkg:godep/golang.org%2Fx%2Fsys@05986578812163b26672dabd9b425240ae2bb0ad"
@@ -135,3 +138,4 @@ packages:
       url: "https://go.googlesource.com/sys"
       revision: "05986578812163b26672dabd9b425240ae2bb0ad"
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/godeps-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/godeps-expected-output.yml
@@ -50,6 +50,7 @@ packages:
       url: "https://github.com/mattn/go-isatty.git"
       revision: "7b513a986450394f7bbf1476909911b3aa3a55ce"
       path: ""
+  curations: []
 - package:
     id: "GoDep::golang.org/x/sys:8d3cce7afc34617998104db7c4b58c2de9e77215"
     purl: "pkg:godep/golang.org%2Fx%2Fsys@8d3cce7afc34617998104db7c4b58c2de9e77215"
@@ -77,3 +78,4 @@ packages:
       url: "https://go.googlesource.com/sys"
       revision: "8d3cce7afc34617998104db7c4b58c2de9e77215"
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
@@ -95,6 +95,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "GoMod::github.com/fatih/color:v1.7.0"
     purl: "pkg:gomod/github.com%2Ffatih%2Fcolor@v1.7.0"
@@ -122,6 +123,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "GoMod::github.com/golang/protobuf:v1.2.0"
     purl: "pkg:gomod/github.com%2Fgolang%2Fprotobuf@v1.2.0"
@@ -149,6 +151,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "GoMod::github.com/hashicorp/errwrap:v1.0.0"
     purl: "pkg:gomod/github.com%2Fhashicorp%2Ferrwrap@v1.0.0"
@@ -176,6 +179,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "GoMod::github.com/hashicorp/go-multierror:v1.0.0"
     purl: "pkg:gomod/github.com%2Fhashicorp%2Fgo-multierror@v1.0.0"
@@ -203,6 +207,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "GoMod::github.com/mattn/go-colorable:v0.1.4"
     purl: "pkg:gomod/github.com%2Fmattn%2Fgo-colorable@v0.1.4"
@@ -230,6 +235,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "GoMod::github.com/mattn/go-isatty:v0.0.10"
     purl: "pkg:gomod/github.com%2Fmattn%2Fgo-isatty@v0.0.10"
@@ -257,6 +263,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "GoMod::github.com/mattn/go-isatty:v0.0.8"
     purl: "pkg:gomod/github.com%2Fmattn%2Fgo-isatty@v0.0.8"
@@ -284,6 +291,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "GoMod::golang.org/x/net:v0.0.0-20180724234803-3673e40ba225"
     purl: "pkg:gomod/golang.org%2Fx%2Fnet@v0.0.0-20180724234803-3673e40ba225"
@@ -311,6 +319,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "GoMod::golang.org/x/net:v0.0.0-20190108225652-1e06a53dbb7e"
     purl: "pkg:gomod/golang.org%2Fx%2Fnet@v0.0.0-20190108225652-1e06a53dbb7e"
@@ -338,6 +347,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "GoMod::golang.org/x/oauth2:v0.0.0-20190226205417-e64efc72b421"
     purl: "pkg:gomod/golang.org%2Fx%2Foauth2@v0.0.0-20190226205417-e64efc72b421"
@@ -365,6 +375,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "GoMod::golang.org/x/sync:v0.0.0-20181221193216-37e7f081c4d4"
     purl: "pkg:gomod/golang.org%2Fx%2Fsync@v0.0.0-20181221193216-37e7f081c4d4"
@@ -392,6 +403,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "GoMod::golang.org/x/sys:v0.0.0-20190222072716-a9d3bda3a223"
     purl: "pkg:gomod/golang.org%2Fx%2Fsys@v0.0.0-20190222072716-a9d3bda3a223"
@@ -419,6 +431,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "GoMod::golang.org/x/sys:v0.0.0-20191008105621-543471e840be"
     purl: "pkg:gomod/golang.org%2Fx%2Fsys@v0.0.0-20191008105621-543471e840be"
@@ -446,6 +459,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "GoMod::golang.org/x/text:v0.3.0"
     purl: "pkg:gomod/golang.org%2Fx%2Ftext@v0.3.0"
@@ -473,6 +487,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "GoMod::google.golang.org/appengine:v1.4.0"
     purl: "pkg:gomod/google.golang.org%2Fappengine@v1.4.0"
@@ -500,3 +515,4 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -441,6 +441,7 @@ analyzer:
           url: "https://github.com/junit-team/junit.git"
           revision: "r4.12"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-lang3:3.5"
         purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
@@ -474,6 +475,7 @@ analyzer:
           url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
           revision: "LANG_3_5"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-text:1.1"
         purl: "pkg:maven/org.apache.commons/commons-text@1.1"
@@ -506,6 +508,7 @@ analyzer:
           url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
         purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
@@ -537,6 +540,7 @@ analyzer:
           url: "https://gitbox.apache.org/repos/asf/struts.git"
           revision: "STRUTS_2_5_14_1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.hamcrest:hamcrest-core:1.3"
         purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -441,6 +441,7 @@ analyzer:
           url: "https://github.com/junit-team/junit.git"
           revision: "r4.12"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-lang3:3.5"
         purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
@@ -474,6 +475,7 @@ analyzer:
           url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
           revision: "LANG_3_5"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-text:1.1"
         purl: "pkg:maven/org.apache.commons/commons-text@1.1"
@@ -506,6 +508,7 @@ analyzer:
           url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
         purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
@@ -537,6 +540,7 @@ analyzer:
           url: "https://gitbox.apache.org/repos/asf/struts.git"
           revision: "STRUTS_2_5_14_1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.hamcrest:hamcrest-core:1.3"
         purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
@@ -570,6 +574,7 @@ analyzer:
           url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
           revision: ""
           path: ""
+      curations: []
     has_issues: true
 scanner: null
 evaluator: null

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
@@ -486,6 +486,7 @@ packages:
       url: "https://github.com/square/okhttp.git"
       revision: "parent-3.10.0"
       path: ""
+  curations: []
 - package:
     id: "Maven:com.squareup.okio:okio:1.14.0"
     purl: "pkg:maven/com.squareup.okio/okio@1.14.0"
@@ -517,6 +518,7 @@ packages:
       url: "https://github.com/square/okio.git"
       revision: "okio-parent-1.14.0"
       path: ""
+  curations: []
 - package:
     id: "Maven:junit:junit:4.12"
     purl: "pkg:maven/junit/junit@4.12"
@@ -549,6 +551,7 @@ packages:
       url: "https://github.com/junit-team/junit.git"
       revision: "r4.12"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-compress:1.17"
     purl: "pkg:maven/org.apache.commons/commons-compress@1.17"
@@ -583,6 +586,7 @@ packages:
       url: "https://git-wip-us.apache.org/repos/asf/commons-compress.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-lang3:3.7"
     purl: "pkg:maven/org.apache.commons/commons-lang3@3.7"
@@ -616,6 +620,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
       revision: "LANG_3_6"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-text:1.2"
     purl: "pkg:maven/org.apache.commons/commons-text@1.2"
@@ -648,6 +653,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-text:1.3"
     purl: "pkg:maven/org.apache.commons/commons-text@1.3"
@@ -680,6 +686,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.hamcrest:hamcrest-core:1.3"
     purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
@@ -713,3 +720,4 @@ packages:
       url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
@@ -205,6 +205,7 @@ packages:
       url: "https://git-wip-us.apache.org/repos/asf/commons-compress.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-lang3:3.7"
     purl: "pkg:maven/org.apache.commons/commons-lang3@3.7"
@@ -238,6 +239,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
       revision: "LANG_3_6"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-text:1.2"
     purl: "pkg:maven/org.apache.commons/commons-text@1.2"
@@ -270,6 +272,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-text:1.3"
     purl: "pkg:maven/org.apache.commons/commons-text@1.3"
@@ -302,3 +305,4 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
@@ -113,6 +113,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
       revision: "LANG_3_5"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-text:1.1"
     purl: "pkg:maven/org.apache.commons/commons-text@1.1"
@@ -143,6 +144,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
     purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
@@ -172,3 +174,4 @@ packages:
       url: "https://gitbox.apache.org/repos/asf/struts.git"
       revision: "STRUTS_2_5_14_1"
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
@@ -99,6 +99,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
       revision: "LANG_3_5"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-text:1.1"
     purl: "pkg:maven/org.apache.commons/commons-text@1.1"
@@ -129,6 +130,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
     purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
@@ -158,3 +160,4 @@ packages:
       url: "https://gitbox.apache.org/repos/asf/struts.git"
       revision: "STRUTS_2_5_14_1"
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -141,6 +141,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
       revision: "LANG_3_5"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-text:1.1"
     purl: "pkg:maven/org.apache.commons/commons-text@1.1"
@@ -173,6 +174,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
     purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
@@ -204,3 +206,4 @@ packages:
       url: "https://gitbox.apache.org/repos/asf/struts.git"
       revision: "STRUTS_2_5_14_1"
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -125,6 +125,7 @@ packages:
       url: "https://github.com/junit-team/junit.git"
       revision: "r4.12"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-lang3:3.5"
     purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
@@ -158,6 +159,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
       revision: "LANG_3_5"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-text:1.1"
     purl: "pkg:maven/org.apache.commons/commons-text@1.1"
@@ -190,6 +192,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
     purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
@@ -221,6 +224,7 @@ packages:
       url: "https://gitbox.apache.org/repos/asf/struts.git"
       revision: "STRUTS_2_5_14_1"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.hamcrest:hamcrest-core:1.3"
     purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
@@ -254,3 +258,4 @@ packages:
       url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
@@ -139,6 +139,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
       revision: "LANG_3_5"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-text:1.1"
     purl: "pkg:maven/org.apache.commons/commons-text@1.1"
@@ -171,6 +172,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
     purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
@@ -202,3 +204,4 @@ packages:
       url: "https://gitbox.apache.org/repos/asf/struts.git"
       revision: "STRUTS_2_5_14_1"
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
@@ -103,6 +103,7 @@ packages:
       url: "https://github.com/junit-team/junit.git"
       revision: "r4.12"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-lang3:3.5"
     purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
@@ -136,6 +137,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
       revision: "LANG_3_5"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-text:1.1"
     purl: "pkg:maven/org.apache.commons/commons-text@1.1"
@@ -168,6 +170,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
     purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
@@ -199,6 +202,7 @@ packages:
       url: "https://gitbox.apache.org/repos/asf/struts.git"
       revision: "STRUTS_2_5_14_1"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.hamcrest:hamcrest-core:1.3"
     purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
@@ -232,3 +236,4 @@ packages:
       url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
@@ -64,6 +64,7 @@ packages:
       url: "https://gitbox.apache.org/repos/asf/beam.git"
       revision: "v2.3.0-RC3"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-lang3:3.5"
     purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
@@ -97,6 +98,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
       revision: "LANG_3_5"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-text:1.1"
     purl: "pkg:maven/org.apache.commons/commons-text@1.1"
@@ -129,6 +131,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jenkins-ci:version-number:1.4"
     purl: "pkg:maven/org.jenkins-ci/version-number@1.4"
@@ -160,3 +163,4 @@ packages:
       url: "https://github.com/jenkinsci/lib-version-number.git"
       revision: "version-number-1.4"
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
@@ -63,6 +63,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.beam:beam-parent:2.3.0"
     purl: "pkg:maven/org.apache.beam/beam-parent@2.3.0"
@@ -96,6 +97,7 @@ packages:
       url: "https://gitbox.apache.org/repos/asf/beam.git"
       revision: "v2.3.0-RC3"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-lang3:3.5"
     purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
@@ -129,6 +131,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
       revision: "LANG_3_5"
       path: ""
+  curations: []
 - package:
     id: "Maven:org.apache.commons:commons-text:1.1"
     purl: "pkg:maven/org.apache.commons/commons-text@1.1"
@@ -161,6 +164,7 @@ packages:
       url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:org.jenkins-ci:version-number:1.4"
     purl: "pkg:maven/org.jenkins-ci/version-number@1.4"
@@ -192,3 +196,4 @@ packages:
       url: "https://github.com/jenkinsci/lib-version-number.git"
       revision: "version-number-1.4"
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -2334,6 +2334,7 @@ packages:
       url: "ssh://git@github.com/isaacs/abbrev-js.git"
       revision: "a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb"
       path: ""
+  curations: []
 - package:
     id: "NPM::ansi-regex:2.1.1"
     purl: "pkg:npm/ansi-regex@2.1.1"
@@ -2363,6 +2364,7 @@ packages:
       url: "https://github.com/chalk/ansi-regex.git"
       revision: "7c908e7b4eb6cd82bfe1295e33fdf6d166c7ed85"
       path: ""
+  curations: []
 - package:
     id: "NPM::ansi-styles:2.2.1"
     purl: "pkg:npm/ansi-styles@2.2.1"
@@ -2392,6 +2394,7 @@ packages:
       url: "https://github.com/chalk/ansi-styles.git"
       revision: "95c59b23be760108b6530ca1c89477c21b258032"
       path: ""
+  curations: []
 - package:
     id: "NPM::anymatch:1.3.2"
     purl: "pkg:npm/anymatch@1.3.2"
@@ -2422,6 +2425,7 @@ packages:
       url: "https://github.com/es128/anymatch.git"
       revision: "a16f5bd07f1e36c4eef08c1291c6c119d1663639"
       path: ""
+  curations: []
 - package:
     id: "NPM::aproba:1.2.0"
     purl: "pkg:npm/aproba@1.2.0"
@@ -2451,6 +2455,7 @@ packages:
       url: "https://github.com/iarna/aproba.git"
       revision: "ee43ce68c9992e8f9d0d925dc2b1f2e1e5c976de"
       path: ""
+  curations: []
 - package:
     id: "NPM::are-we-there-yet:1.1.5"
     purl: "pkg:npm/are-we-there-yet@1.1.5"
@@ -2480,6 +2485,7 @@ packages:
       url: "https://github.com/iarna/are-we-there-yet.git"
       revision: "b4d023b8b754b9d2d540c9db21cc7edf2962ea63"
       path: ""
+  curations: []
 - package:
     id: "NPM::arr-diff:2.0.0"
     purl: "pkg:npm/arr-diff@2.0.0"
@@ -2510,6 +2516,7 @@ packages:
       url: "https://github.com/jonschlinkert/arr-diff.git"
       revision: "b89f54eb88ca51afd0e0ea6be9a4a63e5ccecf27"
       path: ""
+  curations: []
 - package:
     id: "NPM::arr-diff:4.0.0"
     purl: "pkg:npm/arr-diff@4.0.0"
@@ -2540,6 +2547,7 @@ packages:
       url: "https://github.com/jonschlinkert/arr-diff.git"
       revision: "0a04556fb004b3db57f57de2777b1037090f6023"
       path: ""
+  curations: []
 - package:
     id: "NPM::arr-flatten:1.1.0"
     purl: "pkg:npm/arr-flatten@1.1.0"
@@ -2569,6 +2577,7 @@ packages:
       url: "https://github.com/jonschlinkert/arr-flatten.git"
       revision: "76a1ae28b03fdb1cbe5d49fa521bc4807b9f94d3"
       path: ""
+  curations: []
 - package:
     id: "NPM::arr-union:3.1.0"
     purl: "pkg:npm/arr-union@3.1.0"
@@ -2599,6 +2608,7 @@ packages:
       url: "https://github.com/jonschlinkert/arr-union.git"
       revision: "ede857f5d5082467534e372fd3da45ce5e782e93"
       path: ""
+  curations: []
 - package:
     id: "NPM::array-unique:0.2.1"
     purl: "pkg:npm/array-unique@0.2.1"
@@ -2628,6 +2638,7 @@ packages:
       url: "https://github.com/jonschlinkert/array-unique.git"
       revision: "36fde8e586fb7cf880b8b3aa6515df889e64ed85"
       path: ""
+  curations: []
 - package:
     id: "NPM::array-unique:0.3.2"
     purl: "pkg:npm/array-unique@0.3.2"
@@ -2657,6 +2668,7 @@ packages:
       url: "https://github.com/jonschlinkert/array-unique.git"
       revision: "d95d18b0d3188fb95d3c6c2bf349b2ed926b563b"
       path: ""
+  curations: []
 - package:
     id: "NPM::assign-symbols:1.0.0"
     purl: "pkg:npm/assign-symbols@1.0.0"
@@ -2689,6 +2701,7 @@ packages:
       url: "https://github.com/jonschlinkert/assign-symbols.git"
       revision: "2df01f26fce8359fa75688eb89e2a1c65de6f237"
       path: ""
+  curations: []
 - package:
     id: "NPM::async-each:1.0.3"
     purl: "pkg:npm/async-each@1.0.3"
@@ -2719,6 +2732,7 @@ packages:
       url: "https://github.com/paulmillr/async-each.git"
       revision: "9c0980f671fd649e4523e15f5b281aaa5294409e"
       path: ""
+  curations: []
 - package:
     id: "NPM::atob:2.1.2"
     purl: "pkg:npm/atob@2.1.2"
@@ -2748,6 +2762,7 @@ packages:
       url: "git://git.coolaj86.com/coolaj86/atob.js.git"
       revision: "755cfea7899074a17e83a248c7cfc3960d956d82"
       path: ""
+  curations: []
 - package:
     id: "NPM::babel-cli:6.26.0"
     purl: "pkg:npm/babel-cli@6.26.0"
@@ -2777,6 +2792,7 @@ packages:
       url: "https://github.com/babel/babel.git"
       revision: "master"
       path: "packages/babel-cli"
+  curations: []
 - package:
     id: "NPM::babel-code-frame:6.26.0"
     purl: "pkg:npm/babel-code-frame@6.26.0"
@@ -2806,6 +2822,7 @@ packages:
       url: "https://github.com/babel/babel.git"
       revision: "master"
       path: "packages/babel-code-frame"
+  curations: []
 - package:
     id: "NPM::babel-core:6.26.3"
     purl: "pkg:npm/babel-core@6.26.3"
@@ -2835,6 +2852,7 @@ packages:
       url: "https://github.com/babel/babel.git"
       revision: "master"
       path: "packages/babel-core"
+  curations: []
 - package:
     id: "NPM::babel-generator:6.26.1"
     purl: "pkg:npm/babel-generator@6.26.1"
@@ -2864,6 +2882,7 @@ packages:
       url: "https://github.com/babel/babel.git"
       revision: "master"
       path: "packages/babel-generator"
+  curations: []
 - package:
     id: "NPM::babel-helpers:6.24.1"
     purl: "pkg:npm/babel-helpers@6.24.1"
@@ -2893,6 +2912,7 @@ packages:
       url: "https://github.com/babel/babel.git"
       revision: "master"
       path: "packages/babel-helpers"
+  curations: []
 - package:
     id: "NPM::babel-messages:6.23.0"
     purl: "pkg:npm/babel-messages@6.23.0"
@@ -2922,6 +2942,7 @@ packages:
       url: "https://github.com/babel/babel.git"
       revision: "master"
       path: "packages/babel-messages"
+  curations: []
 - package:
     id: "NPM::babel-polyfill:6.26.0"
     purl: "pkg:npm/babel-polyfill@6.26.0"
@@ -2951,6 +2972,7 @@ packages:
       url: "https://github.com/babel/babel.git"
       revision: "master"
       path: "packages/babel-polyfill"
+  curations: []
 - package:
     id: "NPM::babel-register:6.26.0"
     purl: "pkg:npm/babel-register@6.26.0"
@@ -2980,6 +3002,7 @@ packages:
       url: "https://github.com/babel/babel.git"
       revision: "master"
       path: "packages/babel-register"
+  curations: []
 - package:
     id: "NPM::babel-runtime:6.26.0"
     purl: "pkg:npm/babel-runtime@6.26.0"
@@ -3009,6 +3032,7 @@ packages:
       url: "https://github.com/babel/babel.git"
       revision: "master"
       path: "packages/babel-runtime"
+  curations: []
 - package:
     id: "NPM::babel-template:6.26.0"
     purl: "pkg:npm/babel-template@6.26.0"
@@ -3038,6 +3062,7 @@ packages:
       url: "https://github.com/babel/babel.git"
       revision: "master"
       path: "packages/babel-template"
+  curations: []
 - package:
     id: "NPM::babel-traverse:6.26.0"
     purl: "pkg:npm/babel-traverse@6.26.0"
@@ -3068,6 +3093,7 @@ packages:
       url: "https://github.com/babel/babel.git"
       revision: "master"
       path: "packages/babel-traverse"
+  curations: []
 - package:
     id: "NPM::babel-types:6.26.0"
     purl: "pkg:npm/babel-types@6.26.0"
@@ -3097,6 +3123,7 @@ packages:
       url: "https://github.com/babel/babel.git"
       revision: "master"
       path: "packages/babel-types"
+  curations: []
 - package:
     id: "NPM::babylon:6.18.0"
     purl: "pkg:npm/babylon@6.18.0"
@@ -3126,6 +3153,7 @@ packages:
       url: "https://github.com/babel/babylon.git"
       revision: "da66d3f65b0d305c0bb042873d57f26f0c0b0538"
       path: ""
+  curations: []
 - package:
     id: "NPM::balanced-match:1.0.0"
     purl: "pkg:npm/balanced-match@1.0.0"
@@ -3155,6 +3183,7 @@ packages:
       url: "https://github.com/juliangruber/balanced-match.git"
       revision: "d701a549a7653a874eebce7eca25d3577dc868ac"
       path: ""
+  curations: []
 - package:
     id: "NPM::base:0.11.2"
     purl: "pkg:npm/base@0.11.2"
@@ -3186,6 +3215,7 @@ packages:
       url: "https://github.com/node-base/base.git"
       revision: "1885b1dc37dff5479d852dd0810d32207e190bab"
       path: ""
+  curations: []
 - package:
     id: "NPM::binary-extensions:1.13.1"
     purl: "pkg:npm/binary-extensions@1.13.1"
@@ -3215,6 +3245,7 @@ packages:
       url: "https://github.com/sindresorhus/binary-extensions.git"
       revision: "187f5ab83698150abdc4ec8020c233ebe7303f0f"
       path: ""
+  curations: []
 - package:
     id: "NPM::brace-expansion:1.1.11"
     purl: "pkg:npm/brace-expansion@1.1.11"
@@ -3244,6 +3275,7 @@ packages:
       url: "https://github.com/juliangruber/brace-expansion.git"
       revision: "01a21de7441549d26ac0c0a9ff91385d16e5c21c"
       path: ""
+  curations: []
 - package:
     id: "NPM::braces:1.8.5"
     purl: "pkg:npm/braces@1.8.5"
@@ -3274,6 +3306,7 @@ packages:
       url: "https://github.com/jonschlinkert/braces.git"
       revision: "24874614ebeda1c5405180f1f6c9f374bcf384ce"
       path: ""
+  curations: []
 - package:
     id: "NPM::braces:2.3.2"
     purl: "pkg:npm/braces@2.3.2"
@@ -3305,6 +3338,7 @@ packages:
       url: "https://github.com/micromatch/braces.git"
       revision: "8a3edbb31955881ae87ba540b9f86eb390e5c4bd"
       path: ""
+  curations: []
 - package:
     id: "NPM::cache-base:1.0.1"
     purl: "pkg:npm/cache-base@1.0.1"
@@ -3335,6 +3369,7 @@ packages:
       url: "https://github.com/jonschlinkert/cache-base.git"
       revision: "0889aab765c66585ffbe7b41f9a733ef097665cf"
       path: ""
+  curations: []
 - package:
     id: "NPM::chalk:1.1.3"
     purl: "pkg:npm/chalk@1.1.3"
@@ -3364,6 +3399,7 @@ packages:
       url: "https://github.com/chalk/chalk.git"
       revision: "0d8d8c204eb87a4038219131ad4d8369c9f59d24"
       path: ""
+  curations: []
 - package:
     id: "NPM::chokidar:1.7.0"
     purl: "pkg:npm/chokidar@1.7.0"
@@ -3393,6 +3429,7 @@ packages:
       url: "https://github.com/paulmillr/chokidar.git"
       revision: "3b1071a6dd82397842f4f7dc63b72c703bd06275"
       path: ""
+  curations: []
 - package:
     id: "NPM::chownr:1.1.1"
     purl: "pkg:npm/chownr@1.1.1"
@@ -3422,6 +3459,7 @@ packages:
       url: "https://github.com/isaacs/chownr.git"
       revision: "7a5c3d57c3691eebb9c66fa00fa6003d02ef9440"
       path: ""
+  curations: []
 - package:
     id: "NPM::class-utils:0.3.6"
     purl: "pkg:npm/class-utils@0.3.6"
@@ -3451,6 +3489,7 @@ packages:
       url: "https://github.com/jonschlinkert/class-utils.git"
       revision: "0ad9e639d6a63d6dc04043ac5931df85fb898e06"
       path: ""
+  curations: []
 - package:
     id: "NPM::code-point-at:1.1.0"
     purl: "pkg:npm/code-point-at@1.1.0"
@@ -3480,6 +3519,7 @@ packages:
       url: "https://github.com/sindresorhus/code-point-at.git"
       revision: "f8f21c8df2d40248fef1b36ca9076e59c0c34791"
       path: ""
+  curations: []
 - package:
     id: "NPM::collection-visit:1.0.0"
     purl: "pkg:npm/collection-visit@1.0.0"
@@ -3510,6 +3550,7 @@ packages:
       url: "https://github.com/jonschlinkert/collection-visit.git"
       revision: "39c229dceb7e124cb821b59668df5da1d5c81a6c"
       path: ""
+  curations: []
 - package:
     id: "NPM::commander:2.20.0"
     purl: "pkg:npm/commander@2.20.0"
@@ -3539,6 +3580,7 @@ packages:
       url: "https://github.com/tj/commander.js.git"
       revision: "3e8bf54b9b2fb3960fc2320a4174aa79efca90fa"
       path: ""
+  curations: []
 - package:
     id: "NPM::component-emitter:1.3.0"
     purl: "pkg:npm/component-emitter@1.3.0"
@@ -3568,6 +3610,7 @@ packages:
       url: "https://github.com/component/emitter.git"
       revision: "6bd7817e8a444cb16e8abdf7dd2d7f04d5ca3dc8"
       path: ""
+  curations: []
 - package:
     id: "NPM::concat-map:0.0.1"
     purl: "pkg:npm/concat-map@0.0.1"
@@ -3597,6 +3640,7 @@ packages:
       url: "https://github.com/substack/node-concat-map.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::console-control-strings:1.1.0"
     purl: "pkg:npm/console-control-strings@1.1.0"
@@ -3629,6 +3673,7 @@ packages:
       url: "https://github.com/iarna/console-control-strings.git"
       revision: "722439b4998d2964ac3d3f9ec175c008aa9b7b4b"
       path: ""
+  curations: []
 - package:
     id: "NPM::convert-source-map:1.6.0"
     purl: "pkg:npm/convert-source-map@1.6.0"
@@ -3659,6 +3704,7 @@ packages:
       url: "https://github.com/thlorenz/convert-source-map.git"
       revision: "ad25a3e4373c641a2241cf1470b81ae123e4c23d"
       path: ""
+  curations: []
 - package:
     id: "NPM::copy-descriptor:0.1.1"
     purl: "pkg:npm/copy-descriptor@0.1.1"
@@ -3688,6 +3734,7 @@ packages:
       url: "https://github.com/jonschlinkert/copy-descriptor.git"
       revision: "572c31416d4538b7ba5f52e2bb0765ac237f79e2"
       path: ""
+  curations: []
 - package:
     id: "NPM::core-js:2.6.9"
     purl: "pkg:npm/core-js@2.6.9"
@@ -3717,6 +3764,7 @@ packages:
       url: "https://github.com/zloirock/core-js.git"
       revision: "6a3fe85136aaae0e3b099c96a05a5ceb1f515a50"
       path: ""
+  curations: []
 - package:
     id: "NPM::core-util-is:1.0.2"
     purl: "pkg:npm/core-util-is@1.0.2"
@@ -3746,6 +3794,7 @@ packages:
       url: "https://github.com/isaacs/core-util-is.git"
       revision: "a177da234df5638b363ddc15fa324619a38577c8"
       path: ""
+  curations: []
 - package:
     id: "NPM::debug:2.6.9"
     purl: "pkg:npm/debug@2.6.9"
@@ -3775,6 +3824,7 @@ packages:
       url: "https://github.com/visionmedia/debug.git"
       revision: "13abeae468fea297d0dccc50bc55590809241083"
       path: ""
+  curations: []
 - package:
     id: "NPM::debug:4.1.1"
     purl: "pkg:npm/debug@4.1.1"
@@ -3804,6 +3854,7 @@ packages:
       url: "https://github.com/visionmedia/debug.git"
       revision: "68b4dc8d8549d3924673c38fccc5d594f0a38da1"
       path: ""
+  curations: []
 - package:
     id: "NPM::decode-uri-component:0.2.0"
     purl: "pkg:npm/decode-uri-component@0.2.0"
@@ -3833,6 +3884,7 @@ packages:
       url: "https://github.com/samverschueren/decode-uri-component.git"
       revision: "52782a347527a6a05fed02434ffcf8f2ba1b19a3"
       path: ""
+  curations: []
 - package:
     id: "NPM::deep-extend:0.6.0"
     purl: "pkg:npm/deep-extend@0.6.0"
@@ -3862,6 +3914,7 @@ packages:
       url: "https://github.com/unclechu/node-deep-extend.git"
       revision: "f3f2b4f30fffe8abc9a99a7d6469fb354ca206e9"
       path: ""
+  curations: []
 - package:
     id: "NPM::define-property:0.2.5"
     purl: "pkg:npm/define-property@0.2.5"
@@ -3891,6 +3944,7 @@ packages:
       url: "https://github.com/jonschlinkert/define-property.git"
       revision: "5bf4e5e9d8d1fdf8fba07fff4bdf13a5d6df8ae4"
       path: ""
+  curations: []
 - package:
     id: "NPM::define-property:1.0.0"
     purl: "pkg:npm/define-property@1.0.0"
@@ -3920,6 +3974,7 @@ packages:
       url: "https://github.com/jonschlinkert/define-property.git"
       revision: "4811e7c7999e82ab086265eefeb5d9cbffe10912"
       path: ""
+  curations: []
 - package:
     id: "NPM::define-property:2.0.2"
     purl: "pkg:npm/define-property@2.0.2"
@@ -3950,6 +4005,7 @@ packages:
       url: "https://github.com/jonschlinkert/define-property.git"
       revision: "04717307be822f2ca2544778b92e5d2cbe300c55"
       path: ""
+  curations: []
 - package:
     id: "NPM::delegates:1.0.0"
     purl: "pkg:npm/delegates@1.0.0"
@@ -3979,6 +4035,7 @@ packages:
       url: "https://github.com/visionmedia/node-delegates.git"
       revision: "c4dc07ef1ed51c2b2a63f3585e5ef949ee577a49"
       path: ""
+  curations: []
 - package:
     id: "NPM::detect-indent:4.0.0"
     purl: "pkg:npm/detect-indent@4.0.0"
@@ -4008,6 +4065,7 @@ packages:
       url: "https://github.com/sindresorhus/detect-indent.git"
       revision: "dbbc78fcb37907116eb120a8324070a1df0e8d86"
       path: ""
+  curations: []
 - package:
     id: "NPM::detect-libc:1.0.3"
     purl: "pkg:npm/detect-libc@1.0.3"
@@ -4038,6 +4096,7 @@ packages:
       url: "https://github.com/lovell/detect-libc.git"
       revision: "88df1a5950bf3cd9bffa1e0137ab6471c4546118"
       path: ""
+  curations: []
 - package:
     id: "NPM::escape-string-regexp:1.0.5"
     purl: "pkg:npm/escape-string-regexp@1.0.5"
@@ -4067,6 +4126,7 @@ packages:
       url: "https://github.com/sindresorhus/escape-string-regexp.git"
       revision: "db124a3e1aae9d692c4899e42a5c6c3e329eaa20"
       path: ""
+  curations: []
 - package:
     id: "NPM::esutils:2.0.2"
     purl: "pkg:npm/esutils@2.0.2"
@@ -4098,6 +4158,7 @@ packages:
       url: "https://github.com/estools/esutils.git"
       revision: "3ffd1c403f3f29db9e8a9574b1895682e57b6a7f"
       path: ""
+  curations: []
 - package:
     id: "NPM::expand-brackets:0.1.5"
     purl: "pkg:npm/expand-brackets@0.1.5"
@@ -4127,6 +4188,7 @@ packages:
       url: "https://github.com/jonschlinkert/expand-brackets.git"
       revision: "1b07fda8ee8b6426d95e6539785b74c57e9ee542"
       path: ""
+  curations: []
 - package:
     id: "NPM::expand-brackets:2.1.4"
     purl: "pkg:npm/expand-brackets@2.1.4"
@@ -4156,6 +4218,7 @@ packages:
       url: "https://github.com/jonschlinkert/expand-brackets.git"
       revision: "9a0ec493825eb0aa9368c158927ca4ace945fefa"
       path: ""
+  curations: []
 - package:
     id: "NPM::expand-range:1.8.2"
     purl: "pkg:npm/expand-range@1.8.2"
@@ -4186,6 +4249,7 @@ packages:
       url: "https://github.com/jonschlinkert/expand-range.git"
       revision: "4c873af0870df8382bafc66a93d5c89e3aad3d4d"
       path: ""
+  curations: []
 - package:
     id: "NPM::extend-shallow:2.0.1"
     purl: "pkg:npm/extend-shallow@2.0.1"
@@ -4216,6 +4280,7 @@ packages:
       url: "https://github.com/jonschlinkert/extend-shallow.git"
       revision: "e9b1f1d2ff9d2990ec4a127afa7c14732d1eec8a"
       path: ""
+  curations: []
 - package:
     id: "NPM::extend-shallow:3.0.2"
     purl: "pkg:npm/extend-shallow@3.0.2"
@@ -4246,6 +4311,7 @@ packages:
       url: "https://github.com/jonschlinkert/extend-shallow.git"
       revision: "33698c3df7804f0d0e3ea98caa64d53f09c37bd4"
       path: ""
+  curations: []
 - package:
     id: "NPM::extglob:0.3.2"
     purl: "pkg:npm/extglob@0.3.2"
@@ -4276,6 +4342,7 @@ packages:
       url: "https://github.com/jonschlinkert/extglob.git"
       revision: "8c3f38bbd9e0afaf31a87e411c0d15532434ef41"
       path: ""
+  curations: []
 - package:
     id: "NPM::extglob:2.0.4"
     purl: "pkg:npm/extglob@2.0.4"
@@ -4306,6 +4373,7 @@ packages:
       url: "https://github.com/micromatch/extglob.git"
       revision: "b00d865652d844b80164ea544323a36c838b3e58"
       path: ""
+  curations: []
 - package:
     id: "NPM::filename-regex:2.0.1"
     purl: "pkg:npm/filename-regex@2.0.1"
@@ -4335,6 +4403,7 @@ packages:
       url: "https://github.com/regexhq/filename-regex.git"
       revision: "821fec482acdb1ce3f23a804ce8a86724d02b4e6"
       path: ""
+  curations: []
 - package:
     id: "NPM::fill-range:2.2.4"
     purl: "pkg:npm/fill-range@2.2.4"
@@ -4365,6 +4434,7 @@ packages:
       url: "https://github.com/jonschlinkert/fill-range.git"
       revision: "516e5ad9e40486c168b14062158d136aa3163f2b"
       path: ""
+  curations: []
 - package:
     id: "NPM::fill-range:4.0.0"
     purl: "pkg:npm/fill-range@4.0.0"
@@ -4395,6 +4465,7 @@ packages:
       url: "https://github.com/jonschlinkert/fill-range.git"
       revision: "e5a21feaac23f3f34bb4d7ca8e65393e18b451b6"
       path: ""
+  curations: []
 - package:
     id: "NPM::for-in:1.0.2"
     purl: "pkg:npm/for-in@1.0.2"
@@ -4426,6 +4497,7 @@ packages:
       url: "https://github.com/jonschlinkert/for-in.git"
       revision: "5f97ad4f6556e938d9b71614259ddd8044a081e3"
       path: ""
+  curations: []
 - package:
     id: "NPM::for-own:0.1.5"
     purl: "pkg:npm/for-own@0.1.5"
@@ -4457,6 +4529,7 @@ packages:
       url: "https://github.com/jonschlinkert/for-own.git"
       revision: "e64ee3492f218c812011ec3feff4194e9272d2a1"
       path: ""
+  curations: []
 - package:
     id: "NPM::fragment-cache:0.2.1"
     purl: "pkg:npm/fragment-cache@0.2.1"
@@ -4486,6 +4559,7 @@ packages:
       url: "https://github.com/jonschlinkert/fragment-cache.git"
       revision: "33583b03f505c67479ddbc66f825b0e653704207"
       path: ""
+  curations: []
 - package:
     id: "NPM::fs-minipass:1.2.5"
     purl: "pkg:npm/fs-minipass@1.2.5"
@@ -4515,6 +4589,7 @@ packages:
       url: "https://github.com/npm/fs-minipass.git"
       revision: "fceb43535c348c9cd1ad08edb6c188e04850c245"
       path: ""
+  curations: []
 - package:
     id: "NPM::fs-readdir-recursive:1.1.0"
     purl: "pkg:npm/fs-readdir-recursive@1.1.0"
@@ -4544,6 +4619,7 @@ packages:
       url: "https://github.com/fs-utils/fs-readdir-recursive.git"
       revision: "f810b44477696081ebef9c0d5eafb24005c8e82b"
       path: ""
+  curations: []
 - package:
     id: "NPM::fs.realpath:1.0.0"
     purl: "pkg:npm/fs.realpath@1.0.0"
@@ -4574,6 +4650,7 @@ packages:
       url: "https://github.com/isaacs/fs.realpath.git"
       revision: "03e7c884431fe185dfebbc9b771aeca339c1807a"
       path: ""
+  curations: []
 - package:
     id: "NPM::fsevents:1.2.9"
     purl: "pkg:npm/fsevents@1.2.9"
@@ -4603,6 +4680,7 @@ packages:
       url: "https://github.com/strongloop/fsevents.git"
       revision: "0a052f6c0adb5b066cd1c1c2fcfb04e22ccb0fbc"
       path: ""
+  curations: []
 - package:
     id: "NPM::gauge:2.7.4"
     purl: "pkg:npm/gauge@2.7.4"
@@ -4632,6 +4710,7 @@ packages:
       url: "https://github.com/iarna/gauge.git"
       revision: "1011abf6c2cb7ae89a3ee76fb447d3182d4e8d3a"
       path: ""
+  curations: []
 - package:
     id: "NPM::get-value:2.0.6"
     purl: "pkg:npm/get-value@2.0.6"
@@ -4661,6 +4740,7 @@ packages:
       url: "https://github.com/jonschlinkert/get-value.git"
       revision: "5dc7466a65eec37e3b9e3d94f274b7aba193ea60"
       path: ""
+  curations: []
 - package:
     id: "NPM::glob-base:0.3.0"
     purl: "pkg:npm/glob-base@0.3.0"
@@ -4690,6 +4770,7 @@ packages:
       url: "https://github.com/jonschlinkert/glob-base.git"
       revision: "adbc0ab07ec8a85f76ffd1b54dd41cdb9d1d0b83"
       path: ""
+  curations: []
 - package:
     id: "NPM::glob-parent:2.0.0"
     purl: "pkg:npm/glob-parent@2.0.0"
@@ -4719,6 +4800,7 @@ packages:
       url: "https://github.com/es128/glob-parent.git"
       revision: "a956910c7ccb5eafd1b3fe900ceb6335cc5b6d3d"
       path: ""
+  curations: []
 - package:
     id: "NPM::glob:7.1.3"
     purl: "pkg:npm/glob@7.1.3"
@@ -4748,6 +4830,7 @@ packages:
       url: "https://github.com/isaacs/node-glob.git"
       revision: "8882c8fccabbe459465e73cc2581e121a5fdd25b"
       path: ""
+  curations: []
 - package:
     id: "NPM::glob:7.1.4"
     purl: "pkg:npm/glob@7.1.4"
@@ -4777,6 +4860,7 @@ packages:
       url: "https://github.com/isaacs/node-glob.git"
       revision: "2da9af3ed730811d0fe743bec1281e169374428e"
       path: ""
+  curations: []
 - package:
     id: "NPM::globals:9.18.0"
     purl: "pkg:npm/globals@9.18.0"
@@ -4806,6 +4890,7 @@ packages:
       url: "https://github.com/sindresorhus/globals.git"
       revision: "09ba8754235e5953507b8d0543d65098bc7bb78d"
       path: ""
+  curations: []
 - package:
     id: "NPM::graceful-fs:4.2.0"
     purl: "pkg:npm/graceful-fs@4.2.0"
@@ -4835,6 +4920,7 @@ packages:
       url: "https://github.com/isaacs/node-graceful-fs.git"
       revision: "585df780323740a2b562677caa08a80de1f56c62"
       path: ""
+  curations: []
 - package:
     id: "NPM::has-ansi:2.0.0"
     purl: "pkg:npm/has-ansi@2.0.0"
@@ -4864,6 +4950,7 @@ packages:
       url: "https://github.com/sindresorhus/has-ansi.git"
       revision: "0722275e1bef139fcd09137da6e5550c3cd368b9"
       path: ""
+  curations: []
 - package:
     id: "NPM::has-unicode:2.0.1"
     purl: "pkg:npm/has-unicode@2.0.1"
@@ -4893,6 +4980,7 @@ packages:
       url: "https://github.com/iarna/has-unicode.git"
       revision: "0a05df154e8d89a7fb9798da60b68c78c2df6646"
       path: ""
+  curations: []
 - package:
     id: "NPM::has-value:0.3.1"
     purl: "pkg:npm/has-value@0.3.1"
@@ -4923,6 +5011,7 @@ packages:
       url: "https://github.com/jonschlinkert/has-value.git"
       revision: "adecb27b13b7e99688694e228a946e6e635fcc64"
       path: ""
+  curations: []
 - package:
     id: "NPM::has-value:1.0.0"
     purl: "pkg:npm/has-value@1.0.0"
@@ -4953,6 +5042,7 @@ packages:
       url: "https://github.com/jonschlinkert/has-value.git"
       revision: "61b5671a48ac40206eb33b4ea75dc2507168d687"
       path: ""
+  curations: []
 - package:
     id: "NPM::has-values:0.1.4"
     purl: "pkg:npm/has-values@0.1.4"
@@ -4983,6 +5073,7 @@ packages:
       url: "https://github.com/jonschlinkert/has-values.git"
       revision: "199a3eacd663b4ae4b00aef5ef5541aa2c7c8089"
       path: ""
+  curations: []
 - package:
     id: "NPM::has-values:1.0.0"
     purl: "pkg:npm/has-values@1.0.0"
@@ -5013,6 +5104,7 @@ packages:
       url: "https://github.com/jonschlinkert/has-values.git"
       revision: "fead695044aafcfb337c7125af5479c7eaf1c92c"
       path: ""
+  curations: []
 - package:
     id: "NPM::home-or-tmp:2.0.0"
     purl: "pkg:npm/home-or-tmp@2.0.0"
@@ -5042,6 +5134,7 @@ packages:
       url: "https://github.com/sindresorhus/home-or-tmp.git"
       revision: "dd1411a0b2531a4e2c592ae733fd45dd0f9c7163"
       path: ""
+  curations: []
 - package:
     id: "NPM::iconv-lite:0.4.24"
     purl: "pkg:npm/iconv-lite@0.4.24"
@@ -5071,6 +5164,7 @@ packages:
       url: "https://github.com/ashtuchkin/iconv-lite.git"
       revision: "efbbb0937ca8dda1c14e0b69958b9d6f20771f7a"
       path: ""
+  curations: []
 - package:
     id: "NPM::ignore-walk:3.0.1"
     purl: "pkg:npm/ignore-walk@3.0.1"
@@ -5100,6 +5194,7 @@ packages:
       url: "https://github.com/isaacs/ignore-walk.git"
       revision: "2b610fce2c19a5555d4bd74859950d086938c70e"
       path: ""
+  curations: []
 - package:
     id: "NPM::inflight:1.0.6"
     purl: "pkg:npm/inflight@1.0.6"
@@ -5129,6 +5224,7 @@ packages:
       url: "https://github.com/npm/inflight.git"
       revision: "a547881738c8f57b27795e584071d67cf6ac1a57"
       path: ""
+  curations: []
 - package:
     id: "NPM::inherits:2.0.3"
     purl: "pkg:npm/inherits@2.0.3"
@@ -5159,6 +5255,7 @@ packages:
       url: "https://github.com/isaacs/inherits.git"
       revision: "e05d0fb27c61a3ec687214f0476386b765364d5f"
       path: ""
+  curations: []
 - package:
     id: "NPM::inherits:2.0.4"
     purl: "pkg:npm/inherits@2.0.4"
@@ -5189,6 +5286,7 @@ packages:
       url: "https://github.com/isaacs/inherits.git"
       revision: "9a2c29400c6d491e0b7beefe0c32efa3b462545d"
       path: ""
+  curations: []
 - package:
     id: "NPM::ini:1.3.5"
     purl: "pkg:npm/ini@1.3.5"
@@ -5218,6 +5316,7 @@ packages:
       url: "https://github.com/isaacs/ini.git"
       revision: "738eca59d77d8cfdddf5c477c17a0d8f8fbfe0fd"
       path: ""
+  curations: []
 - package:
     id: "NPM::invariant:2.2.4"
     purl: "pkg:npm/invariant@2.2.4"
@@ -5247,6 +5346,7 @@ packages:
       url: "https://github.com/zertosh/invariant.git"
       revision: "ce95a9badeee1c97daff1bca0d1f6cec5dda4fe8"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-accessor-descriptor:0.1.6"
     purl: "pkg:npm/is-accessor-descriptor@0.1.6"
@@ -5277,6 +5377,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-accessor-descriptor.git"
       revision: "e64ae49c456c9f31dab47934b0183e2a9938b5bd"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-accessor-descriptor:1.0.0"
     purl: "pkg:npm/is-accessor-descriptor@1.0.0"
@@ -5307,6 +5408,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-accessor-descriptor.git"
       revision: "22b0a2617ccbebd131247c29e3700ca860d37d06"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-binary-path:1.0.1"
     purl: "pkg:npm/is-binary-path@1.0.1"
@@ -5336,6 +5438,7 @@ packages:
       url: "https://github.com/sindresorhus/is-binary-path.git"
       revision: "ed26bd7be5e29dad159c2771cb99dd48913f9de0"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-buffer:1.1.6"
     purl: "pkg:npm/is-buffer@1.1.6"
@@ -5365,6 +5468,7 @@ packages:
       url: "https://github.com/feross/is-buffer.git"
       revision: "1e84e7ee31cf6b660b12500f3111a05501da387f"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-data-descriptor:0.1.4"
     purl: "pkg:npm/is-data-descriptor@0.1.4"
@@ -5395,6 +5499,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-data-descriptor.git"
       revision: "e6317dbcb27a95281a60120bac83f5938dda4e2c"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-data-descriptor:1.0.0"
     purl: "pkg:npm/is-data-descriptor@1.0.0"
@@ -5425,6 +5530,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-data-descriptor.git"
       revision: "42dcba2627fe655daa21aec843ca8de849f26cd6"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-descriptor:0.1.6"
     purl: "pkg:npm/is-descriptor@0.1.6"
@@ -5455,6 +5561,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-descriptor.git"
       revision: "7559403830553097fcdd56ae93fe69d4ef2b21db"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-descriptor:1.0.2"
     purl: "pkg:npm/is-descriptor@1.0.2"
@@ -5485,6 +5592,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-descriptor.git"
       revision: "324635c990dc7f1e6d169deecd19769dea72114c"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-dotfile:1.0.3"
     purl: "pkg:npm/is-dotfile@1.0.3"
@@ -5515,6 +5623,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-dotfile.git"
       revision: "1548d0045c182dfb0ac7b747e2d484dcd382b09d"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-equal-shallow:0.1.3"
     purl: "pkg:npm/is-equal-shallow@0.1.3"
@@ -5545,6 +5654,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-equal-shallow.git"
       revision: "dceb47dd9c9c21066958116e3b54b3c8c251ee4a"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-extendable:0.1.1"
     purl: "pkg:npm/is-extendable@0.1.1"
@@ -5576,6 +5686,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-extendable.git"
       revision: "c36a0732e6a76931c6f66c5931d1f3e54fa44380"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-extendable:1.0.1"
     purl: "pkg:npm/is-extendable@1.0.1"
@@ -5605,6 +5716,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-extendable.git"
       revision: "230717f6be5be812c16916ec8a745d6252dfa7a5"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-extglob:1.0.0"
     purl: "pkg:npm/is-extglob@1.0.0"
@@ -5634,6 +5746,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-extglob.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::is-finite:1.0.2"
     purl: "pkg:npm/is-finite@1.0.2"
@@ -5663,6 +5776,7 @@ packages:
       url: "https://github.com/sindresorhus/is-finite.git"
       revision: "43f8bb814834d8573d11ba4a631d19006d0c8897"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-fullwidth-code-point:1.0.0"
     purl: "pkg:npm/is-fullwidth-code-point@1.0.0"
@@ -5693,6 +5807,7 @@ packages:
       url: "https://github.com/sindresorhus/is-fullwidth-code-point.git"
       revision: "f2152d357f41f82785436d428e4f8ede143b7548"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-glob:2.0.1"
     purl: "pkg:npm/is-glob@2.0.1"
@@ -5725,6 +5840,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-glob.git"
       revision: "d7db1b2dd559b3d5a73f89dbe72d9e9f4d6587d7"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-number:2.1.0"
     purl: "pkg:npm/is-number@2.1.0"
@@ -5754,6 +5870,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-number.git"
       revision: "d06c6e2cc048d3cad016cb8dfb055bb14d86fffa"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-number:3.0.0"
     purl: "pkg:npm/is-number@3.0.0"
@@ -5783,6 +5900,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-number.git"
       revision: "af885e2e890b9ef0875edd2b117305119ee5bdc5"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-number:4.0.0"
     purl: "pkg:npm/is-number@4.0.0"
@@ -5812,6 +5930,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-number.git"
       revision: "0c6b15a88bc10cd47f67a09506399dfc9ddc075d"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-plain-object:2.0.4"
     purl: "pkg:npm/is-plain-object@2.0.4"
@@ -5841,6 +5960,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-plain-object.git"
       revision: "81345df0d1700a5c285f379cbdca0e273388910d"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-posix-bracket:0.1.1"
     purl: "pkg:npm/is-posix-bracket@0.1.1"
@@ -5871,6 +5991,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-posix-bracket.git"
       revision: "43972556cfdbb681a15072da75c97952c4e4deba"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-primitive:2.0.0"
     purl: "pkg:npm/is-primitive@2.0.0"
@@ -5900,6 +6021,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-primitive.git"
       revision: "c512b7c95fb049aa9b1f039ddc0670611b66cce2"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-windows:1.0.2"
     purl: "pkg:npm/is-windows@1.0.2"
@@ -5930,6 +6052,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-windows.git"
       revision: "4dcfff4ed9e36ad761a1a24d3899c832382d7254"
       path: ""
+  curations: []
 - package:
     id: "NPM::isarray:1.0.0"
     purl: "pkg:npm/isarray@1.0.0"
@@ -5959,6 +6082,7 @@ packages:
       url: "https://github.com/juliangruber/isarray.git"
       revision: "2a23a281f369e9ae06394c0fb4d2381355a6ba33"
       path: ""
+  curations: []
 - package:
     id: "NPM::isobject:2.1.0"
     purl: "pkg:npm/isobject@2.1.0"
@@ -5988,6 +6112,7 @@ packages:
       url: "https://github.com/jonschlinkert/isobject.git"
       revision: "d693ec8d31b02b42a19b2d806407a4ecb2f9fb73"
       path: ""
+  curations: []
 - package:
     id: "NPM::isobject:3.0.1"
     purl: "pkg:npm/isobject@3.0.1"
@@ -6017,6 +6142,7 @@ packages:
       url: "https://github.com/jonschlinkert/isobject.git"
       revision: "7ad1fc405d19f144a21e2bfe947fa82801baa7aa"
       path: ""
+  curations: []
 - package:
     id: "NPM::js-tokens:3.0.2"
     purl: "pkg:npm/js-tokens@3.0.2"
@@ -6046,6 +6172,7 @@ packages:
       url: "https://github.com/lydell/js-tokens.git"
       revision: "8315904c840b14d28de1b0a4968194555f61bea3"
       path: ""
+  curations: []
 - package:
     id: "NPM::jsesc:1.3.0"
     purl: "pkg:npm/jsesc@1.3.0"
@@ -6076,6 +6203,7 @@ packages:
       url: "https://github.com/mathiasbynens/jsesc.git"
       revision: "2c43a8a223e297155b2b2ccca344df4d6ee4233c"
       path: ""
+  curations: []
 - package:
     id: "NPM::json5:0.5.1"
     purl: "pkg:npm/json5@0.5.1"
@@ -6105,6 +6233,7 @@ packages:
       url: "https://github.com/aseemk/json5.git"
       revision: "6be6a70e250e6fbbf42db75cd1f6a1aadeeeeb07"
       path: ""
+  curations: []
 - package:
     id: "NPM::kind-of:3.2.2"
     purl: "pkg:npm/kind-of@3.2.2"
@@ -6134,6 +6263,7 @@ packages:
       url: "https://github.com/jonschlinkert/kind-of.git"
       revision: "0ffe67cf12f5396047c1bacf04232b7deeb24063"
       path: ""
+  curations: []
 - package:
     id: "NPM::kind-of:4.0.0"
     purl: "pkg:npm/kind-of@4.0.0"
@@ -6163,6 +6293,7 @@ packages:
       url: "https://github.com/jonschlinkert/kind-of.git"
       revision: "30bee16e8dffa67417ba35d31bd9bc31517a2d83"
       path: ""
+  curations: []
 - package:
     id: "NPM::kind-of:5.1.0"
     purl: "pkg:npm/kind-of@5.1.0"
@@ -6192,6 +6323,7 @@ packages:
       url: "https://github.com/jonschlinkert/kind-of.git"
       revision: "ed479b6ee194dc1edff852f17095ae1de40bafbc"
       path: ""
+  curations: []
 - package:
     id: "NPM::kind-of:6.0.2"
     purl: "pkg:npm/kind-of@6.0.2"
@@ -6221,6 +6353,7 @@ packages:
       url: "https://github.com/jonschlinkert/kind-of.git"
       revision: "1491da72e8d276479f5f6198a9e79c1379c5d0c7"
       path: ""
+  curations: []
 - package:
     id: "NPM::lodash:4.17.15"
     purl: "pkg:npm/lodash@4.17.15"
@@ -6250,6 +6383,7 @@ packages:
       url: "https://github.com/lodash/lodash.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::loose-envify:1.4.0"
     purl: "pkg:npm/loose-envify@1.4.0"
@@ -6280,6 +6414,7 @@ packages:
       url: "https://github.com/zertosh/loose-envify.git"
       revision: "a8fdd02e3a435195f526053882d64537d627b3e6"
       path: ""
+  curations: []
 - package:
     id: "NPM::map-cache:0.2.2"
     purl: "pkg:npm/map-cache@0.2.2"
@@ -6309,6 +6444,7 @@ packages:
       url: "https://github.com/jonschlinkert/map-cache.git"
       revision: "f36c7567cb85b50824db25a2a588c5f7b858823b"
       path: ""
+  curations: []
 - package:
     id: "NPM::map-visit:1.0.0"
     purl: "pkg:npm/map-visit@1.0.0"
@@ -6338,6 +6474,7 @@ packages:
       url: "https://github.com/jonschlinkert/map-visit.git"
       revision: "73bcd8385c9520c595a825486f19623a5e0550f0"
       path: ""
+  curations: []
 - package:
     id: "NPM::math-random:1.0.4"
     purl: "pkg:npm/math-random@1.0.4"
@@ -6369,6 +6506,7 @@ packages:
       url: "https://github.com/michaelrhodes/math-random.git"
       revision: "13ed513bd579eb868b5054b38836411ae6e29f6a"
       path: ""
+  curations: []
 - package:
     id: "NPM::micromatch:2.3.11"
     purl: "pkg:npm/micromatch@2.3.11"
@@ -6399,6 +6537,7 @@ packages:
       url: "https://github.com/jonschlinkert/micromatch.git"
       revision: "f194c187d04677b03047bb7d8d25643725f7a577"
       path: ""
+  curations: []
 - package:
     id: "NPM::micromatch:3.1.10"
     purl: "pkg:npm/micromatch@3.1.10"
@@ -6429,6 +6568,7 @@ packages:
       url: "https://github.com/micromatch/micromatch.git"
       revision: "0628af9a111c791ca69c809a6f8555337813cc05"
       path: ""
+  curations: []
 - package:
     id: "NPM::minimatch:3.0.4"
     purl: "pkg:npm/minimatch@3.0.4"
@@ -6458,6 +6598,7 @@ packages:
       url: "https://github.com/isaacs/minimatch.git"
       revision: "e46989a323d5f0aa4781eff5e2e6e7aafa223321"
       path: ""
+  curations: []
 - package:
     id: "NPM::minimist:0.0.8"
     purl: "pkg:npm/minimist@0.0.8"
@@ -6487,6 +6628,7 @@ packages:
       url: "https://github.com/substack/minimist.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::minimist:1.2.0"
     purl: "pkg:npm/minimist@1.2.0"
@@ -6516,6 +6658,7 @@ packages:
       url: "https://github.com/substack/minimist.git"
       revision: "dc624482fcfec5bc669c68cdb861f00573ed4e64"
       path: ""
+  curations: []
 - package:
     id: "NPM::minipass:2.3.5"
     purl: "pkg:npm/minipass@2.3.5"
@@ -6545,6 +6688,7 @@ packages:
       url: "https://github.com/isaacs/minipass.git"
       revision: "d362cb255c2b2ad24b0b6bf8cef35c522ba29019"
       path: ""
+  curations: []
 - package:
     id: "NPM::minizlib:1.2.1"
     purl: "pkg:npm/minizlib@1.2.1"
@@ -6575,6 +6719,7 @@ packages:
       url: "https://github.com/isaacs/minizlib.git"
       revision: "ad2e969851c3573eff84a5ddfe906344c814581b"
       path: ""
+  curations: []
 - package:
     id: "NPM::mixin-deep:1.3.2"
     purl: "pkg:npm/mixin-deep@1.3.2"
@@ -6605,6 +6750,7 @@ packages:
       url: "https://github.com/jonschlinkert/mixin-deep.git"
       revision: "754f0c20e1bc13ea5a21a64fbc7d6ba5f7b359b9"
       path: ""
+  curations: []
 - package:
     id: "NPM::mkdirp:0.5.1"
     purl: "pkg:npm/mkdirp@0.5.1"
@@ -6634,6 +6780,7 @@ packages:
       url: "https://github.com/substack/node-mkdirp.git"
       revision: "d4eff0f06093aed4f387e88e9fc301cb76beedc7"
       path: ""
+  curations: []
 - package:
     id: "NPM::ms:2.0.0"
     purl: "pkg:npm/ms@2.0.0"
@@ -6663,6 +6810,7 @@ packages:
       url: "https://github.com/zeit/ms.git"
       revision: "9b88d1568a52ec9bb67ecc8d2aa224fa38fd41f4"
       path: ""
+  curations: []
 - package:
     id: "NPM::ms:2.1.1"
     purl: "pkg:npm/ms@2.1.1"
@@ -6692,6 +6840,7 @@ packages:
       url: "https://github.com/zeit/ms.git"
       revision: "fe0bae301a6c41f68a01595658a4f4f0dcba0e84"
       path: ""
+  curations: []
 - package:
     id: "NPM::nan:2.14.0"
     purl: "pkg:npm/nan@2.14.0"
@@ -6721,6 +6870,7 @@ packages:
       url: "https://github.com/nodejs/nan.git"
       revision: "1dcc61bd06d84e389bfd5311b2b1492a14c74201"
       path: ""
+  curations: []
 - package:
     id: "NPM::nanomatch:1.2.13"
     purl: "pkg:npm/nanomatch@1.2.13"
@@ -6752,6 +6902,7 @@ packages:
       url: "https://github.com/micromatch/nanomatch.git"
       revision: "d2af1083ae338c6c9a5834ee85ae40679be60a46"
       path: ""
+  curations: []
 - package:
     id: "NPM::needle:2.3.0"
     purl: "pkg:npm/needle@2.3.0"
@@ -6781,6 +6932,7 @@ packages:
       url: "https://github.com/tomas/needle.git"
       revision: "0cec93fb08ae9f9ec541b9c4170d748b8f4b80f2"
       path: ""
+  curations: []
 - package:
     id: "NPM::node-pre-gyp:0.12.0"
     purl: "pkg:npm/node-pre-gyp@0.12.0"
@@ -6810,6 +6962,7 @@ packages:
       url: "https://github.com/mapbox/node-pre-gyp.git"
       revision: "ff9e93e969d2e385c22901a3c16cb8877dd1d01c"
       path: ""
+  curations: []
 - package:
     id: "NPM::nopt:4.0.1"
     purl: "pkg:npm/nopt@4.0.1"
@@ -6840,6 +6993,7 @@ packages:
       url: "https://github.com/npm/nopt.git"
       revision: "24921187dc52825d628042c9708bbd8e8734698c"
       path: ""
+  curations: []
 - package:
     id: "NPM::normalize-path:2.1.1"
     purl: "pkg:npm/normalize-path@2.1.1"
@@ -6871,6 +7025,7 @@ packages:
       url: "https://github.com/jonschlinkert/normalize-path.git"
       revision: "da1a45e7a514910ce39875b5327b1d0fa9be3d3e"
       path: ""
+  curations: []
 - package:
     id: "NPM::npm-bundled:1.0.6"
     purl: "pkg:npm/npm-bundled@1.0.6"
@@ -6901,6 +7056,7 @@ packages:
       url: "https://github.com/npm/npm-bundled.git"
       revision: "59c71778359f7801b8fe5070f2c87a5a31974304"
       path: ""
+  curations: []
 - package:
     id: "NPM::npm-packlist:1.4.1"
     purl: "pkg:npm/npm-packlist@1.4.1"
@@ -6930,6 +7086,7 @@ packages:
       url: "https://github.com/npm/npm-packlist.git"
       revision: "1a4c8bfe712f8b2804c0ae48fb2a9dd99c78ef99"
       path: ""
+  curations: []
 - package:
     id: "NPM::npmlog:4.1.2"
     purl: "pkg:npm/npmlog@4.1.2"
@@ -6959,6 +7116,7 @@ packages:
       url: "https://github.com/npm/npmlog.git"
       revision: "f7f9516d35b873c4e45b1aaeb78cff4e43b72c31"
       path: ""
+  curations: []
 - package:
     id: "NPM::number-is-nan:1.0.1"
     purl: "pkg:npm/number-is-nan@1.0.1"
@@ -6988,6 +7146,7 @@ packages:
       url: "https://github.com/sindresorhus/number-is-nan.git"
       revision: "ed9cdac3f428cc929b61bb230da42c87477af4b9"
       path: ""
+  curations: []
 - package:
     id: "NPM::object-assign:4.1.1"
     purl: "pkg:npm/object-assign@4.1.1"
@@ -7017,6 +7176,7 @@ packages:
       url: "https://github.com/sindresorhus/object-assign.git"
       revision: "a89774b252c91612203876984bbd6addbe3b5a0e"
       path: ""
+  curations: []
 - package:
     id: "NPM::object-copy:0.1.0"
     purl: "pkg:npm/object-copy@0.1.0"
@@ -7047,6 +7207,7 @@ packages:
       url: "https://github.com/jonschlinkert/object-copy.git"
       revision: "15b972a4a7137f6bf47886c68e73a2fffa8eacf2"
       path: ""
+  curations: []
 - package:
     id: "NPM::object-visit:1.0.1"
     purl: "pkg:npm/object-visit@1.0.1"
@@ -7076,6 +7237,7 @@ packages:
       url: "https://github.com/jonschlinkert/object-visit.git"
       revision: "2220cd6ea35008481c9e252488bcbde9ebca0983"
       path: ""
+  curations: []
 - package:
     id: "NPM::object.omit:2.0.1"
     purl: "pkg:npm/object.omit@2.0.1"
@@ -7106,6 +7268,7 @@ packages:
       url: "https://github.com/jonschlinkert/object.omit.git"
       revision: "6634673e6e88c65796f1df4bcb787dede6dc7ffc"
       path: ""
+  curations: []
 - package:
     id: "NPM::object.pick:1.3.0"
     purl: "pkg:npm/object.pick@1.3.0"
@@ -7136,6 +7299,7 @@ packages:
       url: "https://github.com/jonschlinkert/object.pick.git"
       revision: "f9d89d96a8d5ec671dc39e2c2319d8aaa04dd2cc"
       path: ""
+  curations: []
 - package:
     id: "NPM::once:1.4.0"
     purl: "pkg:npm/once@1.4.0"
@@ -7165,6 +7329,7 @@ packages:
       url: "https://github.com/isaacs/once.git"
       revision: "0e614d9f5a7e6f0305c625f6b581f6d80b33b8a6"
       path: ""
+  curations: []
 - package:
     id: "NPM::os-homedir:1.0.2"
     purl: "pkg:npm/os-homedir@1.0.2"
@@ -7194,6 +7359,7 @@ packages:
       url: "https://github.com/sindresorhus/os-homedir.git"
       revision: "b1b0ae70a5965fef7005ff6509a5dd1a78c95e36"
       path: ""
+  curations: []
 - package:
     id: "NPM::os-tmpdir:1.0.2"
     purl: "pkg:npm/os-tmpdir@1.0.2"
@@ -7223,6 +7389,7 @@ packages:
       url: "https://github.com/sindresorhus/os-tmpdir.git"
       revision: "1abf9cf5611b4be7377060ea67054b45cbf6813c"
       path: ""
+  curations: []
 - package:
     id: "NPM::osenv:0.1.5"
     purl: "pkg:npm/osenv@0.1.5"
@@ -7252,6 +7419,7 @@ packages:
       url: "https://github.com/npm/osenv.git"
       revision: "1c642b8f5ddb1f99671a300a466bf42ffb9f5ea2"
       path: ""
+  curations: []
 - package:
     id: "NPM::output-file-sync:1.1.2"
     purl: "pkg:npm/output-file-sync@1.1.2"
@@ -7282,6 +7450,7 @@ packages:
       url: "https://github.com/shinnn/output-file-sync.git"
       revision: "42d4b6792bbaee919805b2cb9afc95233addb239"
       path: ""
+  curations: []
 - package:
     id: "NPM::parse-glob:3.0.4"
     purl: "pkg:npm/parse-glob@3.0.4"
@@ -7311,6 +7480,7 @@ packages:
       url: "https://github.com/jonschlinkert/parse-glob.git"
       revision: "9bfccb63acdeb3b1ed62035b3adef0e5081d8fc6"
       path: ""
+  curations: []
 - package:
     id: "NPM::pascalcase:0.1.1"
     purl: "pkg:npm/pascalcase@0.1.1"
@@ -7340,6 +7510,7 @@ packages:
       url: "https://github.com/jonschlinkert/pascalcase.git"
       revision: "c2600f8aa648fe093381a064ba364d99b374911c"
       path: ""
+  curations: []
 - package:
     id: "NPM::path-is-absolute:1.0.1"
     purl: "pkg:npm/path-is-absolute@1.0.1"
@@ -7369,6 +7540,7 @@ packages:
       url: "https://github.com/sindresorhus/path-is-absolute.git"
       revision: "edc91d348b21dac2ab65ea2fbec2868e2eff5eb6"
       path: ""
+  curations: []
 - package:
     id: "NPM::posix-character-classes:0.1.1"
     purl: "pkg:npm/posix-character-classes@0.1.1"
@@ -7398,6 +7570,7 @@ packages:
       url: "https://github.com/jonschlinkert/posix-character-classes.git"
       revision: "93acda996350d0b1571592765e45c31da9376aa7"
       path: ""
+  curations: []
 - package:
     id: "NPM::preserve:0.2.0"
     purl: "pkg:npm/preserve@0.2.0"
@@ -7428,6 +7601,7 @@ packages:
       url: "https://github.com/jonschlinkert/preserve.git"
       revision: "1bf405d35e4aea06a2ee83db2d34dc54abc0a1f9"
       path: ""
+  curations: []
 - package:
     id: "NPM::private:0.1.8"
     purl: "pkg:npm/private@0.1.8"
@@ -7458,6 +7632,7 @@ packages:
       url: "https://github.com/benjamn/private.git"
       revision: "8fde2c4c9f760c0ae17f3ff375c02d6498472fbc"
       path: ""
+  curations: []
 - package:
     id: "NPM::process-nextick-args:2.0.0"
     purl: "pkg:npm/process-nextick-args@2.0.0"
@@ -7487,6 +7662,7 @@ packages:
       url: "https://github.com/calvinmetcalf/process-nextick-args.git"
       revision: "8407900951af3e7651fca50f127f0e4ddc01ad55"
       path: ""
+  curations: []
 - package:
     id: "NPM::process-nextick-args:2.0.1"
     purl: "pkg:npm/process-nextick-args@2.0.1"
@@ -7516,6 +7692,7 @@ packages:
       url: "https://github.com/calvinmetcalf/process-nextick-args.git"
       revision: "b96d59913025441b00c4fd40e6894ddfa8e1c398"
       path: ""
+  curations: []
 - package:
     id: "NPM::randomatic:3.1.1"
     purl: "pkg:npm/randomatic@3.1.1"
@@ -7546,6 +7723,7 @@ packages:
       url: "https://github.com/jonschlinkert/randomatic.git"
       revision: "b7451f4dac44a9920790f76a4d8a1dd081c37a5a"
       path: ""
+  curations: []
 - package:
     id: "NPM::rc:1.2.8"
     purl: "pkg:npm/rc@1.2.8"
@@ -7575,6 +7753,7 @@ packages:
       url: "https://github.com/dominictarr/rc.git"
       revision: "a97f6adcc37ee1cad06ab7dc9b0bd842bbc5c664"
       path: ""
+  curations: []
 - package:
     id: "NPM::readable-stream:2.3.6"
     purl: "pkg:npm/readable-stream@2.3.6"
@@ -7604,6 +7783,7 @@ packages:
       url: "https://github.com/nodejs/readable-stream.git"
       revision: "b3cf9b1f46eaa1865930ae03b96d7a4a570746f0"
       path: ""
+  curations: []
 - package:
     id: "NPM::readdirp:2.2.1"
     purl: "pkg:npm/readdirp@2.2.1"
@@ -7633,6 +7813,7 @@ packages:
       url: "https://github.com/paulmillr/readdirp.git"
       revision: "d0f58fd435d7918706128df1742b69bf5f81dac8"
       path: ""
+  curations: []
 - package:
     id: "NPM::regenerator-runtime:0.10.5"
     purl: "pkg:npm/regenerator-runtime@0.10.5"
@@ -7662,6 +7843,7 @@ packages:
       url: "https://github.com/facebook/regenerator.git"
       revision: "master"
       path: "packages/regenerator-runtime"
+  curations: []
 - package:
     id: "NPM::regenerator-runtime:0.11.1"
     purl: "pkg:npm/regenerator-runtime@0.11.1"
@@ -7691,6 +7873,7 @@ packages:
       url: "https://github.com/facebook/regenerator.git"
       revision: "master"
       path: "packages/regenerator-runtime"
+  curations: []
 - package:
     id: "NPM::regex-cache:0.4.4"
     purl: "pkg:npm/regex-cache@0.4.4"
@@ -7722,6 +7905,7 @@ packages:
       url: "https://github.com/jonschlinkert/regex-cache.git"
       revision: "e5ced08e45d2cc2d286a9e7b5a574963f6577712"
       path: ""
+  curations: []
 - package:
     id: "NPM::regex-not:1.0.2"
     purl: "pkg:npm/regex-not@1.0.2"
@@ -7752,6 +7936,7 @@ packages:
       url: "https://github.com/jonschlinkert/regex-not.git"
       revision: "7e368998898e1fc7428596636ef5412ede414f3e"
       path: ""
+  curations: []
 - package:
     id: "NPM::remove-trailing-separator:1.1.0"
     purl: "pkg:npm/remove-trailing-separator@1.1.0"
@@ -7781,6 +7966,7 @@ packages:
       url: "https://github.com/darsain/remove-trailing-separator.git"
       revision: "f4e8acca09106efeef5a5164f1ad2192fe97fd69"
       path: ""
+  curations: []
 - package:
     id: "NPM::repeat-element:1.1.3"
     purl: "pkg:npm/repeat-element@1.1.3"
@@ -7810,6 +7996,7 @@ packages:
       url: "https://github.com/jonschlinkert/repeat-element.git"
       revision: "32af174b4218263952a77d881f37d6e545b7cfd0"
       path: ""
+  curations: []
 - package:
     id: "NPM::repeat-string:1.6.1"
     purl: "pkg:npm/repeat-string@1.6.1"
@@ -7840,6 +8027,7 @@ packages:
       url: "https://github.com/jonschlinkert/repeat-string.git"
       revision: "1a95c5d99a02999ccd2cf4663959a18bd2def7b8"
       path: ""
+  curations: []
 - package:
     id: "NPM::repeating:2.0.1"
     purl: "pkg:npm/repeating@2.0.1"
@@ -7869,6 +8057,7 @@ packages:
       url: "https://github.com/sindresorhus/repeating.git"
       revision: "be02bcaf9a674b3c155477b3bf282136bcf44770"
       path: ""
+  curations: []
 - package:
     id: "NPM::resolve-url:0.2.1"
     purl: "pkg:npm/resolve-url@0.2.1"
@@ -7898,6 +8087,7 @@ packages:
       url: "https://github.com/lydell/resolve-url.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::ret:0.1.15"
     purl: "pkg:npm/ret@0.1.15"
@@ -7927,6 +8117,7 @@ packages:
       url: "https://github.com/fent/ret.js.git"
       revision: "7f7c436e2a85fbc068e6d94e2611ce78b3e9ad10"
       path: ""
+  curations: []
 - package:
     id: "NPM::rimraf:2.6.3"
     purl: "pkg:npm/rimraf@2.6.3"
@@ -7956,6 +8147,7 @@ packages:
       url: "https://github.com/isaacs/rimraf.git"
       revision: "9442819908e52f2c32620e8fa609d7a5d472cc2c"
       path: ""
+  curations: []
 - package:
     id: "NPM::safe-buffer:5.1.2"
     purl: "pkg:npm/safe-buffer@5.1.2"
@@ -7985,6 +8177,7 @@ packages:
       url: "https://github.com/feross/safe-buffer.git"
       revision: "649435cc8e2d1f3ecdc7caf323f1cb1187307a16"
       path: ""
+  curations: []
 - package:
     id: "NPM::safe-regex:1.1.0"
     purl: "pkg:npm/safe-regex@1.1.0"
@@ -8014,6 +8207,7 @@ packages:
       url: "https://github.com/substack/safe-regex.git"
       revision: "d2570f31bd9d779515015917bb8297c753e46572"
       path: ""
+  curations: []
 - package:
     id: "NPM::safer-buffer:2.1.2"
     purl: "pkg:npm/safer-buffer@2.1.2"
@@ -8043,6 +8237,7 @@ packages:
       url: "https://github.com/ChALkeR/safer-buffer.git"
       revision: "e8ac214944eda30e1e6c6b7d7e7f6a21cf7dce7c"
       path: ""
+  curations: []
 - package:
     id: "NPM::sax:1.2.4"
     purl: "pkg:npm/sax@1.2.4"
@@ -8072,6 +8267,7 @@ packages:
       url: "https://github.com/isaacs/sax-js.git"
       revision: "5aee2163d55cff24b817bbf550bac44841f9df45"
       path: ""
+  curations: []
 - package:
     id: "NPM::semver:5.7.0"
     purl: "pkg:npm/semver@5.7.0"
@@ -8101,6 +8297,7 @@ packages:
       url: "https://github.com/npm/node-semver.git"
       revision: "8055dda0aee91372e3bfc47754a62f40e8a63b98"
       path: ""
+  curations: []
 - package:
     id: "NPM::set-blocking:2.0.0"
     purl: "pkg:npm/set-blocking@2.0.0"
@@ -8131,6 +8328,7 @@ packages:
       url: "https://github.com/yargs/set-blocking.git"
       revision: "7eec10577b5fff264de477ba3b9d07f404946eff"
       path: ""
+  curations: []
 - package:
     id: "NPM::set-value:2.0.1"
     purl: "pkg:npm/set-value@2.0.1"
@@ -8161,6 +8359,7 @@ packages:
       url: "https://github.com/jonschlinkert/set-value.git"
       revision: "bb0f0382f7d7637f3de1bba52d1b4abdbbbde4d4"
       path: ""
+  curations: []
 - package:
     id: "NPM::signal-exit:3.0.2"
     purl: "pkg:npm/signal-exit@3.0.2"
@@ -8190,6 +8389,7 @@ packages:
       url: "https://github.com/tapjs/signal-exit.git"
       revision: "9c5ad9809fe6135ef22e2623989deaffe2a4fa8a"
       path: ""
+  curations: []
 - package:
     id: "NPM::slash:1.0.0"
     purl: "pkg:npm/slash@1.0.0"
@@ -8219,6 +8419,7 @@ packages:
       url: "https://github.com/sindresorhus/slash.git"
       revision: "c801dd4568ad9380b534067eabe88942394f82ff"
       path: ""
+  curations: []
 - package:
     id: "NPM::snapdragon-node:2.1.1"
     purl: "pkg:npm/snapdragon-node@2.1.1"
@@ -8249,6 +8450,7 @@ packages:
       url: "https://github.com/jonschlinkert/snapdragon-node.git"
       revision: "d2bc7304fc1b8103d6bb892d9ef099957468ff14"
       path: ""
+  curations: []
 - package:
     id: "NPM::snapdragon-util:3.0.1"
     purl: "pkg:npm/snapdragon-util@3.0.1"
@@ -8278,6 +8480,7 @@ packages:
       url: "https://github.com/jonschlinkert/snapdragon-util.git"
       revision: "1655d7f02f5957ebddc9cc7757a25bf8f221e5a7"
       path: ""
+  curations: []
 - package:
     id: "NPM::snapdragon:0.8.2"
     purl: "pkg:npm/snapdragon@0.8.2"
@@ -8307,6 +8510,7 @@ packages:
       url: "https://github.com/jonschlinkert/snapdragon.git"
       revision: "6c952b12cabe896a86d9a4fe378f934bccbe6436"
       path: ""
+  curations: []
 - package:
     id: "NPM::source-map-resolve:0.5.2"
     purl: "pkg:npm/source-map-resolve@0.5.2"
@@ -8336,6 +8540,7 @@ packages:
       url: "https://github.com/lydell/source-map-resolve.git"
       revision: "858cd9e2ecce25427761b8be616cabf704c69316"
       path: ""
+  curations: []
 - package:
     id: "NPM::source-map-support:0.4.18"
     purl: "pkg:npm/source-map-support@0.4.18"
@@ -8365,6 +8570,7 @@ packages:
       url: "https://github.com/evanw/node-source-map-support.git"
       revision: "b9b5a5576272916237a253393220770c858685d6"
       path: ""
+  curations: []
 - package:
     id: "NPM::source-map-url:0.4.0"
     purl: "pkg:npm/source-map-url@0.4.0"
@@ -8394,6 +8600,7 @@ packages:
       url: "https://github.com/lydell/source-map-url.git"
       revision: "f13c43ca675379922f26c87737fdcbbeac07eb09"
       path: ""
+  curations: []
 - package:
     id: "NPM::source-map:0.5.7"
     purl: "pkg:npm/source-map@0.5.7"
@@ -8423,6 +8630,7 @@ packages:
       url: "ssh://git@github.com/mozilla/source-map.git"
       revision: "326dd955a366569759d9537ef5f0f167c89d92d2"
       path: ""
+  curations: []
 - package:
     id: "NPM::split-string:3.1.0"
     purl: "pkg:npm/split-string@3.1.0"
@@ -8452,6 +8660,7 @@ packages:
       url: "https://github.com/jonschlinkert/split-string.git"
       revision: "2f83feb70267a54ca01e795e6a0558a51b89d6c8"
       path: ""
+  curations: []
 - package:
     id: "NPM::static-extend:0.1.2"
     purl: "pkg:npm/static-extend@0.1.2"
@@ -8483,6 +8692,7 @@ packages:
       url: "https://github.com/jonschlinkert/static-extend.git"
       revision: "ce41369391163eb9403848a1b4daf00be981c56b"
       path: ""
+  curations: []
 - package:
     id: "NPM::string-width:1.0.2"
     purl: "pkg:npm/string-width@1.0.2"
@@ -8513,6 +8723,7 @@ packages:
       url: "https://github.com/sindresorhus/string-width.git"
       revision: "282cf3d53918a92cc3ee0778dcf938039bcbc47b"
       path: ""
+  curations: []
 - package:
     id: "NPM::string_decoder:1.1.1"
     purl: "pkg:npm/string_decoder@1.1.1"
@@ -8542,6 +8753,7 @@ packages:
       url: "https://github.com/nodejs/string_decoder.git"
       revision: "18c7f89c894ced5f610505bb006dfde9a3d1ac5e"
       path: ""
+  curations: []
 - package:
     id: "NPM::strip-ansi:3.0.1"
     purl: "pkg:npm/strip-ansi@3.0.1"
@@ -8571,6 +8783,7 @@ packages:
       url: "https://github.com/chalk/strip-ansi.git"
       revision: "8270705c704956da865623e564eba4875c3ea17f"
       path: ""
+  curations: []
 - package:
     id: "NPM::strip-json-comments:2.0.1"
     purl: "pkg:npm/strip-json-comments@2.0.1"
@@ -8600,6 +8813,7 @@ packages:
       url: "https://github.com/sindresorhus/strip-json-comments.git"
       revision: "1aef99eaa70d07981156e8aaa722e750c3b4eaf9"
       path: ""
+  curations: []
 - package:
     id: "NPM::supports-color:2.0.0"
     purl: "pkg:npm/supports-color@2.0.0"
@@ -8629,6 +8843,7 @@ packages:
       url: "https://github.com/chalk/supports-color.git"
       revision: "8400d98ade32b2adffd50902c06d9e725a5c6588"
       path: ""
+  curations: []
 - package:
     id: "NPM::tar:4.4.8"
     purl: "pkg:npm/tar@4.4.8"
@@ -8658,6 +8873,7 @@ packages:
       url: "https://github.com/npm/node-tar.git"
       revision: "074c89b1e639485468706af3c141a68ef8826728"
       path: ""
+  curations: []
 - package:
     id: "NPM::to-fast-properties:1.0.3"
     purl: "pkg:npm/to-fast-properties@1.0.3"
@@ -8687,6 +8903,7 @@ packages:
       url: "https://github.com/sindresorhus/to-fast-properties.git"
       revision: "76e30a0b6040781a705cb351fb2e4a1d879f1adb"
       path: ""
+  curations: []
 - package:
     id: "NPM::to-object-path:0.3.0"
     purl: "pkg:npm/to-object-path@0.3.0"
@@ -8716,6 +8933,7 @@ packages:
       url: "https://github.com/jonschlinkert/to-object-path.git"
       revision: "56f6627285b7f5b7563e6f3ffe3766d966368c17"
       path: ""
+  curations: []
 - package:
     id: "NPM::to-regex-range:2.1.1"
     purl: "pkg:npm/to-regex-range@2.1.1"
@@ -8746,6 +8964,7 @@ packages:
       url: "https://github.com/micromatch/to-regex-range.git"
       revision: "de34e5079dbf33f8ac992d87914fa5e3507fa07d"
       path: ""
+  curations: []
 - package:
     id: "NPM::to-regex:3.0.2"
     purl: "pkg:npm/to-regex@3.0.2"
@@ -8775,6 +8994,7 @@ packages:
       url: "https://github.com/jonschlinkert/to-regex.git"
       revision: "cc5735f98f62c8e9cfb98ae5b309abea1c8a2432"
       path: ""
+  curations: []
 - package:
     id: "NPM::trim-right:1.0.1"
     purl: "pkg:npm/trim-right@1.0.1"
@@ -8804,6 +9024,7 @@ packages:
       url: "https://github.com/sindresorhus/trim-right.git"
       revision: "105fb46669afb0deb49d14bd688b276297e59dff"
       path: ""
+  curations: []
 - package:
     id: "NPM::union-value:1.0.1"
     purl: "pkg:npm/union-value@1.0.1"
@@ -8834,6 +9055,7 @@ packages:
       url: "https://github.com/jonschlinkert/union-value.git"
       revision: "ae70c7747afc57d6d868fd55f80041e623d2df6a"
       path: ""
+  curations: []
 - package:
     id: "NPM::unset-value:1.0.0"
     purl: "pkg:npm/unset-value@1.0.0"
@@ -8863,6 +9085,7 @@ packages:
       url: "https://github.com/jonschlinkert/unset-value.git"
       revision: "36b62353cde18d6be17a1c0dc080fddcc262d2da"
       path: ""
+  curations: []
 - package:
     id: "NPM::urix:0.1.0"
     purl: "pkg:npm/urix@0.1.0"
@@ -8892,6 +9115,7 @@ packages:
       url: "https://github.com/lydell/urix.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::use:3.1.1"
     purl: "pkg:npm/use@3.1.1"
@@ -8921,6 +9145,7 @@ packages:
       url: "https://github.com/jonschlinkert/use.git"
       revision: "163104d5c5cc8ed35602625eb90a687df1dbc487"
       path: ""
+  curations: []
 - package:
     id: "NPM::user-home:1.1.1"
     purl: "pkg:npm/user-home@1.1.1"
@@ -8950,6 +9175,7 @@ packages:
       url: "https://github.com/sindresorhus/user-home.git"
       revision: "cf6ba885d3e6bf625fb3c15ad0334fa623968481"
       path: ""
+  curations: []
 - package:
     id: "NPM::util-deprecate:1.0.2"
     purl: "pkg:npm/util-deprecate@1.0.2"
@@ -8979,6 +9205,7 @@ packages:
       url: "https://github.com/TooTallNate/util-deprecate.git"
       revision: "475fb6857cd23fafff20c1be846c1350abf8e6d4"
       path: ""
+  curations: []
 - package:
     id: "NPM::v8flags:2.1.1"
     purl: "pkg:npm/v8flags@2.1.1"
@@ -9008,6 +9235,7 @@ packages:
       url: "https://github.com/tkellen/node-v8flags.git"
       revision: "4c628146efa7eda11df0e10c73b3d8687873569e"
       path: ""
+  curations: []
 - package:
     id: "NPM::wide-align:1.1.3"
     purl: "pkg:npm/wide-align@1.1.3"
@@ -9038,6 +9266,7 @@ packages:
       url: "https://github.com/iarna/wide-align.git"
       revision: "6b766c9874a1e5157eda2ac75b90ccc01b313620"
       path: ""
+  curations: []
 - package:
     id: "NPM::wrappy:1.0.2"
     purl: "pkg:npm/wrappy@1.0.2"
@@ -9067,6 +9296,7 @@ packages:
       url: "https://github.com/npm/wrappy.git"
       revision: "71d91b6dc5bdeac37e218c2cf03f9ab55b60d214"
       path: ""
+  curations: []
 - package:
     id: "NPM::yallist:3.0.3"
     purl: "pkg:npm/yallist@3.0.3"
@@ -9096,3 +9326,4 @@ packages:
       url: "https://github.com/isaacs/yallist.git"
       revision: "47ab1ce288032985c90ee568681b35ad8978be41"
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
@@ -137,6 +137,7 @@ packages:
       url: "https://github.com/kriskowal/asap.git"
       revision: "3e3d99381444379bb0483cb9216caa39ac67bebb"
       path: ""
+  curations: []
 - package:
     id: "NPM::boolbase:1.0.0"
     purl: "pkg:npm/boolbase@1.0.0"
@@ -166,6 +167,7 @@ packages:
       url: "https://github.com/fb55/boolbase.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::cheerio:1.0.0-rc.1"
     purl: "pkg:npm/cheerio@1.0.0-rc.1"
@@ -196,6 +198,7 @@ packages:
       url: "https://github.com/cheeriojs/cheerio.git"
       revision: "f21ffef971826d1ba64ccbdf96adbc44964d30c5"
       path: ""
+  curations: []
 - package:
     id: "NPM::coffee-script:1.12.7"
     purl: "pkg:npm/coffee-script@1.12.7"
@@ -225,6 +228,7 @@ packages:
       url: "https://github.com/jashkenas/coffeescript.git"
       revision: "492111ccfb9b703b49a443c1aa68fb41dc8a2271"
       path: ""
+  curations: []
 - package:
     id: "NPM::cson-parser:1.3.5"
     purl: "pkg:npm/cson-parser@1.3.5"
@@ -254,6 +258,7 @@ packages:
       url: "ssh://git@github.com/groupon/cson-parser.git"
       revision: "fa37e04bc6c516eb76ef01df2d105a413c0253a0"
       path: ""
+  curations: []
 - package:
     id: "NPM::cson:4.1.0"
     purl: "pkg:npm/cson@4.1.0"
@@ -284,6 +289,7 @@ packages:
       url: "https://github.com/bevry/cson.git"
       revision: "0e913a90be66b2f29d2d75433b06ed52e83ba810"
       path: ""
+  curations: []
 - package:
     id: "NPM::css-select:1.2.0"
     purl: "pkg:npm/css-select@1.2.0"
@@ -315,6 +321,7 @@ packages:
       url: "https://github.com/fb55/css-select.git"
       revision: "09c405d8296bd97a660256604d8cdfb23fca47b6"
       path: ""
+  curations: []
 - package:
     id: "NPM::css-what:2.1.3"
     purl: "pkg:npm/css-what@2.1.3"
@@ -344,6 +351,7 @@ packages:
       url: "https://github.com/fb55/css-what.git"
       revision: "2db00ca221922c5b5131d798614aa043f2f6f80e"
       path: ""
+  curations: []
 - package:
     id: "NPM::dom-serializer:0.1.1"
     purl: "pkg:npm/dom-serializer@0.1.1"
@@ -373,6 +381,7 @@ packages:
       url: "https://github.com/cheeriojs/dom-renderer.git"
       revision: "1b9eb87c621a184b97467b03600b50d08e5a5086"
       path: ""
+  curations: []
 - package:
     id: "NPM::domelementtype:1.3.1"
     purl: "pkg:npm/domelementtype@1.3.1"
@@ -402,6 +411,7 @@ packages:
       url: "https://github.com/fb55/domelementtype.git"
       revision: "19b2491101a4de3679b59db8eb7fdd9aa0fbc60b"
       path: ""
+  curations: []
 - package:
     id: "NPM::domhandler:2.4.2"
     purl: "pkg:npm/domhandler@2.4.2"
@@ -431,6 +441,7 @@ packages:
       url: "https://github.com/fb55/DomHandler.git"
       revision: "045bd8d634dca30192fbd23fee0c530adc9c6f52"
       path: ""
+  curations: []
 - package:
     id: "NPM::domutils:1.5.1"
     purl: "pkg:npm/domutils@1.5.1"
@@ -458,6 +469,7 @@ packages:
       url: "https://github.com/FB55/domutils.git"
       revision: "7d4bd16cd36ffce62362ef91616806ea27e30d95"
       path: ""
+  curations: []
 - package:
     id: "NPM::eachr:3.2.0"
     purl: "pkg:npm/eachr@3.2.0"
@@ -489,6 +501,7 @@ packages:
       url: "ssh://git@github.com/bevry/eachr.git"
       revision: "57ef794d001c16fd906b2558137e8ea51c1f6330"
       path: ""
+  curations: []
 - package:
     id: "NPM::editions:1.3.4"
     purl: "pkg:npm/editions@1.3.4"
@@ -519,6 +532,7 @@ packages:
       url: "https://github.com/bevry/editions.git"
       revision: "5580800dc3935e988b7aa2cf8d571f3e9fa2d8f9"
       path: ""
+  curations: []
 - package:
     id: "NPM::editions:2.1.3"
     purl: "pkg:npm/editions@2.1.3"
@@ -549,6 +563,7 @@ packages:
       url: "https://github.com/bevry/editions.git"
       revision: "84f536320f7eff6385e867d9f5c1de0dfb92fa88"
       path: ""
+  curations: []
 - package:
     id: "NPM::entities:1.1.2"
     purl: "pkg:npm/entities@1.1.2"
@@ -578,6 +593,7 @@ packages:
       url: "https://github.com/fb55/entities.git"
       revision: "54a5717d85d886c4aafa2ac5ff83d8d3d730337c"
       path: ""
+  curations: []
 - package:
     id: "NPM::errlop:1.1.1"
     purl: "pkg:npm/errlop@1.1.1"
@@ -608,6 +624,7 @@ packages:
       url: "https://github.com/bevry/errlop.git"
       revision: "ca13727bd3a227cd937d104b3217d1cd778cc99b"
       path: ""
+  curations: []
 - package:
     id: "NPM::extract-opts:3.3.1"
     purl: "pkg:npm/extract-opts@3.3.1"
@@ -637,6 +654,7 @@ packages:
       url: "ssh://git@github.com/bevry/extract-opts.git"
       revision: "87e349bbf92a6f95d1ecc8b064a1631def105dc8"
       path: ""
+  curations: []
 - package:
     id: "NPM::graceful-fs:4.2.0"
     purl: "pkg:npm/graceful-fs@4.2.0"
@@ -666,6 +684,7 @@ packages:
       url: "https://github.com/isaacs/node-graceful-fs.git"
       revision: "585df780323740a2b562677caa08a80de1f56c62"
       path: ""
+  curations: []
 - package:
     id: "NPM::htmlparser2:3.10.1"
     purl: "pkg:npm/htmlparser2@3.10.1"
@@ -695,6 +714,7 @@ packages:
       url: "https://github.com/fb55/htmlparser2.git"
       revision: "537bf2aeb56910d84d2c5aedb839dec678188a43"
       path: ""
+  curations: []
 - package:
     id: "NPM::inherits:2.0.4"
     purl: "pkg:npm/inherits@2.0.4"
@@ -725,6 +745,7 @@ packages:
       url: "https://github.com/isaacs/inherits.git"
       revision: "9a2c29400c6d491e0b7beefe0c32efa3b462545d"
       path: ""
+  curations: []
 - package:
     id: "NPM::lodash:4.17.15"
     purl: "pkg:npm/lodash@4.17.15"
@@ -754,6 +775,7 @@ packages:
       url: "https://github.com/lodash/lodash.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::long:3.2.0"
     purl: "pkg:npm/long@3.2.0"
@@ -784,6 +806,7 @@ packages:
       url: "https://github.com/dcodeIO/long.js.git"
       revision: "8cdc1f74ced4f771aa844f1cbc565b1d4c4451b8"
       path: ""
+  curations: []
 - package:
     id: "NPM::nth-check:1.0.2"
     purl: "pkg:npm/nth-check@1.0.2"
@@ -813,6 +836,7 @@ packages:
       url: "https://github.com/fb55/nth-check.git"
       revision: "03a02587bbd126fafc3d2331ffef6ea5cb2f9b66"
       path: ""
+  curations: []
 - package:
     id: "NPM::parse5:3.0.3"
     purl: "pkg:npm/parse5@3.0.3"
@@ -843,6 +867,7 @@ packages:
       url: "https://github.com/inikulin/parse5.git"
       revision: "723d782abee65aaab9c50f92e73ac2029ae853df"
       path: ""
+  curations: []
 - package:
     id: "NPM::promise:7.3.1"
     purl: "pkg:npm/promise@7.3.1"
@@ -872,6 +897,7 @@ packages:
       url: "https://github.com/then/promise.git"
       revision: "cebfa6049cc08843f428c6fc92dde918f8687e6d"
       path: ""
+  curations: []
 - package:
     id: "NPM::readable-stream:3.4.0"
     purl: "pkg:npm/readable-stream@3.4.0"
@@ -901,6 +927,7 @@ packages:
       url: "https://github.com/nodejs/readable-stream.git"
       revision: "4ba93f84cf8812ca2af793c7304a5c16de72088a"
       path: ""
+  curations: []
 - package:
     id: "NPM::requirefresh:2.2.0"
     purl: "pkg:npm/requirefresh@2.2.0"
@@ -930,6 +957,7 @@ packages:
       url: "https://github.com/bevry/requirefresh.git"
       revision: "f389cbc33b5891468bde8db479bc0f129b0fcc57"
       path: ""
+  curations: []
 - package:
     id: "NPM::safe-buffer:5.1.2"
     purl: "pkg:npm/safe-buffer@5.1.2"
@@ -959,6 +987,7 @@ packages:
       url: "https://github.com/feross/safe-buffer.git"
       revision: "649435cc8e2d1f3ecdc7caf323f1cb1187307a16"
       path: ""
+  curations: []
 - package:
     id: "NPM::safefs:4.1.0"
     purl: "pkg:npm/safefs@4.1.0"
@@ -989,6 +1018,7 @@ packages:
       url: "ssh://git@github.com/bevry/safefs.git"
       revision: "51d15eaa03e53aaedd3002dc67814355073e8a55"
       path: ""
+  curations: []
 - package:
     id: "NPM::semver:5.7.0"
     purl: "pkg:npm/semver@5.7.0"
@@ -1018,6 +1048,7 @@ packages:
       url: "https://github.com/npm/node-semver.git"
       revision: "8055dda0aee91372e3bfc47754a62f40e8a63b98"
       path: ""
+  curations: []
 - package:
     id: "NPM::string_decoder:1.2.0"
     purl: "pkg:npm/string_decoder@1.2.0"
@@ -1047,6 +1078,7 @@ packages:
       url: "https://github.com/nodejs/string_decoder.git"
       revision: "6e0a9286ed4497badebd4ec6a9a7a4d37793aae8"
       path: ""
+  curations: []
 - package:
     id: "NPM::typechecker:4.7.0"
     purl: "pkg:npm/typechecker@4.7.0"
@@ -1077,6 +1109,7 @@ packages:
       url: "https://github.com/bevry/typechecker.git"
       revision: "69008d42927749d7e21cfe9816e478dd8d15ab88"
       path: ""
+  curations: []
 - package:
     id: "NPM::util-deprecate:1.0.2"
     purl: "pkg:npm/util-deprecate@1.0.2"
@@ -1106,6 +1139,7 @@ packages:
       url: "https://github.com/TooTallNate/util-deprecate.git"
       revision: "475fb6857cd23fafff20c1be846c1350abf8e6d4"
       path: ""
+  curations: []
 - package:
     id: "NPM:@types:node:12.6.8"
     purl: "pkg:npm/%40types/node@12.6.8"
@@ -1135,3 +1169,4 @@ packages:
       url: "https://github.com/DefinitelyTyped/DefinitelyTyped.git"
       revision: ""
       path: "types/node"
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
@@ -665,6 +665,7 @@ packages:
       url: "https://github.com/jonschlinkert/ansi-green.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::ansi-wrap:0.1.0"
     purl: "pkg:npm/ansi-wrap@0.1.0"
@@ -694,6 +695,7 @@ packages:
       url: "https://github.com/jonschlinkert/ansi-wrap.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::argparse:1.0.10"
     purl: "pkg:npm/argparse@1.0.10"
@@ -724,6 +726,7 @@ packages:
       url: "https://github.com/nodeca/argparse.git"
       revision: "ea45e14bad13b9e4a10af28f11fb7e731079ab72"
       path: ""
+  curations: []
 - package:
     id: "NPM::arr-union:3.1.0"
     purl: "pkg:npm/arr-union@3.1.0"
@@ -754,6 +757,7 @@ packages:
       url: "https://github.com/jonschlinkert/arr-union.git"
       revision: "ede857f5d5082467534e372fd3da45ce5e782e93"
       path: ""
+  curations: []
 - package:
     id: "NPM::array-each:1.0.1"
     purl: "pkg:npm/array-each@1.0.1"
@@ -784,6 +788,7 @@ packages:
       url: "https://github.com/jonschlinkert/array-each.git"
       revision: "a752d70897f25abfd38bfb51bb1b3a06ffcd2aed"
       path: ""
+  curations: []
 - package:
     id: "NPM::array-slice:0.2.3"
     purl: "pkg:npm/array-slice@0.2.3"
@@ -814,6 +819,7 @@ packages:
       url: "https://github.com/jonschlinkert/array-slice.git"
       revision: "15bcb1d3d2d5689a1f519207cecb3ab3a63b8654"
       path: ""
+  curations: []
 - package:
     id: "NPM::assign-symbols:1.0.0"
     purl: "pkg:npm/assign-symbols@1.0.0"
@@ -846,6 +852,7 @@ packages:
       url: "https://github.com/jonschlinkert/assign-symbols.git"
       revision: "2df01f26fce8359fa75688eb89e2a1c65de6f237"
       path: ""
+  curations: []
 - package:
     id: "NPM::atob:2.1.2"
     purl: "pkg:npm/atob@2.1.2"
@@ -875,6 +882,7 @@ packages:
       url: "git://git.coolaj86.com/coolaj86/atob.js.git"
       revision: "755cfea7899074a17e83a248c7cfc3960d956d82"
       path: ""
+  curations: []
 - package:
     id: "NPM::autolinker:0.28.1"
     purl: "pkg:npm/autolinker@0.28.1"
@@ -905,6 +913,7 @@ packages:
       url: "https://github.com/gregjacobs/Autolinker.js.git"
       revision: "e6634b3736d462b60df5ee10d9e8c3c21a45f8e6"
       path: ""
+  curations: []
 - package:
     id: "NPM::balanced-match:1.0.0"
     purl: "pkg:npm/balanced-match@1.0.0"
@@ -934,6 +943,7 @@ packages:
       url: "https://github.com/juliangruber/balanced-match.git"
       revision: "d701a549a7653a874eebce7eca25d3577dc868ac"
       path: ""
+  curations: []
 - package:
     id: "NPM::base:0.11.2"
     purl: "pkg:npm/base@0.11.2"
@@ -965,6 +975,7 @@ packages:
       url: "https://github.com/node-base/base.git"
       revision: "1885b1dc37dff5479d852dd0810d32207e190bab"
       path: ""
+  curations: []
 - package:
     id: "NPM::brace-expansion:1.1.11"
     purl: "pkg:npm/brace-expansion@1.1.11"
@@ -994,6 +1005,7 @@ packages:
       url: "https://github.com/juliangruber/brace-expansion.git"
       revision: "01a21de7441549d26ac0c0a9ff91385d16e5c21c"
       path: ""
+  curations: []
 - package:
     id: "NPM::browser-stdout:1.3.1"
     purl: "pkg:npm/browser-stdout@1.3.1"
@@ -1023,6 +1035,7 @@ packages:
       url: "ssh://git@github.com/kumavis/browser-stdout.git"
       revision: "456b7f33c2d535fc88cf732d1a0e2d48a7600a1b"
       path: ""
+  curations: []
 - package:
     id: "NPM::cache-base:1.0.1"
     purl: "pkg:npm/cache-base@1.0.1"
@@ -1053,6 +1066,7 @@ packages:
       url: "https://github.com/jonschlinkert/cache-base.git"
       revision: "0889aab765c66585ffbe7b41f9a733ef097665cf"
       path: ""
+  curations: []
 - package:
     id: "NPM::class-utils:0.3.6"
     purl: "pkg:npm/class-utils@0.3.6"
@@ -1082,6 +1096,7 @@ packages:
       url: "https://github.com/jonschlinkert/class-utils.git"
       revision: "0ad9e639d6a63d6dc04043ac5931df85fb898e06"
       path: ""
+  curations: []
 - package:
     id: "NPM::clone-buffer:1.0.0"
     purl: "pkg:npm/clone-buffer@1.0.0"
@@ -1111,6 +1126,7 @@ packages:
       url: "https://github.com/gulpjs/clone-buffer.git"
       revision: "7dab09850f080e2d137c62c6a673344fa8458942"
       path: ""
+  curations: []
 - package:
     id: "NPM::clone-stats:1.0.0"
     purl: "pkg:npm/clone-stats@1.0.0"
@@ -1141,6 +1157,7 @@ packages:
       url: "https://github.com/hughsk/clone-stats.git"
       revision: "25810f469944326c761f9f6273268453734a8465"
       path: ""
+  curations: []
 - package:
     id: "NPM::clone:2.1.2"
     purl: "pkg:npm/clone@2.1.2"
@@ -1170,6 +1187,7 @@ packages:
       url: "https://github.com/pvorb/node-clone.git"
       revision: "765941803d27761a6008cb1aa32b199f0c42deb2"
       path: ""
+  curations: []
 - package:
     id: "NPM::cloneable-readable:1.1.3"
     purl: "pkg:npm/cloneable-readable@1.1.3"
@@ -1199,6 +1217,7 @@ packages:
       url: "https://github.com/mcollina/cloneable-readable.git"
       revision: "88e32675c5816bccda34983ff8fd1d9cd1f027fa"
       path: ""
+  curations: []
 - package:
     id: "NPM::collection-visit:1.0.0"
     purl: "pkg:npm/collection-visit@1.0.0"
@@ -1229,6 +1248,7 @@ packages:
       url: "https://github.com/jonschlinkert/collection-visit.git"
       revision: "39c229dceb7e124cb821b59668df5da1d5c81a6c"
       path: ""
+  curations: []
 - package:
     id: "NPM::commander:2.15.1"
     purl: "pkg:npm/commander@2.15.1"
@@ -1258,6 +1278,7 @@ packages:
       url: "https://github.com/tj/commander.js.git"
       revision: "649eaef336ddc7224eb5c73e4a958685e24de25e"
       path: ""
+  curations: []
 - package:
     id: "NPM::component-emitter:1.3.0"
     purl: "pkg:npm/component-emitter@1.3.0"
@@ -1287,6 +1308,7 @@ packages:
       url: "https://github.com/component/emitter.git"
       revision: "6bd7817e8a444cb16e8abdf7dd2d7f04d5ca3dc8"
       path: ""
+  curations: []
 - package:
     id: "NPM::concat-map:0.0.1"
     purl: "pkg:npm/concat-map@0.0.1"
@@ -1316,6 +1338,7 @@ packages:
       url: "https://github.com/substack/node-concat-map.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::concat-with-sourcemaps:1.1.0"
     purl: "pkg:npm/concat-with-sourcemaps@1.1.0"
@@ -1346,6 +1369,7 @@ packages:
       url: "https://github.com/floridoo/concat-with-sourcemaps.git"
       revision: "fa7922b69c4054a6c5dc8f415f0dfcabaf5b8fe4"
       path: ""
+  curations: []
 - package:
     id: "NPM::copy-descriptor:0.1.1"
     purl: "pkg:npm/copy-descriptor@0.1.1"
@@ -1375,6 +1399,7 @@ packages:
       url: "https://github.com/jonschlinkert/copy-descriptor.git"
       revision: "572c31416d4538b7ba5f52e2bb0765ac237f79e2"
       path: ""
+  curations: []
 - package:
     id: "NPM::core-util-is:1.0.2"
     purl: "pkg:npm/core-util-is@1.0.2"
@@ -1404,6 +1429,7 @@ packages:
       url: "https://github.com/isaacs/core-util-is.git"
       revision: "a177da234df5638b363ddc15fa324619a38577c8"
       path: ""
+  curations: []
 - package:
     id: "NPM::debug:2.6.9"
     purl: "pkg:npm/debug@2.6.9"
@@ -1433,6 +1459,7 @@ packages:
       url: "https://github.com/visionmedia/debug.git"
       revision: "13abeae468fea297d0dccc50bc55590809241083"
       path: ""
+  curations: []
 - package:
     id: "NPM::debug:3.1.0"
     purl: "pkg:npm/debug@3.1.0"
@@ -1462,6 +1489,7 @@ packages:
       url: "https://github.com/visionmedia/debug.git"
       revision: "f073e056f33efdd5b311381eb6bca2bc850745bf"
       path: ""
+  curations: []
 - package:
     id: "NPM::decode-uri-component:0.2.0"
     purl: "pkg:npm/decode-uri-component@0.2.0"
@@ -1491,6 +1519,7 @@ packages:
       url: "https://github.com/samverschueren/decode-uri-component.git"
       revision: "52782a347527a6a05fed02434ffcf8f2ba1b19a3"
       path: ""
+  curations: []
 - package:
     id: "NPM::define-property:0.2.5"
     purl: "pkg:npm/define-property@0.2.5"
@@ -1520,6 +1549,7 @@ packages:
       url: "https://github.com/jonschlinkert/define-property.git"
       revision: "5bf4e5e9d8d1fdf8fba07fff4bdf13a5d6df8ae4"
       path: ""
+  curations: []
 - package:
     id: "NPM::define-property:1.0.0"
     purl: "pkg:npm/define-property@1.0.0"
@@ -1549,6 +1579,7 @@ packages:
       url: "https://github.com/jonschlinkert/define-property.git"
       revision: "4811e7c7999e82ab086265eefeb5d9cbffe10912"
       path: ""
+  curations: []
 - package:
     id: "NPM::define-property:2.0.2"
     purl: "pkg:npm/define-property@2.0.2"
@@ -1579,6 +1610,7 @@ packages:
       url: "https://github.com/jonschlinkert/define-property.git"
       revision: "04717307be822f2ca2544778b92e5d2cbe300c55"
       path: ""
+  curations: []
 - package:
     id: "NPM::diff:3.5.0"
     purl: "pkg:npm/diff@3.5.0"
@@ -1608,6 +1640,7 @@ packages:
       url: "https://github.com/kpdecker/jsdiff.git"
       revision: "e9ab94893a77f1f7d7ea8483b873083e6c6a390a"
       path: ""
+  curations: []
 - package:
     id: "NPM::escape-string-regexp:1.0.5"
     purl: "pkg:npm/escape-string-regexp@1.0.5"
@@ -1637,6 +1670,7 @@ packages:
       url: "https://github.com/sindresorhus/escape-string-regexp.git"
       revision: "db124a3e1aae9d692c4899e42a5c6c3e329eaa20"
       path: ""
+  curations: []
 - package:
     id: "NPM::expand-range:1.8.2"
     purl: "pkg:npm/expand-range@1.8.2"
@@ -1667,6 +1701,7 @@ packages:
       url: "https://github.com/jonschlinkert/expand-range.git"
       revision: "4c873af0870df8382bafc66a93d5c89e3aad3d4d"
       path: ""
+  curations: []
 - package:
     id: "NPM::expand-reflinks:0.2.1"
     purl: "pkg:npm/expand-reflinks@0.2.1"
@@ -1696,6 +1731,7 @@ packages:
       url: "https://github.com/jonschlinkert/expand-reflinks.git"
       revision: "340164e223b46f43a87fcff4644090d0b7133400"
       path: ""
+  curations: []
 - package:
     id: "NPM::extend-shallow:2.0.1"
     purl: "pkg:npm/extend-shallow@2.0.1"
@@ -1726,6 +1762,7 @@ packages:
       url: "https://github.com/jonschlinkert/extend-shallow.git"
       revision: "e9b1f1d2ff9d2990ec4a127afa7c14732d1eec8a"
       path: ""
+  curations: []
 - package:
     id: "NPM::extend-shallow:3.0.2"
     purl: "pkg:npm/extend-shallow@3.0.2"
@@ -1756,6 +1793,7 @@ packages:
       url: "https://github.com/jonschlinkert/extend-shallow.git"
       revision: "33698c3df7804f0d0e3ea98caa64d53f09c37bd4"
       path: ""
+  curations: []
 - package:
     id: "NPM::fill-range:2.2.4"
     purl: "pkg:npm/fill-range@2.2.4"
@@ -1786,6 +1824,7 @@ packages:
       url: "https://github.com/jonschlinkert/fill-range.git"
       revision: "516e5ad9e40486c168b14062158d136aa3163f2b"
       path: ""
+  curations: []
 - package:
     id: "NPM::for-in:1.0.2"
     purl: "pkg:npm/for-in@1.0.2"
@@ -1817,6 +1856,7 @@ packages:
       url: "https://github.com/jonschlinkert/for-in.git"
       revision: "5f97ad4f6556e938d9b71614259ddd8044a081e3"
       path: ""
+  curations: []
 - package:
     id: "NPM::fs-exists-sync:0.1.0"
     purl: "pkg:npm/fs-exists-sync@0.1.0"
@@ -1848,6 +1888,7 @@ packages:
       url: "https://github.com/jonschlinkert/fs-exists-sync.git"
       revision: "3b44654977775bac2d1151520c9b6257249a6374"
       path: ""
+  curations: []
 - package:
     id: "NPM::fs.realpath:1.0.0"
     purl: "pkg:npm/fs.realpath@1.0.0"
@@ -1878,6 +1919,7 @@ packages:
       url: "https://github.com/isaacs/fs.realpath.git"
       revision: "03e7c884431fe185dfebbc9b771aeca339c1807a"
       path: ""
+  curations: []
 - package:
     id: "NPM::get-value:2.0.6"
     purl: "pkg:npm/get-value@2.0.6"
@@ -1907,6 +1949,7 @@ packages:
       url: "https://github.com/jonschlinkert/get-value.git"
       revision: "5dc7466a65eec37e3b9e3d94f274b7aba193ea60"
       path: ""
+  curations: []
 - package:
     id: "NPM::gfm-code-block-regex:1.0.0"
     purl: "pkg:npm/gfm-code-block-regex@1.0.0"
@@ -1936,6 +1979,7 @@ packages:
       url: "https://github.com/regexhq/gfm-code-block-regex.git"
       revision: "91fd47dae730c5da36bd939acac416de221ff5d4"
       path: ""
+  curations: []
 - package:
     id: "NPM::gfm-code-blocks:1.0.0"
     purl: "pkg:npm/gfm-code-blocks@1.0.0"
@@ -1966,6 +2010,7 @@ packages:
       url: "https://github.com/jonschlinkert/gfm-code-blocks.git"
       revision: "1bdaf425f1fdbcedd4966203c5e402d9019421a1"
       path: ""
+  curations: []
 - package:
     id: "NPM::glob:7.1.2"
     purl: "pkg:npm/glob@7.1.2"
@@ -1995,6 +2040,7 @@ packages:
       url: "https://github.com/isaacs/node-glob.git"
       revision: "8fa8d561e08c9eed1d286c6a35be2cd8123b2fb7"
       path: ""
+  curations: []
 - package:
     id: "NPM::growl:1.10.5"
     purl: "pkg:npm/growl@1.10.5"
@@ -2024,6 +2070,7 @@ packages:
       url: "https://github.com/tj/node-growl.git"
       revision: "95393c8da0d8bab06522a5eb36658a639c24a621"
       path: ""
+  curations: []
 - package:
     id: "NPM::gulp-format-md:1.0.0"
     purl: "pkg:npm/gulp-format-md@1.0.0"
@@ -2053,6 +2100,7 @@ packages:
       url: "https://github.com/jonschlinkert/gulp-format-md.git"
       revision: "ebcdcba3d9fb6eb16368921200b0621ec8178535"
       path: ""
+  curations: []
 - package:
     id: "NPM::gulp-header:1.8.12"
     purl: "pkg:npm/gulp-header@1.8.12"
@@ -2082,6 +2130,7 @@ packages:
       url: "https://github.com/tracker1/gulp-header.git"
       revision: "e2db2d463e59dc1ced8895c505b6671ab340dbb5"
       path: ""
+  curations: []
 - package:
     id: "NPM::has-flag:3.0.0"
     purl: "pkg:npm/has-flag@3.0.0"
@@ -2111,6 +2160,7 @@ packages:
       url: "https://github.com/sindresorhus/has-flag.git"
       revision: "8b2ca7e693b2c742b29f2399194077b64b9ff781"
       path: ""
+  curations: []
 - package:
     id: "NPM::has-value:0.3.1"
     purl: "pkg:npm/has-value@0.3.1"
@@ -2141,6 +2191,7 @@ packages:
       url: "https://github.com/jonschlinkert/has-value.git"
       revision: "adecb27b13b7e99688694e228a946e6e635fcc64"
       path: ""
+  curations: []
 - package:
     id: "NPM::has-value:1.0.0"
     purl: "pkg:npm/has-value@1.0.0"
@@ -2171,6 +2222,7 @@ packages:
       url: "https://github.com/jonschlinkert/has-value.git"
       revision: "61b5671a48ac40206eb33b4ea75dc2507168d687"
       path: ""
+  curations: []
 - package:
     id: "NPM::has-values:0.1.4"
     purl: "pkg:npm/has-values@0.1.4"
@@ -2201,6 +2253,7 @@ packages:
       url: "https://github.com/jonschlinkert/has-values.git"
       revision: "199a3eacd663b4ae4b00aef5ef5541aa2c7c8089"
       path: ""
+  curations: []
 - package:
     id: "NPM::has-values:1.0.0"
     purl: "pkg:npm/has-values@1.0.0"
@@ -2231,6 +2284,7 @@ packages:
       url: "https://github.com/jonschlinkert/has-values.git"
       revision: "fead695044aafcfb337c7125af5479c7eaf1c92c"
       path: ""
+  curations: []
 - package:
     id: "NPM::he:1.1.1"
     purl: "pkg:npm/he@1.1.1"
@@ -2260,6 +2314,7 @@ packages:
       url: "https://github.com/mathiasbynens/he.git"
       revision: "670991a4141d01dc015de5194d400d01c863208f"
       path: ""
+  curations: []
 - package:
     id: "NPM::inflight:1.0.6"
     purl: "pkg:npm/inflight@1.0.6"
@@ -2289,6 +2344,7 @@ packages:
       url: "https://github.com/npm/inflight.git"
       revision: "a547881738c8f57b27795e584071d67cf6ac1a57"
       path: ""
+  curations: []
 - package:
     id: "NPM::inherits:2.0.4"
     purl: "pkg:npm/inherits@2.0.4"
@@ -2319,6 +2375,7 @@ packages:
       url: "https://github.com/isaacs/inherits.git"
       revision: "9a2c29400c6d491e0b7beefe0c32efa3b462545d"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-accessor-descriptor:0.1.6"
     purl: "pkg:npm/is-accessor-descriptor@0.1.6"
@@ -2349,6 +2406,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-accessor-descriptor.git"
       revision: "e64ae49c456c9f31dab47934b0183e2a9938b5bd"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-accessor-descriptor:1.0.0"
     purl: "pkg:npm/is-accessor-descriptor@1.0.0"
@@ -2379,6 +2437,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-accessor-descriptor.git"
       revision: "22b0a2617ccbebd131247c29e3700ca860d37d06"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-buffer:1.1.6"
     purl: "pkg:npm/is-buffer@1.1.6"
@@ -2408,6 +2467,7 @@ packages:
       url: "https://github.com/feross/is-buffer.git"
       revision: "1e84e7ee31cf6b660b12500f3111a05501da387f"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-data-descriptor:0.1.4"
     purl: "pkg:npm/is-data-descriptor@0.1.4"
@@ -2438,6 +2498,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-data-descriptor.git"
       revision: "e6317dbcb27a95281a60120bac83f5938dda4e2c"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-data-descriptor:1.0.0"
     purl: "pkg:npm/is-data-descriptor@1.0.0"
@@ -2468,6 +2529,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-data-descriptor.git"
       revision: "42dcba2627fe655daa21aec843ca8de849f26cd6"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-descriptor:0.1.6"
     purl: "pkg:npm/is-descriptor@0.1.6"
@@ -2498,6 +2560,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-descriptor.git"
       revision: "7559403830553097fcdd56ae93fe69d4ef2b21db"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-descriptor:1.0.2"
     purl: "pkg:npm/is-descriptor@1.0.2"
@@ -2528,6 +2591,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-descriptor.git"
       revision: "324635c990dc7f1e6d169deecd19769dea72114c"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-extendable:0.1.1"
     purl: "pkg:npm/is-extendable@0.1.1"
@@ -2559,6 +2623,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-extendable.git"
       revision: "c36a0732e6a76931c6f66c5931d1f3e54fa44380"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-extendable:1.0.1"
     purl: "pkg:npm/is-extendable@1.0.1"
@@ -2588,6 +2653,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-extendable.git"
       revision: "230717f6be5be812c16916ec8a745d6252dfa7a5"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-number:2.1.0"
     purl: "pkg:npm/is-number@2.1.0"
@@ -2617,6 +2683,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-number.git"
       revision: "d06c6e2cc048d3cad016cb8dfb055bb14d86fffa"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-number:3.0.0"
     purl: "pkg:npm/is-number@3.0.0"
@@ -2646,6 +2713,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-number.git"
       revision: "af885e2e890b9ef0875edd2b117305119ee5bdc5"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-number:4.0.0"
     purl: "pkg:npm/is-number@4.0.0"
@@ -2675,6 +2743,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-number.git"
       revision: "0c6b15a88bc10cd47f67a09506399dfc9ddc075d"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-plain-object:2.0.4"
     purl: "pkg:npm/is-plain-object@2.0.4"
@@ -2704,6 +2773,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-plain-object.git"
       revision: "81345df0d1700a5c285f379cbdca0e273388910d"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-win:1.0.8"
     purl: "pkg:npm/is-win@1.0.8"
@@ -2733,6 +2803,7 @@ packages:
       url: "ssh://git@github.com/IonicaBizau/is-win.git"
       revision: "77a92dda6c2a40cc10859b7d77d4d7e23eb27382"
       path: ""
+  curations: []
 - package:
     id: "NPM::is-windows:1.0.2"
     purl: "pkg:npm/is-windows@1.0.2"
@@ -2763,6 +2834,7 @@ packages:
       url: "https://github.com/jonschlinkert/is-windows.git"
       revision: "4dcfff4ed9e36ad761a1a24d3899c832382d7254"
       path: ""
+  curations: []
 - package:
     id: "NPM::isarray:1.0.0"
     purl: "pkg:npm/isarray@1.0.0"
@@ -2792,6 +2864,7 @@ packages:
       url: "https://github.com/juliangruber/isarray.git"
       revision: "2a23a281f369e9ae06394c0fb4d2381355a6ba33"
       path: ""
+  curations: []
 - package:
     id: "NPM::isobject:2.1.0"
     purl: "pkg:npm/isobject@2.1.0"
@@ -2821,6 +2894,7 @@ packages:
       url: "https://github.com/jonschlinkert/isobject.git"
       revision: "d693ec8d31b02b42a19b2d806407a4ecb2f9fb73"
       path: ""
+  curations: []
 - package:
     id: "NPM::isobject:3.0.1"
     purl: "pkg:npm/isobject@3.0.1"
@@ -2850,6 +2924,7 @@ packages:
       url: "https://github.com/jonschlinkert/isobject.git"
       revision: "7ad1fc405d19f144a21e2bfe947fa82801baa7aa"
       path: ""
+  curations: []
 - package:
     id: "NPM::kind-of:3.2.2"
     purl: "pkg:npm/kind-of@3.2.2"
@@ -2879,6 +2954,7 @@ packages:
       url: "https://github.com/jonschlinkert/kind-of.git"
       revision: "0ffe67cf12f5396047c1bacf04232b7deeb24063"
       path: ""
+  curations: []
 - package:
     id: "NPM::kind-of:4.0.0"
     purl: "pkg:npm/kind-of@4.0.0"
@@ -2908,6 +2984,7 @@ packages:
       url: "https://github.com/jonschlinkert/kind-of.git"
       revision: "30bee16e8dffa67417ba35d31bd9bc31517a2d83"
       path: ""
+  curations: []
 - package:
     id: "NPM::kind-of:5.1.0"
     purl: "pkg:npm/kind-of@5.1.0"
@@ -2937,6 +3014,7 @@ packages:
       url: "https://github.com/jonschlinkert/kind-of.git"
       revision: "ed479b6ee194dc1edff852f17095ae1de40bafbc"
       path: ""
+  curations: []
 - package:
     id: "NPM::kind-of:6.0.3"
     purl: "pkg:npm/kind-of@6.0.3"
@@ -2966,6 +3044,7 @@ packages:
       url: "https://github.com/jonschlinkert/kind-of.git"
       revision: "abab085d65f7ee978011da8f135291892fcd97db"
       path: ""
+  curations: []
 - package:
     id: "NPM::lazy-cache:2.0.2"
     purl: "pkg:npm/lazy-cache@2.0.2"
@@ -2995,6 +3074,7 @@ packages:
       url: "https://github.com/jonschlinkert/lazy-cache.git"
       revision: "ca0579a0687f9a7d915d9ecf53a93af7ad72762d"
       path: ""
+  curations: []
 - package:
     id: "NPM::list-item:1.1.1"
     purl: "pkg:npm/list-item@1.1.1"
@@ -3025,6 +3105,7 @@ packages:
       url: "https://github.com/jonschlinkert/list-item.git"
       revision: "26f9ef24523c2374acffd97b7627c217c7fce7c0"
       path: ""
+  curations: []
 - package:
     id: "NPM::lodash._reinterpolate:3.0.0"
     purl: "pkg:npm/lodash._reinterpolate@3.0.0"
@@ -3054,6 +3135,7 @@ packages:
       url: "https://github.com/lodash/lodash.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::lodash.template:4.5.0"
     purl: "pkg:npm/lodash.template@4.5.0"
@@ -3083,6 +3165,7 @@ packages:
       url: "https://github.com/lodash/lodash.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::lodash.templatesettings:4.2.0"
     purl: "pkg:npm/lodash.templatesettings@4.2.0"
@@ -3112,6 +3195,7 @@ packages:
       url: "https://github.com/lodash/lodash.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::log-ok:0.1.1"
     purl: "pkg:npm/log-ok@0.1.1"
@@ -3141,6 +3225,7 @@ packages:
       url: "https://github.com/jonschlinkert/log-ok.git"
       revision: "59edddc6de212f0a339d1903a0e941e46ca36fcc"
       path: ""
+  curations: []
 - package:
     id: "NPM::map-cache:0.2.2"
     purl: "pkg:npm/map-cache@0.2.2"
@@ -3170,6 +3255,7 @@ packages:
       url: "https://github.com/jonschlinkert/map-cache.git"
       revision: "f36c7567cb85b50824db25a2a588c5f7b858823b"
       path: ""
+  curations: []
 - package:
     id: "NPM::map-visit:1.0.0"
     purl: "pkg:npm/map-visit@1.0.0"
@@ -3199,6 +3285,7 @@ packages:
       url: "https://github.com/jonschlinkert/map-visit.git"
       revision: "73bcd8385c9520c595a825486f19623a5e0550f0"
       path: ""
+  curations: []
 - package:
     id: "NPM::markdown-utils:0.7.3"
     purl: "pkg:npm/markdown-utils@0.7.3"
@@ -3228,6 +3315,7 @@ packages:
       url: "https://github.com/jonschlinkert/markdown-utils.git"
       revision: "b574bd7d52f70afb6099d9794cc27326e1bd36d5"
       path: ""
+  curations: []
 - package:
     id: "NPM::math-random:1.0.4"
     purl: "pkg:npm/math-random@1.0.4"
@@ -3259,6 +3347,7 @@ packages:
       url: "https://github.com/michaelrhodes/math-random.git"
       revision: "13ed513bd579eb868b5054b38836411ae6e29f6a"
       path: ""
+  curations: []
 - package:
     id: "NPM::minimatch:3.0.4"
     purl: "pkg:npm/minimatch@3.0.4"
@@ -3288,6 +3377,7 @@ packages:
       url: "https://github.com/isaacs/minimatch.git"
       revision: "e46989a323d5f0aa4781eff5e2e6e7aafa223321"
       path: ""
+  curations: []
 - package:
     id: "NPM::minimist:0.0.8"
     purl: "pkg:npm/minimist@0.0.8"
@@ -3317,6 +3407,7 @@ packages:
       url: "https://github.com/substack/minimist.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::minimist:1.2.5"
     purl: "pkg:npm/minimist@1.2.5"
@@ -3346,6 +3437,7 @@ packages:
       url: "https://github.com/substack/minimist.git"
       revision: "aeb3e27dae0412de5c0494e9563a5f10c82cc7a9"
       path: ""
+  curations: []
 - package:
     id: "NPM::mixin-deep:1.3.2"
     purl: "pkg:npm/mixin-deep@1.3.2"
@@ -3376,6 +3468,7 @@ packages:
       url: "https://github.com/jonschlinkert/mixin-deep.git"
       revision: "754f0c20e1bc13ea5a21a64fbc7d6ba5f7b359b9"
       path: ""
+  curations: []
 - package:
     id: "NPM::mkdirp:0.5.1"
     purl: "pkg:npm/mkdirp@0.5.1"
@@ -3405,6 +3498,7 @@ packages:
       url: "https://github.com/substack/node-mkdirp.git"
       revision: "d4eff0f06093aed4f387e88e9fc301cb76beedc7"
       path: ""
+  curations: []
 - package:
     id: "NPM::mocha:5.2.0"
     purl: "pkg:npm/mocha@5.2.0"
@@ -3434,6 +3528,7 @@ packages:
       url: "https://github.com/mochajs/mocha.git"
       revision: "5bd33a0ba201d227159759e8ced86756595b0c54"
       path: ""
+  curations: []
 - package:
     id: "NPM::ms:2.0.0"
     purl: "pkg:npm/ms@2.0.0"
@@ -3463,6 +3558,7 @@ packages:
       url: "https://github.com/zeit/ms.git"
       revision: "9b88d1568a52ec9bb67ecc8d2aa224fa38fd41f4"
       path: ""
+  curations: []
 - package:
     id: "NPM::object-copy:0.1.0"
     purl: "pkg:npm/object-copy@0.1.0"
@@ -3493,6 +3589,7 @@ packages:
       url: "https://github.com/jonschlinkert/object-copy.git"
       revision: "15b972a4a7137f6bf47886c68e73a2fffa8eacf2"
       path: ""
+  curations: []
 - package:
     id: "NPM::object-visit:1.0.1"
     purl: "pkg:npm/object-visit@1.0.1"
@@ -3522,6 +3619,7 @@ packages:
       url: "https://github.com/jonschlinkert/object-visit.git"
       revision: "2220cd6ea35008481c9e252488bcbde9ebca0983"
       path: ""
+  curations: []
 - package:
     id: "NPM::once:1.4.0"
     purl: "pkg:npm/once@1.4.0"
@@ -3551,6 +3649,7 @@ packages:
       url: "https://github.com/isaacs/once.git"
       revision: "0e614d9f5a7e6f0305c625f6b581f6d80b33b8a6"
       path: ""
+  curations: []
 - package:
     id: "NPM::pascalcase:0.1.1"
     purl: "pkg:npm/pascalcase@0.1.1"
@@ -3580,6 +3679,7 @@ packages:
       url: "https://github.com/jonschlinkert/pascalcase.git"
       revision: "c2600f8aa648fe093381a064ba364d99b374911c"
       path: ""
+  curations: []
 - package:
     id: "NPM::path-is-absolute:1.0.1"
     purl: "pkg:npm/path-is-absolute@1.0.1"
@@ -3609,6 +3709,7 @@ packages:
       url: "https://github.com/sindresorhus/path-is-absolute.git"
       revision: "edc91d348b21dac2ab65ea2fbec2868e2eff5eb6"
       path: ""
+  curations: []
 - package:
     id: "NPM::pretty-remarkable:0.4.1"
     purl: "pkg:npm/pretty-remarkable@0.4.1"
@@ -3639,6 +3740,7 @@ packages:
       url: "https://github.com/jonschlinkert/pretty-remarkable.git"
       revision: "1ff9466caf5c1e483880c0aef5c496b4609e92d2"
       path: ""
+  curations: []
 - package:
     id: "NPM::process-nextick-args:2.0.1"
     purl: "pkg:npm/process-nextick-args@2.0.1"
@@ -3668,6 +3770,7 @@ packages:
       url: "https://github.com/calvinmetcalf/process-nextick-args.git"
       revision: "b96d59913025441b00c4fd40e6894ddfa8e1c398"
       path: ""
+  curations: []
 - package:
     id: "NPM::randomatic:3.1.1"
     purl: "pkg:npm/randomatic@3.1.1"
@@ -3698,6 +3801,7 @@ packages:
       url: "https://github.com/jonschlinkert/randomatic.git"
       revision: "b7451f4dac44a9920790f76a4d8a1dd081c37a5a"
       path: ""
+  curations: []
 - package:
     id: "NPM::readable-stream:2.3.7"
     purl: "pkg:npm/readable-stream@2.3.7"
@@ -3727,6 +3831,7 @@ packages:
       url: "https://github.com/nodejs/readable-stream.git"
       revision: "2eb8861e029107b7e079e22c826835cad6ae7854"
       path: ""
+  curations: []
 - package:
     id: "NPM::regex-not:1.0.2"
     purl: "pkg:npm/regex-not@1.0.2"
@@ -3757,6 +3862,7 @@ packages:
       url: "https://github.com/jonschlinkert/regex-not.git"
       revision: "7e368998898e1fc7428596636ef5412ede414f3e"
       path: ""
+  curations: []
 - package:
     id: "NPM::remarkable:1.7.4"
     purl: "pkg:npm/remarkable@1.7.4"
@@ -3787,6 +3893,7 @@ packages:
       url: "https://github.com/jonschlinkert/remarkable.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::remove-trailing-separator:1.1.0"
     purl: "pkg:npm/remove-trailing-separator@1.1.0"
@@ -3816,6 +3923,7 @@ packages:
       url: "https://github.com/darsain/remove-trailing-separator.git"
       revision: "f4e8acca09106efeef5a5164f1ad2192fe97fd69"
       path: ""
+  curations: []
 - package:
     id: "NPM::repeat-element:1.1.3"
     purl: "pkg:npm/repeat-element@1.1.3"
@@ -3845,6 +3953,7 @@ packages:
       url: "https://github.com/jonschlinkert/repeat-element.git"
       revision: "32af174b4218263952a77d881f37d6e545b7cfd0"
       path: ""
+  curations: []
 - package:
     id: "NPM::repeat-string:1.6.1"
     purl: "pkg:npm/repeat-string@1.6.1"
@@ -3875,6 +3984,7 @@ packages:
       url: "https://github.com/jonschlinkert/repeat-string.git"
       revision: "1a95c5d99a02999ccd2cf4663959a18bd2def7b8"
       path: ""
+  curations: []
 - package:
     id: "NPM::replace-ext:1.0.0"
     purl: "pkg:npm/replace-ext@1.0.0"
@@ -3904,6 +4014,7 @@ packages:
       url: "https://github.com/gulpjs/replace-ext.git"
       revision: "adaec75e316f1c375dc7a2cb51c7b762b135cc0e"
       path: ""
+  curations: []
 - package:
     id: "NPM::resolve-url:0.2.1"
     purl: "pkg:npm/resolve-url@0.2.1"
@@ -3933,6 +4044,7 @@ packages:
       url: "https://github.com/lydell/resolve-url.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::ret:0.1.15"
     purl: "pkg:npm/ret@0.1.15"
@@ -3962,6 +4074,7 @@ packages:
       url: "https://github.com/fent/ret.js.git"
       revision: "7f7c436e2a85fbc068e6d94e2611ce78b3e9ad10"
       path: ""
+  curations: []
 - package:
     id: "NPM::safe-buffer:5.1.2"
     purl: "pkg:npm/safe-buffer@5.1.2"
@@ -3991,6 +4104,7 @@ packages:
       url: "https://github.com/feross/safe-buffer.git"
       revision: "649435cc8e2d1f3ecdc7caf323f1cb1187307a16"
       path: ""
+  curations: []
 - package:
     id: "NPM::safe-regex:1.1.0"
     purl: "pkg:npm/safe-regex@1.1.0"
@@ -4020,6 +4134,7 @@ packages:
       url: "https://github.com/substack/safe-regex.git"
       revision: "d2570f31bd9d779515015917bb8297c753e46572"
       path: ""
+  curations: []
 - package:
     id: "NPM::sections:1.0.0"
     purl: "pkg:npm/sections@1.0.0"
@@ -4050,6 +4165,7 @@ packages:
       url: "https://github.com/jonschlinkert/sections.git"
       revision: "ec3ea81580de43e1b14d160853e1eadbf860006d"
       path: ""
+  curations: []
 - package:
     id: "NPM::set-getter:0.1.0"
     purl: "pkg:npm/set-getter@0.1.0"
@@ -4080,6 +4196,7 @@ packages:
       url: "https://github.com/doowb/set-getter.git"
       revision: "bfdd988ef9aa472ff05d6d6c7501c33bc36dc39e"
       path: ""
+  curations: []
 - package:
     id: "NPM::set-value:2.0.1"
     purl: "pkg:npm/set-value@2.0.1"
@@ -4110,6 +4227,7 @@ packages:
       url: "https://github.com/jonschlinkert/set-value.git"
       revision: "bb0f0382f7d7637f3de1bba52d1b4abdbbbde4d4"
       path: ""
+  curations: []
 - package:
     id: "NPM::snapdragon-node:1.0.6"
     purl: "pkg:npm/snapdragon-node@1.0.6"
@@ -4140,6 +4258,7 @@ packages:
       url: "https://github.com/jonschlinkert/snapdragon-node.git"
       revision: "bea9505d40be74b3c452039e72e857c9ae3c4b5e"
       path: ""
+  curations: []
 - package:
     id: "NPM::snapdragon-util:1.0.6"
     purl: "pkg:npm/snapdragon-util@1.0.6"
@@ -4169,6 +4288,7 @@ packages:
       url: "https://github.com/jonschlinkert/snapdragon-util.git"
       revision: "a8ee4265c9fd7638cadcd5159c023d7b877b83a6"
       path: ""
+  curations: []
 - package:
     id: "NPM::snapdragon-util:2.1.1"
     purl: "pkg:npm/snapdragon-util@2.1.1"
@@ -4198,6 +4318,7 @@ packages:
       url: "https://github.com/jonschlinkert/snapdragon-util.git"
       revision: "0ea032c8ea02010338568e82e8510a4054966203"
       path: ""
+  curations: []
 - package:
     id: "NPM::snapdragon:0.11.5"
     purl: "pkg:npm/snapdragon@0.11.5"
@@ -4228,6 +4349,7 @@ packages:
       url: "https://github.com/here-be/snapdragon.git"
       revision: "3067f0fe16d5d2771aea793c450f09cb2da533ca"
       path: ""
+  curations: []
 - package:
     id: "NPM::snapdragon:0.8.2"
     purl: "pkg:npm/snapdragon@0.8.2"
@@ -4257,6 +4379,7 @@ packages:
       url: "https://github.com/jonschlinkert/snapdragon.git"
       revision: "6c952b12cabe896a86d9a4fe378f934bccbe6436"
       path: ""
+  curations: []
 - package:
     id: "NPM::sort-by-value:0.1.0"
     purl: "pkg:npm/sort-by-value@0.1.0"
@@ -4287,6 +4410,7 @@ packages:
       url: "https://github.com/jonschlinkert/sort-by-value.git"
       revision: "e3ba2adb16e5efd28396f97367e19ed4913f74a6"
       path: ""
+  curations: []
 - package:
     id: "NPM::source-map-resolve:0.5.3"
     purl: "pkg:npm/source-map-resolve@0.5.3"
@@ -4316,6 +4440,7 @@ packages:
       url: "https://github.com/lydell/source-map-resolve.git"
       revision: "b8244f108af0aaf34c32a61e97b66e38db682afc"
       path: ""
+  curations: []
 - package:
     id: "NPM::source-map-url:0.4.0"
     purl: "pkg:npm/source-map-url@0.4.0"
@@ -4345,6 +4470,7 @@ packages:
       url: "https://github.com/lydell/source-map-url.git"
       revision: "f13c43ca675379922f26c87737fdcbbeac07eb09"
       path: ""
+  curations: []
 - package:
     id: "NPM::source-map:0.5.7"
     purl: "pkg:npm/source-map@0.5.7"
@@ -4374,6 +4500,7 @@ packages:
       url: "ssh://git@github.com/mozilla/source-map.git"
       revision: "326dd955a366569759d9537ef5f0f167c89d92d2"
       path: ""
+  curations: []
 - package:
     id: "NPM::source-map:0.6.1"
     purl: "pkg:npm/source-map@0.6.1"
@@ -4403,6 +4530,7 @@ packages:
       url: "ssh://git@github.com/mozilla/source-map.git"
       revision: "ac518d2f21818146f3310557bd51c13d8cff2ba8"
       path: ""
+  curations: []
 - package:
     id: "NPM::split-string:3.1.0"
     purl: "pkg:npm/split-string@3.1.0"
@@ -4432,6 +4560,7 @@ packages:
       url: "https://github.com/jonschlinkert/split-string.git"
       revision: "2f83feb70267a54ca01e795e6a0558a51b89d6c8"
       path: ""
+  curations: []
 - package:
     id: "NPM::sprintf-js:1.0.3"
     purl: "pkg:npm/sprintf-js@1.0.3"
@@ -4461,6 +4590,7 @@ packages:
       url: "https://github.com/alexei/sprintf.js.git"
       revision: "747b806c2dab5b64d5c9958c42884946a187c3b1"
       path: ""
+  curations: []
 - package:
     id: "NPM::static-extend:0.1.2"
     purl: "pkg:npm/static-extend@0.1.2"
@@ -4492,6 +4622,7 @@ packages:
       url: "https://github.com/jonschlinkert/static-extend.git"
       revision: "ce41369391163eb9403848a1b4daf00be981c56b"
       path: ""
+  curations: []
 - package:
     id: "NPM::string_decoder:1.1.1"
     purl: "pkg:npm/string_decoder@1.1.1"
@@ -4521,6 +4652,7 @@ packages:
       url: "https://github.com/nodejs/string_decoder.git"
       revision: "18c7f89c894ced5f610505bb006dfde9a3d1ac5e"
       path: ""
+  curations: []
 - package:
     id: "NPM::success-symbol:0.1.0"
     purl: "pkg:npm/success-symbol@0.1.0"
@@ -4550,6 +4682,7 @@ packages:
       url: "https://github.com/jonschlinkert/success-symbol.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::supports-color:5.4.0"
     purl: "pkg:npm/supports-color@5.4.0"
@@ -4579,6 +4712,7 @@ packages:
       url: "https://github.com/chalk/supports-color.git"
       revision: "bcd82c998094535f3462a3e37856852938ccbb37"
       path: ""
+  curations: []
 - package:
     id: "NPM::through2:2.0.5"
     purl: "pkg:npm/through2@2.0.5"
@@ -4609,6 +4743,7 @@ packages:
       url: "https://github.com/rvagg/through2.git"
       revision: "72a3cefc0ff1ad5cc178be04eb927f40166226f1"
       path: ""
+  curations: []
 - package:
     id: "NPM::to-gfm-code-block:0.1.1"
     purl: "pkg:npm/to-gfm-code-block@0.1.1"
@@ -4638,6 +4773,7 @@ packages:
       url: "https://github.com/jonschlinkert/to-gfm-code-block.git"
       revision: "52089279cf56ced49b7318684094e01954ac4fc6"
       path: ""
+  curations: []
 - package:
     id: "NPM::to-object-path:0.3.0"
     purl: "pkg:npm/to-object-path@0.3.0"
@@ -4667,6 +4803,7 @@ packages:
       url: "https://github.com/jonschlinkert/to-object-path.git"
       revision: "56f6627285b7f5b7563e6f3ffe3766d966368c17"
       path: ""
+  curations: []
 - package:
     id: "NPM::to-regex:3.0.2"
     purl: "pkg:npm/to-regex@3.0.2"
@@ -4696,6 +4833,7 @@ packages:
       url: "https://github.com/jonschlinkert/to-regex.git"
       revision: "cc5735f98f62c8e9cfb98ae5b309abea1c8a2432"
       path: ""
+  curations: []
 - package:
     id: "NPM::tokenize-comment:1.0.3"
     purl: "pkg:npm/tokenize-comment@1.0.3"
@@ -4727,6 +4865,7 @@ packages:
       url: "https://github.com/jonschlinkert/tokenize-comment.git"
       revision: "9132c85a7ab4ac99ec8aafb7288928c55e2ee613"
       path: ""
+  curations: []
 - package:
     id: "NPM::union-value:1.0.1"
     purl: "pkg:npm/union-value@1.0.1"
@@ -4757,6 +4896,7 @@ packages:
       url: "https://github.com/jonschlinkert/union-value.git"
       revision: "ae70c7747afc57d6d868fd55f80041e623d2df6a"
       path: ""
+  curations: []
 - package:
     id: "NPM::unset-value:1.0.0"
     purl: "pkg:npm/unset-value@1.0.0"
@@ -4786,6 +4926,7 @@ packages:
       url: "https://github.com/jonschlinkert/unset-value.git"
       revision: "36b62353cde18d6be17a1c0dc080fddcc262d2da"
       path: ""
+  curations: []
 - package:
     id: "NPM::urix:0.1.0"
     purl: "pkg:npm/urix@0.1.0"
@@ -4815,6 +4956,7 @@ packages:
       url: "https://github.com/lydell/urix.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::use:3.1.1"
     purl: "pkg:npm/use@3.1.1"
@@ -4844,6 +4986,7 @@ packages:
       url: "https://github.com/jonschlinkert/use.git"
       revision: "163104d5c5cc8ed35602625eb90a687df1dbc487"
       path: ""
+  curations: []
 - package:
     id: "NPM::util-deprecate:1.0.2"
     purl: "pkg:npm/util-deprecate@1.0.2"
@@ -4873,6 +5016,7 @@ packages:
       url: "https://github.com/TooTallNate/util-deprecate.git"
       revision: "475fb6857cd23fafff20c1be846c1350abf8e6d4"
       path: ""
+  curations: []
 - package:
     id: "NPM::vinyl:2.2.0"
     purl: "pkg:npm/vinyl@2.2.0"
@@ -4902,6 +5046,7 @@ packages:
       url: "https://github.com/gulpjs/vinyl.git"
       revision: "09c5bf424cca072c2ee63a7d3c68d885923f173c"
       path: ""
+  curations: []
 - package:
     id: "NPM::wrappy:1.0.2"
     purl: "pkg:npm/wrappy@1.0.2"
@@ -4931,6 +5076,7 @@ packages:
       url: "https://github.com/npm/wrappy.git"
       revision: "71d91b6dc5bdeac37e218c2cf03f9ab55b60d214"
       path: ""
+  curations: []
 - package:
     id: "NPM::write:0.3.3"
     purl: "pkg:npm/write@0.3.3"
@@ -4961,6 +5107,7 @@ packages:
       url: "https://github.com/jonschlinkert/write.git"
       revision: "d8d4b0ef32860c9e6f406d301c5266242489f3ee"
       path: ""
+  curations: []
 - package:
     id: "NPM::xtend:4.0.2"
     purl: "pkg:npm/xtend@4.0.2"
@@ -4990,3 +5137,4 @@ packages:
       url: "https://github.com/Raynos/xtend.git"
       revision: "37816c0e2e25da2901d584442235946d5cd8c80d"
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
@@ -53,6 +53,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "nuget::Newtonsoft.Json:5.0.4"
     purl: "pkg:nuget/Newtonsoft.Json@5.0.4"
@@ -83,6 +84,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "nuget::WebGrease:1.5.2"
     purl: "pkg:nuget/WebGrease@1.5.2"
@@ -114,6 +116,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "nuget::jQuery:3.3.1"
     purl: "pkg:nuget/jQuery@3.3.1"
@@ -149,3 +152,4 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output-with-provide.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output-with-provide.yml
@@ -53,6 +53,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:ort:virtual2:1.0.0"
     purl: "pkg:phpcomposer/ort/virtual2@1.0.0"
@@ -80,3 +81,4 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output-with-replace.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output-with-replace.yml
@@ -52,3 +52,4 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/php-composer-expected-output.yml
@@ -167,6 +167,7 @@ packages:
       url: "https://github.com/clue/php-stream-filter.git"
       revision: "5a58cc30a8bd6a4eb8f856adf61dd3e013f53f71"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:doctrine:instantiator:1.3.0"
     purl: "pkg:phpcomposer/doctrine/instantiator@1.3.0"
@@ -197,6 +198,7 @@ packages:
       url: "https://github.com/doctrine/instantiator.git"
       revision: "ae466f726242e637cebdd526a7d991b9433bacf1"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:guzzlehttp:guzzle:6.3.3"
     purl: "pkg:phpcomposer/guzzlehttp/guzzle@6.3.3"
@@ -226,6 +228,7 @@ packages:
       url: "https://github.com/guzzle/guzzle.git"
       revision: "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:guzzlehttp:promises:v1.3.1"
     purl: "pkg:phpcomposer/guzzlehttp/promises@v1.3.1"
@@ -255,6 +258,7 @@ packages:
       url: "https://github.com/guzzle/promises.git"
       revision: "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:guzzlehttp:psr7:1.4.0"
     purl: "pkg:phpcomposer/guzzlehttp/psr7@1.4.0"
@@ -284,6 +288,7 @@ packages:
       url: "https://github.com/guzzle/psr7.git"
       revision: "04a6d1a00ea5da0727ee94309a9f0d3dbaecb569"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:mailgun:mailgun-php:v2.4.0"
     purl: "pkg:phpcomposer/mailgun/mailgun-php@v2.4.0"
@@ -313,6 +318,7 @@ packages:
       url: "https://github.com/mailgun/mailgun-php.git"
       revision: "20783215042b181b0dec92c9e01947b93cb5d085"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:monolog:monolog:1.0.2"
     purl: "pkg:phpcomposer/monolog/monolog@1.0.2"
@@ -342,6 +348,7 @@ packages:
       url: "https://github.com/Seldaek/monolog.git"
       revision: "b704c49a3051536f67f2d39f13568f74615b9922"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:php-http:client-common:1.10.0"
     purl: "pkg:phpcomposer/php-http/client-common@1.10.0"
@@ -371,6 +378,7 @@ packages:
       url: "https://github.com/php-http/client-common.git"
       revision: "c0390ae3c8f2ae9d50901feef0127fb9e396f6b4"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:php-http:discovery:1.7.4"
     purl: "pkg:phpcomposer/php-http/discovery@1.7.4"
@@ -400,6 +408,7 @@ packages:
       url: "https://github.com/php-http/discovery.git"
       revision: "82dbef649ccffd8e4f22e1953c3a5265992b83c0"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:php-http:guzzle6-adapter:v1.0.0"
     purl: "pkg:phpcomposer/php-http/guzzle6-adapter@v1.0.0"
@@ -429,6 +438,7 @@ packages:
       url: "https://github.com/php-http/guzzle6-adapter.git"
       revision: "e884cf6dae5235fffd2a07f761e0066b9ebef170"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:php-http:httplug:v1.1.0"
     purl: "pkg:phpcomposer/php-http/httplug@v1.1.0"
@@ -458,6 +468,7 @@ packages:
       url: "https://github.com/php-http/httplug.git"
       revision: "1c6381726c18579c4ca2ef1ec1498fdae8bdf018"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:php-http:message-factory:v1.0.2"
     purl: "pkg:phpcomposer/php-http/message-factory@v1.0.2"
@@ -487,6 +498,7 @@ packages:
       url: "https://github.com/php-http/message-factory.git"
       revision: "a478cb11f66a6ac48d8954216cfed9aa06a501a1"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:php-http:message:1.8.0"
     purl: "pkg:phpcomposer/php-http/message@1.8.0"
@@ -516,6 +528,7 @@ packages:
       url: "https://github.com/php-http/message.git"
       revision: "ce8f43ac1e294b54aabf5808515c3554a19c1e1c"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:php-http:multipart-stream-builder:1.1.0"
     purl: "pkg:phpcomposer/php-http/multipart-stream-builder@1.1.0"
@@ -545,6 +558,7 @@ packages:
       url: "https://github.com/php-http/multipart-stream-builder.git"
       revision: "5d73adad53cf1d674dcc6c5b288a3ff3f76c4849"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:php-http:promise:v1.0.0"
     purl: "pkg:phpcomposer/php-http/promise@v1.0.0"
@@ -574,6 +588,7 @@ packages:
       url: "https://github.com/php-http/promise.git"
       revision: "dc494cdc9d7160b9a09bd5573272195242ce7980"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:phpdocumentor:reflection-common:2.0.0"
     purl: "pkg:phpcomposer/phpdocumentor/reflection-common@2.0.0"
@@ -604,6 +619,7 @@ packages:
       url: "https://github.com/phpDocumentor/ReflectionCommon.git"
       revision: "63a995caa1ca9e5590304cd845c15ad6d482a62a"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:phpdocumentor:reflection-docblock:5.1.0"
     purl: "pkg:phpcomposer/phpdocumentor/reflection-docblock@5.1.0"
@@ -634,6 +650,7 @@ packages:
       url: "https://github.com/phpDocumentor/ReflectionDocBlock.git"
       revision: "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:phpdocumentor:type-resolver:1.1.0"
     purl: "pkg:phpcomposer/phpdocumentor/type-resolver@1.1.0"
@@ -664,6 +681,7 @@ packages:
       url: "https://github.com/phpDocumentor/TypeResolver.git"
       revision: "7462d5f123dfc080dfdf26897032a6513644fc95"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:phpspec:prophecy:v1.10.3"
     purl: "pkg:phpcomposer/phpspec/prophecy@v1.10.3"
@@ -693,6 +711,7 @@ packages:
       url: "https://github.com/phpspec/prophecy.git"
       revision: "451c3cd1418cf640de218914901e51b064abb093"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:phpunit:php-code-coverage:2.2.4"
     purl: "pkg:phpcomposer/phpunit/php-code-coverage@2.2.4"
@@ -723,6 +742,7 @@ packages:
       url: "https://github.com/sebastianbergmann/php-code-coverage.git"
       revision: "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:phpunit:php-file-iterator:1.4.5"
     purl: "pkg:phpcomposer/phpunit/php-file-iterator@1.4.5"
@@ -753,6 +773,7 @@ packages:
       url: "https://github.com/sebastianbergmann/php-file-iterator.git"
       revision: "730b01bc3e867237eaac355e06a36b85dd93a8b4"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:phpunit:php-text-template:1.2.1"
     purl: "pkg:phpcomposer/phpunit/php-text-template@1.2.1"
@@ -782,6 +803,7 @@ packages:
       url: "https://github.com/sebastianbergmann/php-text-template.git"
       revision: "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:phpunit:php-timer:2.1.2"
     purl: "pkg:phpcomposer/phpunit/php-timer@2.1.2"
@@ -811,6 +833,7 @@ packages:
       url: "https://github.com/sebastianbergmann/php-timer.git"
       revision: "1038454804406b0b5f5f520358e78c1c2f71501e"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:phpunit:php-token-stream:1.4.12"
     purl: "pkg:phpcomposer/phpunit/php-token-stream@1.4.12"
@@ -840,6 +863,7 @@ packages:
       url: "https://github.com/sebastianbergmann/php-token-stream.git"
       revision: "1ce90ba27c42e4e44e6d8458241466380b51fa16"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:phpunit:phpunit-mock-objects:2.3.8"
     purl: "pkg:phpcomposer/phpunit/phpunit-mock-objects@2.3.8"
@@ -869,6 +893,7 @@ packages:
       url: "https://github.com/sebastianbergmann/phpunit-mock-objects.git"
       revision: "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:phpunit:phpunit:4.8.0"
     purl: "pkg:phpcomposer/phpunit/phpunit@4.8.0"
@@ -898,6 +923,7 @@ packages:
       url: "https://github.com/sebastianbergmann/phpunit.git"
       revision: "283111a903eb9225aedb95e846bef876e006a688"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:psr:http-factory:1.0.1"
     purl: "pkg:phpcomposer/psr/http-factory@1.0.1"
@@ -927,6 +953,7 @@ packages:
       url: "https://github.com/php-fig/http-factory.git"
       revision: "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:psr:http-message:1.0.1"
     purl: "pkg:phpcomposer/psr/http-message@1.0.1"
@@ -956,6 +983,7 @@ packages:
       url: "https://github.com/php-fig/http-message.git"
       revision: "f6561bf28d520154e4b0ec72be95418abe6d9363"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:sebastian:comparator:1.2.4"
     purl: "pkg:phpcomposer/sebastian/comparator@1.2.4"
@@ -985,6 +1013,7 @@ packages:
       url: "https://github.com/sebastianbergmann/comparator.git"
       revision: "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:sebastian:diff:1.4.3"
     purl: "pkg:phpcomposer/sebastian/diff@1.4.3"
@@ -1014,6 +1043,7 @@ packages:
       url: "https://github.com/sebastianbergmann/diff.git"
       revision: "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:sebastian:environment:1.3.8"
     purl: "pkg:phpcomposer/sebastian/environment@1.3.8"
@@ -1043,6 +1073,7 @@ packages:
       url: "https://github.com/sebastianbergmann/environment.git"
       revision: "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:sebastian:exporter:1.2.2"
     purl: "pkg:phpcomposer/sebastian/exporter@1.2.2"
@@ -1072,6 +1103,7 @@ packages:
       url: "https://github.com/sebastianbergmann/exporter.git"
       revision: "42c4c2eec485ee3e159ec9884f95b431287edde4"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:sebastian:global-state:1.1.1"
     purl: "pkg:phpcomposer/sebastian/global-state@1.1.1"
@@ -1101,6 +1133,7 @@ packages:
       url: "https://github.com/sebastianbergmann/global-state.git"
       revision: "bc37d50fea7d017d3d340f230811c9f1d7280af4"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:sebastian:recursion-context:1.0.5"
     purl: "pkg:phpcomposer/sebastian/recursion-context@1.0.5"
@@ -1130,6 +1163,7 @@ packages:
       url: "https://github.com/sebastianbergmann/recursion-context.git"
       revision: "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:sebastian:version:1.0.6"
     purl: "pkg:phpcomposer/sebastian/version@1.0.6"
@@ -1160,6 +1194,7 @@ packages:
       url: "https://github.com/sebastianbergmann/version.git"
       revision: "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:symfony:options-resolver:v5.0.7"
     purl: "pkg:phpcomposer/symfony/options-resolver@v5.0.7"
@@ -1189,6 +1224,7 @@ packages:
       url: "https://github.com/symfony/options-resolver.git"
       revision: "09dccfffd24b311df7f184aa80ee7b61ad61ed8d"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:symfony:polyfill-ctype:v1.15.0"
     purl: "pkg:phpcomposer/symfony/polyfill-ctype@v1.15.0"
@@ -1218,6 +1254,7 @@ packages:
       url: "https://github.com/symfony/polyfill-ctype.git"
       revision: "4719fa9c18b0464d399f1a63bf624b42b6fa8d14"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:symfony:yaml:v3.4.39"
     purl: "pkg:phpcomposer/symfony/yaml@v3.4.39"
@@ -1247,6 +1284,7 @@ packages:
       url: "https://github.com/symfony/yaml.git"
       revision: "e701b47e11749970f63803879c4febb520f07b6c"
       path: ""
+  curations: []
 - package:
     id: "PhpComposer:webmozart:assert:1.7.0"
     purl: "pkg:phpcomposer/webmozart/assert@1.7.0"
@@ -1276,3 +1314,4 @@ packages:
       url: "https://github.com/webmozart/assert.git"
       revision: "aed98a490f9a8f78468232db345ab9cf606cf598"
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -64,6 +64,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::Jinja2:2.10.1"
     purl: "pkg:pypi/Jinja2@2.10.1"
@@ -98,6 +99,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::MarkupSafe:1.0"
     purl: "pkg:pypi/MarkupSafe@1.0"
@@ -131,6 +133,7 @@ packages:
       url: "https://github.com/pallets/markupsafe.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::Werkzeug:0.15.3"
     purl: "pkg:pypi/Werkzeug@0.15.3"
@@ -163,6 +166,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::click:6.7"
     purl: "pkg:pypi/click@6.7"
@@ -194,6 +198,7 @@ packages:
       url: "https://github.com/mitsuhiko/click.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::itsdangerous:0.24"
     purl: "pkg:pypi/itsdangerous@0.24"
@@ -226,3 +231,4 @@ packages:
       url: "https://github.com/mitsuhiko/itsdangerous.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-python3-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-python3-expected-output.yml
@@ -57,6 +57,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::pytz:2020.1"
     purl: "pkg:pypi/pytz@2020.1"
@@ -89,6 +90,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::sqlparse:0.3.1"
     purl: "pkg:pypi/sqlparse@0.3.1"
@@ -122,3 +124,4 @@ packages:
       url: "https://github.com/andialbrecht/sqlparse.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
@@ -60,6 +60,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::Jinja2:2.10.1"
     purl: "pkg:pypi/Jinja2@2.10.1"
@@ -94,6 +95,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::MarkupSafe:1.0"
     purl: "pkg:pypi/MarkupSafe@1.0"
@@ -127,6 +129,7 @@ packages:
       url: "https://github.com/pallets/markupsafe.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::Werkzeug:0.15.3"
     purl: "pkg:pypi/Werkzeug@0.15.3"
@@ -159,6 +162,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::click:6.7"
     purl: "pkg:pypi/click@6.7"
@@ -190,6 +194,7 @@ packages:
       url: "https://github.com/mitsuhiko/click.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::itsdangerous:0.24"
     purl: "pkg:pypi/itsdangerous@0.24"
@@ -222,3 +227,4 @@ packages:
       url: "https://github.com/mitsuhiko/itsdangerous.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/pipenv-python3-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pipenv-python3-expected-output.yml
@@ -56,6 +56,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "PyPI::pytz:2019.3"
     purl: "pkg:pypi/pytz@2019.3"
@@ -88,3 +89,4 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/pub-expected-output-any-version.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pub-expected-output-any-version.yml
@@ -121,6 +121,7 @@ packages:
       url: "https://github.com/dart-lang/sdk.git"
       revision: "master"
       path: "pkg/analyzer"
+  curations: []
 - package:
     id: "Pub:args:args:1.5.2"
     purl: "pkg:pub/args/args@1.5.2"
@@ -149,6 +150,7 @@ packages:
       url: "https://github.com/dart-lang/args.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:async:async:2.2.0"
     purl: "pkg:pub/async/async@2.2.0"
@@ -176,6 +178,7 @@ packages:
       url: "https://github.com/dart-lang/async.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:boolean_selector:boolean_selector:1.0.5"
     purl: "pkg:pub/boolean_selector/boolean_selector@1.0.5"
@@ -204,6 +207,7 @@ packages:
       url: "https://github.com/dart-lang/boolean_selector.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:charcode:charcode:1.1.2"
     purl: "pkg:pub/charcode/charcode@1.1.2"
@@ -234,6 +238,7 @@ packages:
       url: "https://github.com/dart-lang/charcode.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:collection:collection:1.14.11"
     purl: "pkg:pub/collection/collection@1.14.11"
@@ -261,6 +266,7 @@ packages:
       url: "https://github.com/dart-lang/collection.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:convert:convert:2.1.1"
     purl: "pkg:pub/convert/convert@2.1.1"
@@ -288,6 +294,7 @@ packages:
       url: "https://github.com/dart-lang/convert.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:crypto:crypto:2.0.6"
     purl: "pkg:pub/crypto/crypto@2.0.6"
@@ -315,6 +322,7 @@ packages:
       url: "https://github.com/dart-lang/crypto.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:csslib:csslib:0.16.0"
     purl: "pkg:pub/csslib/csslib@0.16.0"
@@ -342,6 +350,7 @@ packages:
       url: "https://github.com/dart-lang/csslib.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:fixnum:fixnum:0.10.9"
     purl: "pkg:pub/fixnum/fixnum@0.10.9"
@@ -369,6 +378,7 @@ packages:
       url: "https://github.com/dart-lang/fixnum.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:front_end:front_end:0.1.19"
     purl: "pkg:pub/front_end/front_end@0.1.19"
@@ -396,6 +406,7 @@ packages:
       url: "https://github.com/dart-lang/sdk.git"
       revision: "master"
       path: "pkg/front_end"
+  curations: []
 - package:
     id: "Pub:glob:glob:1.1.7"
     purl: "pkg:pub/glob/glob@1.1.7"
@@ -423,6 +434,7 @@ packages:
       url: "https://github.com/dart-lang/glob.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:html:html:0.14.0+2"
     purl: "pkg:pub/html/html@0.14.0%2B2"
@@ -450,6 +462,7 @@ packages:
       url: "https://github.com/dart-lang/html.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:http:http:0.12.0+2"
     purl: "pkg:pub/http/http@0.12.0%2B2"
@@ -477,6 +490,7 @@ packages:
       url: "https://github.com/dart-lang/http.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:http_multi_server:http_multi_server:2.1.0"
     purl: "pkg:pub/http_multi_server/http_multi_server@2.1.0"
@@ -505,6 +519,7 @@ packages:
       url: "https://github.com/dart-lang/http_multi_server.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:http_parser:http_parser:3.1.3"
     purl: "pkg:pub/http_parser/http_parser@3.1.3"
@@ -533,6 +548,7 @@ packages:
       url: "https://github.com/dart-lang/http_parser.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:io:io:0.3.3"
     purl: "pkg:pub/io/io@0.3.3"
@@ -560,6 +576,7 @@ packages:
       url: "https://github.com/dart-lang/io.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:js:js:0.6.1+1"
     purl: "pkg:pub/js/js@0.6.1%2B1"
@@ -587,6 +604,7 @@ packages:
       url: "https://github.com/dart-lang/sdk.git"
       revision: "master"
       path: "pkg/js"
+  curations: []
 - package:
     id: "Pub:json_rpc_2:json_rpc_2:2.1.0"
     purl: "pkg:pub/json_rpc_2/json_rpc_2@2.1.0"
@@ -614,6 +632,7 @@ packages:
       url: "https://github.com/dart-lang/json_rpc_2.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:kernel:kernel:0.3.19"
     purl: "pkg:pub/kernel/kernel@0.3.19"
@@ -641,6 +660,7 @@ packages:
       url: "https://github.com/dart-lang/sdk.git"
       revision: "master"
       path: "pkg/kernel"
+  curations: []
 - package:
     id: "Pub:matcher:matcher:0.12.5"
     purl: "pkg:pub/matcher/matcher@0.12.5"
@@ -670,6 +690,7 @@ packages:
       url: "https://github.com/dart-lang/matcher.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:meta:meta:1.1.7"
     purl: "pkg:pub/meta/meta@1.1.7"
@@ -699,6 +720,7 @@ packages:
       url: "https://github.com/dart-lang/sdk.git"
       revision: "master"
       path: "pkg/meta"
+  curations: []
 - package:
     id: "Pub:mime:mime:0.9.6+3"
     purl: "pkg:pub/mime/mime@0.9.6%2B3"
@@ -727,6 +749,7 @@ packages:
       url: "https://github.com/dart-lang/mime.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:multi_server_socket:multi_server_socket:1.0.2"
     purl: "pkg:pub/multi_server_socket/multi_server_socket@1.0.2"
@@ -754,6 +777,7 @@ packages:
       url: "https://github.com/dart-lang/multi_server_socket.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:node_preamble:node_preamble:1.4.4"
     purl: "pkg:pub/node_preamble/node_preamble@1.4.4"
@@ -781,6 +805,7 @@ packages:
       url: "https://github.com/mbullington/node_preamble.dart.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:package_config:package_config:1.0.5"
     purl: "pkg:pub/package_config/package_config@1.0.5"
@@ -808,6 +833,7 @@ packages:
       url: "https://github.com/dart-lang/package_config.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:package_resolver:package_resolver:1.0.10"
     purl: "pkg:pub/package_resolver/package_resolver@1.0.10"
@@ -835,6 +861,7 @@ packages:
       url: "https://github.com/dart-lang/package_resolver.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:path:path:1.6.2"
     purl: "pkg:pub/path/path@1.6.2"
@@ -864,6 +891,7 @@ packages:
       url: "https://github.com/dart-lang/path.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:pedantic:pedantic:1.7.0"
     purl: "pkg:pub/pedantic/pedantic@1.7.0"
@@ -891,6 +919,7 @@ packages:
       url: "https://github.com/dart-lang/pedantic.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:pool:pool:1.4.0"
     purl: "pkg:pub/pool/pool@1.4.0"
@@ -919,6 +948,7 @@ packages:
       url: "https://github.com/dart-lang/pool.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:protobuf:protobuf:0.13.12"
     purl: "pkg:pub/protobuf/protobuf@0.13.12"
@@ -947,6 +977,7 @@ packages:
       url: "https://github.com/dart-lang/protobuf.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:pub_semver:pub_semver:1.4.2"
     purl: "pkg:pub/pub_semver/pub_semver@1.4.2"
@@ -975,6 +1006,7 @@ packages:
       url: "https://github.com/dart-lang/pub_semver.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:shelf:shelf:0.7.5"
     purl: "pkg:pub/shelf/shelf@0.7.5"
@@ -1003,6 +1035,7 @@ packages:
       url: "https://github.com/dart-lang/shelf.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:shelf_packages_handler:shelf_packages_handler:1.0.4"
     purl: "pkg:pub/shelf_packages_handler/shelf_packages_handler@1.0.4"
@@ -1030,6 +1063,7 @@ packages:
       url: "https://github.com/dart-lang/shelf_packages_handler.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:shelf_static:shelf_static:0.2.8"
     purl: "pkg:pub/shelf_static/shelf_static@0.2.8"
@@ -1057,6 +1091,7 @@ packages:
       url: "https://github.com/dart-lang/shelf_static.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:shelf_web_socket:shelf_web_socket:0.2.3"
     purl: "pkg:pub/shelf_web_socket/shelf_web_socket@0.2.3"
@@ -1084,6 +1119,7 @@ packages:
       url: "https://github.com/dart-lang/shelf_web_socket.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:source_map_stack_trace:source_map_stack_trace:1.1.5"
     purl: "pkg:pub/source_map_stack_trace/source_map_stack_trace@1.1.5"
@@ -1111,6 +1147,7 @@ packages:
       url: "https://github.com/dart-lang/source_map_stack_trace.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:source_maps:source_maps:0.10.8"
     purl: "pkg:pub/source_maps/source_maps@0.10.8"
@@ -1138,6 +1175,7 @@ packages:
       url: "https://github.com/dart-lang/source_maps.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:source_span:source_span:1.5.5"
     purl: "pkg:pub/source_span/source_span@1.5.5"
@@ -1165,6 +1203,7 @@ packages:
       url: "https://github.com/dart-lang/source_span.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:stack_trace:stack_trace:1.9.3"
     purl: "pkg:pub/stack_trace/stack_trace@1.9.3"
@@ -1192,6 +1231,7 @@ packages:
       url: "https://github.com/dart-lang/stack_trace.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:stream_channel:stream_channel:2.0.0"
     purl: "pkg:pub/stream_channel/stream_channel@2.0.0"
@@ -1219,6 +1259,7 @@ packages:
       url: "https://github.com/dart-lang/stream_channel.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:string_scanner:string_scanner:1.0.4"
     purl: "pkg:pub/string_scanner/string_scanner@1.0.4"
@@ -1246,6 +1287,7 @@ packages:
       url: "https://github.com/dart-lang/string_scanner.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:term_glyph:term_glyph:1.1.0"
     purl: "pkg:pub/term_glyph/term_glyph@1.1.0"
@@ -1273,6 +1315,7 @@ packages:
       url: "https://github.com/dart-lang/term_glyph.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:test:test:1.6.4"
     purl: "pkg:pub/test/test@1.6.4"
@@ -1300,6 +1343,7 @@ packages:
       url: "https://github.com/dart-lang/test.git"
       revision: "master"
       path: "pkgs/test"
+  curations: []
 - package:
     id: "Pub:test_api:test_api:0.2.6"
     purl: "pkg:pub/test_api/test_api@0.2.6"
@@ -1327,6 +1371,7 @@ packages:
       url: "https://github.com/dart-lang/test.git"
       revision: "master"
       path: "pkgs/test_api"
+  curations: []
 - package:
     id: "Pub:test_core:test_core:0.2.6"
     purl: "pkg:pub/test_core/test_core@0.2.6"
@@ -1354,6 +1399,7 @@ packages:
       url: "https://github.com/dart-lang/test.git"
       revision: "master"
       path: "pkgs/test_core"
+  curations: []
 - package:
     id: "Pub:typed_data:typed_data:1.1.6"
     purl: "pkg:pub/typed_data/typed_data@1.1.6"
@@ -1381,6 +1427,7 @@ packages:
       url: "https://github.com/dart-lang/typed_data.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:vm_service_client:vm_service_client:0.2.6+2"
     purl: "pkg:pub/vm_service_client/vm_service_client@0.2.6%2B2"
@@ -1408,6 +1455,7 @@ packages:
       url: "https://github.com/dart-lang/vm_service_client.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:watcher:watcher:0.9.7+10"
     purl: "pkg:pub/watcher/watcher@0.9.7%2B10"
@@ -1436,6 +1484,7 @@ packages:
       url: "https://github.com/dart-lang/watcher.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:web_socket_channel:web_socket_channel:1.0.13"
     purl: "pkg:pub/web_socket_channel/web_socket_channel@1.0.13"
@@ -1465,6 +1514,7 @@ packages:
       url: "https://github.com/dart-lang/web_socket_channel.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:yaml:yaml:2.1.16"
     purl: "pkg:pub/yaml/yaml@2.1.16"
@@ -1492,3 +1542,4 @@ packages:
       url: "https://github.com/dart-lang/yaml.git"
       revision: ""
       path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/pub-expected-output-project-with-flutter.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pub-expected-output-project-with-flutter.yml
@@ -152,6 +152,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:com.crashlytics.sdk.android:beta:1.2.10"
     purl: "pkg:maven/com.crashlytics.sdk.android/beta@1.2.10"
@@ -182,6 +183,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:com.crashlytics.sdk.android:crashlytics-core:2.6.8"
     purl: "pkg:maven/com.crashlytics.sdk.android/crashlytics-core@2.6.8"
@@ -212,6 +214,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:com.crashlytics.sdk.android:crashlytics-ndk:2.0.5"
     purl: "pkg:maven/com.crashlytics.sdk.android/crashlytics-ndk@2.0.5"
@@ -242,6 +245,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:com.crashlytics.sdk.android:crashlytics:2.9.9"
     purl: "pkg:maven/com.crashlytics.sdk.android/crashlytics@2.9.9"
@@ -272,6 +276,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Maven:io.fabric.sdk.android:fabric:1.4.8"
     purl: "pkg:maven/io.fabric.sdk.android/fabric@1.4.8"
@@ -302,6 +307,7 @@ packages:
       url: ""
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:analyzer:analyzer:0.36.4"
     purl: "pkg:pub/analyzer/analyzer@0.36.4"
@@ -329,6 +335,7 @@ packages:
       url: "https://github.com/dart-lang/sdk.git"
       revision: "master"
       path: "pkg/analyzer"
+  curations: []
 - package:
     id: "Pub:archive:archive:2.0.11"
     purl: "pkg:pub/archive/archive@2.0.11"
@@ -357,6 +364,7 @@ packages:
       url: "https://github.com/brendan-duncan/archive.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:args:args:1.5.2"
     purl: "pkg:pub/args/args@1.5.2"
@@ -385,6 +393,7 @@ packages:
       url: "https://github.com/dart-lang/args.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:async:async:2.4.0"
     purl: "pkg:pub/async/async@2.4.0"
@@ -412,6 +421,7 @@ packages:
       url: "https://github.com/dart-lang/async.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:boolean_selector:boolean_selector:1.0.5"
     purl: "pkg:pub/boolean_selector/boolean_selector@1.0.5"
@@ -440,6 +450,7 @@ packages:
       url: "https://github.com/dart-lang/boolean_selector.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:charcode:charcode:1.1.2"
     purl: "pkg:pub/charcode/charcode@1.1.2"
@@ -470,6 +481,7 @@ packages:
       url: "https://github.com/dart-lang/charcode.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:collection:collection:1.14.11"
     purl: "pkg:pub/collection/collection@1.14.11"
@@ -497,6 +509,7 @@ packages:
       url: "https://github.com/dart-lang/collection.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:convert:convert:2.1.1"
     purl: "pkg:pub/convert/convert@2.1.1"
@@ -524,6 +537,7 @@ packages:
       url: "https://github.com/dart-lang/convert.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:coverage:coverage:0.13.7"
     purl: "pkg:pub/coverage/coverage@0.13.7"
@@ -551,6 +565,7 @@ packages:
       url: "https://github.com/dart-lang/coverage.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:crypto:crypto:2.1.3"
     purl: "pkg:pub/crypto/crypto@2.1.3"
@@ -578,6 +593,7 @@ packages:
       url: "https://github.com/dart-lang/crypto.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:csslib:csslib:0.16.0"
     purl: "pkg:pub/csslib/csslib@0.16.0"
@@ -605,6 +621,7 @@ packages:
       url: "https://github.com/dart-lang/csslib.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:flutter:flutter:0.0.0"
     purl: "pkg:pub/flutter/flutter@0.0.0"
@@ -632,6 +649,7 @@ packages:
       url: "https://github.com/flutter/flutter.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:flutter:flutter:0.0.99"
     purl: "pkg:pub/flutter/flutter@0.0.99"
@@ -659,6 +677,7 @@ packages:
       url: "https://github.com/flutter/flutter.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:flutter_crashlytics:flutter_crashlytics:1.0.0"
     purl: "pkg:pub/flutter_crashlytics/flutter_crashlytics@1.0.0"
@@ -687,6 +706,7 @@ packages:
       url: "https://github.com/kiwi-bop/flutter_crashlytics.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:front_end:front_end:0.1.19"
     purl: "pkg:pub/front_end/front_end@0.1.19"
@@ -714,6 +734,7 @@ packages:
       url: "https://github.com/dart-lang/sdk.git"
       revision: "master"
       path: "pkg/front_end"
+  curations: []
 - package:
     id: "Pub:glob:glob:1.1.7"
     purl: "pkg:pub/glob/glob@1.1.7"
@@ -741,6 +762,7 @@ packages:
       url: "https://github.com/dart-lang/glob.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:html:html:0.14.0+2"
     purl: "pkg:pub/html/html@0.14.0%2B2"
@@ -768,6 +790,7 @@ packages:
       url: "https://github.com/dart-lang/html.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:http:http:0.12.0+2"
     purl: "pkg:pub/http/http@0.12.0%2B2"
@@ -795,6 +818,7 @@ packages:
       url: "https://github.com/dart-lang/http.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:http_multi_server:http_multi_server:2.1.0"
     purl: "pkg:pub/http_multi_server/http_multi_server@2.1.0"
@@ -823,6 +847,7 @@ packages:
       url: "https://github.com/dart-lang/http_multi_server.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:http_parser:http_parser:3.1.3"
     purl: "pkg:pub/http_parser/http_parser@3.1.3"
@@ -851,6 +876,7 @@ packages:
       url: "https://github.com/dart-lang/http_parser.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:image:image:2.1.4"
     purl: "pkg:pub/image/image@2.1.4"
@@ -880,6 +906,7 @@ packages:
       url: "https://github.com/brendan-duncan/image.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:io:io:0.3.3"
     purl: "pkg:pub/io/io@0.3.3"
@@ -907,6 +934,7 @@ packages:
       url: "https://github.com/dart-lang/io.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:js:js:0.6.1+1"
     purl: "pkg:pub/js/js@0.6.1%2B1"
@@ -934,6 +962,7 @@ packages:
       url: "https://github.com/dart-lang/sdk.git"
       revision: "master"
       path: "pkg/js"
+  curations: []
 - package:
     id: "Pub:kernel:kernel:0.3.19"
     purl: "pkg:pub/kernel/kernel@0.3.19"
@@ -961,6 +990,7 @@ packages:
       url: "https://github.com/dart-lang/sdk.git"
       revision: "master"
       path: "pkg/kernel"
+  curations: []
 - package:
     id: "Pub:logging:logging:0.11.4"
     purl: "pkg:pub/logging/logging@0.11.4"
@@ -990,6 +1020,7 @@ packages:
       url: "https://github.com/dart-lang/logging.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:matcher:matcher:0.12.6"
     purl: "pkg:pub/matcher/matcher@0.12.6"
@@ -1019,6 +1050,7 @@ packages:
       url: "https://github.com/dart-lang/matcher.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:meta:meta:1.1.8"
     purl: "pkg:pub/meta/meta@1.1.8"
@@ -1048,6 +1080,7 @@ packages:
       url: "https://github.com/dart-lang/sdk.git"
       revision: "master"
       path: "pkg/meta"
+  curations: []
 - package:
     id: "Pub:mime:mime:0.9.6+3"
     purl: "pkg:pub/mime/mime@0.9.6%2B3"
@@ -1076,6 +1109,7 @@ packages:
       url: "https://github.com/dart-lang/mime.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:multi_server_socket:multi_server_socket:1.0.2"
     purl: "pkg:pub/multi_server_socket/multi_server_socket@1.0.2"
@@ -1103,6 +1137,7 @@ packages:
       url: "https://github.com/dart-lang/multi_server_socket.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:node_preamble:node_preamble:1.4.4"
     purl: "pkg:pub/node_preamble/node_preamble@1.4.4"
@@ -1130,6 +1165,7 @@ packages:
       url: "https://github.com/mbullington/node_preamble.dart.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:package_config:package_config:1.0.5"
     purl: "pkg:pub/package_config/package_config@1.0.5"
@@ -1157,6 +1193,7 @@ packages:
       url: "https://github.com/dart-lang/package_config.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:package_resolver:package_resolver:1.0.10"
     purl: "pkg:pub/package_resolver/package_resolver@1.0.10"
@@ -1184,6 +1221,7 @@ packages:
       url: "https://github.com/dart-lang/package_resolver.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:path:path:1.6.4"
     purl: "pkg:pub/path/path@1.6.4"
@@ -1213,6 +1251,7 @@ packages:
       url: "https://github.com/dart-lang/path.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:pedantic:pedantic:1.8.0+1"
     purl: "pkg:pub/pedantic/pedantic@1.8.0%2B1"
@@ -1240,6 +1279,7 @@ packages:
       url: "https://github.com/dart-lang/pedantic.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:petitparser:petitparser:2.4.0"
     purl: "pkg:pub/petitparser/petitparser@2.4.0"
@@ -1268,6 +1308,7 @@ packages:
       url: "https://github.com/petitparser/dart-petitparser.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:pool:pool:1.4.0"
     purl: "pkg:pub/pool/pool@1.4.0"
@@ -1296,6 +1337,7 @@ packages:
       url: "https://github.com/dart-lang/pool.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:pub_semver:pub_semver:1.4.2"
     purl: "pkg:pub/pub_semver/pub_semver@1.4.2"
@@ -1324,6 +1366,7 @@ packages:
       url: "https://github.com/dart-lang/pub_semver.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:quiver:quiver:2.0.5"
     purl: "pkg:pub/quiver/quiver@2.0.5"
@@ -1351,6 +1394,7 @@ packages:
       url: "https://github.com/google/quiver-dart.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:shelf:shelf:0.7.5"
     purl: "pkg:pub/shelf/shelf@0.7.5"
@@ -1379,6 +1423,7 @@ packages:
       url: "https://github.com/dart-lang/shelf.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:shelf_packages_handler:shelf_packages_handler:1.0.4"
     purl: "pkg:pub/shelf_packages_handler/shelf_packages_handler@1.0.4"
@@ -1406,6 +1451,7 @@ packages:
       url: "https://github.com/dart-lang/shelf_packages_handler.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:shelf_static:shelf_static:0.2.8"
     purl: "pkg:pub/shelf_static/shelf_static@0.2.8"
@@ -1433,6 +1479,7 @@ packages:
       url: "https://github.com/dart-lang/shelf_static.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:shelf_web_socket:shelf_web_socket:0.2.3"
     purl: "pkg:pub/shelf_web_socket/shelf_web_socket@0.2.3"
@@ -1460,6 +1507,7 @@ packages:
       url: "https://github.com/dart-lang/shelf_web_socket.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:source_map_stack_trace:source_map_stack_trace:1.1.5"
     purl: "pkg:pub/source_map_stack_trace/source_map_stack_trace@1.1.5"
@@ -1487,6 +1535,7 @@ packages:
       url: "https://github.com/dart-lang/source_map_stack_trace.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:source_maps:source_maps:0.10.8"
     purl: "pkg:pub/source_maps/source_maps@0.10.8"
@@ -1514,6 +1563,7 @@ packages:
       url: "https://github.com/dart-lang/source_maps.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:source_span:source_span:1.5.5"
     purl: "pkg:pub/source_span/source_span@1.5.5"
@@ -1541,6 +1591,7 @@ packages:
       url: "https://github.com/dart-lang/source_span.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:stack_trace:stack_trace:1.9.3"
     purl: "pkg:pub/stack_trace/stack_trace@1.9.3"
@@ -1568,6 +1619,7 @@ packages:
       url: "https://github.com/dart-lang/stack_trace.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:stream_channel:stream_channel:2.0.0"
     purl: "pkg:pub/stream_channel/stream_channel@2.0.0"
@@ -1595,6 +1647,7 @@ packages:
       url: "https://github.com/dart-lang/stream_channel.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:string_scanner:string_scanner:1.0.5"
     purl: "pkg:pub/string_scanner/string_scanner@1.0.5"
@@ -1622,6 +1675,7 @@ packages:
       url: "https://github.com/dart-lang/string_scanner.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:term_glyph:term_glyph:1.1.0"
     purl: "pkg:pub/term_glyph/term_glyph@1.1.0"
@@ -1649,6 +1703,7 @@ packages:
       url: "https://github.com/dart-lang/term_glyph.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:test:test:1.9.4"
     purl: "pkg:pub/test/test@1.9.4"
@@ -1676,6 +1731,7 @@ packages:
       url: "https://github.com/dart-lang/test.git"
       revision: "master"
       path: "pkgs/test"
+  curations: []
 - package:
     id: "Pub:test_api:test_api:0.2.11"
     purl: "pkg:pub/test_api/test_api@0.2.11"
@@ -1703,6 +1759,7 @@ packages:
       url: "https://github.com/dart-lang/test.git"
       revision: "master"
       path: "pkgs/test_api"
+  curations: []
 - package:
     id: "Pub:test_core:test_core:0.2.15"
     purl: "pkg:pub/test_core/test_core@0.2.15"
@@ -1730,6 +1787,7 @@ packages:
       url: "https://github.com/dart-lang/test.git"
       revision: "master"
       path: "pkgs/test_core"
+  curations: []
 - package:
     id: "Pub:typed_data:typed_data:1.1.6"
     purl: "pkg:pub/typed_data/typed_data@1.1.6"
@@ -1757,6 +1815,7 @@ packages:
       url: "https://github.com/dart-lang/typed_data.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:vector_math:vector_math:2.0.8"
     purl: "pkg:pub/vector_math/vector_math@2.0.8"
@@ -1784,6 +1843,7 @@ packages:
       url: "https://github.com/google/vector_math.dart.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:vm_service:vm_service:2.3.1"
     purl: "pkg:pub/vm_service/vm_service@2.3.1"
@@ -1812,6 +1872,7 @@ packages:
       url: "https://github.com/dart-lang/sdk.git"
       revision: "master"
       path: "pkg/vm_service"
+  curations: []
 - package:
     id: "Pub:watcher:watcher:0.9.7+10"
     purl: "pkg:pub/watcher/watcher@0.9.7%2B10"
@@ -1840,6 +1901,7 @@ packages:
       url: "https://github.com/dart-lang/watcher.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:web_socket_channel:web_socket_channel:1.0.13"
     purl: "pkg:pub/web_socket_channel/web_socket_channel@1.0.13"
@@ -1869,6 +1931,7 @@ packages:
       url: "https://github.com/dart-lang/web_socket_channel.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:xml:xml:3.5.0"
     purl: "pkg:pub/xml/xml@3.5.0"
@@ -1897,6 +1960,7 @@ packages:
       url: "https://github.com/renggli/dart-xml.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "Pub:yaml:yaml:2.1.16"
     purl: "pkg:pub/yaml/yaml@2.1.16"
@@ -1924,6 +1988,7 @@ packages:
       url: "https://github.com/dart-lang/yaml.git"
       revision: ""
       path: ""
+  curations: []
 issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "Pub"

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
@@ -137,6 +137,7 @@ packages:
       url: "https://github.com/kriskowal/asap.git"
       revision: "3e3d99381444379bb0483cb9216caa39ac67bebb"
       path: ""
+  curations: []
 - package:
     id: "NPM::boolbase:1.0.0"
     purl: "pkg:npm/boolbase@1.0.0"
@@ -166,6 +167,7 @@ packages:
       url: "https://github.com/fb55/boolbase.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::cheerio:1.0.0-rc.1"
     purl: "pkg:npm/cheerio@1.0.0-rc.1"
@@ -196,6 +198,7 @@ packages:
       url: "https://github.com/cheeriojs/cheerio.git"
       revision: "f21ffef971826d1ba64ccbdf96adbc44964d30c5"
       path: ""
+  curations: []
 - package:
     id: "NPM::coffee-script:1.12.7"
     purl: "pkg:npm/coffee-script@1.12.7"
@@ -225,6 +228,7 @@ packages:
       url: "https://github.com/jashkenas/coffeescript.git"
       revision: "492111ccfb9b703b49a443c1aa68fb41dc8a2271"
       path: ""
+  curations: []
 - package:
     id: "NPM::cson-parser:1.3.5"
     purl: "pkg:npm/cson-parser@1.3.5"
@@ -254,6 +258,7 @@ packages:
       url: "ssh://git@github.com/groupon/cson-parser.git"
       revision: "fa37e04bc6c516eb76ef01df2d105a413c0253a0"
       path: ""
+  curations: []
 - package:
     id: "NPM::cson:4.1.0"
     purl: "pkg:npm/cson@4.1.0"
@@ -284,6 +289,7 @@ packages:
       url: "https://github.com/bevry/cson.git"
       revision: "0e913a90be66b2f29d2d75433b06ed52e83ba810"
       path: ""
+  curations: []
 - package:
     id: "NPM::css-select:1.2.0"
     purl: "pkg:npm/css-select@1.2.0"
@@ -315,6 +321,7 @@ packages:
       url: "https://github.com/fb55/css-select.git"
       revision: "09c405d8296bd97a660256604d8cdfb23fca47b6"
       path: ""
+  curations: []
 - package:
     id: "NPM::css-what:2.1.3"
     purl: "pkg:npm/css-what@2.1.3"
@@ -344,6 +351,7 @@ packages:
       url: "https://github.com/fb55/css-what.git"
       revision: "2db00ca221922c5b5131d798614aa043f2f6f80e"
       path: ""
+  curations: []
 - package:
     id: "NPM::dom-serializer:0.1.1"
     purl: "pkg:npm/dom-serializer@0.1.1"
@@ -373,6 +381,7 @@ packages:
       url: "https://github.com/cheeriojs/dom-renderer.git"
       revision: "1b9eb87c621a184b97467b03600b50d08e5a5086"
       path: ""
+  curations: []
 - package:
     id: "NPM::domelementtype:1.3.1"
     purl: "pkg:npm/domelementtype@1.3.1"
@@ -402,6 +411,7 @@ packages:
       url: "https://github.com/fb55/domelementtype.git"
       revision: "19b2491101a4de3679b59db8eb7fdd9aa0fbc60b"
       path: ""
+  curations: []
 - package:
     id: "NPM::domhandler:2.4.2"
     purl: "pkg:npm/domhandler@2.4.2"
@@ -431,6 +441,7 @@ packages:
       url: "https://github.com/fb55/DomHandler.git"
       revision: "045bd8d634dca30192fbd23fee0c530adc9c6f52"
       path: ""
+  curations: []
 - package:
     id: "NPM::domutils:1.5.1"
     purl: "pkg:npm/domutils@1.5.1"
@@ -458,6 +469,7 @@ packages:
       url: "https://github.com/FB55/domutils.git"
       revision: "7d4bd16cd36ffce62362ef91616806ea27e30d95"
       path: ""
+  curations: []
 - package:
     id: "NPM::domutils:1.7.0"
     purl: "pkg:npm/domutils@1.7.0"
@@ -487,6 +499,7 @@ packages:
       url: "https://github.com/FB55/domutils.git"
       revision: "34f193ca17d11a98d9310b1965efe5f73d32d79f"
       path: ""
+  curations: []
 - package:
     id: "NPM::eachr:3.2.0"
     purl: "pkg:npm/eachr@3.2.0"
@@ -518,6 +531,7 @@ packages:
       url: "ssh://git@github.com/bevry/eachr.git"
       revision: "57ef794d001c16fd906b2558137e8ea51c1f6330"
       path: ""
+  curations: []
 - package:
     id: "NPM::editions:1.3.4"
     purl: "pkg:npm/editions@1.3.4"
@@ -548,6 +562,7 @@ packages:
       url: "https://github.com/bevry/editions.git"
       revision: "5580800dc3935e988b7aa2cf8d571f3e9fa2d8f9"
       path: ""
+  curations: []
 - package:
     id: "NPM::editions:2.1.3"
     purl: "pkg:npm/editions@2.1.3"
@@ -578,6 +593,7 @@ packages:
       url: "https://github.com/bevry/editions.git"
       revision: "84f536320f7eff6385e867d9f5c1de0dfb92fa88"
       path: ""
+  curations: []
 - package:
     id: "NPM::entities:1.1.2"
     purl: "pkg:npm/entities@1.1.2"
@@ -607,6 +623,7 @@ packages:
       url: "https://github.com/fb55/entities.git"
       revision: "54a5717d85d886c4aafa2ac5ff83d8d3d730337c"
       path: ""
+  curations: []
 - package:
     id: "NPM::errlop:1.1.1"
     purl: "pkg:npm/errlop@1.1.1"
@@ -637,6 +654,7 @@ packages:
       url: "https://github.com/bevry/errlop.git"
       revision: "ca13727bd3a227cd937d104b3217d1cd778cc99b"
       path: ""
+  curations: []
 - package:
     id: "NPM::extract-opts:3.3.1"
     purl: "pkg:npm/extract-opts@3.3.1"
@@ -666,6 +684,7 @@ packages:
       url: "ssh://git@github.com/bevry/extract-opts.git"
       revision: "87e349bbf92a6f95d1ecc8b064a1631def105dc8"
       path: ""
+  curations: []
 - package:
     id: "NPM::graceful-fs:4.2.0"
     purl: "pkg:npm/graceful-fs@4.2.0"
@@ -695,6 +714,7 @@ packages:
       url: "https://github.com/isaacs/node-graceful-fs.git"
       revision: "585df780323740a2b562677caa08a80de1f56c62"
       path: ""
+  curations: []
 - package:
     id: "NPM::htmlparser2:3.10.1"
     purl: "pkg:npm/htmlparser2@3.10.1"
@@ -724,6 +744,7 @@ packages:
       url: "https://github.com/fb55/htmlparser2.git"
       revision: "537bf2aeb56910d84d2c5aedb839dec678188a43"
       path: ""
+  curations: []
 - package:
     id: "NPM::inherits:2.0.4"
     purl: "pkg:npm/inherits@2.0.4"
@@ -754,6 +775,7 @@ packages:
       url: "https://github.com/isaacs/inherits.git"
       revision: "9a2c29400c6d491e0b7beefe0c32efa3b462545d"
       path: ""
+  curations: []
 - package:
     id: "NPM::lodash:4.17.15"
     purl: "pkg:npm/lodash@4.17.15"
@@ -783,6 +805,7 @@ packages:
       url: "https://github.com/lodash/lodash.git"
       revision: ""
       path: ""
+  curations: []
 - package:
     id: "NPM::long:3.2.0"
     purl: "pkg:npm/long@3.2.0"
@@ -813,6 +836,7 @@ packages:
       url: "https://github.com/dcodeIO/long.js.git"
       revision: "8cdc1f74ced4f771aa844f1cbc565b1d4c4451b8"
       path: ""
+  curations: []
 - package:
     id: "NPM::nth-check:1.0.2"
     purl: "pkg:npm/nth-check@1.0.2"
@@ -842,6 +866,7 @@ packages:
       url: "https://github.com/fb55/nth-check.git"
       revision: "03a02587bbd126fafc3d2331ffef6ea5cb2f9b66"
       path: ""
+  curations: []
 - package:
     id: "NPM::parse5:3.0.3"
     purl: "pkg:npm/parse5@3.0.3"
@@ -872,6 +897,7 @@ packages:
       url: "https://github.com/inikulin/parse5.git"
       revision: "723d782abee65aaab9c50f92e73ac2029ae853df"
       path: ""
+  curations: []
 - package:
     id: "NPM::promise:7.3.1"
     purl: "pkg:npm/promise@7.3.1"
@@ -901,6 +927,7 @@ packages:
       url: "https://github.com/then/promise.git"
       revision: "cebfa6049cc08843f428c6fc92dde918f8687e6d"
       path: ""
+  curations: []
 - package:
     id: "NPM::readable-stream:3.4.0"
     purl: "pkg:npm/readable-stream@3.4.0"
@@ -930,6 +957,7 @@ packages:
       url: "https://github.com/nodejs/readable-stream.git"
       revision: "4ba93f84cf8812ca2af793c7304a5c16de72088a"
       path: ""
+  curations: []
 - package:
     id: "NPM::requirefresh:2.2.0"
     purl: "pkg:npm/requirefresh@2.2.0"
@@ -959,6 +987,7 @@ packages:
       url: "https://github.com/bevry/requirefresh.git"
       revision: "f389cbc33b5891468bde8db479bc0f129b0fcc57"
       path: ""
+  curations: []
 - package:
     id: "NPM::safe-buffer:5.1.2"
     purl: "pkg:npm/safe-buffer@5.1.2"
@@ -988,6 +1017,7 @@ packages:
       url: "https://github.com/feross/safe-buffer.git"
       revision: "649435cc8e2d1f3ecdc7caf323f1cb1187307a16"
       path: ""
+  curations: []
 - package:
     id: "NPM::safefs:4.1.0"
     purl: "pkg:npm/safefs@4.1.0"
@@ -1018,6 +1048,7 @@ packages:
       url: "ssh://git@github.com/bevry/safefs.git"
       revision: "51d15eaa03e53aaedd3002dc67814355073e8a55"
       path: ""
+  curations: []
 - package:
     id: "NPM::semver:5.7.0"
     purl: "pkg:npm/semver@5.7.0"
@@ -1047,6 +1078,7 @@ packages:
       url: "https://github.com/npm/node-semver.git"
       revision: "8055dda0aee91372e3bfc47754a62f40e8a63b98"
       path: ""
+  curations: []
 - package:
     id: "NPM::string_decoder:1.2.0"
     purl: "pkg:npm/string_decoder@1.2.0"
@@ -1076,6 +1108,7 @@ packages:
       url: "https://github.com/nodejs/string_decoder.git"
       revision: "6e0a9286ed4497badebd4ec6a9a7a4d37793aae8"
       path: ""
+  curations: []
 - package:
     id: "NPM::typechecker:4.7.0"
     purl: "pkg:npm/typechecker@4.7.0"
@@ -1106,6 +1139,7 @@ packages:
       url: "https://github.com/bevry/typechecker.git"
       revision: "69008d42927749d7e21cfe9816e478dd8d15ab88"
       path: ""
+  curations: []
 - package:
     id: "NPM::util-deprecate:1.0.2"
     purl: "pkg:npm/util-deprecate@1.0.2"
@@ -1135,6 +1169,7 @@ packages:
       url: "https://github.com/TooTallNate/util-deprecate.git"
       revision: "475fb6857cd23fafff20c1be846c1350abf8e6d4"
       path: ""
+  curations: []
 - package:
     id: "NPM:@types:node:12.6.8"
     purl: "pkg:npm/%40types/node@12.6.8"
@@ -1164,3 +1199,4 @@ packages:
       url: "https://github.com/DefinitelyTyped/DefinitelyTyped.git"
       revision: ""
       path: "types/node"
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces-expected-output.yml
@@ -58,6 +58,7 @@ packages:
       url: "https://github.com/bitinn/node-fetch.git"
       revision: "95286f52bb866283bc69521a04efe1de37b26a33"
       path: ""
+  curations: []
 - package:
     id: "NPM::pkg2:1.0.0"
     purl: "pkg:npm/pkg2@1.0.0"
@@ -87,6 +88,7 @@ packages:
       url: "<REPLACE_URL>"
       revision: "<REPLACE_REVISION>"
       path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg2"
+  curations: []
 - package:
     id: "NPM:@here:harp-fetch:0.11.0"
     purl: "pkg:npm/%40here/harp-fetch@0.11.0"
@@ -116,6 +118,7 @@ packages:
       url: "https://github.com/heremaps/harp.gl.git"
       revision: "ce42b2ce221de76b25ef8aea54f50ff007da2664"
       path: "@here/harp-fetch"
+  curations: []
 - package:
     id: "NPM:@here:harp-fetch:0.3.6"
     purl: "pkg:npm/%40here/harp-fetch@0.3.6"
@@ -145,6 +148,7 @@ packages:
       url: "https://github.com/heremaps/harp.gl.git"
       revision: "0c2857f958a34ef7638384afada4fceec427d48d"
       path: "@here/harp-fetch"
+  curations: []
 - package:
     id: "NPM:@scope1:pkg1:1.0.0"
     purl: "pkg:npm/%40scope1/pkg1@1.0.0"
@@ -174,3 +178,4 @@ packages:
       url: "<REPLACE_URL>"
       revision: "<REPLACE_REVISION>"
       path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg1"
+  curations: []

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -229,6 +229,7 @@ analyzer:
           url: "ssh://git@github.com/isaacs/abbrev-js.git"
           revision: "c386cd9dbb1d8d7581718c54d4ba944cc9298d6f"
           path: ""
+      curations: []
 # ...
 # Finally a list of project related issues that happened during dependency analysis. Fortunately empty in this case.
     issues: {}

--- a/model/src/main/kotlin/CuratedPackage.kt
+++ b/model/src/main/kotlin/CuratedPackage.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.model
 
-import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
 /**
@@ -36,8 +35,7 @@ data class CuratedPackage(
     /**
      * The curations in the order they were applied.
      */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val curations: List<PackageCurationResult> = emptyList()
+    val curations: List<PackageCurationResult>
 ) : Comparable<CuratedPackage> {
     /**
      * A comparison function to sort packages by their identifier.

--- a/reporter-web-app/public/index.html
+++ b/reporter-web-app/public/index.html
@@ -12824,6 +12824,7 @@
       "revision" : "47b62ac45e9b176a2af35532d0eea4968bb9eb6d",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ ],
     "levels" : [ 0 ],
     "scopes" : [ ],
@@ -12930,6 +12931,7 @@
       "revision" : "c30617bd8d3763ee96fc76abfc0a9bb00e036d68",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 0 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -13015,6 +13017,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 1 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -13107,6 +13110,7 @@
       "revision" : "58a3c04da70abd6e4795a0bc77dcd173dd86050a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 2 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -13178,6 +13182,7 @@
       "revision" : "6a671057ea6aae690b5967ee26a0ddf8452c6297",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 3 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -13305,6 +13310,7 @@
       "revision" : "d2a3fcdcd6babdd8c9429fa9277a858e2fc97e3b",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 4 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -13390,6 +13396,7 @@
       "revision" : "2e6a4359b10e4b0320e6dad9857ea04f0decbda4",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 5 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -13461,6 +13468,7 @@
       "revision" : "0a8cc19946c03c38520fe8c086b8adb66f9cce0b",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 6 ],
     "levels" : [ 4 ],
     "scopes" : [ 1 ],
@@ -13539,6 +13547,7 @@
       "revision" : "a079ab2d30cfb752a3f247dcf358d0a591c288c5",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 7 ],
     "levels" : [ 2, 4, 5, 6, 7 ],
     "scopes" : [ 1 ],
@@ -13617,6 +13626,7 @@
       "revision" : "2b56fb0c7a07108e5b54241e8faec160d393aedb",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 8 ],
     "levels" : [ 3, 4, 5, 6 ],
     "scopes" : [ 1 ],
@@ -13688,6 +13698,7 @@
       "revision" : "de7527a86c1cf49906b0eb32a0de1402d849ccc2",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 9 ],
     "levels" : [ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ],
     "scopes" : [ 1 ],
@@ -13766,6 +13777,7 @@
       "revision" : "74d421cf32342ac6ec7b507bd903a9e1105f74d7",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 10 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -13837,6 +13849,7 @@
       "revision" : "e0ec3c077d6fd64753b0c9f149614f78c9d54285",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 11 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -13901,6 +13914,7 @@
       "revision" : "3c2618eb953a5de61099452f2b4764a1e1d10674",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 12 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -13986,6 +14000,7 @@
       "revision" : "30223c16191e877bf027b15b12daf077b9b55b84",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 13 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -14057,6 +14072,7 @@
       "revision" : "ea45e14bad13b9e4a10af28f11fb7e731079ab72",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 14 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -14142,6 +14158,7 @@
       "revision" : "b83a70df057b7bcf03f51fcf6741620539024952",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 15 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -14213,6 +14230,7 @@
       "revision" : "33c7855d8eb6d63133bd6321b208cf691e6c0a2a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 16 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -14284,6 +14302,7 @@
       "revision" : "20d5f406d37af3697145eb415355a89fdd4a2279",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 17 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -14369,6 +14388,7 @@
       "revision" : "2628e331be0feef42b66cf546f468f3e92670dd4",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 18 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -14454,6 +14474,7 @@
       "revision" : "d701a549a7653a874eebce7eca25d3577dc868ac",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 19 ],
     "levels" : [ 3, 4, 5, 6, 7 ],
     "scopes" : [ 1 ],
@@ -14539,6 +14560,7 @@
       "revision" : "11e076d96c41369015cc3c338428f7f456d3a92f",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 20 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -14624,6 +14646,7 @@
       "revision" : "01a21de7441549d26ac0c0a9ff91385d16e5c21c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 21 ],
     "levels" : [ 2, 3, 4, 5, 6 ],
     "scopes" : [ 1 ],
@@ -14709,6 +14732,7 @@
       "revision" : "25791512d219b284bd62bb068cae85d8e68bd05b",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 22 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -14794,6 +14818,7 @@
       "revision" : "456b7f33c2d535fc88cf732d1a0e2d48a7600a1b",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 23 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -14858,6 +14883,7 @@
       "revision" : "961cc0dab59f4327795446eb41e700c067d0b87d",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 24 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -14943,6 +14969,7 @@
       "revision" : "f89815af2e0255094283c86977f1e679a8fb411b",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 25 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -15028,6 +15055,7 @@
       "revision" : "cbe5a519ec6745adbb5283d5ee8c5c9889050d74",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 26 ],
     "levels" : [ 2, 3, 4 ],
     "scopes" : [ 1 ],
@@ -15113,6 +15141,7 @@
       "revision" : "9776a2ae5b5b1712ccf16416b55f47e575a81fb9",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 27 ],
     "levels" : [ 1, 2, 3, 5, 6, 7, 8, 9, 10 ],
     "scopes" : [ 1 ],
@@ -15191,6 +15220,7 @@
       "revision" : "20002d8bd1dfd6f68bfa8bdacba520ff6027a450",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 28 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -15262,6 +15292,7 @@
       "revision" : "a983fb63050ae146da051e5bf3c579809d122297",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 29 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -15347,6 +15378,7 @@
       "revision" : "2980174764642927ff8643393d3ecbb5ee7483e6",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 30 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -15432,6 +15464,7 @@
       "revision" : "9f6490130b554f70c655517af887250db28daef4",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 31 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -15517,6 +15550,7 @@
       "revision" : "5156e3063ae8e8ba7f0d599378d024a4f403993c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 32 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -15595,6 +15629,7 @@
       "revision" : "ccf759aac9af8a484924aeacd1e1a5280f508a75",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 33 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -15680,6 +15715,7 @@
       "revision" : "91440c5a1615354fb9419354650937c434eb9f49",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 34 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -15765,6 +15801,7 @@
       "revision" : "49edacfb841a9dac691972c2aa5d40dba8e0b56b",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 35 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -15836,6 +15873,7 @@
       "revision" : "271bf678a0925cc5f400404cfc78ffb71e7057e6",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 36 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -15914,6 +15952,7 @@
       "revision" : "e49b32f3358d0269663f80d4e2a81c9936af3ba9",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 37 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -15978,6 +16017,7 @@
       "revision" : "7761da3e8cddd1f49024252a6b0195a94565b357",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 38 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -16042,6 +16082,7 @@
       "revision" : "27d6d182f649b2a27f958fffa7d974ed30ebce97",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 39 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -16127,6 +16168,7 @@
       "revision" : "99dc5da127d3d17d0ff8d13a995fd2d6aab404aa",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 40 ],
     "levels" : [ 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ],
     "scopes" : [ 1 ],
@@ -16219,6 +16261,7 @@
       "revision" : "e1cb7846258e1d7aa25873814684d4fbbbca53ed",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 41 ],
     "levels" : [ 4, 5 ],
     "scopes" : [ 1 ],
@@ -16311,6 +16354,7 @@
       "revision" : "cb7d4629b00fe38564f741a0779f6ad84d8007a2",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 42 ],
     "levels" : [ 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 ],
     "scopes" : [ 1 ],
@@ -16382,6 +16426,7 @@
       "revision" : "4536ce5944f56659a2dfb2198eaf81b5ad5f2ad9",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 43 ],
     "levels" : [ 5, 6 ],
     "scopes" : [ 1 ],
@@ -16453,6 +16498,7 @@
       "revision" : "57797b60db24c60029f7593995241749b1704902",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 44 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -16531,6 +16577,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 45 ],
     "levels" : [ 3, 4, 5, 6, 7 ],
     "scopes" : [ 1 ],
@@ -16602,6 +16649,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 46 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -16687,6 +16735,7 @@
       "revision" : "9e9a7a9b652c30878c9c9aa591d861a9fdf61a7e",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 47 ],
     "levels" : [ 1, 3 ],
     "scopes" : [ 1 ],
@@ -16758,6 +16807,7 @@
       "revision" : "301187a05b7509aa1d6ff35d8ff6d6064f597bc9",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 48 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -16836,6 +16886,7 @@
       "revision" : "7501971226a7c8b2cf0c1acd1703547e3798491b",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 49 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -16921,6 +16972,7 @@
       "revision" : "13abeae468fea297d0dccc50bc55590809241083",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 50 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -17013,6 +17065,7 @@
       "revision" : "a7a17c9955460435592de2a4d3c722e9b32047a8",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 51 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -17105,6 +17158,7 @@
       "revision" : "68b4dc8d8549d3924673c38fccc5d594f0a38da1",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 52 ],
     "levels" : [ 1, 2, 3, 4, 5, 6 ],
     "scopes" : [ 1 ],
@@ -17197,6 +17251,7 @@
       "revision" : "95980ab6fb44c40eaca7792bdf93aff7c210c805",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 53 ],
     "levels" : [ 1, 2, 3, 4 ],
     "scopes" : [ 1 ],
@@ -17282,6 +17337,7 @@
       "revision" : "f126057628423458636dec9df3d621843b9ac55e",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 54 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -17388,6 +17444,7 @@
       "revision" : "8ad71fa5481e5117b1e44e76e83bb53c08f401f0",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 55 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -17459,6 +17516,7 @@
       "revision" : "e5478e3d2880b90a97daa62d76abed34d91154dd",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 56 ],
     "levels" : [ 2, 3, 4, 5, 6 ],
     "scopes" : [ 1 ],
@@ -17530,6 +17588,7 @@
       "revision" : "e9ab94893a77f1f7d7ea8483b873083e6c6a390a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 57 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -17608,6 +17667,7 @@
       "revision" : "dcd631feb5dd5bcd0899dd35548da2752ea2263e",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 58 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -17756,6 +17816,7 @@
       "revision" : "42434ca1f85b264a88afcfd317487a7417e6004b",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 59 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -17883,6 +17944,7 @@
       "revision" : "3cbaf44e18f4996464ce97f1484ef425bbe8864a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 60 ],
     "levels" : [ 3, 4, 5, 6 ],
     "scopes" : [ 1 ],
@@ -17968,6 +18030,7 @@
       "revision" : "a9f2e514523d4c0931974aff5059052da10c52c5",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 61 ],
     "levels" : [ 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -18053,6 +18116,7 @@
       "revision" : "3953ebb9e4a33287e67676a70a8ad72bbbe38075",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 62 ],
     "levels" : [ 5 ],
     "scopes" : [ 1 ],
@@ -18131,6 +18195,7 @@
       "revision" : "3641bbb4196ad6bc31d443bd2fbdb81c61fb664e",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 63 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -18237,6 +18302,7 @@
       "revision" : "fc864b766689e70707a0b86a136b0ec0021e4d17",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 64 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -18308,6 +18374,7 @@
       "revision" : "5b553293429bac6b15d8caeab8a4174faeb38fa0",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 65 ],
     "levels" : [ 4 ],
     "scopes" : [ 1 ],
@@ -18386,6 +18453,7 @@
       "revision" : "db124a3e1aae9d692c4899e42a5c6c3e329eaa20",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 66 ],
     "levels" : [ 1, 2, 3, 4, 6, 7, 8, 9, 10, 11 ],
     "scopes" : [ 1 ],
@@ -18471,6 +18539,7 @@
       "revision" : "3f4a3fed2c5d5fdf03e5c32e6c87d2fdc3ea4282",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 67 ],
     "levels" : [ 0 ],
     "scopes" : [ 1 ],
@@ -18556,6 +18625,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 68 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -18662,6 +18732,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 69 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -18733,6 +18804,7 @@
       "revision" : "bd47858106a7ce73619aba59ad35990df791cc13",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 70 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -18804,6 +18876,7 @@
       "revision" : "71ca88f0a1e7e1270f1c1f9633d3ae8f136f58e1",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 71 ],
     "levels" : [ 0 ],
     "scopes" : [ 1 ],
@@ -18910,6 +18983,7 @@
       "revision" : "66b565b3763c30dcbc193e4bb74aee976860335d",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 72 ],
     "levels" : [ 0 ],
     "scopes" : [ 1 ],
@@ -18981,6 +19055,7 @@
       "revision" : "4a348e7d24e0d806d7873f293c91a922d0316d14",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 73 ],
     "levels" : [ 0 ],
     "scopes" : [ 1 ],
@@ -19059,6 +19134,7 @@
       "revision" : "5b935bdd3c3760a2e58eea9b89c86b6d3243e321",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 74 ],
     "levels" : [ 0 ],
     "scopes" : [ 1 ],
@@ -19130,6 +19206,7 @@
       "revision" : "116eb98b8cd26a04edcfa758e9513a9422f35b5e",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 75 ],
     "levels" : [ 0 ],
     "scopes" : [ 1 ],
@@ -19299,6 +19376,7 @@
       "revision" : "dbddf14d5771b21b5da704213e4508c660ca1c64",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 76 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -19979,6 +20057,7 @@
       "revision" : "23f4ddc58eda5e6aec3d6a43c6266acbe19345cd",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 77 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -20050,6 +20129,7 @@
       "revision" : "fd094d7f3ccc668aab7593192e4fe71ebdaab9cf",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 78 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -20121,6 +20201,7 @@
       "revision" : "0516192692d32b22509d3b34705dc13ec713f996",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 79 ],
     "levels" : [ 1, 2, 3 ],
     "scopes" : [ 1 ],
@@ -20185,6 +20266,7 @@
       "revision" : "9738f8cc864d769988ccf42bb70f524444df1349",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 80 ],
     "levels" : [ 0 ],
     "scopes" : [ 1 ],
@@ -20501,6 +20583,7 @@
       "revision" : "6b7d0b8100537dcd5c84a7fb17bbe28edcabe05d",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 81 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -21896,6 +21979,7 @@
       "revision" : "0ed4b8afdf2abd416f738977672c6232836f410a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 82 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -22835,6 +22919,7 @@
       "revision" : "a48262deb20861568acf1bca0b7e02867e0b2c48",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 83 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -22906,6 +22991,7 @@
       "revision" : "c6e650de18ed2bb313025bfba97622af10064478",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 84 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -23019,6 +23105,7 @@
       "revision" : "54d608c4ce0eb36d9bade685edcc3177e90e9f3c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 85 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -23307,6 +23394,7 @@
       "revision" : "e22afb3779f7e8a928fc6f3154ae32a799ffe425",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 86 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -23595,6 +23683,7 @@
       "revision" : "8c2741c0154723fb92da137a0c97845b03b0943a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 87 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -23785,6 +23874,7 @@
       "revision" : "8d106d23931c0802e8b88188b0aac433e13358d9",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 88 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -23870,6 +23960,7 @@
       "revision" : "3069d69f023f7e46ab06a01791d256655ccf634e",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 89 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -23962,6 +24053,7 @@
       "revision" : "32f8e288c2ed5b7f71aa47d5f9b980da5c9951aa",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 90 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -24040,6 +24132,7 @@
       "revision" : "b3ab8bdfb91cb182c93475c2c3518d6224672bb4",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 91 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -24125,6 +24218,7 @@
       "revision" : "5bffe7151f99fb02f319f70a004e653105a760fb",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 92 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -24217,6 +24311,7 @@
       "revision" : "add96242a5467efdcca234433a21da6554df6410",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 93 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -24288,6 +24383,7 @@
       "revision" : "03f700c99b76133dc14648b465a1550ec2930e5c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 94 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -24366,6 +24462,7 @@
       "revision" : "39f421b499d5c97b62e955c179fa34c062aab2a5",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 95 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -24479,6 +24576,7 @@
       "revision" : "c35ae06d3ac6158d37bc8b559d54295fce40e667",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 96 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -24550,6 +24648,7 @@
       "revision" : "10202fb1621f0c277d5d5eeaf01c1c32b008fbef",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 97 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -24635,6 +24734,7 @@
       "revision" : "2319b79a9e728fc13fc1a1a15e84bf5df100719e",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 98 ],
     "levels" : [ 1, 2, 3 ],
     "scopes" : [ 1 ],
@@ -24720,6 +24820,7 @@
       "revision" : "6c32f0caed1684ef778053b6f79b13a772e22ba4",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 99 ],
     "levels" : [ 1, 2, 3 ],
     "scopes" : [ 1 ],
@@ -24791,6 +24892,7 @@
       "revision" : "9e95cdca746ccc5c066d277f1edde9c9b9f95348",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 100 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -24869,6 +24971,7 @@
       "revision" : "32432ddde3f08c44cc9e9e4f01616cd3fbf355bf",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 101 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -24940,6 +25043,7 @@
       "revision" : "5e3ec39a3e613e70c56f3775c790ddebdbc363a6",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 102 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -25060,6 +25164,7 @@
       "revision" : "efba8bb6d7607b5c3b0d3e3897c73727577c8b45",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 103 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -25124,6 +25229,7 @@
       "revision" : "2192031b31e6a6add13ffa4e955eb4319eece169",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 104 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -25209,6 +25315,7 @@
       "revision" : "03e7c884431fe185dfebbc9b771aeca339c1807a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 105 ],
     "levels" : [ 2, 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -25301,6 +25408,7 @@
       "revision" : "1213f807066d1cb8d39a0592d5118f4b1f03de4a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 106 ],
     "levels" : [ 2, 3, 4, 5, 6 ],
     "scopes" : [ 1 ],
@@ -25379,6 +25487,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 107 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -25464,6 +25573,7 @@
       "revision" : "6846e54e4afb9ecd7e055cd0259e5dfcc65ff4cb",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 108 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -25535,6 +25645,7 @@
       "revision" : "2383bf9e98ed3c568ff69d7586cf59c0f1dcb9d3",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 109 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -25599,6 +25710,7 @@
       "revision" : "6ce8d11f2f1ed8e80a9526b1dc8cf3aa71f43474",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 110 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -25663,6 +25775,7 @@
       "revision" : "8882c8fccabbe459465e73cc2581e121a5fdd25b",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 111 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -25734,6 +25847,7 @@
       "revision" : "f5a57d3d6e19b324522a3fa5bdd5075fd1aa79d1",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 112 ],
     "levels" : [ 1, 2, 3, 4 ],
     "scopes" : [ 1 ],
@@ -25833,6 +25947,7 @@
       "revision" : "6bf39e6d2aaf5b107a840fd18f29be45760f2749",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 113 ],
     "levels" : [ 4, 5, 6 ],
     "scopes" : [ 1 ],
@@ -25918,6 +26033,7 @@
       "revision" : "92bbb85fc797e03465fbf6e69fb881be4f07e23d",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 114 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -25989,6 +26105,7 @@
       "revision" : "5a29f6c50ccdb412cb198b06ee248e65f365145b",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 115 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -26053,6 +26170,7 @@
       "revision" : "95393c8da0d8bab06522a5eb36658a639c24a621",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 116 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -26145,6 +26263,7 @@
       "revision" : "8b2ca7e693b2c742b29f2399194077b64b9ff781",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 117 ],
     "levels" : [ 2, 3, 4, 5, 7, 8, 9, 10, 11, 12 ],
     "scopes" : [ 1 ],
@@ -26265,6 +26384,7 @@
       "revision" : "474aa39afca7333d356c022fc5be4d31732bbba3",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 118 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -26350,6 +26470,7 @@
       "revision" : "132fe9ce5c2e443e0570606d4568a242eb86b5f5",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 119 ],
     "levels" : [ 2, 3, 4, 5, 6 ],
     "scopes" : [ 1 ],
@@ -26421,6 +26542,7 @@
       "revision" : "4edf96f2dec87ad6b6e68482e8f6d7c8eb7e07e6",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 120 ],
     "levels" : [ 1, 2, 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -26499,6 +26621,7 @@
       "revision" : "c93f8230153a35d1bbe5a3d274a688107792d2ec",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 121 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -26570,6 +26693,7 @@
       "revision" : "36afe179392226cf1b6ccdb16ebbb7a5a844d93a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 122 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -26683,6 +26807,7 @@
       "revision" : "afeaefdd86ba9bb5044be3c1554a666d007cf19a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 123 ],
     "levels" : [ 4 ],
     "scopes" : [ 1 ],
@@ -26747,6 +26872,7 @@
       "revision" : "88f420ad94369f9be46c24ca52eb77e3da224f37",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 124 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -26860,6 +26986,7 @@
       "revision" : "efbbb0937ca8dda1c14e0b69958b9d6f20771f7a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 125 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -27022,6 +27149,7 @@
       "revision" : "56976cef6d5ec0e5651910801669f9aa3daa8120",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 126 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -27100,6 +27228,7 @@
       "revision" : "151048b3f09166ffff42c23b78f3aedc58be5f0b",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 127 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -27178,6 +27307,7 @@
       "revision" : "8a7a217edee030110b0412853c64a37f6d055fac",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 128 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -27249,6 +27379,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 129 ],
     "levels" : [ 1, 3 ],
     "scopes" : [ 1 ],
@@ -27369,6 +27500,7 @@
       "revision" : "99280aa24669a3fab303bb231d6caafd7d5029d3",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 130 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -27454,6 +27586,7 @@
       "revision" : "a547881738c8f57b27795e584071d67cf6ac1a57",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 131 ],
     "levels" : [ 2, 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -27532,6 +27665,7 @@
       "revision" : "9a2c29400c6d491e0b7beefe0c32efa3b462545d",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 132 ],
     "levels" : [ 2, 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -27596,6 +27730,7 @@
       "revision" : "cdce9828f5f27b89e5743b1826876b9042db410a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 133 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -27793,6 +27928,7 @@
       "revision" : "a2b5486bec2543d16782b2d56f79e70bd1075c51",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 134 ],
     "levels" : [ 2, 4 ],
     "scopes" : [ 1 ],
@@ -27878,6 +28014,7 @@
       "revision" : "76c8c4d9baec221aa7b358df1afd2a78dda0d46b",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 135 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -27963,6 +28100,7 @@
       "revision" : "53f22aa6ce557d7d31a3d1152a590a2df220df9d",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 136 ],
     "levels" : [ 6 ],
     "scopes" : [ 1 ],
@@ -28069,6 +28207,7 @@
       "revision" : "efe99d8b3d0ef825925e8b986d047e39bee173c3",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 137 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -28154,6 +28293,7 @@
       "revision" : "1e84e7ee31cf6b660b12500f3111a05501da387f",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 138 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -28246,6 +28386,7 @@
       "revision" : "65d2f6ba6c4e336be90c3cb6a656a69ce8f24210",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 139 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -28338,6 +28479,7 @@
       "revision" : "d7faa7acdf76c41851e6b05b1c77bd5a3dde01f4",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 140 ],
     "levels" : [ 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -28409,6 +28551,7 @@
       "revision" : "e7e895d71f6820547627ce21a719632c17f3700f",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 141 ],
     "levels" : [ 4, 5 ],
     "scopes" : [ 1 ],
@@ -28480,6 +28623,7 @@
       "revision" : "eccc588e219ad3067099fc5f5f2e3950eccdc41e",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 142 ],
     "levels" : [ 2, 3, 4 ],
     "scopes" : [ 1 ],
@@ -28565,6 +28709,7 @@
       "revision" : "10a74787acbe79abf02141c5d487950d1b197b15",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 143 ],
     "levels" : [ 2, 3, 4 ],
     "scopes" : [ 1 ],
@@ -28678,6 +28823,7 @@
       "revision" : "e94a78056056c5546f2bf4c4cf812a2163a46dae",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 144 ],
     "levels" : [ 3, 4, 5, 6 ],
     "scopes" : [ 1 ],
@@ -28763,6 +28909,7 @@
       "revision" : "80e5e314d86e5f76bd1b0573aa9d33e615a372db",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 145 ],
     "levels" : [ 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -28848,6 +28995,7 @@
       "revision" : "4ac6a0cb019fa39141457946c2d455f281f73659",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 146 ],
     "levels" : [ 1, 2, 3 ],
     "scopes" : [ 1 ],
@@ -28961,6 +29109,7 @@
       "revision" : "32211606f81b71f134830764d5079a45536cc8fd",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 147 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -29046,6 +29195,7 @@
       "revision" : "98e8ff1da1a89f93d1397a24d7413ed15421c139",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 148 ],
     "levels" : [ 5 ],
     "scopes" : [ 1 ],
@@ -29159,6 +29309,7 @@
       "revision" : "b687098cc30d85bbec07f1633dee4c2d6acb1aa5",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 149 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -29279,6 +29430,7 @@
       "revision" : "840278ad33eb09c12a47d819b86274287b3144d5",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 150 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -29350,6 +29502,7 @@
       "revision" : "1a70a7f985a00bf25de8437e68c849bf0e434bfb",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 151 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -29435,6 +29588,7 @@
       "revision" : "fdf72b6bf93438b8e7a54345467ab8cf35ef56e2",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 152 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -29506,6 +29660,7 @@
       "revision" : "f42e0be5f676e6c82c83c9cad70f1fbb3b81c8ca",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 153 ],
     "levels" : [ 4, 5 ],
     "scopes" : [ 1 ],
@@ -29577,6 +29732,7 @@
       "revision" : "0617cfa871686cf541af62b144f130488f44f6fe",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 154 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -29648,6 +29804,7 @@
       "revision" : "433a8149f14c0a1db3a66224b2757ef9f8611e94",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 155 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -29733,6 +29890,7 @@
       "revision" : "4dcfff4ed9e36ad761a1a24d3899c832382d7254",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 156 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -29832,6 +29990,7 @@
       "revision" : "c69ac2f7221ff5b515fd1f61424738dd6dcb96f2",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 157 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -29917,6 +30076,7 @@
       "revision" : "2a23a281f369e9ae06394c0fb4d2381355a6ba33",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 158 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -29995,6 +30155,7 @@
       "revision" : "10f8be491aab2e158c7e20df64a7f90ab5b5475c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 159 ],
     "levels" : [ 2, 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -30059,6 +30220,7 @@
       "revision" : "5319df684b508ff6fb19fe8b9a6147a3c5924e4b",
       "path" : "packages/istanbul-lib-coverage"
     },
+    "curations" : [ ],
     "paths" : [ 160 ],
     "levels" : [ 1, 2, 3 ],
     "scopes" : [ 1 ],
@@ -30200,6 +30362,7 @@
       "revision" : "5319df684b508ff6fb19fe8b9a6147a3c5924e4b",
       "path" : "packages/istanbul-lib-hook"
     },
+    "curations" : [ ],
     "paths" : [ 161 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -30299,6 +30462,7 @@
       "revision" : "2c6f0e24680d050503d404de0ebff53467fefbff",
       "path" : "packages/istanbul-lib-instrument"
     },
+    "curations" : [ ],
     "paths" : [ 162 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -30384,6 +30548,7 @@
       "revision" : "5c356cd1a541c1b22a72a6ce5e09070386162dee",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 163 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -30448,6 +30613,7 @@
       "revision" : "5319df684b508ff6fb19fe8b9a6147a3c5924e4b",
       "path" : "packages/istanbul-lib-report"
     },
+    "curations" : [ ],
     "paths" : [ 164 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -30631,6 +30797,7 @@
       "revision" : "5319df684b508ff6fb19fe8b9a6147a3c5924e4b",
       "path" : "packages/istanbul-lib-source-maps"
     },
+    "curations" : [ ],
     "paths" : [ 165 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -30800,6 +30967,7 @@
       "revision" : "73c25ce79f91010d1ff073aa6ff3fd01114f90db",
       "path" : "packages/istanbul-reports"
     },
+    "curations" : [ ],
     "paths" : [ 166 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -31095,6 +31263,7 @@
       "revision" : "0eb6e9daee32160ab0fca979b6dc91a1991b720c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 167 ],
     "levels" : [ 3, 5, 6, 7, 8, 9, 10 ],
     "scopes" : [ 1 ],
@@ -31243,6 +31412,7 @@
       "revision" : "665aadda42349dcae869f12040d9b10ef18d12da",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 168 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -31342,6 +31512,7 @@
       "revision" : "5169a48f015437b7cdaffecaa10db52f155dace7",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 169 ],
     "levels" : [ 4, 5, 6, 7 ],
     "scopes" : [ 1 ],
@@ -31427,6 +31598,7 @@
       "revision" : "bc898eeee723833fc9d604523e00014350bcc4e1",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 170 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -31505,6 +31677,7 @@
       "revision" : "c0b3c36d976c54e31a814c492cd1c2557a4d3758",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 171 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -31583,6 +31756,7 @@
       "revision" : "32bb2cdae4864b2ac80a6d9b4045efc4cc54f47a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 172 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -31668,6 +31842,7 @@
       "revision" : "a92b9acf928282ba81134b4ae8e6a5f29e1f5e1e",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 173 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -31753,6 +31928,7 @@
       "revision" : "49620f12bce627dc2459a08f5ef18cd2ff151eb2",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 174 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -31838,6 +32014,7 @@
       "revision" : "a30b86df0934329c66ff6a2be395db03d65478b8",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 175 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -31923,6 +32100,7 @@
       "revision" : "d6f19ffa31544161ee94118963deb3b683418151",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 176 ],
     "levels" : [ 2, 3, 4 ],
     "scopes" : [ 1 ],
@@ -32008,6 +32186,7 @@
       "revision" : "630c0bbd609055c1895089c715649e21000a1ab7",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 177 ],
     "levels" : [ 2, 3, 4 ],
     "scopes" : [ 1 ],
@@ -32093,6 +32272,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 178 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -32192,6 +32372,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 179 ],
     "levels" : [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ],
     "scopes" : [ 1 ],
@@ -32606,6 +32787,7 @@
       "revision" : "1f4ac6ef31cb4c7c4c4c67b7d6f9db712d4c0186",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 180 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -32691,6 +32873,7 @@
       "revision" : "6d029fe1f75f1a02fcdd7a67f34eadf0941a424f",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 181 ],
     "levels" : [ 1, 2, 3 ],
     "scopes" : [ 1 ],
@@ -32762,6 +32945,7 @@
       "revision" : "3134eb6b85e27d568e587eb2290340c3f189427b",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 182 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -32847,6 +33031,7 @@
       "revision" : "661ef0cf02b2800c5c5c6dc273c0a0b9eb3c410b",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 183 ],
     "levels" : [ 0 ],
     "scopes" : [ 0 ],
@@ -32932,6 +33117,7 @@
       "revision" : "d29f5387f4c19814a042d03a780ff4481ceac5a3",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 184 ],
     "levels" : [ 5 ],
     "scopes" : [ 1 ],
@@ -33017,6 +33203,7 @@
       "revision" : "e46989a323d5f0aa4781eff5e2e6e7aafa223321",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 185 ],
     "levels" : [ 1, 2, 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -33081,6 +33268,7 @@
       "revision" : "aeb3e27dae0412de5c0494e9563a5f10c82cc7a9",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 186 ],
     "levels" : [ 2, 4, 5 ],
     "scopes" : [ 1 ],
@@ -33152,6 +33340,7 @@
       "revision" : "d784e70d1eb3fc73bcda52f22f57ec55c00c2525",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 187 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -33237,6 +33426,7 @@
       "revision" : "049cf185c9e91727bc505b796a2d16a4fe70d64d",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 188 ],
     "levels" : [ 1, 4 ],
     "scopes" : [ 1 ],
@@ -33357,6 +33547,7 @@
       "revision" : "7c09e634267ddc18d1ec08a4bfd999efa317d684",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 189 ],
     "levels" : [ 0 ],
     "scopes" : [ 1 ],
@@ -33617,6 +33808,7 @@
       "revision" : "9b88d1568a52ec9bb67ecc8d2aa224fa38fd41f4",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 190 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -33688,6 +33880,7 @@
       "revision" : "fe0bae301a6c41f68a01595658a4f4f0dcba0e84",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 191 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -33759,6 +33952,7 @@
       "revision" : "7920885eb232fbe7a5efdab956d3e7c507c92ddf",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 192 ],
     "levels" : [ 2, 3, 4, 5, 6, 7 ],
     "scopes" : [ 1 ],
@@ -33830,6 +34024,7 @@
       "revision" : "aa4a4baeaff5eeec83b5717738a44642f6948a9f",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 193 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -33894,6 +34089,7 @@
       "revision" : "eec83eee67cfac84d6db30cdd65363f155673770",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 194 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -33993,6 +34189,7 @@
       "revision" : "87013431e0877520763863f77dcb77dfd11eb2a9",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 195 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -34064,6 +34261,7 @@
       "revision" : "fbf451941e4721392c7c346de843514d7ad14a95",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 196 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -34142,6 +34340,7 @@
       "revision" : "f59d60cb94bafc4f4259d598ec26b543d293586d",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 197 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -34220,6 +34419,7 @@
       "revision" : "dedb606de22fa4bdf21c3679dece5fd07b4a0b1a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 198 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -34347,6 +34547,7 @@
       "revision" : "0979eb807a1725d83d5a996347d41067cf773d1f",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 199 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -34481,6 +34682,7 @@
       "revision" : "d9a76d5f9c1df5920684f5e43abe95ded361075e",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 200 ],
     "levels" : [ 0 ],
     "scopes" : [ 1 ],
@@ -34545,6 +34747,7 @@
       "revision" : "a89774b252c91612203876984bbd6addbe3b5a0e",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 201 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -34644,6 +34847,7 @@
       "revision" : "7dd1224072239f08bd5dbb82ae5e7120d88ac562",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 202 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -34750,6 +34954,7 @@
       "revision" : "ba2c1989270c7de969aa8498fc3b7c8e677806f3",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 203 ],
     "levels" : [ 2, 3, 4, 5, 6, 7 ],
     "scopes" : [ 1 ],
@@ -34821,6 +35026,7 @@
       "revision" : "5fd74aee40aba36e9a8eb0c329abd33a07b93164",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 204 ],
     "levels" : [ 1, 3, 4 ],
     "scopes" : [ 1 ],
@@ -34899,6 +35105,7 @@
       "revision" : "cbe9a13b3e153d4f16c7c2002904dc4dee9f26d4",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 205 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -34970,6 +35177,7 @@
       "revision" : "e00dd4a6b6aef218167b4e20c959d43adcc33f2b",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 206 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -35041,6 +35249,7 @@
       "revision" : "0e614d9f5a7e6f0305c625f6b581f6d80b33b8a6",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 207 ],
     "levels" : [ 2, 3, 4, 5, 6 ],
     "scopes" : [ 1 ],
@@ -35105,6 +35314,7 @@
       "revision" : "8bb24f70649ee69849a0701477ebc7170e7a4f87",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 208 ],
     "levels" : [ 4 ],
     "scopes" : [ 1 ],
@@ -35190,6 +35400,7 @@
       "revision" : "80318611b86ad28a38671f811d6c80bf564cdbda",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 209 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -35275,6 +35486,7 @@
       "revision" : "1abf9cf5611b4be7377060ea67054b45cbf6813c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 210 ],
     "levels" : [ 4 ],
     "scopes" : [ 1 ],
@@ -35360,6 +35572,7 @@
       "revision" : "cf076d73844ebbfda8ae4e184fc436396998ecb2",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 211 ],
     "levels" : [ 5, 6 ],
     "scopes" : [ 1 ],
@@ -35445,6 +35658,7 @@
       "revision" : "a11f02bc5c04490b7c3de2663d866c211fb915ea",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 212 ],
     "levels" : [ 4, 5, 6 ],
     "scopes" : [ 1 ],
@@ -35537,6 +35751,7 @@
       "revision" : "6300abb6451f04bbaa760f42844ec1c501d79120",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 213 ],
     "levels" : [ 4, 5 ],
     "scopes" : [ 1 ],
@@ -35622,6 +35837,7 @@
       "revision" : "d37f108c0b04779e307b4e7203981caa367bac57",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 214 ],
     "levels" : [ 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -35707,6 +35923,7 @@
       "revision" : "a650b26e49713a8cca58f669a7f8aef9b655554c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 215 ],
     "levels" : [ 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -35792,6 +36009,7 @@
       "revision" : "a8c06732e440214da89c410fa8d0cd74e110868e",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 216 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -35863,6 +36081,7 @@
       "revision" : "8a6f2c232b80e12c138714e553fc8dd6313604c2",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 217 ],
     "levels" : [ 6, 7 ],
     "scopes" : [ 1 ],
@@ -35948,6 +36167,7 @@
       "revision" : "e80e2e130b2d16807345be02aa03541e6e085952",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 218 ],
     "levels" : [ 5, 6, 7 ],
     "scopes" : [ 1 ],
@@ -36033,6 +36253,7 @@
       "revision" : "6afce110db308d4ed70dbdb5658fc4ec50522c86",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 219 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -36139,6 +36360,7 @@
       "revision" : "48267d001c4d215ba21a701a6882dba30fb8d614",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 220 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -36224,6 +36446,7 @@
       "revision" : "3fd80962ca032e5782210ca915b639f005e85a15",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 221 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -36309,6 +36532,7 @@
       "revision" : "419b0cbb83e67af53f9fd3f7ff98605ea2020eb6",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 222 ],
     "levels" : [ 4 ],
     "scopes" : [ 1 ],
@@ -36401,6 +36625,7 @@
       "revision" : "4696c60a8b2b9ac61902aa9eab7cb326ab6005c8",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 223 ],
     "levels" : [ 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -36486,6 +36711,7 @@
       "revision" : "26b1adf80aa6761a7db35927a20cf59e0fd1a00d",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 224 ],
     "levels" : [ 2, 3, 4 ],
     "scopes" : [ 1 ],
@@ -36571,6 +36797,7 @@
       "revision" : "edc91d348b21dac2ab65ea2fbec2868e2eff5eb6",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 225 ],
     "levels" : [ 2, 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -36656,6 +36883,7 @@
       "revision" : "d60207f9ab9dc9e60d49c87faacf415a4946287c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 226 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -36741,6 +36969,7 @@
       "revision" : "caea269db3a5eb0c09c793f4be5435312971d2fa",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 227 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -36812,6 +37041,7 @@
       "revision" : "97efc90ce24455d23ec6acedf47589df46e48ea0",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 228 ],
     "levels" : [ 2, 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -36897,6 +37127,7 @@
       "revision" : "ef08bdbd35fa01342ef6d80f2e8eb8b9c2cccc30",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 229 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -36982,6 +37213,7 @@
       "revision" : "aed790f037736f5c760f7b120935714d21503fe9",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 230 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -37081,6 +37313,7 @@
       "revision" : "2dd0d8b880e4ebcc5cc33ae126b02647418e4440",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 231 ],
     "levels" : [ 4 ],
     "scopes" : [ 1 ],
@@ -37166,6 +37399,7 @@
       "revision" : "c18df2945cd928787f3290042a6c69352b4e13a5",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 232 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -37251,6 +37485,7 @@
       "revision" : "e25e5342c5ec425bb4a2c93787a880c29cbf0a49",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 233 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -37336,6 +37571,7 @@
       "revision" : "d69be8fd8a682321ba24eced17caf3a1b8ca73b8",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 234 ],
     "levels" : [ 2, 3, 4 ],
     "scopes" : [ 1 ],
@@ -37442,6 +37678,7 @@
       "revision" : "333106fa246ae4577ce010f8a5405d38061ec359",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 235 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -37520,6 +37757,7 @@
       "revision" : "0790207ef077cbfb7ebde24a1dd9895ebf4643e1",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 236 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -37612,6 +37850,7 @@
       "revision" : "68df855dc42d1086ada161331b3074468e8d848d",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 237 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -37697,6 +37936,7 @@
       "revision" : "3b8a594ab581f000f705e43e8abdb1a23e8822f2",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 238 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -37782,6 +38022,7 @@
       "revision" : "c1664a2f42d1f1898b7648534576e6dcfa1f48c8",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 239 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -37867,6 +38108,7 @@
       "revision" : "cdfb3df2192e0721be258b28c19b9be1d43fcdd0",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 240 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -37952,6 +38194,7 @@
       "revision" : "d68b435cbf6d37e3fa6af186965a7b6c738bf685",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 241 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -38023,6 +38266,7 @@
       "revision" : "5563cf33c4976d01a348472b818221fc199bbeb6",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 242 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -38094,6 +38338,7 @@
       "revision" : "696e6ac92340120fe4b26fce4152f0197b45183b",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 243 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -38158,6 +38403,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 244 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -38306,6 +38552,7 @@
       "revision" : "1a95c5d99a02999ccd2cf4663959a18bd2def7b8",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 245 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -38447,6 +38694,7 @@
       "revision" : "adaec75e316f1c375dc7a2cb51c7b762b135cc0e",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 246 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -38525,6 +38773,7 @@
       "revision" : "cc71c23dd0c16cefd26855303c16ca1b9b50a36d",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 247 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -38603,6 +38852,7 @@
       "revision" : "1acaf42e8ababa22c191319b319f25df833ffd79",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 248 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -38667,6 +38917,7 @@
       "revision" : "60cd04e69135b96b98b848fff719b1276a5610c0",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 249 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -38752,6 +39003,7 @@
       "revision" : "53f4a1b40f972dbfc4dda9627d24068000eae897",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 250 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -38837,6 +39089,7 @@
       "revision" : "3a76ef8d2cc232fc4d4246e0748506258a104484",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 251 ],
     "levels" : [ 1, 2, 3, 4 ],
     "scopes" : [ 1 ],
@@ -38936,6 +39189,7 @@
       "revision" : "32accb3425dbcde0b303583b9137857451b67045",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 252 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -39021,6 +39275,7 @@
       "revision" : "9442819908e52f2c32620e8fa609d7a5d472cc2c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 253 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -39085,6 +39340,7 @@
       "revision" : "8c10fb8d685d5cc35708e0ffc4dac9ec5dd5b444",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 254 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -39149,6 +39405,7 @@
       "revision" : "f3e0a18abf6e9569abfcf327daa9351c95f109b1",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 255 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -39234,6 +39491,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 256 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -39998,6 +40256,7 @@
       "revision" : "649435cc8e2d1f3ecdc7caf323f1cb1187307a16",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 257 ],
     "levels" : [ 2, 4 ],
     "scopes" : [ 1 ],
@@ -40083,6 +40342,7 @@
       "revision" : "e8ac214944eda30e1e6c6b7d7e7f6a21cf7dce7c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 258 ],
     "levels" : [ 4 ],
     "scopes" : [ 1 ],
@@ -40154,6 +40414,7 @@
       "revision" : "c83c18cf84f9ccaea3431c929bb285fd168c01e4",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 259 ],
     "levels" : [ 2, 3, 4 ],
     "scopes" : [ 1 ],
@@ -40232,6 +40493,7 @@
       "revision" : "0eeceecfba490d136eb3ccae3a8dc118a28565a0",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 260 ],
     "levels" : [ 1, 2, 3, 4 ],
     "scopes" : [ 1 ],
@@ -40338,6 +40600,7 @@
       "revision" : "7eec10577b5fff264de477ba3b9d07f404946eff",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 261 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -40402,6 +40665,7 @@
       "revision" : "01de9b7d355f21e00417650a6fb1eb56321bc23c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 262 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -40487,6 +40751,7 @@
       "revision" : "003c4c7d6882d029aa8b3e5777716d726894d734",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 263 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -40558,6 +40823,7 @@
       "revision" : "cb774c70d5f569479ca997abf8ee7e558e617284",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 264 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -40643,6 +40909,7 @@
       "revision" : "27a9a6f0f85c04b9c37a43cf7503fdb58f5ae8d6",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 265 ],
     "levels" : [ 4, 5 ],
     "scopes" : [ 1 ],
@@ -40728,6 +40995,7 @@
       "revision" : "bb32fe5e3126e9bb55acf83168628839d3a81ea6",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 266 ],
     "levels" : [ 1, 2, 3, 4 ],
     "scopes" : [ 1 ],
@@ -40806,6 +41074,7 @@
       "revision" : "bfb33a3eb13f2d3b8023f37ddb421eff3ea7a3ae",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 267 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -40884,6 +41153,7 @@
       "revision" : "326dd955a366569759d9537ef5f0f167c89d92d2",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 268 ],
     "levels" : [ 3, 4, 5, 6, 7 ],
     "scopes" : [ 1 ],
@@ -43069,6 +43339,7 @@
       "revision" : "ac518d2f21818146f3310557bd51c13d8cff2ba8",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 269 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -47389,6 +47660,7 @@
       "revision" : "c1c6cea28dc9d6760ae2c4eebeff8a60a80d7fd7",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 270 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -47454,6 +47726,7 @@
       "revision" : "6e556b4af7bee9899e7f16ae8f745719e5517e5d",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 271 ],
     "levels" : [ 5 ],
     "scopes" : [ 1 ],
@@ -48541,6 +48814,7 @@
       "revision" : "b1405b421074aae250f5cfefc1adff1c6085b293",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 272 ],
     "levels" : [ 6, 7 ],
     "scopes" : [ 1 ],
@@ -48837,6 +49111,7 @@
       "revision" : "063e2d555cc5aef6c433c7dce7c543894476bcb8",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 273 ],
     "levels" : [ 5, 6 ],
     "scopes" : [ 1 ],
@@ -49546,6 +49821,7 @@
       "revision" : "2bc004aae6f30d625d3aad95eac09d9aaf1c97cc",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 274 ],
     "levels" : [ 6, 7 ],
     "scopes" : [ 1 ],
@@ -51122,6 +51398,7 @@
       "revision" : "747b806c2dab5b64d5c9958c42884946a187c3b1",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 275 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -51270,6 +51547,7 @@
       "revision" : "c0f63ed146ecc0fa8dea34a7ccfea013a753d470",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 276 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -51355,6 +51633,7 @@
       "revision" : "74d8d552b465692790c41169b123409669d41079",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 277 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -51440,6 +51719,7 @@
       "revision" : "3b3da68dfea82e193f9d6deee77224cf8e5c3803",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 278 ],
     "levels" : [ 2, 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -51525,6 +51805,7 @@
       "revision" : "34bca56b5b301b46fef0258aba4446792d794dab",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 279 ],
     "levels" : [ 2, 3, 4 ],
     "scopes" : [ 1 ],
@@ -51596,6 +51877,7 @@
       "revision" : "db875b3155c8711b9ee6ab4f8ed0653c94879416",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 280 ],
     "levels" : [ 4, 5 ],
     "scopes" : [ 1 ],
@@ -51688,6 +51970,7 @@
       "revision" : "c6ac1de830193bc8f1f8d2c569f74a132d590415",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 281 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -51780,6 +52063,7 @@
       "revision" : "1aa1537aa636b47b10d3c52e0e1fca6a074f8870",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 282 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -51872,6 +52156,7 @@
       "revision" : "7ce7634165aa317a3a28f09be576237167f052be",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 283 ],
     "levels" : [ 4, 5 ],
     "scopes" : [ 1 ],
@@ -51964,6 +52249,7 @@
       "revision" : "c299056a42b31d7a479d6a89b41318b2a2462cc7",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 284 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -52042,6 +52328,7 @@
       "revision" : "b9c492921b72c48f93568565dbdc929cf63c20e1",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 285 ],
     "levels" : [ 1, 3, 4, 5, 6 ],
     "scopes" : [ 1 ],
@@ -52120,6 +52407,7 @@
       "revision" : "59533da99981f9d550de1ae0eb9d1a93c2383be3",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 286 ],
     "levels" : [ 2, 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -52191,6 +52479,7 @@
       "revision" : "8258d09a069a5d5eb3d787c1d5d29737df1c8bba",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 287 ],
     "levels" : [ 4 ],
     "scopes" : [ 1 ],
@@ -52276,6 +52565,7 @@
       "revision" : "9aef0f38ffefca91d3852c82cd6366e5d36d6dd1",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 288 ],
     "levels" : [ 4 ],
     "scopes" : [ 1 ],
@@ -52361,6 +52651,7 @@
       "revision" : "1aef99eaa70d07981156e8aaa722e750c3b4eaf9",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 289 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -52481,6 +52772,7 @@
       "revision" : "159140d19a5c2ec08a9895ca255c1f1699915e66",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 290 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -52573,6 +52865,7 @@
       "revision" : "7759fc135b1be07cb7411178d7b1ac33d367fec8",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 291 ],
     "levels" : [ 2, 3, 4, 6, 7, 8, 9, 10, 11 ],
     "scopes" : [ 1 ],
@@ -52679,6 +52972,7 @@
       "revision" : "bfbe6692d549b423230292946756f3fdd79a808e",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 292 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -52757,6 +53051,7 @@
       "revision" : "8a40054cdbcd3f42b4f68eaefb41c3064835b991",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 293 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -52828,6 +53123,7 @@
       "revision" : "db1ad68d74b8e859448deebaeb823da39e40fa98",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 294 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -52899,6 +53195,7 @@
       "revision" : "b788e7bd7cfdec8b471ad7b79d0d4a44975e2e99",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 295 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -52963,6 +53260,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 296 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -53034,6 +53332,7 @@
       "revision" : "2c5a6f9a0cc54da759b6e10964f2081c358e49dc",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 297 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -53168,6 +53467,7 @@
       "revision" : "0900dd5b112ac7a482e4bdf3cb002bfe1b3acf77",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 298 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -53274,6 +53574,7 @@
       "revision" : "5b2ddf09843cacf5e9c2f9403155ef5a742edd83",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 299 ],
     "levels" : [ 4, 5, 6, 7, 8, 9 ],
     "scopes" : [ 1 ],
@@ -53359,6 +53660,7 @@
       "revision" : "c05ef9ec07e7703d146467934098ecbde9d0bd95",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 300 ],
     "levels" : [ 4 ],
     "scopes" : [ 1 ],
@@ -53458,6 +53760,7 @@
       "revision" : "95c93d3233a99384b336b9160e352586bbf16eee",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 301 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -53543,6 +53846,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 302 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -53621,6 +53925,7 @@
       "revision" : "1e1ccc351816677c62202bd66aa385a572eafa1a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 303 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -53706,6 +54011,7 @@
       "revision" : "3d93421d7be470d614f527ff207d47559c859510",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 304 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -53840,6 +54146,7 @@
       "revision" : "0ab04e7a660485d0cc3aa87e95f2f9a6464cf8e6",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 305 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -53953,6 +54260,7 @@
       "revision" : "74d8d4aa2b616ab55869372fb52e45947bd9df3c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 306 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -54052,6 +54360,7 @@
       "revision" : "92c02842eaa4f56b8dec183d10c85bcb0d447bd8",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 307 ],
     "levels" : [ 2, 3, 4 ],
     "scopes" : [ 1 ],
@@ -54151,6 +54460,7 @@
       "revision" : "328a952e480a143bdc3fc98a2133490e28e2b3a2",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 308 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -54243,6 +54553,7 @@
       "revision" : "2e64baeea9450acd28bd50d1a0bf87ee067e06d3",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 309 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -54328,6 +54639,7 @@
       "revision" : "f3cc0cced79b86018bbeec58391bafeab18da944",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 310 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -54413,6 +54725,7 @@
       "revision" : "aee63b5e0b0062e3d2fcb6a1fc3d32c274dea160",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 311 ],
     "levels" : [ 5 ],
     "scopes" : [ 1 ],
@@ -54498,6 +54811,7 @@
       "revision" : "5a94c592a85f4e691b0be93e4d2922d3557d2867",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 312 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -54583,6 +54897,7 @@
       "revision" : "9a20ab40be4981b0b9ceec762a6f100fb276939c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 313 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -54668,6 +54983,7 @@
       "revision" : "74da40a04af87f881314999d5b4ff7740ce5ac31",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 314 ],
     "levels" : [ 4 ],
     "scopes" : [ 1 ],
@@ -54753,6 +55069,7 @@
       "revision" : "c0309c28042225908adb91d80ab482c03b829539",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 315 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -54839,6 +55156,7 @@
       "revision" : "4f6f600fade03398c08adf2755c3a2ad66d31b3c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 316 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -55064,6 +55382,7 @@
       "revision" : "3df73a98f07c0a38a94bcaf1ecde0e384dc3b126",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 317 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -55178,6 +55497,7 @@
       "revision" : "0b9eae0a5f61955f0001d8ebcf3f8410df42f4b6",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 318 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -59470,6 +59790,7 @@
       "revision" : "6bbe26201fa7e5c7281516b04b9f3f4cc6db145c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 319 ],
     "levels" : [ 4 ],
     "scopes" : [ 1 ],
@@ -59632,6 +59953,7 @@
       "revision" : "d0262408af6c830fd37374e21a7521211b6d9bbd",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 320 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -59717,6 +60039,7 @@
       "revision" : "c7ea8c0d236299e9ff39faac89e230b178263f58",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 321 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -59802,6 +60125,7 @@
       "revision" : "542a7fd62abf83224e59c5364903915867e0902f",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 322 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -59887,6 +60211,7 @@
       "revision" : "7f78f42d0761133263c3947a3b24dde324a467ce",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 323 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -59951,6 +60276,7 @@
       "revision" : "563406d75b97f97a33e506b9cc7a82b268332b6f",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 324 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -60043,6 +60369,7 @@
       "revision" : "6a822d836de79f92fb3170f685a6e283fbfeff87",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 325 ],
     "levels" : [ 2, 3, 4 ],
     "scopes" : [ 1 ],
@@ -60114,6 +60441,7 @@
       "revision" : "6b766c9874a1e5157eda2ac75b90ccc01b313620",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 326 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -60178,6 +60506,7 @@
       "revision" : "cdab7f263a0af97df0626043d908aa087d3d3089",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 327 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -60284,6 +60613,7 @@
       "revision" : "2a1a55446d67c55a29e84173e99eb6abc91c937c",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 328 ],
     "levels" : [ 3, 4 ],
     "scopes" : [ 1 ],
@@ -60362,6 +60692,7 @@
       "revision" : "a28eb7d6cdbf91bccb56d04d095ca9463c15d3db",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 329 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -60433,6 +60764,7 @@
       "revision" : "71d91b6dc5bdeac37e218c2cf03f9ab55b60d214",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 330 ],
     "levels" : [ 3, 4, 5, 6, 7 ],
     "scopes" : [ 1 ],
@@ -60511,6 +60843,7 @@
       "revision" : "eb8dff15f83f16be1e0b89be54fa80200356614a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 331 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -60575,6 +60908,7 @@
       "revision" : "6a48d4e363510c52653fabc25f620a484d6058bf",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 332 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -60688,6 +61022,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 333 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -60780,6 +61115,7 @@
       "revision" : "37816c0e2e25da2901d584442235946d5cd8c80d",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 334 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -60858,6 +61194,7 @@
       "revision" : "45d2568800d6c57be045e76dc4984b2ef3432233",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 335 ],
     "levels" : [ 2, 3 ],
     "scopes" : [ 1 ],
@@ -60922,6 +61259,7 @@
       "revision" : "034e7c0ebf1047a866eb84b529aeea9216669d4a",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 336 ],
     "levels" : [ 1, 2, 3 ],
     "scopes" : [ 1 ],
@@ -60986,6 +61324,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 337 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -61050,6 +61389,7 @@
       "revision" : "707b456935e881fe63a670d895ac15950cf1bbb5",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 338 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -61128,6 +61468,7 @@
       "revision" : "c5547b1333ab1821152d0a334a278fcb5496a0a6",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 339 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -61262,6 +61603,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 340 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -61382,6 +61724,7 @@
       "revision" : "master",
       "path" : "packages/babel-code-frame"
     },
+    "curations" : [ ],
     "paths" : [ 341 ],
     "levels" : [ 1, 3, 4, 5, 6, 7, 8 ],
     "scopes" : [ 1 ],
@@ -61460,6 +61803,7 @@
       "revision" : "master",
       "path" : "packages/babel-core"
     },
+    "curations" : [ ],
     "paths" : [ 342 ],
     "levels" : [ 2 ],
     "scopes" : [ 1 ],
@@ -61538,6 +61882,7 @@
       "revision" : "master",
       "path" : "packages/babel-generator"
     },
+    "curations" : [ ],
     "paths" : [ 343 ],
     "levels" : [ 3, 4, 5, 6 ],
     "scopes" : [ 1 ],
@@ -61728,6 +62073,7 @@
       "revision" : "master",
       "path" : "packages/babel-helper-function-name"
     },
+    "curations" : [ ],
     "paths" : [ 344 ],
     "levels" : [ 4, 5, 6 ],
     "scopes" : [ 1 ],
@@ -61806,6 +62152,7 @@
       "revision" : "master",
       "path" : "packages/babel-helper-get-function-arity"
     },
+    "curations" : [ ],
     "paths" : [ 345 ],
     "levels" : [ 5, 6, 7 ],
     "scopes" : [ 1 ],
@@ -61884,6 +62231,7 @@
       "revision" : "master",
       "path" : "packages/babel-helper-member-expression-to-functions"
     },
+    "curations" : [ ],
     "paths" : [ 346 ],
     "levels" : [ 5 ],
     "scopes" : [ 1 ],
@@ -61962,6 +62310,7 @@
       "revision" : "master",
       "path" : "packages/babel-helper-module-imports"
     },
+    "curations" : [ ],
     "paths" : [ 347 ],
     "levels" : [ 4 ],
     "scopes" : [ 1 ],
@@ -62040,6 +62389,7 @@
       "revision" : "master",
       "path" : "packages/babel-helper-module-transforms"
     },
+    "curations" : [ ],
     "paths" : [ 348 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -62146,6 +62496,7 @@
       "revision" : "master",
       "path" : "packages/babel-helper-optimise-call-expression"
     },
+    "curations" : [ ],
     "paths" : [ 349 ],
     "levels" : [ 5 ],
     "scopes" : [ 1 ],
@@ -62224,6 +62575,7 @@
       "revision" : "master",
       "path" : "packages/babel-helper-replace-supers"
     },
+    "curations" : [ ],
     "paths" : [ 350 ],
     "levels" : [ 4 ],
     "scopes" : [ 1 ],
@@ -62302,6 +62654,7 @@
       "revision" : "master",
       "path" : "packages/babel-helper-simple-access"
     },
+    "curations" : [ ],
     "paths" : [ 351 ],
     "levels" : [ 4 ],
     "scopes" : [ 1 ],
@@ -62380,6 +62733,7 @@
       "revision" : "master",
       "path" : "packages/babel-helper-split-export-declaration"
     },
+    "curations" : [ ],
     "paths" : [ 352 ],
     "levels" : [ 4, 5, 6 ],
     "scopes" : [ 1 ],
@@ -62458,6 +62812,7 @@
       "revision" : "master",
       "path" : "packages/babel-helper-validator-identifier"
     },
+    "curations" : [ ],
     "paths" : [ 353 ],
     "levels" : [ 3, 4, 5, 6, 7, 8, 9, 10 ],
     "scopes" : [ 1 ],
@@ -62536,6 +62891,7 @@
       "revision" : "master",
       "path" : "packages/babel-helpers"
     },
+    "curations" : [ ],
     "paths" : [ 354 ],
     "levels" : [ 3 ],
     "scopes" : [ 1 ],
@@ -62614,6 +62970,7 @@
       "revision" : "master",
       "path" : "packages/babel-highlight"
     },
+    "curations" : [ ],
     "paths" : [ 355 ],
     "levels" : [ 2, 4, 5, 6, 7, 8, 9 ],
     "scopes" : [ 1 ],
@@ -62720,6 +63077,7 @@
       "revision" : "master",
       "path" : "packages/babel-parser"
     },
+    "curations" : [ ],
     "paths" : [ 356 ],
     "levels" : [ 3, 4, 5, 6, 7, 8 ],
     "scopes" : [ 1 ],
@@ -62847,6 +63205,7 @@
       "revision" : "master",
       "path" : "packages/babel-template"
     },
+    "curations" : [ ],
     "paths" : [ 357 ],
     "levels" : [ 3, 4, 5, 6, 7 ],
     "scopes" : [ 1 ],
@@ -62925,6 +63284,7 @@
       "revision" : "master",
       "path" : "packages/babel-traverse"
     },
+    "curations" : [ ],
     "paths" : [ 358 ],
     "levels" : [ 3, 4, 5 ],
     "scopes" : [ 1 ],
@@ -63003,6 +63363,7 @@
       "revision" : "master",
       "path" : "packages/babel-types"
     },
+    "curations" : [ ],
     "paths" : [ 359 ],
     "levels" : [ 3, 4, 5, 6, 7, 8 ],
     "scopes" : [ 1 ],
@@ -63081,6 +63442,7 @@
       "revision" : "6e6427d8daf2853c2ab46127dc0d463c2ea2f6ca",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 360 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
@@ -63145,6 +63507,7 @@
       "revision" : "61c69da39a0af8f4387ba8aa1eddb633227c3938",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 361 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 1 ],
@@ -63223,6 +63586,7 @@
       "revision" : "",
       "path" : ""
     },
+    "curations" : [ ],
     "paths" : [ 362 ],
     "levels" : [ 4, 5 ],
     "scopes" : [ 1 ],

--- a/reporter/src/funTest/assets/gradle-all-dependencies-result.yml
+++ b/reporter/src/funTest/assets/gradle-all-dependencies-result.yml
@@ -415,6 +415,7 @@ analyzer:
           url: "https://github.com/junit-team/junit.git"
           revision: "r4.12"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-lang3:3.5"
         purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
@@ -446,6 +447,7 @@ analyzer:
           url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
           revision: "LANG_3_5"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-text:1.1"
         purl: "pkg:maven/org.apache.commons/commons-text@1.1"
@@ -476,6 +478,7 @@ analyzer:
           url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
         purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
@@ -505,6 +508,7 @@ analyzer:
           url: "https://gitbox.apache.org/repos/asf/struts.git"
           revision: "STRUTS_2_5_14_1"
           path: ""
+      curations: []
     - package:
         id: "Maven:org.hamcrest:hamcrest-core:1.3"
         purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
@@ -536,6 +540,7 @@ analyzer:
           url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
           revision: ""
           path: ""
+      curations: []
     has_issues: true
 scanner: null
 evaluator: null

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -126,6 +126,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-lang3:3.5"
         purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
@@ -159,6 +160,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-text:1.1"
         purl: "pkg:maven/org.apache.commons/commons-text@1.1"
@@ -191,6 +193,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.hamcrest:hamcrest-core:1.3"
         purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
@@ -224,6 +227,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     has_issues: false
 scanner:
   start_time: "1970-01-01T00:00:00Z"

--- a/scanner/src/funTest/assets/analyzer-result.yml
+++ b/scanner/src/funTest/assets/analyzer-result.yml
@@ -86,6 +86,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-lang3:3.5"
         purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
@@ -119,6 +120,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-text:1.1"
         purl: "pkg:maven/org.apache.commons/commons-text@1.1"
@@ -151,6 +153,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.hamcrest:hamcrest-core:1.3"
         purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
@@ -184,6 +187,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     has_issues: false
 scanner: null
 evaluator: null

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -87,6 +87,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-lang3:3.5"
         purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
@@ -120,6 +121,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.apache.commons:commons-text:1.1"
         purl: "pkg:maven/org.apache.commons/commons-text@1.1"
@@ -152,6 +154,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     - package:
         id: "Maven:org.hamcrest:hamcrest-core:1.3"
         purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
@@ -185,6 +188,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
+      curations: []
     has_issues: false
 scanner:
   start_time: "1970-01-01T00:00:00Z"


### PR DESCRIPTION
…empty"

Explicitly writing empty curations helps with understanding the file
format and might simplify parsing. These slightly outweigh the reduced
file size, in particular since there are usually relatively few
CuratedPackage objects contained in OrtResults.

This reverts commit f5eb87d626c38460e4e25a5b50ebcff7a1a6315d.

Signed-off-by: Frank Viernau <frank.viernau@here.com>