### PR TITLE
Prepare LicenseView for use with ResolvedLicenseInfo

### DIFF
--- a/evaluator/src/main/kotlin/PackageRule.kt
+++ b/evaluator/src/main/kotlin/PackageRule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.PathExclude
+import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.spdx.SpdxExpression
 import org.ossreviewtoolkit.spdx.SpdxLicense
 import org.ossreviewtoolkit.spdx.SpdxLicenseIdExpression

--- a/evaluator/src/test/kotlin/RuleSetTest.kt
+++ b/evaluator/src/test/kotlin/RuleSetTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ package org.ossreviewtoolkit.evaluator
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.should
+
+import org.ossreviewtoolkit.model.licenses.LicenseView
 
 import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
 

--- a/model/src/main/kotlin/licenses/LicenseView.kt
+++ b/model/src/main/kotlin/licenses/LicenseView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.evaluator
+package org.ossreviewtoolkit.model.licenses
 
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.Package
@@ -94,7 +94,6 @@ class LicenseView(vararg licenseSources: List<LicenseSource>) {
                     LicenseSource.DECLARED -> declaredLicenses
                     LicenseSource.DETECTED -> detectedLicenses
                     LicenseSource.CONCLUDED -> concludedLicenses
-                    else -> throw NotImplementedError()
                 }.map { license -> Pair(license, source) }.distinct()
             }
 

--- a/model/src/test/kotlin/licenses/LicenseViewTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseViewTest.kt
@@ -20,11 +20,13 @@
 package org.ossreviewtoolkit.model.licenses
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.Matcher
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.should
 
 import org.ossreviewtoolkit.model.LicenseSource
+import org.ossreviewtoolkit.spdx.SpdxExpression
 import org.ossreviewtoolkit.spdx.toSpdx
 
 class LicenseViewTest : WordSpec() {
@@ -35,52 +37,52 @@ class LicenseViewTest : WordSpec() {
 
                 view.licenses(packageWithoutLicense, emptyList()) should beEmpty()
 
-                view.licenses(packageWithoutLicense, detectedLicenses) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
+                view.licenses(packageWithoutLicense, detectedLicenses) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DETECTED,
+                    "LicenseRef-b" to LicenseSource.DETECTED
                 )
 
-                view.licenses(packageWithOnlyConcludedLicense, emptyList()) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                view.licenses(packageWithOnlyConcludedLicense, emptyList()) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
 
-                view.licenses(packageWithOnlyConcludedLicense, detectedLicenses) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
+                view.licenses(packageWithOnlyConcludedLicense, detectedLicenses) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED,
+                    "LicenseRef-a" to LicenseSource.DETECTED,
+                    "LicenseRef-b" to LicenseSource.DETECTED
                 )
 
-                view.licenses(packageWithOnlyDeclaredLicense, emptyList()) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
+                view.licenses(packageWithOnlyDeclaredLicense, emptyList()) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DECLARED,
+                    "LicenseRef-b" to LicenseSource.DECLARED
                 )
 
-                view.licenses(packageWithOnlyDeclaredLicense, detectedLicenses) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED,
-                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
+                view.licenses(packageWithOnlyDeclaredLicense, detectedLicenses) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DECLARED,
+                    "LicenseRef-b" to LicenseSource.DECLARED,
+                    "LicenseRef-a" to LicenseSource.DETECTED,
+                    "LicenseRef-b" to LicenseSource.DETECTED
                 )
 
-                view.licenses(packageWithConcludedAndDeclaredLicense, emptyList()) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
+                view.licenses(packageWithConcludedAndDeclaredLicense, emptyList()) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED,
+                    "LicenseRef-a" to LicenseSource.DECLARED,
+                    "LicenseRef-b" to LicenseSource.DECLARED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED,
-                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED,
+                    "LicenseRef-a" to LicenseSource.DECLARED,
+                    "LicenseRef-b" to LicenseSource.DECLARED,
+                    "LicenseRef-a" to LicenseSource.DETECTED,
+                    "LicenseRef-b" to LicenseSource.DETECTED
                 )
             }
         }
@@ -97,59 +99,59 @@ class LicenseViewTest : WordSpec() {
                 view.licenses(
                     packageWithoutLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DETECTED,
+                    "LicenseRef-b" to LicenseSource.DETECTED
                 )
 
                 view.licenses(
                     packageWithOnlyConcludedLicense,
                     emptyList()
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithOnlyConcludedLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithOnlyDeclaredLicense,
                     emptyList()
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DECLARED,
+                    "LicenseRef-b" to LicenseSource.DECLARED
                 )
 
                 view.licenses(
                     packageWithOnlyDeclaredLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED,
-                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DECLARED,
+                    "LicenseRef-b" to LicenseSource.DECLARED,
+                    "LicenseRef-a" to LicenseSource.DETECTED,
+                    "LicenseRef-b" to LicenseSource.DETECTED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     emptyList()
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
             }
         }
