### PR TITLE
AppVeyor: Skip CI runs if only Markdown files are modified

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,9 @@
 skip_branch_with_pr: true
 
+skip_commits:
+  files:
+    - '**/*.md'
+
 environment:
   HOME: $(HOMEDRIVE)$(HOMEPATH)
   BOWER_VERSION: 1.8.8


### PR DESCRIPTION
Analog to Travis in 52f5e7a. Also see

https://www.appveyor.com/docs/how-to/filtering-commits/#commit-files-github-and-bitbucket-only

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>