### PR TITLE
Gradle: Upgrade detekt to version 1.13.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,6 +94,10 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
 allprojects {
     buildscript {
         repositories {
+            // Explicitly add Maven Central as some plugins continue to have problems with JCenter, see
+            // https://github.com/detekt/detekt/issues/3062.
+            mavenCentral()
+
             jcenter()
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-detektPluginVersion = 1.12.0
+detektPluginVersion = 1.13.1
 dokkaPluginVersion = 1.4.0
 ideaExtPluginVersion = 0.6.1
 kotlinPluginVersion = 1.4.10


### PR DESCRIPTION
See https://github.com/detekt/detekt/releases/tag/v1.13.1.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>