### PR TITLE
analyzer: Rewrite NuGetSupport

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
@@ -147,6 +147,7 @@ packages:
     path: ""
 issues:
 - timestamp: "1970-01-01T00:00:00Z"
-  source: "nuget-API"
-  message: "foobar:1.2.3 can not be found on Nugets RestAPI."
+  source: "NuGet"
+  message: "Failed to get package data for 'NuGet::foobar:1.2.3': IOException: Failed\
+    \ to get a response body from 'https://api.nuget.org/v3/registration5-gz-semver2/foobar/1.2.3.json'."
   severity: "ERROR"

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
@@ -147,6 +147,7 @@ packages:
     path: ""
 issues:
 - timestamp: "1970-01-01T00:00:00Z"
-  source: "nuget-API"
-  message: "foobar:1.2.3 can not be found on Nugets RestAPI."
+  source: "NuGet"
+  message: "Failed to get package data for 'NuGet::foobar:1.2.3': IOException: Failed\
+    \ to get a response body from 'https://api.nuget.org/v3/registration5-gz-semver2/foobar/1.2.3.json'."
   severity: "ERROR"

--- a/analyzer/src/funTest/kotlin/managers/DotNetTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/DotNetTest.kt
@@ -49,9 +49,9 @@ class DotNetTest : StringSpec() {
             val result = reader.getPackageReferences(packageFile)
 
             result should containExactly(
-                Identifier.EMPTY.copy(name = "jQuery", version = "3.3.1"),
-                Identifier.EMPTY.copy(name = "WebGrease", version = "1.5.2"),
-                Identifier.EMPTY.copy(name = "foobar", version = "1.2.3")
+                Identifier(type = "NuGet", namespace = "", name = "jQuery", version = "3.3.1"),
+                Identifier(type = "NuGet", namespace = "", name = "WebGrease", version = "1.5.2"),
+                Identifier(type = "NuGet", namespace = "", name = "foobar", version = "1.2.3")
             )
         }
 

--- a/analyzer/src/funTest/kotlin/managers/NuGetTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NuGetTest.kt
@@ -49,9 +49,9 @@ class NuGetTest : StringSpec() {
             val result = reader.getPackageReferences(packageFile)
 
             result should containExactly(
-                Identifier.EMPTY.copy(name = "jQuery", version = "3.3.1"),
-                Identifier.EMPTY.copy(name = "WebGrease", version = "1.5.2"),
-                Identifier.EMPTY.copy(name = "foobar", version = "1.2.3")
+                Identifier(type = "NuGet", namespace = "", name = "jQuery", version = "3.3.1"),
+                Identifier(type = "NuGet", namespace = "", name = "WebGrease", version = "1.5.2"),
+                Identifier(type = "NuGet", namespace = "", name = "foobar", version = "1.2.3")
             )
         }
 

