### PR TITLE
Ignore android.com in Markdown link checks

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -16,6 +16,10 @@ Files: *.md
 Copyright: 2017-2020 HERE Europe B.V. <opensource@here.com>
 License: Apache-2.0
 
+Files: mlc_config.json
+Copyright: 2017-2020 HERE Europe B.V. <opensource@here.com>
+License: Apache-2.0
+
 Files: ci/*
 Copyright: 2017-2020 HERE Europe B.V. <opensource@here.com>
 License: Apache-2.0

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,7 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^https://source.android.com/setup/develop/repo$"
+        }
+    ]
+}


### PR DESCRIPTION
As https://source.android.com/setup/develop/repo continues to trigger
false positives.

Also see https://github.com/tcort/markdown-link-check#config-file-format.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>