### PR TITLE
OrtProxySelector: Support no_proxy entries without a port

### DIFF
--- a/utils/src/main/kotlin/OrtProxySelector.kt
+++ b/utils/src/main/kotlin/OrtProxySelector.kt
@@ -157,7 +157,7 @@ class OrtProxySelector(private val fallback: ProxySelector? = null) : ProxySelec
     override fun select(uri: URI?): List<Proxy> {
         requireNotNull(uri)
 
-        if (noProxyUrls.any { uri.authority.endsWith(it) }) return NO_PROXY_LIST
+        if (noProxyUrls.any { uri.authority.endsWith(it) || uri.host.endsWith(it) }) return NO_PROXY_LIST
 
         val proxies = proxyOrigins.flatMap { (_, proxiesForProtocol) ->
             proxiesForProtocol.getOrDefault(uri.scheme, mutableListOf())


### PR DESCRIPTION
The authority contains the port, but a no_proxy entry might not, so also
compare by only the host.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>