### PR TITLE
Add a template based notice reporter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,9 @@ gradlew						text eol=lf
 */src/*/assets/**/*expected*.yml		text eol=lf
 reporter/src/funTest/assets/*-expected-*	text eol=lf
 
+# Use Unix line endings for Freemarker templates for consistency across platforms.
+reporter/src/main/resources/**/*.ftlh		text eol=lf
+
 # Use Unix line endings for scan results which are misused for also testing the calculation of the SPDX package verification code.
 scanner/src/test/assets/*.json			text eol=lf
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,6 +36,7 @@ cyclonedxCoreJavaVersion = 3.0.0
 digraphVersion = 1.0
 disklrucacheVersion = 2.0.2
 flexmarkVersion = 0.62.2
+freemarkerVersion = 2.3.30
 hamcrestCoreVersion = 1.3
 jacksonVersion = 2.11.1
 jgitVersion = 5.8.0.202006091008-r

--- a/model/src/main/kotlin/licenses/LicenseView.kt
+++ b/model/src/main/kotlin/licenses/LicenseView.kt
@@ -121,12 +121,14 @@ class LicenseView(vararg licenseSources: Set<LicenseSource>) {
         // codes can be expensive for resolved licenses with many license and copyright findings.
         val licenses = mutableSetOf<SpdxSingleLicenseExpression>()
 
-        licenseSources.forEach { sources ->
-            resolvedLicense.licenses.filter { license ->
-                license.sources.any { it in sources }
-            }.mapTo(licenses) { it.license }
+        run loop@{
+            licenseSources.forEach { sources ->
+                resolvedLicense.licenses.filter { license ->
+                    license.sources.any { it in sources }
+                }.mapTo(licenses) { it.license }
 
-            if (licenses.isNotEmpty()) return@forEach
+                if (licenses.isNotEmpty()) return@loop
+            }
         }
 
         return resolvedLicense.copy(licenses = resolvedLicense.licenses.filter { it.license in licenses })

--- a/reporter/build.gradle.kts
+++ b/reporter/build.gradle.kts
@@ -25,6 +25,7 @@ val apachePoiSchemasVersion: String by project
 val commonsCompressVersion: String by project
 val cyclonedxCoreJavaVersion: String by project
 val flexmarkVersion: String by project
+val freemarkerVersion: String by project
 val hamcrestCoreVersion: String by project
 val jacksonVersion: String by project
 val kotlinxHtmlVersion: String by project
@@ -113,6 +114,7 @@ dependencies {
     implementation("org.cyclonedx:cyclonedx-core-java:$cyclonedxCoreJavaVersion")
     implementation("org.eclipse.sw360.antenna:attribution-document-core:$antennaVersion")
     implementation("org.eclipse.sw360.antenna:attribution-document-basic-bundle:$antennaVersion")
+    implementation("org.freemarker:freemarker:$freemarkerVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:$kotlinxHtmlVersion")
 
     // This is required to not depend on the version of Apache Xalan bundled with the JDK. Otherwise the formatting of

--- a/reporter/src/funTest/assets/notice-template-reporter-expected-results
+++ b/reporter/src/funTest/assets/notice-template-reporter-expected-results
@@ -1,0 +1,223 @@
+This software includes external packages and source code.
+The applicable license information is listed below:
+
+----
+
+Copyright 1
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----
+
+This project contains or depends on third-party software components pursuant to the following licenses:
+
+----
+
+Package: @ort:concluded-license:1.0
+
+The following copyrights and licenses were found in the source code of this package:
+
+Copyright 1
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----
+
+Package: @ort:declared-license:1.0
+
+The following copyrights and licenses were found in the source code of this package:
+
+Copyright 1
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list
+of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the name of the ORGANIZATION nor the names of its contributors may be
+used to endorse or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  --
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----
+
+Package: @ort:license-file-and-additional-licenses:1.0
+
+The following copyrights and licenses were found in the source code of this package:
+
+Copyright 3
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list
+of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the name of the ORGANIZATION nor the names of its contributors may be
+used to endorse or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  --
+
+Copyright 1
+Copyright 2
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----
+
+Package: @ort:license-file:1.0
+
+The following copyrights and licenses were found in the source code of this package:
+
+Copyright 1
+Copyright 2
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----
+
+Package: @ort:no-license-file:1.0
+
+The following copyrights and licenses were found in the source code of this package:
+
+Copyright 1
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.reporter.reporters
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import java.io.File
+
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.config.CopyrightGarbage
+import org.ossreviewtoolkit.model.config.OrtConfiguration
+import org.ossreviewtoolkit.reporter.ORT_RESULT
+import org.ossreviewtoolkit.reporter.ReporterInput
+import org.ossreviewtoolkit.utils.ORT_NAME
+
+class NoticeTemplateReporterTest : WordSpec({
+    "NoticeTemplateReporter" should {
+        "generate the correct license notes" {
+            val expectedText = File("src/funTest/assets/notice-template-reporter-expected-results").readText()
+
+            val report = generateReport(ORT_RESULT)
+
+            report shouldBe expectedText
+        }
+    }
+})
+
+private fun generateReport(
+    ortResult: OrtResult,
+    config: OrtConfiguration = OrtConfiguration(),
+    copyrightGarbage: CopyrightGarbage = CopyrightGarbage()
+): String {
+    val input = ReporterInput(
+        ortResult,
+        config,
+        copyrightGarbage = copyrightGarbage
+    )
+
+    val outputDir = createTempDir(ORT_NAME, NoticeTemplateReporterTest::class.simpleName).apply { deleteOnExit() }
+
+    return NoticeTemplateReporter().generateReport(input, outputDir).single().readText()
+}

--- a/reporter/src/main/kotlin/reporters/NoticeByPackageReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeByPackageReporter.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.reporter.reporters
 
 import java.io.File
+import java.util.SortedMap
 
 import org.apache.logging.log4j.Level
 
@@ -88,7 +89,7 @@ class NoticeByPackageProcessor(input: ReporterInput) : AbstractNoticeReporter.No
             } else {
                 add { model.headerWithLicenses }
 
-                addPackageFindings(packageFindings)
+                addPackageFindings(packageFindings.toSortedMap())
             }
 
             model.footers.forEach { footer ->
@@ -121,7 +122,7 @@ class NoticeByPackageProcessor(input: ReporterInput) : AbstractNoticeReporter.No
         addProcessedFindings(processedFindings)
     }
 
-    private fun MutableList<() -> String>.addPackageFindings(findings: Map<Identifier, LicenseFindingsMap>) {
+    private fun MutableList<() -> String>.addPackageFindings(findings: SortedMap<Identifier, LicenseFindingsMap>) {
         val archiver = input.ortConfig.scanner?.archive?.createFileArchiver() ?: FileArchiver.DEFAULT
 
         findings.forEach { (id, licenseFindingsMap) ->

--- a/reporter/src/main/kotlin/reporters/NoticeTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeTemplateReporter.kt
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.reporter.reporters
+
+import freemarker.cache.ClassTemplateLoader
+import freemarker.template.Configuration
+import freemarker.template.TemplateExceptionHandler
+
+import java.io.File
+
+import kotlin.reflect.full.memberProperties
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.licenses.License
+import org.ossreviewtoolkit.model.licenses.LicenseConfiguration
+import org.ossreviewtoolkit.model.licenses.LicenseView
+import org.ossreviewtoolkit.model.licenses.ResolvedLicense
+import org.ossreviewtoolkit.model.licenses.ResolvedLicenseFileInfo
+import org.ossreviewtoolkit.model.licenses.ResolvedLicenseInfo
+import org.ossreviewtoolkit.model.licenses.filterExcluded
+import org.ossreviewtoolkit.reporter.Reporter
+import org.ossreviewtoolkit.reporter.ReporterInput
+import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
+import org.ossreviewtoolkit.utils.expandTilde
+import org.ossreviewtoolkit.utils.log
+
+/**
+ * A [Reporter] that creates notice files using [Apache Freemarker][1] templates. For each template provided using the
+ * options described below a separate output file is created. If no options are provided the "default" template is used.
+ * The name of the template id or template path (without extension) is used for the generated file, so be careful to not
+ * use two different templates with the same name.
+ *
+ * This reporter supports the following options:
+ * - *template.id*: A comma-separated list of IDs of templates provided by ORT. Currently only the "default" template is
+ *                  available.
+ * - *template.path*: A comma-separated list of paths to template files provided by the user.
+ *
+ * [1]: https://freemarker.apache.org
+ */
+class NoticeTemplateReporter : Reporter {
+    companion object {
+        private const val NOTICE_FILE_PREFIX = "NOTICE_"
+
+        private const val OPTION_TEMPLATE_ID = "template.id"
+        private const val OPTION_TEMPLATE_PATH = "template.path"
+    }
+
+    override val reporterName = "NoticeTemplate"
+
+    override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
+        val projects = input.ortResult.getProjects().map { project ->
+            PackageNoticeModel(project.id, input)
+        }
+
+        val packages = input.ortResult.getPackages().map { pkg ->
+            PackageNoticeModel(pkg.pkg.id, input)
+        }
+
+        val dataModel = mapOf(
+            "projects" to projects,
+            "packages" to packages,
+            "licenseTextProvider" to input.licenseTextProvider,
+            "helper" to NoticeHelper(input.licenseConfiguration)
+        )
+
+        val freemarkerConfig = Configuration(Configuration.VERSION_2_3_30).apply {
+            defaultEncoding = "UTF-8"
+            fallbackOnNullLoopVariable = false
+            logTemplateExceptions = true
+            tagSyntax = Configuration.SQUARE_BRACKET_TAG_SYNTAX
+            templateExceptionHandler = TemplateExceptionHandler.RETHROW_HANDLER
+            templateLoader = ClassTemplateLoader(this@NoticeTemplateReporter.javaClass.classLoader, "template.notice")
+            wrapUncheckedExceptions = true
+        }
+
+        val templateIds = options[OPTION_TEMPLATE_ID]?.split(",") ?: listOf("default")
+        val templatePaths = options[OPTION_TEMPLATE_PATH]?.split(",").orEmpty()
+
+        val templateFiles = templatePaths.map { path ->
+            File(path).expandTilde().also {
+                require(it.exists()) { "Could not find template file at ${it.absolutePath}." }
+            }
+        }
+
+        val outputFiles = mutableListOf<File>()
+
+        templateIds.forEach { id ->
+            log.info { "Generating notice file using template id '$id'." }
+
+            val outputFile = outputDir.resolve("$NOTICE_FILE_PREFIX$id")
+            outputFiles += outputFile
+
+            val template = freemarkerConfig.getTemplate("$id.ftlh")
+            outputFile.writer().use { template.process(dataModel, it) }
+        }
+
+        templateFiles.forEach { file ->
+            log.info { "Generating notice file using template file '${file.absolutePath}'." }
+
+            val outputFile = outputDir.resolve("$NOTICE_FILE_PREFIX${file.nameWithoutExtension}")
+            outputFiles += outputFile
+
+            freemarkerConfig.setDirectoryForTemplateLoading(file.parentFile)
+
+            val template = freemarkerConfig.getTemplate(file.name)
+            outputFile.writer().use { template.process(dataModel, it) }
+        }
+
+        return outputFiles
+    }
+
+    /**
+     * License information for a single package or project.
+     */
+    class PackageNoticeModel(
+        val id: Identifier,
+        private val input: ReporterInput
+    ) {
+        /**
+         * True if the package is excluded.
+         */
+        val excluded: Boolean by lazy { input.ortResult.isExcluded(id) }
+
+        /**
+         * The resolved license information for the package.
+         */
+        val license: ResolvedLicenseInfo by lazy {
+            val resolved = input.licenseInfoResolver.resolveLicenseInfo(id)
+            resolved.copy(licenses = resolved.licenses.sortedBy { it.license.toString() })
+        }
+
+        /**
+         * The resolved license file information for the package.
+         */
+        val licenseFiles: ResolvedLicenseFileInfo by lazy { input.licenseInfoResolver.resolveLicenseFiles(id) }
+
+        /**
+         * Returns all [ResolvedLicense]s for this package excluding those licenses which are contained in any of the
+         * license files. This is useful when the raw texts of the license files are included in the generated notice
+         * file and all licenses not contained in those files shall be listed separately.
+         */
+        @Suppress("UNUSED") // This function is used in the templates.
+        fun licensesNotInLicenseFiles(): List<ResolvedLicense> {
+            val noticeFileLicenses = licenseFiles.files.flatMap { it.licenses }
+            return license.filter { it !in noticeFileLicenses }
+        }
+    }
+
+    /**
+     * A collection of helper functions for the Freemarker templates.
+     */
+    class NoticeHelper(private val licenseConfiguration: LicenseConfiguration) {
+        /**
+         * Filter licenses that are configured to be [included in the notice file][License.includeInNoticeFile] in the
+         * [LicenseConfiguration].
+         */
+        @Suppress("UNUSED") // This function is used in the templates.
+        fun filterIncludeInNoticeFile(licenses: List<ResolvedLicense>): List<ResolvedLicense> =
+            licenses.filter { resolvedLicense ->
+                licenseConfiguration.licenses.find { it.id == resolvedLicense.license }?.includeInNoticeFile ?: true
+            }
+
+        /**
+         * Return a [LicenseView] constant by name to make them easily available to the Freemarker templates.
+         */
+        @Suppress("UNUSED") // This function is used in the templates.
+        fun licenseView(name: String): LicenseView =
+            LicenseView.Companion::class.memberProperties
+                .first { it.name == name }
+                .get(LicenseView.Companion) as LicenseView
+
+        /**
+         * Merge the [ResolvedLicense]s of multiple [models] and filter them using [licenseView]. [Omits][omitExcluded]
+         * excluded packages, licenses, and copyrights by default. The returned list is sorted by license identifier.
+         */
+        @JvmOverloads
+        @Suppress("UNUSED") // This function is used in the templates.
+        fun mergeLicenses(
+            models: Collection<PackageNoticeModel>,
+            licenseView: LicenseView = LicenseView.ALL,
+            omitExcluded: Boolean = true
+        ): List<ResolvedLicense> =
+            models
+                .filter { !omitExcluded || !it.excluded }
+                .flatMap {
+                    val licenses = it.license.filter(licenseView).licenses
+                    if (omitExcluded) licenses.filterExcluded() else licenses
+                }
+                // TODO: Currently exceptions are ignored, implement proper exception handling.
+                .map { it.copy(license = SpdxSingleLicenseExpression.parse(it.license.simpleLicense())) }
+                .groupBy { it.license }
+                .map { (_, licenses) -> licenses.merge() }
+                .sortedBy { it.license.toString() }
+    }
+}
+
+private fun List<ResolvedLicense>.merge(): ResolvedLicense {
+    require(isNotEmpty()) { "Cannot not merge an empty list." }
+    return ResolvedLicense(
+        license = first().license,
+        sources = flatMapTo(mutableSetOf()) { it.sources },
+        originalDeclaredLicenses = flatMapTo(mutableSetOf()) { it.originalDeclaredLicenses },
+        locations = flatMapTo(mutableSetOf()) { it.locations }
+    )
+}

