### PR TITLE
declared-license-mapping: Add 'MIT -or- Apache License 2.0'

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -299,6 +299,7 @@
 "Lesser General Public License (LGPL)": LGPL-2.1-only
 "Lesser General Public License, version 3 or greater": LGPL-3.0-or-later
 "License Agreement For Open Source Computer Vision Library (3-clause BSD License)": BSD-3-Clause
+"MIT -or- Apache License 2.0": MIT OR Apache-2.0
 "MIT / http://rem.mit-license.org": MIT
 "MIT Licence": MIT
 "MIT License (http://opensource.org/licenses/MIT)": MIT


### PR DESCRIPTION
As found in [1].

[1] https://github.com/python-trio/async_generator/blob/master/setup.py#L16

Signed-off-by: Frank Viernau <frank.viernau@here.com>