### PR TITLE
Fix a wrong property reference in the help text of the -P option

### DIFF
--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -87,7 +87,7 @@ class OrtMain : CliktCommand(name = ORT_NAME, epilog = "* denotes required optio
     private val configArguments by option(
         "-P",
         help = "Override a key-value pair in the configuration file. For example: " +
-                "-P scanner.postgresStorage.schema=testSchema"
+                "-P ort.scanner.storages.postgresStorage.schema=testSchema"
     ).associate()
 
     private val forceOverwrite by option(


### PR DESCRIPTION
The help text of the -P command line option contains an example of a
configuration property that is overridden on the command line.
However, the path of this property is outdated. This fix corrects the
example by setting a valid property path.

Signed-off-by: Oliver Heger <oliver.heger@bosch.io>