### PR TITLE
Change the "nuget" package provider name to "NuGet"

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
@@ -18,14 +18,14 @@ project:
   scopes:
   - name: "dependencies"
     dependencies:
-    - id: "nuget::WebGrease:1.5.2"
+    - id: "NuGet::WebGrease:1.5.2"
       dependencies:
-      - id: "nuget::Antlr:3.4.1.9004"
-      - id: "nuget::Newtonsoft.Json:5.0.4"
-    - id: "nuget::jQuery:3.3.1"
+      - id: "NuGet::Antlr:3.4.1.9004"
+      - id: "NuGet::Newtonsoft.Json:5.0.4"
+    - id: "NuGet::jQuery:3.3.1"
 packages:
 - package:
-    id: "nuget::Antlr:3.4.1.9004"
+    id: "NuGet::Antlr:3.4.1.9004"
     purl: "pkg:nuget/Antlr@3.4.1.9004"
     declared_licenses: []
     declared_licenses_processed: {}
@@ -55,7 +55,7 @@ packages:
       path: ""
   curations: []
 - package:
-    id: "nuget::Newtonsoft.Json:5.0.4"
+    id: "NuGet::Newtonsoft.Json:5.0.4"
     purl: "pkg:nuget/Newtonsoft.Json@5.0.4"
     declared_licenses:
     - "http://json.codeplex.com/license"
@@ -86,7 +86,7 @@ packages:
       path: ""
   curations: []
 - package:
-    id: "nuget::WebGrease:1.5.2"
+    id: "NuGet::WebGrease:1.5.2"
     purl: "pkg:nuget/WebGrease@1.5.2"
     declared_licenses:
     - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
@@ -118,7 +118,7 @@ packages:
       path: ""
   curations: []
 - package:
-    id: "nuget::jQuery:3.3.1"
+    id: "NuGet::jQuery:3.3.1"
     purl: "pkg:nuget/jQuery@3.3.1"
     declared_licenses:
     - "http://jquery.org/license"

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
@@ -18,14 +18,14 @@ project:
   scopes:
   - name: "dependencies"
     dependencies:
-    - id: "nuget::WebGrease:1.5.2"
+    - id: "NuGet::WebGrease:1.5.2"
       dependencies:
-      - id: "nuget::Antlr:3.4.1.9004"
-      - id: "nuget::Newtonsoft.Json:5.0.4"
-    - id: "nuget::jQuery:3.3.1"
+      - id: "NuGet::Antlr:3.4.1.9004"
+      - id: "NuGet::Newtonsoft.Json:5.0.4"
+    - id: "NuGet::jQuery:3.3.1"
 packages:
 - package:
-    id: "nuget::Antlr:3.4.1.9004"
+    id: "NuGet::Antlr:3.4.1.9004"
     purl: "pkg:nuget/Antlr@3.4.1.9004"
     declared_licenses: []
     declared_licenses_processed: {}
@@ -55,7 +55,7 @@ packages:
       path: ""
   curations: []
 - package:
-    id: "nuget::Newtonsoft.Json:5.0.4"
+    id: "NuGet::Newtonsoft.Json:5.0.4"
     purl: "pkg:nuget/Newtonsoft.Json@5.0.4"
     declared_licenses:
     - "http://json.codeplex.com/license"
@@ -86,7 +86,7 @@ packages:
       path: ""
   curations: []
 - package:
-    id: "nuget::WebGrease:1.5.2"
+    id: "NuGet::WebGrease:1.5.2"
     purl: "pkg:nuget/WebGrease@1.5.2"
     declared_licenses:
     - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
@@ -118,7 +118,7 @@ packages:
       path: ""
   curations: []
 - package:
-    id: "nuget::jQuery:3.3.1"
+    id: "NuGet::jQuery:3.3.1"
     purl: "pkg:nuget/jQuery@3.3.1"
     declared_licenses:
     - "http://jquery.org/license"

--- a/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
@@ -51,7 +51,7 @@ fun Identifier.toClearlyDefinedTypeAndProvider(): Pair<ComponentType, Provider> 
         "Bundler" -> ComponentType.GEM to Provider.RUBYGEMS
         "Cargo" -> ComponentType.CRATE to Provider.CRATES_IO
         "CocoaPods" -> ComponentType.POD to Provider.COCOAPODS
-        "DotNet", "nuget" -> ComponentType.NUGET to Provider.NUGET
+        "DotNet", "NuGet" -> ComponentType.NUGET to Provider.NUGET
         "GoDep", "GoMod" -> ComponentType.GIT to Provider.GITHUB
         "Maven" -> ComponentType.MAVEN to Provider.MAVEN_CENTRAL
         "NPM" -> ComponentType.NPM to Provider.NPM_JS

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -50,7 +50,7 @@ import org.ossreviewtoolkit.utils.textValueOrEmpty
 
 class NuGetSupport(packageReferences: Set<Identifier>) {
     companion object {
-        private const val PROVIDER_NAME = "nuget"
+        private const val PROVIDER_NAME = "NuGet"
 
         private fun extractRepositoryType(node: JsonNode) =
             VcsType(node["repository"]?.get("type").textValueOrEmpty())


### PR DESCRIPTION
"NuGet" is the official spelling, and it was already used as the
Identifier type for projects, so it makes sense to use that spelling
also for packages where the type describes the provider.

Note that the GitLabLicenseModelMapper prematurely already used the
"NuGet" spelling in toPackageManagerName(), which becomes correct with
this change.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>