### PR TITLE
Improve checking the syntax for evaluator scripts

### DIFF
--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -165,8 +165,8 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate rules 
                 "the input ORT result is overwritten. For example: --label distribution=external"
     ).associate()
 
-    private val syntaxCheck by option(
-        "--syntax-check",
+    private val checkSyntax by option(
+        "--check-syntax",
         help = "Do not evaluate the script but only check its syntax. No output is written in this case."
     ).flag()
 
@@ -209,7 +209,7 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate rules 
             }
         }
 
-        if (syntaxCheck) {
+        if (checkSyntax) {
             if (Evaluator().checkSyntax(script)) {
                 return
             } else {
@@ -229,7 +229,7 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate rules 
         }
 
         val finalOrtResult = requireNotNull(ortResultInput) {
-            "The '--ort-file' option is required unless the '--syntax-check' option is used."
+            "The '--ort-file' option is required unless the '--check-syntax' option is used."
         }
 
         val packageConfigurationProvider = packageConfigurationOption.createProvider()

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -175,10 +175,11 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate rules 
     private val globalOptionsForSubcommands by requireObject<GlobalOptions>()
 
     override fun run() {
-        val outputFiles = mutableListOf<File>()
+        // Fail early if output files exist and must not be overwritten.
+        val outputFiles = mutableSetOf<File>()
 
         outputDir?.let { absoluteOutputDir ->
-            outputFiles += outputFormats.mapTo(mutableSetOf()) { format ->
+            outputFormats.mapTo(outputFiles) { format ->
                 absoluteOutputDir.resolve("evaluation-result.${format.fileExtension}")
             }
 

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -192,14 +192,10 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate rules 
         }
 
         var ortResultInput = ortFile.readValue<OrtResult>()
+
         repositoryConfigurationFile?.let {
             ortResultInput = ortResultInput.replaceConfig(it.readValue())
         }
-
-        val packageConfigurationProvider = packageConfigurationOption.createProvider()
-
-        val licenseConfiguration =
-            licenseConfigurationFile.takeIf { it.isFile }?.readValue<LicenseConfiguration>().orEmpty()
 
         packageCurationsFile?.let {
             ortResultInput = ortResultInput.replacePackageCurations(it.readValue())
@@ -225,6 +221,7 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate rules 
             }
         }
 
+        val packageConfigurationProvider = packageConfigurationOption.createProvider()
         val copyrightGarbage = copyrightGarbageFile.takeIf { it.isFile }?.readValue<CopyrightGarbage>().orEmpty()
 
         val licenseInfoResolver = LicenseInfoResolver(
@@ -233,6 +230,8 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate rules 
             archiver = globalOptionsForSubcommands.config.scanner?.archive?.createFileArchiver() ?: FileArchiver.DEFAULT
         )
 
+        val licenseConfiguration =
+            licenseConfigurationFile.takeIf { it.isFile }?.readValue<LicenseConfiguration>().orEmpty()
         val evaluator = Evaluator(ortResultInput, licenseInfoResolver, licenseConfiguration)
 
         if (syntaxCheck) {

--- a/evaluator/src/main/kotlin/Evaluator.kt
+++ b/evaluator/src/main/kotlin/Evaluator.kt
@@ -26,11 +26,12 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.licenses.LicenseConfiguration
 import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
+import org.ossreviewtoolkit.model.utils.createLicenseInfoResolver
 import org.ossreviewtoolkit.utils.ScriptRunner
 
 class Evaluator(
-    ortResult: OrtResult,
-    licenseInfoResolver: LicenseInfoResolver,
+    ortResult: OrtResult = OrtResult.EMPTY,
+    licenseInfoResolver: LicenseInfoResolver = OrtResult.EMPTY.createLicenseInfoResolver(),
     licenseConfiguration: LicenseConfiguration = LicenseConfiguration()
 ) : ScriptRunner() {
     override val preface = """

--- a/utils/src/main/kotlin/ScriptRunner.kt
+++ b/utils/src/main/kotlin/ScriptRunner.kt
@@ -27,7 +27,7 @@ import javax.script.ScriptException
 /**
  * A class providing the framework to run Kotlin scripts.
  */
-abstract class ScriptRunner {
+open class ScriptRunner {
     /**
      * The engine to run Kotlin scripts.
      */
@@ -36,12 +36,12 @@ abstract class ScriptRunner {
     /**
      * The text that should get prepended to the main script.
      */
-    abstract val preface: String
+    open val preface: String = ""
 
     /**
      * The text that should get appended to the main script.
      */
-    abstract val postface: String
+    open val postface: String = ""
 
     private fun completeScript(script: String) = preface + script + postface
 


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.