### PR TITLE
Rework mapping of Identifiers to ClearlyDefined

### DIFF
--- a/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
@@ -77,8 +77,8 @@ class ClearlyDefinedPackageCurationProvider(server: Server = Server.PRODUCTION) 
     private val service = ClearlyDefinedService.create(server, OkHttpClientHelper.buildClient())
 
     override fun getCurationsFor(pkgId: Identifier): List<PackageCuration> {
+        val (type, provider) = pkgId.toClearlyDefinedTypeAndProvider() ?: return emptyList()
         val namespace = pkgId.namespace.takeUnless { it.isEmpty() } ?: "-"
-        val (type, provider) = pkgId.toClearlyDefinedTypeAndProvider()
         val curationCall = service.getCuration(type, provider, namespace, pkgId.name, pkgId.version)
 
         val response = try {

--- a/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
+++ b/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
@@ -65,7 +65,7 @@ private fun VcsInfo.toVcsInfoCurationData(): VcsInfoCurationData =
 /**
  * Generate the coordinates for ClearlyDefined based on the [id], the [vcs], and a [sourceArtifact].
  * If information about a Git repository in GitHub is available, this is used. Otherwise, the coordinates
- * are derived from the identifier.
+ * are derived from the identifier. Throws [IllegalArgumentException] if generating coordinates is not possible.
  */
 private fun packageCoordinates(
     id: Identifier,
@@ -74,6 +74,7 @@ private fun packageCoordinates(
 ): ClearlyDefinedService.Coordinates {
     val sourceLocation = id.toClearlyDefinedSourceLocation(vcs?.toVcsInfoCurationData(), sourceArtifact)
     return sourceLocation?.toCoordinates() ?: id.toClearlyDefinedCoordinates()
+        ?: throw IllegalArgumentException("Unable to create ClearlyDefined coordinates for '${id.toCoordinates()}'.")
 }
 
 /**


### PR DESCRIPTION
Stop requiring to be able to map any ORT Identifier to a ClearlyDefined
type and provider, as e.g. any Identifier originating from the
SpdxDocumentFile "package manager" simply is not mappable. Make
Identifier.toClearlyDefinedTypeAndProvider() nullable instead and handle
that case in the callers in the respective proper ways.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>