### PR TITLE
FileMatcher: Use Springs' instead of Java's PathMatcher

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -55,6 +55,7 @@ reflectionsVersion = 0.9.12
 retrofitVersion = 2.9.0
 semverVersion = 3.1.0
 simpleExcelVersion = 1.1
+springCoreVersion = 5.2.8.RELEASE
 svnkitVersion = 1.10.1
 toml4jVersion = 0.7.2
 xalanVersion = 2.7.2

--- a/utils/build.gradle.kts
+++ b/utils/build.gradle.kts
@@ -25,6 +25,7 @@ val kotlinxCoroutinesVersion: String by project
 val log4jApiKotlinVersion: String by project
 val okhttpVersion: String by project
 val semverVersion: String by project
+val springCoreVersion: String by project
 val xzVersion: String by project
 
 plugins {
@@ -44,5 +45,6 @@ dependencies {
     implementation("org.apache.commons:commons-compress:$commonsCompressVersion")
     implementation("org.jetbrains.kotlin:kotlin-scripting-jsr223")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
+    implementation("org.springframework:spring-core:$springCoreVersion")
     implementation("org.tukaani:xz:$xzVersion")
 }

--- a/utils/src/main/kotlin/FileMatcher.kt
+++ b/utils/src/main/kotlin/FileMatcher.kt
@@ -44,7 +44,10 @@ class FileMatcher(
         /**
          * A matcher which uses the default license file names.
          */
-        val LICENSE_FILE_MATCHER = FileMatcher(LICENSE_FILENAMES + ROOT_LICENSE_FILENAMES)
+        val LICENSE_FILE_MATCHER = FileMatcher(
+            patterns = LICENSE_FILENAMES + ROOT_LICENSE_FILENAMES,
+            caseSensitive = false // This does not have any effect when used with (case-sensitive) sparse checkouts.
+        )
     }
 
     constructor(vararg patterns: String, caseSensitive: Boolean = true) : this(patterns.asList(), caseSensitive)

--- a/utils/src/main/kotlin/FileMatcher.kt
+++ b/utils/src/main/kotlin/FileMatcher.kt
@@ -33,7 +33,12 @@ class FileMatcher(
      *
      * [1]: https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob
      */
-    val patterns: List<String>
+    val patterns: List<String>,
+
+    /**
+     * Toggle the case-sensitivity of the matching.
+     */
+    caseSensitive: Boolean = true
 ) {
     companion object {
         /**
@@ -42,9 +47,11 @@ class FileMatcher(
         val LICENSE_FILE_MATCHER = FileMatcher(LICENSE_FILENAMES + ROOT_LICENSE_FILENAMES)
     }
 
-    constructor(vararg patterns: String) : this(patterns.asList())
+    constructor(vararg patterns: String, caseSensitive: Boolean = true) : this(patterns.asList(), caseSensitive)
 
-    private val matcher = AntPathMatcher()
+    private val matcher = AntPathMatcher().apply {
+        setCaseSensitive(caseSensitive)
+    }
 
     /**
      * Return true if and only if the given [path] is matched by any of the file globs passed to the

--- a/utils/src/main/kotlin/FileMatcher.kt
+++ b/utils/src/main/kotlin/FileMatcher.kt
@@ -19,12 +19,10 @@
 
 package org.ossreviewtoolkit.utils
 
-import java.nio.file.FileSystems
-import java.nio.file.InvalidPathException
-import java.nio.file.Paths
-
 import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.LICENSE_FILENAMES
 import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.ROOT_LICENSE_FILENAMES
+
+import org.springframework.util.AntPathMatcher
 
 /**
  * A class to determine whether a path is matched by any of the given globs.
@@ -46,18 +44,11 @@ class FileMatcher(
 
     constructor(vararg patterns: String) : this(patterns.asList())
 
-    private val matchers = patterns.map {
-        FileSystems.getDefault().getPathMatcher("glob:$it")
-    }
+    private val matcher = AntPathMatcher()
 
     /**
      * Return true if and only if the given [path] is matched by any of the file globs passed to the
-     * constructor.
+     * constructor. The [path] must use '/' as separators, if it contains any.
      */
-    fun matches(path: String): Boolean =
-        try {
-            matchers.any { it.matches(Paths.get(path)) }
-        } catch (e: InvalidPathException) {
-            false
-        }
+    fun matches(path: String): Boolean = patterns.any { pattern -> matcher.match(pattern, path) }
 }

--- a/utils/src/main/kotlin/FileMatcher.kt
+++ b/utils/src/main/kotlin/FileMatcher.kt
@@ -38,7 +38,7 @@ class FileMatcher(
     /**
      * Toggle the case-sensitivity of the matching.
      */
-    caseSensitive: Boolean = true
+    ignoreCase: Boolean = false
 ) {
     companion object {
         /**
@@ -46,14 +46,14 @@ class FileMatcher(
          */
         val LICENSE_FILE_MATCHER = FileMatcher(
             patterns = LICENSE_FILENAMES + ROOT_LICENSE_FILENAMES,
-            caseSensitive = false // This does not have any effect when used with (case-sensitive) sparse checkouts.
+            ignoreCase = true // This does not have any effect when used with (case-sensitive) sparse checkouts.
         )
     }
 
-    constructor(vararg patterns: String, caseSensitive: Boolean = true) : this(patterns.asList(), caseSensitive)
+    constructor(vararg patterns: String, ignoreCase: Boolean = false) : this(patterns.asList(), ignoreCase)
 
     private val matcher = AntPathMatcher().apply {
-        setCaseSensitive(caseSensitive)
+        setCaseSensitive(!ignoreCase)
     }
 
     /**

--- a/utils/src/main/kotlin/storage/FileArchiver.kt
+++ b/utils/src/main/kotlin/storage/FileArchiver.kt
@@ -73,8 +73,9 @@ class FileArchiver(
         zipFile.deleteOnExit()
 
         directory.packZip(zipFile, overwrite = true) { path ->
-            val relativePath = directory.toPath().relativize(path)
-            matcher.matches(relativePath.toString()).also { result ->
+            val relativePath = path.toFile().relativeTo(directory).invariantSeparatorsPath
+
+            matcher.matches(relativePath).also { result ->
                 if (result) {
                     log.debug { "Adding '$relativePath' to archive." }
                 } else {

--- a/utils/src/test/kotlin/FileMatcherTest.kt
+++ b/utils/src/test/kotlin/FileMatcherTest.kt
@@ -62,6 +62,15 @@ class FileMatcherTest : WordSpec({
                 defaultMatcher.matches(it) shouldBe true
             }
         }
+
+        "be case insensitive" {
+            with(defaultMatcher) {
+                matches("LICENSE") shouldBe true
+                matches("License") shouldBe true
+                matches("LiCeNsE") shouldBe true
+                matches("license") shouldBe true
+            }
+        }
     }
 
     "matches" should {

--- a/utils/src/test/kotlin/FileMatcherTest.kt
+++ b/utils/src/test/kotlin/FileMatcherTest.kt
@@ -85,12 +85,12 @@ class FileMatcherTest : WordSpec({
         }
 
         "adhere to the case-sensitivity" {
-            FileMatcher("LICENSE", caseSensitive = true).apply {
+            FileMatcher("LICENSE", ignoreCase = false).apply {
                 matches("LICENSE") shouldBe true
                 matches("license") shouldBe false
             }
 
-            FileMatcher("LICENSE", caseSensitive = false).apply {
+            FileMatcher("LICENSE", ignoreCase = true).apply {
                 matches("LICENSE") shouldBe true
                 matches("license") shouldBe true
             }

--- a/utils/src/test/kotlin/FileMatcherTest.kt
+++ b/utils/src/test/kotlin/FileMatcherTest.kt
@@ -50,6 +50,18 @@ class FileMatcherTest : WordSpec({
                 defaultMatcher.matches(it) shouldBe true
             }
         }
+
+        "match commonly used license file paths in lower-case" {
+            COMMONLY_USED_LICENSE_FILE_NAMES.map { it.toLowerCase() }.forAll {
+                defaultMatcher.matches(it) shouldBe true
+            }
+        }
+
+        "match commonly used license file paths in capital (case)" {
+            COMMONLY_USED_LICENSE_FILE_NAMES.map { it.capitalize() }.forAll {
+                defaultMatcher.matches(it) shouldBe true
+            }
+        }
     }
 
     "matches" should {

--- a/utils/src/test/kotlin/FileMatcherTest.kt
+++ b/utils/src/test/kotlin/FileMatcherTest.kt
@@ -74,5 +74,17 @@ class FileMatcherTest : WordSpec({
                 matches("c/LICENSE") shouldBe false
             }
         }
+
+        "adhere to the case-sensitivity" {
+            FileMatcher("LICENSE", caseSensitive = true).apply {
+                matches("LICENSE") shouldBe true
+                matches("license") shouldBe false
+            }
+
+            FileMatcher("LICENSE", caseSensitive = false).apply {
+                matches("LICENSE") shouldBe true
+                matches("license") shouldBe true
+            }
+        }
     }
 })

--- a/utils/src/test/kotlin/FileMatcherTest.kt
+++ b/utils/src/test/kotlin/FileMatcherTest.kt
@@ -20,33 +20,34 @@
 package org.ossreviewtoolkit.utils
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.inspectors.forAll
 import io.kotest.matchers.shouldBe
+
+private val COMMONLY_USED_LICENSE_FILE_NAMES = listOf(
+    "copying",
+    "copyright",
+    "licence",
+    "licence.extension",
+    "licencesuffix",
+    "license",
+    "license.extension",
+    "licensesuffix",
+    "filename.license",
+    "patents",
+    "readme",
+    "readme.extension",
+    "readmesuffix",
+    "unlicence",
+    "unlicense"
+)
 
 class FileMatcherTest : WordSpec({
     val defaultMatcher = FileMatcher.LICENSE_FILE_MATCHER
 
     "default license file matcher" should {
-        "match commonly used license file paths" {
-            with(defaultMatcher) {
-                matches("LICENSE") shouldBe true
-                matches("LICENSE.BSD") shouldBe true
-                // TODO: add more important license file names
-            }
-        }
-
-        "match relative and absolute paths to LICENSE file also in subdirectories as expected" {
-            with(defaultMatcher) {
-                matches("LICENSE") shouldBe true
-                matches("path/LICENSE") shouldBe false
-                matches("prefixLICENSE") shouldBe false
-
-                matches("/LICENSE") shouldBe false
-                matches("/path/LICENSE") shouldBe false
-                matches("/prefixLICENSE") shouldBe false
-
-                matches("./LICENSE") shouldBe false
-                matches("./path/LICENSE") shouldBe false
-                matches("./prefixLICENSE") shouldBe false
+        "match commonly used license file paths in upper-case" {
+            COMMONLY_USED_LICENSE_FILE_NAMES.map { it.toUpperCase() }.forAll {
+                defaultMatcher.matches(it) shouldBe true
             }
         }
     }


### PR DESCRIPTION
The `java.nio.file.PathMatcher` we used previously is incapable of
- matching `case-insensitive` (which is nice to have for matching license files)
- matching zero or many leading directories with `**/LICENSE` (which does not match `LICENSE`)

So use Springs' `AntPathMatcher` in order to eliminate these limitations, so that the patterns become compatible with
the patterns used for Git's and Mercurial's sparse checkouts.

As consequence the patterns can be shared between `FileArchiver` and the mentioned sparse checkouts in context of #3054.