### PR TITLE
FindingsMatcher: Migrate to the RootLicenseMatcher

### DIFF
--- a/model/src/test/kotlin/RootLicenseMatcherTest.kt
+++ b/model/src/test/kotlin/RootLicenseMatcherTest.kt
@@ -20,9 +20,28 @@
 package org.ossreviewtoolkit.model
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.inspectors.forAll
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
+
+private val COMMONLY_USED_LICENSE_FILE_NAMES = listOf(
+    "copying",
+    "copyright",
+    "licence",
+    "licence.extension",
+    "licencesuffix",
+    "license",
+    "license.extension",
+    "licensesuffix",
+    "filename.license",
+    "patents",
+    "readme",
+    "readme.extension",
+    "readmesuffix",
+    "unlicence",
+    "unlicense"
+)
 
 class RootLicenseMatcherTest : WordSpec({
     "getApplicableLicenseFilesForDirectories" should {
@@ -64,6 +83,33 @@ class RootLicenseMatcherTest : WordSpec({
                 ),
                 directories = listOf("")
             ).paths() shouldBe mapOf("" to setOf("PATENTS", "README"))
+        }
+
+        "match commonly used license file paths in upper-case" {
+            COMMONLY_USED_LICENSE_FILE_NAMES.map { it.toUpperCase() }.forAll {
+                RootLicenseMatcher().getApplicableLicenseFilesForDirectories(
+                    licenseFindings = licenseFindings(it),
+                    directories = listOf("")
+                ).paths() shouldBe mapOf("" to setOf(it))
+            }
+        }
+
+        "match commonly used license file paths in lower-case" {
+            COMMONLY_USED_LICENSE_FILE_NAMES.map { it.toLowerCase() }.forAll {
+                RootLicenseMatcher().getApplicableLicenseFilesForDirectories(
+                    licenseFindings = licenseFindings(it),
+                    directories = listOf("")
+                ).paths() shouldBe mapOf("" to setOf(it))
+            }
+        }
+
+        "match commonly used license file paths in capital (case)" {
+            COMMONLY_USED_LICENSE_FILE_NAMES.map { it.capitalize() }.forAll {
+                RootLicenseMatcher().getApplicableLicenseFilesForDirectories(
+                    licenseFindings = licenseFindings(it),
+                    directories = listOf("")
+                ).paths() shouldBe mapOf("" to setOf(it))
+            }
         }
     }
 })

--- a/model/src/test/kotlin/utils/FindingsMatcherTest.kt
+++ b/model/src/test/kotlin/utils/FindingsMatcherTest.kt
@@ -80,10 +80,12 @@ class FindingsMatcherTest : WordSpec() {
 
                 val result = matcher.match(licenseFindings, copyrightFindings)
 
-                result.size shouldBe 1
-                val findings = result.getFindings("some-id")
-                findings.locations.map { it.path } should containExactlyInAnyOrder(NESTED_LICENSE_FILE_A)
-                findings.copyrights.map { it.statement } should containExactlyInAnyOrder("some stmt")
+                with(result) {
+                    result.size shouldBe 1
+                    val findings = result.getFindings("some-id")
+                    findings.locations.map { it.path } should containExactlyInAnyOrder(NESTED_LICENSE_FILE_A)
+                    findings.copyrights.map { it.statement } should containExactlyInAnyOrder("some stmt")
+                }
             }
         }
 
@@ -108,10 +110,12 @@ class FindingsMatcherTest : WordSpec() {
 
                 val result = matcher.match(licenseFindings, copyrightFindings)
 
-                result.size shouldBe 3
-                result.getFindings("license-a1").copyrights.map { it.statement } should containExactly("some stmt")
-                result.getFindings("license-a2").copyrights.map { it.statement } should containExactly("some stmt")
-                result.getFindings("license-b1").copyrights.map { it.statement } should containExactly("some stmt")
+                with(result) {
+                    size shouldBe 3
+                    getFindings("license-a1").copyrights.map { it.statement } should containExactly("some stmt")
+                    getFindings("license-a2").copyrights.map { it.statement } should containExactly("some stmt")
+                    getFindings("license-b1").copyrights.map { it.statement } should containExactly("some stmt")
+                }
             }
         }
 
@@ -130,19 +134,21 @@ class FindingsMatcherTest : WordSpec() {
 
                 val result = matcher.match(licenseFindings, copyrightFindings)
 
-                result.size shouldBe 2
-                result.flatMap { licenseFindings ->
-                    licenseFindings.copyrights.filter { it.statement == "stmt 1" }
-                } should beEmpty()
-                result.getFindings("license-nearby").copyrights.map { it.statement } should containExactlyInAnyOrder(
-                    "stmt 8",
-                    "stmt 10",
-                    "stmt 11",
-                    "stmt 12",
-                    "stmt 13",
-                    "stmt 14",
-                    "stmt 15"
-                )
+                with(result) {
+                    size shouldBe 2
+                    flatMap { licenseFindings ->
+                        licenseFindings.copyrights.filter { it.statement == "stmt 1" }
+                    } should beEmpty()
+                    getFindings("license-nearby").copyrights.map { it.statement } should containExactlyInAnyOrder(
+                        "stmt 8",
+                        "stmt 10",
+                        "stmt 11",
+                        "stmt 12",
+                        "stmt 13",
+                        "stmt 14",
+                        "stmt 15"
+                    )
+                }
             }
         }
 
