### PR TITLE
Npm: Do not throw a NullPointerException for missing name or version

### DIFF
--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -461,9 +461,23 @@ open class Npm(
         val packageJsonFile = moduleDir.resolve("package.json")
         val json = jsonMapper.readTree(packageJsonFile)
 
+        val name = json["name"].textValueOrEmpty()
+        if (name.isBlank()) {
+            log.warn {
+                "The '$packageJsonFile' does not set a name, which is only allowed for unpublished packages."
+            }
+        }
+
+        val version = json["version"].textValueOrEmpty()
+        if (version.isBlank()) {
+            log.warn {
+                "The '$packageJsonFile' does not set a version, which is only allowed for unpublished packages."
+            }
+        }
+
         return ModuleInfo(
-            name = json["name"].textValue(),
-            version = json["version"].textValue(),
+            name = name,
+            version = version,
             dependencyNames = scopes.map { scope ->
                 json[scope]?.fieldNames()?.asSequence()?.toSet().orEmpty()
             }.flatten().toSet()


### PR DESCRIPTION
While it is correct that for *published* NPM packages the name and
version are required [1], a user may want to run the analyzer on local
source code of an unpublished NPM package, in which case both name and
version are optional, so simply use an empty string in that case.

[1] https://docs.npmjs.com/files/package.json#version

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>