### PR TITLE
Extensions: Do not print a trailing comma when collecting exception messages

### DIFF
--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -228,9 +228,8 @@ scanner:
               \ DownloadException: Download failed for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\n\
               Suppressed: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\
               \ Please make sure the release POM file includes the SCM connection,\
-              \ see: https://docs.gradle.org/current/userguide/publishing_maven.html#example_customizing_the_pom_file,\
-              \ \nSuppressed: DownloadException: No source artifact URL provided for\
-              \ 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'."
+              \ see: https://docs.gradle.org/current/userguide/publishing_maven.html#example_customizing_the_pom_file\n\
+              Suppressed: DownloadException: No source artifact URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'."
             severity: "ERROR"
     - id: "Maven:junit:junit:4.12"
       results:

--- a/utils/src/main/kotlin/Extensions.kt
+++ b/utils/src/main/kotlin/Extensions.kt
@@ -323,7 +323,7 @@ fun Throwable.collectMessages(): List<String> {
     val messages = mutableListOf<String>()
     var cause: Throwable? = this
     while (cause != null) {
-        val suppressed = cause.suppressed.joinToString { "\nSuppressed: ${it.javaClass.simpleName}: ${it.message}" }
+        val suppressed = cause.suppressed.joinToString("") { "\nSuppressed: ${it.javaClass.simpleName}: ${it.message}" }
         messages += "${cause.javaClass.simpleName}: ${cause.message}$suppressed"
         cause = cause.cause
     }


### PR DESCRIPTION
As all lines are prefixed by "Suppressed: " having a trailing comma
between these simply looks (arguably) odd. See e.g.

Suppressed: DownloadException: Unsupported VCS type ''.,
Suppressed: DownloadException: No source artifact URL provided for 'Downloader::ciam-ids4-centralids:'.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>