### PR TITLE
GitLabLicenseModelReporter: Add schema version

### DIFF
--- a/reporter/src/funTest/assets/gitlab-license-model-test-expected-output.json
+++ b/reporter/src/funTest/assets/gitlab-license-model-test-expected-output.json
@@ -1,4 +1,5 @@
 {
+  "version" : "2.1",
   "licenses" : [ {
     "id" : "Apache-2.0",
     "name" : "Apache License 2.0",

--- a/reporter/src/funTest/assets/gitlab-license-model-test-skip-excluded-expected-output.json
+++ b/reporter/src/funTest/assets/gitlab-license-model-test-skip-excluded-expected-output.json
@@ -1,4 +1,5 @@
 {
+  "version" : "2.1",
   "licenses" : [ {
     "id" : "Apache-2.0",
     "name" : "Apache License 2.0",

--- a/reporter/src/main/kotlin/gitlab/GitLabLicenseModel.kt
+++ b/reporter/src/main/kotlin/gitlab/GitLabLicenseModel.kt
@@ -19,6 +19,8 @@
 
 package org.ossreviewtoolkit.reporter.gitlab
 
+private const val GITLAB_LICENSE_SCANNING_SCHEMA_VERSION_MAJOR_MINOR = "2.1"
+
 /**
  * The GitLab license model according to
  * https://gitlab.com/gitlab-org/security-products/license-management/-/blob/f4ec1f1bf826654ab963d32a2d4a2588ecb91c04/spec/fixtures/schema/v2.1.json,
@@ -26,6 +28,11 @@ package org.ossreviewtoolkit.reporter.gitlab
  * https://gitlab.com/gitlab-org/security-products/license-management/-/tree/f4ec1f1bf826654ab963d32a2d4a2588ecb91c04/spec/fixtures/expected.
  */
 internal data class GitLabLicenseModel(
+    /**
+     * The schema version of this model, must equal [GITLAB_LICENSE_SCANNING_SCHEMA_VERSION_MAJOR_MINOR].
+     */
+    val version: String = GITLAB_LICENSE_SCANNING_SCHEMA_VERSION_MAJOR_MINOR,
+
     /**
      * The complete and distinct list of licenses referred to by [dependencies].
      */


### PR DESCRIPTION
The schema specification [1] requires gl-license-scanning-report.json
to include a version number so GitLab knows how to render it.

[1]: https://gitlab.com/gitlab-org/security-products/license-management/-/blob/e1bb260b43763a36536b7d3fa4d73108ffb604d4/spec/fixtures/schema/v2.1.json

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>