### PR TITLE
Broaden the license file matching for sparse checkouts

### DIFF
--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -144,8 +144,10 @@ class Git : VersionControlSystem(), CommandLineTool {
 
                     val gitInfoDir = targetDir.resolve(".git/info").apply { safeMkdirs() }
                     val path = vcs.path.let { if (it.startsWith("/")) it else "/$it" }
-                    gitInfoDir.resolve("sparse-checkout").writeText("$path\n" +
-                            FileMatcher.LICENSE_FILE_MATCHER.patterns.joinToString("\n") { "/$it" })
+                    val sparseCheckoutPatterns = "$path\n" +
+                            FileMatcher.LICENSE_FILE_MATCHER.patterns.joinToString("\n") { "/$it" }
+
+                    gitInfoDir.resolve("sparse-checkout").writeText(sparseCheckoutPatterns)
                 }
 
                 git.repository.config.save()

--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -45,7 +45,7 @@ import org.ossreviewtoolkit.downloader.WorkingTree
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.CommandLineTool
-import org.ossreviewtoolkit.utils.FileMatcher
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.Os
 import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.installAuthenticatorAndProxySelector
@@ -145,7 +145,7 @@ class Git : VersionControlSystem(), CommandLineTool {
                     val gitInfoDir = targetDir.resolve(".git/info").apply { safeMkdirs() }
                     val path = vcs.path.let { if (it.startsWith("/")) it else "/$it" }
                     val sparseCheckoutPatterns = "$path\n" +
-                            FileMatcher.LICENSE_FILE_MATCHER.patterns.joinToString("\n") { "/$it" }
+                            LicenseFilenamePatterns.getLicenseFileGlobsForDirectory(path).joinToString("\n")
 
                     gitInfoDir.resolve("sparse-checkout").writeText(sparseCheckoutPatterns)
                 }

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -54,7 +54,7 @@ import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.spdx.getLicenseText
 import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
-import org.ossreviewtoolkit.utils.LICENSE_FILENAMES
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.LICENSE_FILENAMES
 import org.ossreviewtoolkit.utils.storage.FileArchiver
 import org.ossreviewtoolkit.utils.storage.LocalFileStorage
 

--- a/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterTest.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
-import org.ossreviewtoolkit.utils.LICENSE_FILENAMES
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.LICENSE_FILENAMES
 import org.ossreviewtoolkit.utils.ORT_NAME
 
 class NoticeTemplateReporterTest : WordSpec({

--- a/utils/src/main/kotlin/FileMatcher.kt
+++ b/utils/src/main/kotlin/FileMatcher.kt
@@ -23,6 +23,9 @@ import java.nio.file.FileSystems
 import java.nio.file.InvalidPathException
 import java.nio.file.Paths
 
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.LICENSE_FILENAMES
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.ROOT_LICENSE_FILENAMES
+
 /**
  * A class to determine whether a path is matched by any of the given globs.
  */

--- a/utils/src/main/kotlin/LicenseFilenamePatterns.kt
+++ b/utils/src/main/kotlin/LicenseFilenamePatterns.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.utils
+
+private fun List<String>.generateCapitalizationVariants() = flatMap { listOf(it, it.toUpperCase(), it.capitalize()) }
+
+object LicenseFilenamePatterns {
+    /**
+     * A list of globs that match default license file names.
+     */
+    val LICENSE_FILENAMES = listOf(
+        "license*",
+        "licence*",
+        "*.license",
+        "*.licence",
+        "unlicense",
+        "unlicence",
+        "copying*",
+        "copyright",
+        "patents"
+    ).generateCapitalizationVariants()
+
+    /**
+     * A list of globs that match files that often define the root license of a project, but are no license files and
+     * are therefore not contained in [LICENSE_FILENAMES].
+     */
+    val ROOT_LICENSE_FILENAMES = listOf(
+        "readme*"
+    ).generateCapitalizationVariants()
+}

--- a/utils/src/main/kotlin/LicenseFilenamePatterns.kt
+++ b/utils/src/main/kotlin/LicenseFilenamePatterns.kt
@@ -26,15 +26,15 @@ object LicenseFilenamePatterns {
      * A list of globs that match default license file names.
      */
     val LICENSE_FILENAMES = listOf(
-        "license*",
-        "licence*",
-        "*.license",
-        "*.licence",
-        "unlicense",
-        "unlicence",
         "copying*",
         "copyright",
-        "patents"
+        "licence*",
+        "license*",
+        "*.licence",
+        "*.license",
+        "patents",
+        "unlicence",
+        "unlicense"
     ).generateCapitalizationVariants()
 
     /**

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -28,31 +28,6 @@ import java.security.Permission
 
 import kotlin.reflect.full.memberProperties
 
-private fun List<String>.generateCapitalizationVariants() = flatMap { listOf(it, it.toUpperCase(), it.capitalize()) }
-
-/**
- * A list of globs that match default license file names.
- */
-val LICENSE_FILENAMES = listOf(
-    "license*",
-    "licence*",
-    "*.license",
-    "*.licence",
-    "unlicense",
-    "unlicence",
-    "copying*",
-    "copyright",
-    "patents"
-).generateCapitalizationVariants()
-
-/**
- * A list of globs that match files that often define the root license of a project, but are no license files and are
- * therefore not contained in [LICENSE_FILENAMES].
- */
-val ROOT_LICENSE_FILENAMES = listOf(
-    "readme*"
-).generateCapitalizationVariants()
-
 /**
  * The directory to store ORT (read-only) configuration in.
  */

--- a/utils/src/main/kotlin/storage/FileArchiver.kt
+++ b/utils/src/main/kotlin/storage/FileArchiver.kt
@@ -23,7 +23,7 @@ import java.io.File
 import java.io.IOException
 
 import org.ossreviewtoolkit.utils.FileMatcher
-import org.ossreviewtoolkit.utils.LICENSE_FILENAMES
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.LICENSE_FILENAMES
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.log

--- a/utils/src/test/kotlin/LicenseFilenamePatternsTest.kt
+++ b/utils/src/test/kotlin/LicenseFilenamePatternsTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.utils
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containAll
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.should
+
+class LicenseFilenamePatternsTest : WordSpec({
+    "globFileInDirectoryOrAncestors" should {
+        "return the expected globs given a non-root directory" {
+            LicenseFilenamePatterns.getFileGlobsForDirectoryAndAncestors(
+                directory = "/some/path",
+                filenamePatterns = listOf("LICENSE", "PATENTS")
+            ) should containExactly(
+                "/LICENSE",
+                "/PATENTS",
+                "/some/LICENSE",
+                "/some/PATENTS",
+                "/some/path/**/LICENSE",
+                "/some/path/**/PATENTS"
+            )
+        }
+
+        "return the expected globs given the root directory" {
+            LicenseFilenamePatterns.getFileGlobsForDirectoryAndAncestors(
+                directory = "/",
+                filenamePatterns = listOf("LICENSE", "PATENTS")
+            ) should containExactly(
+                "**/LICENSE",
+                "**/PATENTS"
+            )
+        }
+    }
+
+    "getLicenseFileGlobsForDirectory" should {
+        "return a list containing the expected patterns for the LICENSE file" {
+            LicenseFilenamePatterns.getLicenseFileGlobsForDirectory("/dir") should containAll(
+                "/LICENSE*",
+                "/dir/**/LICENSE*"
+            )
+        }
+    }
+})


### PR DESCRIPTION
In order to adjust the so called root license heuristic to consider also files which are not direct children of the root directory [1], the sparse checkout needs to checkout these files in the first place. This is what this PR is about.

[1] #3054