### PR TITLE
Allow discarding declared licenses

### DIFF
--- a/spdx-utils/src/main/kotlin/SpdxDeclaredLicenseMapping.kt
+++ b/spdx-utils/src/main/kotlin/SpdxDeclaredLicenseMapping.kt
@@ -41,7 +41,8 @@ object SpdxDeclaredLicenseMapping {
     val mapping = rawMapping.toSortedMap(String.CASE_INSENSITIVE_ORDER)
 
     /**
-     * Return the [SpdxExpression] the [license] string maps to, or null if there is no corresponding expression.
+     * Return the [SpdxExpression] the [license] string maps to, [SpdxConstants.NONE] if the [license] should be
+     * discarded, or null if there is no corresponding expression.
      */
     fun map(license: String) = mapping[license] ?: SpdxLicense.forId(license)?.toExpression()
 }

--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -1,4 +1,5 @@
 # Sort the entries below via IntelliJ's "Edit" -> "Sort Lines".
+# Map a declared license string to "NONE" in order to discard it.
 ---
 "(MIT-style) netCDF C library license": NetCDF
 "2-clause BSD license": BSD-2-Clause

--- a/utils/src/test/kotlin/DeclaredLicenseProcessorTest.kt
+++ b/utils/src/test/kotlin/DeclaredLicenseProcessorTest.kt
@@ -31,6 +31,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 
+import org.ossreviewtoolkit.spdx.SpdxConstants
 import org.ossreviewtoolkit.spdx.SpdxDeclaredLicenseMapping
 import org.ossreviewtoolkit.spdx.SpdxException
 import org.ossreviewtoolkit.spdx.SpdxExpression
@@ -116,6 +117,19 @@ class DeclaredLicenseProcessorTest : StringSpec() {
 
             processedLicenses.spdxExpression shouldBe "Apache-2.0 AND MIT".toSpdx()
             processedLicenses.mapped shouldContainExactly mapOf("https://domain/path/license.html" to "MIT".toSpdx())
+            processedLicenses.unmapped should beEmpty()
+        }
+
+        "The declared license mapping discards licenses which are mapped to 'NONE' when applied " {
+            val declaredLicenses = listOf("Copyright (c) the authors.", "Apache-2.0", "MIT")
+            val declaredLicenseMapping = mapOf("Copyright (c) the authors." to SpdxConstants.NONE.toSpdx())
+
+            val processedLicenses = DeclaredLicenseProcessor.process(declaredLicenses, declaredLicenseMapping)
+
+            processedLicenses.spdxExpression shouldBe "Apache-2.0 AND MIT".toSpdx()
+            processedLicenses.mapped shouldContainExactly mapOf(
+                "Copyright (c) the authors." to SpdxConstants.NONE.toSpdx()
+            )
             processedLicenses.unmapped should beEmpty()
         }
     }


### PR DESCRIPTION
Some declared license entries are just invalid, like e.g. if a copyright statement is used as declared license, and should be just discarded. This PR enables discarding such entries by mapping the declared license to (SPDX) "NONE", either
- via a declared license curation
- or via ORT's internal `declared license mapping` data

The entry for the `delcared_license_processed` contains e.g. "Copyright a,b,c" -> "NONE" in case a license was discarded with that new mechanism.

This improves on #2898 .