### PR TITLE
Introduce performance logging

### DIFF
--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -48,6 +48,7 @@ import org.ossreviewtoolkit.utils.ORT_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ORT_DATA_DIR_ENV_NAME
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.Os
+import org.ossreviewtoolkit.utils.PERFORMANCE
 import org.ossreviewtoolkit.utils.expandTilde
 import org.ossreviewtoolkit.utils.ortConfigDirectory
 import org.ossreviewtoolkit.utils.ortDataDirectory
@@ -77,6 +78,7 @@ class OrtMain : CliktCommand(name = ORT_NAME, epilog = "* denotes required optio
 
     private val logLevel by option(help = "Set the verbosity level of log output.").switch(
         "--info" to Level.INFO,
+        "--performance" to PERFORMANCE,
         "--debug" to Level.DEBUG
     ).default(Level.WARN)
 

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -64,8 +64,10 @@ import org.ossreviewtoolkit.utils.PackageConfigurationOption
 import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.createProvider
 import org.ossreviewtoolkit.utils.expandTilde
+import org.ossreviewtoolkit.utils.formatSizeInMib
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.ortConfigDirectory
+import org.ossreviewtoolkit.utils.perf
 import org.ossreviewtoolkit.utils.safeMkdirs
 import org.ossreviewtoolkit.utils.showStackTrace
 import org.ossreviewtoolkit.utils.storage.FileArchiver
@@ -196,7 +198,12 @@ class ReporterCommand : CliktCommand(
     private val globalOptionsForSubcommands by requireObject<GlobalOptions>()
 
     override fun run() {
-        var ortResult = ortFile.readValue<OrtResult>()
+        var (ortResult, readDuration) = measureTimedValue { ortFile.readValue<OrtResult>() }
+
+        log.perf {
+            "Read ORT result from '${ortFile.name}' (${ortFile.formatSizeInMib}) in ${readDuration.inMilliseconds}ms."
+        }
+
         repositoryConfigurationFile?.let {
             ortResult = ortResult.replaceConfig(it.readValue())
         }

--- a/integrations/Jenkinsfile
+++ b/integrations/Jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
         choice(
             name: 'LOG_LEVEL',
             description: 'Log message level',
-            choices: ['--info', '--debug', '']
+            choices: ['--info', '--performance', '--debug', '']
         )
 
         booleanParam(

--- a/utils/src/main/kotlin/Extensions.kt
+++ b/utils/src/main/kotlin/Extensions.kt
@@ -48,6 +48,11 @@ import java.security.MessageDigest
 fun ByteArray.toHexString(): String = joinToString("") { String.format("%02x", it) }
 
 /**
+ * Format this [Double] as a string with the provided number of [decimalPlaces].
+ */
+fun Double.format(decimalPlaces: Int = 2) = "%.${decimalPlaces}f".format(this)
+
+/**
  * If the SHELL environment variable is set, return the absolute file with a leading "~" expanded to the current user's
  * home directory, otherwise return just the absolute file.
  */
@@ -208,6 +213,11 @@ fun File.searchUpwardsForSubdirectory(searchDirName: String): File? {
 }
 
 /**
+ * Get the size of this [File] in mebibytes (MiB) with two decimal places as [String].
+ */
+val File.formatSizeInMib: String get() = "${length().bytesToMiB().format()} MiB"
+
+/**
  * Construct a "file:" URI in a safe way by never using a null authority for wider compatibility.
  */
 fun File.toSafeURI(): URI {
@@ -232,6 +242,11 @@ fun JsonNode?.fieldsOrEmpty(): Iterator<Map.Entry<String, JsonNode>> = this?.fie
  * or the text value is null.
  */
 fun JsonNode?.textValueOrEmpty(): String = this?.textValue().orEmpty()
+
+/**
+ * Converts this [Long] from bytes to mebibytes (MiB).
+ */
+fun Long.bytesToMiB(): Double = this / (1024.0 * 1024.0)
 
 /**
  * Merge two maps by iterating over the combined key set of both maps and applying [operation] to the entries for the

--- a/utils/src/main/kotlin/Logger.kt
+++ b/utils/src/main/kotlin/Logger.kt
@@ -17,13 +17,18 @@
  * License-Filename: LICENSE
  */
 
+@file:Suppress("TooManyFunctions")
+
 package org.ossreviewtoolkit.utils
 
 import java.util.concurrent.ConcurrentHashMap
 
 import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.Marker
 import org.apache.logging.log4j.kotlin.KotlinLogger
+import org.apache.logging.log4j.kotlin.asLog4jSupplier
 import org.apache.logging.log4j.kotlin.loggerOf
+import org.apache.logging.log4j.message.Message
 
 /**
  * Global map of loggers for classes so only one logger needs to be instantiated per class.
@@ -47,4 +52,74 @@ inline fun <reified T : Any> T.logOnce(level: Level, supplier: () -> String) {
         log.statements += statement
         log.log(statement.second, statement.third)
     }
+}
+
+/**
+ * A log [Level] for logging performance information. The int value of the level is between [Level.INFO] and
+ * [Level.DEBUG].
+ */
+val PERFORMANCE = Level.forName("PERFORMANCE", 450)
+
+fun KotlinLogger.perf(marker: Marker, msg: Message) {
+    delegate.logIfEnabled(KotlinLogger.FQCN, PERFORMANCE, marker, msg, null)
+}
+
+fun KotlinLogger.perf(marker: Marker, msg: Message, t: Throwable?) {
+    delegate.logIfEnabled(KotlinLogger.FQCN, PERFORMANCE, marker, msg, t)
+}
+
+fun KotlinLogger.perf(marker: Marker, msg: CharSequence) {
+    delegate.logIfEnabled(KotlinLogger.FQCN, PERFORMANCE, marker, msg, null)
+}
+
+fun KotlinLogger.perf(marker: Marker, msg: CharSequence, t: Throwable?) {
+    delegate.logIfEnabled(KotlinLogger.FQCN, PERFORMANCE, marker, msg, t)
+}
+
+fun KotlinLogger.perf(marker: Marker, msg: Any) {
+    delegate.logIfEnabled(KotlinLogger.FQCN, PERFORMANCE, marker, msg, null)
+}
+
+fun KotlinLogger.perf(marker: Marker, msg: Any, t: Throwable?) {
+    delegate.logIfEnabled(KotlinLogger.FQCN, PERFORMANCE, marker, msg, t)
+}
+
+fun KotlinLogger.perf(msg: Message) {
+    delegate.logIfEnabled(KotlinLogger.FQCN, PERFORMANCE, null, msg, null)
+}
+
+fun KotlinLogger.perf(msg: Message, t: Throwable?) {
+    delegate.logIfEnabled(KotlinLogger.FQCN, PERFORMANCE, null, msg, t)
+}
+
+fun KotlinLogger.perf(msg: CharSequence) {
+    delegate.logIfEnabled(KotlinLogger.FQCN, PERFORMANCE, null, msg, null)
+}
+
+fun KotlinLogger.perf(msg: CharSequence, t: Throwable?) {
+    delegate.logIfEnabled(KotlinLogger.FQCN, PERFORMANCE, null, msg, t)
+}
+
+fun KotlinLogger.perf(msg: Any) {
+    delegate.logIfEnabled(KotlinLogger.FQCN, PERFORMANCE, null, msg, null)
+}
+
+fun KotlinLogger.perf(msg: Any, t: Throwable?) {
+    delegate.logIfEnabled(KotlinLogger.FQCN, PERFORMANCE, null, msg, t)
+}
+
+fun KotlinLogger.perf(supplier: () -> Any?) {
+    delegate.logIfEnabled(KotlinLogger.FQCN, PERFORMANCE, null, supplier.asLog4jSupplier(), null)
+}
+
+fun KotlinLogger.perf(t: Throwable, supplier: () -> Any?) {
+    delegate.logIfEnabled(KotlinLogger.FQCN, PERFORMANCE, null, supplier.asLog4jSupplier(), t)
+}
+
+fun KotlinLogger.perf(marker: Marker, supplier: () -> Any?) {
+    delegate.logIfEnabled(KotlinLogger.FQCN, PERFORMANCE, marker, supplier.asLog4jSupplier(), null)
+}
+
+fun KotlinLogger.perf(marker: Marker, t: Throwable?, supplier: () -> Any?) {
+    delegate.logIfEnabled(KotlinLogger.FQCN, PERFORMANCE, marker, supplier.asLog4jSupplier(), t)
 }


### PR DESCRIPTION
Add a log level for performance logging and use it initially for logging (de-)serialization durations.