### PR TITLE
FileArchiver: Archive all candidate license files, no matter of their file location

### DIFF
--- a/utils/src/main/kotlin/FileMatcher.kt
+++ b/utils/src/main/kotlin/FileMatcher.kt
@@ -19,8 +19,7 @@
 
 package org.ossreviewtoolkit.utils
 
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.LICENSE_FILENAMES
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.ROOT_LICENSE_FILENAMES
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.ALL_LICENSE_FILENAMES
 
 import org.springframework.util.AntPathMatcher
 
@@ -45,7 +44,7 @@ class FileMatcher(
          * A matcher which uses the default license file names.
          */
         val LICENSE_FILE_MATCHER = FileMatcher(
-            patterns = LICENSE_FILENAMES + ROOT_LICENSE_FILENAMES,
+            patterns = ALL_LICENSE_FILENAMES,
             ignoreCase = true // This does not have any effect when used with (case-sensitive) sparse checkouts.
         )
     }

--- a/utils/src/main/kotlin/LicenseFilenamePatterns.kt
+++ b/utils/src/main/kotlin/LicenseFilenamePatterns.kt
@@ -48,11 +48,17 @@ object LicenseFilenamePatterns {
     ).generateCapitalizationVariants()
 
     /**
+     * A list of globs that match all kind of license file names, equaling the union of [LICENSE_FILENAMES] and
+     * [ROOT_LICENSE_FILENAMES].
+     */
+    val ALL_LICENSE_FILENAMES = LICENSE_FILENAMES + ROOT_LICENSE_FILENAMES
+
+    /**
      * Return glob patterns which match all files which may contain license information residing recursively within the
      * given absolute [directory] or in any of its ancestor directories.
      */
     fun getLicenseFileGlobsForDirectory(directory: String): List<String> =
-        getFileGlobsForDirectoryAndAncestors(directory, LICENSE_FILENAMES + ROOT_LICENSE_FILENAMES)
+        getFileGlobsForDirectoryAndAncestors(directory, ALL_LICENSE_FILENAMES)
 
     /**
      * Return recursively all ancestor directories of the given absolute [directory].

--- a/utils/src/main/kotlin/storage/FileArchiver.kt
+++ b/utils/src/main/kotlin/storage/FileArchiver.kt
@@ -49,12 +49,17 @@ class FileArchiver(
 ) {
     companion object {
         private const val ARCHIVE_FILE_NAME = "archive.zip"
-        private val DEFAULT_ARCHIVE_DIR by lazy { ortDataDirectory.resolve("scanner/archive") }
+        internal val DEFAULT_ARCHIVE_DIR by lazy { ortDataDirectory.resolve("scanner/archive") }
 
         /**
          * A default [FileArchiver] that archives [license files][LICENSE_FILENAMES] in a local directory.
          */
-        val DEFAULT by lazy { FileArchiver(LICENSE_FILENAMES, LocalFileStorage(DEFAULT_ARCHIVE_DIR)) }
+        val DEFAULT by lazy {
+            FileArchiver(
+                patterns = LICENSE_FILENAMES.map { "**/$it" },
+                storage = LocalFileStorage(DEFAULT_ARCHIVE_DIR)
+            )
+        }
     }
 
     private val matcher = FileMatcher(patterns)

--- a/utils/src/main/kotlin/storage/FileArchiver.kt
+++ b/utils/src/main/kotlin/storage/FileArchiver.kt
@@ -62,7 +62,10 @@ class FileArchiver(
         }
     }
 
-    private val matcher = FileMatcher(patterns)
+    private val matcher = FileMatcher(
+        patterns = patterns,
+        ignoreCase = true
+    )
 
     /**
      * Return whether '[storagePath]/[ARCHIVE_FILE_NAME]' exists.

--- a/utils/src/test/kotlin/storage/FileArchiverTest.kt
+++ b/utils/src/test/kotlin/storage/FileArchiverTest.kt
@@ -111,5 +111,18 @@ class FileArchiverTest : StringSpec() {
                 assertFileContent("c/b")
             }
         }
+
+        "LICENSE files are archived by default, independently of the directory" {
+            createFile("LICENSE")
+            createFile("path/LICENSE")
+
+            FileArchiver.DEFAULT.archive(workingDir, "save")
+            FileArchiver.DEFAULT.unarchive(targetDir, "save")
+
+            with(targetDir) {
+                assertFileContent("LICENSE")
+                assertFileContent("path/LICENSE")
+            }
+        }
     }
 }

--- a/utils/src/test/kotlin/storage/FileArchiverTest.kt
+++ b/utils/src/test/kotlin/storage/FileArchiverTest.kt
@@ -104,10 +104,12 @@ class FileArchiverTest : StringSpec() {
             val result = archiver.unarchive(targetDir, storagePath)
 
             result shouldBe true
-            targetDir.assertFileContent("a")
-            targetDir.assertFileContent("b")
-            targetDir.assertFileContent("c/a")
-            targetDir.assertFileContent("c/b")
+            with(targetDir) {
+                assertFileContent("a")
+                assertFileContent("b")
+                assertFileContent("c/a")
+                assertFileContent("c/b")
+            }
         }
     }
 }

--- a/utils/src/test/kotlin/storage/FileArchiverTest.kt
+++ b/utils/src/test/kotlin/storage/FileArchiverTest.kt
@@ -124,5 +124,22 @@ class FileArchiverTest : StringSpec() {
                 assertFileContent("path/LICENSE")
             }
         }
+
+        "The pattern matching is case-insensitive" {
+            createFile("a/LICENSE")
+            createFile("b/License")
+            createFile("c/license")
+            createFile("d/LiCeNsE")
+
+            FileArchiver.DEFAULT.archive(workingDir, "save")
+            FileArchiver.DEFAULT.unarchive(targetDir, "save")
+
+            with(targetDir) {
+                assertFileContent("a/LICENSE")
+                assertFileContent("b/License")
+                assertFileContent("c/license")
+                assertFileContent("d/LiCeNsE")
+            }
+        }
     }
 }


### PR DESCRIPTION
To enable re-use of the archives, independent of any VCS path or project path.
This aligns with the planned nicely with the planned`scan by repository` / `sparse-checkout removal` refactoring, which aims at re-using cached scan results independently of the mentioned paths. Apart from that make the file matching case-insensitive to align with the broadened matching of the sparse-checkouts.

Note that the "readme*" files cannot be archived yet, since these would end-up in the notices.

This PR is done in the context of #3054, e.g. picking so called root license files from potentially any location.
