### PR TITLE
OrtMain: Show CPU and memory info in the header

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -18,6 +18,8 @@ analyzer:
     ort_version: "HEAD"
     java_version: "<REPLACE_JAVA>"
     os: "<REPLACE_OS>"
+    processors: "<REPLACE_PROCESSORS>"
+    max_memory: "<REPLACE_MAX_MEMORY>"
     variables: {}
     tool_versions: {}
   config:

--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -49,6 +49,8 @@ analyzer:
     ort_version: "HEAD"
     java_version: "<REPLACE_JAVA>"
     os: "<REPLACE_OS>"
+    processors: "<REPLACE_PROCESSORS>"
+    max_memory: "<REPLACE_MAX_MEMORY>"
     variables: {}
     tool_versions: {}
   config:

--- a/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
@@ -18,6 +18,8 @@ analyzer:
     ort_version: "HEAD"
     java_version: "<REPLACE_JAVA>"
     os: "<REPLACE_OS>"
+    processors: "<REPLACE_PROCESSORS>"
+    max_memory: "<REPLACE_MAX_MEMORY>"
     variables: {}
     tool_versions: {}
   config:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -42,6 +42,8 @@ analyzer:
     ort_version: "HEAD"
     java_version: "<REPLACE_JAVA>"
     os: "<REPLACE_OS>"
+    processors: "<REPLACE_PROCESSORS>"
+    max_memory: "<REPLACE_MAX_MEMORY>"
     variables: {}
     tool_versions: {}
   config:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -42,6 +42,8 @@ analyzer:
     ort_version: "HEAD"
     java_version: "<REPLACE_JAVA>"
     os: "<REPLACE_OS>"
+    processors: "<REPLACE_PROCESSORS>"
+    max_memory: "<REPLACE_MAX_MEMORY>"
     variables: {}
     tool_versions: {}
   config:

--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -34,7 +34,6 @@ import com.github.ajalt.clikt.parameters.options.versionOption
 import com.github.ajalt.clikt.parameters.types.file
 
 import java.io.File
-import java.lang.Runtime
 
 import kotlin.system.exitProcess
 
