### PR TITLE
Correctly handle license findings in nested repositories

### DIFF
--- a/model/src/main/kotlin/licenses/LicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfo.kt
@@ -24,6 +24,10 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.PackageCurationResult
 import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.Repository
+import org.ossreviewtoolkit.model.config.LicenseFindingCuration
+import org.ossreviewtoolkit.model.config.PathExclude
+import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.ProcessedDeclaredLicense
 
@@ -115,5 +119,26 @@ data class Findings(
     /**
      * The set of all copyright findings.
      */
-    val copyrights: Set<CopyrightFinding>
+    val copyrights: Set<CopyrightFinding>,
+
+    /**
+     * The list of all license finding curations that apply to this [provenance].
+     */
+    val licenseFindingCurations: List<LicenseFindingCuration>,
+
+    /**
+     * The list of all path excludes that apply to this [provenance].
+     */
+    val pathExcludes: List<PathExclude>,
+
+    /**
+     * The root path of the locations of the [licenses] and [copyrights] relative to the paths used in the
+     * [licenseFindingCurations] and [pathExcludes]. An empty string, if all refer to the same root path.
+     *
+     * The roots can be different in case of projects inside nested repositories (see [Repository.nestedRepositories]),
+     * where the license and copyright finding locations are relative to the nested repository, but the
+     * [licenseFindingCurations] and [pathExcludes] are relative to the root repository, because they are configured in
+     * the [RepositoryConfiguration] of the root repository.
+     */
+    val relativeFindingsPath: String
 )

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.utils
+
+import org.ossreviewtoolkit.model.TextLocation
+
+internal fun TextLocation.prependPath(prefix: String): String =
+    if (prefix.isBlank()) path else "${prefix.removeSuffix("/")}/$path"

--- a/model/src/main/kotlin/utils/LicenseResolver.kt
+++ b/model/src/main/kotlin/utils/LicenseResolver.kt
@@ -77,7 +77,10 @@ internal class LicenseResolver(
                 pathExcludes.none { it.matches(copyright.location.getRelativePathToRoot(id)) }
             }
 
-            val curatedLicenseFindings = curationMatcher.applyAll(rawLicenseFindings, curations)
+            val relativeFindingsPath = ortResult.getProject(id)?.let { project ->
+                ortResult.repository.getRelativePath(project.vcsProcessed)
+            }.orEmpty()
+            val curatedLicenseFindings = curationMatcher.applyAll(rawLicenseFindings, curations, relativeFindingsPath)
                 .mapNotNullTo(mutableSetOf()) { it.curatedFinding }
             val decomposedFindings = curatedLicenseFindings.flatMap { finding ->
                 finding.license.decompose().map { finding.copy(license = it) }


### PR DESCRIPTION
Correctly handle license findings for projects in nested repositories. This was broken when applying path excludes and license finding curations, because the paths in the configuration are relative to the analyzer root, but the paths in the findings are relative to the root of the nested repository.