### PR TITLE
Add ScanOSS as a RemoteScanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ![OSS Review Toolkit Logo](./logos/ort.png)
 
+
+
+
 &nbsp;
 
 [![Slack][1]][2]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 ![OSS Review Toolkit Logo](./logos/ort.png)
 
-
-
 &nbsp;
 
 [![Slack][1]][2]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![OSS Review Toolkit Logo](./logos/ort.png)
 
+
+
 &nbsp;
 
 [![Slack][1]][2]

--- a/scanner/build.gradle.kts
+++ b/scanner/build.gradle.kts
@@ -55,7 +55,9 @@ dependencies {
     implementation(project(":utils"))
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    implementation("com.scanoss:scanner:1.1.1")
     implementation("com.squareup.retrofit2:converter-jackson:$retrofitVersion")
+
     implementation("com.zaxxer:HikariCP:$hikariVersion")
     implementation("org.eclipse.sw360:client:$sw360ClientVersion")
     implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")

--- a/scanner/src/main/kotlin/RemoteScanner.kt
+++ b/scanner/src/main/kotlin/RemoteScanner.kt
@@ -19,8 +19,18 @@
 
 package org.ossreviewtoolkit.scanner
 
-import org.ossreviewtoolkit.model.ScannerDetails
+import com.vdurmont.semver4j.Semver
+import org.ossreviewtoolkit.downloader.DownloadException
+import org.ossreviewtoolkit.downloader.Downloader
+import org.ossreviewtoolkit.model.*
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.config.createFileArchiver
+import org.ossreviewtoolkit.scanner.storages.PostgresStorage
+import org.ossreviewtoolkit.utils.*
+import java.io.File
+import java.time.Instant
+import kotlin.time.measureTime
+import kotlin.time.measureTimedValue
 
 /**
  * Abstraction for a [Scanner] that runs on a remote host.
@@ -41,4 +51,297 @@ abstract class RemoteScanner(name: String, config: ScannerConfiguration) : Scann
      * Return the [ScannerDetails] of this [RemoteScanner].
      */
     val details by lazy { ScannerDetails(scannerName, version, configuration) }
+
+    /**
+     * A property containing the file name extension of the scanner's native output format, without the dot.
+     */
+    abstract val resultFileExt: String
+
+    private val archiver by lazy {
+        config.archive.createFileArchiver()
+    }
+
+    /**
+     * Return a [ScannerCriteria] object to be used when looking up existing scan results from a [ScanResultsStorage].
+     * Per default, the properties of this object are initialized to match this scanner implementation. It is,
+     * however, possible to override these defaults from the configuration, in the [ScannerConfiguration.options]
+     * property: Use properties of the form _scannerName.criteria.property_, where _scannerName_ is the name of
+     * the scanner the configuration applies to, and _property_ is the name of a property of the [ScannerCriteria]
+     * class. For instance, to specify that a specific minimum version of ScanCode is allowed, set this property:
+     * `options.ScanCode.criteria.minScannerVersion=3.0.2`.
+     */
+    open fun getScannerCriteria(): ScannerCriteria {
+        val options = config.options?.get(scannerName).orEmpty()
+        val minVersion =
+            parseVersion(options[LocalScanner.PROP_CRITERIA_MIN_VERSION]) ?: Semver(normalizeVersion(version))
+        val maxVersion = parseVersion(options[LocalScanner.PROP_CRITERIA_MAX_VERSION]) ?: minVersion.nextMinor()
+        val name = options[LocalScanner.PROP_CRITERIA_NAME] ?: scannerName
+        return ScannerCriteria(name, minVersion, maxVersion, ScannerCriteria.exactConfigMatcher(configuration))
+    }
+
+    override suspend fun scanPackages(
+        packages: List<Package>,
+        outputDirectory: File,
+        downloadDirectory: File
+    ): Map<Package, List<ScanResult>> {
+        val scannerCriteria = getScannerCriteria()
+
+        log.info { "Searching scan results for ${packages.size} packages." }
+
+        val remainingPackages = packages.filterTo(mutableListOf()) { pkg ->
+            !pkg.isMetaDataOnly.also {
+                if (it) RemoteScanner.log.info { "Skipping '${pkg.id.toCoordinates()}' as it is meta data only." }
+            }
+        }
+
+        val resultsFromStorage = readResultsFromStorage(packages, scannerCriteria)
+
+        log.info { "Found stored scan results for ${resultsFromStorage.size} packages and $scannerCriteria." }
+
+        if (config.createMissingArchives) {
+            createMissingArchives(resultsFromStorage, downloadDirectory)
+        }
+
+        remainingPackages.removeAll { it in resultsFromStorage.keys }
+
+        log.info { "Scanning ${remainingPackages.size} packages for which no stored scan results were found." }
+
+        val resultsFromScanner = remainingPackages.scan(outputDirectory, downloadDirectory)
+
+        return resultsFromStorage + resultsFromScanner
+    }
+
+    private fun List<Package>.scan(outputDirectory: File, downloadDirectory: File): Map<Package, List<ScanResult>> {
+        var index = 0
+
+        return associateWith { pkg ->
+            index++
+
+            val packageIndex = "($index of $size)"
+
+            RemoteScanner.log.info {
+                "Scanning ${pkg.id.toCoordinates()}' in thread '${Thread.currentThread().name}' $packageIndex"
+            }
+
+            val scanResult = try {
+                scanPackage(details, pkg, outputDirectory, downloadDirectory).also {
+                    RemoteScanner.log.info {
+                        "Finished scanning ${pkg.id.toCoordinates()} in thread '${Thread.currentThread().name}' " +
+                                "$packageIndex."
+                    }
+                }
+            } catch (e: ScanException) {
+                e.showStackTrace()
+                e.createFailedScanResult(pkg, packageIndex)
+            }
+
+            listOf(scanResult)
+        }
+    }
+
+    private fun ScanException.createFailedScanResult(pkg: Package, packageIndex: String): ScanResult {
+        val issue = createAndLogIssue(
+            source = scannerName,
+            message = "Could not scan '${pkg.id.toCoordinates()}' $packageIndex: ${collectMessagesAsString()}"
+        )
+
+        val now = Instant.now()
+        return ScanResult(
+            provenance = Provenance(),
+            scanner = details,
+            summary = ScanSummary(
+                startTime = now,
+                endTime = now,
+                fileCount = 0,
+                packageVerificationCode = "",
+                licenseFindings = sortedSetOf(),
+                copyrightFindings = sortedSetOf(),
+                issues = listOf(issue)
+            )
+        )
+    }
+
+
+    private fun readResultsFromStorage(packages: List<Package>, scannerCriteria: ScannerCriteria) =
+        when (val results = ScanResultsStorage.storage.read(packages, scannerCriteria)) {
+            is Success -> results.result
+            is Failure -> emptyMap()
+        }.filter { it.value.isNotEmpty() }
+            .mapKeys { (id, _) -> packages.single { it.id == id } }
+            .mapValues { it.value.deduplicateScanResults() }
+            .mapValues { (_, scanResults) ->
+                // Due to a bug that has been fixed in d839f6e the scan results for packages were not properly filtered
+                // by VCS path. Filter them again to fix the problem.
+                // TODO: Remove this workaround together with the next change that requires recreating the scan storage.
+                scanResults.map { it.filterByVcsPath().filterByIgnorePatterns(config.ignorePatterns) }
+            }
+
+    /**
+     * Parse the given [versionStr] to a [Semver] object, trying to be failure tolerant.
+     */
+    private fun parseVersion(versionStr: String?): Semver? =
+        versionStr?.let { Semver(normalizeVersion(it)) }
+
+    /**
+     * Normalize the given [versionStr] to make sure that it can be parsed to a [Semver]. The [Semver] class
+     * requires that all components of a semantic version number are present. This function enables a more lenient
+     * style when declaring a version. So for instance, the user can just write "2", and this gets expanded to
+     * "2.0.0".
+     */
+    private fun normalizeVersion(versionStr: String): String =
+        versionStr.takeIf { v -> v.count { it == '.' } >= 2 } ?: normalizeVersion("$versionStr.0")
+
+    private fun archiveFiles(directory: File, id: Identifier, provenance: Provenance) {
+        log.info { "Archiving files for ${id.toCoordinates()}." }
+
+        val duration = measureTime { archiver.archive(directory, provenance) }
+
+        log.perf { "Archived files for '${id.toCoordinates()}' in ${duration.inMilliseconds}ms." }
+    }
+
+    /**
+     * Scan the provided [path] for license information and write the results to [resultsFile] using the scanner's
+     * native file format.
+     *
+     * No scan results storage is used by this function.
+     *
+     * The return value is a [ScanSummary]. If the path could not be scanned, a [ScanException] is thrown.
+     */
+    protected abstract fun scanPathInternal(path: File, resultsFile: File): ScanSummary
+
+    /**
+     * Return the result file inside [outputDirectory]. The name of the file is derived from [pkg] and
+     * [scannerDetails].
+     */
+    private fun getResultsFile(scannerDetails: ScannerDetails, pkg: Package, outputDirectory: File): File {
+        val scanResultsForPackageDirectory = outputDirectory.resolve(pkg.id.toPath()).apply { safeMkdirs() }
+        return scanResultsForPackageDirectory.resolve("scan-results_${scannerDetails.name}.$resultFileExt")
+    }
+
+    private fun createMissingArchives(scanResults: Map<Package, List<ScanResult>>, downloadDirectory: File) {
+        scanResults.forEach { (pkg, results) ->
+            val missingArchives = results.mapNotNullTo(mutableSetOf()) { result ->
+                result.provenance.takeUnless { archiver.hasArchive(result.provenance) }
+            }
+
+            if (missingArchives.isNotEmpty()) {
+                val pkgDownloadDirectory = downloadDirectory.resolve(pkg.id.toPath())
+                Downloader.download(pkg, pkgDownloadDirectory)
+
+                missingArchives.forEach { provenance ->
+                    archiveFiles(pkgDownloadDirectory, pkg.id, provenance)
+                }
+            }
+        }
+    }
+
+    /**
+     * Scan the provided [pkg] for license information and write the results to [outputDirectory] using the scanner's
+     * native file format.
+     *
+     * The package's source code is downloaded to [downloadDirectory] and scanned afterwards.
+     *
+     * Return the [ScanResult], if the package could not be scanned a [ScanException] is thrown.
+     */
+    fun scanPackage(
+        scannerDetails: ScannerDetails,
+        pkg: Package,
+        outputDirectory: File,
+        downloadDirectory: File
+    ): ScanResult {
+        val resultsFile = getResultsFile(scannerDetails, pkg, outputDirectory)
+        val pkgDownloadDirectory = downloadDirectory.resolve(pkg.id.toPath())
+
+        val provenance = try {
+            Downloader.download(pkg, pkgDownloadDirectory)
+        } catch (e: DownloadException) {
+            e.showStackTrace()
+
+            val now = Instant.now()
+            return ScanResult(
+                Provenance(),
+                scannerDetails,
+                ScanSummary(
+                    startTime = now,
+                    endTime = now,
+                    fileCount = 0,
+                    packageVerificationCode = "",
+                    licenseFindings = sortedSetOf(),
+                    copyrightFindings = sortedSetOf(),
+                    issues = listOf(
+                        createAndLogIssue(
+                            source = scannerName,
+                            message = "Could not download '${pkg.id.toCoordinates()}': ${e.collectMessagesAsString()}"
+                        )
+                    )
+                )
+            )
+        }
+
+        log.info {
+            "Running $scannerDetails on directory '${pkgDownloadDirectory.absolutePath}'."
+        }
+
+        archiveFiles(pkgDownloadDirectory, pkg.id, provenance)
+
+        val (scanSummary, scanDuration) = measureTimedValue {
+            val vcsPath = provenance.vcsInfo?.takeUnless { it.type == VcsType.GIT_REPO }?.path.orEmpty()
+            scanPathInternal(pkgDownloadDirectory, resultsFile).filterByPath(vcsPath)
+        }
+
+        log.perf {
+            "Scanned source code of '${pkg.id.toCoordinates()}' with ${javaClass.simpleName} in " +
+                    "${scanDuration.inMilliseconds}ms."
+        }
+
+        val scanResult = ScanResult(provenance, scannerDetails, scanSummary)
+        val storageResult = ScanResultsStorage.storage.add(pkg.id, scanResult)
+        val filteredResult = scanResult.filterByIgnorePatterns(config.ignorePatterns)
+
+        return when (storageResult) {
+            is Success -> filteredResult
+            is Failure -> {
+                val issue = OrtIssue(
+                    source = ScanResultsStorage.storage.name,
+                    message = storageResult.error,
+                    severity = Severity.WARNING
+                )
+                val issues = scanSummary.issues + issue
+                val summary = scanSummary.copy(issues = issues)
+                filteredResult.copy(summary = summary)
+            }
+        }
+    }
+
+    /**
+     * Workaround to prevent that duplicate [ScanResult]s from the [ScanResultsStorage] do get duplicated in the
+     * [OrtResult] produced by this scanner.
+     *
+     * The time interval between a failing read from storage and the resulting scan with the following store operation
+     * can be relatively large. Thus this [LocalScanner] is prone to adding duplicate scan results if multiple instances
+     * of the scanner run in parallel. In particular the [PostgresStorage] allows adding duplicate tuples
+     * (identifier, provenance, scanner details) which should be made unique.
+     *
+     * TODO: Implement a solution that prevents duplicate scan results in the storages.
+     */
+    private fun List<ScanResult>.deduplicateScanResults(): List<ScanResult> {
+        // Use vcsInfo and sourceArtifact instead of provenance in order to ignore the download time and original VCS
+        // info.
+        data class Key(
+            val vcsInfo: VcsInfo?,
+            val sourceArtifact: RemoteArtifact?,
+            val scannerDetails: ScannerDetails
+        )
+
+        fun ScanResult.key() = Key(provenance.vcsInfo, provenance.sourceArtifact, scanner)
+
+        val deduplicatedResults = distinctBy { it.key() }
+
+        val duplicatesCount = size - deduplicatedResults.size
+        if (duplicatesCount > 0) {
+            LocalScanner.log.info { "Removed $duplicatesCount duplicates out of $size scan results." }
+        }
+
+        return deduplicatedResults
+    }
 }