@@ -165,15 +164,14 @@ class OrtMain : CliktCommand(name = ORT_NAME, epilog = "* denotes required optio
         val command = commandName?.let { " '$commandName'" }.orEmpty()
 
         val header = mutableListOf<String>()
-        val numCpus = Runtime.getRuntime().availableProcessors()
-        val maxMemInMib = Runtime.getRuntime().maxMemory() / (1024L * 1024L)
+        val maxMemInMib = env.maxMemory / (1024L * 1024L)
 
         """
             ________ _____________________
             \_____  \\______   \__    ___/ the OSS Review Toolkit, version $version.
              /   |   \|       _/ |    |
             /    |    \    |   \ |    |    Running$command under Java ${env.javaVersion} on ${env.os} with
-            \_______  /____|_  / |____|    $numCpus CPUs and a maximum of $maxMemInMib MiB of memory.
+            \_______  /____|_  / |____|    ${env.processors} CPUs and a maximum of $maxMemInMib MiB of memory.
                     \/       \/
         """.trimIndent().lines().mapTo(header) { it.trimEnd() }
 

--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -34,6 +34,7 @@ import com.github.ajalt.clikt.parameters.options.versionOption
 import com.github.ajalt.clikt.parameters.types.file
 
 import java.io.File
+import java.lang.Runtime
 
 import kotlin.system.exitProcess
 
@@ -162,24 +163,23 @@ class OrtMain : CliktCommand(name = ORT_NAME, epilog = "* denotes required optio
 
         val commandName = currentContext.invokedSubcommand?.commandName
         val command = commandName?.let { " '$commandName'" }.orEmpty()
-        val with = if (variables.isNotEmpty()) " with" else "."
-
-        var variableIndex = 0
 
         val header = mutableListOf<String>()
+        val numCpus = Runtime.getRuntime().availableProcessors()
+        val maxMemInMib = Runtime.getRuntime().maxMemory() / (1024L * 1024L)
+
         """
             ________ _____________________
             \_____  \\______   \__    ___/ the OSS Review Toolkit, version $version.
-             /   |   \|       _/ |    |    Running$command under Java ${env.javaVersion} on ${env.os}$with
-            /    |    \    |   \ |    |    ${variables.getOrElse(variableIndex++) { "" }}
-            \_______  /____|_  / |____|    ${variables.getOrElse(variableIndex++) { "" }}
+             /   |   \|       _/ |    |
+            /    |    \    |   \ |    |    Running$command under Java ${env.javaVersion} on ${env.os} with
+            \_______  /____|_  / |____|    $numCpus CPUs and a maximum of $maxMemInMib MiB of memory.
                     \/       \/
         """.trimIndent().lines().mapTo(header) { it.trimEnd() }
 
-        val moreVariables = variables.drop(variableIndex)
-        if (moreVariables.isNotEmpty()) {
-            header += "More environment variables:"
-            header += moreVariables
+        if (variables.isNotEmpty()) {
+            header += "Environment variables:"
+            header += variables
         }
 
         return header.joinToString("\n", postfix = "\n")

--- a/model/src/main/kotlin/Environment.kt
+++ b/model/src/main/kotlin/Environment.kt
@@ -19,6 +19,8 @@
 
 package org.ossreviewtoolkit.model
 
+import java.lang.Runtime
+
 import org.ossreviewtoolkit.utils.Os
 
 /**
@@ -39,6 +41,16 @@ data class Environment(
      * Name of the operating system, defaults to [Os.name].
      */
     val os: String = Os.name,
+
+    /**
+     * The number of logical processors available.
+     */
+    val processors: Int = Runtime.getRuntime().availableProcessors(),
+
+    /**
+     * The maximum amount of memory available.
+     */
+    val maxMemory: Long = Runtime.getRuntime().maxMemory(),
 
     /**
      * Map of selected environment variables that might be relevant for debugging.

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -28,20 +28,17 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldMatch
 
-import java.io.File
 import java.lang.IllegalArgumentException
 
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
-
-private fun readOrtResult(relativeOrtResultFilePath: String): OrtResult =
-    File("../analyzer/src/funTest/assets/projects")
-        .resolve(relativeOrtResultFilePath)
-        .readValue()
+import org.ossreviewtoolkit.utils.test.readOrtResult
 
 class OrtResultTest : WordSpec({
     "collectDependencies" should {
         "be able to get all direct dependencies of a package" {
-            val ortResult = readOrtResult("external/sbt-multi-project-example-expected-output.yml")
+            val ortResult = readOrtResult(
+                "../analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml"
+            )
 
             val id = Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
             val dependencies = ortResult.collectDependencies(id, 1).map { it.toCoordinates() }
@@ -56,7 +53,9 @@ class OrtResultTest : WordSpec({
 
     "collectProjectsAndPackages" should {
         "be able to get all ids except for ones for sub-projects" {
-            val ortResult = readOrtResult("synthetic/gradle-all-dependencies-expected-result.yml")
+            val ortResult = readOrtResult(
+                "../analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml"
+            )
 
             val ids = ortResult.collectProjectsAndPackages()
             val idsWithoutSubProjects = ortResult.collectProjectsAndPackages(false)

--- a/reporter/src/funTest/assets/gradle-all-dependencies-result.yml
+++ b/reporter/src/funTest/assets/gradle-all-dependencies-result.yml
@@ -18,6 +18,8 @@ analyzer:
     ort_version: "HEAD"
     java_version: "<REPLACE_JAVA>"
     os: "<REPLACE_OS>"
+    processors: "<REPLACE_PROCESSORS>"
+    max_memory: "<REPLACE_MAX_MEMORY>"
     variables: {}
     tool_versions: {}
   config:

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -18,6 +18,8 @@ analyzer:
     ort_version: "HEAD"
     java_version: "<REPLACE_JAVA>"
     os: "Linux"
+    processors: "<REPLACE_PROCESSORS>"
+    max_memory: "<REPLACE_MAX_MEMORY>"
     variables: {}
     tool_versions: {}
   config:
@@ -197,6 +199,8 @@ scanner:
     ort_version: "HEAD"
     java_version: "<REPLACE_JAVA>"
     os: "<REPLACE_OS>"
+    processors: "<REPLACE_PROCESSORS>"
+    max_memory: "<REPLACE_MAX_MEMORY>"
     variables: {}
     tool_versions: {}
   config:

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -18,6 +18,7 @@
  * License-Filename: LICENSE
  */
 
+val jacksonVersion: String by project
 val kotestVersion: String by project
 val log4jCoreVersion: String by project
 
@@ -32,6 +33,7 @@ dependencies {
     api("io.kotest:kotest-assertions-core:$kotestVersion")
     api("io.kotest:kotest-framework-api:$kotestVersion")
 
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     implementation("io.kotest:kotest-extensions-junitxml:$kotestVersion")
     implementation("io.kotest:kotest-framework-engine:$kotestVersion")
     implementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jCoreVersion")

--- a/test-utils/src/main/kotlin/Utils.kt
+++ b/test-utils/src/main/kotlin/Utils.kt
@@ -43,8 +43,12 @@ private val START_AND_END_TIME_REGEX = Regex("((start|end)_time): \".*\"")
 private val TIMESTAMP_REGEX = Regex("(timestamp): \".*\"")
 
 fun patchExpectedResult(
-    result: File, custom: Map<String, String> = emptyMap(), definitionFilePath: String? = null,
-    url: String? = null, revision: String? = null, path: String? = null,
+    result: File,
+    custom: Map<String, String> = emptyMap(),
+    definitionFilePath: String? = null,
+    url: String? = null,
+    revision: String? = null,
+    path: String? = null,
     urlProcessed: String? = null
 ): String {
     fun String.replaceIfNotNull(oldValue: String, newValue: String?) =
@@ -60,8 +64,11 @@ fun patchExpectedResult(
         .replaceIfNotNull("<REPLACE_URL_PROCESSED>", urlProcessed)
 }
 
-fun patchActualResult(result: String, patchDownloadTime: Boolean = false, patchStartAndEndTime: Boolean = false):
-        String {
+fun patchActualResult(
+    result: String,
+    patchDownloadTime: Boolean = false,
+    patchStartAndEndTime: Boolean = false
+): String {
     fun String.replaceIf(condition: Boolean, regex: Regex, transform: (MatchResult) -> CharSequence) =
         if (condition) replace(regex, transform) else this
 


### PR DESCRIPTION
This is useful to debug memory issues and to learn how much CPUs a local
scanner like ScanCode would be using.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>