### PR TITLE
simple-license-mapping: Add an entry for "Apache2.0"

### DIFF
--- a/spdx-utils/src/main/resources/simple-license-mapping.yml
+++ b/spdx-utils/src/main/resources/simple-license-mapping.yml
@@ -8,6 +8,7 @@ APLv2.0: APACHE_2_0
 ASL: APACHE_2_0
 Apache-2: APACHE_2_0
 Apache-style: APACHE_2_0
+Apache2.0: APACHE_2_0
 Apache2: APACHE_2_0
 Apache: APACHE_2_0
 BSD-3: BSD_3_CLAUSE


### PR DESCRIPTION
As found in
https://repo1.maven.org/maven2/com/sksamuel/exts/exts_2.13/1.61.1/exts_2.13-1.61.1.pom.

Signed-off-by: Frank Viernau <frank.viernau@here.com>