### PR TITLE
VcsHostTest: Stop using Mercurial repos from Bitbucket

### DIFF
--- a/downloader/src/funTest/kotlin/vcs/MercurialWorkingTreeTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/MercurialWorkingTreeTest.kt
@@ -86,7 +86,8 @@ class MercurialWorkingTreeTest : StringSpec() {
             workingTree.getPathToRoot(File(zipContentDir, "tests")) shouldBe "tests"
         }
 
-        "Mercurial correctly lists remote branches" {
+        // TODO: Find an alternative to Bitbucket that hosts public Mercurial repositories.
+        "Mercurial correctly lists remote branches".config(enabled = false) {
             val expectedBranches = listOf(
                 "default"
             )
@@ -95,7 +96,8 @@ class MercurialWorkingTreeTest : StringSpec() {
             workingTree.listRemoteBranches().joinToString("\n") shouldBe expectedBranches.joinToString("\n")
         }
 
-        "Mercurial correctly lists remote tags" {
+        // TODO: Find an alternative to Bitbucket that hosts public Mercurial repositories.
+        "Mercurial correctly lists remote tags".config(enabled = false) {
             val expectedTags = listOf(
                 "1.0",
                 "1.0.1",

--- a/downloader/src/test/kotlin/VcsHostTest.kt
+++ b/downloader/src/test/kotlin/VcsHostTest.kt
@@ -31,38 +31,39 @@ import org.ossreviewtoolkit.model.VcsType
 
 class VcsHostTest : WordSpec({
     "The Bitbucket implementation" should {
-        val projectUrl = "https://bitbucket.org/facebook/lz4revlog/src/4c259957d2904604115a02543dc73f5be95761d7/COPYING"
+        val projectUrl = "https://bitbucket.org/yevster/spdxtraxample/" +
+                "src/287aebca5e7ff4167af1fb648640dcdbdf4ec666/LICENSE.txt"
 
         "correctly get the user or organization name" {
-            BITBUCKET.getUserOrOrganization(projectUrl) shouldBe "facebook"
+            BITBUCKET.getUserOrOrganization(projectUrl) shouldBe "yevster"
         }
 
         "correctly get the project name" {
-            BITBUCKET.getProject(projectUrl) shouldBe "lz4revlog"
+            BITBUCKET.getProject(projectUrl) shouldBe "spdxtraxample"
         }
 
         "be able to extract VCS information from a project URL" {
             BITBUCKET.toVcsInfo(projectUrl) shouldBe
                     VcsInfo(
-                        type = VcsType.MERCURIAL,
-                        url = "https://bitbucket.org/facebook/lz4revlog",
-                        revision = "4c259957d2904604115a02543dc73f5be95761d7",
-                        path = "COPYING"
+                        type = VcsType.GIT,
+                        url = "https://bitbucket.org/yevster/spdxtraxample.git",
+                        revision = "287aebca5e7ff4167af1fb648640dcdbdf4ec666",
+                        path = "LICENSE.txt"
                     )
         }
 
         "be able to create permalinks from VCS information" {
             val vcsInfo = VcsInfo(
-                type = VcsType.MERCURIAL,
-                url = "ssh://hg@bitbucket.org/paniq/masagin",
-                revision = "23349a9ba924f6341bd7f1ed907b1b413b298342",
-                path = "masagin.gpl"
+                type = VcsType.GIT,
+                url = "https://bitbucket.org/yevster/spdxtraxample",
+                revision = "287aebca5e7ff4167af1fb648640dcdbdf4ec666",
+                path = "LICENSE.txt"
             )
 
-            BITBUCKET.toPermalink(vcsInfo, 5) shouldBe "https://bitbucket.org/paniq/masagin/" +
-                    "src/23349a9ba924f6341bd7f1ed907b1b413b298342/masagin.gpl#lines-5"
-            BITBUCKET.toPermalink(vcsInfo, 5, 8) shouldBe "https://bitbucket.org/paniq/masagin/" +
-                    "src/23349a9ba924f6341bd7f1ed907b1b413b298342/masagin.gpl#lines-5:8"
+            BITBUCKET.toPermalink(vcsInfo, 1) shouldBe "https://bitbucket.org/yevster/spdxtraxample/" +
+                    "src/287aebca5e7ff4167af1fb648640dcdbdf4ec666/LICENSE.txt#lines-1"
+            BITBUCKET.toPermalink(vcsInfo, 4, 8) shouldBe "https://bitbucket.org/yevster/spdxtraxample/" +
+                    "src/287aebca5e7ff4167af1fb648640dcdbdf4ec666/LICENSE.txt#lines-4:8"
         }
     }
 


### PR DESCRIPTION
As Bitbucket stopped hosting Mercurial in favor of only Git, see
https://bitbucket.org/blog/sunsetting-mercurial-support-in-bitbucket.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>