### PR TITLE
Replace / by OR in the license field of Rust crates

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/cargo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/cargo-expected-output.yml
@@ -3,10 +3,9 @@ project:
   id: "Cargo::lib:0.1.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   declared_licenses:
-  - "Apache-2.0"
-  - "MIT"
+  - "MIT OR Apache-2.0"
   declared_licenses_processed:
-    spdx_expression: "Apache-2.0 AND MIT"
+    spdx_expression: "MIT OR Apache-2.0"
   vcs:
     type: ""
     url: ""
@@ -128,10 +127,9 @@ packages:
     id: "Cargo::autocfg:0.1.6"
     purl: "pkg:cargo/autocfg@0.1.6"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "Apache-2.0 OR MIT"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "Apache-2.0 OR MIT"
     description: "Automatic cfg for Rust compiler features"
     homepage_url: ""
     binary_artifact:
@@ -159,10 +157,9 @@ packages:
     id: "Cargo::bitflags:1.1.0"
     purl: "pkg:cargo/bitflags@1.1.0"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "MIT OR Apache-2.0"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "MIT OR Apache-2.0"
     description: "A macro to generate structures which behave like bitflags.\n"
     homepage_url: ""
     binary_artifact:
@@ -190,10 +187,9 @@ packages:
     id: "Cargo::cfg-if:0.1.9"
     purl: "pkg:cargo/cfg-if@0.1.9"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "MIT OR Apache-2.0"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "MIT OR Apache-2.0"
     description: "A macro to ergonomically define an item depending on a large number\
       \ of #[cfg]\nparameters. Structured like an if-else chain, the first matching\
       \ branch is the\nitem that gets emitted.\n"
@@ -313,10 +309,9 @@ packages:
     id: "Cargo::rand:0.6.5"
     purl: "pkg:cargo/rand@0.6.5"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "MIT OR Apache-2.0"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "MIT OR Apache-2.0"
     description: "Random number generators and other randomness functionality.\n"
     homepage_url: ""
     binary_artifact:
@@ -344,10 +339,9 @@ packages:
     id: "Cargo::rand_chacha:0.1.1"
     purl: "pkg:cargo/rand_chacha@0.1.1"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "MIT OR Apache-2.0"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "MIT OR Apache-2.0"
     description: "ChaCha random number generator\n"
     homepage_url: ""
     binary_artifact:
@@ -375,10 +369,9 @@ packages:
     id: "Cargo::rand_core:0.3.1"
     purl: "pkg:cargo/rand_core@0.3.1"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "MIT OR Apache-2.0"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "MIT OR Apache-2.0"
     description: "Core random number generator traits and tools for implementation.\n"
     homepage_url: ""
     binary_artifact:
@@ -406,10 +399,9 @@ packages:
     id: "Cargo::rand_core:0.4.2"
     purl: "pkg:cargo/rand_core@0.4.2"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "MIT OR Apache-2.0"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "MIT OR Apache-2.0"
     description: "Core random number generator traits and tools for implementation.\n"
     homepage_url: ""
     binary_artifact:
@@ -437,10 +429,9 @@ packages:
     id: "Cargo::rand_hc:0.1.0"
     purl: "pkg:cargo/rand_hc@0.1.0"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "MIT OR Apache-2.0"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "MIT OR Apache-2.0"
     description: "HC128 random number generator\n"
     homepage_url: ""
     binary_artifact:
@@ -468,10 +459,9 @@ packages:
     id: "Cargo::rand_isaac:0.1.1"
     purl: "pkg:cargo/rand_isaac@0.1.1"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "MIT OR Apache-2.0"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "MIT OR Apache-2.0"
     description: "ISAAC random number generator\n"
     homepage_url: ""
     binary_artifact:
@@ -529,10 +519,9 @@ packages:
     id: "Cargo::rand_os:0.1.3"
     purl: "pkg:cargo/rand_os@0.1.3"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "MIT OR Apache-2.0"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "MIT OR Apache-2.0"
     description: "OS backed Random Number Generator"
     homepage_url: ""
     binary_artifact:
@@ -560,10 +549,9 @@ packages:
     id: "Cargo::rand_pcg:0.1.2"
     purl: "pkg:cargo/rand_pcg@0.1.2"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "MIT OR Apache-2.0"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "MIT OR Apache-2.0"
     description: "Selected PCG random number generators\n"
     homepage_url: ""
     binary_artifact:
