### PR TITLE
analyzer: Make CarthageFunTest and GoDepFunTest pass on forks of ORT

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/carthage-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/carthage-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "Carthage:oss-review-toolkit:ort:<REPLACE_REVISION>"
+  id: "Carthage:<REPLACE_GITHUB_PROJECT>:<REPLACE_REVISION>"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/glide-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/glide-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "GoDep::github.com/oss-review-toolkit/ort/analyzer/src/funtest/assets/projects/synthetic/godep/glide:<REPLACE_REVISION>"
+  id: "GoDep::<REPLACE_GITHUB_PROJECT>/analyzer/src/funtest/assets/projects/synthetic/godep/glide:<REPLACE_REVISION>"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/godep/glide/glide.yaml"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/godep-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/godep-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "GoDep::github.com/oss-review-toolkit/ort/analyzer/src/funtest/assets/projects/synthetic/godep/lockfile:<REPLACE_REVISION>"
+  id: "GoDep::<REPLACE_GITHUB_PROJECT>/analyzer/src/funtest/assets/projects/synthetic/godep/lockfile:<REPLACE_REVISION>"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/godep/lockfile/Gopkg.toml"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/godeps-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/godeps-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "GoDep::github.com/oss-review-toolkit/ort/analyzer/src/funtest/assets/projects/synthetic/godep/godeps/godeps:<REPLACE_REVISION>"
+  id: "GoDep::<REPLACE_GITHUB_PROJECT>/analyzer/src/funtest/assets/projects/synthetic/godep/godeps/godeps:<REPLACE_REVISION>"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/godep/godeps/Godeps/Godeps.json"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/kotlin/managers/CarthageFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/CarthageFunTest.kt
@@ -46,7 +46,8 @@ class CarthageFunTest : StringSpec() {
                 definitionFilePath = "$vcsPath/Cartfile.resolved",
                 path = vcsPath,
                 revision = vcsRevision,
-                url = normalizeVcsUrl(vcsUrl)
+                url = normalizeVcsUrl(vcsUrl),
+                custom = mapOf("<REPLACE_GITHUB_PROJECT>" to "oss-review-toolkit:ort")
             )
 
             val result = createCarthage().resolveSingleProject(cartfileResolved)

--- a/analyzer/src/funTest/kotlin/managers/GoDepFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoDepFunTest.kt
@@ -57,7 +57,8 @@ class GoDepFunTest : WordSpec() {
                     projectsDir.resolve("synthetic/godep-expected-output.yml"),
                     url = normalizeVcsUrl(vcsUrl),
                     revision = vcsRevision,
-                    path = vcsPath
+                    path = vcsPath,
+                    custom = mapOf("<REPLACE_GITHUB_PROJECT>" to "github.com/oss-review-toolkit/ort")
                 )
 
                 result.toYaml() shouldBe expectedResult
@@ -102,7 +103,8 @@ class GoDepFunTest : WordSpec() {
                     projectsDir.resolve("synthetic/glide-expected-output.yml"),
                     url = normalizeVcsUrl(vcsUrl),
                     revision = vcsRevision,
-                    path = vcsPath
+                    path = vcsPath,
+                    custom = mapOf("<REPLACE_GITHUB_PROJECT>" to "github.com/oss-review-toolkit/ort")
                 )
 
                 result.toYaml() shouldBe expectedResult
@@ -118,7 +120,8 @@ class GoDepFunTest : WordSpec() {
                     projectsDir.resolve("synthetic/godeps-expected-output.yml"),
                     url = normalizeVcsUrl(vcsUrl),
                     revision = vcsRevision,
-                    path = vcsPath
+                    path = vcsPath,
+                    custom = mapOf("<REPLACE_GITHUB_PROJECT>" to "github.com/oss-review-toolkit/ort")
                 )
 
                 result.toYaml() shouldBe expectedResult


### PR DESCRIPTION
Otherwise a.g. Travis CI enabled on forks of ORT fails, see

https://travis-ci.com/github/bosch-io/oss-review-toolkit/builds/189639710#L1245
https://travis-ci.com/github/bosch-io/oss-review-toolkit/builds/189639710#L1598

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>