### PR TITLE
cli: Rename the command to upload curations to ClearlyDefined

### DIFF
--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -102,12 +102,12 @@ class OrtMain : CliktCommand(name = ORT_NAME, epilog = "* denotes required optio
 
         subcommands(
             AnalyzerCommand(),
-            ClearlyDefinedUploadCommand(),
             DownloaderCommand(),
             EvaluatorCommand(),
             ReporterCommand(),
             RequirementsCommand(),
             ScannerCommand(),
+            UploadCurationsCommand(),
             UploadResultCommand()
         )
 

--- a/cli/src/main/kotlin/commands/UploadCurationsCommand.kt
+++ b/cli/src/main/kotlin/commands/UploadCurationsCommand.kt
@@ -58,8 +58,8 @@ import org.ossreviewtoolkit.utils.log
 
 import retrofit2.Call
 
-class ClearlyDefinedUploadCommand : CliktCommand(
-    name = "cd-upload",
+class UploadCurationsCommand : CliktCommand(
+    name = "upload-curations",
     help = "Upload ORT package curations to ClearlyDefined."
 ) {
     private val inputFile by option(


### PR DESCRIPTION
ORT's sub-command aim to be / start with verbs, so rename the command
accordingly. Also generalize the name as curations might get uploaded to
other providers using the same sub-command in the future.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>