### PR TITLE
analyzer: Add a package curation provider based on SW360

### DIFF
--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
  * Copyright (C) 2019 Bosch Software Innovations GmbH
+ * Copyright (C) 2020-2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +19,7 @@
  * License-Filename: LICENSE
  */
 
+val antennaVersion: String by project
 val digraphVersion: String by project
 val jacksonVersion: String by project
 val kotlinxCoroutinesVersion: String by project
@@ -42,6 +44,16 @@ repositories {
             includeGroup("org.gradle")
         }
     }
+
+    exclusiveContent {
+        forRepository {
+            maven("https://download.eclipse.org/antenna/releases/")
+        }
+
+        filter {
+            includeGroup("org.eclipse.sw360.antenna")
+        }
+    }
 }
 
 dependencies {
@@ -58,6 +70,7 @@ dependencies {
     implementation("com.vdurmont:semver4j:$semverVersion")
     implementation("org.apache.maven:maven-core:$mavenVersion")
     implementation("org.apache.maven:maven-compat:$mavenVersion")
+    implementation("org.eclipse.sw360.antenna:sw360-client:$antennaVersion")
 
     // The classes from the maven-resolver dependencies are not used directly but initialized by the Plexus IoC
     // container automatically. They are required on the classpath for Maven dependency resolution to work.

--- a/analyzer/src/main/kotlin/curation/Sw360PackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/Sw360PackageCurationProvider.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2020-2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.curation
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+
+import org.eclipse.sw360.antenna.http.HttpClientFactoryImpl
+import org.eclipse.sw360.antenna.http.config.HttpClientConfig
+import org.eclipse.sw360.antenna.sw360.client.adapter.SW360Connection
+import org.eclipse.sw360.antenna.sw360.client.adapter.SW360ConnectionFactory
+import org.eclipse.sw360.antenna.sw360.client.config.SW360ClientConfig
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.attachments.SW360AttachmentType
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360ClearingState
+import org.eclipse.sw360.antenna.sw360.client.rest.resource.releases.SW360Release
+
+import org.ossreviewtoolkit.analyzer.PackageCurationProvider
+import org.ossreviewtoolkit.model.Hash
+import org.ossreviewtoolkit.model.HashAlgorithm
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.PackageCuration
+import org.ossreviewtoolkit.model.PackageCurationData
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.config.Sw360StorageConfiguration
+import org.ossreviewtoolkit.model.jsonMapper
+
+/**
+ * A [PackageCurationProvider] for curated package meta-data from the configured SW360 instance using the REST API.
+ */
+class Sw360PackageCurationProvider(sw360Configuration: Sw360StorageConfiguration) : PackageCurationProvider {
+    private val sw360Connection = createSw360Connection(
+        sw360Configuration,
+        jsonMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    )
+
+    override fun getCurationsFor(pkgId: Identifier): List<PackageCuration> {
+        val name = listOfNotNull(pkgId.namespace, pkgId.name).joinToString("/")
+        val sw360ReleaseClient = sw360Connection.releaseAdapter
+
+        return sw360ReleaseClient.getSparseReleaseByNameAndVersion(name, pkgId.version)
+            .flatMap { sw360ReleaseClient.enrichSparseRelease(it) }
+            .filter { it.sw360ClearingState == SW360ClearingState.APPROVED }
+            .map { sw360Release ->
+                listOf(
+                    PackageCuration(
+                        id = pkgId,
+                        data = PackageCurationData(
+                            declaredLicenses = sw360Release.embedded?.licenses
+                                ?.mapNotNullTo(sortedSetOf()) { it?.shortName },
+                            homepageUrl = getHomepageOfRelease(sw360Release).orEmpty(),
+                            binaryArtifact = getAttachmentAsRemoteArtifact(sw360Release, SW360AttachmentType.BINARY)
+                                ?: RemoteArtifact.EMPTY,
+                            sourceArtifact = getAttachmentAsRemoteArtifact(sw360Release, SW360AttachmentType.SOURCE)
+                                ?: RemoteArtifact.EMPTY,
+                            vcs = null,
+                            comment = "Provided by SW360."
+                        )
+                    )
+                )
+            }
+            .orElse(emptyList())
+    }
+
+    private fun getAttachmentAsRemoteArtifact(release: SW360Release, type: SW360AttachmentType): RemoteArtifact? =
+        release.embedded?.attachments?.singleOrNull { it.attachmentType == type }?.let { attachment ->
+            return RemoteArtifact(
+                url = attachment.links.self.href,
+                hash = Hash(
+                    value = attachment.sha1,
+                    algorithm = HashAlgorithm.SHA1
+                )
+            )
+        }
+
+    private fun getHomepageOfRelease(release: SW360Release): String? =
+        sw360Connection.componentAdapter.getComponentById(release.componentId).orElse(null)?.homepage
+
+    private fun createSw360Connection(config: Sw360StorageConfiguration, jsonMapper: ObjectMapper): SW360Connection {
+        val httpClientConfig = HttpClientConfig
+            .basicConfig()
+            .withObjectMapper(jsonMapper)
+        val httpClient = HttpClientFactoryImpl().newHttpClient(httpClientConfig)
+
+        val sw360ClientConfig = SW360ClientConfig.createConfig(
+            config.restUrl,
+            config.authUrl,
+            config.username,
+            config.password,
+            config.clientId,
+            config.clientPassword,
+            httpClient,
+            jsonMapper
+        )
+
+        return SW360ConnectionFactory().newConnection(sw360ClientConfig)
+    }
+}

--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -101,20 +101,9 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
         .convert { it.absoluteFile.normalize() }
         .configurationGroup()
 
-    private val allowDynamicVersions by option(
-        "--allow-dynamic-versions",
-        help = "Allow dynamic versions of dependencies. This can result in unstable results when dependencies use " +
-                "version ranges. This option only affects package managers that support lock files, like NPM."
-    ).flag()
-
     private val useClearlyDefinedCurations by option(
         "--clearly-defined-curations",
         help = "Whether to fall back to package curation data from the ClearlyDefine service or not."
-    ).flag()
-
-    private val ignoreToolVersions by option(
-        "--ignore-tool-versions",
-        help = "Ignore versions of required tools. NOTE: This may lead to erroneous results."
     ).flag()
 
     private val useSw360Curations by option(
@@ -161,12 +150,7 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
         println("Analyzing project path:\n\t$inputDir")
 
         val config = globalOptionsForSubcommands.config
-        val analyzerConfig = AnalyzerConfiguration(
-            ignoreToolVersions,
-            allowDynamicVersions,
-            config.analyzer?.sw360Configuration
-        )
-        val analyzer = Analyzer(analyzerConfig)
+        val analyzer = Analyzer(config.analyzer ?: AnalyzerConfiguration())
 
         val curationProvider = FallbackPackageCurationProvider(
             listOfNotNull(

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -91,10 +91,10 @@ Writing analyzer result to '[analyzer-output-dir]/analyzer-result.yml'.
 
 This happens because `mime-types` does not have `package-lock.json` file. Without this file the versions of (transitive)
 dependencies that are defined with version ranges could change at any time, leading to different results of the
-analyzer. To override this check use the `--allow-dynamic-versions` option:
+analyzer. To override this check, use the `-P ort.analyzer.allowDynamicVersions=true` option:
 
 ```bash
-$ cli/build/install/ort/bin/ort analyze -i [mime-types-dir] -o [analyzer-output-dir] --allow-dynamic-versions
+$ cli/build/install/ort/bin/ort analyze -i [mime-types-dir] -o [analyzer-output-dir] -P ort.analyzer.allowDynamicVersions=true
 The following package managers are activated:
         Bundler, Composer, GoDep, Gradle, Maven, NPM, PIP, SBT, Stack, Yarn
 Analyzing project path:

--- a/integrations/Jenkinsfile
+++ b/integrations/Jenkinsfile
@@ -293,16 +293,12 @@ pipeline {
                             STACKTRACE_OPTION="--stacktrace"
                         fi
 
-                        if [ "$ALLOW_DYNAMIC_VERSIONS" = "true" ]; then
-                            ALLOW_DYNAMIC_VERSIONS_OPTION="--allow-dynamic-versions"
-                        fi
-
                         if [ "$USE_CLEARLY_DEFINED_CURATIONS" = "true" ]; then
                             USE_CLEARLY_DEFINED_CURATIONS_OPTION="--clearly-defined-curations"
                         fi
 
                         rm -fr out/results
-                        /opt/ort/bin/ort $LOG_LEVEL $STACKTRACE_OPTION analyze $ALLOW_DYNAMIC_VERSIONS_OPTION $USE_CLEARLY_DEFINED_CURATIONS_OPTION -i $PROJECT_DIR/source -o out/results/analyzer
+                        /opt/ort/bin/ort $LOG_LEVEL $STACKTRACE_OPTION analyze -P ort.analyzer.allowDynamicVersions=$ALLOW_DYNAMIC_VERSIONS $USE_CLEARLY_DEFINED_CURATIONS_OPTION -i $PROJECT_DIR/source -o out/results/analyzer
                     '''
 
                     if (status >= ORT_FAILURE_STATUS_CODE) unstable('Analyzer issues found.')

--- a/model/src/main/kotlin/config/AnalyzerConfiguration.kt
+++ b/model/src/main/kotlin/config/AnalyzerConfiguration.kt
@@ -20,6 +20,8 @@
 
 package org.ossreviewtoolkit.model.config
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
 data class AnalyzerConfiguration(
     /**
      * If set to true, ignore the versions of used command line tools. Note that this might lead to erroneous
@@ -36,4 +38,10 @@ data class AnalyzerConfiguration(
      * false.
      */
     val allowDynamicVersions: Boolean = false,
+
+    /**
+     * Configuration of the SW360 package curation provider.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val sw360Configuration: Sw360StorageConfiguration? = null
 )

--- a/model/src/main/kotlin/config/AnalyzerConfiguration.kt
+++ b/model/src/main/kotlin/config/AnalyzerConfiguration.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2020-2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,15 +24,16 @@ data class AnalyzerConfiguration(
     /**
      * If set to true, ignore the versions of used command line tools. Note that this might lead to erroneous
      * results if the tools have changed in usage or behavior. If set to false, check the versions to match the
-     * expected versions and fail the analysis on a mismatch.
+     * expected versions and fail the analysis on a mismatch. Defaults to false.
      */
-    val ignoreToolVersions: Boolean,
+    val ignoreToolVersions: Boolean = false,
 
     /**
      * Enable the analysis of projects that use version ranges to declare their dependencies. If set to true,
      * dependencies of exactly the same project might change with another scan done at a later time if any of the
      * (transitive) dependencies are declared using version ranges and a new version of such a dependency was
-     * published in the meantime. If set to false, analysis of projects that use version ranges will fail.
+     * published in the meantime. If set to false, analysis of projects that use version ranges will fail. Defaults to
+     * false.
      */
-    val allowDynamicVersions: Boolean
+    val allowDynamicVersions: Boolean = false,
 )

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2020-2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +36,11 @@ import org.ossreviewtoolkit.utils.log
  * The configuration model for all ORT components.
  */
 data class OrtConfiguration(
+    /**
+     * The configuration of the analyzer.
+     */
+    val analyzer: AnalyzerConfiguration? = null,
+
     /**
      * The configuration of the scanner.
      */

--- a/model/src/main/kotlin/config/ScanStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/ScanStorageConfiguration.kt
@@ -139,7 +139,8 @@ data class Sw360StorageConfiguration(
     /**
      * The password of the SW360 user.
      */
-    val password: String,
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    val password: String = "",
 
     /**
      * The client ID of the SW360 instance for the two step authentication.
@@ -149,5 +150,6 @@ data class Sw360StorageConfiguration(
     /**
      * The password of the client ID.
      */
-    val clientPassword: String
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    val clientPassword: String = ""
 ) : ScanStorageConfiguration()

--- a/model/src/test/assets/reference.conf
+++ b/model/src/test/assets/reference.conf
@@ -10,6 +10,11 @@ ort {
     }
   }
 
+  analyzer {
+    ignoreToolVersions = true
+    allowDynamicVersions = true
+  }
+
   licenseFilePatterns {
     licenseFilenames = ["license*"]
     patentFilenames = ["patents"]

--- a/model/src/test/assets/reference.conf
+++ b/model/src/test/assets/reference.conf
@@ -13,6 +13,15 @@ ort {
   analyzer {
     ignoreToolVersions = true
     allowDynamicVersions = true
+
+    sw360Configuration {
+      restUrl = "https://your-sw360-rest-url"
+      authUrl = "https://your-authentication-url"
+      username = username
+      password = password
+      clientId = clientId
+      clientPassword = clientPassword
+    }
   }
 
   licenseFilePatterns {

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -48,6 +48,15 @@ class OrtConfigurationTest : WordSpec({
             ortConfig.analyzer shouldNotBeNull {
                 ignoreToolVersions shouldBe true
                 allowDynamicVersions shouldBe true
+
+                sw360Configuration shouldNotBeNull {
+                    restUrl shouldBe "https://your-sw360-rest-url"
+                    authUrl shouldBe "https://your-authentication-url"
+                    username shouldBe "username"
+                    password shouldBe "password"
+                    clientId shouldBe "clientId"
+                    clientPassword shouldBe "clientPassword"
+                }
             }
 
             ortConfig.scanner shouldNotBeNull {

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -45,6 +45,11 @@ class OrtConfigurationTest : WordSpec({
             val refConfig = File("src/test/assets/reference.conf")
             val ortConfig = OrtConfiguration.load(configFile = refConfig)
 
+            ortConfig.analyzer shouldNotBeNull {
+                ignoreToolVersions shouldBe true
+                allowDynamicVersions shouldBe true
+            }
+
             ortConfig.scanner shouldNotBeNull {
                 archive shouldNotBeNull {
                     storage.httpFileStorage.shouldBeNull()

--- a/model/src/test/kotlin/config/Sw360StorageConfigurationTest.kt
+++ b/model/src/test/kotlin/config/Sw360StorageConfigurationTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.config
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.string.shouldNotContain
+
+import org.ossreviewtoolkit.model.yamlMapper
+
+class Sw360StorageConfigurationTest : StringSpec({
+    "Credentials should be ignored in serialization" {
+        val sw360StorageConfiguration = Sw360StorageConfiguration(
+            "url",
+            "url",
+            "username",
+            "maskedPassword",
+            "clientId",
+            "maskedClientPassword"
+        )
+        val yaml = yamlMapper.writeValueAsString(sw360StorageConfiguration).trim()
+
+        yaml.toLowerCase() shouldNotContain "password"
+    }
+})

--- a/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterFunTest.kt
@@ -57,7 +57,7 @@ class NoticeTemplateReporterFunTest : WordSpec({
 
             val archiveDir = File("src/funTest/assets/archive")
             val config = OrtConfiguration(
-                ScannerConfiguration(
+                scanner = ScannerConfiguration(
                     archive = FileArchiverConfiguration(
                         storage = FileStorageConfiguration(
                             localFileStorage = LocalFileStorageConfiguration(


### PR DESCRIPTION
This PR adds a package curation provider based on SW360. In order to use it set the flag `--sw360-curations` and add a config file with `-c <path-to-ort.conf>` in order to pass SW360 connection configurations like URLs, credentials and proxy. 

Resolves #2210.

Signed-off-by: Onur Demirci <onur.demirci@bosch.io>