### PR TITLE
Remove custom data

### DIFF
--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -202,9 +202,7 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate rules 
 
         outputDir?.let { absoluteOutputDir ->
             // Note: This overwrites any existing EvaluatorRun from the input file.
-            val ortResultOutput = ortResultInput.copy(evaluator = evaluatorRun).apply {
-                data += ortResultInput.data
-            }.mergeLabels(labels)
+            val ortResultOutput = ortResultInput.copy(evaluator = evaluatorRun).mergeLabels(labels)
 
             absoluteOutputDir.safeMkdirs()
 

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 
 import java.util.SortedSet
@@ -33,12 +34,11 @@ import org.ossreviewtoolkit.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.zipWithDefault
 
-typealias CustomData = MutableMap<String, Any>
-
 /**
  * The common output format for the analyzer and scanner. It contains information about the scanned repository, and the
  * analyzer and scanner will add their result to it.
  */
+@JsonIgnoreProperties("data")
 @Suppress("TooManyFunctions")
 data class OrtResult(
     /**
@@ -84,12 +84,6 @@ data class OrtResult(
             labels = emptyMap()
         )
     }
-
-    /**
-     * A map that holds arbitrary data. Can be used by third-party tools to add custom data to the model.
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val data: CustomData = mutableMapOf()
 
     private data class ProjectEntry(val project: Project, val isExcluded: Boolean)
 
@@ -316,8 +310,7 @@ data class OrtResult(
     /**
      * Return a copy of this [OrtResult] with the [Repository.config] replaced by [config].
      */
-    fun replaceConfig(config: RepositoryConfiguration): OrtResult =
-        copy(repository = repository.copy(config = config)).also { it.data += data }
+    fun replaceConfig(config: RepositoryConfiguration): OrtResult = copy(repository = repository.copy(config = config))
 
     /**
      * Return a copy of this [OrtResult] with the [PackageCuration]s replaced by the given [curations].
@@ -334,7 +327,7 @@ data class OrtResult(
                     }.toSortedSet()
                 )
             )
-        ).also { it.data += data }
+        )
 
     fun getProject(id: Identifier): Project? = projects[id]?.project
 

--- a/model/src/main/kotlin/utils/OrtResultExtensions.kt
+++ b/model/src/main/kotlin/utils/OrtResultExtensions.kt
@@ -88,5 +88,4 @@ fun OrtResult.getDetectedLicensesWithCopyrights(
 /**
  * Copy this [OrtResult] and add all [labels] to the existing labels, overwriting existing labels on conflict.
  */
-fun OrtResult.mergeLabels(labels: Map<String, String>) =
-    copy(labels = this.labels + labels).apply { data += this@mergeLabels.data }
+fun OrtResult.mergeLabels(labels: Map<String, String>) = copy(labels = this.labels + labels)

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -58,13 +58,13 @@ ul {
     width: 110px;
 }
 
-.ort-report-metadata {
+.ort-report-labels {
     font-size: 12px;
     border-spacing: 0;
     table-layout: fixed;
 }
 
-.ort-report-metadata td {
+.ort-report-labels td {
     border-bottom: 1px solid rgba(34, 36, 38, .15);
     overflow: hidden;
     padding: 5px 20px 5px 0px;
@@ -72,7 +72,7 @@ ul {
     word-wrap: break-word;
 }
 
-.ort-report-metadata tr:first-child td {
+.ort-report-labels tr:first-child td {
     border-top: 1px solid rgba(34, 36, 38, .15);
 }
 
@@ -425,8 +425,8 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
     <div id="report-container">
       <div class="ort-report-label">Scan Report</div>
       <div>Created by <strong>ORT</strong>, the <a href="http://oss-review-toolkit.org/">OSS Review Toolkit</a>, version <REPLACE_ORT_VERSION> on <REPLACE_TIMESTAMP>.</div>
-      <h2>Metadata</h2>
-      <table class="ort-report-metadata">
+      <h2>Labels</h2>
+      <table class="ort-report-labels">
         <tbody>
           <tr>
             <td>JOB_PARAM_1</td><td>label job param 1</td>
@@ -583,7 +583,7 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
       </table>
       <h2 id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0 (analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle)</h2>
       <h3 class="">VCS Information</h3>
-      <table class="ort-report-metadata ">
+      <table class="ort-report-labels ">
         <tbody>
           <tr>
             <td>Type</td><td>Git</td>
@@ -711,7 +711,7 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
         <div class="ort-reason">EXAMPLE_OF - The project is an example.</div>
       </p>
       <h3 class="ort-excluded">VCS Information</h3>
-      <table class="ort-report-metadata ort-excluded">
+      <table class="ort-report-labels ort-excluded">
         <tbody>
           <tr>
             <td>Type</td><td>Git</td>

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -473,12 +473,3 @@ labels:
   process_parameters.PROCESS_PARAM_1: "label process param 1"
   process_parameters.PROCESS_PARAM_2: "label process param 2"
   OTHER: "label other"
-data:
-  job_parameters:
-    JOB_PARAM_1: "custom data job param 1"
-    JOB_PARAM_2: "custom data job param 2"
-  process_parameters:
-    PROCESS_PARAM_1: "custom data process param 1"
-    PROCESS_PARAM_2: "custom data process param 2"
-  other_parameters:
-    OTHER_PARAM_1: "custom data other param 1"

--- a/reporter/src/main/kotlin/reporters/ExcelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ExcelReporter.kt
@@ -163,8 +163,8 @@ class ExcelReporter : Reporter {
 
         creationHelper = workbook.creationHelper
 
-        if (tabularScanRecord.metadata.isNotEmpty()) {
-            createMetadataSheet(workbook, tabularScanRecord.metadata)
+        if (tabularScanRecord.labels.isNotEmpty()) {
+            createLabelsSheet(workbook, tabularScanRecord.labels)
         }
 
         createSummarySheet(
@@ -195,18 +195,18 @@ class ExcelReporter : Reporter {
         return listOf(outputFile)
     }
 
-    private fun createMetadataSheet(workbook: XSSFWorkbook, metadata: Map<String, String>) {
-        val sheetName = createUniqueSheetName(workbook, "Metadata")
+    private fun createLabelsSheet(workbook: XSSFWorkbook, labels: Map<String, String>) {
+        val sheetName = createUniqueSheetName(workbook, "Labels")
 
         val sheet = workbook.createSheet(sheetName)
 
         var currentRow = 0
 
         sheet.createRow(currentRow).apply {
-            CellUtil.createCell(this, 0, "Metadata", headerStyle)
+            CellUtil.createCell(this, 0, "Labels", headerStyle)
         }
 
-        metadata.forEach { (key, value) ->
+        labels.forEach { (key, value) ->
             sheet.createRow(++currentRow).let { row ->
                 CellUtil.createCell(row, 0, "$key:", defaultStyle)
                 CellUtil.createCell(row, 1, value, defaultStyle).apply {

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -130,8 +130,8 @@ class StaticHtmlReporter : Reporter {
                         +", version ${Environment().ortVersion} on ${Instant.now()}."
                     }
 
-                    if (reportTableModel.metadata.isNotEmpty()) {
-                        metadataTable(reportTableModel.metadata)
+                    if (reportTableModel.labels.isNotEmpty()) {
+                        labelsTable(reportTableModel.labels)
                     }
 
                     index(reportTableModel)
@@ -156,14 +156,14 @@ class StaticHtmlReporter : Reporter {
         return document.serialize().normalizeLineBreaks()
     }
 
-    private fun DIV.metadataTable(metadata: Map<String, String>) {
-        h2 { +"Metadata" }
-        table("ort-report-metadata") {
-            tbody { metadata.forEach { (key, value) -> metadataRow(key, value) } }
+    private fun DIV.labelsTable(labels: Map<String, String>) {
+        h2 { +"Labels" }
+        table("ort-report-labels") {
+            tbody { labels.forEach { (key, value) -> labelRow(key, value) } }
         }
     }
 
-    private fun TBODY.metadataRow(key: String, value: String) {
+    private fun TBODY.labelRow(key: String, value: String) {
         tr {
             td { +key }
             td { if (value.isValidUrl()) a(value) { +value } else +value }
@@ -426,7 +426,7 @@ class StaticHtmlReporter : Reporter {
         project.vcsProcessed.let { vcsInfo ->
             h3(excludedClass) { +"VCS Information" }
 
-            table("ort-report-metadata $excludedClass") {
+            table("ort-report-labels $excludedClass") {
                 tbody {
                     tr {
                         td { +"Type" }

--- a/reporter/src/main/kotlin/utils/ReportTableModel.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModel.kt
@@ -74,9 +74,9 @@ data class ReportTableModel(
     val projectDependencies: SortedMap<Project, ProjectTable>,
 
     /**
-     * Additional metadata read from the [OrtResult.data] field.
+     * The labels from [OrtResult.labels].
      */
-    val metadata: Map<String, String>
+    val labels: Map<String, String>
 ) {
     data class ProjectTable(
         /**

--- a/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
@@ -229,7 +229,7 @@ class ReportTableModelMapper(
 
         // TODO: Use the prefixes up until the first '.' (which below get discarded) for some visual grouping in the
         // report.
-        val metadata = ortResult.labels.mapKeys { it.key.substringAfter(".") }
+        val labels = ortResult.labels.mapKeys { it.key.substringAfter(".") }
 
         val ruleViolations = ortResult.getRuleViolations()
             .map { it.toResolvableViolation() }
@@ -242,7 +242,7 @@ class ReportTableModelMapper(
             issueSummaryTable,
             summaryTable,
             projectTables,
-            metadata
+            labels
         )
     }
 }

--- a/reporter/src/main/resources/static-html-reporter.css
+++ b/reporter/src/main/resources/static-html-reporter.css
@@ -51,13 +51,13 @@ ul {
     width: 110px;
 }
 
-.ort-report-metadata {
+.ort-report-labels {
     font-size: 12px;
     border-spacing: 0;
     table-layout: fixed;
 }
 
-.ort-report-metadata td {
+.ort-report-labels td {
     border-bottom: 1px solid rgba(34, 36, 38, .15);
     overflow: hidden;
     padding: 5px 20px 5px 0px;
@@ -65,7 +65,7 @@ ul {
     word-wrap: break-word;
 }
 
-.ort-report-metadata tr:first-child td {
+.ort-report-labels tr:first-child td {
     border-top: 1px solid rgba(34, 36, 38, .15);
 }
 

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -132,9 +132,7 @@ abstract class Scanner(val scannerName: String, protected val config: ScannerCon
         val scannerRun = ScannerRun(startTime, endTime, Environment(), config, scanRecord)
 
         // Note: This overwrites any existing ScannerRun from the input file.
-        return ortResult.copy(scanner = scannerRun).apply {
-            data += ortResult.data
-        }
+        return ortResult.copy(scanner = scannerRun)
     }
 
     /**


### PR DESCRIPTION
Remove the `data`  property from `OrtResult`, because the `labels` property should now be used for custom data.