### PR TITLE
LocalScanner: Align on using "of" instead of "/" in indices

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -160,7 +160,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
         return try {
             coroutineScope {
                 packages.withIndex().map { (index, pkg) ->
-                    val packageIndex = "(${index + 1}/${packages.size})"
+                    val packageIndex = "(${index + 1} of ${packages.size})"
 
                     async {
                         pkg to scanPackage(


### PR DESCRIPTION
In other similar output we use "of", and " of " is easier to search for
in logs than "/", so align on using "of".

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>