### PR TITLE
AmazonOssAttributionBuilderReporter: Migrate to the new license API

### DIFF
--- a/reporter/src/main/kotlin/reporters/AmazonOssAttributionBuilderReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AmazonOssAttributionBuilderReporter.kt
@@ -109,7 +109,7 @@ class AmazonOssAttributionBuilderReporter : Reporter {
                 val allCopyrights = licenseInfo.filter(LicenseView.ONLY_DETECTED).flatMapTo(mutableSetOf()) {
                     it.getCopyrights(omitExcluded = true)
                 }.ifEmpty {
-                    // This cannot be empty.
+                    // The copyright set must not be empty as otherwise the Attribution builder rejects the request.
                     setOf("No Copyright detected.")
                 }
 

--- a/reporter/src/main/kotlin/reporters/AmazonOssAttributionBuilderReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AmazonOssAttributionBuilderReporter.kt
@@ -107,9 +107,7 @@ class AmazonOssAttributionBuilderReporter : Reporter {
                 val licensesWithCopyrights =
                     input.ortResult.getDetectedLicensesWithCopyrights(pkg.id, input.packageConfigurationProvider)
 
-                val allCopyrights = if (licensesWithCopyrights.isNotEmpty()) {
-                    licensesWithCopyrights.values.reduce { acc, set -> acc + set }
-                } else {
+                val allCopyrights = licensesWithCopyrights.flatMapTo(mutableSetOf()) { it.value }.ifEmpty {
                     // This cannot be empty.
                     setOf("No Copyright detected.")
                 }

--- a/reporter/src/main/kotlin/reporters/AmazonOssAttributionBuilderReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AmazonOssAttributionBuilderReporter.kt
@@ -106,10 +106,9 @@ class AmazonOssAttributionBuilderReporter : Reporter {
 
                 val licenseInfo = input.licenseInfoResolver.resolveLicenseInfo(pkg.id)
 
-                val licensesWithCopyrights = licenseInfo.filter(LicenseView.ONLY_DETECTED)
-                    .associate { it.license.simpleLicense() to it.getCopyrights(omitExcluded = true) }
-
-                val allCopyrights = licensesWithCopyrights.flatMapTo(mutableSetOf()) { it.value }.ifEmpty {
+                val allCopyrights = licenseInfo.filter(LicenseView.ONLY_DETECTED).flatMapTo(mutableSetOf()) {
+                    it.getCopyrights(omitExcluded = true)
+                }.ifEmpty {
                     // This cannot be empty.
                     setOf("No Copyright detected.")
                 }


### PR DESCRIPTION
Signed-off-by: Frank Viernau <frank.viernau@here.com>