### PR TITLE
Docker: Upgrade Node.js to version 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ RUN apt-get update && \
     echo 'Acquire::https::dl.bintray.com::Verify-Peer "false";' | tee -a /etc/apt/apt.conf.d/00sbt && \
     echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
     curl -ksS "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key adv --import - && \
+    curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         # Install general tools required by this Dockerfile.
@@ -98,7 +99,7 @@ RUN apt-get update && \
         bundler=$BUNDLER_VERSION \
         cargo=$CARGO_VERSION \
         composer=$COMPOSER_VERSION \
-        npm \
+        nodejs \
         python-pip=$PYTHON_PIP_VERSION \
         python-setuptools \
         python3-pip=$PYTHON_PIP_VERSION \


### PR DESCRIPTION
This PR upgrades Node.js to the latest LTS version 12.
Used the PPA installation method because adoptopenjdk:11-jre-hotspot-focal is not available, yet (and would only offer nodejs version 10 anyways)

Resolves #3189.