### PR TITLE
Travis: Skip CI runs if only Markdown files are modified

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,10 @@ addons:
       - lib32stdc++6
 
 before_install:
+  - if [ -z $(git diff --name-only --diff-filter=d $TRAVIS_COMMIT_RANGE | grep -v "\.md$") ]; then
+        echo "Only Markdown files were modified, skipping CI run.";
+        exit;
+    fi
   - sudo rm -f $JAVA_HOME/lib/security/cacerts
   - sudo ln -s /etc/ssl/certs/java/cacerts $JAVA_HOME/lib/security/cacerts
 


### PR DESCRIPTION
Markdown files are not checked by our regular Gradle build, so there is
no value in triggering it. Instead, rely on the Markdown links check run
by GitHub actions.

If this works as expected we can apply the same logic to other CI runs,
like AppVeyor.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>