### PR TITLE
Add a declared license mapping for "Eclipse Public License - v 2.0"

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -173,6 +173,7 @@
 "Eclipse Public License (EPL), Version 1.0": EPL-1.0
 "Eclipse Public License - Version 1.0": EPL-1.0
 "Eclipse Public License - v 1.0": EPL-1.0
+"Eclipse Public License - v 2.0": EPL-2.0
 "Eclipse Public License 1.0 (EPL-1.0)": EPL-1.0
 "Eclipse Public License 2.0 (EPL-2.0)": EPL-2.0
 "Eclipse Public License v. 2.0": EPL-2.0


### PR DESCRIPTION
Found in [1].

[1]: https://github.com/jnr/jnr-posix/blob/jnr-posix-3.0.61/pom.xml#L32

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>