### PR TITLE
npm: Handle empty version number

### DIFF
--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -463,7 +463,7 @@ open class Npm(
 
         return ModuleInfo(
             name = json["name"].textValue(),
-            version = json["version"].textValue(),
+            version = json["version"]?.textValue() ?: "0.0.0",
             dependencyNames = scopes.map { scope ->
                 json[scope]?.fieldNames()?.asSequence()?.toSet().orEmpty()
             }.flatten().toSet()


### PR DESCRIPTION
We had an exception in a project where no version number was given which lead to a `NullPointerException`.

Not sure if this is the best default value or we should just leave it empty as the identifier omits it anyway.