### PR TITLE
declared-license-mapping: Strip a trailing white space

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -36,7 +36,7 @@
 "Apache License, V2.0 or later": Apache-2.0
 "Apache License, Version 2": Apache-2.0
 "Apache License, Version 2.0 and Common Development And Distribution License (CDDL) Version 1.0": Apache-2.0 AND CDDL-1.0
-"Apache License, Version 2.0 and\n        Common Development And Distribution License (CDDL) Version 1.0 ": Apache-2.0 AND CDDL-1.0
+"Apache License, Version 2.0 and\n        Common Development And Distribution License (CDDL) Version 1.0": Apache-2.0 AND CDDL-1.0
 "Apache License, Version 2.0": Apache-2.0
 "Apache License,Version 2.0": Apache-2.0
 "Apache Public License 2.0": Apache-2.0


### PR DESCRIPTION
declared-license-mapping: Strip a trailing white space in a declared license

This entry was originally added in b3595cd for a Maven package, but since
a49dbba we strip declared licenses coming from Maven, so also strip the
lookup key in the mapping.

A future change will ensure that we consistently do trimming of declared
licenses for all package managers.

Signed-off-by: Frank Viernau <frank.viernau@here.com>