### PR TITLE
Pip: Prepare for obtaining package meta data from additional sources

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -621,9 +621,9 @@ class Pip(
                 sourceArtifact = RemoteArtifact.EMPTY,
                 vcs = VcsInfo.EMPTY
             )
-            allPackages += pkg
-
             val packageRef = pkg.toReference()
+
+            allPackages += pkg
             installDependencies += packageRef
 
             parseDependencies(dependency["dependencies"], allPackages, packageRef.dependencies)

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -62,9 +62,9 @@ import java.util.SortedSet
 import okhttp3.Request
 
 // The lowest version that supports "--prefer-binary".
-const val PIP_VERSION = "18.0"
+private const val PIP_VERSION = "18.0"
 
-const val PIPDEPTREE_VERSION = "0.13.2"
+private const val PIPDEPTREE_VERSION = "0.13.2"
 private val PHONY_DEPENDENCIES = mapOf(
     "pipdeptree" to "", // A dependency of pipdeptree itself.
     "pkg-resources" to "0.0.0", // Added by a bug with some Ubuntu distributions.
@@ -77,7 +77,7 @@ private fun isPhonyDependency(name: String, version: String): Boolean =
         PHONY_DEPENDENCIES.containsKey(name) && (ignoredVersion.isEmpty() || version == ignoredVersion)
     }
 
-const val PYDEP_REVISION = "license-and-classifiers"
+private const val PYDEP_REVISION = "license-and-classifiers"
 
 object VirtualEnv : CommandLineTool {
     override fun command(workingDir: File?) = "virtualenv"
@@ -182,7 +182,7 @@ class Pip(
         /**
          * Return a version string with leading zeros of components stripped.
          */
-        fun stripLeadingZerosFromVersion(version: String) =
+        private fun stripLeadingZerosFromVersion(version: String) =
             version.split(".").joinToString(".") {
                 try {
                     it.toInt().toString()

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -607,15 +607,12 @@ class Pip(
         allPackages: SortedSet<Package>, installDependencies: SortedSet<PackageReference>
     ) {
         dependencies.forEach { dependency ->
-            val name = dependency["package_name"].textValue()
-            val version = dependency["installed_version"].textValue()
-
             val pkg = Package(
                 id = Identifier(
                     type = "PyPI",
                     namespace = "",
-                    name = name,
-                    version = version
+                    name = dependency["package_name"].textValue(),
+                    version = dependency["installed_version"].textValue()
                 ),
                 declaredLicenses = sortedSetOf(),
                 description = "",

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -381,14 +381,14 @@ class Pip(
         )
     }
 
-    private fun getBinaryArtifact(pkg: Package, releaseNode: ArrayNode): RemoteArtifact {
+    private fun getBinaryArtifact(releaseNode: ArrayNode): RemoteArtifact {
         // Prefer python wheels and fall back to the first entry (probably a sdist).
         val binaryArtifact = releaseNode.asSequence().find {
             it["packagetype"].textValue() == "bdist_wheel"
         } ?: releaseNode[0]
 
-        val url = binaryArtifact["url"]?.textValue() ?: pkg.binaryArtifact.url
-        val hash = binaryArtifact["md5_digest"]?.textValue()?.let { Hash.create(it) } ?: pkg.binaryArtifact.hash
+        val url = binaryArtifact["url"]?.textValue() ?: return RemoteArtifact.EMPTY
+        val hash = binaryArtifact["md5_digest"]?.textValue()?.let { Hash.create(it) } ?: return RemoteArtifact.EMPTY
 
         return RemoteArtifact(url, hash)
     }
@@ -609,7 +609,7 @@ class Pip(
                     description = pkgDescription,
                     homepageUrl = pkgHomepage,
                     binaryArtifact = if (pkgRelease != null) {
-                        getBinaryArtifact(pkg, pkgRelease)
+                        getBinaryArtifact(pkgRelease)
                     } else {
                         pkg.binaryArtifact
                     },

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -65,6 +65,7 @@ import okhttp3.Request
 private const val PIP_VERSION = "18.0"
 
 private const val PIPDEPTREE_VERSION = "0.13.2"
+
 private val PHONY_DEPENDENCIES = mapOf(
     "pipdeptree" to "", // A dependency of pipdeptree itself.
     "pkg-resources" to "0.0.0", // Added by a bug with some Ubuntu distributions.


### PR DESCRIPTION
Pip currently "enriches" the package meta data by querying PyPI. When using an additional repository, for example when
`--extra-index-url` is specified in `requirements.txt` then the enriching won't work for the packages obtained from that additonal repository. This change prepares for enriching the package meta-data also from other sources, namely
- querying also the other repository
- examining locally installed packages e.g. via `pip show`

Therefore the "query and enrich" functionality is split-up into "query" and "enrich" so that the latter can be re-used.
