### PR TITLE
Add a declared license mapping for "Apache License (v2.0)"

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -24,6 +24,7 @@
 "Apache 2.0 License": Apache-2.0
 "Apache 2.0": Apache-2.0
 "Apache License (2.0)": Apache-2.0
+"Apache License (v2.0)": Apache-2.0
 "Apache License 2": Apache-2.0
 "Apache License Version 2": Apache-2.0
 "Apache License Version 2.0": Apache-2.0


### PR DESCRIPTION
Found in [1].

[1]: https://github.com/vy/flatbuffers/blob/600952fca1c5a7ca8c3c1ce4530116191f78530b/pom.xml#L17

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>