### PR TITLE
Allow defining custom declared license mappings via package curations

### DIFF
--- a/docs/config-file-curations-yml.md
+++ b/docs/config-file-curations-yml.md
@@ -20,6 +20,12 @@ Curations can be used to:
   * metadata-only packages, such as Maven BOM files, do not have any source code. Thus, when the flag is set the
   _downloader_ just skips the download and the _scanner_ skips the scan. Also, any _evaluator rule_ may optionally skip
   its execution.
+* set the _declared_license_mapping_ property:
+  * Packages may have declared license string values which cannot be parsed to SpdxExpressions. In some cases this can
+    be fixed by mapping these strings to a valid license. If multiple curations declare license mapping they get
+    combined into a single mapping. Thus, multiple curations can contribute to the declared license mapping for the
+    package. The effect of its application can be seen in the _declared_license_processed_ property of the respective
+    curated package. 
 
 The sections below explain how to create curations in the `curations.yml` file which,
 if passed to the _analyzer_, is applied to all package metadata found in the analysis.
@@ -64,6 +70,8 @@ The structure of the curations file consist of one or more `id` entries:
       revision: "1234abc"
       path: "subdirectory"
     is_meta_data_only: true
+    declared_license_mapping:
+      "license a": "Apache-2.0"
 ````
 
 ## Command Line

--- a/examples/curations.yml
+++ b/examples/curations.yml
@@ -53,3 +53,9 @@
   curations:
     comment: "The package is a Maven BOM file and thus is metadata only."
     is_meta_data_only: true
+
+- id: "Pip::pyramid_workflow:1.0.0"
+  curations:
+    comment: "The package has an unmappable declared license entry."
+    declared_license_mapping:
+      "BSD-derived (http://www.repoze.org/LICENSE.txt)": "LicenseRef-scancode-repoze"

--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -21,6 +21,10 @@ package org.ossreviewtoolkit.model
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.maps.beEmpty
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.spdx.toSpdx
@@ -48,6 +52,7 @@ class PackageCurationTest : WordSpec({
                 id = pkg.id,
                 data = PackageCurationData(
                     declaredLicenses = sortedSetOf("license a", "license b"),
+                    declaredLicenseMapping = mapOf("license a" to "Apache-2.0".toSpdx()),
                     concludedLicense = "license1 OR license2".toSpdx(),
                     description = "description",
                     homepageUrl = "http://home.page",
@@ -75,6 +80,8 @@ class PackageCurationTest : WordSpec({
             curatedPkg.pkg.apply {
                 id.toCoordinates() shouldBe pkg.id.toCoordinates()
                 declaredLicenses shouldBe curation.data.declaredLicenses
+                declaredLicensesProcessed.spdxExpression shouldBe "Apache-2.0".toSpdx()
+                declaredLicensesProcessed.unmapped should containExactlyInAnyOrder("license b")
                 concludedLicense shouldBe curation.data.concludedLicense
                 description shouldBe curation.data.description
                 homepageUrl shouldBe curation.data.homepageUrl
@@ -283,4 +290,48 @@ class PackageCurationTest : WordSpec({
             result3.curations[2].curation shouldBe curation3.data
         }
     }
+
+    "Applying multiple declared license mapping curations" should {
+        "accumulate the map entries and override the entries with same key" {
+            val pkg = Package(
+                id = Identifier("type", "namespace", "name", "version"),
+                declaredLicenses = sortedSetOf("license a", "license b", "license c"),
+                description = "",
+                homepageUrl = "",
+                binaryArtifact = RemoteArtifact.EMPTY,
+                sourceArtifact = RemoteArtifact.EMPTY,
+                vcs = VcsInfo.EMPTY
+            )
+
+            val curation1 =
+                declaredLicenseMappingCuration(pkg.id, "license a" to "Apache-2.0", "license b" to "BSD-3-Clause")
+            val curation2 = declaredLicenseMappingCuration(pkg.id, "license c" to "CC-BY-1.0")
+            val curation3 = declaredLicenseMappingCuration(pkg.id, "license c" to "CC-BY-2.0")
+
+            val result1 = curation1.apply(pkg.toCuratedPackage())
+            val result2 = curation2.apply(result1)
+            val result3 = curation3.apply(result2)
+
+            result1.pkg.declaredLicensesProcessed.spdxExpression shouldBe
+                    "Apache-2.0 AND BSD-3-Clause".toSpdx()
+            result2.pkg.declaredLicensesProcessed.spdxExpression shouldBe
+                    "Apache-2.0 AND BSD-3-Clause AND CC-BY-1.0".toSpdx()
+            result3.pkg.declaredLicensesProcessed.spdxExpression shouldBe
+                    "Apache-2.0 AND BSD-3-Clause AND CC-BY-2.0".toSpdx()
+
+            result3.curations[0].base.declaredLicenseMapping should beEmpty()
+            result3.curations[1].base.declaredLicenseMapping should beEmpty()
+            result3.curations[2].base.declaredLicenseMapping.shouldContainExactly(
+                mapOf("license c" to "CC-BY-1.0".toSpdx())
+            )
+        }
+    }
 })
+
+private fun declaredLicenseMappingCuration(id: Identifier, vararg entries: Pair<String, String>): PackageCuration =
+    PackageCuration(
+        id,
+        PackageCurationData(
+            declaredLicenseMapping = entries.map { it.first to it.second.toSpdx() }.toMap()
+        )
+    )

--- a/utils/src/test/kotlin/DeclaredLicenseProcessorTest.kt
+++ b/utils/src/test/kotlin/DeclaredLicenseProcessorTest.kt
@@ -25,6 +25,7 @@ import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.maps.beEmpty as beEmptyMap
+import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -37,6 +38,7 @@ import org.ossreviewtoolkit.spdx.SpdxLicense
 import org.ossreviewtoolkit.spdx.SpdxLicenseIdExpression
 import org.ossreviewtoolkit.spdx.SpdxSimpleLicenseMapping
 import org.ossreviewtoolkit.spdx.toExpression
+import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.test.containExactly as containExactlyEntries
 
 class DeclaredLicenseProcessorTest : StringSpec() {
@@ -104,6 +106,17 @@ class DeclaredLicenseProcessorTest : StringSpec() {
             processedLicenses.spdxExpression shouldBe SpdxLicenseIdExpression("Apache-2.0")
             processedLicenses.mapped should beEmptyMap()
             processedLicenses.unmapped should containExactly("invalid")
+        }
+
+        "The declared license mapping is applied" {
+            val declaredLicenses = listOf("Apache-2.0", "https://domain/path/license.html")
+            val declaredLicenseMapping = mapOf("https://domain/path/license.html" to "MIT".toSpdx())
+
+            val processedLicenses = DeclaredLicenseProcessor.process(declaredLicenses, declaredLicenseMapping)
+
+            processedLicenses.spdxExpression shouldBe "Apache-2.0 AND MIT".toSpdx()
+            processedLicenses.mapped shouldContainExactly mapOf("https://domain/path/license.html" to "MIT".toSpdx())
+            processedLicenses.unmapped should beEmpty()
         }
     }
 }


### PR DESCRIPTION
I decided for making the entries additive, so that multiple declared license mapping curations can be applied to
any packages, and the entries are added. They override only if the keys equal. This approach is a good basis for enabling the curation of declared license mappings on broader scopes, e.g. by introducing wildcards to the identifier matching of curations.

See the individual commits for the details.

Fixes #2898.