### PR TITLE
Revert "reporter-web-app: Make some Kotlin 1.4 related improvements"

### DIFF
--- a/reporter-web-app/build.gradle.kts
+++ b/reporter-web-app/build.gradle.kts
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnSetupTask
 YarnPlugin.apply(project).version = "1.22.4"
 
 // The Yarn plugin registers tasks always on the root project, see
-// https://github.com/JetBrains/kotlin/blob/1.4.0/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnPlugin.kt#L53-L57
+// https://github.com/JetBrains/kotlin/blob/2f90742/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnPlugin.kt#L27-L31
 val kotlinNodeJsSetup by rootProject.tasks.existing(NodeJsSetupTask::class)
 val kotlinYarnSetup by rootProject.tasks.existing(YarnSetupTask::class)
 
@@ -39,6 +39,22 @@ val nodeExecutable = if (Os.isFamily(Os.FAMILY_WINDOWS)) nodeBinDir.resolve("nod
 
 val yarnDir = kotlinYarnSetup.get().destination
 val yarnJs = yarnDir.resolve("bin/yarn.js")
+
+kotlinNodeJsSetup {
+    outputs.cacheIf { true }
+    logger.quiet("Will use the Node executable file from '$nodeExecutable'.")
+
+    // If the node binary is missing, force a re-download of the NodeJs distribution, see
+    // https://youtrack.jetbrains.com/issue/KT-34989.
+    if (!nodeExecutable.isFile && nodeDir.deleteRecursively()) {
+        logger.info("Successfully deleted the incomplete '$nodeDir' directory to trigger the NodeJs download.")
+    }
+}
+
+kotlinYarnSetup {
+    outputs.cacheIf { true }
+    logger.quiet("Will use the Yarn JavaScript file from '$yarnJs'.")
+}
 
 tasks.addRule("Pattern: yarn<Command>") {
     val taskName = this


### PR DESCRIPTION
This reverts commit ed604e3 because not our version of Kotlin counts,
but the version of Kotlin embedded into Gradle (or its kotlin-dsl
plugin), which still is Kotlin 1.3.72 for Gradle 6.6.1 (and 6.7).

Gradle will switch to Kotlin 1.4 only in version 6.8, see
https://github.com/gradle/gradle/issues/12660.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>