--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOSSResultParser.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOSSResultParser.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2020 SCANOSS TECNOLOGIAS SL
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.scanoss
+
+import com.fasterxml.jackson.databind.JsonNode
+
+import java.io.File
+import java.time.Instant
+
+import org.ossreviewtoolkit.model.CopyrightFinding
+import org.ossreviewtoolkit.model.EMPTY_JSON_NODE
+import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.model.jsonMapper
+import org.ossreviewtoolkit.spdx.SpdxConstants
+import org.ossreviewtoolkit.spdx.SpdxException
+import org.ossreviewtoolkit.spdx.calculatePackageVerificationCode
+
+/**
+ * Generate a summary from the given raw ScanOSS [result], using [startTime] and [endTime] metadata.
+ * From the [scanPath] the package verification code is generated.
+ */
+internal fun generateSummary(startTime: Instant, endTime: Instant, scanPath: File, result: JsonNode) =
+    generateSummary(
+        startTime,
+        endTime,
+        calculatePackageVerificationCode(scanPath),
+        result
+    )
+
+/**
+ * Generate a summary from the given raw ScanOSS [result], using [startTime], [endTime], and [verificationCode]
+ * metadata. This variant can be used if the result is not read from a local file.
+ */
+internal fun generateSummary(startTime: Instant, endTime: Instant, verificationCode: String, result: JsonNode) =
+    ScanSummary(
+        startTime = startTime,
+        endTime = endTime,
+        fileCount = result.size(),
+        packageVerificationCode = verificationCode,
+        licenseFindings = getLicenseFindings(result).toSortedSet(),
+        copyrightFindings = getCopyrightFindings(result).toSortedSet(),
+        issues = emptyList<OrtIssue>()
+    )
+
+/**
+ * Parses result file and returns a JsonNode
+ */
+internal fun parseResult(resultsFile: File): JsonNode {
+    return if (resultsFile.isFile && resultsFile.length() > 0L) {
+        jsonMapper.readTree(resultsFile)
+    } else {
+        EMPTY_JSON_NODE
+    }
+}
+
+/**
+ * Get the license findings from the given [result].
+ */
+private fun getLicenseFindings(result: JsonNode): List<LicenseFinding> {
+    val licenseFindings = mutableListOf<LicenseFinding>()
+
+    val files = result.fields()
+    while (files.hasNext()) {
+        val file = files.next()
+        val matches = file.value?.asSequence().orEmpty()
+        for (match in matches) {
+            val licenses = match["licenses"]?.asSequence().orEmpty()
+            licenseFindings.addAll(licenses.map {
+                try {
+                    LicenseFinding(
+                        license = it["name"].asText(),
+                        location = TextLocation(
+                            path = file.key,
+                            startLine = 1,
+                            endLine = 1
+                        )
+                    )
+                } catch (e: SpdxException) {
+                    LicenseFinding(
+                        license = SpdxConstants.NOASSERTION,
+                        location = TextLocation(
+                            path = file.key,
+                            startLine = 1,
+                            endLine = 1
+                        )
+                    )
+                }
+            })
+        }
+    }
+
+    return licenseFindings
+}
+
+/**
+ * Get the copyright findings from the given [result].
+ */
+private fun getCopyrightFindings(result: JsonNode): List<CopyrightFinding> {
+    val copyrightFindings = mutableListOf<CopyrightFinding>()
+
+    val files = result.fields()
+    while (files.hasNext()) {
+        val file = files.next()
+        val matches = file.value?.asSequence().orEmpty()
+        for (match in matches) {
+            val copyrights = match["copyrights"]?.asSequence().orEmpty()
+            copyrightFindings.addAll(copyrights.map {
+                CopyrightFinding(
+                    statement = it["name"].asText(),
+                    location = TextLocation(
+                        path = file.key,
+                        startLine = 1,
+                        endLine = 1
+                    )
+                )
+            })
+        }
+    }
+
+    return copyrightFindings
+}

