### PR TITLE
Update Trigger in DockerBuild.yml

### DIFF
--- a/.azure-pipelines/DockerBuild.yml
+++ b/.azure-pipelines/DockerBuild.yml
@@ -1,5 +1,13 @@
+# Running the Docker job only if the Dockerfile was changed.
+trigger:
+  branches:
+    include:
+    - '*'
+  paths:
+    include:
+    - Dockerfile
+    
 jobs:
-# TODO: Consider running the Docker job only if the Dockerfile was changed.
 - job: DockerBuild
   pool:
     vmImage: ubuntu-18.04


### PR DESCRIPTION
Run the Docker job only if the Dockerfile was changed.

When you specify paths, you must explicitly specify branches to trigger on. You can't trigger a pipeline with only a path filter; you must also have a branch filter, and the changed files that match the path filter must be from a branch that matches the branch filter.

Details in https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#ci-triggers
