### PR TITLE
WebApp: Display the custom how-to-fix messages

### DIFF
--- a/reporter-web-app/src/components/IssuesTable.js
+++ b/reporter-web-app/src/components/IssuesTable.js
@@ -29,6 +29,7 @@ import {
     WarningOutlined
 } from '@ant-design/icons';
 
+import Markdown from 'markdown-to-jsx';
 import PackageDetails from './PackageDetails';
 import PackageLicenses from './PackageLicenses';
 import PackagePaths from './PackagePaths';
@@ -246,6 +247,18 @@ const IssuesTable = (props) => {
                             bordered={false}
                             defaultActiveKey={defaultActiveKey}
                         >
+                            {
+                                webAppOrtIssue.hasHowToFix()
+                                && (
+                                    <Panel header="How to fix" key="0">
+                                        <Markdown
+                                            className="ort-how-to-fix"
+                                        >
+                                            {webAppOrtIssue.howToFix}
+                                        </Markdown>
+                                    </Panel>
+                                )
+                            }
                             {
                                 webAppOrtIssue.isResolved
                                 && (

--- a/reporter-web-app/src/models/WebAppOrtIssue.js
+++ b/reporter-web-app/src/models/WebAppOrtIssue.js
@@ -22,6 +22,8 @@ import { randomStringGenerator } from '../utils';
 class WebAppOrtIssue {
     #_id;
 
+    #howToFix
+
     #message;
 
     #package;
@@ -54,6 +56,11 @@ class WebAppOrtIssue {
         if (obj) {
             if (Number.isInteger(obj._id)) {
                 this.#_id = obj._id;
+            }
+
+            if (obj.how_to_fix || obj.howToFix) {
+                this.#howToFix = obj.how_to_fix
+                    || obj.howToFix;
             }
 
             if (obj.message) {
@@ -112,6 +119,10 @@ class WebAppOrtIssue {
 
     get _id() {
         return this.#_id;
+    }
+
+    get howToFix() {
+        return this.#howToFix;
     }
 
     get isResolved() {
@@ -212,6 +223,10 @@ class WebAppOrtIssue {
         }
 
         return this.#resolutionReasons;
+    }
+
+    hasHowToFix() {
+        return !!this.#howToFix;
     }
 }
 

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -77,7 +77,8 @@
     "message" : "DownloadException: No source artifact URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\nCaused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'. Please make sure the release POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#example_customizing_the_pom_file",
     "severity" : "ERROR",
     "pkg" : 0,
-    "scan_result" : 0
+    "scan_result" : 0,
+    "how_to_fix" : "Some how to fix text."
   } ],
   "scan_results" : [ {
     "_id" : 0,

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -62,6 +62,7 @@ issues:
   severity: "ERROR"
   pkg: 0
   scan_result: 0
+  how_to_fix: "Some how to fix text."
 scan_results:
 - _id: 0
   provenance:

--- a/reporter/src/funTest/kotlin/reporters/EvaluatedModelReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/EvaluatedModelReporterTest.kt
@@ -24,12 +24,20 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
+import org.ossreviewtoolkit.reporter.HowToFixTextProvider
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.normalizeLineBreaks
 import org.ossreviewtoolkit.utils.test.readOrtResult
+
+private val HOW_TO_FIX_TEXT_PROVIDER: HowToFixTextProvider = object : HowToFixTextProvider {
+    override fun getHowToFixText(issue: OrtIssue): String? {
+        return "Some how to fix text.".trimIndent()
+    }
+}
 
 class EvaluatedModelReporterTest : WordSpec({
     "EvaluatedModelReporter" should {
@@ -56,7 +64,8 @@ class EvaluatedModelReporterTest : WordSpec({
 private fun generateReport(reporter: EvaluatedModelReporter, ortResult: OrtResult): String {
     val input = ReporterInput(
         ortResult = ortResult,
-        resolutionProvider = DefaultResolutionProvider().add(ortResult.getResolutions())
+        resolutionProvider = DefaultResolutionProvider().add(ortResult.getResolutions()),
+        howToFixTextProvider = HOW_TO_FIX_TEXT_PROVIDER
     )
 
     val outputDir = createTempDir(ORT_NAME, EvaluatedModelReporterTest::class.simpleName).apply { deleteOnExit() }

--- a/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
@@ -500,7 +500,8 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
                 resolutions = resolutions,
                 pkg = pkg,
                 scanResult = scanResult,
-                path = path
+                path = path,
+                howToFix = input.howToFixTextProvider.getHowToFixText(issue).orEmpty()
             )
         }
 

--- a/reporter/src/main/kotlin/model/EvaluatedOrtIssue.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedOrtIssue.kt
@@ -49,5 +49,7 @@ data class EvaluatedOrtIssue(
     val scanResult: EvaluatedScanResult?,
     @JsonIdentityReference(alwaysAsId = true)
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    val path: EvaluatedPackagePath?
+    val path: EvaluatedPackagePath?,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val howToFix: String
 )


### PR DESCRIPTION
This PR follows up on #2966 by handling the `HowToFixTextProvider` in the `evaluated model` and in the `WebApp`.

Fixes #2347.