### PR TITLE
Link ORT configuration file docs from storage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ table below for the supported environment variables and their defaults:
 
 The following provides an overview of the various configuration files that can be used to customize ORT behavior:
 
-[ORT configuration file](./model/src/test/assets/reference.conf)
+#### [ORT configuration file](./model/src/test/assets/reference.conf)
 
 The main configuration file for the operation of ORT. This configuration is maintained by an administrator who manages
 the ORT instance. In contrast to the configuration files in the following, this file rarely changes once ORT is
@@ -181,7 +181,7 @@ operational.
 | ------ | ----- | ---------------- | ------------- |
 | HOCON | Global | `$ORT_CONFIG_DIR/ort.conf` | Empty ([built-in](./model/src/main/resources/default.conf)) |
 
-[Copyright garbage file](./docs/config-file-copyright-garbage-yml.md)
+#### [Copyright garbage file](./docs/config-file-copyright-garbage-yml.md)
 
 A list of copyright statements that are considered garbage, for example statements that were incorrectly classified as
 copyrights by the scanner.
@@ -190,7 +190,7 @@ copyrights by the scanner.
 | ------ | ----- | ---------------- | ------------- |
 | YAML / JSON | Global | `$ORT_CONFIG_DIR/copyright-garbage.yml` | Empty (n/a) |
 
-[Curations file](./docs/config-file-curations-yml.md)
+#### [Curations file](./docs/config-file-curations-yml.md)
 
 A file to correct invalid or missing package metadata, and to set the concluded license for packages.
 
@@ -198,7 +198,7 @@ A file to correct invalid or missing package metadata, and to set the concluded 
 | ------ | ----- | ---------------- | ------------- |
 | YAML / JSON | Global | `$ORT_CONFIG_DIR/curations.yml` | Empty (n/a) |
 
-[Custom license texts dir](./docs/dir-custom-license-texts.md)
+#### [Custom license texts dir](./docs/dir-custom-license-texts.md)
 
 A directory that contains license texts which are not provided by ORT.
 
@@ -206,7 +206,7 @@ A directory that contains license texts which are not provided by ORT.
 | ------ | ----- | ---------------- | ------------- |
 | Text | Global | `$ORT_CONFIG_DIR/custom-license-texts/` | Empty (n/a) |
 
-[How to fix text provider script](./docs/how-to-fix-text-provider-kts.md)
+#### [How to fix text provider script](./docs/how-to-fix-text-provider-kts.md)
 
 A Kotlin script that enables the injection of how-to-fix texts in markdown format for ORT issues into the reports.
 
@@ -214,7 +214,7 @@ A Kotlin script that enables the injection of how-to-fix texts in markdown forma
 | ------ | ----- | ---------------- | ------------- |
 | Kotlin script | Global | `$ORT_CONFIG_DIR/how-to-fix-text-provider.kts` | Empty (n/a) |
 
-[License configuration file](./docs/config-file-licenses-yml.md)
+#### [License configuration file](./docs/config-file-licenses-yml.md)
 
 A file that contains user-defined categorization of licenses.
 
@@ -222,7 +222,7 @@ A file that contains user-defined categorization of licenses.
 | ------ | ----- | ---------------- | ------------- |
 | YAML / JSON | Global | `$ORT_CONFIG_DIR/licenses.yml` | Empty (n/a) |
 
-[Resolution file](./docs/config-file-resolutions-yml.md)
+#### [Resolution file](./docs/config-file-resolutions-yml.md)
 
 Configurations to resolve any issues or rule violations by providing a mandatory reason, and an optional comment to
 justify the resolution on a global scale.
@@ -231,7 +231,7 @@ justify the resolution on a global scale.
 | ------ | ----- | ---------------- | ------------- |
 | YAML / JSON | Global | `$ORT_CONFIG_DIR/resolutions.yml` | Empty (n/a) |
 
-[Repository configuration file](./docs/config-file-ort-yml.md)
+#### [Repository configuration file](./docs/config-file-ort-yml.md)
 
 A configuration file, usually stored in the project's repository, for license finding curations, exclusions, and issues
 or rule violations resolutions in the context of the repository.
@@ -240,7 +240,7 @@ or rule violations resolutions in the context of the repository.
 | ------ | ----- | ---------------- | ------------- |
 | YAML / JSON | Repository (project) | `[analyzer-input-dir]/.ort.yml` | Empty (n/a) |
 
-[Package configuration file / directory](./docs/config-file-package-configuration-yml.md)
+#### [Package configuration file / directory](./docs/config-file-package-configuration-yml.md)
 
 A single file or a directory with multiple files containing configurations to set provenance-specific path excludes and
 license finding curations for dependency packages to address issues found within a scan result. The `helper-cli`'s
@@ -251,7 +251,7 @@ can be used to populate a directory with template package configuration files.
 | ------ | ----- | ---------------- | ------------- |
 | YAML / JSON | Package (dependency) | `$ORT_CONFIG_DIR/package-configurations/` | Empty (n/a) |
 
-[Policy rules file](./docs/file-rules-kts.md)
+#### [Policy rules file](./docs/file-rules-kts.md)
 
 The file containing any policy rule implementations to be used with the _evaluator_.
 

--- a/README.md
+++ b/README.md
@@ -362,11 +362,11 @@ queried. Only if all of these steps fail, the scanner has to actually process th
 When storing a newly generated scan result the scanner invokes all the storages declared as writers. The storage
 operation is considered successful if all writer storages could successfully persist the scan result.
 
-The configuration of storage backends is located in the ORT configuration file. (For the general structure of this file
-and the set of options available refer to the [reference configuration](./model/src/test/assets/reference.conf).)
-The file has a section named _storages_ that lists all the storage backends and assigns them a name. Each storage 
-backend is of a specific type and needs to be configured with type-specific properties. The different types of storage
-backends supported by ORT are described below.
+The configuration of storage backends is located in the [ORT configuration file](#ort-configuration-file). (For the
+general structure of this file and the set of options available refer to the
+[reference configuration](./model/src/test/assets/reference.conf).) The file has a section named _storages_ that lists
+all the storage backends and assigns them a name. Each storage backend is of a specific type and needs to be configured
+with type-specific properties. The different types of storage backends supported by ORT are described below.
 
 After the declaration of the storage backends, the configuration file has to specify which ones of them the
 scanner should use for looking up existing scan results or to store new results. This is done in two list properties

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ or
 ## Running on CI
 
 A basic ORT pipeline (using the _analyzer_, _scanner_ and _reporter_) can easily be run on
-[Jenkins CI](https://jenkins.io/) by using the [Jenkinsfile](./Jenkinsfile) in a (declarative)
-[pipeline](https://jenkins.io/doc/book/pipeline/) job. Please see the [Jenkinsfile](./Jenkinsfile) itself for
-documentation of the required Jenkins plugins. The job accepts various parameters that are translated to ORT command
+[Jenkins CI](https://jenkins.io/) by using the [Jenkinsfile](./integrations/Jenkinsfile) in a (declarative)
+[pipeline](https://jenkins.io/doc/book/pipeline/) job. Please see the [Jenkinsfile](./integrations/Jenkinsfile) itself
+for documentation of the required Jenkins plugins. The job accepts various parameters that are translated to ORT command
 line arguments. Additionally, one can trigger a downstream job which e.g. further processes scan results. Note that it
 is the downstream job's responsibility to copy any artifacts it needs from the upstream job.
 


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.