### PR TITLE
Fix for unit test when running on Java 14 and on modern Linux distributions

### DIFF
--- a/analyzer/src/test/kotlin/managers/utils/NodeSupportTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/NodeSupportTest.kt
@@ -31,6 +31,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import java.io.File
+import java.net.InetSocketAddress
 
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.ProtocolProxyMap
@@ -204,8 +205,9 @@ class NodeSupportTest : WordSpec() {
                 fun ProtocolProxyMap.mapSingleValuesToString() =
                     mapValues { (_, proxies) ->
                         val (proxy, authentication) = proxies.single()
+                        val address = proxy.address() as InetSocketAddress
                         listOfNotNull(
-                            proxy.toString(),
+                            "${proxy.type()} @ ${address.hostString}:${address.port}",
                             authentication?.userName,
                             authentication?.password?.let { String(it) }
                         )

--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.utils
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldBeIn
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
@@ -243,7 +244,7 @@ class UtilsTest : WordSpec({
 
         "find system executables on non-Windows".config(enabled = !Os.isWindows) {
             getPathFromEnvironment("sh").shouldNotBeNull()
-            getPathFromEnvironment("sh") shouldBe File("/bin/sh")
+            getPathFromEnvironment("sh").toString() shouldBeIn listOf("/bin/sh", "/usr/bin/sh")
 
             getPathFromEnvironment("").shouldBeNull()
             getPathFromEnvironment("/").shouldBeNull()


### PR DESCRIPTION
This PR fixes two issues:
1. A test failure when running the NodeSupportTest on Java 14.
2. A test failure when running the UtilitsTest on Ubuntu 20.04.