### PR TITLE
NoticeTemplateReporter: Add a helper function for merging licenses

### DIFF
--- a/reporter/src/main/kotlin/reporters/NoticeTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeTemplateReporter.kt
@@ -225,13 +225,20 @@ class NoticeTemplateReporter : Reporter {
             licenseView: LicenseView = LicenseView.ALL,
             omitExcluded: Boolean = true
         ): List<ResolvedLicense> =
-            models
-                .filter { !omitExcluded || !it.excluded }
-                .flatMap {
+            mergeResolvedLicenses(
+                models.filter { !omitExcluded || !it.excluded }.flatMap {
                     val licenses = it.license.filter(licenseView).licenses
                     if (omitExcluded) licenses.filterExcluded() else licenses
                 }
-                .groupBy { it.license }
+            )
+
+        /**
+         * Return a list of [ResolvedLicense]s where all duplicate entries for a single license in [licenses] are
+         * merged. The returned list is sorted by license identifier.
+         */
+        @Suppress("UNUSED") // This function is used in the templates.
+        fun mergeResolvedLicenses(licenses: List<ResolvedLicense>): List<ResolvedLicense> =
+            licenses.groupBy { it.license }
                 .map { (_, licenses) -> licenses.merge() }
                 .sortedBy { it.license.toString() }
     }


### PR DESCRIPTION
Extract the part that merges a list of resolved licenses from the
existing `mergeLicenses()` function into a separate function, because
this function can also be useful in templates.