### PR TITLE
docs: Update notice-pre-processor example

### DIFF
--- a/docs/notice-pre-processor-kts.md
+++ b/docs/notice-pre-processor-kts.md
@@ -8,12 +8,13 @@ to create your custom open source notices.
 
 ## Command Line
 
-To use the `notice-pre-processor.kts` file pass it to the `--pre-processing-script` option of the _reporter_:
+To use the `notice-pre-processor.kts` file pass it to the `preProcessingScript` option of the _NoticeByPackage_ and _NoticeSummary_ reporters:
 
 ```bash
 cli/build/install/ort/bin/ort report
   -i [evaluator-output-path]/evaluation-result.yml
   -o [reporter-output-path]
   --report-formats NoticeByPackage,StaticHtml,WebApp
-  --pre-processing-script [ort-configuration-path]/notice-pre-processor.kts
+  -O NoticeByPackage=preProcessingScript=[ort-configuration-path]/notice-pre-processor.kts \
+  -O NoticeSummary=preProcessingScript=[ort-configuration-path]/notice-pre-processor.kts \
 ```


### PR DESCRIPTION
The "--pre-processing-script" option is now a report specific option, see [1].

[1]: https://github.com/oss-review-toolkit/ort/commit/5f17abbc70e5f153fe08f1f4a56ea289a8f91f93

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>