### PR TITLE
Oheger bosch/scanner/#3247 scanner details compatibility

### DIFF
--- a/scanner/src/main/kotlin/ScannerCriteria.kt
+++ b/scanner/src/main/kotlin/ScannerCriteria.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner
+
+import com.vdurmont.semver4j.Semver
+
+import org.ossreviewtoolkit.model.ScannerDetails
+
+/**
+ * Definition of a predicate to check whether the configuration of a scanner is compatible with the requirements
+ * specified by a [ScannerCriteria] object.
+ *
+ * When testing whether a scan result is compatible with specific criteria this function is invoked on the
+ * scanner configuration data stored in the result. By having different, scanner-specific matcher functions, this
+ * compatibility check can be made very flexible.
+ *
+ * TODO: Switch to a more advanced type than String to represent the scanner configuration.
+ */
+typealias ScannerConfigMatcher = (String) -> Boolean
+
+/**
+ * A data class defining selection criteria for scanners.
+ *
+ * An instance of this class is passed to a [ScanResultsStorage] to define the criteria a scan result must match,
+ * so that it can be used as a replacement for a result produced by an actual scanner. A scanner implementation
+ * creates a criteria object with its exact properties. Users can override some or all of these properties to
+ * state the criteria under which results from a storage are acceptable even if they deviate from the exact
+ * properties of the scanner. That way it can be configured for instance, that results produced by an older
+ * version of the scanner can be used.
+ */
+data class ScannerCriteria(
+    /**
+     * Criterion to match the scanner name. This string is interpreted as a regular expression. In the most basic
+     * form, it can be an exact scanner name, but by using features of regular expressions, a more advanced
+     * matching can be achieved. So it is possible for instance to select multiple scanners using an alternative ('|')
+     * expression or an arbitrary one using a wildcard ('.*').
+     */
+    val regScannerName: String,
+
+    /**
+     * Criterion to match for the minimum scanner version. Results are accepted if they are produced from scanners
+     * with at least this version.
+     */
+    val minVersion: Semver,
+
+    /**
+     * Criterion to match for the maximum scanner version. Results are accepted if they are produced from scanners
+     * with a version lower than this one. (This bound of the version range is excluding.)
+     */
+    val maxVersion: Semver,
+
+    /**
+     * A function to check whether the configuration of a scanner is compatible with this criteria object.
+     */
+    val configMatcher: ScannerConfigMatcher
+) {
+    companion object {
+        /**
+         * A matcher for scanner configurations that accepts all configurations passed in. This function can be
+         * used if the concrete configuration of a scanner is irrelevant.
+         */
+        val ALL_CONFIG_MATCHER: ScannerConfigMatcher = { true }
+
+        /**
+         * A matcher for scanner configurations that accepts only exact matches of the [originalConfig]. This
+         * function can be used by scanners that are extremely sensitive about their configuration.
+         */
+        fun exactConfigMatcher(originalConfig: String): ScannerConfigMatcher = { config -> originalConfig == config }
+    }
+
+    /** The regular expression to match for the scanner name. */
+    private val nameRegex: Regex by lazy { Regex(regScannerName) }
+
+    /**
+     * Check whether the [details] specified match the criteria stored in this object. Return true if and only if
+     * the result described by the [details] fulfills all the requirements expressed by the properties of this
+     * object.
+     */
+    fun matches(details: ScannerDetails): Boolean {
+        if (!nameRegex.matches(details.name)) {
+            return false
+        }
+
+        val version = Semver(details.version)
+        return minVersion <= version && maxVersion > version && configMatcher(details.configuration)
+    }
+}

--- a/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
+++ b/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
@@ -32,7 +32,6 @@ import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Result
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanResultContainer
-import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.Success
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsInfoCurationData
@@ -41,6 +40,7 @@ import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.utils.toClearlyDefinedCoordinates
 import org.ossreviewtoolkit.model.utils.toClearlyDefinedSourceLocation
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
+import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.scanner.scanners.generateScannerDetails
 import org.ossreviewtoolkit.scanner.scanners.generateSummary
 import org.ossreviewtoolkit.utils.collectMessagesAsString
