### PR TITLE
Add a hierarchical heuristic for determining the root license files

### DIFF
--- a/model/src/test/kotlin/RootLicenseMatcherTest.kt
+++ b/model/src/test/kotlin/RootLicenseMatcherTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
+
+class RootLicenseMatcherTest : WordSpec({
+    "getApplicableLicenseFilesForDirectories" should {
+        "override license files of ancestors as expected" {
+            RootLicenseMatcher().getApplicableLicenseFilesForDirectories(
+                licenseFindings = licenseFindings(
+                    "README",
+                    "PATENTS",
+                    "a/LICENSE",
+                    "a/a/README",
+                    "a/a/a/LICENSE",
+                    "a/a/a/a/PATENTS"
+                ),
+                directories = listOf("", "a", "a/a", "a/a/a", "a/a/a/a")
+            ).paths() shouldBe mapOf(
+                "" to setOf("PATENTS", "README"),
+                "a" to setOf("a/LICENSE", "PATENTS"),
+                "a/a" to setOf("a/LICENSE", "PATENTS"),
+                "a/a/a" to setOf("a/a/a/LICENSE", "PATENTS"),
+                "a/a/a/a" to setOf("a/a/a/LICENSE", "a/a/a/a/PATENTS"),
+            )
+        }
+
+        "not use the readme if there is a license file" {
+            RootLicenseMatcher().getApplicableLicenseFilesForDirectories(
+                licenseFindings = licenseFindings(
+                    "README",
+                    "LICENSE"
+                ),
+                directories = listOf("")
+            ).paths() shouldBe mapOf("" to setOf("LICENSE"))
+        }
+
+        "use the readme if there is no license but a patents file" {
+            RootLicenseMatcher().getApplicableLicenseFilesForDirectories(
+                licenseFindings = licenseFindings(
+                    "README",
+                    "PATENTS"
+                ),
+                directories = listOf("")
+            ).paths() shouldBe mapOf("" to setOf("PATENTS", "README"))
+        }
+    }
+})
+
+private fun licenseFindings(vararg paths: String): List<LicenseFinding> =
+    paths.map {
+        LicenseFinding(
+            license = "LicenseRef-not-relevant",
+            location = TextLocation(it, startLine = 1, endLine = 2)
+        )
+    }
+
+private fun Map<String, Collection<LicenseFinding>>.paths(): Map<String, Set<String>> =
+    mapValues { (_, licenseFindings) ->
+        licenseFindings.mapTo(mutableSetOf()) { it.location.path }
+    }

