### PR TITLE
Introduce meta data only packages

### DIFF
--- a/docs/config-file-curations-yml.md
+++ b/docs/config-file-curations-yml.md
@@ -16,6 +16,10 @@ Curations can be used to:
   * package description or URL to its homepage.
 * set the concluded license for a package:
   * concluded license is the license applicable to a package dependency defined as an SPDX license expression.
+* set the _is_meta_data_only_ flag:
+  * metadata-only packages, such as Maven BOM files, do not have any source code. Thus, when the flag is set the
+  _downloader_ just skips the download and the _scanner_ skips the scan. Also, any _evaluator rule_ may optionally skip
+  its execution.
 
 The sections below explain how to create curations in the `curations.yml` file which,
 if passed to the _analyzer_, is applied to all package metadata found in the analysis.
@@ -59,6 +63,7 @@ The structure of the curations file consist of one or more `id` entries:
       url: "http://example.com/repo.git"
       revision: "1234abc"
       path: "subdirectory"
+    is_meta_data_only: true
 ````
 
 ## Command Line

--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -80,13 +80,14 @@ object Downloader {
         val downloadDirectory: File,
 
         /**
-         * The source artifact that was downloaded, or null if the download was performed from a [VCS][vcsInfo].
+         * The source artifact that was downloaded, or null if either the download was performed from a [VCS][vcsInfo]
+         * or there was no download performed at all because [Package.isMetaDataOnly] is true.
          */
         val sourceArtifact: RemoteArtifact? = null,
 
         /**
-         * Information about the VCS from which was downloaded, or null if a [source artifact][sourceArtifact] was
-         * downloaded.
+         * Information about the VCS from which was downloaded, or null if either a [source artifact][sourceArtifact]
+         * was downloaded or there was no download performed at all because [Package.isMetaDataOnly] is true.
          */
         val vcsInfo: VcsInfo? = null,
 
@@ -97,8 +98,8 @@ object Downloader {
         val originalVcsInfo: VcsInfo? = null
     ) {
         init {
-            require((sourceArtifact == null) != (vcsInfo == null)) {
-                "Either sourceArtifact or vcsInfo must be set, but not both."
+            require(sourceArtifact == null || vcsInfo == null) {
+                "Not both sourceArtifact and vcsInfo may be set."
             }
         }
     }
@@ -118,6 +119,8 @@ object Downloader {
         }
 
         outputDirectory.apply { safeMkdirs() }
+
+        if (pkg.isMetaDataOnly) return DownloadResult(dateTime = Instant.now(), downloadDirectory = outputDirectory)
 
         val exception = DownloadException("Download failed for '${pkg.id.toCoordinates()}'.")
 

--- a/evaluator/src/main/kotlin/PackageRule.kt
+++ b/evaluator/src/main/kotlin/PackageRule.kt
@@ -106,6 +106,16 @@ open class PackageRule(
         }
 
     /**
+     * A [RuleMatcher] that checks whether the [package][pkg] is meta data only.
+     */
+    fun isMetaDataOnly() =
+        object : RuleMatcher {
+            override val description = "isMetaDataOnly()"
+
+            override fun matches() = pkg.isMetaDataOnly
+        }
+
+    /**
      * A [RuleMatcher] that checks if the [package][pkg] was created from a [Project].
      */
     fun isProject() =

--- a/examples/curations.yml
+++ b/examples/curations.yml
@@ -48,3 +48,8 @@
       but it is not part of the distributed .tar.gz package, see the `README.md` which says: \
       Ramda logo artwork © 2014 J. C. Phillipps. Licensed Creative Commons CC BY-NC-SA 3.0"
     concluded_license: "MIT"
+
+- id: "Maven:org.jetbrains.kotlin:kotlin-bom"
+  curations:
+    comment: "The package is a Maven BOM file and thus is metadata only."
+    is_meta_data_only: true

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -100,7 +100,14 @@ data class Package(
     /**
      * Processed VCS-related information about the [Package] that has e.g. common mistakes corrected.
      */
-    val vcsProcessed: VcsInfo = vcs.normalize()
+    val vcsProcessed: VcsInfo = vcs.normalize(),
+
+    /**
+     * Indicates whether this [Package] is just meta data, like e.g. Maven BOM artifacts which only define constraints
+     * for dependency versions.
+     */
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    val isMetaDataOnly: Boolean = false
 ) : Comparable<Package> {
     companion object {
         /**

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -73,7 +73,12 @@ data class PackageCurationData(
      * A plain-text comment about this curation. Should contain information about how and why the curation was
      * created.
      */
-    val comment: String? = null
+    val comment: String? = null,
+
+    /**
+     * Whether the package is meta data only.
+     */
+    val isMetaDataOnly: Boolean? = null
 ) {
     /**
      * Apply the curation data to the provided package, by overriding all values of the original package with non-null
@@ -106,7 +111,8 @@ data class PackageCurationData(
                 homepageUrl = homepageUrl ?: pkg.homepageUrl,
                 binaryArtifact = binaryArtifact ?: pkg.binaryArtifact,
                 sourceArtifact = sourceArtifact ?: pkg.sourceArtifact,
-                vcs = curatedVcs
+                vcs = curatedVcs,
+                isMetaDataOnly = isMetaDataOnly ?: pkg.isMetaDataOnly
             )
         }
 

--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -40,7 +40,8 @@ class PackageCurationTest : WordSpec({
                 homepageUrl = "",
                 binaryArtifact = RemoteArtifact.EMPTY,
                 sourceArtifact = RemoteArtifact.EMPTY,
-                vcs = VcsInfo.EMPTY
+                vcs = VcsInfo.EMPTY,
+                isMetaDataOnly = false
             )
 
             val curation = PackageCuration(
@@ -64,7 +65,8 @@ class PackageCurationTest : WordSpec({
                         revision = "revision",
                         resolvedRevision = "resolvedRevision",
                         path = "path"
-                    )
+                    ),
+                    isMetaDataOnly = true
                 )
             )
 
@@ -79,6 +81,7 @@ class PackageCurationTest : WordSpec({
                 binaryArtifact shouldBe curation.data.binaryArtifact
                 sourceArtifact shouldBe curation.data.sourceArtifact
                 vcs.toCuration() shouldBe curation.data.vcs
+                isMetaDataOnly shouldBe true
             }
 
             curatedPkg.curations.size shouldBe 1
@@ -105,7 +108,8 @@ class PackageCurationTest : WordSpec({
                     revision = "revision",
                     resolvedRevision = "resolvedRevision",
                     path = "path"
-                )
+                ),
+                isMetaDataOnly = false
             )
 
             val curation = PackageCuration(
@@ -135,6 +139,7 @@ class PackageCurationTest : WordSpec({
                     resolvedRevision = pkg.vcs.resolvedRevision,
                     path = pkg.vcs.path
                 )
+                isMetaDataOnly shouldBe false
             }
 
             curatedPkg.curations.size shouldBe 1
@@ -212,6 +217,35 @@ class PackageCurationTest : WordSpec({
             shouldThrow<IllegalArgumentException> {
                 curation.apply(pkg.toCuratedPackage())
             }
+        }
+
+        "be able to clear isMetaDataOnly" {
+            val pkg = Package(
+                id = Identifier(
+                    type = "Maven",
+                    namespace = "org.hamcrest",
+                    name = "hamcrest-core",
+                    version = "1.3"
+                ),
+                declaredLicenses = sortedSetOf(),
+                description = "",
+                homepageUrl = "",
+                binaryArtifact = RemoteArtifact.EMPTY,
+                sourceArtifact = RemoteArtifact.EMPTY,
+                vcs = VcsInfo.EMPTY,
+                isMetaDataOnly = true
+            )
+
+            val curation = PackageCuration(
+                id = pkg.id,
+                data = PackageCurationData(
+                    isMetaDataOnly = false
+                )
+            )
+
+            val curatedPkg = curation.apply(pkg.toCuratedPackage())
+
+            curatedPkg.pkg.isMetaDataOnly shouldBe false
         }
     }
 

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -193,6 +193,12 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
     ): List<ScanResult> {
         val scannerDetails = getDetails()
 
+        if (pkg.isMetaDataOnly) {
+            log.info { "Skipping '${pkg.id.toCoordinates()}' as it is meta data only." }
+
+            return emptyList()
+        }
+
         return try {
             val storedResults = withContext(storageDispatcher) {
                 log.info {


### PR DESCRIPTION
Packages which are just meta data do not have any source code attached and thus nothing needs to be scanned or downloaded.
Also some evaluator rules may want to skip such packages. 

Thus introduce a corresponding flag and allow setting it via a package curation. Skip such packages in the downloader and scanner and provide a rule matcher to allow conditionally skipping such packages also in the evaluator rules.

A following PR will add logic for automatically set the flag for Maven BOM files.

#2897