### PR TITLE
(StaticHtml|Excel)Reporter: Use `labels` instead of `data` for the metadata section

### DIFF
--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -762,5 +762,17 @@
     }
   },
   "repository_configuration" : "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/project/build.gradle\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"The project is an example.\"\n  - pattern: \"**.java\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"These are example files.\"\n  scopes:\n  - pattern: \"testCompile\"\n    reason: \"TEST_DEPENDENCY_OF\"\n    comment: \"The scope only contains test dependencies.\"\nresolutions:\n  rule_violations:\n  - message: \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2 is not an issue.\"\n",
-  "custom_data" : { }
+  "custom_data" : {
+    "job_parameters" : {
+      "JOB_PARAM_1" : "custom data job param 1",
+      "JOB_PARAM_2" : "custom data job param 2"
+    },
+    "process_parameters" : {
+      "PROCESS_PARAM_1" : "custom data process param 1",
+      "PROCESS_PARAM_2" : "custom data process param 2"
+    },
+    "other_parameters" : {
+      "OTHER_PARAM_1" : "custom data other param 1"
+    }
+  }
 }

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -700,4 +700,12 @@ repository_configuration: "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/p
   \    comment: \"The scope only contains test dependencies.\"\nresolutions:\n  rule_violations:\n\
   \  - message: \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment:\
   \ \"Apache-2 is not an issue.\"\n"
-custom_data: {}
+custom_data:
+  job_parameters:
+    JOB_PARAM_1: "custom data job param 1"
+    JOB_PARAM_2: "custom data job param 2"
+  process_parameters:
+    PROCESS_PARAM_1: "custom data process param 1"
+    PROCESS_PARAM_2: "custom data process param 2"
+  other_parameters:
+    OTHER_PARAM_1: "custom data other param 1"

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -425,6 +425,23 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
     <div id="report-container">
       <div class="ort-report-label">Scan Report</div>
       <div>Created by <strong>ORT</strong>, the <a href="http://oss-review-toolkit.org/">OSS Review Toolkit</a>, version <REPLACE_ORT_VERSION> on <REPLACE_TIMESTAMP>.</div>
+      <h2>Metadata</h2>
+      <table class="ort-report-metadata">
+        <tbody>
+          <tr>
+            <td>JOB_PARAM_1</td><td>custom data job param 1</td>
+          </tr>
+          <tr>
+            <td>JOB_PARAM_2</td><td>custom data job param 2</td>
+          </tr>
+          <tr>
+            <td>PROCESS_PARAM_1</td><td>custom data process param 1</td>
+          </tr>
+          <tr>
+            <td>PROCESS_PARAM_2</td><td>custom data process param 2</td>
+          </tr>
+        </tbody>
+      </table>
       <h2>Index</h2>
       <ul>
         <li>

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -429,16 +429,19 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
       <table class="ort-report-metadata">
         <tbody>
           <tr>
-            <td>JOB_PARAM_1</td><td>custom data job param 1</td>
+            <td>JOB_PARAM_1</td><td>label job param 1</td>
           </tr>
           <tr>
-            <td>JOB_PARAM_2</td><td>custom data job param 2</td>
+            <td>JOB_PARAM_2</td><td>label job param 2</td>
           </tr>
           <tr>
-            <td>PROCESS_PARAM_1</td><td>custom data process param 1</td>
+            <td>PROCESS_PARAM_1</td><td>label process param 1</td>
           </tr>
           <tr>
-            <td>PROCESS_PARAM_2</td><td>custom data process param 2</td>
+            <td>PROCESS_PARAM_2</td><td>label process param 2</td>
+          </tr>
+          <tr>
+            <td>OTHER</td><td>label other</td>
           </tr>
         </tbody>
       </table>

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -467,6 +467,12 @@ evaluator:
     message: "BSD-3-Clause warning"
     how_to_fix: "* *Step 1*\n* __Step 2__\n* ***Step 3***\n```\nSome long text verify\
       \ that overflow:scroll is working as expected.\n```"
+labels:
+  job_parameters.JOB_PARAM_1: "label job param 1"
+  job_parameters.JOB_PARAM_2: "label job param 2"
+  process_parameters.PROCESS_PARAM_1: "label process param 1"
+  process_parameters.PROCESS_PARAM_2: "label process param 2"
+  OTHER: "label other"
 data:
   job_parameters:
     JOB_PARAM_1: "custom data job param 1"

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -467,3 +467,12 @@ evaluator:
     message: "BSD-3-Clause warning"
     how_to_fix: "* *Step 1*\n* __Step 2__\n* ***Step 3***\n```\nSome long text verify\
       \ that overflow:scroll is working as expected.\n```"
+data:
+  job_parameters:
+    JOB_PARAM_1: "custom data job param 1"
+    JOB_PARAM_2: "custom data job param 2"
+  process_parameters:
+    PROCESS_PARAM_1: "custom data process param 1"
+    PROCESS_PARAM_2: "custom data process param 2"
+  other_parameters:
+    OTHER_PARAM_1: "custom data other param 1"

--- a/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
@@ -227,13 +227,9 @@ class ReportTableModelMapper(
             summaryRows.values.toList().sortedWith(compareBy({ ortResult.isExcluded(it.id) }, { it.id }))
         )
 
-        val metadata = mutableMapOf<String, String>()
-        (ortResult.data["job_parameters"] as? Map<*, *>)?.let {
-            it.entries.associateTo(metadata) { (key, value) -> key.toString() to value.toString() }
-        }
-        (ortResult.data["process_parameters"] as? Map<*, *>)?.let {
-            it.entries.associateTo(metadata) { (key, value) -> key.toString() to value.toString() }
-        }
+        // TODO: Use the prefixes up until the first '.' (which below get discarded) for some visual grouping in the
+        // report.
+        val metadata = ortResult.labels.mapKeys { it.key.substringAfter(".") }
 
         val ruleViolations = ortResult.getRuleViolations()
             .map { it.toResolvableViolation() }


### PR DESCRIPTION
The changes prepare for the removal of `OrtResult.data`. 
Please see the individual commit messages.