### PR TITLE
NoticeTemplateReporter: Handle license files

### DIFF
--- a/model/src/main/kotlin/licenses/ResolvedLicenseFileInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseFileInfo.kt
@@ -63,4 +63,9 @@ data class ResolvedLicenseFile(
      * The unarchived license file.
      */
     val file: File
-)
+) {
+    /**
+     * Return the content of the [license file][file].
+     */
+    fun readFile(): String = file.readText()
+}

--- a/model/src/main/kotlin/licenses/ResolvedLicenseFileInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseFileInfo.kt
@@ -23,6 +23,7 @@ import java.io.File
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.config.PathExclude
 
 /**
  * Information about license files of a package and the licenses detected in those files.
@@ -64,6 +65,13 @@ data class ResolvedLicenseFile(
      */
     val file: File
 ) {
+    /**
+     * Return all copyright statements associated to the licenses found in this license file. Optionally
+     * [excludes][omitExcluded] copyright findings excluded by [PathExclude]s.
+     */
+    fun getCopyrights(omitExcluded: Boolean = false): Set<String> =
+        licenses.flatMapTo(mutableSetOf()) { it.getCopyrights(omitExcluded) }
+
     /**
      * Return the content of the [license file][file].
      */

--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -121,6 +121,10 @@ data class ResolvedLicense(
         LicenseSource.DETECTED in sources && locations.all { it.matchingPathExcludes.isNotEmpty() }
     }
 
+    /**
+     * Return all copyright statements associated to this license. Optionally [excludes][omitExcluded] copyright
+     * findings excluded by [PathExclude]s.
+     */
     fun getCopyrights(omitExcluded: Boolean = false): Set<String> =
         locations.flatMapTo(sortedSetOf()) { location ->
             location.copyrights.filter { copyright ->

--- a/reporter/src/funTest/assets/notice-template-reporter-expected-results-with-license-files
+++ b/reporter/src/funTest/assets/notice-template-reporter-expected-results-with-license-files
@@ -1,0 +1,226 @@
+This software includes external packages and source code.
+The applicable license information is listed below:
+
+----
+
+Copyright 1
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----
+
+This project contains or depends on third-party software components pursuant to the following licenses:
+
+----
+
+Package: @ort:concluded-license:1.0
+
+The following copyrights and licenses were found in the source code of this package:
+
+Copyright 1
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----
+
+Package: @ort:declared-license:1.0
+
+The following copyrights and licenses were found in the source code of this package:
+
+Copyright 1
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list
+of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the name of the ORGANIZATION nor the names of its contributors may be
+used to endorse or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  --
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----
+
+Package: @ort:license-file-and-additional-licenses:1.0
+
+This package contains the file LICENSE with the following contents:
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+The following copyright holder information relates to the license(s) above:
+
+Copyright 1
+Copyright 2
+
+The following copyrights and licenses were found in the source code of this package:
+
+Copyright 3
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list
+of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the name of the ORGANIZATION nor the names of its contributors may be
+used to endorse or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+----
+
+Package: @ort:license-file:1.0
+
+This package contains the file LICENSE with the following contents:
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+The following copyright holder information relates to the license(s) above:
+
+Copyright 1
+Copyright 2
+----
+
+Package: @ort:no-license-file:1.0
+
+The following copyrights and licenses were found in the source code of this package:
+
+Copyright 1
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterTest.kt
@@ -26,9 +26,14 @@ import java.io.File
 
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
+import org.ossreviewtoolkit.model.config.FileArchiverConfiguration
+import org.ossreviewtoolkit.model.config.FileStorageConfiguration
+import org.ossreviewtoolkit.model.config.LocalFileStorageConfiguration
 import org.ossreviewtoolkit.model.config.OrtConfiguration
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
+import org.ossreviewtoolkit.utils.LICENSE_FILENAMES
 import org.ossreviewtoolkit.utils.ORT_NAME
 
 class NoticeTemplateReporterTest : WordSpec({
@@ -37,6 +42,29 @@ class NoticeTemplateReporterTest : WordSpec({
             val expectedText = File("src/funTest/assets/notice-template-reporter-expected-results").readText()
 
             val report = generateReport(ORT_RESULT)
+
+            report shouldBe expectedText
+        }
+
+        "generate the correct license notes with archived license files" {
+            val expectedText =
+                File("src/funTest/assets/notice-template-reporter-expected-results-with-license-files").readText()
+
+            val archiveDir = File("src/funTest/assets/archive")
+            val config = OrtConfiguration(
+                ScannerConfiguration(
+                    archive = FileArchiverConfiguration(
+                        patterns = LICENSE_FILENAMES,
+                        storage = FileStorageConfiguration(
+                            localFileStorage = LocalFileStorageConfiguration(
+                                directory = archiveDir,
+                                compression = false
+                            )
+                        )
+                    )
+                )
+            )
+            val report = generateReport(ORT_RESULT, config)
 
             report shouldBe expectedText
         }

--- a/reporter/src/main/kotlin/reporters/NoticeTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeTemplateReporter.kt
@@ -152,7 +152,7 @@ class NoticeTemplateReporter : Reporter {
         val licenseFiles: ResolvedLicenseFileInfo by lazy { input.licenseInfoResolver.resolveLicenseFiles(id) }
 
         /**
-         * Returns all [ResolvedLicense]s for this package excluding those licenses which are contained in any of the
+         * Return all [ResolvedLicense]s for this package excluding those licenses which are contained in any of the
          * license files. This is useful when the raw texts of the license files are included in the generated notice
          * file and all licenses not contained in those files shall be listed separately.
          */

--- a/reporter/src/main/resources/template.notice/default.ftlh
+++ b/reporter/src/main/resources/template.notice/default.ftlh
@@ -63,12 +63,32 @@ This project contains or depends on third-party software components pursuant to 
 ----
 
 Package: [#if package.id.namespace?has_content]${package.id.namespace}:[/#if]${package.id.name}:${package.id.version}
+[#-- List the content of archived license files and associated copyrights. --]
+[#list package.licenseFiles.files as licenseFile]
+
+This package contains the file ${licenseFile.path} with the following contents:
+
+${licenseFile.readFile()}
+[#assign copyrights = licenseFile.getCopyrights(true)]
+[#if copyrights?has_content]
+The following copyright holder information relates to the license(s) above:
+
+[#list copyrights as copyright]
+${copyright}
+[/#list]
+[/#if]
+[/#list]
 [#--
 Filter the licenses of the package using LicenseView.CONCLUDED_OR_REST. This is the default view which ignores declared
 and detected licenses if a license conclusion for the package was made. If copyrights were detected for a concluded
-license those statements are kept. Also filter all licenses that are configured not to be included in notice files.
+license those statements are kept. Also filter all licenses that are configured not to be included in notice files, and
+filter all licenses that are contained in the license files already printed above.
 --]
-[#assign resolvedLicenses = helper.filterIncludeInNoticeFile(package.license.filter(helper.licenseView("CONCLUDED_OR_REST")).licenses)]
+[#assign
+resolvedLicenses = helper.filterIncludeInNoticeFile(
+    helper.licenseView("CONCLUDED_OR_REST").filter(package.licensesNotInLicenseFiles())
+)
+]
 [#if resolvedLicenses?has_content]
 
 The following copyrights and licenses were found in the source code of this package:


### PR DESCRIPTION
NoticeTemplateReporter: Add license file handling to default template

Add the content of archived license files of packages to the default
template, similar to how they are used in the `NoticeByPackageReporter`.
Licenses that are contained in a license file are not listed again.
All copyright findings associated to licenses detected in a license file
are listed below the content of the file.