--- a/reporter/src/main/resources/META-INF/services/org.ossreviewtoolkit.reporter.Reporter
+++ b/reporter/src/main/resources/META-INF/services/org.ossreviewtoolkit.reporter.Reporter
@@ -7,6 +7,7 @@ org.ossreviewtoolkit.reporter.reporters.ExcelReporter
 org.ossreviewtoolkit.reporter.reporters.GitLabLicenseModelReporter
 org.ossreviewtoolkit.reporter.reporters.NoticeByPackageReporter
 org.ossreviewtoolkit.reporter.reporters.NoticeSummaryReporter
+org.ossreviewtoolkit.reporter.reporters.NoticeTemplateReporter
 org.ossreviewtoolkit.reporter.reporters.SpdxDocumentReporter
 org.ossreviewtoolkit.reporter.reporters.StaticHtmlReporter
 org.ossreviewtoolkit.reporter.reporters.WebAppReporter

--- a/reporter/src/main/resources/template.notice/default.ftlh
+++ b/reporter/src/main/resources/template.notice/default.ftlh
@@ -1,0 +1,98 @@
+[#--
+Copyright (C) 2020 HERE Europe B.V.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+License-Filename: LICENSE
+--]
+[#-- Disable auto-escaping because we write a plain-text file. --]
+[#noautoesc]
+[#-- Add the licenses of the projects. --]
+[#if projects?has_content]
+This software includes external packages and source code.
+The applicable license information is listed below:
+
+----
+[#assign isFirst = true]
+[#--
+Merge the licenses and copyrights of all projects into a single list. The default LicenseView.ALL is used because
+projects cannot have a concluded license (compare with the handling of packages below). Also filter all licenses that
+are configured not to be included in notice files.
+--]
+[#assign mergedLicenses = helper.filterIncludeInNoticeFile(helper.mergeLicenses(projects))]
+[#list mergedLicenses as resolvedLicense]
+[#assign licenseText = licenseTextProvider.getLicenseText(resolvedLicense.license.toString())!""]
+[#if licenseText?has_content]
+[#if isFirst]
+[#assign isFirst = false]
+[#else]
+  --
+[/#if]
+[#assign copyrights = resolvedLicense.getCopyrights(true)]
+[#list copyrights as copyright]
+[#if copyright?is_first]
+
+[/#if]
+${copyright}
+[/#list]
+
+${licenseText}
+[/#if]
+[/#list]
+----
+[/#if]
+
+[#-- Add the licenses of all dependencies. --]
+[#if packages?has_content]
+This project contains or depends on third-party software components pursuant to the following licenses:
+[/#if]
+
+[#list packages as package]
+[#if !package.excluded]
+----
+
+Package: [#if package.id.namespace?has_content]${package.id.namespace}:[/#if]${package.id.name}:${package.id.version}
+[#--
+Filter the licenses of the package using LicenseView.CONCLUDED_OR_REST. This is the default view which ignores declared
+and detected licenses if a license conclusion for the package was made. If copyrights were detected for a concluded
+license those statements are kept. Also filter all licenses that are configured not to be included in notice files.
+--]
+[#assign resolvedLicenses = helper.filterIncludeInNoticeFile(package.license.filter(helper.licenseView("CONCLUDED_OR_REST")).licenses)]
+[#if resolvedLicenses?has_content]
+
+The following copyrights and licenses were found in the source code of this package:
+[/#if]
+[#assign isFirst = true]
+[#list resolvedLicenses as resolvedLicense]
+[#assign licenseText = licenseTextProvider.getLicenseText(resolvedLicense.license.toString())!""]
+[#if licenseText?has_content]
+[#if isFirst]
+[#assign isFirst = false]
+[#else]
+  --
+[/#if]
+[#assign copyrights = resolvedLicense.getCopyrights(true)]
+[#list copyrights as copyright]
+[#if copyright?is_first]
+
+[/#if]
+${copyright}
+[/#list]
+
+${licenseText}
+[/#if]
+[/#list]
+[/#if]
+[/#list]
+[/#noautoesc]


### PR DESCRIPTION
Add a notice reporter that generates a notice file using Apache
Freemarker [1] templates. Templates can be provided by ORT or by the
user. This commit adds a default template that resembles the
`NoticeByPackageReporter` without handling of archived license files
which will be added in a later commit. Another template that resembles
the `NoticeSummaryReporter` will also be added in a later commit.

This notice reporter makes use of the `LicenseInfoResolver` which in
combination with the logic that can be implemented in the templates
makes the notice pre processing script obsolete. The reporter will
replace the other two notice reporters once the implementation is
complete.

Apache Freemarker was chosen because it has a large userbase, detailed
documentation, and good support for rendering plain text files as well
as other output formats like HTML. Other evaluated options were
Thymeleaf [2] which was discarded because it is very much focused on
generating HTML, and Korte [3] which had the advantage that is supports
Kotlin multiplatform projects, but has a small userbase and does not
support writing directly to a stream or a file which is a requirement
for large projects.

[1] https://freemarker.apache.org
[2] https://www.thymeleaf.org
[3] https://korlibs.soywiz.com/korte