### PR TITLE
declared-license-mapping: Add an entry for the JDOM license

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -362,6 +362,7 @@
 "SIL Open Font License 1.1 (OFL-1.1)": OFL-1.1
 "Scala License": Apache-2.0 AND BSD-3-Clause AND MIT
 "Sequence Library License (BSD-like)": BSD-3-Clause
+"Similar to Apache License but with the acknowledgment clause removed": LicenseRef-scancode-jdom
 "Simplified BSD License": BSD-2-Clause
 "Simplified BSD Liscence": BSD-2-Clause
 "Simplified BSD": BSD-2-Clause


### PR DESCRIPTION
As found in [1], see also [2][3].

[1] https://repo.maven.apache.org/maven2/org/jdom/jdom/1.1.3/jdom-1.1.3.pom
[2] https://github.com/nexB/scancode-toolkit/blob/v3.2.1rc2/src/licensedcode/data/licenses/jdom.LICENSE
[3] https://github.com/nexB/scancode-toolkit/blob/v3.2.1rc2/src/licensedcode/data/licenses/jdom.yml

Signed-off-by: Frank Viernau <frank.viernau@here.com>