### PR TITLE
Fix skipping the AppVeyor build if only *.md files were modified

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,9 +1,5 @@
 skip_branch_with_pr: true
 
-skip_commits:
-  files:
-    - '**/*.md'
-
 environment:
   HOME: $(HOMEDRIVE)$(HOMEPATH)
   BOWER_VERSION: 1.8.8
@@ -31,6 +27,12 @@ cache:
 clone_depth: 50
 
 install:
+  - ps: |
+      $range = "$env:APPVEYOR_REPO_BRANCH..$env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT"
+      if (-not (git diff --name-only --diff-filter=d $range | Where-Object { $_ -NotMatch "\.md$" })) {
+        Write-Host "Only Markdown files were modified, skipping CI run."
+        Exit-AppVeyorBuild
+      }
   - git submodule update --init --recursive
   - npm install -g npm@%NPM_VERSION%
   - npm install -g bower@%BOWER_VERSION% yarn@%YARN_VERSION%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -69,8 +69,8 @@ build_script:
   - echo org.gradle.java.home=C:/Program Files/Java/jdk11>>"%HOME%\.gradle\gradle.properties"
   - ps: |
       $file = 'gradle\wrapper\gradle-wrapper.properties'
-      get-content $file | %{ $_ -replace '(^distributionUrl=)(.+)-all\.zip$', '$1$2-bin.zip' } | set-content "${file}.new"
-      mv -force "${file}.new" $file
+      Get-Content $file | %{ $_ -replace '(^distributionUrl=)(.+)-all\.zip$', '$1$2-bin.zip' } | Set-Content "${file}.new"
+      Move-Item -Force "${file}.new" $file
   - gradlew --stacktrace detekt
 
 test_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ addons:
       - lib32stdc++6
 
 before_install:
-  - if [ -z $(git diff --name-only --diff-filter=d $TRAVIS_COMMIT_RANGE | grep -v "\.md$") ]; then
+  - if ! (git diff --name-only --diff-filter=d $TRAVIS_COMMIT_RANGE | grep -v "\.md$"); then
         echo "Only Markdown files were modified, skipping CI run.";
         exit;
     fi


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.