@@ -110,7 +110,7 @@ class ClearlyDefinedStorage(
     override fun readFromStorage(id: Identifier): Result<ScanResultContainer> =
         readPackageFromClearlyDefined(id, null, null)
 
-    override fun readFromStorage(pkg: Package, scannerDetails: ScannerDetails): Result<ScanResultContainer> =
+    override fun readFromStorage(pkg: Package, scannerCriteria: ScannerCriteria): Result<ScanResultContainer> =
         readPackageFromClearlyDefined(pkg.id, pkg.vcs, pkg.sourceArtifact.takeIf { it.url.isNotEmpty() })
 
     override fun addToStorage(id: Identifier, scanResult: ScanResult): Result<Unit> =

--- a/scanner/src/main/kotlin/storages/CompositeStorage.kt
+++ b/scanner/src/main/kotlin/storages/CompositeStorage.kt
@@ -25,9 +25,9 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Result
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanResultContainer
-import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.Success
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
+import org.ossreviewtoolkit.scanner.ScannerCriteria
 
 /**
  * A [ScanResultsStorage] implementation that manages multiple concrete storages for reading and writing scan results.
@@ -61,11 +61,11 @@ class CompositeStorage(
         fetchReadResult(id) { read(id) }
 
     /**
-     * Try to find scan results for the provided [pkg] and [scannerDetails]. This implementation iterates over all
+     * Try to find scan results for the provided [pkg] and [scannerCriteria]. This implementation iterates over all
      * the reader storages provided until it receives a non-empty success result.
      */
-    override fun readFromStorage(pkg: Package, scannerDetails: ScannerDetails): Result<ScanResultContainer> =
-        fetchReadResult(pkg.id) { read(pkg, scannerDetails) }
+    override fun readFromStorage(pkg: Package, scannerCriteria: ScannerCriteria): Result<ScanResultContainer> =
+        fetchReadResult(pkg.id) { read(pkg, scannerCriteria) }
 
     /**
      * Trigger all configured writer storages to add the [scanResult] for the given [id]. Return a success result

--- a/scanner/src/main/kotlin/storages/NoStorage.kt
+++ b/scanner/src/main/kotlin/storages/NoStorage.kt
@@ -25,9 +25,9 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Result
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanResultContainer
-import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.Success
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
+import org.ossreviewtoolkit.scanner.ScannerCriteria
 
 /**
  * A dummy storage that does not store scan results at all. Can be used to disable storing of scan results to always
@@ -37,7 +37,7 @@ import org.ossreviewtoolkit.scanner.ScanResultsStorage
 class NoStorage : ScanResultsStorage() {
     override fun readFromStorage(id: Identifier) = Success(ScanResultContainer(id, emptyList()))
 
-    override fun readFromStorage(pkg: Package, scannerDetails: ScannerDetails) =
+    override fun readFromStorage(pkg: Package, scannerCriteria: ScannerCriteria) =
         Success(ScanResultContainer(pkg.id, emptyList()))
 
     override fun addToStorage(id: Identifier, scanResult: ScanResult) = Success(Unit)

--- a/scanner/src/main/kotlin/storages/PostgresStorage.kt
+++ b/scanner/src/main/kotlin/storages/PostgresStorage.kt
@@ -22,7 +22,10 @@ package org.ossreviewtoolkit.scanner.storages
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.module.kotlin.readValue
 
+import com.vdurmont.semver4j.Semver
+
 import java.io.IOException
+import java.sql.Array
 import java.sql.Connection
 import java.sql.SQLException
 
@@ -58,6 +61,28 @@ class PostgresStorage(
      */
     private val schema: String
 ) : ScanResultsStorage() {
+    companion object {
+        /** Expression to reference the scanner version as an array. */
+        private const val VERSION_ARRAY =
+            "string_to_array(regexp_replace(scan_result->'scanner'->>'version', '[^0-9.]', '', 'g'), '.')"
+
+        /** Expression to convert the scanner version to a numeric array for comparisons. */
+        private const val VERSION_EXPRESSION = "$VERSION_ARRAY::int[]"
+
+        /**
+         * The null character "\u0000" can appear in raw scan results, for example in ScanCode if the matched text for a
+         * license or copyright contains this character. Since it is not allowed in PostgreSQL JSONB columns we need to
+         * escape it before writing a string to the database.
+         * See: [https://www.postgresql.org/docs/11/datatype-json.html]
+         */
+        private fun String.escapeNull() = replace("\\u0000", "\\\\u0000")
+
+        /**
+         * Unescape the null character "\u0000". For details see [escapeNull].
+         */
+        private fun String.unescapeNull() = replace("\\\\u0000", "\\u0000")
+    }
+
     private val table = "scan_results" // TODO: make configurable
 
     /**
@@ -128,8 +153,7 @@ class PostgresStorage(
                 (
                     identifier,
                     (scan_result->'scanner'->>'name'),
-                    substring(scan_result->'scanner'->>'version' from '([0-9]+\.[0-9]+)\.?.*'),
-                    (scan_result->'scanner'->>'configuration')
+                    $VERSION_ARRAY
                 )
                 TABLESPACE pg_default
             """.trimIndent()
@@ -186,15 +210,13 @@ class PostgresStorage(
     }
 
     override fun readFromStorage(pkg: Package, scannerCriteria: ScannerCriteria): Result<ScanResultContainer> {
-        // TODO: Evaluate the version range
-        val version = scannerCriteria.minVersion
-
         val query = """
             SELECT scan_result
               FROM $schema.$table
               WHERE identifier = ?
-                AND scan_result->'scanner'->>'name' = ?
-                AND substring(scan_result->'scanner'->>'version' from '([0-9]+\.[0-9]+)\.?.*') = ?;
+                AND scan_result->'scanner'->>'name' ~ ?
+                AND $VERSION_EXPRESSION >= ?
+                AND $VERSION_EXPRESSION < ?;
         """.trimIndent()
 
         @Suppress("TooGenericExceptionCaught")
@@ -202,7 +224,8 @@ class PostgresStorage(
             val statement = connection.prepareStatement(query).apply {
                 setString(1, pkg.id.toCoordinates())
                 setString(2, scannerCriteria.regScannerName)
-                setString(3, "${version.major}.${version.minor}")
+                setArray(3, scannerCriteria.minVersion.toSqlArray())
+                setArray(4, scannerCriteria.maxVersion.toSqlArray())
             }
 
             val (resultSet, queryDuration) = measureTimedValue { statement.executeQuery() }
@@ -287,15 +310,10 @@ class PostgresStorage(
     }
 
     /**
-     * The null character "\u0000" can appear in raw scan results, for example in ScanCode if the matched text for a
-     * license or copyright contains this character. Since it is not allowed in PostgreSQL JSONB columns we need to
-     * escape it before writing a string to the database.
-     * See: [https://www.postgresql.org/docs/11/datatype-json.html]
+     * Generate an SQL array parameter for the version numbers contained in this [Semver].
      */
-    private fun String.escapeNull() = replace("\\u0000", "\\\\u0000")
-
-    /**
-     * Unescape the null character "\u0000". For details see [escapeNull].
-     */
-    private fun String.unescapeNull() = replace("\\\\u0000", "\\u0000")
+    private fun Semver.toSqlArray(): Array {
+        val versionArray = intArrayOf(major, minor, patch)
+        return connection.createArrayOf("int4", versionArray.toTypedArray())
+    }
 }

