### PR TITLE
Update documentation for scanner storage backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,8 +344,38 @@ For a comparison of some of these, see this
 
 ## Storage Backends
 
-In order to not download or scan any previously scanned sources again, the _scanner_ can use a storage backend to store
-scan results for later reuse.
+In order to not download or scan any previously scanned sources again, or to reuse scan results generated via other
+services, the _scanner_ can be configured to use so-called storage backends. Before processing a package, it checks
+whether compatible scan results are already available in one of the storages declared; if this is the case, they
+are fetched and reused. Otherwise, the package's source code is downloaded and scanned. Afterwards, the new scan
+results can be put into a storage for later reuse.
+
+It is possible to configure multiple storages to read scan results from or to write scan results to. For reading,
+the declaration order in the configuration is important, as the scanner queries the storages in this order and uses
+the first matching result. This allows a fine-grained control over the sources, from which existing scan results are
+loaded. For instance, you can specify that the scanner checks first whether results for a specific package are
+available in a local storage on the file system. If this is not the case, it can look up the package in a Postgres
+database. If this does not yield any results either, a service like [ClearlyDefined](https://clearlydefined.io) can be
+queried. Only if all of these steps fail, the scanner has to actually process the package.
+
+When storing a newly generated scan result the scanner invokes all the storages declared as writers. The storage
+operation is considered successful if all writer storages could successfully persist the scan result.
+
+The configuration of storage backends is located in the ORT configuration file. (For the general structure of this file
+and the set of options available refer to the [reference configuration](./model/src/test/assets/reference.conf).)
+The file has a section named _storages_ that lists all the storage backends and assigns them a name. Each storage 
+backend is of a specific type and needs to be configured with type-specific properties. The different types of storage
+backends supported by ORT are described below.
+
+After the declaration of the storage backends, the configuration file has to specify which ones of them the
+scanner should use for looking up existing scan results or to store new results. This is done in two list properties
+named _storageReaders_ and _storageWriters_. The lists reference the names of the storage backends declared in the
+_storages_ section. The scanner invokes the storage backends in the order they appear in the lists; so for readers,
+this defines a priority for look-up operations. Each storage backend can act as a reader; however, some types do not 
+support updates and thus cannot serve as writers. If a storage backend is referenced both as reader and writer, the 
+scanner creates only a single instance of this storage class.
+
+The following subsections describe the different storage backend implementations supported by ORT. 
 
 ### Local File Storage
 
@@ -356,14 +386,24 @@ file (`-c`) that contains a respective local file storage configuration:
 ```hocon
 ort {
   scanner {
-    fileBasedStorage {
-      backend {
-        localFileStorage {
-          directory = "/tmp/ort/scan-results"
-          compression = false
+    storages {
+      fileBasedStorage {
+        backend {
+          localFileStorage {
+            directory = "/tmp/ort/scan-results"
+            compression = false
+          }
         }
       }
     }
+
+    storageReaders: [
+      "fileBasedStorage"
+    ]
+
+    storageWriters: [
+      "fileBasedStorage"
+    ]
   }
 }
 ```
@@ -376,16 +416,26 @@ credentials. For example, to use Artifactory to store scan results, use the foll
 ```hocon
 ort {
   scanner {
-    fileBasedStorage {
-      backend {
-        httpFileStorage {
-          url = "https://artifactory.domain.com/artifactory/repository/scan-results"
-          headers {
-            X-JFrog-Art-Api = "api-token"
+    storages {
+      artifactoryStorage {
+        backend {
+          httpFileStorage {
+            url = "https://artifactory.domain.com/artifactory/repository/scan-results"
+            headers {
+              X-JFrog-Art-Api = "api-token"
+            }
           }
         }
       }
     }
+
+    storageReaders: [
+      "artifactoryStorage"
+    ]
+
+    storageWriters: [
+      "artifactoryStorage"
+    ]
   }
 }
 ```
@@ -398,13 +448,23 @@ set to `UTF8`, and a configuration like the following:
 ```hocon
 ort {
   scanner {
-    postgresStorage {
-      url = "jdbc:postgresql://example.com:5444/database"
-      schema = "schema"
-      username = "username"
-      password = "password"
-      sslmode = "verify-full"
+    storages {
+      postgresStorage {
+        url = "jdbc:postgresql://example.com:5444/database"
+        schema = "schema"
+        username = "username"
+        password = "password"
+        sslmode = "verify-full"
+      }
     }
+
+    storageReaders: [
+      "postgresStorage"
+    ]
+
+    storageWriters: [
+      "postgresStorage"
+    ]
   }
 }
 ```
@@ -415,6 +475,30 @@ store the data in a [jsonb](https://www.postgresql.org/docs/current/datatype-jso
 If you do not want to use SSL set the `sslmode` to `disable`, other possible values are explained in the
 [documentation](https://jdbc.postgresql.org/documentation/head/ssl-client.html). For other supported configuration
 options see [PostgresStorageConfiguration.kt](./model/src/main/kotlin/config/PostgresStorageConfiguration.kt).
+
+### ClearlyDefined Storage
+
+[ClearlyDefined](https://clearlydefined.io) is a service offering curated metadata for Open Source components. This
+includes scan results that can be used by ORT's _scanner_ tool (if they have been generated by a compatible scanner
+version with a suitable configuration). This storage backend queries the ClearlyDefined service for scan results of the
+packages to be processed. It is read-only; so it will not upload any new scan results to ClearlyDefined. In the
+configuration the URL of the ClearlyDefined service needs to be set:
+
+```hocon
+ort {
+  scanner {
+    storages {
+      clearlyDefined {
+        serverUrl = "https://api.clearlydefined.io"
+      }
+    }
+
+    storageReaders: [
+      "clearlyDefined"
+    ]
+  }
+}
+```
 
 <a name="evaluator">&nbsp;</a>
 


### PR DESCRIPTION
With the support of multiple scan storage backends the format of the
ORT configuration file has changed. Update the documentation in
README.md to reflect these changes. Also list the new ClearlyDefined
storage.

Resolves #3194.

Signed-off-by: Oliver Heger <oliver.heger@bosch.io>