### PR TITLE
VersionControlSystem: Fix an issue with isFixedRevision()

### DIFF
--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -291,7 +291,9 @@ abstract class VersionControlSystem {
      * Check whether the given [revision] is likely to name a fixed revision that does not move.
      */
     fun isFixedRevision(workingTree: WorkingTree, revision: String) =
-        revision.isNotBlank() && revision !in latestRevisionNames && revision !in workingTree.listRemoteBranches()
+        revision.isNotBlank()
+                && revision !in latestRevisionNames
+                && (revision !in workingTree.listRemoteBranches() || revision in workingTree.listRemoteTags())
 
     /**
      * Check whether the VCS tool is at least of the specified [expectedVersion], e.g. to check for features.


### PR DESCRIPTION
In Git repositories it is possible to have a git tag and a remote branch
sharing the same name, see e.g. the 'release-9.0' tag or branch in
https://github.com/apache/flink-shaded/.

In this case the Downloader is not able to determine a revision to
download in case the meta data of the package has the revision set to
the tag name and when moving revisions are not enabled. Fix this by
returning true in that case.

Signed-off-by: Frank Viernau <frank.viernau@here.com>