### PR TITLE
declared-license-mapping: Add an entry for the SQLCipher License

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -508,6 +508,7 @@
 "https://www.eclipse.org/legal/epl-v20.html": EPL-2.0
 "https://www.scala-lang.org/license.html": Apache-2.0 AND BSD-3-Clause AND MIT
 "https://www.scala-lang.org/license/": Apache-2.0 AND BSD-3-Clause AND MIT
+"https://www.zetetic.net/sqlcipher/license/": BSD-3-Clause
 "icu-unicode license": ICU
 "jQuery license": MIT
 "lgplv2 or later": LGPL-2.1-or-later


### PR DESCRIPTION
As found in [1].

[1] https://repo1.maven.org/maven2/net/zetetic/android-database-sqlcipher/4.4.0/android-database-sqlcipher-4.4.0.pom

Signed-off-by: Frank Viernau <frank.viernau@here.com>