### PR TITLE
LocalScanner: Put the proper ScanCode version into ScannerDetails

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -131,7 +131,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
     /**
      * Return the actual version of the scanner, or an empty string in case of failure.
      */
-    open fun getVersion() = super.getVersion(scannerDir)
+    open fun getVersion() = getVersion(scannerDir)
 
     /**
      * Bootstrap the scanner to be ready for use, like downloading and / or configuring it.


### PR DESCRIPTION
Call the `getVersion()` implementation of the actual class as opposed to
the super class, so that an override of that function takes effect. In
particular call the implementation done in 7406b3a is now called.

The scanner version put into the scanner details were missing the hyphen
as of fff03db. When such scan result is read from the storage it causes
a Semver exception. This change fixes that problem.

Signed-off-by: Frank Viernau <frank.viernau@here.com>