--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2020 SCANOSS TECNOLOGIAS SL
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.scanoss
+
+import com.fasterxml.jackson.databind.JsonNode
+
+import com.scanoss.scanner.ScanFormat
+import com.scanoss.scanner.Scanner
+import com.scanoss.scanner.ScannerConf
+
+import java.io.File
+import java.time.Instant
+
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.scanner.AbstractScannerFactory
+import org.ossreviewtoolkit.scanner.RemoteScanner
+
+class ScanOss(
+    name: String,
+    config: ScannerConfiguration
+) : RemoteScanner(name, config) {
+    class Factory : AbstractScannerFactory<ScanOss>("ScanOSS") {
+        override fun create(config: ScannerConfiguration) = ScanOss(scannerName, config)
+    }
+
+    override val version = "1.1.0"
+
+    override val configuration = ""
+
+
+    // TODO Implement support for Scanning with SBOM
+    // TODO Support API configuration other than OSS KB.
+    override fun scanPathInternal(path: File, resultsFile: File): ScanResult {
+        val startTime = Instant.now()
+
+        val scannerConf = ScannerConf.defaultConf()
+        val scanner = Scanner(scannerConf)
+        if (path.isDirectory) {
+            scanner.scanDirectory(path.absolutePath, null, "", ScanFormat.plain, resultsFile.absolutePath)
+        } else if (path.isFile) {
+            scanner.scanFileAndSave(path.absolutePath, null, "", ScanFormat.plain, resultsFile.absolutePath)
+        }
+        val endTime = Instant.now()
+        val result = getRawResult(resultsFile)
+        val summary = generateSummary(startTime, endTime, path, result)
+        return ScanResult(Provenance(), getDetails(), summary)
+    }
+
+    fun getRawResult(resultsFile: File): JsonNode =
+        parseResult(resultsFile)
+
+
+
+}

