### PR TITLE
Add several NuGet-realted mappings for declared licenses

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -489,6 +489,7 @@
 "https://dotnet.microsoft.com/en/dotnet_library_license.htm": LicenseRef-scancode-ms-net-library-2018-11
 "https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT": MIT
 "https://raw.github.com/RDFLib/rdflib/master/LICENSE": BSD-3-Clause
+"https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt": Apache-2.0
 "https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt": Apache-2.0
 "https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt": Apache-2.0
 "https://www.eclipse.org/legal/epl-v10.html": EPL-1.0

--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -489,6 +489,7 @@
 "https://dotnet.microsoft.com/en/dotnet_library_license.htm": LicenseRef-scancode-ms-net-library-2018-11
 "https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT": MIT
 "https://raw.github.com/RDFLib/rdflib/master/LICENSE": BSD-3-Clause
+"https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt": Apache-2.0
 "https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt": Apache-2.0
 "https://www.eclipse.org/legal/epl-v10.html": EPL-1.0
 "https://www.eclipse.org/legal/epl-v20.html": EPL-2.0

--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -488,6 +488,7 @@
 "https://creativecommons.org/publicdomain/zero/1.0/": CC0-1.0
 "https://dotnet.microsoft.com/en/dotnet_library_license.htm": LicenseRef-scancode-ms-net-library-2018-11
 "https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT": MIT
+"https://github.com/dotnet/corefx/blob/master/LICENSE.TXT": MIT
 "https://raw.github.com/RDFLib/rdflib/master/LICENSE": BSD-3-Clause
 "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt": Apache-2.0
 "https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt": Apache-2.0

--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -487,6 +487,7 @@
 "https://creativecommons.org/licenses/by/4.0": CC-BY-4.0
 "https://creativecommons.org/publicdomain/zero/1.0/": CC0-1.0
 "https://dotnet.microsoft.com/en/dotnet_library_license.htm": LicenseRef-scancode-ms-net-library-2018-11
+"https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT": MIT
 "https://raw.github.com/RDFLib/rdflib/master/LICENSE": BSD-3-Clause
 "https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt": Apache-2.0
 "https://www.eclipse.org/legal/epl-v10.html": EPL-1.0

--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -487,6 +487,7 @@
 "https://creativecommons.org/publicdomain/zero/1.0/": CC0-1.0
 "https://dotnet.microsoft.com/en/dotnet_library_license.htm": LicenseRef-scancode-ms-net-library-2018-11
 "https://raw.github.com/RDFLib/rdflib/master/LICENSE": BSD-3-Clause
+"https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt": Apache-2.0
 "https://www.eclipse.org/legal/epl-v10.html": EPL-1.0
 "https://www.eclipse.org/legal/epl-v20.html": EPL-2.0
 "https://www.scala-lang.org/license.html": Apache-2.0 AND BSD-3-Clause AND MIT

--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -447,6 +447,7 @@
 "http://creativecommons.org/licenses/publicdomain": CC-PDDC
 "http://creativecommons.org/publicdomain/zero/1.0/legalcode": CC0-1.0
 "http://go.microsoft.com/fwlink/?LinkId=329770": LicenseRef-scancode-ms-net-library-2018-11
+"http://go.microsoft.com/fwlink/?LinkId=529443": LicenseRef-scancode-ms-net-library-2018-11
 "http://polymer.github.io/LICENSE.txt": BSD-3-Clause
 "http://svnkit.com/license.html": TMate
 "http://www.apache.org/licenses/LICENSE-2.0": Apache-2.0

--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -492,6 +492,7 @@
 "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt": Apache-2.0
 "https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt": Apache-2.0
 "https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt": Apache-2.0
+"https://www.apache.org/licenses/LICENSE-2.0": Apache-2.0
 "https://www.eclipse.org/legal/epl-v10.html": EPL-1.0
 "https://www.eclipse.org/legal/epl-v20.html": EPL-2.0
 "https://www.scala-lang.org/license.html": Apache-2.0 AND BSD-3-Clause AND MIT


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.

Note that, as discussed [here](https://github.com/oss-review-toolkit/ort/pull/2938#discussion_r473835224), we should in future avoid adding non-version specific mapping to this file to avoid relicensings of a projects go unnoticed with version major changes.