### PR TITLE
helper-cli: Fix using absolute paths for File options

### DIFF
--- a/helper-cli/src/main/kotlin/commands/ExportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ExportLicenseFindingCurationsCommand.kt
@@ -47,6 +47,7 @@ internal class ExportLicenseFindingCurationsCommand : CliktCommand(
         help = "The output license finding curations file."
     ).convert { it.expandTilde() }
         .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val ortResultFile by option(
@@ -61,6 +62,7 @@ internal class ExportLicenseFindingCurationsCommand : CliktCommand(
         help = "Override the repository configuration contained in the given input ORT file."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
 
     private val updateOnlyExisting by option(
         "--update-only-existing",

--- a/helper-cli/src/main/kotlin/commands/ExportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ExportPathExcludesCommand.kt
@@ -47,6 +47,7 @@ internal class ExportPathExcludesCommand : CliktCommand(
         help = "The output path excludes file."
     ).convert { it.expandTilde() }
         .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val ortResultFile by option(
@@ -54,6 +55,7 @@ internal class ExportPathExcludesCommand : CliktCommand(
         help = "The input ORT file from which the path excludes are to be read."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val repositoryConfigurationFile by option(
@@ -61,6 +63,7 @@ internal class ExportPathExcludesCommand : CliktCommand(
         help = "Override the repository configuration contained in the given input ORT file."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
 
     private val updateOnlyExisting by option(
         "--update-only-existing",

--- a/helper-cli/src/main/kotlin/commands/ExtractRepositoryConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ExtractRepositoryConfigurationCommand.kt
@@ -38,6 +38,7 @@ class ExtractRepositoryConfigurationCommand : CliktCommand(
         help = "The input ORT file from which repository configuration shall be extracted."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val repositoryConfigurationFile by option(
@@ -45,6 +46,7 @@ class ExtractRepositoryConfigurationCommand : CliktCommand(
         help = "The output repository configuration file."
     ).convert { it.expandTilde() }
         .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     override fun run() {

--- a/helper-cli/src/main/kotlin/commands/FormatRepositoryConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/FormatRepositoryConfigurationCommand.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.helper.commands
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.convert
+import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.types.file
 
 import org.ossreviewtoolkit.helper.common.writeAsYaml
@@ -38,6 +39,7 @@ internal class FormatRepositoryConfigurationCommand : CliktCommand(
         help = "The repository configuration file to be formatted."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
 
     override fun run() {
         repositoryConfigurationFile

--- a/helper-cli/src/main/kotlin/commands/GenerateProjectExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateProjectExcludesCommand.kt
@@ -44,6 +44,7 @@ internal class GenerateProjectExcludesCommand : CliktCommand(
         help = "The input ORT file from which the rule violations are read."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val repositoryConfigurationFile by option(
@@ -52,6 +53,7 @@ internal class GenerateProjectExcludesCommand : CliktCommand(
                 "overrides the repository configuration contained in the given input ORT file."
     ).convert { it.expandTilde() }
         .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     override fun run() {

--- a/helper-cli/src/main/kotlin/commands/GenerateRuleViolationResolutionsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateRuleViolationResolutionsCommand.kt
@@ -48,6 +48,7 @@ internal class GenerateRuleViolationResolutionsCommand : CliktCommand(
         help = "The input ORT file from which the rule violations are read."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val repositoryConfigurationFile by option(
@@ -55,6 +56,7 @@ internal class GenerateRuleViolationResolutionsCommand : CliktCommand(
         help = "Override the repository configuration contained in the given input ORT file."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val severity by option(

--- a/helper-cli/src/main/kotlin/commands/GenerateScopeExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateScopeExcludesCommand.kt
@@ -45,6 +45,7 @@ internal class GenerateScopeExcludesCommand : CliktCommand(
         help = "The input ORT file from which the rule violations are read."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val repositoryConfigurationFile by option(
@@ -52,6 +53,7 @@ internal class GenerateScopeExcludesCommand : CliktCommand(
         help = "Override the repository configuration contained in the given input ORT file."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     override fun run() {

--- a/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
@@ -45,6 +45,7 @@ internal class GenerateTimeoutErrorResolutionsCommand : CliktCommand(
         help = "The input ORT file containing the scan timeout errors."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val repositoryConfigurationFile by option(
@@ -52,12 +53,14 @@ internal class GenerateTimeoutErrorResolutionsCommand : CliktCommand(
         help = "Override the repository configuration contained in the given input ORT file."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
 
     private val resolutionsFile by option(
         "--resolutions-file",
         help = "A file containing issue resolutions to be used in addition to the ones contained in the given ORT file."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
 
     private val omitExcluded by option(
         "--omit-excluded",

--- a/helper-cli/src/main/kotlin/commands/ImportCopyrightGarbageCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportCopyrightGarbageCommand.kt
@@ -45,6 +45,7 @@ internal class ImportCopyrightGarbageCommand : CliktCommand(
         help = "The input copyright garbage text file."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val outputCopyrightGarbageFile by option(
@@ -52,6 +53,7 @@ internal class ImportCopyrightGarbageCommand : CliktCommand(
         help = "The output copyright garbage YAML file where the input entries are merged into."
     ).convert { it.expandTilde() }
         .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     override fun run() {

--- a/helper-cli/src/main/kotlin/commands/ImportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportLicenseFindingCurationsCommand.kt
@@ -48,6 +48,7 @@ internal class ImportLicenseFindingCurationsCommand : CliktCommand(
         help = "The input license finding curations file."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val ortResultFile by option(
@@ -55,6 +56,7 @@ internal class ImportLicenseFindingCurationsCommand : CliktCommand(
         help = "The ORT file containing the findings the imported curations need to match against."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val repositoryConfigurationFile by option(
@@ -62,6 +64,7 @@ internal class ImportLicenseFindingCurationsCommand : CliktCommand(
         help = "The repository configuration file where the imported curations are to be merged into."
     ).convert { it.expandTilde() }
         .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val updateOnlyExisting by option(

--- a/helper-cli/src/main/kotlin/commands/ImportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportPathExcludesCommand.kt
@@ -46,6 +46,7 @@ internal class ImportPathExcludesCommand : CliktCommand(
         help = "The input path excludes file."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val sourceCodeDir by option(
@@ -54,6 +55,7 @@ internal class ImportPathExcludesCommand : CliktCommand(
                 "supposed to be used."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = false, canBeDir = true, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val repositoryConfigurationFile by option(
@@ -61,6 +63,7 @@ internal class ImportPathExcludesCommand : CliktCommand(
         help = "The repository configuration file where the imported path excludes are to be merged into."
     ).convert { it.expandTilde() }
         .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val updateOnlyExisting by option(

--- a/helper-cli/src/main/kotlin/commands/ListCopyrightsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListCopyrightsCommand.kt
@@ -46,6 +46,7 @@ internal class ListCopyrightsCommand : CliktCommand(
         help = "The ORT result file to read as input."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val copyrightGarbageFile by option(
@@ -53,6 +54,7 @@ internal class ListCopyrightsCommand : CliktCommand(
         help = "A file containing garbage copyright statements entries which are to be ignored."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
 
     private val packageId by option(
         "--package-id",

--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -59,6 +59,7 @@ internal class ListLicensesCommand : CliktCommand(
         help = "The ORT result file to read as input."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val packageId by option(
@@ -74,6 +75,7 @@ internal class ListLicensesCommand : CliktCommand(
                 "needed."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = false, canBeDir = true, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
 
     private val offendingOnly by option(
         "--offending-only",
@@ -117,6 +119,7 @@ internal class ListLicensesCommand : CliktCommand(
         help = "Override the repository configuration contained in the ORT result."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
 
     private val packageConfigurationOption by mutuallyExclusiveOptions<PackageConfigurationOption>(
         option(

--- a/helper-cli/src/main/kotlin/commands/ListPackagesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListPackagesCommand.kt
@@ -40,6 +40,7 @@ class ListPackagesCommand : CliktCommand(
         help = "The ORT result file to read as input."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val matchDetectedLicenses by option(

--- a/helper-cli/src/main/kotlin/commands/ListStoredScanResultsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListStoredScanResultsCommand.kt
@@ -45,6 +45,7 @@ internal class ListStoredScanResultsCommand : CliktCommand(
         help = "The path to the ORT configuration file that configures the scan results storage."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
 
     private val packageId by option(
         "--package-id",

--- a/helper-cli/src/main/kotlin/commands/MapCopyrightsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/MapCopyrightsCommand.kt
@@ -39,6 +39,7 @@ internal class MapCopyrightsCommand : CliktCommand(
         help = "The input copyrights text file containing one processed copyright statement per line."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val outputCopyrightsFile by option(
@@ -46,6 +47,7 @@ internal class MapCopyrightsCommand : CliktCommand(
         help = "The output copyrights text file."
     ).convert { it.expandTilde() }
         .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val ortResultFile by option(
@@ -53,6 +55,7 @@ internal class MapCopyrightsCommand : CliktCommand(
         help = "The ORT file utilized for mapping the processed to unprocessed statements."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     override fun run() {

--- a/helper-cli/src/main/kotlin/commands/MergeRepositoryConfigurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/MergeRepositoryConfigurationsCommand.kt
@@ -41,13 +41,14 @@ internal class MergeRepositoryConfigurationsCommand : CliktCommand(
     private val inputRepositoryConfigurationFiles by option(
         "--input-repository-configuration-files", "-i",
         help = "A comma separated list of the repository configuration files to be merged."
-    ).convert { File(it.expandTilde()) }.split(",").required()
+    ).convert { File(it.expandTilde()).absoluteFile.normalize() }.split(",").required()
 
     private val outputRepositoryConfigurationFile by option(
         "--output-repository-configuration-file", "-o",
         help = "The output repository configuration file."
     ).convert { it.expandTilde() }
         .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     override fun run() {

--- a/helper-cli/src/main/kotlin/commands/RemoveConfigurationEntriesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/RemoveConfigurationEntriesCommand.kt
@@ -48,6 +48,7 @@ internal class RemoveConfigurationEntriesCommand : CliktCommand(
         help = "The ORT result file to read as input which should contain an evaluator result."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val repositoryConfigurationFile by option(
@@ -56,6 +57,7 @@ internal class RemoveConfigurationEntriesCommand : CliktCommand(
                 "the repository configuration contained in the given ORT result file."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = true, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val sourceCodeDir by option(
@@ -65,6 +67,7 @@ internal class RemoveConfigurationEntriesCommand : CliktCommand(
                 "ORT result file."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = false, canBeDir = true, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
         .required()
 
     private val resolutionsFile by option(
@@ -72,6 +75,7 @@ internal class RemoveConfigurationEntriesCommand : CliktCommand(
         help = "A file containing issue resolutions."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
 
     override fun run() {
         val repositoryConfiguration = repositoryConfigurationFile.readValue<RepositoryConfiguration>()

--- a/helper-cli/src/main/kotlin/commands/SortRepositoryConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/SortRepositoryConfigurationCommand.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.helper.commands
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.convert
+import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.types.file
 
 import org.ossreviewtoolkit.helper.common.sortEntries
@@ -39,6 +40,7 @@ internal class SortRepositoryConfigurationCommand : CliktCommand(
         help = "The repository configuration file to be sorted."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
 
     override fun run() {
         repositoryConfigurationFile

--- a/helper-cli/src/main/kotlin/commands/VerifySourceArtifactCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/VerifySourceArtifactCurationsCommand.kt
@@ -23,6 +23,7 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.convert
+import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.types.file
 
 import java.io.IOException
@@ -42,6 +43,7 @@ internal class VerifySourceArtifactCurationsCommand : CliktCommand(
         help = "A file containing package curation data."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
 
     override fun run() {
         val curations = packageCurationsFile.readValue<List<PackageCuration>>()


### PR DESCRIPTION
String.expandTilde() does not make the returned path absolute if it does
not contain a tilde. Ensure that all File options are absolute paths by
performing a conversion to absolute paths, and also a normalization while
at it.

See also f470815.

Signed-off-by: Frank Viernau <frank.viernau@here.com>