### PR TITLE
analyzer: Add Carthage package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Currently, the following package managers are supported:
 * [Bower](http://bower.io/) (JavaScript)
 * [Bundler](http://bundler.io/) (Ruby)
 * [Cargo](https://doc.rust-lang.org/cargo/) (Rust)
+* [Carthage](https://github.com/Carthage/Carthage) (iOS / Cocoa)
 * [Conan](https://conan.io/) (C / C++, *experimental* as the VCS locations often times do not contain the actual source
   code, see [issue #2037](https://github.com/oss-review-toolkit/ort/issues/2037))
 * [dep](https://golang.github.io/dep/) (Go)

--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -23,6 +23,7 @@ val jacksonVersion: String by project
 val kotlinxCoroutinesVersion: String by project
 val mavenVersion: String by project
 val mavenResolverVersion: String by project
+val mockkVersion: String by project
 val semverVersion: String by project
 val toml4jVersion: String by project
 
@@ -66,4 +67,6 @@ dependencies {
 
     implementation("org.gradle:gradle-tooling-api:${gradle.gradleVersion}")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
+
+    testImplementation("io.mockk:mockk:$mockkVersion")
 }

--- a/analyzer/src/funTest/assets/projects/synthetic/carthage-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/carthage-expected-output.yml
@@ -1,0 +1,123 @@
+---
+project:
+  id: "Carthage:oss-review-toolkit:ort:"
+  definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scopes: []
+packages:
+- id: "Carthage::binaryspec:1.0.0"
+  purl: "pkg:carthage/binaryspec@1.0.0"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: ""
+  binary_artifact:
+    url: "https://path/to/binary/artifact.zip"
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "Carthage:Alamofire:Alamofire:5.2.2"
+  purl: "pkg:carthage/Alamofire/Alamofire@5.2.2"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: "https://github.com/Alamofire/Alamofire"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: "Git"
+    url: "https://github.com/Alamofire/Alamofire.git"
+    revision: "5.2.2"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/Alamofire/Alamofire.git"
+    revision: "5.2.2"
+    path: ""
+- id: "Carthage:ReactiveCocoa:ReactiveCocoa:11.0.0"
+  purl: "pkg:carthage/ReactiveCocoa/ReactiveCocoa@11.0.0"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: "https://github.com/ReactiveCocoa/ReactiveCocoa"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: "Git"
+    url: "https://github.com/ReactiveCocoa/ReactiveCocoa.git"
+    revision: "11.0.0"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/ReactiveCocoa/ReactiveCocoa.git"
+    revision: "11.0.0"
+    path: ""
+- id: "Carthage:realm:realm-cocoa:v5.3.3"
+  purl: "pkg:carthage/realm/realm-cocoa@v5.3.3"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
+  homepage_url: "https://github.com/realm/realm-cocoa"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: "Git"
+    url: "https://github.com/realm/realm-cocoa.git"
+    revision: "v5.3.3"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/realm/realm-cocoa.git"
+    revision: "v5.3.3"
+    path: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/carthage/Cartfile.resolved
+++ b/analyzer/src/funTest/assets/projects/synthetic/carthage/Cartfile.resolved
@@ -1,0 +1,12 @@
+# Carthage funTest Cartfile.resolved
+# Dependencies from Github
+github "realm/realm-cocoa" "v5.3.3"
+
+# Github dependency e.g. from a Github enterprise instance
+github "https://github.com/ReactiveCocoa/ReactiveCocoa" "11.0.0"
+
+# Generic git dependencies
+git "https://github.com/Alamofire/Alamofire.git" "5.2.2"
+
+# Binary dependency as relative local file
+binary "binaryspec.json" "1.0.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/carthage/binaryspec.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/carthage/binaryspec.json
@@ -1,0 +1,3 @@
+{
+  "1.0.0": "https://path/to/binary/artifact.zip"
+}

--- a/analyzer/src/funTest/kotlin/managers/CarthageFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/CarthageFunTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+import java.io.File
+
+import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.utils.normalizeVcsUrl
+import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+import org.ossreviewtoolkit.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
+import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.patchExpectedResult
+
+class CarthageFunTest : StringSpec() {
+    private val projectDir = File("src/funTest/assets/projects/synthetic/carthage").absoluteFile
+    private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
+    private val vcsUrl = vcsDir.getRemoteUrl()
+    private val vcsRevision = vcsDir.getRevision()
+
+    init {
+        "Project dependencies are detected correctly" {
+            val cartfileResolved = projectDir.resolve("Cartfile.resolved")
+            val vcsPath = vcsDir.getPathToRoot(projectDir)
+            val expectedResult = patchExpectedResult(
+                projectDir.parentFile.resolve("carthage-expected-output.yml"),
+                definitionFilePath = "$vcsPath/Cartfile.resolved",
+                path = vcsPath,
+                revision = vcsRevision,
+                url = normalizeVcsUrl(vcsUrl)
+            )
+
+            val result = createCarthage().resolveSingleProject(cartfileResolved)
+
+            result.toYaml() shouldBe expectedResult
+        }
+    }
+
+    private fun createCarthage() =
+        Carthage("Carthage", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+}

--- a/analyzer/src/main/resources/META-INF/services/org.ossreviewtoolkit.analyzer.PackageManagerFactory
+++ b/analyzer/src/main/resources/META-INF/services/org.ossreviewtoolkit.analyzer.PackageManagerFactory
@@ -1,6 +1,7 @@
 org.ossreviewtoolkit.analyzer.managers.Bower$Factory
 org.ossreviewtoolkit.analyzer.managers.Bundler$Factory
 org.ossreviewtoolkit.analyzer.managers.Cargo$Factory
+org.ossreviewtoolkit.analyzer.managers.Carthage$Factory
 org.ossreviewtoolkit.analyzer.managers.Conan$Factory
 org.ossreviewtoolkit.analyzer.managers.DotNet$Factory
 org.ossreviewtoolkit.analyzer.managers.GoDep$Factory

--- a/analyzer/src/test/assets/carthage/Cartfile-binary.resolved
+++ b/analyzer/src/test/assets/carthage/Cartfile-binary.resolved
@@ -1,0 +1,2 @@
+# Cartfile that declares binary dependencies
+binary "https://host.tld/path/to/binary/spec.json" "1.0.0"

--- a/analyzer/src/test/assets/carthage/Cartfile-faulty.resolved
+++ b/analyzer/src/test/assets/carthage/Cartfile-faulty.resolved
@@ -1,0 +1,2 @@
+# Cartfile that declares binary dependencies
+github "user/project" "1.0.0" "comment"

--- a/analyzer/src/test/assets/carthage/Cartfile-generic-git.resolved
+++ b/analyzer/src/test/assets/carthage/Cartfile-generic-git.resolved
@@ -1,0 +1,2 @@
+# Testfile for Carthage package manager for generic git urls
+git "https://host.tld/path/to/project.git" "1.0.0"

--- a/analyzer/src/test/assets/carthage/Cartfile-github.resolved
+++ b/analyzer/src/test/assets/carthage/Cartfile-github.resolved
@@ -1,0 +1,2 @@
+# Testfile for Carthage package manager for github dependencies
+github "Alamofire/AlamofireImage" "3.2.0"

--- a/analyzer/src/test/assets/carthage/Cartfile-mixed.resolved
+++ b/analyzer/src/test/assets/carthage/Cartfile-mixed.resolved
@@ -1,0 +1,6 @@
+# Cartfile that declares multiple dependencies of mixed types
+github "user/project" "4.5.0"
+
+git "https://host.tld/path/to/git/project/user-2/project_2.git" "1.0.0"
+
+binary "https://host.tld/path/to/binary/spec.json" "1.0.0"

--- a/analyzer/src/test/assets/carthage/Carthage-binary-specification.json
+++ b/analyzer/src/test/assets/carthage/Carthage-binary-specification.json
@@ -1,0 +1,3 @@
+{
+  "1.0.0": "https://host.tld/path/to/binary/dependency.zip"
+}

--- a/analyzer/src/test/kotlin/PackageManagerTest.kt
+++ b/analyzer/src/test/kotlin/PackageManagerTest.kt
@@ -51,6 +51,7 @@ class PackageManagerTest : WordSpec({
             managedFilesByName["Bower"] should containExactly(projectDir.resolve("bower.json"))
             managedFilesByName["Bundler"] should containExactly(projectDir.resolve("Gemfile"))
             managedFilesByName["Cargo"] should containExactly(projectDir.resolve("Cargo.toml"))
+            managedFilesByName["Carthage"] should containExactly(projectDir.resolve("Cartfile.resolved"))
             managedFilesByName["Conan"] should containExactly(projectDir.resolve("conanfile.py"))
             managedFilesByName["DotNet"] should containExactly(projectDir.resolve("test.csproj"))
             managedFilesByName["GoDep"] should containExactly(projectDir.resolve("Gopkg.toml"))

--- a/analyzer/src/test/kotlin/managers/CarthageTest.kt
+++ b/analyzer/src/test/kotlin/managers/CarthageTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import io.mockk.every
+import io.mockk.mockkStatic
+
+import java.io.File
+import java.net.URL
+
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+import org.ossreviewtoolkit.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
+import org.ossreviewtoolkit.utils.test.USER_DIR
+
+class CarthageTest : WordSpec() {
+    private val carthage =
+        Carthage("Carthage", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+
+    init {
+        "resolveDependencies" should {
+            "parse a github dependency" {
+                val cartfile = File("src/test/assets/carthage/Cartfile-github.resolved")
+
+                val result = carthage.resolveDependencies(cartfile).single()
+
+                with(result.packages) {
+                    size shouldBe 1
+                    single().apply {
+                        id.type shouldBe "Carthage"
+                        vcs.url shouldBe "https://github.com/Alamofire/AlamofireImage.git"
+                        vcs.revision shouldBe "3.2.0"
+                    }
+                }
+            }
+
+            "parse a generic git dependency" {
+                val cartfile = File("src/test/assets/carthage/Cartfile-generic-git.resolved")
+
+                val result = carthage.resolveDependencies(cartfile).single()
+
+                with(result.packages) {
+                    size shouldBe 1
+                    single().apply {
+                        id.type shouldBe "Carthage"
+                        vcs.type shouldBe VcsType.GIT
+                        vcs.url shouldBe "https://host.tld/path/to/project.git"
+                        vcs.revision shouldBe "1.0.0"
+                    }
+                }
+            }
+
+            "parse a binary dependency url" {
+                mockkStatic("kotlin.io.TextStreamsKt")
+                every { URL("https://host.tld/path/to/binary/spec.json").readBytes() } returns
+                        File("src/test/assets/carthage/Carthage-binary-specification.json").readText().toByteArray()
+
+                val cartfile = File("src/test/assets/carthage/Cartfile-binary.resolved")
+
+                val result = carthage.resolveDependencies(cartfile).single()
+                with(result.packages) {
+                    size shouldBe 1
+                    single().apply {
+                        id.type shouldBe "Carthage"
+                        id.name shouldBe "spec"
+                        binaryArtifact.url shouldBe "https://host.tld/path/to/binary/dependency.zip"
+                    }
+                }
+            }
+
+            "parse mixed dependencies" {
+                mockkStatic("kotlin.io.TextStreamsKt")
+                every { URL("https://host.tld/path/to/binary/spec.json").readBytes() } returns
+                        File("src/test/assets/carthage/Carthage-binary-specification.json").readText().toByteArray()
+
+                val cartfile = File("src/test/assets/carthage/Cartfile-mixed.resolved")
+
+                val result = carthage.resolveDependencies(cartfile).single()
+
+                with(result.packages) {
+                    size shouldBe 3
+                    forEach {
+                        it.id.type shouldBe "Carthage"
+                    }
+                    count { it.vcs.url.contains("user/project") } shouldBe 1
+                    count { it.vcs.url.contains("user-2/project_2") } shouldBe 1
+                    count { it.binaryArtifact.url.contains("binary/dependency.zip") } shouldBe 1
+                }
+            }
+
+            "throw an error for a wrongly defined dependency" {
+                val cartfile = File("src/test/assets/carthage/Cartfile-faulty.resolved")
+
+                shouldThrow<IllegalArgumentException> {
+                    carthage.resolveDependencies(cartfile)
+                }
+            }
+        }
+    }
+}

--- a/downloader/src/main/kotlin/VcsHost.kt
+++ b/downloader/src/main/kotlin/VcsHost.kt
@@ -225,7 +225,7 @@ enum class VcsHost(
                             if (startLine > 0) {
                                 permalink += "#L$startLine"
 
-                                // SourceHut does not support an end line in permalinks to Mercural repos.
+                                // SourceHut does not support an end line in permalinks to Mercurial repos.
                             }
                         }
                     }

--- a/downloader/src/main/kotlin/VcsHost.kt
+++ b/downloader/src/main/kotlin/VcsHost.kt
@@ -247,9 +247,7 @@ enum class VcsHost(
          */
         fun toVcsInfo(projectUrl: String): VcsInfo {
             val vcs = try {
-                URI(projectUrl).let {
-                    values().find { host -> host.isApplicable(it) }?.toVcsInfoInternal(it)
-                }
+                URI(projectUrl).let { toVcsHost(it)?.toVcsInfoInternal(it) }
             } catch (e: URISyntaxException) {
                 null
             }
@@ -308,6 +306,11 @@ enum class VcsHost(
             return values().find { host -> host.isApplicable(vcsInfo) }
                 ?.toPermalinkInternal(vcsInfo.normalize(), startLine, endLine)
         }
+
+        /**
+         * Return the [VcsHost] for a [vcsUrl].
+         */
+        fun toVcsHost(vcsUrl: URI): VcsHost? = values().find { host -> host.isApplicable(vcsUrl) }
     }
 
     private val supportedTypes = supportedTypes.asList()

--- a/downloader/src/test/kotlin/VcsHostTest.kt
+++ b/downloader/src/test/kotlin/VcsHostTest.kt
@@ -225,7 +225,7 @@ class VcsHostTest : WordSpec({
 
             SOURCEHUT.toPermalink(vcsInfo, 9) shouldBe
                     "https://hg.sr.ht/~duangle/paniq_legacy/browse/f04521a92844/masagin/README.txt#L9"
-            // SourceHut does not support an end line in permalinks to Mercural repos.
+            // SourceHut does not support an end line in permalinks to Mercurial repos.
         }
     }
 

--- a/downloader/src/test/kotlin/VcsHostTest.kt
+++ b/downloader/src/test/kotlin/VcsHostTest.kt
@@ -20,7 +20,10 @@
 package org.ossreviewtoolkit.downloader
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
+
+import java.net.URI
 
 import org.ossreviewtoolkit.downloader.VcsHost.BITBUCKET
 import org.ossreviewtoolkit.downloader.VcsHost.GITHUB
@@ -332,6 +335,32 @@ class VcsHostTest : WordSpec({
                 path = "pom.xml"
             )
             actual shouldBe expected
+        }
+    }
+
+    "The conversion from URI to VcsHost" should {
+        "convert a Github URI" {
+            VcsHost.toVcsHost(URI("https://github.com/oss-review-toolkit/ort")) shouldBe GITHUB
+        }
+
+        "convert a Gitlab URI" {
+            VcsHost.toVcsHost(URI("https://gitlab.com/gitlab-org/gitlab")) shouldBe GITLAB
+        }
+
+        "convert a Bitbucket URI" {
+            VcsHost.toVcsHost(URI("https://bitbucket.org/yevster/spdxtraxample")) shouldBe BITBUCKET
+        }
+
+        "convert a SourceHut git URI" {
+            VcsHost.toVcsHost(URI("https://git.sr.ht/~sircmpwn/sourcehut.org")) shouldBe SOURCEHUT
+        }
+
+        "convert a SourceHut hg URI" {
+            VcsHost.toVcsHost(URI("https://hg.sr.ht/~sircmpwn/invertbucket")) shouldBe SOURCEHUT
+        }
+
+        "handle an unknown URI" {
+            VcsHost.toVcsHost(URI("https://host.tld/path/to/repo")).shouldBeNull()
         }
     }
 })


### PR DESCRIPTION
Carthage is a package manager for Cocoa applications.
See: https://github.com/Carthage/Carthage
The implementation supports 3 types of dependencies:
* github: Dependencies specified by the Github user and project name.
* git: Generic git dependencies from any git service.
* binary: Dependencies that are only available as compiled binaries.
See: https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#binary-only-frameworks

Resolves #725

An example Cartfile can be found here: https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#example-cartfile