### PR TITLE
declared-license-mapping: Fix-up a broken license identifier

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -268,7 +268,7 @@
 "IBM Public License": IPL-1.0
 "ISC License (ISCL)": ISC
 "ISC/BSD License": ISC OR BSD-2-Clause
-"Indiana University Extreme! Lab Software License, vesion 1.1.1": LicenseRef-indiana-extreme-scancode
+"Indiana University Extreme! Lab Software License, vesion 1.1.1": LicenseRef-scancode-indiana-extreme
 "Individual BSD License": BSD-3-Clause
 "Jabber Open Source License": LicenseRef-scancode-josl-1.0
 "Jython Software License": Python-2.0


### PR DESCRIPTION
This is a fix-up for a7aa9bf.

Signed-off-by: Frank Viernau <frank.viernau@here.com>