### PR TITLE
declared-license-mapping: Adjust the entry for "EDL 1.0"

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -164,7 +164,7 @@
 "DFSG approved": LicenseRef-scancode-free-unknown
 "Dual License: CDDL 1.0 and GPL V2 with Classpath Exception": CDDL-1.0 AND GPL-2.0-only
 "Dual license consisting of the CDDL v1.1 and GPL v2": CDDL-1.1 AND GPL-2.0-only
-"EDL 1.0": LicenseRef-scancode-edl-1.0
+"EDL 1.0": BSD-3-Clause
 "EPL (Eclipse Public License), V1.0 or later": EPL-1.0
 "Eclipse Distribution License (EDL), Version 1.0": BSD-3-Clause
 "Eclipse Distribution License (New BSD License)": BSD-3-Clause


### PR DESCRIPTION
When a license rule for 'edl-1.0' is triggered in ScanCode (3.2.1rc2), it
does not report 'edl-1.0' as detected license but 'bsd-new'. This is
because 'edl-1.0' is internally mapped due to the mapping entry defined
in [1]. Since 'bsd-new' has 'BSD-3-Clause' set as 'spdx_license_key' [2],
ORT uses that SPDX license ID. Furthermore ORT's license text import task
[3] won't generate a license text resource for 'bsd-new', and thus
mapping the entry to 'LicenseRef-scancode-bsd-new' is not an option.

Mapping "EDL 1.0" to "BSD-3-Clause" anyhow aligns best with ScanCode and
with how ORT integrates ScanCode.

[1] https://github.com/nexB/scancode-toolkit/blob/v3.2.1rc2/src/licensedcode/data/rules/edl-1.0.yml
[2] https://github.com/nexB/scancode-toolkit/blob/v3.2.1rc2/src/licensedcode/data/licenses/bsd-new.yml
[3] ./gradlew spdx-utils:generateLicenseRefTextResources

Signed-off-by: Frank Viernau <frank.viernau@here.com>