### PR TITLE
README: Remove the mention of a planned Documenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ use):
 The following tools are [planned](https://github.com/oss-review-toolkit/ort/projects/1) but not yet available:
 
 * _Advisor_ - retrieves security advisories based on the Analyzer result.
-* _Documenter_ - generates the final outcome of the review process incl. legal conclusions, e.g. annotated
-  [SPDX](https://spdx.dev/) files that can be included into the distribution.
 
 # Installation
 


### PR DESCRIPTION
As agreed in the TSC meeting from 2020-10-23 [1] that functionality will
be part of the reporter.

[1] https://github.com/oss-review-toolkit/ort-governance/pull/12

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>