### PR TITLE
OrtResult: Simplify the type of the labels

### DIFF
--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -23,10 +23,10 @@ import com.github.ajalt.clikt.core.BadParameterValue
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.UsageError
-import com.github.ajalt.clikt.parameters.options.associate
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.options.split
@@ -114,7 +114,7 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
     private val labels by option(
         "--label", "-l",
         help = "Add a label to the ORT result. Can be used multiple times. For example: --label distribution=external"
-    ).associate()
+    ).multiple()
 
     override fun run() {
         val outputFiles = outputFormats.distinct().map { format ->

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -25,10 +25,10 @@ import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.parameters.groups.mutuallyExclusiveOptions
 import com.github.ajalt.clikt.parameters.groups.required
 import com.github.ajalt.clikt.parameters.groups.single
-import com.github.ajalt.clikt.parameters.options.associate
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.options.split
@@ -141,7 +141,7 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate rules 
         "--label", "-l",
         help = "Add a label to the ORT result. Can be used multiple times. Any existing label with the same key in " +
                 "the input ORT result will be overwritten. For example: --label distribution=external"
-    ).associate()
+    ).multiple()
 
     override fun run() {
         val outputFiles = mutableListOf<File>()

--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -27,10 +27,10 @@ import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.parameters.groups.mutuallyExclusiveOptions
 import com.github.ajalt.clikt.parameters.groups.required
 import com.github.ajalt.clikt.parameters.groups.single
-import com.github.ajalt.clikt.parameters.options.associate
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.options.split
@@ -109,7 +109,7 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run existing copyrigh
         help = "Add a label to the ORT result. Can be used multiple times. If an ORT result is used as input for the" +
                 "scanner any existing label with the same key will be overwritten. For example: " +
                 "--label distribution=external"
-    ).associate()
+    ).multiple()
 
     private val config by requireObject<OrtConfiguration>()
 

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -69,7 +69,7 @@ data class OrtResult(
      * which are customizable by the user, for example in evaluator rules or in the notice reporter.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val labels: Map<String, String> = emptyMap()
+    val labels: SortedSet<String> = sortedSetOf()
 ) {
     companion object {
         /**
@@ -81,7 +81,7 @@ data class OrtResult(
             analyzer = null,
             scanner = null,
             evaluator = null,
-            labels = emptyMap()
+            labels = sortedSetOf()
         )
     }
 

--- a/model/src/main/kotlin/utils/OrtResultExtensions.kt
+++ b/model/src/main/kotlin/utils/OrtResultExtensions.kt
@@ -88,5 +88,5 @@ fun OrtResult.getDetectedLicensesWithCopyrights(
 /**
  * Copy this [OrtResult] and add all [labels] to the existing labels, overwriting existing labels on conflict.
  */
-fun OrtResult.mergeLabels(labels: Map<String, String>) =
-    copy(labels = this.labels + labels).apply { data += this@mergeLabels.data }
+fun OrtResult.mergeLabels(labels: Collection<String>) =
+    copy(labels = (this.labels + labels).toSortedSet()).apply { data += this@mergeLabels.data }


### PR DESCRIPTION
Use a set strings instead of a map, to simplify the code for accessing
labels in the rules and notice templates later on. A map would be better
to look up the value of a specific key, however, this is not a use-case
we currently have.