### PR TITLE
Fix typo in GitLab license_scanning report fixture.

### DIFF
--- a/reporter/src/funTest/assets/gitlab-license-model-test-expected-output.json
+++ b/reporter/src/funTest/assets/gitlab-license-model-test-expected-output.json
@@ -28,19 +28,19 @@
   "dependencies" : [ {
     "name" : "excluded-package",
     "version" : "0.0.4",
-    "package_manger" : "maven",
+    "package_manager" : "maven",
     "path" : "some/path/build.gradle",
     "licenses" : [ "LicenseRef-scancode-josl-1.0" ]
   }, {
     "name" : "first-package",
     "version" : "0.0.1",
-    "package_manger" : "maven",
+    "package_manager" : "maven",
     "path" : "some/path/build.gradle",
     "licenses" : [ "BSD-2-Clause", "GPL-2.0-or-later WITH Classpath-exception-2.0", "MIT", "LicenseRef-scancode-asmus" ]
   }, {
     "name" : "second-package",
     "version" : "0.0.2",
-    "package_manger" : "pip",
+    "package_manager" : "pip",
     "path" : "",
     "licenses" : [ "BSD-2-Clause", "Apache-2.0" ]
   } ]

--- a/reporter/src/funTest/assets/gitlab-license-model-test-skip-excluded-expected-output.json
+++ b/reporter/src/funTest/assets/gitlab-license-model-test-skip-excluded-expected-output.json
@@ -24,13 +24,13 @@
   "dependencies" : [ {
     "name" : "first-package",
     "version" : "0.0.1",
-    "package_manger" : "maven",
+    "package_manager" : "maven",
     "path" : "some/path/build.gradle",
     "licenses" : [ "BSD-2-Clause", "GPL-2.0-or-later WITH Classpath-exception-2.0", "MIT", "LicenseRef-scancode-asmus" ]
   }, {
     "name" : "second-package",
     "version" : "0.0.2",
-    "package_manger" : "pip",
+    "package_manager" : "pip",
     "path" : "",
     "licenses" : [ "BSD-2-Clause", "Apache-2.0" ]
   } ]

--- a/reporter/src/main/kotlin/gitlab/GitLabLicenseModel.kt
+++ b/reporter/src/main/kotlin/gitlab/GitLabLicenseModel.kt
@@ -77,7 +77,7 @@ internal data class GitLabLicenseModel(
         /**
          * The package manager corresponding to the project which depends on this dependency.
          */
-        val packageManger: String,
+        val packageManager: String,
 
         /**
          * A comma separate list of the definition file paths of all projects depending on this dependency.

--- a/reporter/src/main/kotlin/gitlab/GitLabLicenseModelMapper.kt
+++ b/reporter/src/main/kotlin/gitlab/GitLabLicenseModelMapper.kt
@@ -61,7 +61,7 @@ private fun Collection<Package>.toLicenses(): List<License> {
 private fun Map<Package, List<String>>.toDependencies(): List<Dependency> =
     map { (pkg, definitionFilePaths) ->
         pkg.toDependency(definitionFilePaths)
-    }.sortedBy { "${it.packageManger}${it.name}${it.version}" }
+    }.sortedBy { "${it.packageManager}${it.name}${it.version}" }
 
 private fun OrtResult.getTargetPackagesWithDefinitionFiles(skipExcluded: Boolean): Map<Package, List<String>> {
     val result = mutableMapOf<Identifier, MutableList<String>>()
@@ -86,7 +86,7 @@ private fun Package.toDependency(definitionFilePaths: Collection<String>): Depen
         version = id.version,
         licenses = declaredLicensesProcessed.spdxExpression?.decompose().orEmpty().map { it.toString() },
         path = definitionFilePaths.sorted().joinToString(","),
-        packageManger = id.toPackageManagerName()
+        packageManager = id.toPackageManagerName()
     )
 
 private fun SpdxSingleLicenseExpression.toLicenseName(): String {


### PR DESCRIPTION
This change updates the key "package_manger" to "package_manager" in the GitLab license scanning report.