### PR TITLE
Rename VcsType.NONE to VcsType.UNKNOWN

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -167,7 +167,7 @@ abstract class PackageManager(
             }
 
             // Use the first VCS information with a valid type, or the normalized VCS information from the package.
-            return availableVcsInfo.find { it.type != VcsType.NONE } ?: normalizedVcsFromPackage
+            return availableVcsInfo.find { it.type != VcsType.UNKNOWN } ?: normalizedVcsFromPackage
         }
 
         /**

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -359,7 +359,7 @@ open class Npm(
             val url = repo.textValue() ?: repo["url"].textValueOrEmpty()
             val path = repo["directory"].textValueOrEmpty()
             VcsInfo(VcsType(type), expandNpmShortcutURL(url), head, path = path)
-        } ?: VcsInfo(VcsType.NONE, "", head)
+        } ?: VcsInfo(VcsType.UNKNOWN, "", head)
     }
 
     private fun getPackageReferenceForMissingModule(moduleName: String, rootModuleDir: File): PackageReference {

--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -165,7 +165,7 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
                 val projectUrl = (input as StringType).string
 
                 val vcs = VersionControlSystem.forUrl(projectUrl)
-                val vcsType = vcsTypeOption?.let { VcsType(it) } ?: (vcs?.type ?: VcsType.NONE)
+                val vcsType = vcsTypeOption?.let { VcsType(it) } ?: (vcs?.type ?: VcsType.UNKNOWN)
                 val vcsRevision = vcsRevisionOption ?: vcs?.defaultBranchName.orEmpty()
 
                 val projectFile = File(projectUrl)

--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -195,7 +195,7 @@ object Downloader {
 
         var applicableVcs: VersionControlSystem? = null
 
-        if (pkg.vcsProcessed.type != VcsType.NONE) {
+        if (pkg.vcsProcessed.type != VcsType.UNKNOWN) {
             applicableVcs = VersionControlSystem.forType(pkg.vcsProcessed.type)
             log.info {
                 applicableVcs?.let {

--- a/downloader/src/main/kotlin/VcsHost.kt
+++ b/downloader/src/main/kotlin/VcsHost.kt
@@ -76,7 +76,7 @@ enum class VcsHost(
                 }
             }
 
-            val type = VersionControlSystem.forUrl(url)?.type ?: VcsType.NONE
+            val type = VersionControlSystem.forUrl(url)?.type ?: VcsType.UNKNOWN
             if (type == VcsType.GIT) {
                 url += ".git"
             }
@@ -145,7 +145,7 @@ enum class VcsHost(
             val type = when (projectUrl.host.substringBefore('.')) {
                 "git" -> VcsType.GIT
                 "hg" -> VcsType.MERCURIAL
-                else -> VcsType.NONE
+                else -> VcsType.UNKNOWN
             }
 
             var url = projectUrl.scheme + "://" + projectUrl.authority
@@ -266,7 +266,7 @@ enum class VcsHost(
                     VcsInfo(VcsType.GIT, url, revision, null, "")
                 }
 
-                else -> VcsInfo(VcsType.NONE, projectUrl, "")
+                else -> VcsInfo(VcsType.UNKNOWN, projectUrl, "")
             }
         }
 

--- a/model/src/main/kotlin/VcsInfo.kt
+++ b/model/src/main/kotlin/VcsInfo.kt
@@ -73,7 +73,7 @@ data class VcsInfo(
          */
         @JvmField
         val EMPTY = VcsInfo(
-            type = VcsType.NONE,
+            type = VcsType.UNKNOWN,
             url = "",
             revision = "",
             resolvedRevision = null,

--- a/model/src/main/kotlin/VcsType.kt
+++ b/model/src/main/kotlin/VcsType.kt
@@ -78,9 +78,9 @@ data class VcsType(val aliases: List<String>) {
         )
 
         /**
-         * No VCS type.
+         * An unkown VCS type.
          */
-        val NONE = VcsType(listOf(""))
+        val UNKNOWN = VcsType(listOf(""))
     }
 
     @JsonValue

--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -172,7 +172,7 @@ class PackageCurationTest : WordSpec({
                 id = pkg.id,
                 data = PackageCurationData(
                     vcs = VcsInfoCurationData(
-                        type = VcsType.NONE,
+                        type = VcsType.UNKNOWN,
                         url = "",
                         revision = "",
                         path = ""
@@ -207,7 +207,7 @@ class PackageCurationTest : WordSpec({
                 data = PackageCurationData(
                     homepageUrl = "http://home.page",
                     vcs = VcsInfoCurationData(
-                        type = VcsType.NONE,
+                        type = VcsType.UNKNOWN,
                         url = "http://url.git",
                         revision = ""
                     )

--- a/model/src/test/kotlin/VcsInfoTest.kt
+++ b/model/src/test/kotlin/VcsInfoTest.kt
@@ -71,7 +71,7 @@ class VcsInfoTest : WordSpec({
 
             val vcsInfo = yamlMapper.readValue<VcsInfo>(yaml)
 
-            vcsInfo.type shouldBe VcsType.NONE
+            vcsInfo.type shouldBe VcsType.UNKNOWN
             vcsInfo.url shouldBe ""
             vcsInfo.revision shouldBe ""
             vcsInfo.path shouldBe "path"
@@ -101,7 +101,7 @@ class VcsInfoTest : WordSpec({
     "Merging VcsInfo" should {
         "ignore empty information" {
             val inputA = VcsInfo(
-                type = VcsType.NONE,
+                type = VcsType.UNKNOWN,
                 url = "",
                 revision = ""
             )
@@ -151,7 +151,7 @@ class VcsInfoTest : WordSpec({
 
         "prefer more complete information for GitLab" {
             val inputA = VcsInfo(
-                type = VcsType.NONE,
+                type = VcsType.UNKNOWN,
                 url = "https://gitlab.com/rich-harris/rollup-plugin-buble.git",
                 revision = ""
             )


### PR DESCRIPTION
We actually use this to describe an unknown VCS, not necessarily only
URLs that point to no VCS at all.

Also compare to the HashAlgorithm semantics, where we have both NONE and
UNKNOWN.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>