### PR TITLE
Revert "CycloneDxReporter: Escape the component description if needed"

### DIFF
--- a/reporter/src/funTest/kotlin/reporters/CycloneDxReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/CycloneDxReporterTest.kt
@@ -91,8 +91,6 @@ class CycloneDxReporterTest : WordSpec({
                     // The official Gradle plugin does not seem to be able to get all descriptions that the ORT analyzer
                     // gets, so clear out ORT's one if the plugin has none, but still compare them if both are present.
                     componentFromReporter.description = null
-                } else {
-                    componentFromPlugin.description = escapeXml(componentFromPlugin.description)
                 }
             }
 

--- a/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
+++ b/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
@@ -43,18 +43,6 @@ import org.ossreviewtoolkit.spdx.SpdxLicense
 private const val REPORT_BASE_FILENAME = "bom"
 private const val REPORT_EXTENSION = "xml"
 
-private val XML_ESCAPES = mapOf(
-    "\"" to "&quot;",
-    "'" to "&apos;",
-    "<" to "&lt;",
-    ">" to "&gt;",
-    "&" to "&amp;"
-)
-
-private val ESCAPES_REGEX = XML_ESCAPES.keys.joinToString("|", "(", ")").toRegex()
-
-fun escapeXml(text: String) = ESCAPES_REGEX.replace(text) { XML_ESCAPES.getValue(it.value) }
-
 class CycloneDxReporter : Reporter {
     override val reporterName = "CycloneDx"
 
@@ -200,7 +188,7 @@ class CycloneDxReporter : Reporter {
             group = pkg.id.namespace
             name = pkg.id.name
             version = pkg.id.version
-            description = escapeXml(pkg.description)
+            description = pkg.description
 
             // TODO: Map package-manager-specific OPTIONAL scopes.
             scope = if (input.ortResult.isPackageExcluded(pkg.id)) {


### PR DESCRIPTION
This reverts commit c918ff9 as [1] has been fixed in cyclonedx-core-java
3.0.0 which was taken into use in b953b98.

[1] https://github.com/CycloneDX/cyclonedx-core-java/issues/38