### PR TITLE
Trivially align the wording of using 'sourceArtifact' vs 'vcsInfo'

### DIFF
--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -99,7 +99,7 @@ object Downloader {
     ) {
         init {
             require(sourceArtifact == null || vcsInfo == null) {
-                "Not both sourceArtifact and vcsInfo may be set."
+                "Not both 'sourceArtifact' and 'vcsInfo' may be set, as otherwise it is ambiguous which one to use."
             }
         }
     }

--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -70,8 +70,7 @@ data class Provenance(
 
     init {
         require(sourceArtifact == null || vcsInfo == null) {
-            "Provenance does not allow both 'sourceArtifact' and 'vcsInfo' to be set, otherwise it is ambiguous " +
-                    "which was used."
+            "Not both 'sourceArtifact' and 'vcsInfo' may be set, as otherwise it is ambiguous which one to use."
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>