@@ -591,10 +579,9 @@ packages:
     id: "Cargo::rand_xorshift:0.1.1"
     purl: "pkg:cargo/rand_xorshift@0.1.1"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "MIT OR Apache-2.0"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "MIT OR Apache-2.0"
     description: "Xorshift random number generator\n"
     homepage_url: ""
     binary_artifact:
@@ -684,10 +671,9 @@ packages:
     id: "Cargo::winapi-i686-pc-windows-gnu:0.4.0"
     purl: "pkg:cargo/winapi-i686-pc-windows-gnu@0.4.0"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "MIT OR Apache-2.0"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "MIT OR Apache-2.0"
     description: "Import libraries for the i686-pc-windows-gnu target. Please don't\
       \ use this crate directly, depend on winapi instead."
     homepage_url: ""
@@ -716,10 +702,9 @@ packages:
     id: "Cargo::winapi-x86_64-pc-windows-gnu:0.4.0"
     purl: "pkg:cargo/winapi-x86_64-pc-windows-gnu@0.4.0"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "MIT OR Apache-2.0"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "MIT OR Apache-2.0"
     description: "Import libraries for the x86_64-pc-windows-gnu target. Please don't\
       \ use this crate directly, depend on winapi instead."
     homepage_url: ""
@@ -748,10 +733,9 @@ packages:
     id: "Cargo::winapi:0.3.8"
     purl: "pkg:cargo/winapi@0.3.8"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "MIT OR Apache-2.0"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "MIT OR Apache-2.0"
     description: "Raw FFI bindings for all of Windows API."
     homepage_url: ""
     binary_artifact:

--- a/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate-client-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate-client-expected-output.yml
@@ -32,10 +32,9 @@ packages:
     id: "Cargo::cfg-if:0.1.9"
     purl: "pkg:cargo/cfg-if@0.1.9"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "MIT OR Apache-2.0"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "MIT OR Apache-2.0"
     description: "A macro to ergonomically define an item depending on a large number\
       \ of #[cfg]\nparameters. Structured like an if-else chain, the first matching\
       \ branch is the\nitem that gets emitted.\n"

--- a/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate-lib-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate-lib-expected-output.yml
@@ -3,10 +3,9 @@ project:
   id: "Cargo::lib:0.1.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   declared_licenses:
-  - "Apache-2.0"
-  - "MIT"
+  - "MIT OR Apache-2.0"
   declared_licenses_processed:
-    spdx_expression: "Apache-2.0 AND MIT"
+    spdx_expression: "MIT OR Apache-2.0"
   vcs:
     type: ""
     url: ""
@@ -39,10 +38,9 @@ packages:
     id: "Cargo::cfg-if:0.1.9"
     purl: "pkg:cargo/cfg-if@0.1.9"
     declared_licenses:
-    - "Apache-2.0"
-    - "MIT"
+    - "MIT OR Apache-2.0"
     declared_licenses_processed:
-      spdx_expression: "Apache-2.0 AND MIT"
+      spdx_expression: "MIT OR Apache-2.0"
     description: "A macro to ergonomically define an item depending on a large number\
       \ of #[cfg]\nparameters. Structured like an if-else chain, the first matching\
       \ branch is the\nitem that gets emitted.\n"

--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.moandjiezana.toml.Toml
 
 import java.io.File
+import java.util.SortedSet
 
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
@@ -89,11 +90,13 @@ class Cargo(
     private fun extractVcsInfo(node: JsonNode) =
         VcsHost.toVcsInfo(extractRepositoryUrl(node))
 
-    private fun extractDeclaredLicenses(node: JsonNode) =
-        node["license"].textValueOrEmpty().split("/")
+    private fun extractDeclaredLicenses(node: JsonNode): SortedSet<String> {
+        val licenses = node["license"].textValueOrEmpty().split('/')
             .map { it.trim() }
             .filter { it.isNotEmpty() }
-            .toSortedSet()
+
+        return if (licenses.isEmpty()) sortedSetOf() else sortedSetOf(licenses.joinToString(" OR "))
+    }
 
     private fun extractSourceArtifact(
         node: JsonNode,


### PR DESCRIPTION
`cargo` supports arbitrary formats to specify multiple licenses, but `/` should be interpreted as `OR`.

It looks like the consensus is that crates.io should [only accept SPDX 2.1 license expressions](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields), but this is not the reality for all crates as it's not validated.
  
Related issue in cargo: https://github.com/rust-lang/cargo/issues/2039