### PR TITLE
HowToFixTextProvider: Pass the OrtResult to the Kotlin script

### DIFF
--- a/cli/src/funTest/kotlin/ExamplesTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesTest.kt
@@ -124,7 +124,7 @@ class ExamplesTest : StringSpec() {
 
         "how-to-fix-text-provider.kts provides the expected how-to-fix text" {
             val script = takeExampleFile("how-to-fix-text-provider.kts").readText()
-            val howToFixTextProvider = HowToFixTextProvider.fromKotlinScript(script)
+            val howToFixTextProvider = HowToFixTextProvider.fromKotlinScript(script, OrtResult.EMPTY)
             val issue = OrtIssue(
                 message = "ERROR: Timeout after 360 seconds while scanning file 'src/res/data.json'.",
                 source = "ScanCode",

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -194,7 +194,7 @@ class ReporterCommand : CliktCommand(
         val licenseConfiguration = licenseConfigurationFile?.readValue<LicenseConfiguration>().orEmpty()
 
         val howToFixTextProvider =
-            howToFixTextProviderScript?.let { HowToFixTextProvider.fromKotlinScript(it.readText()) }
+            howToFixTextProviderScript?.let { HowToFixTextProvider.fromKotlinScript(it.readText(), ortResult) }
                 ?: HowToFixTextProvider.NONE
 
         outputDir.safeMkdirs()

--- a/reporter/src/main/kotlin/HowToFixTextProvider.kt
+++ b/reporter/src/main/kotlin/HowToFixTextProvider.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.reporter
 
 import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.utils.ScriptRunner
 
 /**
@@ -37,8 +38,10 @@ interface HowToFixTextProvider {
         /**
          * Return the [HowToFixTextProvider] which in-turn has to be returned by the given [script].
          */
-        fun fromKotlinScript(script: String): HowToFixTextProvider = HowToFixScriptRunner().run(script)
+        fun fromKotlinScript(script: String, ortResult: OrtResult): HowToFixTextProvider =
+            HowToFixScriptRunner(ortResult).run(script)
     }
+
     /**
      * Return a Markdown text describing how to fix the given [issue]. Non-null return values override the default
      * how-to-fix texts, while a null value keeps the default.
@@ -46,15 +49,19 @@ interface HowToFixTextProvider {
     fun getHowToFixText(issue: OrtIssue): String?
 }
 
-private class HowToFixScriptRunner : ScriptRunner() {
+private class HowToFixScriptRunner(ortResult: OrtResult) : ScriptRunner() {
     override val preface = """
             import org.ossreviewtoolkit.model.*
             import org.ossreviewtoolkit.reporter.HowToFixTextProvider
-                        
+
         """.trimIndent()
 
     override val postface = """
         """.trimIndent()
+
+    init {
+        engine.put("ortResult", ortResult)
+    }
 
     override fun run(script: String): HowToFixTextProvider = super.run(script) as HowToFixTextProvider
 }


### PR DESCRIPTION
In order to allow the processing of that OrtResult.

Signed-off-by: Frank Viernau <frank.viernau@here.com>