--- a/utils/src/main/kotlin/LicenseFilenamePatterns.kt
+++ b/utils/src/main/kotlin/LicenseFilenamePatterns.kt
@@ -93,7 +93,7 @@ object LicenseFilenamePatterns {
      * Return glob patterns which match files in [directory], in any ancestor directory of [directory] recursively
      * and in any sub-directory of directory, if the filename matches any of the [filenamePatterns].
      */
-    fun getFileGlobsForDirectoryAndAncestors(directory: String, filenamePatterns: List<String>): List<String> {
+    internal fun getFileGlobsForDirectoryAndAncestors(directory: String, filenamePatterns: List<String>): List<String> {
         val patternsForDir = filenamePatterns.map {
             getFileGlobForDirectory(File(directory).invariantSeparatorsPath, it, true)
         }

--- a/utils/src/main/kotlin/LicenseFilenamePatterns.kt
+++ b/utils/src/main/kotlin/LicenseFilenamePatterns.kt
@@ -67,22 +67,6 @@ object LicenseFilenamePatterns {
         getFileGlobsForDirectoryAndAncestors(directory, ALL_LICENSE_FILENAMES)
 
     /**
-     * Return recursively all ancestor directories of the given absolute [file], ordered along the path from
-     * the parent of [file] to the root.
-     */
-    internal fun getAllAncestorDirectories(file: String): List<String> {
-        val result = mutableListOf<String>()
-
-        var ancestorDir = File(file).parentFile
-        while (ancestorDir != null) {
-            result += ancestorDir.invariantSeparatorsPath
-            ancestorDir = ancestorDir.parentFile
-        }
-
-        return result
-    }
-
-    /**
      * Return a glob pattern which matches files in [directory], in any ancestor directory of [directory] and
      * [optionally][matchSubDirs] recursively in any sub-directory of directory, if the filename matches the
      * [filenamePattern].

--- a/utils/src/main/kotlin/LicenseFilenamePatterns.kt
+++ b/utils/src/main/kotlin/LicenseFilenamePatterns.kt
@@ -34,9 +34,15 @@ object LicenseFilenamePatterns {
         "license*",
         "*.licence",
         "*.license",
-        "patents",
         "unlicence",
         "unlicense"
+    ).generateCapitalizationVariants()
+
+    /**
+     * A list of globs that match default patent file names.
+     */
+    val PATENT_FILENAMES = listOf(
+        "patents"
     ).generateCapitalizationVariants()
 
     /**
@@ -48,10 +54,10 @@ object LicenseFilenamePatterns {
     ).generateCapitalizationVariants()
 
     /**
-     * A list of globs that match all kind of license file names, equaling the union of [LICENSE_FILENAMES] and
-     * [ROOT_LICENSE_FILENAMES].
+     * A list of globs that match all kind of license file names, equaling the union of [LICENSE_FILENAMES],
+     * [PATENT_FILENAMES] and [ROOT_LICENSE_FILENAMES].
      */
-    val ALL_LICENSE_FILENAMES = LICENSE_FILENAMES + ROOT_LICENSE_FILENAMES
+    val ALL_LICENSE_FILENAMES = LICENSE_FILENAMES + PATENT_FILENAMES + ROOT_LICENSE_FILENAMES
 
     /**
      * Return glob patterns which match all files which may contain license information residing recursively within the

--- a/utils/src/main/kotlin/LicenseFilenamePatterns.kt
+++ b/utils/src/main/kotlin/LicenseFilenamePatterns.kt
@@ -61,13 +61,13 @@ object LicenseFilenamePatterns {
         getFileGlobsForDirectoryAndAncestors(directory, ALL_LICENSE_FILENAMES)
 
     /**
-     * Return recursively all ancestor directories of the given absolute [directory], ordered along the path from
-     * [directory] to the root.
+     * Return recursively all ancestor directories of the given absolute [file], ordered along the path from
+     * the parent of [file] to the root.
      */
-    internal fun getAllAncestorDirectories(directory: String): List<String> {
+    internal fun getAllAncestorDirectories(file: String): List<String> {
         val result = mutableListOf<String>()
 
-        var ancestorDir = File(directory).parentFile
+        var ancestorDir = File(file).parentFile
         while (ancestorDir != null) {
             result += ancestorDir.invariantSeparatorsPath
             ancestorDir = ancestorDir.parentFile

--- a/utils/src/main/kotlin/LicenseFilenamePatterns.kt
+++ b/utils/src/main/kotlin/LicenseFilenamePatterns.kt
@@ -61,9 +61,10 @@ object LicenseFilenamePatterns {
         getFileGlobsForDirectoryAndAncestors(directory, ALL_LICENSE_FILENAMES)
 
     /**
-     * Return recursively all ancestor directories of the given absolute [directory].
+     * Return recursively all ancestor directories of the given absolute [directory], ordered along the path from
+     * [directory] to the root.
      */
-    private fun getAllAncestorDirectories(directory: String): List<String> {
+    internal fun getAllAncestorDirectories(directory: String): List<String> {
         val result = mutableListOf<String>()
 
         var ancestorDir = File(directory).parentFile

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -320,3 +320,19 @@ fun trapSystemExitCall(block: () -> Unit): Int? {
 
     return exitCode
 }
+
+/**
+ * Return recursively all ancestor directories of the given absolute [file], ordered along the path from
+ * the parent of [file] to the root.
+ */
+fun getAllAncestorDirectories(file: String): List<String> {
+    val result = mutableListOf<String>()
+
+    var ancestorDir = File(file).parentFile
+    while (ancestorDir != null) {
+        result += ancestorDir.invariantSeparatorsPath
+        ancestorDir = ancestorDir.parentFile
+    }
+
+    return result
+}

--- a/utils/src/main/kotlin/storage/FileArchiver.kt
+++ b/utils/src/main/kotlin/storage/FileArchiver.kt
@@ -24,6 +24,7 @@ import java.io.IOException
 
 import org.ossreviewtoolkit.utils.FileMatcher
 import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.LICENSE_FILENAMES
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.PATENT_FILENAMES
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.log
@@ -56,7 +57,7 @@ class FileArchiver(
          */
         val DEFAULT by lazy {
             FileArchiver(
-                patterns = LICENSE_FILENAMES.map { "**/$it" },
+                patterns = (LICENSE_FILENAMES + PATENT_FILENAMES).map { "**/$it" },
                 storage = LocalFileStorage(DEFAULT_ARCHIVE_DIR)
             )
         }

--- a/utils/src/test/kotlin/LicenseFilenamePatternsTest.kt
+++ b/utils/src/test/kotlin/LicenseFilenamePatternsTest.kt
@@ -59,14 +59,4 @@ class LicenseFilenamePatternsTest : WordSpec({
             )
         }
     }
-
-    "getAllAncestorDirectories" should {
-        "return all ancestor directories ordered along the path to root" {
-            LicenseFilenamePatterns.getAllAncestorDirectories("/a/b/c") should containExactly(
-                "/a/b",
-                "/a",
-                "/"
-            )
-        }
-    }
 })

--- a/utils/src/test/kotlin/LicenseFilenamePatternsTest.kt
+++ b/utils/src/test/kotlin/LicenseFilenamePatternsTest.kt
@@ -59,4 +59,14 @@ class LicenseFilenamePatternsTest : WordSpec({
             )
         }
     }
+
+    "getAllAncestorDirectories" should {
+        "return all ancestor directories ordered along the path to root" {
+            LicenseFilenamePatterns.getAllAncestorDirectories("/a/b/c") should containExactly(
+                "/a/b",
+                "/a",
+                "/"
+            )
+        }
+    }
 })

--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.utils
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.shouldBeIn
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -399,6 +400,16 @@ class UtilsTest : WordSpec({
             packages.entries.forAll { (actualUrl, expectedUrl) ->
                 normalizeVcsUrl(actualUrl) shouldBe expectedUrl
             }
+        }
+    }
+
+    "getAllAncestorDirectories" should {
+        "return all ancestor directories ordered along the path to root" {
+            getAllAncestorDirectories("/a/b/c") should containExactly(
+                "/a/b",
+                "/a",
+                "/"
+            )
         }
     }
 })


### PR DESCRIPTION
This PR implements a new hierarchical heuristic based on a two pass recursive search upwards the directory tree for finding files matching a given pattern. That new heuristic is taken into use for `ScanResult.filterPath()`.

The heuristic needs to be also integrated with the `FindingsMatcher`, which is left for a following PR.

See also #3054.
