### PR TITLE
Use `distinct` only if a list is required

### DIFF
--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -92,7 +92,7 @@ class GoMod(
             val edges = getDependencyGraph(projectDir)
             val vendorModules = getVendorModules(projectDir)
 
-            val projectName = edges.getNodes().filter { it.version.isBlank() }.distinct().let { idsWithoutVersion ->
+            val projectName = edges.getNodes().filter { it.version.isBlank() }.toSet().let { idsWithoutVersion ->
                 require(idsWithoutVersion.size == 1) {
                     "Expected exactly one unique package without version but got ${idsWithoutVersion.joinToString()}."
                 }

--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -364,7 +364,7 @@ class MavenSupport(workspaceReader: WorkspaceReader) {
         val artifactDescriptorRequest = ArtifactDescriptorRequest(artifact, repositories, "project")
         val artifactDescriptorResult = repoSystem
             .readArtifactDescriptor(repositorySystemSession, artifactDescriptorRequest)
-        val allRepositories = (artifactDescriptorResult.repositories + repositories).distinct()
+        val allRepositories = (artifactDescriptorResult.repositories + repositories).toSet()
 
         // Filter out local repositories, as remote artifacts should never point to files on the local disk.
         val remoteRepositories = allRepositories.filterNot {

--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -126,7 +126,7 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
     private val globalOptionsForSubcommands by requireObject<GlobalOptions>()
 
     override fun run() {
-        val outputFiles = outputFormats.distinct().map { format ->
+        val outputFiles = outputFormats.toSet().map { format ->
             outputDir.resolve("analyzer-result.${format.fileExtension}")
         }
 

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -163,7 +163,7 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate rules 
         val outputFiles = mutableListOf<File>()
 
         outputDir?.let { absoluteOutputDir ->
-            outputFiles += outputFormats.distinct().map { format ->
+            outputFiles += outputFormats.toSet().map { format ->
                 absoluteOutputDir.resolve("evaluation-result.${format.fileExtension}")
             }
 

--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -142,7 +142,7 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run existing copyrigh
     override fun run() {
         val nativeOutputDir = outputDir.resolve("native-scan-results")
 
-        val outputFiles = outputFormats.distinct().map { format ->
+        val outputFiles = outputFormats.toSet().map { format ->
             outputDir.resolve("scan-result.${format.fileExtension}")
         }
 

--- a/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
@@ -95,7 +95,7 @@ internal class GenerateTimeoutErrorResolutionsCommand : CliktCommand(
                 reason = IssueResolutionReason.SCANNER_ISSUE,
                 comment = "TODO"
             )
-        }.distinct().sortedBy { it.message }
+        }.toSet().sortedBy { it.message }
 
         println(yamlMapper.writeValueAsString(generatedResolutions))
     }

--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -288,7 +288,7 @@ private fun Collection<TextLocation>.groupByText(baseDir: File): List<TextLocati
         }
     }
 
-    val unresolvedLocations = (this - resolvedLocations.values.flatten()).distinct()
+    val unresolvedLocations = (this - resolvedLocations.values.flatten()).toSet()
 
     return resolvedLocations.map { (text, locations) -> TextLocationGroup(locations = locations, text = text) } +
             unresolvedLocations.map { TextLocationGroup(locations = setOf(it)) }

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -296,7 +296,7 @@ internal fun OrtResult.getLicenseFindingsById(
             scanResult.summary.licenseFindings.let { findings ->
                 if (applyCurations) {
                     FindingCurationMatcher().applyAll(findings, getLicenseFindingsCurations(scanResult.provenance))
-                        .mapNotNull { it.curatedFinding }.distinct()
+                        .mapNotNull { it.curatedFinding }.toSet()
                 } else {
                     findings
                 }

--- a/model/src/main/kotlin/ScanResult.kt
+++ b/model/src/main/kotlin/ScanResult.kt
@@ -72,7 +72,7 @@ data class ScanResult(
         val licenseFindings = summary.licenseFindings.filter { it.location.matchesPath() }.toSortedSet()
         val copyrightFindings = summary.copyrightFindings.filter { it.location.matchesPath() }.toSortedSet()
         val fileCount = (licenseFindings.map { it.location.path } + copyrightFindings.map { it.location.path })
-            .distinct().size
+            .toSet().size
 
         val summary = summary.copy(
             fileCount = fileCount,

--- a/model/src/main/kotlin/licenses/LicenseView.kt
+++ b/model/src/main/kotlin/licenses/LicenseView.kt
@@ -94,7 +94,7 @@ class LicenseView(vararg licenseSources: Set<LicenseSource>) {
                     LicenseSource.DECLARED -> declaredLicenses
                     LicenseSource.DETECTED -> detectedLicenses
                     LicenseSource.CONCLUDED -> concludedLicenses
-                }.map { license -> Pair(license, source) }.distinct()
+                }.map { license -> Pair(license, source) }.toSet()
             }
 
         licenseSources.forEach { sources ->

--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -91,7 +91,7 @@ class FindingsMatcher(
         licenseStartLine: Int,
         licenseEndLine: Int
     ): Set<CopyrightFinding> {
-        require(copyrights.map { it.location.path }.distinct().size <= 1) {
+        require(copyrights.map { it.location.path }.toSet().size <= 1) {
             "Given copyright statements must all point to the same file."
         }
 

--- a/reporter/src/main/kotlin/reporters/SpdxDocumentReporter.kt
+++ b/reporter/src/main/kotlin/reporters/SpdxDocumentReporter.kt
@@ -60,8 +60,8 @@ class SpdxDocumentReporter : Reporter {
         val outputFileFormats = options[OPTION_OUTPUT_FILE_FORMATS]
             ?.split(",")
             ?.map { FileFormat.valueOf(it.toUpperCase()) }
-            ?.distinct()
-            ?: listOf(FileFormat.YAML)
+            ?.toSet()
+            ?: setOf(FileFormat.YAML)
 
         val params = SpdxDocumentModelMapper.SpdxDocumentParams(
             documentName = options.getOrDefault(OPTION_DOCUMENT_NAME, DOCUMENT_NAME_DEFAULT_VALUE),

--- a/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
@@ -147,7 +147,7 @@ class ReportTableModelMapper(
 
                 val scanIssues = scanResult?.results?.flatMap {
                     it.summary.issues
-                }?.distinct().orEmpty()
+                }?.toSet().orEmpty()
 
                 val packageForId = ortResult.getPackage(id)?.pkg ?: ortResult.getProject(id)?.toPackage()
 

--- a/reporter/src/main/kotlin/utils/SpdxDocumentModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/SpdxDocumentModelMapper.kt
@@ -188,7 +188,7 @@ private fun getSpdxCopyrightText(
 ): String {
     val copyrightStatements = ortResult.getDetectedLicensesWithCopyrights(id, packageConfigurationProvider)
         .flatMap { it.value }
-        .distinct()
+        .toSet()
         .sorted()
 
     return if (copyrightStatements.isNotEmpty()) {

--- a/scanner/src/test/kotlin/scanners/ScanCodeResultParserTest.kt
+++ b/scanner/src/test/kotlin/scanners/ScanCodeResultParserTest.kt
@@ -678,7 +678,7 @@ class ScanCodeResultParserTest : WordSpec({
                 generateSummary(Instant.now(), Instant.now(), resultFile, result)
                     .copyrightFindings
 
-            actualFindings.map { it.statement }.distinct() should containExactlyInAnyOrder(
+            actualFindings.map { it.statement }.toSet() should containExactlyInAnyOrder(
                 "Copyright (c) 2016 Amazon.com, Inc.",
                 "Copyright (c) 2016. Amazon.com, Inc.",
                 "Copyright 2010-2017 Amazon.com, Inc.",

--- a/utils/src/main/kotlin/DeclaredLicenseProcessor.kt
+++ b/utils/src/main/kotlin/DeclaredLicenseProcessor.kt
@@ -95,13 +95,13 @@ object DeclaredLicenseProcessor {
         val processedLicenses = mutableMapOf<String, SpdxExpression>()
         val unmapped = mutableListOf<String>()
 
-        declaredLicenses.distinct().forEach { declaredLicense ->
+        declaredLicenses.toSet().forEach { declaredLicense ->
             process(declaredLicense, declaredLicenseMapping)?.let {
                 processedLicenses[declaredLicense] = it
             } ?: run { unmapped += declaredLicense }
         }
 
-        val spdxExpression = processedLicenses.values.distinct().filter {
+        val spdxExpression = processedLicenses.values.toSet().filter {
             it.toString() != SpdxConstants.NONE
         }.reduceOrNull { left, right -> left and right }
 


### PR DESCRIPTION
The `distinct` function converts a collection first to a set to
eliminate duplicate entries, and then to a list. Therefore use
`distinct` only if the `List` type is required, otherwise use `toSet` to
avoid the duplicate conversion. Note that both functions preserve the 
iteration order.