### PR TITLE
Gradle: Upgrade dokka to version 1.4.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 # License-Filename: LICENSE
 
 detektPluginVersion = 1.13.1
-dokkaPluginVersion = 1.4.0
+dokkaPluginVersion = 1.4.10
 ideaExtPluginVersion = 0.9
 kotlinPluginVersion = 1.4.10
 reckonPluginVersion = 0.12.0


### PR DESCRIPTION
Note that, contrary to stated in 20729b0, all dokka version supporting
Kotlin 1.4 are still considered "alpha", also see

https://github.com/Kotlin/dokka/issues/1434#issuecomment-687050994

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>