@@ -166,57 +168,57 @@ class LicenseViewTest : WordSpec() {
                 view.licenses(
                     packageWithoutLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DETECTED,
+                    "LicenseRef-b" to LicenseSource.DETECTED
                 )
 
                 view.licenses(
                     packageWithOnlyConcludedLicense,
                     emptyList()
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithOnlyConcludedLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithOnlyDeclaredLicense,
                     emptyList()
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DECLARED,
+                    "LicenseRef-b" to LicenseSource.DECLARED
                 )
 
                 view.licenses(
                     packageWithOnlyDeclaredLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DECLARED,
+                    "LicenseRef-b" to LicenseSource.DECLARED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     emptyList()
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
             }
         }
@@ -232,25 +234,25 @@ class LicenseViewTest : WordSpec() {
                 view.licenses(
                     packageWithoutLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DETECTED,
+                    "LicenseRef-b" to LicenseSource.DETECTED
                 )
 
                 view.licenses(
                     packageWithOnlyConcludedLicense,
                     emptyList()
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithOnlyConcludedLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
@@ -261,25 +263,25 @@ class LicenseViewTest : WordSpec() {
                 view.licenses(
                     packageWithOnlyDeclaredLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DETECTED,
+                    "LicenseRef-b" to LicenseSource.DETECTED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     emptyList()
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
             }
         }
@@ -300,17 +302,17 @@ class LicenseViewTest : WordSpec() {
                 view.licenses(
                     packageWithOnlyConcludedLicense,
                     emptyList()
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithOnlyConcludedLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
@@ -326,17 +328,17 @@ class LicenseViewTest : WordSpec() {
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     emptyList()
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.CONCLUDED,
+                    "LicenseRef-b" to LicenseSource.CONCLUDED
                 )
             }
         }
@@ -368,33 +370,33 @@ class LicenseViewTest : WordSpec() {
                 view.licenses(
                     packageWithOnlyDeclaredLicense,
                     emptyList()
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DECLARED,
+                    "LicenseRef-b" to LicenseSource.DECLARED
                 )
 
                 view.licenses(
                     packageWithOnlyDeclaredLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DECLARED,
+                    "LicenseRef-b" to LicenseSource.DECLARED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     emptyList()
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DECLARED,
+                    "LicenseRef-b" to LicenseSource.DECLARED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DECLARED,
+                    "LicenseRef-b" to LicenseSource.DECLARED
                 )
             }
         }
@@ -411,9 +413,9 @@ class LicenseViewTest : WordSpec() {
                 view.licenses(
                     packageWithoutLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DETECTED,
+                    "LicenseRef-b" to LicenseSource.DETECTED
                 )
 
                 view.licenses(
@@ -424,9 +426,9 @@ class LicenseViewTest : WordSpec() {
                 view.licenses(
                     packageWithOnlyConcludedLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DETECTED,
+                    "LicenseRef-b" to LicenseSource.DETECTED
                 )
 
                 view.licenses(
@@ -437,9 +439,9 @@ class LicenseViewTest : WordSpec() {
                 view.licenses(
                     packageWithOnlyDeclaredLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DETECTED,
+                    "LicenseRef-b" to LicenseSource.DETECTED
                 )
 
                 view.licenses(
@@ -450,11 +452,16 @@ class LicenseViewTest : WordSpec() {
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     detectedLicenses
-                ) should containExactlyInAnyOrder(
-                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
-                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
+                ) should containLicensesWithSources(
+                    "LicenseRef-a" to LicenseSource.DETECTED,
+                    "LicenseRef-b" to LicenseSource.DETECTED
                 )
             }
         }
     }
 }
+
+fun containLicensesWithSources(
+    vararg licenses: Pair<String, LicenseSource>
+): Matcher<List<Pair<SpdxExpression, LicenseSource>>?> =
+    containExactlyInAnyOrder(licenses.map { Pair(it.first.toSpdx(), it.second) })

--- a/model/src/test/kotlin/licenses/LicenseViewTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseViewTest.kt
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.spdx.toSpdx
 
 class LicenseViewTest : WordSpec() {
     init {
-        "All" should {
+        "ALL" should {
             "return the correct licenses" {
                 val view = LicenseView.ALL
 
@@ -85,7 +85,7 @@ class LicenseViewTest : WordSpec() {
             }
         }
 
-        "ConcludedOrRest" should {
+        "CONCLUDED_OR_REST" should {
             "return the correct licenses" {
                 val view = LicenseView.CONCLUDED_OR_REST
 
@@ -154,7 +154,7 @@ class LicenseViewTest : WordSpec() {
             }
         }
 
-        "ConcludedOrDeclaredOrDetected" should {
+        "CONCLUDED_OR_DECLARED_OR_DETECTED" should {
             "return the correct licenses" {
                 val view = LicenseView.CONCLUDED_OR_DECLARED_OR_DETECTED
 
@@ -221,7 +221,7 @@ class LicenseViewTest : WordSpec() {
             }
         }
 
-        "ConcludedOrDetected" should {
+        "CONCLUDED_OR_DETECTED" should {
             "return the correct licenses" {
                 val view = LicenseView.CONCLUDED_OR_DETECTED
                 view.licenses(
@@ -284,7 +284,7 @@ class LicenseViewTest : WordSpec() {
             }
         }
 
-        "OnlyConcluded" should {
+        "ONLY_CONCLUDED" should {
             "return only the concluded licenses" {
                 val view = LicenseView.ONLY_CONCLUDED
                 view.licenses(
@@ -341,7 +341,7 @@ class LicenseViewTest : WordSpec() {
             }
         }
 
-        "OnlyDeclared" should {
+        "ONLY_DECLARED" should {
             "return only the declared licenses" {
                 val view = LicenseView.ONLY_DECLARED
 
@@ -399,7 +399,7 @@ class LicenseViewTest : WordSpec() {
             }
         }
 
-        "OnlyDetected" should {
+        "ONLY_DETECTED" should {
             "return only the detected licenses" {
                 val view = LicenseView.ONLY_DETECTED
 

--- a/model/src/test/kotlin/licenses/LicenseViewTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseViewTest.kt
@@ -53,13 +53,13 @@ class LicenseViewTest : WordSpec() {
                 )
 
                 view.licenses(packageWithOnlyDeclaredLicense, emptyList()) should containExactlyInAnyOrder(
-                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
                 )
 
                 view.licenses(packageWithOnlyDeclaredLicense, detectedLicenses) should containExactlyInAnyOrder(
-                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                    Pair("MIT".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED),
                     Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
                     Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
                 )
@@ -67,8 +67,8 @@ class LicenseViewTest : WordSpec() {
                 view.licenses(packageWithConcludedAndDeclaredLicense, emptyList()) should containExactlyInAnyOrder(
                     Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
                     Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
                 )
 
                 view.licenses(
@@ -77,8 +77,8 @@ class LicenseViewTest : WordSpec() {
                 ) should containExactlyInAnyOrder(
                     Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
                     Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                    Pair("MIT".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED),
                     Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
                     Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
                 )
@@ -122,16 +122,16 @@ class LicenseViewTest : WordSpec() {
                     packageWithOnlyDeclaredLicense,
                     emptyList()
                 ) should containExactlyInAnyOrder(
-                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
                 )
 
                 view.licenses(
                     packageWithOnlyDeclaredLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                    Pair("MIT".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED),
                     Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
                     Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
                 )
@@ -191,16 +191,16 @@ class LicenseViewTest : WordSpec() {
                     packageWithOnlyDeclaredLicense,
                     emptyList()
                 ) should containExactlyInAnyOrder(
-                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
                 )
 
                 view.licenses(
                     packageWithOnlyDeclaredLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
                 )
 
                 view.licenses(
@@ -369,32 +369,32 @@ class LicenseViewTest : WordSpec() {
                     packageWithOnlyDeclaredLicense,
                     emptyList()
                 ) should containExactlyInAnyOrder(
-                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
                 )
 
                 view.licenses(
                     packageWithOnlyDeclaredLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     emptyList()
                 ) should containExactlyInAnyOrder(
-                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
                 )
             }
         }

--- a/model/src/test/kotlin/licenses/LicenseViewTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseViewTest.kt
@@ -27,432 +27,434 @@ import io.kotest.matchers.should
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.spdx.toSpdx
 
-class LicenseViewTest : WordSpec({
-    "All" should {
-        "return the correct licenses" {
-            val view = LicenseView.ALL
+class LicenseViewTest : WordSpec() {
+    init {
+        "All" should {
+            "return the correct licenses" {
+                val view = LicenseView.ALL
 
-            view.licenses(packageWithoutLicense, emptyList()) should beEmpty()
+                view.licenses(packageWithoutLicense, emptyList()) should beEmpty()
 
-            view.licenses(packageWithoutLicense, detectedLicenses) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
-            )
+                view.licenses(packageWithoutLicense, detectedLicenses) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                )
 
-            view.licenses(packageWithOnlyConcludedLicense, emptyList()) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
+                view.licenses(packageWithOnlyConcludedLicense, emptyList()) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
 
-            view.licenses(packageWithOnlyConcludedLicense, detectedLicenses) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
-            )
+                view.licenses(packageWithOnlyConcludedLicense, detectedLicenses) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                )
 
-            view.licenses(packageWithOnlyDeclaredLicense, emptyList()) should containExactlyInAnyOrder(
-                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
-            )
+                view.licenses(packageWithOnlyDeclaredLicense, emptyList()) should containExactlyInAnyOrder(
+                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                )
 
-            view.licenses(packageWithOnlyDeclaredLicense, detectedLicenses) should containExactlyInAnyOrder(
-                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                Pair("MIT".toSpdx(), LicenseSource.DECLARED),
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
-            )
+                view.licenses(packageWithOnlyDeclaredLicense, detectedLicenses) should containExactlyInAnyOrder(
+                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                    Pair("MIT".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                )
 
-            view.licenses(packageWithConcludedAndDeclaredLicense, emptyList()) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
-            )
+                view.licenses(packageWithConcludedAndDeclaredLicense, emptyList()) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                )
 
-            view.licenses(
-                packageWithConcludedAndDeclaredLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                Pair("MIT".toSpdx(), LicenseSource.DECLARED),
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
-            )
+                view.licenses(
+                    packageWithConcludedAndDeclaredLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                    Pair("MIT".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                )
+            }
+        }
+
+        "ConcludedOrRest" should {
+            "return the correct licenses" {
+                val view = LicenseView.CONCLUDED_OR_REST
+
+                view.licenses(
+                    packageWithoutLicense,
+                    emptyList()
+                ) should beEmpty()
+
+                view.licenses(
+                    packageWithoutLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                )
+
+                view.licenses(
+                    packageWithOnlyConcludedLicense,
+                    emptyList()
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
+
+                view.licenses(
+                    packageWithOnlyConcludedLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
+
+                view.licenses(
+                    packageWithOnlyDeclaredLicense,
+                    emptyList()
+                ) should containExactlyInAnyOrder(
+                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                )
+
+                view.licenses(
+                    packageWithOnlyDeclaredLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                    Pair("MIT".toSpdx(), LicenseSource.DECLARED),
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                )
+
+                view.licenses(
+                    packageWithConcludedAndDeclaredLicense,
+                    emptyList()
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
+
+                view.licenses(
+                    packageWithConcludedAndDeclaredLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
+            }
+        }
+
+        "ConcludedOrDeclaredOrDetected" should {
+            "return the correct licenses" {
+                val view = LicenseView.CONCLUDED_OR_DECLARED_OR_DETECTED
+
+                view.licenses(
+                    packageWithoutLicense,
+                    emptyList()
+                ) should beEmpty()
+
+                view.licenses(
+                    packageWithoutLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                )
+
+                view.licenses(
+                    packageWithOnlyConcludedLicense,
+                    emptyList()
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
+
+                view.licenses(
+                    packageWithOnlyConcludedLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
+
+                view.licenses(
+                    packageWithOnlyDeclaredLicense,
+                    emptyList()
+                ) should containExactlyInAnyOrder(
+                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                )
+
+                view.licenses(
+                    packageWithOnlyDeclaredLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                )
+
+                view.licenses(
+                    packageWithConcludedAndDeclaredLicense,
+                    emptyList()
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
+
+                view.licenses(
+                    packageWithConcludedAndDeclaredLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
+            }
+        }
+
+        "ConcludedOrDetected" should {
+            "return the correct licenses" {
+                val view = LicenseView.CONCLUDED_OR_DETECTED
+                view.licenses(
+                    packageWithoutLicense,
+                    emptyList()
+                ) should beEmpty()
+
+                view.licenses(
+                    packageWithoutLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                )
+
+                view.licenses(
+                    packageWithOnlyConcludedLicense,
+                    emptyList()
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
+
+                view.licenses(
+                    packageWithOnlyConcludedLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
+
+                view.licenses(
+                    packageWithOnlyDeclaredLicense,
+                    emptyList()
+                ) should beEmpty()
+
+                view.licenses(
+                    packageWithOnlyDeclaredLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                )
+
+                view.licenses(
+                    packageWithConcludedAndDeclaredLicense,
+                    emptyList()
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
+
+                view.licenses(
+                    packageWithConcludedAndDeclaredLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
+            }
+        }
+
+        "OnlyConcluded" should {
+            "return only the concluded licenses" {
+                val view = LicenseView.ONLY_CONCLUDED
+                view.licenses(
+                    packageWithoutLicense,
+                    emptyList()
+                ) should beEmpty()
+
+                view.licenses(
+                    packageWithoutLicense,
+                    detectedLicenses
+                ) should beEmpty()
+
+                view.licenses(
+                    packageWithOnlyConcludedLicense,
+                    emptyList()
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
+
+                view.licenses(
+                    packageWithOnlyConcludedLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
+
+                view.licenses(
+                    packageWithOnlyDeclaredLicense,
+                    emptyList()
+                ) should beEmpty()
+
+                view.licenses(
+                    packageWithOnlyDeclaredLicense,
+                    detectedLicenses
+                ) should beEmpty()
+
+                view.licenses(
+                    packageWithConcludedAndDeclaredLicense,
+                    emptyList()
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
+
+                view.licenses(
+                    packageWithConcludedAndDeclaredLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                )
+            }
+        }
+
+        "OnlyDeclared" should {
+            "return only the declared licenses" {
+                val view = LicenseView.ONLY_DECLARED
+
+                view.licenses(
+                    packageWithoutLicense,
+                    emptyList()
+                ) should beEmpty()
+
+                view.licenses(
+                    packageWithoutLicense,
+                    detectedLicenses
+                ) should beEmpty()
+
+                view.licenses(
+                    packageWithOnlyConcludedLicense,
+                    emptyList()
+                ) should beEmpty()
+
+                view.licenses(
+                    packageWithOnlyConcludedLicense,
+                    detectedLicenses
+                ) should beEmpty()
+
+                view.licenses(
+                    packageWithOnlyDeclaredLicense,
+                    emptyList()
+                ) should containExactlyInAnyOrder(
+                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                )
+
+                view.licenses(
+                    packageWithOnlyDeclaredLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                )
+
+                view.licenses(
+                    packageWithConcludedAndDeclaredLicense,
+                    emptyList()
+                ) should containExactlyInAnyOrder(
+                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                )
+
+                view.licenses(
+                    packageWithConcludedAndDeclaredLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
+                    Pair("MIT".toSpdx(), LicenseSource.DECLARED)
+                )
+            }
+        }
+
+        "OnlyDetected" should {
+            "return only the detected licenses" {
+                val view = LicenseView.ONLY_DETECTED
+
+                view.licenses(
+                    packageWithoutLicense,
+                    emptyList()
+                ) should beEmpty()
+
+                view.licenses(
+                    packageWithoutLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                )
+
+                view.licenses(
+                    packageWithOnlyConcludedLicense,
+                    emptyList()
+                ) should beEmpty()
+
+                view.licenses(
+                    packageWithOnlyConcludedLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                )
+
+                view.licenses(
+                    packageWithOnlyDeclaredLicense,
+                    emptyList()
+                ) should beEmpty()
+
+                view.licenses(
+                    packageWithOnlyDeclaredLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                )
+
+                view.licenses(
+                    packageWithConcludedAndDeclaredLicense,
+                    emptyList()
+                ) should beEmpty()
+
+                view.licenses(
+                    packageWithConcludedAndDeclaredLicense,
+                    detectedLicenses
+                ) should containExactlyInAnyOrder(
+                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
+                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                )
+            }
         }
     }
-
-    "ConcludedOrRest" should {
-        "return the correct licenses" {
-            val view = LicenseView.CONCLUDED_OR_REST
-
-            view.licenses(
-                packageWithoutLicense,
-                emptyList()
-            ) should beEmpty()
-
-            view.licenses(
-                packageWithoutLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
-            )
-
-            view.licenses(
-                packageWithOnlyConcludedLicense,
-                emptyList()
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
-
-            view.licenses(
-                packageWithOnlyConcludedLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
-
-            view.licenses(
-                packageWithOnlyDeclaredLicense,
-                emptyList()
-            ) should containExactlyInAnyOrder(
-                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
-            )
-
-            view.licenses(
-                packageWithOnlyDeclaredLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                Pair("MIT".toSpdx(), LicenseSource.DECLARED),
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
-            )
-
-            view.licenses(
-                packageWithConcludedAndDeclaredLicense,
-                emptyList()
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
-
-            view.licenses(
-                packageWithConcludedAndDeclaredLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
-        }
-    }
-
-    "ConcludedOrDeclaredOrDetected" should {
-        "return the correct licenses" {
-            val view = LicenseView.CONCLUDED_OR_DECLARED_OR_DETECTED
-
-            view.licenses(
-                packageWithoutLicense,
-                emptyList()
-            ) should beEmpty()
-
-            view.licenses(
-                packageWithoutLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
-            )
-
-            view.licenses(
-                packageWithOnlyConcludedLicense,
-                emptyList()
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
-
-            view.licenses(
-                packageWithOnlyConcludedLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
-
-            view.licenses(
-                packageWithOnlyDeclaredLicense,
-                emptyList()
-            ) should containExactlyInAnyOrder(
-                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
-            )
-
-            view.licenses(
-                packageWithOnlyDeclaredLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
-            )
-
-            view.licenses(
-                packageWithConcludedAndDeclaredLicense,
-                emptyList()
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
-
-            view.licenses(
-                packageWithConcludedAndDeclaredLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
-        }
-    }
-
-    "ConcludedOrDetected" should {
-        "return the correct licenses" {
-            val view = LicenseView.CONCLUDED_OR_DETECTED
-            view.licenses(
-                packageWithoutLicense,
-                emptyList()
-            ) should beEmpty()
-
-            view.licenses(
-                packageWithoutLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
-            )
-
-            view.licenses(
-                packageWithOnlyConcludedLicense,
-                emptyList()
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
-
-            view.licenses(
-                packageWithOnlyConcludedLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
-
-            view.licenses(
-                packageWithOnlyDeclaredLicense,
-                emptyList()
-            ) should beEmpty()
-
-            view.licenses(
-                packageWithOnlyDeclaredLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
-            )
-
-            view.licenses(
-                packageWithConcludedAndDeclaredLicense,
-                emptyList()
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
-
-            view.licenses(
-                packageWithConcludedAndDeclaredLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
-        }
-    }
-
-    "OnlyConcluded" should {
-        "return only the concluded licenses" {
-            val view = LicenseView.ONLY_CONCLUDED
-            view.licenses(
-                packageWithoutLicense,
-                emptyList()
-            ) should beEmpty()
-
-            view.licenses(
-                packageWithoutLicense,
-                detectedLicenses
-            ) should beEmpty()
-
-            view.licenses(
-                packageWithOnlyConcludedLicense,
-                emptyList()
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
-
-            view.licenses(
-                packageWithOnlyConcludedLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
-
-            view.licenses(
-                packageWithOnlyDeclaredLicense,
-                emptyList()
-            ) should beEmpty()
-
-            view.licenses(
-                packageWithOnlyDeclaredLicense,
-                detectedLicenses
-            ) should beEmpty()
-
-            view.licenses(
-                packageWithConcludedAndDeclaredLicense,
-                emptyList()
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
-
-            view.licenses(
-                packageWithConcludedAndDeclaredLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
-            )
-        }
-    }
-
-    "OnlyDeclared" should {
-        "return only the declared licenses" {
-            val view = LicenseView.ONLY_DECLARED
-
-            view.licenses(
-                packageWithoutLicense,
-                emptyList()
-            ) should beEmpty()
-
-            view.licenses(
-                packageWithoutLicense,
-                detectedLicenses
-            ) should beEmpty()
-
-            view.licenses(
-                packageWithOnlyConcludedLicense,
-                emptyList()
-            ) should beEmpty()
-
-            view.licenses(
-                packageWithOnlyConcludedLicense,
-                detectedLicenses
-            ) should beEmpty()
-
-            view.licenses(
-                packageWithOnlyDeclaredLicense,
-                emptyList()
-            ) should containExactlyInAnyOrder(
-                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
-            )
-
-            view.licenses(
-                packageWithOnlyDeclaredLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
-            )
-
-            view.licenses(
-                packageWithConcludedAndDeclaredLicense,
-                emptyList()
-            ) should containExactlyInAnyOrder(
-                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
-            )
-
-            view.licenses(
-                packageWithConcludedAndDeclaredLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("Apache-2.0".toSpdx(), LicenseSource.DECLARED),
-                Pair("MIT".toSpdx(), LicenseSource.DECLARED)
-            )
-        }
-    }
-
-    "OnlyDetected" should {
-        "return only the detected licenses" {
-            val view = LicenseView.ONLY_DETECTED
-
-            view.licenses(
-                packageWithoutLicense,
-                emptyList()
-            ) should beEmpty()
-
-            view.licenses(
-                packageWithoutLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
-            )
-
-            view.licenses(
-                packageWithOnlyConcludedLicense,
-                emptyList()
-            ) should beEmpty()
-
-            view.licenses(
-                packageWithOnlyConcludedLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
-            )
-
-            view.licenses(
-                packageWithOnlyDeclaredLicense,
-                emptyList()
-            ) should beEmpty()
-
-            view.licenses(
-                packageWithOnlyDeclaredLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
-            )
-
-            view.licenses(
-                packageWithConcludedAndDeclaredLicense,
-                emptyList()
-            ) should beEmpty()
-
-            view.licenses(
-                packageWithConcludedAndDeclaredLicense,
-                detectedLicenses
-            ) should containExactlyInAnyOrder(
-                Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
-            )
-        }
-    }
-})
+}

--- a/model/src/test/kotlin/licenses/LicenseViewTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseViewTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.evaluator
+package org.ossreviewtoolkit.model.licenses
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty

--- a/model/src/test/kotlin/licenses/LicenseViewTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseViewTest.kt
@@ -36,51 +36,51 @@ class LicenseViewTest : WordSpec() {
                 view.licenses(packageWithoutLicense, emptyList()) should beEmpty()
 
                 view.licenses(packageWithoutLicense, detectedLicenses) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
                 )
 
                 view.licenses(packageWithOnlyConcludedLicense, emptyList()) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(packageWithOnlyConcludedLicense, detectedLicenses) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
                 )
 
                 view.licenses(packageWithOnlyDeclaredLicense, emptyList()) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
                 )
 
                 view.licenses(packageWithOnlyDeclaredLicense, detectedLicenses) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED),
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED,
+                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
                 )
 
                 view.licenses(packageWithConcludedAndDeclaredLicense, emptyList()) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED),
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED,
+                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
                 )
             }
         }
@@ -98,58 +98,58 @@ class LicenseViewTest : WordSpec() {
                     packageWithoutLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
                 )
 
                 view.licenses(
                     packageWithOnlyConcludedLicense,
                     emptyList()
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithOnlyConcludedLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithOnlyDeclaredLicense,
                     emptyList()
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
                 )
 
                 view.licenses(
                     packageWithOnlyDeclaredLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED),
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED,
+                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     emptyList()
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
             }
         }
@@ -167,56 +167,56 @@ class LicenseViewTest : WordSpec() {
                     packageWithoutLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
                 )
 
                 view.licenses(
                     packageWithOnlyConcludedLicense,
                     emptyList()
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithOnlyConcludedLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithOnlyDeclaredLicense,
                     emptyList()
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
                 )
 
                 view.licenses(
                     packageWithOnlyDeclaredLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     emptyList()
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
             }
         }
@@ -233,24 +233,24 @@ class LicenseViewTest : WordSpec() {
                     packageWithoutLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
                 )
 
                 view.licenses(
                     packageWithOnlyConcludedLicense,
                     emptyList()
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithOnlyConcludedLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
@@ -262,24 +262,24 @@ class LicenseViewTest : WordSpec() {
                     packageWithOnlyDeclaredLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     emptyList()
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
             }
         }
@@ -301,16 +301,16 @@ class LicenseViewTest : WordSpec() {
                     packageWithOnlyConcludedLicense,
                     emptyList()
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithOnlyConcludedLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
@@ -327,16 +327,16 @@ class LicenseViewTest : WordSpec() {
                     packageWithConcludedAndDeclaredLicense,
                     emptyList()
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.CONCLUDED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.CONCLUDED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.CONCLUDED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.CONCLUDED
                 )
             }
         }
@@ -369,32 +369,32 @@ class LicenseViewTest : WordSpec() {
                     packageWithOnlyDeclaredLicense,
                     emptyList()
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
                 )
 
                 view.licenses(
                     packageWithOnlyDeclaredLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     emptyList()
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
                 )
 
                 view.licenses(
                     packageWithConcludedAndDeclaredLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DECLARED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DECLARED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DECLARED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DECLARED
                 )
             }
         }
@@ -412,8 +412,8 @@ class LicenseViewTest : WordSpec() {
                     packageWithoutLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
                 )
 
                 view.licenses(
@@ -425,8 +425,8 @@ class LicenseViewTest : WordSpec() {
                     packageWithOnlyConcludedLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
                 )
 
                 view.licenses(
@@ -438,8 +438,8 @@ class LicenseViewTest : WordSpec() {
                     packageWithOnlyDeclaredLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
                 )
 
                 view.licenses(
@@ -451,8 +451,8 @@ class LicenseViewTest : WordSpec() {
                     packageWithConcludedAndDeclaredLicense,
                     detectedLicenses
                 ) should containExactlyInAnyOrder(
-                    Pair("LicenseRef-a".toSpdx(), LicenseSource.DETECTED),
-                    Pair("LicenseRef-b".toSpdx(), LicenseSource.DETECTED)
+                    "LicenseRef-a".toSpdx() to LicenseSource.DETECTED,
+                    "LicenseRef-b".toSpdx() to LicenseSource.DETECTED
                 )
             }
         }

--- a/model/src/test/kotlin/licenses/TestData.kt
+++ b/model/src/test/kotlin/licenses/TestData.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.licenses
+
+import org.ossreviewtoolkit.model.AccessStatistics
+import org.ossreviewtoolkit.model.AnalyzerResult
+import org.ossreviewtoolkit.model.AnalyzerRun
+import org.ossreviewtoolkit.model.CuratedPackage
+import org.ossreviewtoolkit.model.Environment
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.LicenseFindings
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageLinkage
+import org.ossreviewtoolkit.model.Project
+import org.ossreviewtoolkit.model.Repository
+import org.ossreviewtoolkit.model.ScanRecord
+import org.ossreviewtoolkit.model.ScannerRun
+import org.ossreviewtoolkit.model.Scope
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
+import org.ossreviewtoolkit.model.config.Excludes
+import org.ossreviewtoolkit.model.config.PathExclude
+import org.ossreviewtoolkit.model.config.PathExcludeReason
+import org.ossreviewtoolkit.model.config.RepositoryConfiguration
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.spdx.SpdxLicenseReferenceExpression
+import org.ossreviewtoolkit.spdx.toSpdx
+import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
+
+val concludedLicense = "LicenseRef-a AND LicenseRef-b".toSpdx()
+val declaredLicenses = sortedSetOf("Apache-2.0", "MIT")
+val declaredLicensesProcessed = DeclaredLicenseProcessor.process(declaredLicenses)
+val detectedLicenses = listOf(
+    SpdxLicenseReferenceExpression("LicenseRef-a"),
+    SpdxLicenseReferenceExpression("LicenseRef-b")
+)
+
+val licenseFindings = listOf(
+    LicenseFindings(SpdxLicenseReferenceExpression("LicenseRef-a"), sortedSetOf(), sortedSetOf()),
+    LicenseFindings(SpdxLicenseReferenceExpression("LicenseRef-b"), sortedSetOf(), sortedSetOf())
+)
+
+val packageExcluded = Package.EMPTY.copy(
+    id = Identifier("Maven:org.ossreviewtoolkit:package-excluded:1.0")
+)
+
+val packageDynamicallyLinked = Package.EMPTY.copy(
+    id = Identifier("Maven:org.ossreviewtoolkit:package-dynamically-linked:1.0")
+)
+
+val packageStaticallyLinked = Package.EMPTY.copy(
+    id = Identifier("Maven:org.ossreviewtoolkit:package-statically-linked:1.0")
+)
+
+val packageWithoutLicense = Package.EMPTY.copy(
+    id = Identifier("Maven:org.ossreviewtoolkit:package-without-license:1.0")
+)
+
+val packageWithOnlyConcludedLicense = Package.EMPTY.copy(
+    id = Identifier("Maven:org.ossreviewtoolkit:package-with-only-concluded-license:1.0"),
+    concludedLicense = concludedLicense
+)
+
+val packageWithOnlyDeclaredLicense = Package.EMPTY.copy(
+    id = Identifier("Maven:org.ossreviewtoolkit:package-with-only-declared-license:1.0"),
+    declaredLicenses = declaredLicenses,
+    declaredLicensesProcessed = declaredLicensesProcessed
+)
+
+val packageWithConcludedAndDeclaredLicense = Package.EMPTY.copy(
+    id = Identifier("Maven:org.ossreviewtoolkit:package-with-concluded-and-declared-license:1.0"),
+    concludedLicense = concludedLicense,
+    declaredLicenses = declaredLicenses,
+    declaredLicensesProcessed = declaredLicensesProcessed
+)
+
+val allPackages = listOf(
+    packageExcluded,
+    packageDynamicallyLinked,
+    packageStaticallyLinked,
+    packageWithoutLicense,
+    packageWithOnlyConcludedLicense,
+    packageWithOnlyDeclaredLicense,
+    packageWithConcludedAndDeclaredLicense
+)
+
+val scopeExcluded = Scope(
+    name = "compile",
+    dependencies = sortedSetOf(
+        packageExcluded.toReference()
+    )
+)
+
+val projectExcluded = Project.EMPTY.copy(
+    id = Identifier("Maven:org.ossreviewtoolkit:project-excluded:1.0"),
+    definitionFilePath = "excluded/pom.xml",
+    scopes = sortedSetOf(scopeExcluded)
+)
+
+val packageRefDynamicallyLinked = packageDynamicallyLinked.toReference(PackageLinkage.DYNAMIC)
+val packageRefStaticallyLinked = packageStaticallyLinked.toReference(PackageLinkage.STATIC)
+
+val scopeIncluded = Scope(
+    name = "compile",
+    dependencies = sortedSetOf(
+        packageWithoutLicense.toReference(),
+        packageWithOnlyConcludedLicense.toReference(),
+        packageWithOnlyDeclaredLicense.toReference(),
+        packageWithConcludedAndDeclaredLicense.toReference(),
+        packageRefDynamicallyLinked,
+        packageRefStaticallyLinked
+    )
+)
+
+val projectIncluded = Project.EMPTY.copy(
+    id = Identifier("Maven:org.ossreviewtoolkit:project-included:1.0"),
+    definitionFilePath = "included/pom.xml",
+    scopes = sortedSetOf(scopeIncluded)
+)
+
+val allProjects = listOf(
+    projectExcluded,
+    projectIncluded
+)
+
+val ortResult = OrtResult(
+    repository = Repository(
+        vcs = VcsInfo.EMPTY,
+        config = RepositoryConfiguration(
+            excludes = Excludes(
+                paths = listOf(
+                    PathExclude(
+                        pattern = "excluded/**",
+                        reason = PathExcludeReason.TEST_TOOL_OF,
+                        comment = "excluded"
+                    )
+                )
+            )
+        )
+    ),
+    analyzer = AnalyzerRun(
+        environment = Environment(),
+        config = AnalyzerConfiguration(ignoreToolVersions = true, allowDynamicVersions = true),
+        result = AnalyzerResult(
+            projects = sortedSetOf(
+                projectExcluded,
+                projectIncluded
+            ),
+            packages = allPackages.mapTo(sortedSetOf()) { CuratedPackage(it) }
+        )
+    ),
+    scanner = ScannerRun(
+        environment = Environment(),
+        config = ScannerConfiguration(),
+        results = ScanRecord(
+            scanResults = sortedSetOf(),
+            storageStats = AccessStatistics()
+        )
+    )
+)

--- a/model/src/test/kotlin/licenses/TestData.kt
+++ b/model/src/test/kotlin/licenses/TestData.kt
@@ -46,7 +46,7 @@ import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
 
 val concludedLicense = "LicenseRef-a AND LicenseRef-b".toSpdx()
-val declaredLicenses = sortedSetOf("Apache-2.0", "MIT")
+val declaredLicenses = sortedSetOf("LicenseRef-a", "LicenseRef-b")
 val declaredLicensesProcessed = DeclaredLicenseProcessor.process(declaredLicenses)
 val detectedLicenses = listOf(
     SpdxLicenseReferenceExpression("LicenseRef-a"),


### PR DESCRIPTION
Apply several refactorings to prepare `LicenseView` and `LicenseViewTest` to be used with `ResolvedLicenseInfo`.