### PR TITLE
Dockerfile: Configure ScanCode to use Python 3 even if Python 2 is installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ RUN /opt/ort/bin/import_proxy_certs.sh && \
     # Add scanners (in versions known to work).
     curl -ksSL https://github.com/nexB/scancode-toolkit/archive/v$SCANCODE_VERSION.tar.gz | \
         tar -zxC /usr/local && \
-        # Trigger configuration for end-users.
+        # Trigger ScanCode configuration for Python 3 and reindex licenses initially.
         PYTHON_EXE=/usr/bin/python3 /usr/local/scancode-toolkit-$SCANCODE_VERSION/scancode --reindex-licenses && \
         chmod -R o=u /usr/local/scancode-toolkit-$SCANCODE_VERSION && \
         ln -s /usr/local/scancode-toolkit-$SCANCODE_VERSION/scancode /usr/local/bin/scancode

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,7 +145,7 @@ RUN /opt/ort/bin/import_proxy_certs.sh && \
     curl -ksSL https://github.com/nexB/scancode-toolkit/archive/v$SCANCODE_VERSION.tar.gz | \
         tar -zxC /usr/local && \
         # Trigger configuration for end-users.
-        /usr/local/scancode-toolkit-$SCANCODE_VERSION/scancode --version && \
+        PYTHON_EXE=/usr/bin/python3 /usr/local/scancode-toolkit-$SCANCODE_VERSION/scancode --version && \
         chmod -R o=u /usr/local/scancode-toolkit-$SCANCODE_VERSION && \
         ln -s /usr/local/scancode-toolkit-$SCANCODE_VERSION/scancode /usr/local/bin/scancode
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,7 +145,7 @@ RUN /opt/ort/bin/import_proxy_certs.sh && \
     curl -ksSL https://github.com/nexB/scancode-toolkit/archive/v$SCANCODE_VERSION.tar.gz | \
         tar -zxC /usr/local && \
         # Trigger configuration for end-users.
-        PYTHON_EXE=/usr/bin/python3 /usr/local/scancode-toolkit-$SCANCODE_VERSION/scancode --version && \
+        PYTHON_EXE=/usr/bin/python3 /usr/local/scancode-toolkit-$SCANCODE_VERSION/scancode --reindex-licenses && \
         chmod -R o=u /usr/local/scancode-toolkit-$SCANCODE_VERSION && \
         ln -s /usr/local/scancode-toolkit-$SCANCODE_VERSION/scancode /usr/local/bin/scancode
 


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>