### PR TITLE
cli: Rework the returned status codes

### DIFF
--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.commands
 
 import com.github.ajalt.clikt.core.BadParameterValue
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
@@ -113,7 +114,7 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
 
         val existingOutputFiles = outputFiles.filter { it.exists() }
         if (existingOutputFiles.isNotEmpty()) {
-            throw UsageError("None of the output files $existingOutputFiles must exist yet.", statusCode = 2)
+            throw UsageError("None of the output files $existingOutputFiles must exist yet.")
         }
 
         val distinctPackageManagers = packageManagers.distinct()
@@ -147,6 +148,18 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
         outputFiles.forEach { file ->
             println("Writing analyzer result to '$file'.")
             file.mapper().writerWithDefaultPrettyPrinter().writeValue(file, ortResult)
+        }
+
+        val analyzerResult = ortResult.analyzer?.result
+
+        if (analyzerResult == null) {
+            println("There was an error creating the analyzer result.")
+            throw ProgramResult(1)
+        }
+
+        if (analyzerResult.hasIssues) {
+            println("The analyzer result contains issues.")
+            throw ProgramResult(2)
         }
     }
 }

--- a/cli/src/main/kotlin/commands/ClearlyDefinedUploadCommand.kt
+++ b/cli/src/main/kotlin/commands/ClearlyDefinedUploadCommand.kt
@@ -162,7 +162,7 @@ class ClearlyDefinedUploadCommand : CliktCommand(
         println("Successfully uploaded $uploadedCurationsCount of ${uploadableCurations.size} curations.")
 
         if (uploadedCurationsCount != uploadableCurations.size) {
-            println("At least one error occurred.")
+            println("At least one curation failed to be uploaded.")
             throw ProgramResult(2)
         }
     }

--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -122,7 +122,7 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
     ).flag()
 
     override fun run() {
-        val errorMessages = mutableListOf<String>()
+        val failureMessages = mutableListOf<String>()
 
         when (input) {
             is FileType -> {
@@ -151,11 +151,11 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
                     } catch (e: DownloadException) {
                         e.showStackTrace()
 
-                        val errorMessage = "Could not download '${pkg.id.toCoordinates()}': " +
+                        val failureMessage = "Could not download '${pkg.id.toCoordinates()}': " +
                                 e.collectMessagesAsString()
-                        errorMessages += errorMessage
+                        failureMessages += failureMessage
 
-                        log.error { errorMessage }
+                        log.error { failureMessage }
                     }
                 }
             }
@@ -191,17 +191,17 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
                 } catch (e: DownloadException) {
                     e.showStackTrace()
 
-                    val errorMessage = "Could not download '${dummyPackage.id.toCoordinates()}': " +
+                    val failureMessage = "Could not download '${dummyPackage.id.toCoordinates()}': " +
                             e.collectMessagesAsString()
-                    errorMessages += errorMessage
+                    failureMessages += failureMessage
 
-                    log.error { errorMessage }
+                    log.error { failureMessage }
                 }
             }
         }
 
-        if (errorMessages.isNotEmpty()) {
-            log.error { "Error Summary:\n\n${errorMessages.joinToString("\n\n")}" }
+        if (failureMessages.isNotEmpty()) {
+            log.error { "Failure summary:\n\n${failureMessages.joinToString("\n\n")}" }
             throw ProgramResult(2)
         }
     }

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -141,7 +141,7 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate rules 
 
             val existingOutputFiles = outputFiles.filter { it.exists() }
             if (existingOutputFiles.isNotEmpty()) {
-                throw UsageError("None of the output files $existingOutputFiles must exist yet.", statusCode = 2)
+                throw UsageError("None of the output files $existingOutputFiles must exist yet.")
             }
         }
 
@@ -163,7 +163,7 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate rules 
             is StringType -> {
                 val rulesResource = (rules as StringType).string
                 javaClass.classLoader.getResource(rulesResource)?.readText()
-                    ?: throw UsageError("Invalid rules resource '$rulesResource'.", statusCode = 2)
+                    ?: throw UsageError("Invalid rules resource '$rulesResource'.")
             }
         }
 

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -196,7 +196,7 @@ class ReporterCommand : CliktCommand(
             reportSpecificOptionsMap[option.first] = option.second
         }
 
-        var statusCode = 0
+        var failure = false
         val reportDurationMap = mutableMapOf<Reporter, TimedValue<List<File>>>()
 
         reportFormats.forEach { reporter ->
@@ -214,7 +214,7 @@ class ReporterCommand : CliktCommand(
 
                 log.error { "Could not create '${reporter.reporterName}' report: ${e.collectMessagesAsString()}" }
 
-                statusCode = 1
+                failure = true
             }
         }
 
@@ -223,14 +223,16 @@ class ReporterCommand : CliktCommand(
             println("Successfully created the '$name' report at ${files.value} in ${files.duration.inSeconds}s.")
         }
 
-        if (reportDurationMap.isEmpty()) {
-            println("Failed to create any report.")
-        } else {
-            println("Successfully created ${reportDurationMap.size} of ${reportFormats.size} report(s).")
-        }
+        println("Created ${reportDurationMap.size} of ${reportFormats.size} report(s).")
 
-        if (statusCode != 0) {
-            throw ProgramResult(statusCode)
+        if (failure) {
+            if (reportDurationMap.isEmpty()) {
+                println("Failed to create any report.")
+            } else {
+                println("At least one report was not created successfully.")
+            }
+
+            throw ProgramResult(2)
         }
     }
 }


### PR DESCRIPTION
The general rules are:

- Throw a UsageError (with a default status code of 1) to indicate that
  the user did something wrong.

- Throw a ProgramResult for errors or failures that are out of the
  user's control.

- Use a status code of 1 with ProgramResult for errors that prevented the
  program to execute correctly.

- Use a status code >= 2 with ProgramResult for failures found during
  successful execution, like rule violations.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>