--- a/scanner/src/test/kotlin/LocalScannerTest.kt
+++ b/scanner/src/test/kotlin/LocalScannerTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.vdurmont.semver4j.Semver
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import java.io.File
+import java.lang.UnsupportedOperationException
+
+import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+
+class LocalScannerTest : WordSpec({
+    "LocalScanner.getScannerCriteria()" should {
+        "obtain default values from the scanner" {
+            val scanner = createScanner(createConfig(emptyMap()))
+
+            val criteria = scanner.getScannerCriteria()
+
+            criteria.regScannerName shouldBe SCANNER_NAME
+            criteria.minVersion.originalValue shouldBe SCANNER_VERSION
+            criteria.maxVersion shouldBe Semver(SCANNER_VERSION).nextMinor()
+        }
+
+        "obtain values from the configuration" {
+            val config = mapOf(
+                LocalScanner.PROP_CRITERIA_NAME to "foo",
+                LocalScanner.PROP_CRITERIA_MIN_VERSION to "1.2.3",
+                LocalScanner.PROP_CRITERIA_MAX_VERSION to "4.5.6"
+            )
+            val scanner = createScanner(createConfig(config))
+
+            val criteria = scanner.getScannerCriteria()
+
+            criteria.regScannerName shouldBe "foo"
+            criteria.minVersion.originalValue shouldBe "1.2.3"
+            criteria.maxVersion.originalValue shouldBe "4.5.6"
+        }
+
+        "parse versions in a lenient way" {
+            val config = mapOf(
+                LocalScanner.PROP_CRITERIA_MIN_VERSION to "1",
+                LocalScanner.PROP_CRITERIA_MAX_VERSION to "3.7"
+            )
+            val scanner = createScanner(createConfig(config))
+
+            val criteria = scanner.getScannerCriteria()
+
+            criteria.minVersion.originalValue shouldBe "1.0.0"
+            criteria.maxVersion.originalValue shouldBe "3.7.0"
+        }
+
+        "use an exact configuration matcher" {
+            val scanner = createScanner(createConfig(emptyMap()))
+
+            val criteria = scanner.getScannerCriteria()
+
+            criteria.configMatcher(scanner.getConfiguration()) shouldBe true
+            criteria.configMatcher(scanner.getConfiguration() + "_other") shouldBe false
+        }
+    }
+})
+
+private const val SCANNER_NAME = "TestScanner"
+private const val SCANNER_VERSION = "3.2.1.final"
+
+/**
+ * Creates a [ScannerConfiguration] with the given properties for the test scanner.
+ */
+private fun createConfig(properties: Map<String, String>): ScannerConfiguration {
+    val options = mapOf(SCANNER_NAME to properties)
+    return ScannerConfiguration(options = options)
+}
+
+/**
+ * Create a test instance of [LocalScanner].
+ */
+private fun createScanner(config: ScannerConfiguration): LocalScanner =
+    object : LocalScanner(SCANNER_NAME, config) {
+        override val resultFileExt: String
+            get() = "xml"
+
+        override val scannerVersion: String
+            get() = SCANNER_VERSION
+
+        override fun getConfiguration(): String = "someConfig"
+
+        override fun scanPathInternal(path: File, resultsFile: File): ScanResult {
+            throw UnsupportedOperationException("Unexpected call")
+        }
+
+        override fun getRawResult(resultsFile: File): JsonNode {
+            throw UnsupportedOperationException("Unexpected call")
+        }
+
+        override fun command(workingDir: File?): String {
+            throw UnsupportedOperationException("Unexpected call")
+        }
+    }

