### PR TITLE
Replace all spdx.org links with spdx.dev

### DIFF
--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -48,7 +48,7 @@ data class ScanSummary(
     val fileCount: Int,
 
     /**
-     * The [SPDX package verification code](https://spdx.org/spdx_specification_2_0_html#h.2p2csry), calculated from
+     * The [SPDX package verification code](https://spdx.dev/spdx_specification_2_0_html#h.2p2csry), calculated from
      * all files in the package. Note that if the scanner is configured to ignore certain files they will still be
      * included in the calculation of this code.
      */

--- a/model/src/main/kotlin/config/LicenseFindingCuration.kt
+++ b/model/src/main/kotlin/config/LicenseFindingCuration.kt
@@ -61,7 +61,7 @@ data class LicenseFindingCuration(
 
     /**
      * The concluded license as SPDX expression or [org.ossreviewtoolkit.spdx.SpdxConstants.NONE] for no license,
-     * see https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60.
+     * see https://spdx.dev/spdx-specification-21-web-version#h.jxpfx0ykyb60.
      */
     val concludedLicense: SpdxExpression,
 

--- a/spdx-utils/src/main/kotlin/SpdxExpression.kt
+++ b/spdx-utils/src/main/kotlin/SpdxExpression.kt
@@ -29,7 +29,7 @@ import org.antlr.v4.runtime.CommonTokenStream
 /**
  * An SPDX expression as defined by version 2.1 of the [SPDX specification, appendix IV][1].
  *
- * [1]: https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60
+ * [1]: https://spdx.dev/spdx-specification-21-web-version#h.jxpfx0ykyb60
  */
 @JsonSerialize(using = ToStringSerializer::class)
 sealed class SpdxExpression {
@@ -168,7 +168,7 @@ sealed class SpdxExpression {
  * An SPDX expression compound of a [left] and a [right] expression with an [operator] as defined by version 2.1 of the
  * [SPDX specification, appendix IV][1].
  *
- * [1]: https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60
+ * [1]: https://spdx.dev/spdx-specification-21-web-version#h.jxpfx0ykyb60
  */
 class SpdxCompoundExpression(
     val left: SpdxExpression,
@@ -358,7 +358,7 @@ class SpdxLicenseWithExceptionExpression(
  * A simple SPDX expression as defined by version 2.1 of the [SPDX specification, appendix IV][1]. A simple expression
  * can be either a [SpdxLicenseIdExpression] or a [SpdxLicenseReferenceExpression].
  *
- * [1]: https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60
+ * [1]: https://spdx.dev/spdx-specification-21-web-version#h.jxpfx0ykyb60
  */
 sealed class SpdxSimpleExpression : SpdxSingleLicenseExpression() {
     /**
@@ -371,7 +371,7 @@ sealed class SpdxSimpleExpression : SpdxSingleLicenseExpression() {
  * An SPDX expression for a license [id] as defined by version 2.1 of the [SPDX specification, appendix I][1].
  * [orLaterVersion] indicates whether the license id also describes later versions of the license.
  *
- * [1]: https://spdx.org/spdx-specification-21-web-version#h.luq9dgcle9mo
+ * [1]: https://spdx.dev/spdx-specification-21-web-version#h.luq9dgcle9mo
  */
 class SpdxLicenseIdExpression(
     val id: String,
@@ -421,7 +421,7 @@ class SpdxLicenseIdExpression(
  * An SPDX expression for a license reference [id] as defined by version 2.1 of the
  * [SPDX specification, appendix IV][1].
  *
- * [1]: https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60
+ * [1]: https://spdx.dev/spdx-specification-21-web-version#h.jxpfx0ykyb60
  */
 data class SpdxLicenseReferenceExpression(
     val id: String
@@ -459,7 +459,7 @@ data class SpdxLicenseReferenceExpression(
  * An SPDX operator for use in compound expressions as defined by version 2.1 of the
  * [SPDX specification, appendix IV][1].
  *
- * [1]: https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60
+ * [1]: https://spdx.dev/spdx-specification-21-web-version#h.jxpfx0ykyb60
  */
 enum class SpdxOperator(
     /**

--- a/spdx-utils/src/main/kotlin/SpdxUtils.kt
+++ b/spdx-utils/src/main/kotlin/SpdxUtils.kt
@@ -68,7 +68,7 @@ private fun ByteArray.toHexString(): String = joinToString("") { String.format("
 /**
  * Calculate the [SPDX package verification code][1] for a list of [known SHA1s][sha1sums] of files and [excludes].
  *
- * [1]: https://spdx.org/spdx_specification_2_0_html#h.2p2csry
+ * [1]: https://spdx.dev/spdx_specification_2_0_html#h.2p2csry
  */
 @JvmName("calculatePackageVerificationCodeForStrings")
 fun calculatePackageVerificationCode(sha1sums: Sequence<String>, excludes: Sequence<String> = emptySequence()): String {
@@ -86,7 +86,7 @@ fun calculatePackageVerificationCode(sha1sums: Sequence<String>, excludes: Seque
 /**
  * Calculate the [SPDX package verification code][1] for a list of [files] and paths of [excludes].
  *
- * [1]: https://spdx.org/spdx_specification_2_0_html#h.2p2csry
+ * [1]: https://spdx.dev/spdx_specification_2_0_html#h.2p2csry
  */
 @JvmName("calculatePackageVerificationCodeForFiles")
 fun calculatePackageVerificationCode(files: Sequence<File>, excludes: Sequence<String> = emptySequence()): String =
@@ -117,7 +117,7 @@ private fun sha1sum(file: File): String =
  * All files with the extension ".spdx" are automatically excluded from the generated code. Additionally files from
  * [VCS directories][VCS_DIRECTORIES] are excluded.
  *
- * [1]: https://spdx.org/spdx_specification_2_0_html#h.2p2csry
+ * [1]: https://spdx.dev/spdx_specification_2_0_html#h.2p2csry
  */
 @JvmName("calculatePackageVerificationCodeForDirectory")
 fun calculatePackageVerificationCode(directory: File): String {

--- a/spdx-utils/src/main/kotlin/model/SpdxCreationInfo.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxCreationInfo.kt
@@ -46,7 +46,7 @@ data class SpdxCreationInfo(
     val creators: List<String> = emptyList(),
 
     /**
-     * The version of SPDX license list (https://spdx.org/licenses/) used in the related [SpdxDocument].
+     * The version of SPDX license list (https://spdx.dev/licenses/) used in the related [SpdxDocument].
      * Data Format: "M.N"
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/utils/src/main/kotlin/DeclaredLicenseProcessor.kt
+++ b/utils/src/main/kotlin/DeclaredLicenseProcessor.kt
@@ -34,6 +34,7 @@ object DeclaredLicenseProcessor {
         "gnu.org/licenses/",
         "licenses.nuget.org/",
         "opensource.org/licenses/",
+        "spdx.dev/licenses/",
         "spdx.org/licenses/",
         "tldrlegal.com/license/"
     ).flatMap {


### PR DESCRIPTION
Now https://spdx.org/ forwards to https://spdx.dev/.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>