@@ -176,9 +182,11 @@ class FindingsMatcherTest : WordSpec() {
 
                 val result = matcher.match(licenseFindings, copyrightFindings)
 
-                result.size shouldBe 2
-                result.getFindings("some-id").copyrights.map { it.statement } should containExactly("some stmt")
-                result.getFindings("some-other-id").copyrights.map { it.statement } should containExactly("some stmt")
+                with(result) {
+                    size shouldBe 2
+                    getFindings("some-id").copyrights.map { it.statement } should containExactly("some stmt")
+                    getFindings("some-other-id").copyrights.map { it.statement } should containExactly("some stmt")
+                }
             }
         }
 
@@ -198,11 +206,13 @@ class FindingsMatcherTest : WordSpec() {
 
                 val result = matcher.match(licenseFindings, copyrightFindings)
 
-                result.getFindings("license-nearby").copyrights.map { it.statement } should containExactlyInAnyOrder(
-                    "statement2",
-                    "statement3"
-                )
-                result.getFindings("license-far-away").copyrights should beEmpty()
+                with(result) {
+                    getFindings("license-nearby").copyrights.map { it.statement } should containExactlyInAnyOrder(
+                        "statement2",
+                        "statement3"
+                    )
+                    getFindings("license-far-away").copyrights should beEmpty()
+                }
             }
         }
 

--- a/utils/src/main/kotlin/FileMatcher.kt
+++ b/utils/src/main/kotlin/FileMatcher.kt
@@ -19,8 +19,6 @@
 
 package org.ossreviewtoolkit.utils
 
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.ALL_LICENSE_FILENAMES
-
 import org.springframework.util.AntPathMatcher
 
 /**
@@ -39,16 +37,6 @@ class FileMatcher(
      */
     ignoreCase: Boolean = false
 ) {
-    companion object {
-        /**
-         * A matcher which uses the default license file names.
-         */
-        val LICENSE_FILE_MATCHER = FileMatcher(
-            patterns = ALL_LICENSE_FILENAMES,
-            ignoreCase = true // This does not have any effect when used with (case-sensitive) sparse checkouts.
-        )
-    }
-
     constructor(vararg patterns: String, ignoreCase: Boolean = false) : this(patterns.asList(), ignoreCase)
 
     private val matcher = AntPathMatcher().apply {

--- a/utils/src/test/kotlin/FileMatcherTest.kt
+++ b/utils/src/test/kotlin/FileMatcherTest.kt
@@ -20,59 +20,9 @@
 package org.ossreviewtoolkit.utils
 
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.inspectors.forAll
 import io.kotest.matchers.shouldBe
 
-private val COMMONLY_USED_LICENSE_FILE_NAMES = listOf(
-    "copying",
-    "copyright",
-    "licence",
-    "licence.extension",
-    "licencesuffix",
-    "license",
-    "license.extension",
-    "licensesuffix",
-    "filename.license",
-    "patents",
-    "readme",
-    "readme.extension",
-    "readmesuffix",
-    "unlicence",
-    "unlicense"
-)
-
 class FileMatcherTest : WordSpec({
-    val defaultMatcher = FileMatcher.LICENSE_FILE_MATCHER
-
-    "default license file matcher" should {
-        "match commonly used license file paths in upper-case" {
-            COMMONLY_USED_LICENSE_FILE_NAMES.map { it.toUpperCase() }.forAll {
-                defaultMatcher.matches(it) shouldBe true
-            }
-        }
-
-        "match commonly used license file paths in lower-case" {
-            COMMONLY_USED_LICENSE_FILE_NAMES.map { it.toLowerCase() }.forAll {
-                defaultMatcher.matches(it) shouldBe true
-            }
-        }
-
-        "match commonly used license file paths in capital (case)" {
-            COMMONLY_USED_LICENSE_FILE_NAMES.map { it.capitalize() }.forAll {
-                defaultMatcher.matches(it) shouldBe true
-            }
-        }
-
-        "be case insensitive" {
-            with(defaultMatcher) {
-                matches("LICENSE") shouldBe true
-                matches("License") shouldBe true
-                matches("LiCeNsE") shouldBe true
-                matches("license") shouldBe true
-            }
-        }
-    }
-
     "matches" should {
         "match the given patterns" {
             val matcher = FileMatcher("a/LICENSE", "b/LICENSE")


### PR DESCRIPTION
To make use of the new hierarchical heuristic for determining which files are root license files, as we call them.

Fixes #3054.