### PR TITLE
VcsInfoTest: Fix test type to WordSpec

### DIFF
--- a/model/src/test/kotlin/VcsInfoTest.kt
+++ b/model/src/test/kotlin/VcsInfoTest.kt
@@ -23,12 +23,12 @@ import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
 import com.fasterxml.jackson.module.kotlin.readValue
 
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.StringSpec
+import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containAll
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
-class VcsInfoTest : StringSpec({
+class VcsInfoTest : WordSpec({
     "Deserializing VcsInfo" should {
         "work when all fields are given" {
             val yaml = """


### PR DESCRIPTION
StringSpec is not supposed to be used with nested tests.