--- a/analyzer/src/main/kotlin/managers/NuGet.kt
+++ b/analyzer/src/main/kotlin/managers/NuGet.kt
@@ -30,13 +30,13 @@ import java.io.File
 
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
+import org.ossreviewtoolkit.analyzer.managers.utils.NuGetSupport
 import org.ossreviewtoolkit.analyzer.managers.utils.XmlPackageFileReader
 import org.ossreviewtoolkit.analyzer.managers.utils.resolveNuGetDependencies
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
-import org.ossreviewtoolkit.model.xmlMapper
 
 /**
  * The [NuGet](https://www.nuget.org/) package manager for .NET.
@@ -58,9 +58,10 @@ class NuGet(
     }
 
     private val reader = NuGetPackageFileReader()
+    private val support = NuGetSupport()
 
     override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> =
-        listOfNotNull(resolveNuGetDependencies(definitionFile, reader))
+        listOf(resolveNuGetDependencies(definitionFile, reader, support))
 }
 
 /**
@@ -85,10 +86,10 @@ class NuGetPackageFileReader : XmlPackageFileReader {
 
     override fun getPackageReferences(definitionFile: File): Set<Identifier> {
         val ids = mutableSetOf<Identifier>()
-        val packagesConfig = xmlMapper.readValue<PackagesConfig>(definitionFile)
+        val packagesConfig = NuGetSupport.XML_MAPPER.readValue<PackagesConfig>(definitionFile)
 
         packagesConfig.packages.forEach {
-            ids += Identifier.EMPTY.copy(name = it.id, version = it.version)
+            ids += Identifier(type = "NuGet", namespace = "", name = it.id, version = it.version)
         }
 
         return ids

--- a/analyzer/src/main/kotlin/managers/utils/NuGetAllPackageData.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetAllPackageData.kt
@@ -1,0 +1,120 @@
+/*
+* Copyright (C) 2020 Bosch.IO GmbH
+  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers.utils
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
+
+internal class NuGetAllPackageData(
+    val data: PackageData,
+    val details: PackageDetails,
+    val spec: PackageSpec
+) {
+    // See https://docs.microsoft.com/en-us/nuget/api/service-index.
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class ServiceIndex(
+        val version: String,
+        val resources: List<ServiceResource>
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class ServiceResource(
+        @JsonProperty("@id")
+        val id: String,
+        @JsonProperty("@type")
+        val type: String
+    )
+
+    // See https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource.
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    class PackageData(
+        val catalogEntry: String,
+        val packageContent: String
+    )
+
+    // See https://docs.microsoft.com/en-us/nuget/api/catalog-resource#package-details-catalog-items.
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class PackageDetails(
+        // Mandatory fields.
+        val id: String,
+        val version: String,
+        val packageHash: String,
+        val packageHashAlgorithm: String,
+        val packageSize: Int,
+
+        // Optional fields.
+        val description: String? = null,
+        val projectUrl: String? = null,
+        val dependencyGroups: List<DependencyGroup> = emptyList(),
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class DependencyGroup(
+        val targetFramework: String? = null,
+        val dependencies: List<Dependency> = emptyList()
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class Dependency(
+        val id: String,
+        val range: String
+    )
+
+    // See https://docs.microsoft.com/en-us/nuget/reference/nuspec.
+    data class PackageSpec(
+        val metadata: MetaData
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class MetaData(
+        // See https://docs.microsoft.com/en-us/nuget/reference/nuspec#required-metadata-elements
+        val id: String,
+        val version: String,
+        val description: String,
+        val authors: String,
+
+        // See https://docs.microsoft.com/en-us/nuget/reference/nuspec#optional-metadata-elements.
+        val licenseUrl: String? = null,
+        val license: License? = null,
+        val repository: Repository? = null,
+    )
+
+    data class License(
+        @JacksonXmlProperty(isAttribute = true)
+        val type: String,
+        @JacksonXmlProperty(isAttribute = true)
+        val version: String? = null,
+
+        // The (non-attribute) tag value.
+        val value: String
+    )
+
+    data class Repository(
+        @JacksonXmlProperty(isAttribute = true)
+        val type: String? = null,
+        @JacksonXmlProperty(isAttribute = true)
+        val url: String? = null,
+        @JacksonXmlProperty(isAttribute = true)
+        val branch: String? = null,
+        @JacksonXmlProperty(isAttribute = true)
+        val commit: String? = null
+    )
+}

--- a/utils/build.gradle.kts
+++ b/utils/build.gradle.kts
@@ -21,6 +21,7 @@
 val commonsCompressVersion: String by project
 val disklrucacheVersion: String by project
 val jacksonVersion: String by project
+val kotlinxCoroutinesVersion: String by project
 val log4jApiKotlinVersion: String by project
 val okhttpVersion: String by project
 val semverVersion: String by project
@@ -41,6 +42,7 @@ dependencies {
 
     implementation("com.jakewharton:disklrucache:$disklrucacheVersion")
     implementation("org.apache.commons:commons-compress:$commonsCompressVersion")
-    implementation("org.tukaani:xz:$xzVersion")
     implementation("org.jetbrains.kotlin:kotlin-scripting-jsr223")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
+    implementation("org.tukaani:xz:$xzVersion")
 }


### PR DESCRIPTION
This rewrites NuGetSupport which an emphasis on speed and
maintainability:

- Use data classes for deserialization to increase readability.
- Use the service index to dynamically get the best registration base URL.
- Use URL types that support GZIP compression.
- Fix package names to always be lower-case to avoid unnecessary package
  searches.
- Get independent URLs in parallel using coroutines.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>