### PR TITLE
Scanner: Filter out not applicable license files for packages

### DIFF
--- a/model/src/main/kotlin/ScanResult.kt
+++ b/model/src/main/kotlin/ScanResult.kt
@@ -57,6 +57,8 @@ data class ScanResult(
      * for [provenance]. Findings which [RootLicenseMatcher] assigns as root license files for [path] are also kept.
      */
     fun filterPath(path: String): ScanResult {
+        if (path.isBlank()) return this
+
         val applicableLicenseFiles = RootLicenseMatcher().getApplicableLicenseFilesForDirectories(
             licenseFindings = summary.licenseFindings,
             directories = listOf(path)

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -352,7 +352,9 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
 
         archiveFiles(downloadResult.downloadDirectory, pkg.id, provenance)
 
-        val scanResult = scanPathInternal(downloadResult.downloadDirectory, resultsFile).copy(provenance = provenance)
+        val scanResult = scanPathInternal(downloadResult.downloadDirectory, resultsFile).let { scanResult ->
+            provenance.vcsInfo?.let { scanResult.filterPath(it.path) } ?: scanResult
+        }.copy(provenance = provenance)
 
         return when (val storageResult = ScanResultsStorage.storage.add(pkg.id, scanResult)) {
             is Success -> scanResult

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -307,7 +307,9 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
      * Return the [ScanResult], if the package could not be scanned a [ScanException] is thrown.
      */
     private fun scanPackage(
-        scannerDetails: ScannerDetails, pkg: Package, outputDirectory: File,
+        scannerDetails: ScannerDetails,
+        pkg: Package,
+        outputDirectory: File,
         downloadDirectory: File
     ): ScanResult {
         val resultsFile = getResultsFile(scannerDetails, pkg, outputDirectory)

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -215,7 +215,12 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
                             "and $scannerDetails, not scanning the package again $packageIndex."
                 }
 
-                storedResults
+                // Due to a temporary bug that has been fixed by now the scan results for packages were not properly
+                // filtered. Filter them again to fix the problem also scan storage entries which exhibit that problem.
+                // TODO: This filtering can be removed after a while.
+                storedResults.map { scanResult ->
+                    scanResult.provenance.vcsInfo?.let { scanResult.filterPath(it.path) } ?: scanResult
+                }
             } else {
                 withContext(scanDispatcher) {
                     log.info {


### PR DESCRIPTION
The filtering was accidentally applied only to projects.