### PR TITLE
Carthage: Add missing project info for unknown VcsHost

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/carthage-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/carthage-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "Carthage:oss-review-toolkit:ort:"
+  id: "Carthage:oss-review-toolkit:ort:<REPLACE_REVISION>"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/main/kotlin/managers/Carthage.kt
+++ b/analyzer/src/main/kotlin/managers/Carthage.kt
@@ -104,7 +104,7 @@ class Carthage(
             namespace = vcsHost?.getUserOrOrganization(normalizedVcsUrl),
             projectName = vcsHost?.getProject(normalizedVcsUrl)
                 ?: workingDir.relativeTo(analysisRoot).invariantSeparatorsPath,
-            revision = vcsInfo.resolvedRevision
+            revision = vcsInfo.revision
         )
     }
 

--- a/analyzer/src/main/kotlin/managers/Carthage.kt
+++ b/analyzer/src/main/kotlin/managers/Carthage.kt
@@ -75,8 +75,8 @@ class Carthage(
                 project = Project(
                     id = Identifier(
                         type = managerName,
-                        namespace = projectInfo.user.orEmpty(),
-                        name = projectInfo.project.orEmpty(),
+                        namespace = projectInfo.namespace.orEmpty(),
+                        name = projectInfo.projectName.orEmpty(),
                         version = projectInfo.revision.orEmpty()
                     ),
                     definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
@@ -101,8 +101,9 @@ class Carthage(
         val vcsHost = VcsHost.toVcsHost(URI(normalizedVcsUrl))
 
         return ProjectInfo(
-            user = vcsHost?.getUserOrOrganization(normalizedVcsUrl),
-            project = vcsHost?.getProject(normalizedVcsUrl),
+            namespace = vcsHost?.getUserOrOrganization(normalizedVcsUrl),
+            projectName = vcsHost?.getProject(normalizedVcsUrl)
+                ?: workingDir.relativeTo(analysisRoot).invariantSeparatorsPath,
             revision = vcsInfo.resolvedRevision
         )
     }
@@ -243,6 +244,6 @@ private enum class DependencyType {
     GITHUB, GIT, BINARY
 }
 
-private data class ProjectInfo(val user: String?, val project: String?, val revision: String?)
+private data class ProjectInfo(val namespace: String?, val projectName: String?, val revision: String?)
 
 private fun String.isComment() = trim().startsWith("#")


### PR DESCRIPTION
When using a VcsHost unknown to ORT the project name and revision are not set.
This PR fixes this by using the working dir's name as a fallback and not relying on the `resolvedRevision`