### PR TITLE
ScannerCommand: Rename a variable

### DIFF
--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -161,8 +161,8 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run existing copyrigh
             "The download directory '$downloadDir' must not exist yet."
         }
 
-        val scannerConfiguration = globalOptionsForSubcommands.config
-        val scanner = configureScanner(scannerConfiguration.scanner)
+        val config = globalOptionsForSubcommands.config
+        val scanner = configureScanner(config.scanner)
 
         val ortResult = if (input.isFile) {
             scanner.scanOrtResult(


### PR DESCRIPTION
"config" is a better name, because the type is `OrtConfiguration`, not
`ScannerConfiguration`.