### PR TITLE
test-utils: Add a dependency required for the kotest IntelliJ plugin

### DIFF
--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
 
     api("io.kotest:kotest-core-jvm:$kotestVersion")
     api("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
+    api("io.kotest:kotest-runner-console-jvm:$kotestVersion")
 
     // kotest uses slf4j 1.7, so route these calls to log4j to avoid the slf4j warning about no logger being bound.
     implementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jCoreVersion")


### PR DESCRIPTION
Add a dependency to kotest-runner-console-jvm which is required for the
kotest IntelliJ plugin [1]. The plugin allows to execute individual
tests in IntelliJ which is otherwise impossible.

[1] https://github.com/kotest/kotest-intellij-plugin#getting-started