--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
@@ -28,8 +28,7 @@ import com.scanoss.scanner.ScannerConf
 import java.io.File
 import java.time.Instant
 
-import org.ossreviewtoolkit.model.Provenance
-import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.AbstractScannerFactory
 import org.ossreviewtoolkit.scanner.RemoteScanner
@@ -46,10 +45,11 @@ class ScanOss(
 
     override val configuration = ""
 
+    override val resultFileExt = "json"
 
     // TODO Implement support for Scanning with SBOM
     // TODO Support API configuration other than OSS KB.
-    override fun scanPathInternal(path: File, resultsFile: File): ScanResult {
+    override fun scanPathInternal(path: File, resultsFile: File): ScanSummary {
         val startTime = Instant.now()
 
         val scannerConf = ScannerConf.defaultConf()
@@ -61,11 +61,10 @@ class ScanOss(
         }
         val endTime = Instant.now()
         val result = getRawResult(resultsFile)
-        val summary = generateSummary(startTime, endTime, path, result)
-        return ScanResult(Provenance(), getDetails(), summary)
+        return generateSummary(startTime, endTime, path, result)
     }
 
-    fun getRawResult(resultsFile: File): JsonNode =
+    private fun getRawResult(resultsFile: File): JsonNode =
         parseResult(resultsFile)
 
 

--- a/scanner/src/main/resources/META-INF/services/org.ossreviewtoolkit.scanner.ScannerFactory
+++ b/scanner/src/main/resources/META-INF/services/org.ossreviewtoolkit.scanner.ScannerFactory
@@ -4,3 +4,4 @@ org.ossreviewtoolkit.scanner.scanners.FileCounter$Factory
 org.ossreviewtoolkit.scanner.scanners.Licensee$Factory
 org.ossreviewtoolkit.scanner.scanners.fossid.FossId$Factory
 org.ossreviewtoolkit.scanner.scanners.scancode.ScanCode$Factory
+org.ossreviewtoolkit.scanner.scanners.scanoss.ScanOss$Factory

--- a/scanner/src/test/assets/pigz-c-scanoss.json
+++ b/scanner/src/test/assets/pigz-c-scanoss.json
@@ -1,0 +1,30 @@
+{
+  "pigz.c": [
+    {
+      "id": "file",
+      "lines": "all",
+      "oss_lines": "all",
+      "matched": "100%",
+      "vendor": "madler",
+      "component": "pigz",
+      "version": "v2.4",
+      "latest": "v2.4",
+      "url": "https://github.com/madler/pigz/archive/v2.4.tar.gz",
+      "file": "pigz-2.4/pigz.c",
+      "dependencies": [],
+      "licenses": [
+        {
+          "name": "Zlib",
+          "source": "file_header"
+        }
+      ],
+      "copyrights": [
+        {
+          "name": "Copyright (C) 2007-2017 Mark Adler",
+          "source": "file_header"
+        }
+      ],
+      "elapsed": "0.000907s"
+    }
+  ]
+}

--- a/scanner/src/test/kotlin/scanners/scanoss/ScanOSSResultParserTest.kt
+++ b/scanner/src/test/kotlin/scanners/scanoss/ScanOSSResultParserTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 SCANOSS TECNOLOGIAS SL
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.scanoss
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import java.io.File
+import java.time.Instant
+
+import org.ossreviewtoolkit.model.CopyrightFinding
+import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.TextLocation
+
+class ScanOSSResultParserTest : WordSpec({
+    "generateScanOSSSummary()" should {
+        "properly summarise pigz.c findings" {
+            val resultFile = File("src/test/assets/pigz-c-scanoss.json")
+            val result = parseResult(resultFile)
+
+            val summary = generateSummary(Instant.now(), Instant.now(), resultFile, result)
+
+            summary.fileCount shouldBe 1
+            summary.packageVerificationCode shouldBe "6a8a8c64b8735e4de579d124fa27ae2ac820fe09"
+            summary.licenseFindings should containExactlyInAnyOrder(
+                    LicenseFinding(
+                            license = "Zlib",
+                            location = TextLocation(path = "pigz.c", startLine = 1, endLine = 1)
+                    )
+            )
+            summary.copyrightFindings should containExactlyInAnyOrder(
+                    CopyrightFinding(
+                            statement = "Copyright (C) 2007-2017 Mark Adler",
+                            location = TextLocation(path = "pigz.c", startLine = 1, endLine = 1)
+                    )
+            )
+        }
+    }
+})


### PR DESCRIPTION
This PR adds initial support for ScanOSS as a Scanner, scanning against osskb.org. 

In order to fully benefit from ScanOSS, changes should be made to the ORT data model to add support for snippet scanners.
 
