### PR TITLE
model: Remove the LicenseFindingsMap typealias and related functions

### DIFF
--- a/model/src/main/kotlin/LicenseFindings.kt
+++ b/model/src/main/kotlin/LicenseFindings.kt
@@ -19,60 +19,9 @@
 
 package org.ossreviewtoolkit.model
 
-import java.util.SortedMap
 import java.util.SortedSet
 
-import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
-import org.ossreviewtoolkit.utils.CopyrightStatementsProcessor
-
-/**
- * A map that associates licenses with their belonging copyrights. This is provided mostly for convenience as creating
- * a similar collection based on the [LicenseFindings] class is a bit cumbersome due to its required layout to support
- * legacy serialized formats.
- */
-typealias LicenseFindingsMap = SortedMap<String, MutableSet<String>>
-
-/**
- * Process all copyright statements contained in this [LicenseFindingsMap] using the [CopyrightStatementsProcessor].
- */
-fun LicenseFindingsMap.processStatements() =
-    mapValues { (_, copyrights) ->
-        CopyrightStatementsProcessor()
-            .process(copyrights)
-            .getAllStatements()
-            .toMutableSet()
-    }.toSortedMap()
-
-/**
- * Remove all copyright statements from this [LicenseFindingsMap] which are contained in the provided
- * [copyrightGarbage].
- */
-fun LicenseFindingsMap.removeGarbage(copyrightGarbage: CopyrightGarbage) =
-    mapValues { (_, copyrights) ->
-        copyrights.filterNot {
-            it in copyrightGarbage.items
-        }.toMutableSet()
-    }.toSortedMap()
-
-/**
- * Clean this [LicenseFindingsMap] by calling [removeGarbage], [processStatements], and again [removeGarbage] to make
- * sure that processed statements which are contained in [copyrightGarbage] are also removed.
- */
-fun LicenseFindingsMap.clean(copyrightGarbage: CopyrightGarbage) =
-    removeGarbage(copyrightGarbage).processStatements().removeGarbage(copyrightGarbage)
-
-/**
- * Merge all [LicenseFindingsMap]s into a single one.
- */
-fun Collection<LicenseFindingsMap>.merge() =
-    reduceOrNull { left, right ->
-        left.apply {
-            right.forEach { (license, copyrights) ->
-                getOrPut(license) { mutableSetOf() } += copyrights
-            }
-        }
-    } ?: sortedMapOf()
 
 /**
  * A class to store a [license] finding along with its belonging [copyrights] and the [locations] where the license was


### PR DESCRIPTION
The code using the typealias and the functions has been migrated to use
the `ResolvedLicenseInfo` instead.