### PR TITLE
Downloader: Remove the initial log message when downloading

### DIFF
--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -112,8 +112,6 @@ object Downloader {
      * failure.
      */
     fun download(pkg: Package, outputDirectory: File, allowMovingRevisions: Boolean = false): DownloadResult {
-        log.info { "Trying to download source code for '${pkg.id.toCoordinates()}'." }
-
         require(!outputDirectory.exists() || outputDirectory.list().isEmpty()) {
             "The output directory '$outputDirectory' must not contain any files yet."
         }


### PR DESCRIPTION
Having the VCS / source artifact specific log messages is enough, and
the log message became confusing in the context of meta data only
packages.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>