### PR TITLE
cli: Fix reading the configuration from GlobalOptions

### DIFF
--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -39,9 +39,9 @@ import java.io.File
 import kotlin.time.TimedValue
 import kotlin.time.measureTimedValue
 
+import org.ossreviewtoolkit.GlobalOptions
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
-import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.Resolutions
 import org.ossreviewtoolkit.model.config.orEmpty
 import org.ossreviewtoolkit.model.licenses.DefaultLicenseInfoProvider
@@ -193,7 +193,7 @@ class ReporterCommand : CliktCommand(
         upperCaseFormat to Pair(option.substringBefore("="), option.substringAfter("=", ""))
     }.multiple()
 
-    private val config by requireObject<OrtConfiguration>()
+    private val globalOptionsForSubcommands by requireObject<GlobalOptions>()
 
     override fun run() {
         var ortResult = ortFile.readValue<OrtResult>()
@@ -212,7 +212,7 @@ class ReporterCommand : CliktCommand(
         val licenseInfoResolver = LicenseInfoResolver(
             provider = DefaultLicenseInfoProvider(ortResult, packageConfigurationProvider),
             copyrightGarbage = copyrightGarbage,
-            archiver = config.scanner?.archive?.createFileArchiver() ?: FileArchiver.DEFAULT
+            archiver = globalOptionsForSubcommands.config.scanner?.archive?.createFileArchiver() ?: FileArchiver.DEFAULT
         )
 
         val licenseConfiguration =
@@ -226,7 +226,7 @@ class ReporterCommand : CliktCommand(
 
         val input = ReporterInput(
             ortResult,
-            config,
+            globalOptionsForSubcommands.config,
             packageConfigurationProvider,
             resolutionProvider,
             DefaultLicenseTextProvider(customLicenseTextsDir.takeIf { it.isDirectory }),

--- a/cli/src/main/kotlin/commands/UploadResultCommand.kt
+++ b/cli/src/main/kotlin/commands/UploadResultCommand.kt
@@ -31,8 +31,8 @@ import java.sql.DriverManager
 import java.sql.SQLException
 import java.util.Properties
 
+import org.ossreviewtoolkit.GlobalOptions
 import org.ossreviewtoolkit.model.OrtResult
-import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.PostgresStorageConfiguration
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.readValue
@@ -66,12 +66,12 @@ class UploadResultCommand : CliktCommand(
         help = "The name of the JSONB column to store the ORT result."
     ).required()
 
-    private val config by requireObject<OrtConfiguration>()
+    private val globalOptionsForSubcommands by requireObject<GlobalOptions>()
 
     override fun run() {
         val ortResult = ortFile.readValue<OrtResult>()
 
-        val postgresConfig = config.scanner?.postgresStorage
+        val postgresConfig = globalOptionsForSubcommands.config.scanner?.postgresStorage
 
         requireNotNull(postgresConfig) {
             "No PostgreSQL storage is configured for the scanner."


### PR DESCRIPTION
Use the `GlobalOptions` in the `ReporterCommand` and
`UploadResultCommand`. Otherwise these command fail with a
`NullPointerException`.

This is a fixup for 5f7ebe5.