### PR TITLE
Gradle: Upgrade dokka to version 1.4.0 (final)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -200,32 +200,32 @@ subprojects {
     tasks.dokkaHtml.configure {
         dokkaSourceSets {
             configureEach {
-                jdkVersion = 8
+                jdkVersion.set(8)
 
                 externalDocumentationLink {
                     val baseUrl = "https://codehaus-plexus.github.io/plexus-containers/plexus-container-default/apidocs"
-                    url = URL(baseUrl)
-                    packageListUrl = URL("$baseUrl/package-list")
+                    url.set(URL(baseUrl))
+                    packageListUrl.set(URL("$baseUrl/package-list"))
                 }
 
                 externalDocumentationLink {
                     val majorMinorVersion = jacksonVersion.split('.').let { "${it[0]}.${it[1]}" }
                     val baseUrl = "https://fasterxml.github.io/jackson-databind/javadoc/$majorMinorVersion"
-                    url = URL(baseUrl)
-                    packageListUrl = URL("$baseUrl/package-list")
+                    url.set(URL(baseUrl))
+                    packageListUrl.set(URL("$baseUrl/package-list"))
                 }
 
                 externalDocumentationLink {
                     val baseUrl = "https://jakewharton.github.io/DiskLruCache"
-                    url = URL(baseUrl)
-                    packageListUrl = URL("$baseUrl/package-list")
+                    url.set(URL(baseUrl))
+                    packageListUrl.set(URL("$baseUrl/package-list"))
                 }
 
                 externalDocumentationLink {
                     val majorVersion = log4jCoreVersion.substringBefore('.')
                     val baseUrl = "https://logging.apache.org/log4j/$majorVersion.x/log4j-api/apidocs"
-                    url = URL(baseUrl)
-                    packageListUrl = URL("$baseUrl/package-list")
+                    url.set(URL(baseUrl))
+                    packageListUrl.set(URL("$baseUrl/package-list"))
                 }
             }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 # License-Filename: LICENSE
 
 detektPluginVersion = 1.12.0
-dokkaPluginVersion = 1.4.0-rc
+dokkaPluginVersion = 1.4.0
 ideaExtPluginVersion = 0.6.1
 kotlinPluginVersion = 1.4.0
 reckonPluginVersion = 0.12.0


### PR DESCRIPTION
See https://github.com/Kotlin/dokka/releases/tag/1.4.0. Do not get
confused by the bogus "Alpha" in the title on that page.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>