### PR TITLE
helper-cli: Add a command to subtract two scan results

### DIFF
--- a/helper-cli/src/main/kotlin/HelperMain.kt
+++ b/helper-cli/src/main/kotlin/HelperMain.kt
@@ -50,6 +50,7 @@ import org.ossreviewtoolkit.helper.commands.MapCopyrightsCommand
 import org.ossreviewtoolkit.helper.commands.MergeRepositoryConfigurationsCommand
 import org.ossreviewtoolkit.helper.commands.RemoveConfigurationEntriesCommand
 import org.ossreviewtoolkit.helper.commands.SortRepositoryConfigurationCommand
+import org.ossreviewtoolkit.helper.commands.SubtractScanResultsCommand
 import org.ossreviewtoolkit.helper.commands.VerifySourceArtifactCurationsCommand
 import org.ossreviewtoolkit.helper.common.ORTH_NAME
 import org.ossreviewtoolkit.utils.printStackTrace
@@ -95,6 +96,7 @@ internal class HelperMain : CliktCommand(name = ORTH_NAME, epilog = "* denotes r
             MergeRepositoryConfigurationsCommand(),
             RemoveConfigurationEntriesCommand(),
             SortRepositoryConfigurationCommand(),
+            SubtractScanResultsCommand(),
             VerifySourceArtifactCurationsCommand()
         )
     }

--- a/helper-cli/src/main/kotlin/commands/SubtractScanResultsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/SubtractScanResultsCommand.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.file
+
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.mapper
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.utils.expandTilde
+
+internal class SubtractScanResultsCommand : CliktCommand(
+    help = "Subtracts the given right-hand side scan results from the given left-hand side scan results. The output " +
+            "is written to the given output ORT file."
+) {
+    private val lhsOrtResultFile by option(
+        "--lhs-ort-result-file",
+        help = "The ORT result containing the left-hand-side scan result."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val rhsOrtResultFile by option(
+        "--rhs-ort-result-file",
+        help = "The ORT result containing the left-hand-side scan result."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val outputOrtResultFile by option(
+        "--output-ort-result-file",
+        help = "The ORT result containing the left-hand-side scan result."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    override fun run() {
+        val lhsOrtResult = lhsOrtResultFile.readValue<OrtResult>()
+        val rhsOrtResult = rhsOrtResultFile.readValue<OrtResult>()
+
+        val rhsScanSummaries = rhsOrtResult.scanner!!.results.scanResults.flatMap { it.results }.associateBy(
+            keySelector = { it.provenance.key() },
+            valueTransform = { it.summary }
+        )
+
+        val scanResultContainers = lhsOrtResult.scanner!!.results.scanResults.mapTo(sortedSetOf()) { container ->
+            val results = container.results.map { lhsScanResult ->
+                val lhsSummary = lhsScanResult.summary
+                val rhsSummary = rhsScanSummaries[lhsScanResult.provenance.key()]
+
+                lhsScanResult.copy(summary = lhsSummary - rhsSummary)
+            }
+            container.copy(results = results)
+       }
+
+       val result = lhsOrtResult.copy(
+           scanner = lhsOrtResult.scanner!!.copy(
+               results = lhsOrtResult.scanner!!.results.copy(
+                    scanResults = scanResultContainers
+               )
+           )
+       )
+
+       outputOrtResultFile.mapper().writerWithDefaultPrettyPrinter().writeValue(outputOrtResultFile, result)
+    }
+}
+
+private operator fun ScanSummary.minus(other: ScanSummary?): ScanSummary {
+    if (other == null) return this
+
+    return copy(
+        licenseFindings = (licenseFindings - other.licenseFindings).toSortedSet(),
+        copyrightFindings = (copyrightFindings - other.copyrightFindings).toSortedSet(),
+    )
+}
+
+private data class Key(
+    val vcsType: VcsType?,
+    val vcsUrl: String?,
+    val vcsRevision: String?,
+    val vcsPath: String?,
+    val sourceArtifactUrl: String?
+)
+
+private fun Provenance.key(): Key =
+    Key(
+        vcsType = vcsInfo?.type,
+        vcsUrl = vcsInfo?.url,
+        vcsRevision = vcsInfo?.resolvedRevision,
+        vcsPath = vcsInfo?.path,
+        sourceArtifactUrl = sourceArtifact?.url
+    )


### PR DESCRIPTION
Upgrading a scanner in ORT usually requires investigating the
effect of that upgrade on the scan results. Thus, provide a diff command
in order to reduce the manual efforts.

Signed-off-by: Frank Viernau <frank.viernau@here.com>