### PR TITLE
NoticeTemplateReporter: Pass the labels to the template

### DIFF
--- a/reporter/src/main/kotlin/reporters/NoticeTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeTemplateReporter.kt
@@ -75,6 +75,7 @@ class NoticeTemplateReporter : Reporter {
         val dataModel = mapOf(
             "projects" to projects,
             "packages" to packages,
+            "labels" to input.ortResult.labels,
             "licenseTextProvider" to input.licenseTextProvider,
             "helper" to NoticeHelper(input.licenseConfiguration)
         )


### PR DESCRIPTION
Pass the labels from the `OrtResult` to the notice template. This allows
to use labels to control notice file generation.