--- a/scanner/src/test/kotlin/ScannerCriteriaTest.kt
+++ b/scanner/src/test/kotlin/ScannerCriteriaTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner
+
+import com.vdurmont.semver4j.Semver
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.model.ScannerDetails
+
+class ScannerCriteriaTest : WordSpec({
+    "ScannerCriteria" should {
+        "provide a config matcher that accepts every configuration" {
+            ScannerCriteria.ALL_CONFIG_MATCHER("") shouldBe true
+            ScannerCriteria.ALL_CONFIG_MATCHER("foo") shouldBe true
+            ScannerCriteria.ALL_CONFIG_MATCHER("Supercalifragilisticexpialidocious") shouldBe true
+        }
+
+        "provide a config matcher that accepts only exact configuration matches" {
+            val orgConfig = "--info --copyright --licenses"
+            val matcher = ScannerCriteria.exactConfigMatcher(orgConfig)
+
+            matcher(orgConfig) shouldBe true
+            matcher("$orgConfig --more") shouldBe false
+        }
+    }
+
+    "ScannerCriteria.isCompatible()" should {
+        "accept matching details" {
+            matchingCriteria.matches(testDetails) shouldBe true
+        }
+
+        "detect a different name" {
+            val criteria = matchingCriteria.copy(regScannerName = testDetails.name + "_other")
+
+            criteria.matches(testDetails) shouldBe false
+        }
+
+        "use a regular expression to match the scanner name" {
+            val criteria = matchingCriteria.copy(regScannerName = "Sc.*Cr.+Te.t")
+
+            criteria.matches(testDetails) shouldBe true
+        }
+
+        "detect a scanner version that is too old" {
+            val criteria = matchingCriteria.copy(
+                minVersion = matchingCriteria.maxVersion,
+                maxVersion = Semver("2.0.0")
+            )
+
+            criteria.matches(testDetails) shouldBe false
+        }
+
+        "detect a scanner version that is too new" {
+            val criteria = matchingCriteria.copy(
+                minVersion = Semver("1.0.0"),
+                maxVersion = Semver(testDetails.version)
+            )
+
+            criteria.matches(testDetails) shouldBe false
+        }
+
+        "detect a difference reported by the config matcher" {
+            val criteria = matchingCriteria.copy(
+                configMatcher = ScannerCriteria.exactConfigMatcher(testDetails.configuration + "_other")
+            )
+
+            criteria.matches(testDetails) shouldBe false
+        }
+    }
+})
+
+/** Test details to match against. */
+private val testDetails = ScannerDetails("ScannerCriteriaTest", "1.2.3.beta-47", "a b c")
+
+/** A test instance which should accept the test details. */
+private val matchingCriteria = ScannerCriteria(
+    regScannerName = testDetails.name,
+    minVersion = Semver(testDetails.version),
+    maxVersion = Semver(testDetails.version).nextPatch(),
+    configMatcher = ScannerCriteria.exactConfigMatcher(testDetails.configuration)
+)

