### PR TITLE
Azure: Disable parallel builds for the Windows test job

### DIFF
--- a/.azure-pipelines/WindowsTest.yml
+++ b/.azure-pipelines/WindowsTest.yml
@@ -80,7 +80,7 @@ jobs:
     inputs:
       gradleWrapperFile: gradlew.bat
       # TODO: Only exclude ExpensiveTag on PR builds.
-      options: --no-daemon --stacktrace -Dkotest.tags.exclude=ExpensiveTag -Dkotest.assertions.multi-line-diff=simple -x analyzer:test -x analyzer:funTest -PbuildCacheRetentionDays=3
+      options: --no-daemon -Dorg.gradle.parallel=false --stacktrace -Dkotest.tags.exclude=ExpensiveTag -Dkotest.assertions.multi-line-diff=simple -x analyzer:test -x analyzer:funTest -PbuildCacheRetentionDays=3
       tasks: test funTest
       publishJUnitResults: true
       testResultsFiles: '**/flattened/TEST-*.xml'


### PR DESCRIPTION
The "WindowsTest" job often fails with `OutOfMemoryError`s. Disable
parallel builds to reduce memory usage by running only one test task at
once.