### PR TITLE
reporter: Implement custom how-to-fix texts for `OrtIssue`s

### DIFF
--- a/cli/src/funTest/kotlin/ExamplesTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesTest.kt
@@ -26,19 +26,24 @@ import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
+import io.kotest.matchers.string.shouldContain
 
 import java.io.File
 import java.io.IOException
+import java.time.Instant
 
 import org.ossreviewtoolkit.evaluator.Evaluator
+import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.PackageCuration
+import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.Resolutions
 import org.ossreviewtoolkit.model.licenses.LicenseConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
+import org.ossreviewtoolkit.reporter.HowToFixTextProvider
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.reporters.AbstractNoticeReporter
 import org.ossreviewtoolkit.reporter.reporters.AntennaAttributionDocumentReporter
@@ -115,6 +120,21 @@ class ExamplesTest : StringSpec() {
             shouldNotThrow<IOException> {
                 takeExampleFile("resolutions.yml").readValue<Resolutions>()
             }
+        }
+
+        "how-to-fix-text-provider.kts provides the expected how-to-fix text" {
+            val script = takeExampleFile("how-to-fix-text-provider.kts").readText()
+            val howToFixTextProvider = HowToFixTextProvider.fromKotlinScript(script)
+            val issue = OrtIssue(
+                message = "ERROR: Timeout after 360 seconds while scanning file 'src/res/data.json'.",
+                source = "ScanCode",
+                severity = Severity.ERROR,
+                timestamp = Instant.now()
+            )
+
+            val howToFixText = howToFixTextProvider.getHowToFixText(issue)
+
+            howToFixText shouldContain "Manually verify that the file does not contain any license information."
         }
 
         "rules.kts can be compiled" {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -343,7 +343,8 @@ Created 'NoticeByPackage' report: [reporter-output-path]/NOTICE_BY_PACKAGE
 
 If you do not want to run the _evaluator_ you can pass the _scanner_ result e.g. `[scanner-output-path/scan-result.yml`
 to the `reporter` instead. To learn how you can customize generated notices see
-[notice-pre-processor-kts.md](notice-pre-processor-kts.md).
+[notice-pre-processor-kts.md](notice-pre-processor-kts.md). To learn how to customize the how-to-fix texts for scanner
+and analyzer issues see [how-to-fix-text-provider-kts.md](how-to-fix-text-provider-kts.md).
 
 ## 8. Curating Package Metadata or License Findings
 

--- a/docs/how-to-fix-text-provider-kts.md
+++ b/docs/how-to-fix-text-provider-kts.md
@@ -1,0 +1,20 @@
+# The `how-to-fix-text-provider.kts` file
+
+The `how-to-fix-text-provider.kts` file enables the injection of how-to-fix texts in markdown format for ORT issues
+into the reports.
+
+You can use the [how-to-fix-text-provider.kts example](../examples/how-to-fix-text-provider.kts) as the base script file
+to create your custom how-to-fix messages in the generated reports.
+
+## Command Line
+
+To use the `how-to-fix-text-provider.kts` file and pass it to the `--how-to-fix-text-provider-script` option of the
+_Reporter_:
+
+```bash
+cli/build/install/ort/bin/ort report
+  -i [evaluator-output-path]/evaluation-result.yml
+  -o [reporter-output-path]
+  --report-formats StaticHtml,WebApp
+  --how-to-fix-text-provider-script [ort-configuration-path]/how-to-fix-text-provider.kts
+```

--- a/examples/how-to-fix-text-provider.kts
+++ b/examples/how-to-fix-text-provider.kts
@@ -1,0 +1,20 @@
+object : HowToFixTextProvider {
+    fun OrtIssue.matchesMessage(pattern: String): Boolean = pattern.toRegex().matches(message)
+
+    override fun getHowToFixText(issue: OrtIssue): String? {
+        // How-to-fix instruction Markdown for scan timeout errors.
+        if (issue.matchesMessage("ERROR: Timeout after .* seconds while scanning file.*")) {
+            return """
+                | To fix this issue please proceed with the following steps:
+                |
+                |1. Manually verify that the file does not contain any license information.
+                |2. File an error resolution in the resolutions file of your configuration directory with a comment
+                |   stating that the file does not contain any license information.
+                |   ```
+                |
+            """.trimIndent()
+        }
+
+        return null
+    }
+}

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -536,6 +536,26 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
                   <p>Unknown time [ERROR]: FileCounter - DownloadException: No source artifact URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.<br>Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'. Please make sure the release POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#example_customizing_the_pom_file</p>
                   <p></p>
                 </li>
+                <details>
+                  <summary>How to fix</summary>
+                  <ul>
+
+                    <li>
+                      <em>Step 1</em>
+                    </li>
+
+                    <li>
+                      <strong>Step 2</strong>
+                    </li>
+
+                    <li>
+                      <em><strong>Step 3</strong></em>
+<code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code>
+                    </li>
+
+                  </ul>
+
+                </details>
               </ul>
             </td>
           </tr>

--- a/reporter/src/funTest/kotlin/reporters/StaticHtmlReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/StaticHtmlReporterTest.kt
@@ -59,7 +59,7 @@ class StaticHtmlReporterTest : WordSpec({
 
 private fun generateReport(ortResult: OrtResult): String {
     val input = ReporterInput(
-        ortResult,
+        ortResult = ortResult,
         resolutionProvider = DefaultResolutionProvider().add(ortResult.getResolutions())
     )
 

--- a/reporter/src/funTest/kotlin/reporters/StaticHtmlReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/StaticHtmlReporterTest.kt
@@ -27,12 +27,25 @@ import java.io.File
 import javax.xml.transform.TransformerFactory
 
 import org.ossreviewtoolkit.model.Environment
+import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
+import org.ossreviewtoolkit.reporter.HowToFixTextProvider
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.readOrtResult
+
+private val HOW_TO_FIX_TEXT_PROVIDER: HowToFixTextProvider = object : HowToFixTextProvider {
+    override fun getHowToFixText(issue: OrtIssue): String? {
+        return """
+            * *Step 1*
+            * __Step 2__
+            * ***Step 3***
+            ```Some long issue resolution text to verify that overflow:scroll is working as expected.``` 
+        """.trimIndent()
+    }
+}
 
 class StaticHtmlReporterTest : WordSpec({
     "StaticHtmlReporter" should {
@@ -60,7 +73,8 @@ class StaticHtmlReporterTest : WordSpec({
 private fun generateReport(ortResult: OrtResult): String {
     val input = ReporterInput(
         ortResult = ortResult,
-        resolutionProvider = DefaultResolutionProvider().add(ortResult.getResolutions())
+        resolutionProvider = DefaultResolutionProvider().add(ortResult.getResolutions()),
+        howToFixTextProvider = HOW_TO_FIX_TEXT_PROVIDER
     )
 
     val outputDir = createTempDir(ORT_NAME, StaticHtmlReporterTest::class.simpleName).apply { deleteOnExit() }

--- a/reporter/src/main/kotlin/HowToFixTextProvider.kt
+++ b/reporter/src/main/kotlin/HowToFixTextProvider.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.reporter
+
+import org.ossreviewtoolkit.model.OrtIssue
+
+/**
+ * Provides how-to-fix texts in Markdown format for any given [OrtIssue].
+ */
+interface HowToFixTextProvider {
+    /**
+     * Return a Markdown text describing how to fix the given [issue]. Non-null return values override the default
+     * how-to-fix texts, while a null value keeps the default.
+     */
+    fun getHowToFixText(issue: OrtIssue): String?
+}

--- a/reporter/src/main/kotlin/HowToFixTextProvider.kt
+++ b/reporter/src/main/kotlin/HowToFixTextProvider.kt
@@ -25,6 +25,15 @@ import org.ossreviewtoolkit.model.OrtIssue
  * Provides how-to-fix texts in Markdown format for any given [OrtIssue].
  */
 interface HowToFixTextProvider {
+    companion object {
+        /**
+         * A [HowToFixTextProvider] which returns null for any given [OrtIssue].
+         */
+        val NONE = object : HowToFixTextProvider {
+            override fun getHowToFixText(issue: OrtIssue): String? = null
+        }
+    }
+
     /**
      * Return a Markdown text describing how to fix the given [issue]. Non-null return values override the default
      * how-to-fix texts, while a null value keeps the default.

--- a/reporter/src/main/kotlin/HowToFixTextProvider.kt
+++ b/reporter/src/main/kotlin/HowToFixTextProvider.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.reporter
 
 import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.utils.ScriptRunner
 
 /**
  * Provides how-to-fix texts in Markdown format for any given [OrtIssue].
@@ -32,11 +33,28 @@ interface HowToFixTextProvider {
         val NONE = object : HowToFixTextProvider {
             override fun getHowToFixText(issue: OrtIssue): String? = null
         }
-    }
 
+        /**
+         * Return the [HowToFixTextProvider] which in-turn has to be returned by the given [script].
+         */
+        fun fromKotlinScript(script: String): HowToFixTextProvider = HowToFixScriptRunner().run(script)
+    }
     /**
      * Return a Markdown text describing how to fix the given [issue]. Non-null return values override the default
      * how-to-fix texts, while a null value keeps the default.
      */
     fun getHowToFixText(issue: OrtIssue): String?
+}
+
+private class HowToFixScriptRunner : ScriptRunner() {
+    override val preface = """
+            import org.ossreviewtoolkit.model.*
+            import org.ossreviewtoolkit.reporter.HowToFixTextProvider
+                        
+        """.trimIndent()
+
+    override val postface = """
+        """.trimIndent()
+
+    override fun run(script: String): HowToFixTextProvider = super.run(script) as HowToFixTextProvider
 }

--- a/reporter/src/main/kotlin/ReporterInput.kt
+++ b/reporter/src/main/kotlin/ReporterInput.kt
@@ -81,5 +81,10 @@ data class ReporterInput(
      * A [LicenseConfiguration], can be used to handle licenses based on the user's configuration, for example to
      * determine which licenses to include in a notice file.
      */
-    val licenseConfiguration: LicenseConfiguration = LicenseConfiguration()
+    val licenseConfiguration: LicenseConfiguration = LicenseConfiguration(),
+
+    /**
+     * A [HowToFixTextProvider], can be used to integrate how to fix texts for [OrtIssue]s into reports.
+     */
+    val howToFixTextProvider: HowToFixTextProvider = HowToFixTextProvider.NONE
 )

--- a/reporter/src/main/kotlin/reporters/ExcelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ExcelReporter.kt
@@ -102,7 +102,7 @@ class ExcelReporter : Reporter {
             .map { it.trim() }
             .filter { it.isNotEmpty() }
 
-        val tabularScanRecord = ReportTableModelMapper(input.resolutionProvider)
+        val tabularScanRecord = ReportTableModelMapper(input.resolutionProvider, input.howToFixTextProvider)
             .mapToReportTableModel(
                 input.ortResult,
                 input.licenseInfoResolver

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -66,7 +66,7 @@ class StaticHtmlReporter : Reporter {
         outputDir: File,
         options: Map<String, String>
     ): List<File> {
-        val tabularScanRecord = ReportTableModelMapper(input.resolutionProvider)
+        val tabularScanRecord = ReportTableModelMapper(input.resolutionProvider, input.howToFixTextProvider)
             .mapToReportTableModel(
                 input.ortResult,
                 input.licenseInfoResolver

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -368,6 +368,13 @@ class StaticHtmlReporter : Reporter {
                                 issueDescription(issue)
                                 p { +issue.resolutionDescription }
                             }
+
+                            if (!issue.isResolved && issue.howToFix.isNotBlank()) {
+                                details {
+                                    unsafe { +"<summary>How to fix</summary>" }
+                                    markdown(issue.howToFix)
+                                }
+                            }
                         }
                     }
                 }
@@ -382,6 +389,13 @@ class StaticHtmlReporter : Reporter {
                             li {
                                 issueDescription(issue)
                                 p { +issue.resolutionDescription }
+                            }
+
+                            if (!issue.isResolved && issue.howToFix.isNotBlank()) {
+                                details {
+                                    unsafe { +"<summary>How to fix</summary>" }
+                                    markdown(issue.howToFix)
+                                }
                             }
                         }
                     }

--- a/reporter/src/main/kotlin/utils/ReportTableModel.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModel.kt
@@ -255,7 +255,8 @@ data class ReportTableModel(
         val description: String,
         val resolutionDescription: String,
         val isResolved: Boolean,
-        val severity: Severity
+        val severity: Severity,
+        val howToFix: String
     )
 
     data class ResolvableViolation(

--- a/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
@@ -31,6 +31,7 @@ import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
 import org.ossreviewtoolkit.model.utils.ResolutionProvider
+import org.ossreviewtoolkit.reporter.HowToFixTextProvider
 import org.ossreviewtoolkit.reporter.utils.ReportTableModel.DependencyRow
 import org.ossreviewtoolkit.reporter.utils.ReportTableModel.IssueRow
 import org.ossreviewtoolkit.reporter.utils.ReportTableModel.IssueTable
@@ -58,7 +59,8 @@ private fun Project.getScopesForDependencies(excludes: Excludes): Map<Identifier
  * A mapper which converts an [OrtIssue] to a [ReportTableModel] view model.
  */
 class ReportTableModelMapper(
-    private val resolutionProvider: ResolutionProvider
+    private val resolutionProvider: ResolutionProvider,
+    private val howToFixTextProvider: HowToFixTextProvider
 ) {
     companion object {
         private val VIOLATION_COMPARATOR = compareBy<ReportTableModel.ResolvableViolation>(
@@ -85,7 +87,8 @@ class ReportTableModelMapper(
                 }
             },
             isResolved = resolutions.isNotEmpty(),
-            severity = severity
+            severity = severity,
+            howToFix = howToFixTextProvider.getHowToFixText(this).orEmpty()
         )
     }
 


### PR DESCRIPTION
Add a (reporter) command line option to inject custom how-to-fix Markdown texts for OrtIssues from within a Kotlin Script.
Display these injected how-to-fix texts in the `static HTML report` to show that it works.

The integration into the `WebApp` is going to be done in a following PR.

See also: #2347.