### PR TITLE
PathExcludeReason: Deprecate TEST_TOOL_OF

### DIFF
--- a/evaluator/src/test/kotlin/TestData.kt
+++ b/evaluator/src/test/kotlin/TestData.kt
@@ -48,10 +48,6 @@ import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
 val concludedLicense = "LicenseRef-a AND LicenseRef-b".toSpdx()
 val declaredLicenses = sortedSetOf("Apache-2.0", "MIT")
 val declaredLicensesProcessed = DeclaredLicenseProcessor.process(declaredLicenses)
-val detectedLicenses = listOf(
-    SpdxLicenseReferenceExpression("LicenseRef-a"),
-    SpdxLicenseReferenceExpression("LicenseRef-b")
-)
 
 val licenseFindings = listOf(
     LicenseFindings(SpdxLicenseReferenceExpression("LicenseRef-a"), sortedSetOf(), sortedSetOf()),

--- a/evaluator/src/test/kotlin/TestData.kt
+++ b/evaluator/src/test/kotlin/TestData.kt
@@ -152,7 +152,7 @@ val ortResult = OrtResult(
                 paths = listOf(
                     PathExclude(
                         pattern = "excluded/**",
-                        reason = PathExcludeReason.TEST_TOOL_OF,
+                        reason = PathExcludeReason.TEST_OF,
                         comment = "excluded"
                     )
                 )

--- a/model/src/main/kotlin/config/PathExcludeReason.kt
+++ b/model/src/main/kotlin/config/PathExcludeReason.kt
@@ -72,5 +72,12 @@ enum class PathExcludeReason {
      * The path only contains tools used for testing source code which are not included in distributed build
      * artifacts.
      */
+    @Deprecated(
+        message = "Use SPDX-2.2-style enum value instead.",
+        replaceWith = ReplaceWith(
+            expression = "PathExcludeReason.TEST_OF",
+            imports = ["org.ossreviewtoolkit.model.config.PathExcludeReason"]
+        )
+    )
     TEST_TOOL_OF
 }

--- a/model/src/test/kotlin/licenses/TestData.kt
+++ b/model/src/test/kotlin/licenses/TestData.kt
@@ -167,7 +167,7 @@ val ortResult = OrtResult(
                 paths = listOf(
                     PathExclude(
                         pattern = "excluded/**",
-                        reason = PathExcludeReason.TEST_TOOL_OF,
+                        reason = PathExcludeReason.TEST_OF,
                         comment = "excluded"
                     )
                 )


### PR DESCRIPTION
Since TEST_OF should be used instead.

Signed-off-by: Frank Viernau <frank.viernau@here.com>