--- a/scanner/src/test/kotlin/storages/ClearlyDefinedStorageTest.kt
+++ b/scanner/src/test/kotlin/storages/ClearlyDefinedStorageTest.kt
@@ -28,6 +28,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.vdurmont.semver4j.Semver
 
 import io.kotest.assertions.fail
 import io.kotest.core.spec.style.WordSpec
@@ -52,11 +53,11 @@ import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Result
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanResultContainer
-import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.Success
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.ClearlyDefinedStorageConfiguration
+import org.ossreviewtoolkit.scanner.ScannerCriteria
 
 private const val PACKAGE_TYPE = "Maven"
 private const val NAMESPACE = "someNamespace"
@@ -98,8 +99,11 @@ private val TEST_PACKAGE =
     )
 
 /** The scanner details used by tests. */
-private val SCANNER_DETAILS =
-    ScannerDetails("aScanner", "aVersion", "aConfig")
+private val SCANNER_CRITERIA =
+    ScannerCriteria(
+        "aScanner", Semver("1.0.0"), Semver("2.0.0"),
+        ScannerCriteria.exactConfigMatcher("aConfig")
+    )
 
 /**
  * Return a storage configuration that points to the mock [server].
@@ -221,7 +225,7 @@ class ClearlyDefinedStorageTest : WordSpec({
 
             val storage = ClearlyDefinedStorage(storageConfiguration(wiremock))
 
-            assertValidResult(storage.read(TEST_PACKAGE, SCANNER_DETAILS))
+            assertValidResult(storage.read(TEST_PACKAGE, SCANNER_CRITERIA))
         }
 
         "load existing scan results for an identifier from ClearlyDefined" {
@@ -247,7 +251,7 @@ class ClearlyDefinedStorageTest : WordSpec({
 
             val storage = ClearlyDefinedStorage(storageConfiguration(wiremock))
 
-            assertValidResult(storage.read(TEST_PACKAGE, SCANNER_DETAILS))
+            assertValidResult(storage.read(TEST_PACKAGE, SCANNER_CRITERIA))
         }
 
         "set correct metadata in the package scan result" {
@@ -299,7 +303,7 @@ class ClearlyDefinedStorageTest : WordSpec({
 
             val storage = ClearlyDefinedStorage(storageConfiguration(wiremock))
 
-            assertEmptyResult(storage.read(TEST_PACKAGE, SCANNER_DETAILS))
+            assertEmptyResult(storage.read(TEST_PACKAGE, SCANNER_CRITERIA))
         }
 
         "use GitHub VCS info if available" {
@@ -317,7 +321,7 @@ class ClearlyDefinedStorageTest : WordSpec({
 
             val storage = ClearlyDefinedStorage(storageConfiguration(wiremock))
 
-            assertValidResult(storage.read(pkg, SCANNER_DETAILS))
+            assertValidResult(storage.read(pkg, SCANNER_CRITERIA))
         }
 
         "only use VCS info pointing to GitHub" {
@@ -329,7 +333,7 @@ class ClearlyDefinedStorageTest : WordSpec({
 
             val storage = ClearlyDefinedStorage(storageConfiguration(wiremock))
 
-            assertValidResult(storage.read(pkg, SCANNER_DETAILS))
+            assertValidResult(storage.read(pkg, SCANNER_CRITERIA))
         }
 
         "use information from a source artifact if available" {
@@ -342,7 +346,7 @@ class ClearlyDefinedStorageTest : WordSpec({
 
             val storage = ClearlyDefinedStorage(storageConfiguration(wiremock))
 
-            assertValidResult(storage.read(pkg, SCANNER_DETAILS))
+            assertValidResult(storage.read(pkg, SCANNER_CRITERIA))
         }
 
         "deal with package coordinates not supported by ClearlyDefined" {

--- a/scanner/src/test/kotlin/storages/CompositeStorageTest.kt
+++ b/scanner/src/test/kotlin/storages/CompositeStorageTest.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.scanner.storages
 
 import com.fasterxml.jackson.databind.node.TextNode
+import com.vdurmont.semver4j.Semver
 
 import io.kotest.assertions.fail
 import io.kotest.core.spec.style.WordSpec
@@ -45,6 +46,7 @@ import org.ossreviewtoolkit.model.Success
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
+import org.ossreviewtoolkit.scanner.ScannerCriteria
 
 private val ID = Identifier(type = "Gradle", namespace = "testNS", name = "test", version = "1.0.9")
 
@@ -54,7 +56,10 @@ private val PACKAGE = Package(
     declaredLicenses = sortedSetOf()
 )
 
-private val DETAILS = ScannerDetails("testScanner", "0.1", "testConfig")
+private val CRITERIA = ScannerCriteria(
+    "testScanner", Semver("0.0.1"), Semver("2.0.0"),
+    ScannerCriteria.exactConfigMatcher("testConfig")
+)
 
 /**
  * Create a mock [ScanResultsStorage] that reports the specified [name].
@@ -146,7 +151,7 @@ class CompositeStorageTest : WordSpec({
         "return an empty result if no readers are configured when asked for a package" {
             val storage = CompositeStorage(emptyList(), listOf(mockk()))
 
-            when (val result = storage.read(PACKAGE, DETAILS)) {
+            when (val result = storage.read(PACKAGE, CRITERIA)) {
                 is Success -> {
                     result.result.id shouldBe ID
                     result.result.results.isEmpty() shouldBe true
@@ -162,15 +167,15 @@ class CompositeStorageTest : WordSpec({
             val readerEmptyContainer = storageMock("r2")
             val readerResult = storageMock("r3")
             val readerUnused = storageMock("r4")
-            every { readerErr.read(PACKAGE, DETAILS) } returns Failure("an error")
-            every { readerEmptyContainer.read(PACKAGE, DETAILS) } returns Success(ScanResultContainer(ID, emptyList()))
-            every { readerResult.read(PACKAGE, DETAILS) } returns result
+            every { readerErr.read(PACKAGE, CRITERIA) } returns Failure("an error")
+            every { readerEmptyContainer.read(PACKAGE, CRITERIA) } returns Success(ScanResultContainer(ID, emptyList()))
+            every { readerResult.read(PACKAGE, CRITERIA) } returns result
 
             val storage = CompositeStorage(
                 listOf(readerErr, readerEmptyContainer, readerResult, readerUnused),
                 emptyList()
             )
-            val readResult = storage.read(PACKAGE, DETAILS)
+            val readResult = storage.read(PACKAGE, CRITERIA)
 
             readResult shouldBe result
         }


### PR DESCRIPTION
This PR is a first step towards making queries for results from ScanResultsStorage more flexible. The basic idea is that storages are not queried in terms of a ScannerDetails object, but using a ScannerCriteria object. This object allows specifying more advanced matching criteria, for instance a range for the scanner version. ScannerCriteria are created by scanner implementations; per default, they match the properties of their scanner very strictly, but users can override their criteria via the scanner configuration. That way it can be stated for instance that scan results produced by an older scanner version can be reused.

The existing ScanResultsStorage implementations have been adapted to support all the criteria currently available. For PostgresStorage, this even happens in the query statement for the most relevant criteria.

The mechanism with the scanner criteria can be extended in future. For instance, properties could be added to include or exclude scan results based on the data they contain. Also, the comparison of the scanner configuration can be customized; to prepare this, the ScannerConfigMatcher function has been introduced.