### PR TITLE
PackageManager: Stop using the experimental time API

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -28,7 +28,7 @@ import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
 import java.util.ServiceLoader
 
-import kotlin.time.measureTime
+import kotlin.system.measureTimeMillis
 
 import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.downloader.VersionControlSystem
@@ -226,7 +226,7 @@ abstract class PackageManager(
         definitionFiles.forEach { definitionFile ->
             log.info { "Resolving $managerName dependencies for '$definitionFile'..." }
 
-            val duration = measureTime {
+            val duration = measureTimeMillis {
                 @Suppress("TooGenericExceptionCaught")
                 try {
                     result[definitionFile] = resolveDependencies(definitionFile)
@@ -255,7 +255,7 @@ abstract class PackageManager(
             }
 
             log.info {
-                "Resolving $managerName dependencies for '${definitionFile.name}' took ${duration.inSeconds}s."
+                "Resolving $managerName dependencies for '${definitionFile.name}' took ${duration / 1000}s."
             }
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -183,7 +183,7 @@ subprojects {
     }
 
     tasks.withType<KotlinCompile>().configureEach {
-        val customCompilerArgs = listOf("-Xallow-result-return-type", "-Xopt-in=kotlin.time.ExperimentalTime")
+        val customCompilerArgs = listOf("-Xallow-result-return-type")
 
         kotlinOptions {
             allWarningsAsErrors = true

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -35,9 +35,6 @@ import com.github.ajalt.clikt.parameters.types.file
 
 import java.io.File
 
-import kotlin.time.TimedValue
-import kotlin.time.measureTimedValue
-
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.OrtConfiguration
@@ -57,6 +54,7 @@ import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.createProvider
 import org.ossreviewtoolkit.utils.expandTilde
 import org.ossreviewtoolkit.utils.log
+import org.ossreviewtoolkit.utils.measureTime
 import org.ossreviewtoolkit.utils.safeMkdirs
 import org.ossreviewtoolkit.utils.showStackTrace
 import org.ossreviewtoolkit.utils.storage.FileArchiver
@@ -205,7 +203,7 @@ class ReporterCommand : CliktCommand(
         }
 
         var failure = false
-        val reportDurationMap = mutableMapOf<Reporter, TimedValue<List<File>>>()
+        val reportDurationMap = mutableMapOf<Reporter, Pair<List<File>, Long>>()
 
         reportFormats.forEach { reporter ->
             val options = reportOptionsMap[reporter.reporterName.toUpperCase()].orEmpty()
@@ -214,7 +212,7 @@ class ReporterCommand : CliktCommand(
 
             @Suppress("TooGenericExceptionCaught")
             try {
-                reportDurationMap[reporter] = measureTimedValue {
+                reportDurationMap[reporter] = measureTime {
                     reporter.generateReport(input, outputDir, options)
                 }
             } catch (e: Exception) {
@@ -228,7 +226,7 @@ class ReporterCommand : CliktCommand(
 
         reportDurationMap.forEach { (reporter, files) ->
             val name = reporter.reporterName
-            println("Successfully created the '$name' report at ${files.value} in ${files.duration.inSeconds}s.")
+            println("Successfully created the '$name' report at ${files.first} in ${files.second / 1000}s.")
         }
 
         println("Created ${reportDurationMap.size} of ${reportFormats.size} report(s).")

--- a/reporter/src/main/kotlin/reporters/EvaluatedModelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/EvaluatedModelReporter.kt
@@ -22,12 +22,11 @@ package org.ossreviewtoolkit.reporter.reporters
 import java.io.File
 import java.io.Writer
 
-import kotlin.time.measureTimedValue
-
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.model.EvaluatedModel
 import org.ossreviewtoolkit.utils.log
+import org.ossreviewtoolkit.utils.measureTime
 
 private fun EvaluatedModel.toJson(writer: Writer) = toJson(writer, prettyPrint = true)
 
@@ -63,14 +62,14 @@ abstract class EvaluatedModelReporter(
         outputDir: File,
         options: Map<String, String>
     ): List<File> {
-        val evaluatedModel = measureTimedValue { EvaluatedModel.create(input) }
+        val evaluatedModel = measureTime { EvaluatedModel.create(input) }
 
-        log.debug { "Generating evaluated model took ${evaluatedModel.duration.inMilliseconds}ms." }
+        log.debug { "Generating evaluated model took ${System.currentTimeMillis() - evaluatedModel.second}ms." }
 
         val outputFile = outputDir.resolve(reportFilename)
 
         outputFile.bufferedWriter().use {
-            evaluatedModel.value.serialize(it)
+            evaluatedModel.first.serialize(it)
         }
 
         return listOf(outputFile)

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -218,6 +218,15 @@ fun joinNonBlank(vararg strings: String, separator: String = " - ") =
     strings.filter { it.isNotBlank() }.joinToString(separator)
 
 /**
+ * Return the result of [block] and the duration it took to execute in milliseconds.
+ */
+fun <T> measureTime(block: () -> T): Pair<T, Long> {
+    val start = System.currentTimeMillis()
+    val result = block()
+    return Pair(result, System.currentTimeMillis() - start)
+}
+
+/**
  * Normalize a string representing a [VCS URL][vcsUrl] to a common string form.
  */
 fun normalizeVcsUrl(vcsUrl: String): String {


### PR DESCRIPTION
On our infrastructure the analyzer currently fails consistently with the
below error for unknown reason. Switching to the non-experimental API
fixes that issue.

Exception in thread "main" java.lang.NoSuchMethodError: 'double kotlin.time.TimeMark.elapsedNow()'
        at org.ossreviewtoolkit.analyzer.PackageManager.resolveDependencies(PackageManager.kt:318)
        at org.ossreviewtoolkit.analyzer.Analyzer$analyzeInParallel$$inlined$use$lambda$1$1$1.invokeSuspend(Analyzer.kt:143)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)

Signed-off-by: Frank Viernau <frank.viernau@here.com>