### PR TITLE
Gradle: Omit the "-jvm" suffix for kotest dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -168,8 +168,8 @@ subprojects {
         dependencies {
             "testImplementation"(project(":test-utils"))
 
-            "testImplementation"("io.kotest:kotest-runner-junit5-jvm:$kotestVersion")
-            "testImplementation"("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
+            "testImplementation"("io.kotest:kotest-runner-junit5:$kotestVersion")
+            "testImplementation"("io.kotest:kotest-assertions-core:$kotestVersion")
 
             "funTestImplementation"(sourceSets["main"].output)
         }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -137,8 +137,8 @@ dependencies {
 
     testImplementation(project(":test-utils"))
 
-    testImplementation("io.kotest:kotest-runner-junit5-jvm:$kotestVersion")
-    testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
+    testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
+    testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
 
     funTestImplementation(sourceSets["main"].output)
     funTestImplementation(sourceSets["test"].output)

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -29,10 +29,10 @@ plugins {
 dependencies {
     api(project(":model"))
 
-    api("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
+    api("io.kotest:kotest-assertions-core:$kotestVersion")
     api("io.kotest:kotest-framework-api:$kotestVersion")
 
     implementation("io.kotest:kotest-extensions-junitxml:$kotestVersion")
-    implementation("io.kotest:kotest-framework-engine-jvm:$kotestVersion")
+    implementation("io.kotest:kotest-framework-engine:$kotestVersion")
     implementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jCoreVersion")
 }


### PR DESCRIPTION
Since Gradle version 6 the correct platform for multi-platform
dependencies will automatically be picked. Also see

https://github.com/kotest/kotest/issues/279#issuecomment-705213677

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>