### PR TITLE
LicenseInfoResolver: Filter copyright garbage before processing statements

### DIFF
--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -45,6 +45,12 @@ data class ResolvedLicenseInfo(
      */
     val licenses: List<ResolvedLicense>,
 
+    /**
+     * All copyright findings with statements that are contained in [CopyrightGarbage], mapped to the [Provenance] where
+     * they were detected.
+     */
+    val copyrightGarbage: Map<Provenance, Set<CopyrightFinding>>,
+
     val unmatchedCopyrights: Map<Provenance, Set<CopyrightFinding>>
 ) : Iterable<ResolvedLicense> by licenses {
     operator fun get(license: SpdxSingleLicenseExpression): ResolvedLicense? = find { it.license == license }
@@ -119,12 +125,7 @@ data class ResolvedCopyright(
      * The resolved findings for this copyright. The statements in the findings can be different to [statement] if they
      * were processed by the [CopyrightStatementsProcessor].
      */
-    val findings: Set<ResolvedCopyrightFinding>,
-
-    /**
-     * True, if this [statement] is contained in the [CopyrightGarbage] used during resolution.
-     */
-    val isGarbage: Boolean
+    val findings: Set<ResolvedCopyrightFinding>
 )
 
 /**
@@ -144,10 +145,5 @@ data class ResolvedCopyrightFinding(
     /**
      * All [PathExclude]s matching this [location].
      */
-    val matchingPathExcludes: List<PathExclude>,
-
-    /**
-     * True, if this [statement] is contained in the [CopyrightGarbage] used during resolution.
-     */
-    val isGarbage: Boolean
+    val matchingPathExcludes: List<PathExclude>
 )

--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -51,6 +51,10 @@ data class ResolvedLicenseInfo(
      */
     val copyrightGarbage: Map<Provenance, Set<CopyrightFinding>>,
 
+    /**
+     * All copyright findings that could not be matched to a license finding, mapped to the [Provenance] where they were
+     * detected.
+     */
     val unmatchedCopyrights: Map<Provenance, Set<CopyrightFinding>>
 ) : Iterable<ResolvedLicense> by licenses {
     operator fun get(license: SpdxSingleLicenseExpression): ResolvedLicense? = find { it.license == license }


### PR DESCRIPTION
Filter out any copyright garbage before passing the copyrights to the
copyright statements processor. This avoids that garbage entries affect
the result of the processor.

To reflect this change in the model, add a map of all copyright garbage
findings mapped to their provenance to the `ResolvedLicenseInfo`, and
remove the `isGarbage` properties from `ResolvedCopyright` and
`ResolvedCopyrightFinding`.

This is a functional change compared to the existing code which cleans
copyright garbage before and after running the copyright statements
processor. The reason for the change is, that it is easier to understand
for the user that only actual copyright findings should be added to the
copyright garbage list, and it makes it independent of any changes in
the copyright statements processor.