### PR TITLE
NuGet: Support multiple configured NuGet indices

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
@@ -149,5 +149,5 @@ issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "NuGet"
   message: "Failed to get package data for 'NuGet::foobar:1.2.3': IOException: Failed\
-    \ to get a response body from 'https://api.nuget.org/v3/registration5-gz-semver2/foobar/1.2.3.json'."
+    \ to retrieve package data for 'foobar' from any of [https://api.nuget.org/v3/registration5-gz-semver2]."
   severity: "ERROR"

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
@@ -149,5 +149,6 @@ issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "NuGet"
   message: "Failed to get package data for 'NuGet::foobar:1.2.3': IOException: Failed\
-    \ to retrieve package data for 'foobar' from any of [https://api.nuget.org/v3/registration5-gz-semver2]."
+    \ to retrieve package data for 'foobar' from any of [https://api.nuget.org/v3/registration5-gz-semver2,\
+    \ https://pkgs.dev.azure.com/ms/20953fb4-d427-4ad6-b78c-13142d0c5462/_packaging/64e3bf16-3e04-41cd-b90f-60fdc9ccf494/nuget/v3/registrations2-semver2]."
   severity: "ERROR"

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet/nuget.config
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet/nuget.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!-- Ignore previously configured packageSources. -->
+    <clear />
+
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="TerminalDependencies" value="https://pkgs.dev.azure.com/ms/terminal/_packaging/TerminalDependencies/nuget/v3/index.json" />
+    <add key="Test Source" value="c:\packages" />
+  </packageSources>
+</configuration>

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
@@ -149,5 +149,6 @@ issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "NuGet"
   message: "Failed to get package data for 'NuGet::foobar:1.2.3': IOException: Failed\
-    \ to get a response body from 'https://api.nuget.org/v3/registration5-gz-semver2/foobar/1.2.3.json'."
+    \ to retrieve package data for 'foobar' from any of [https://api.nuget.org/v3/registration5-gz-semver2,\
+    \ https://pkgs.dev.azure.com/ms/20953fb4-d427-4ad6-b78c-13142d0c5462/_packaging/64e3bf16-3e04-41cd-b90f-60fdc9ccf494/nuget/v3/registrations2-semver2]."
   severity: "ERROR"

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget/nuget.config
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget/nuget.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!-- Ignore previously configured packageSources. -->
+    <clear />
+
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="TerminalDependencies" value="https://pkgs.dev.azure.com/ms/terminal/_packaging/TerminalDependencies/nuget/v3/index.json" />
+    <add key="Test Source" value="c:\packages" />
+  </packageSources>
+</configuration>

--- a/analyzer/src/main/kotlin/managers/DotNet.kt
+++ b/analyzer/src/main/kotlin/managers/DotNet.kt
@@ -59,10 +59,9 @@ class DotNet(
     }
 
     private val reader = DotNetPackageFileReader()
-    private val support = NuGetSupport()
 
     override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> =
-        listOf(resolveNuGetDependencies(definitionFile, reader, support))
+        listOf(resolveNuGetDependencies(definitionFile, reader, NuGetSupport.create(definitionFile)))
 }
 
 /**

--- a/analyzer/src/main/kotlin/managers/NuGet.kt
+++ b/analyzer/src/main/kotlin/managers/NuGet.kt
@@ -58,10 +58,9 @@ class NuGet(
     }
 
     private val reader = NuGetPackageFileReader()
-    private val support = NuGetSupport()
 
     override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> =
-        listOf(resolveNuGetDependencies(definitionFile, reader, support))
+        listOf(resolveNuGetDependencies(definitionFile, reader, NuGetSupport.create(definitionFile)))
 }
 
 /**

--- a/analyzer/src/test/kotlin/managers/utils/NuGetSupportTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/NuGetSupportTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers.utils
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.should
+
+import java.io.File
+
+class NuGetSupportTest : WordSpec({
+    "getRegistrationsBaseUrls" should {
+        "parse index urls" {
+            val reader = NuGetConfigFileReader()
+            val configFile = File("src/funTest/assets/projects/synthetic/nuget/nuget.config")
+            val result = reader.getRegistrationsBaseUrls(configFile)
+
+            result should containExactly(
+                "https://api.nuget.org/v3/index.json",
+                "https://pkgs.dev.azure.com/ms/terminal/_packaging/TerminalDependencies/nuget/v3/index.json"
+            )
+        }
+    }
+})

--- a/utils/src/main/kotlin/Extensions.kt
+++ b/utils/src/main/kotlin/Extensions.kt
@@ -183,6 +183,31 @@ fun File.searchUpwardsForSubdirectory(searchDirName: String): File? {
 }
 
 /**
+ * Search [this] directory upwards towards the root until a file called [searchFileName] is found and return this file,
+ * or return null if no such file is found.
+ */
+fun File.searchUpwardsForFile(searchFileName: String, ignoreCase: Boolean = false): File? {
+    fun resolveFile(dir: File, fileName: String, ignoreCase: Boolean): File? {
+        val files = dir.list() ?: return null
+
+        return files.filter { it.equals(fileName, ignoreCase = ignoreCase) }
+            .map { dir.resolve(it) }
+            .find { it.isFile }
+    }
+
+    if (!isDirectory) return null
+
+    var currentDir: File? = absoluteFile
+    var currentFile = currentDir?.let { resolveFile(it, searchFileName, ignoreCase) }
+    while (currentDir != null && currentFile == null) {
+        currentDir = currentDir.parentFile ?: break
+        currentFile = resolveFile(currentDir, searchFileName, ignoreCase)
+    }
+
+    return currentFile
+}
+
+/**
  * Construct a "file:" URI in a safe way by never using a null authority for wider compatibility.
  */
 fun File.toSafeURI(): URI {

--- a/utils/src/test/kotlin/ExtensionsTest.kt
+++ b/utils/src/test/kotlin/ExtensionsTest.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.utils
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -126,6 +127,28 @@ class ExtensionsTest : WordSpec({
 
             gitRoot.shouldNotBeNull()
             gitRoot shouldBe File("..").absoluteFile.normalize()
+        }
+    }
+
+    "File.searchUpwardsForFile" should {
+        "find the README.md file case insensitive" {
+            val readmeFile = File(".").searchUpwardsForFile("ReadMe.MD", true)
+
+            readmeFile.shouldNotBeNull()
+            readmeFile shouldBe File("..").absoluteFile.normalize().resolve("README.md")
+        }
+
+        "find the README.md file case sensitive" {
+            val readmeFile = File(".").searchUpwardsForFile("README.md", false)
+
+            readmeFile.shouldNotBeNull()
+            readmeFile shouldBe File("..").absoluteFile.normalize().resolve("README.md")
+        }
+
+        "not find the README.md with wrong cases" {
+            val readmeFile = File(".").searchUpwardsForFile("ReadMe.MD", false)
+
+            readmeFile.shouldBeNull()
         }
     }
 


### PR DESCRIPTION
Use the NuGet.config file to get the configured indices for the analyzed
project and support package sources other than the default `api.nuget.org`.

Resolves #2189

This might not work for all service indices, as some do not provide valid catalogEntries.
e.g. [The service for windows terminal dependencies](https://pkgs.dev.azure.com/ms/terminal/_packaging/TerminalDependencies/nuget/v3/index.json) links to [this Package Data](https://pkgs.dev.azure.com/ms/20953fb4-d427-4ad6-b78c-13142d0c5462/_packaging/64e3bf16-3e04-41cd-b90f-60fdc9ccf494/nuget/v3/registrations2-semver2/terminal.themehelpers/0.2.200324001.json) which does not contain a valid catalogEntry URL
