### PR TITLE
Jenkinsfile: Use default instead of example evaluator configurations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -412,7 +412,7 @@ pipeline {
                                 STACKTRACE_OPTION="--stacktrace"
                             fi
 
-                            /opt/ort/bin/ort $LOG_LEVEL $STACKTRACE_OPTION evaluate -i out/results/current-result.yml -o out/results/evaluator -r examples/rules.kts --license-configuration-file examples/licenses.yml
+                            /opt/ort/bin/ort $LOG_LEVEL $STACKTRACE_OPTION evaluate -i out/results/current-result.yml -o out/results/evaluator
                         '''
 
                         if (status >= ORT_FAILURE_STATUS_CODE) unstable('Rule violations found.')


### PR DESCRIPTION
Since da9fcae all global configuration files have default locations, so
use them implicitly here instead of explicitly using example files.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>