### PR TITLE
MavenSupport: Treat packages with "pom" packaging as meta data only

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -1459,6 +1459,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/jena.git"
           revision: "jena-3.9.0-rc1"
           path: ""
+        is_meta_data_only: true
       curations: []
     - package:
         id: "Maven:org.apache.jena:jena-arq:3.9.0"
@@ -2108,6 +2109,7 @@ analyzer:
           url: "https://git-wip-us.apache.org/repos/asf/thrift.git"
           revision: ""
           path: ""
+        is_meta_data_only: true
       curations: []
     - package:
         id: "Maven:org.apache.xmlbeans:xmlbeans:2.6.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -540,6 +540,7 @@ analyzer:
           url: "https://gitbox.apache.org/repos/asf/struts.git"
           revision: "STRUTS_2_5_14_1"
           path: ""
+        is_meta_data_only: true
       curations: []
     - package:
         id: "Maven:org.hamcrest:hamcrest-core:1.3"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -540,6 +540,7 @@ analyzer:
           url: "https://gitbox.apache.org/repos/asf/struts.git"
           revision: "STRUTS_2_5_14_1"
           path: ""
+        is_meta_data_only: true
       curations: []
     - package:
         id: "Maven:org.hamcrest:hamcrest-core:1.3"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -206,4 +206,5 @@ packages:
       url: "https://gitbox.apache.org/repos/asf/struts.git"
       revision: "STRUTS_2_5_14_1"
       path: ""
+    is_meta_data_only: true
   curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -224,6 +224,7 @@ packages:
       url: "https://gitbox.apache.org/repos/asf/struts.git"
       revision: "STRUTS_2_5_14_1"
       path: ""
+    is_meta_data_only: true
   curations: []
 - package:
     id: "Maven:org.hamcrest:hamcrest-core:1.3"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
@@ -204,4 +204,5 @@ packages:
       url: "https://gitbox.apache.org/repos/asf/struts.git"
       revision: "STRUTS_2_5_14_1"
       path: ""
+    is_meta_data_only: true
   curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
@@ -202,6 +202,7 @@ packages:
       url: "https://gitbox.apache.org/repos/asf/struts.git"
       revision: "STRUTS_2_5_14_1"
       path: ""
+    is_meta_data_only: true
   curations: []
 - package:
     id: "Maven:org.hamcrest:hamcrest-core:1.3"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
@@ -64,6 +64,7 @@ packages:
       url: "https://gitbox.apache.org/repos/asf/beam.git"
       revision: "v2.3.0-RC3"
       path: ""
+    is_meta_data_only: true
   curations: []
 - package:
     id: "Maven:org.apache.commons:commons-lang3:3.5"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
@@ -97,6 +97,7 @@ packages:
       url: "https://gitbox.apache.org/repos/asf/beam.git"
       revision: "v2.3.0-RC3"
       path: ""
+    is_meta_data_only: true
   curations: []
 - package:
     id: "Maven:org.apache.commons:commons-lang3:3.5"

--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -591,7 +591,8 @@ class MavenSupport(workspaceReader: WorkspaceReader) {
             binaryArtifact = binaryRemoteArtifact,
             sourceArtifact = sourceRemoteArtifact,
             vcs = vcsFromPackage,
-            vcsProcessed = vcsProcessed
+            vcsProcessed = vcsProcessed,
+            isMetaDataOnly = mavenProject.packaging == "pom"
         )
     }
 


### PR DESCRIPTION
To eliminate download and scan issues related to these packages (which
do not have any corresponding source code). Note that "pom" packaging
may be used e.g. for parent-, aggregation- or BOM packages.

Fixes #2897 .

Signed-off-by: Frank Viernau <frank.viernau@here.com>