### PR TITLE
GeneratePackageConfigurationCommand: Create hierarchical dirs optionally

### DIFF
--- a/model/src/main/kotlin/Identifier.kt
+++ b/model/src/main/kotlin/Identifier.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.model
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonValue
 
-import org.ossreviewtoolkit.utils.encodeOrUnknown
+import org.ossreviewtoolkit.utils.encodeOr
 import org.ossreviewtoolkit.utils.percentEncode
 
 /**
@@ -114,9 +114,10 @@ data class Identifier(
 
     /**
      * Create a file system path based on the properties of the [Identifier]. All properties are encoded using
-     * [encodeOrUnknown].
+     * [encodeOr] with [emptyValue] as parameter.
      */
-    fun toPath(separator: String = "/") = components.joinToString(separator) { it.encodeOrUnknown() }
+    fun toPath(separator: String = "/", emptyValue: String = "unknown"): String =
+        components.joinToString(separator) { it.encodeOr(emptyValue) }
 
     /**
      * Create the canonical [package URL](https://github.com/package-url/purl-spec) ("purl") based on the properties of

--- a/utils/src/main/kotlin/Extensions.kt
+++ b/utils/src/main/kotlin/Extensions.kt
@@ -232,7 +232,17 @@ inline fun <K, V, W> Map<K, V>.zipWithDefault(other: Map<K, V>, default: V, oper
 /**
  * Return the string encoded for safe use as a file name or "unknown", if the string is empty.
  */
-fun String.encodeOrUnknown() = fileSystemEncode().takeUnless { it.isEmpty() } ?: "unknown"
+fun String.encodeOrUnknown(): String = encodeOr("unknown")
+
+/**
+ * Return the string encoded for safe use as a file name or [emptyValue] encoded for safe use as a file name, if this
+ * string is empty. Throws an exception if [emptyValue] is empty.
+ */
+fun String.encodeOr(emptyValue: String): String {
+    require(emptyValue.isNotEmpty())
+
+    return ifEmpty { emptyValue }.fileSystemEncode()
+}
 
 /**
  * If the SHELL environment variable is set, return the string with a leading "~" expanded to the current user's home


### PR DESCRIPTION
This supports organizing the files in a hierarchical directory structure
using each package identifier component as path element.

Signed-off-by: Frank Viernau <frank.viernau@here.com>