### PR TITLE
AntennaAttributionDocumentReporterTest: Apply some minor code improvements

### DIFF
--- a/reporter/src/funTest/kotlin/reporters/AntennaAttributionDocumentReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/AntennaAttributionDocumentReporterTest.kt
@@ -40,16 +40,16 @@ class AntennaAttributionDocumentReporterTest : StringSpec({
             "../scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml"
         )
 
-        val actualReport = generateReport(ortResult)
+        val report = generateReport(ortResult)
 
-        actualReport.length() shouldBe 53797L
+        report.single().length() shouldBe 53797L
     }
 })
 
-private fun generateReport(ortResult: OrtResult): File {
+private fun generateReport(ortResult: OrtResult): List<File> {
     val outputDir = createTempDir(
         ORT_NAME, AntennaAttributionDocumentReporterTest::class.simpleName
     ).apply { deleteOnExit() }
 
-    return AntennaAttributionDocumentReporter().generateReport(ReporterInput(ortResult), outputDir).single()
+    return AntennaAttributionDocumentReporter().generateReport(ReporterInput(ortResult), outputDir)
 }


### PR DESCRIPTION
As Antenna could now generate multiple report files, move the single()
check to the test itself as it depends on the test case whether a single
or multiple report files are expected.

Also simply name the variable "report" as there is no matching "expected
report".

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>