### PR TITLE
Add NexusIQ Server Advisor module

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,12 @@ use):
   Version Control System (VCS) or other means are used to retrieve the source code.
 * [_Scanner_](#scanner) - uses configured source code scanners to detect license / copyright findings, abstracting
   the type of scanner.
+* [_Advisor_](#advisor) - retrieves security advisories for used dependencies from configured vulnerability data 
+  services.
 * [_Evaluator_](#evaluator) - evaluates license / copyright findings against customizable policy rules and license
   classifications.
 * [_Reporter_](#reporter) - presents results in various formats such as visual reports, Open Source notices or
   Bill-Of-Materials (BOMs) to easily identify dependencies, licenses, copyrights or policy rule violations.
-
-The following tools are [planned](https://github.com/oss-review-toolkit/ort/projects/1) but not yet available:
-
-* _Advisor_ - retrieves security advisories based on the Analyzer result.
 
 # Installation
 
@@ -539,6 +537,31 @@ ort {
   }
 }
 ```
+
+<a name="advisor">&nbsp;</a>
+
+[![Advisor](./logos/advisor.png)](./advisor/src/main/kotlin)
+
+The _advisor_ retrieves security advisories from configured services. It requires the analyzer result as an input.
+
+### Configuration
+
+The advisor needs to be configured in the ORT configuration file:
+
+```hocon
+ort {
+  advisor {
+    nexusiq {
+      serverUrl = "https://nexusiq.ossreviewtoolkit.org"
+      username = myUser
+      password = myPassword
+    }
+  }
+}
+```
+
+Currently [Nexus IQ Server](https://help.sonatype.com/iqserver) (`-a NexusIQ`) is the only supported security data
+provider.
 
 <a name="evaluator">&nbsp;</a>
 

--- a/advisor/build.gradle.kts
+++ b/advisor/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+val kotlinxCoroutinesVersion: String by project
+
+plugins {
+    // Apply core plugins.
+    `java-library`
+}
+
+dependencies {
+    api(project(":model"))
+
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
+}

--- a/advisor/build.gradle.kts
+++ b/advisor/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
 }
 
 dependencies {
+    api(project(":clients:nexus-iq"))
     api(project(":model"))
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")

--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.advisor
+
+import java.io.File
+import java.time.Instant
+import java.util.ServiceLoader
+
+import kotlinx.coroutines.runBlocking
+
+import org.ossreviewtoolkit.model.AdvisorRecord
+import org.ossreviewtoolkit.model.AdvisorResult
+import org.ossreviewtoolkit.model.AdvisorResultContainer
+import org.ossreviewtoolkit.model.AdvisorRun
+import org.ossreviewtoolkit.model.Environment
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.config.AdvisorConfiguration
+import org.ossreviewtoolkit.model.readValue
+
+/**
+ * The class to retrieve security advisories.
+ */
+abstract class Advisor(val advisorName: String, protected val config: AdvisorConfiguration) {
+    companion object {
+        private val LOADER = ServiceLoader.load(AdvisorFactory::class.java)!!
+
+        /**
+         * The list of all available advisors in the classpath
+         */
+        val ALL by lazy { LOADER.iterator().asSequence().toList() }
+    }
+
+    fun retrieveVulnerabilityInformation(
+        ortResultFile: File,
+        skipExcluded: Boolean = false
+    ): OrtResult {
+        require(ortResultFile.isFile) {
+            "The provided ORT result file '${ortResultFile.canonicalPath}' does not exist."
+        }
+
+        val startTime = Instant.now()
+
+        val ortResult = ortResultFile.readValue<OrtResult>()
+
+        requireNotNull(ortResult.analyzer) {
+            "The provided ORT result file '${ortResultFile.invariantSeparatorsPath}' does not contain an analyzer " +
+                    "result."
+        }
+
+        val packages = ortResult.getPackages(skipExcluded).map { it.pkg }
+
+        val results = runBlocking { retrievePackageVulnerabilities(packages) }
+        val resultContainers = results.map { (pkg, results) ->
+            AdvisorResultContainer(pkg.id, results)
+        }.toSortedSet()
+        val advisorRecord = AdvisorRecord(resultContainers)
+
+        val endTime = Instant.now()
+
+        val advisorRun = AdvisorRun(startTime, endTime, Environment(), config, advisorRecord)
+
+        return ortResult.copy(advisor = advisorRun)
+    }
+
+    protected abstract suspend fun retrievePackageVulnerabilities(
+        packages: List<Package>
+    ): Map<Package, List<AdvisorResult>>
+}

--- a/advisor/src/main/kotlin/AdvisorFactory.kt
+++ b/advisor/src/main/kotlin/AdvisorFactory.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.advisor
+
+import java.util.ServiceLoader
+
+import org.ossreviewtoolkit.model.config.AdvisorConfiguration
+
+/**
+ * A common interface for use with [ServiceLoader] that all [AbstractAdvisorFactory] classes need to implement.
+ */
+interface AdvisorFactory {
+    /**
+     * The name to use to refer to the advisor.
+     */
+    val advisorName: String
+
+    /**
+     * Create an [Advisor] using the specified [config].
+     */
+    fun create(config: AdvisorConfiguration): Advisor
+}
+
+/**
+ * A generic factory class for an [Advisor].
+ */
+abstract class AbstractAdvisorFactory<out T : Advisor>(
+    override val advisorName: String
+) : AdvisorFactory {
+    abstract override fun create(config: AdvisorConfiguration): T
+
+    /**
+     * Return the advisor's name here to allow Clikt to display something meaningful when listing the scanners
+     * which are enabled by default via their factories.
+     */
+    override fun toString() = advisorName
+}

--- a/advisor/src/main/kotlin/advisors/NexusIq.kt
+++ b/advisor/src/main/kotlin/advisors/NexusIq.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.advisor.advisors
+
+import java.io.IOException
+import java.net.URL
+import java.time.Instant
+import java.util.concurrent.Executors
+
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+
+import org.ossreviewtoolkit.advisor.AbstractAdvisorFactory
+import org.ossreviewtoolkit.advisor.Advisor
+import org.ossreviewtoolkit.model.AdvisorDetails
+import org.ossreviewtoolkit.model.AdvisorResult
+import org.ossreviewtoolkit.model.AdvisorSummary
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.Vulnerability
+import org.ossreviewtoolkit.model.config.AdvisorConfiguration
+import org.ossreviewtoolkit.model.config.NexusIqConfiguration
+import org.ossreviewtoolkit.model.createAndLogIssue
+import org.ossreviewtoolkit.nexusiq.NexusIqService
+import org.ossreviewtoolkit.utils.NamedThreadFactory
+import org.ossreviewtoolkit.utils.OkHttpClientHelper
+import org.ossreviewtoolkit.utils.collectMessagesAsString
+import org.ossreviewtoolkit.utils.log
+import org.ossreviewtoolkit.utils.showStackTrace
+
+import retrofit2.Call
+
+/**
+ * A wrapper for [Nexus IQ Server](https://help.sonatype.com/iqserver) security vulnerability data.
+ */
+class NexusIq(
+    name: String,
+    config: AdvisorConfiguration
+) : Advisor(name, config) {
+    class Factory : AbstractAdvisorFactory<NexusIq>("NexusIQ") {
+        override fun create(config: AdvisorConfiguration) = NexusIq(advisorName, config)
+    }
+
+    data class NexusIqVulnerability(
+        override val id: String,
+        override val severity: Float,
+
+        // URL to http://mitre.org for more information about the CVE.
+        val url: URL
+    ) : Vulnerability
+
+    private val nexusIqConfig = config as NexusIqConfiguration
+
+    override suspend fun retrievePackageVulnerabilities(packages: List<Package>): Map<Package, List<AdvisorResult>> {
+        val service = NexusIqService.create(
+            nexusIqConfig.serverUrl,
+            nexusIqConfig.username,
+            nexusIqConfig.password,
+            OkHttpClientHelper.buildClient()
+        )
+
+        val advisorDispatcher =
+            Executors.newSingleThreadExecutor(NamedThreadFactory(advisorName)).asCoroutineDispatcher()
+
+        return coroutineScope {
+            val startTime = Instant.now()
+
+            val components = packages.map { pkg ->
+                val packageUrl = buildString {
+                    append(pkg.purl)
+                    val purlType = pkg.id.getPurlType()
+                    if (purlType == Identifier.PurlType.MAVEN) append("?type=jar")
+                    if (purlType == Identifier.PurlType.PYPI) append("?extension=tar.gz")
+                }
+
+                NexusIqService.Component(packageUrl)
+            }
+
+            try {
+                val componentDetails =
+                    execute(withContext(advisorDispatcher) {
+                        service.getComponentDetails(NexusIqService.ComponentsWrapper(components))
+                    }).componentDetails
+                        .associateBy { it.component.packageUrl.substringBefore("?") }
+
+                val endTime = Instant.now()
+
+                packages.mapNotNullTo(mutableListOf()) { pkg ->
+                    componentDetails[pkg.id.toPurl()]?.takeUnless {
+                        it.securityData.securityIssues.isEmpty()
+                    }?.let { details ->
+                        pkg to listOf(
+                            AdvisorResult(
+                                details.securityData.securityIssues.mapToVulnerabilities(),
+                                AdvisorDetails(advisorName),
+                                AdvisorSummary(startTime, endTime)
+                            )
+                        )
+                    }
+                }.toMap()
+            } catch (e: IOException) {
+                e.showStackTrace()
+
+                val now = Instant.now()
+                packages.associateWith {
+                    listOf(
+                        AdvisorResult(
+                            vulnerability = emptyList(),
+                            advisor = AdvisorDetails(advisorName),
+                            summary = AdvisorSummary(
+                                startTime = now,
+                                endTime = now,
+                                issues = listOf(
+                                    createAndLogIssue(
+                                        source = advisorName,
+                                        message = "Failed to retrieve security vulnerabilities from $advisorName: " +
+                                                e.collectMessagesAsString()
+                                    )
+                                )
+                            )
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    private fun Collection<NexusIqService.SecurityIssue>.mapToVulnerabilities() =
+        map {
+            NexusIqVulnerability(
+                it.reference,
+                it.severity,
+                it.url
+            )
+        }
+
+    /**
+     * Execute an HTTP request specified by the given [call]. The response status is checked. If everything went
+     * well, the marshalled body of the request is returned; otherwise, the function throws an exception.
+     */
+    private fun <T> execute(call: Call<T>): T {
+        val request = "${call.request().method} on ${call.request().url}"
+        log.debug { "Executing HTTP $request." }
+
+        val response = call.execute()
+        log.debug { "HTTP response is (status ${response.code()}): ${response.message()}" }
+
+        val body = response.body()
+        if (!response.isSuccessful || body == null) {
+            throw IOException(
+                "Failed HTTP $request with status ${response.code()} and error: ${response.errorBody()?.string()}."
+            )
+        }
+
+        return body
+    }
+}

--- a/advisor/src/main/resources/META-INF/services/org.ossreviewtoolkit.advisor.AdvisorFactory
+++ b/advisor/src/main/resources/META-INF/services/org.ossreviewtoolkit.advisor.AdvisorFactory
@@ -1,0 +1,1 @@
+org.ossreviewtoolkit.advisor.advisors.NexusIq$Factory

--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -206,4 +206,5 @@ analyzer:
       curations: []
     has_issues: false
 scanner: null
+advisor: null
 evaluator: null

--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -3882,4 +3882,5 @@ analyzer:
         severity: "ERROR"
     has_issues: true
 scanner: null
+advisor: null
 evaluator: null

--- a/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
@@ -1233,4 +1233,5 @@ analyzer:
       curations: []
     has_issues: false
 scanner: null
+advisor: null
 evaluator: null

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
@@ -46,7 +46,7 @@ project:
         - id: "Bundler::rspec-support:3.7.1"
 packages:
 - id: "Bundler::addressable:2.7.0"
-  purl: "pkg:bundler/addressable@2.7.0"
+  purl: "pkg:gem/addressable@2.7.0"
   declared_licenses:
   - "Apache-2.0"
   declared_licenses_processed:
@@ -76,7 +76,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::diff-lcs:1.3"
-  purl: "pkg:bundler/diff-lcs@1.3"
+  purl: "pkg:gem/diff-lcs@1.3"
   declared_licenses:
   - "Artistic-2.0"
   - "GPL-2.0+"
@@ -114,7 +114,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::faraday:0.17.3"
-  purl: "pkg:bundler/faraday@0.17.3"
+  purl: "pkg:gem/faraday@0.17.3"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -142,7 +142,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::jwt:2.2.1"
-  purl: "pkg:bundler/jwt@2.2.1"
+  purl: "pkg:gem/jwt@2.2.1"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -171,7 +171,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::multi_json:1.14.1"
-  purl: "pkg:bundler/multi_json@1.14.1"
+  purl: "pkg:gem/multi_json@1.14.1"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -201,7 +201,7 @@ packages:
     revision: "v1.14.1"
     path: ""
 - id: "Bundler::multipart-post:2.1.1"
-  purl: "pkg:bundler/multipart-post@2.1.1"
+  purl: "pkg:gem/multipart-post@2.1.1"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -231,7 +231,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::public_suffix:4.0.5"
-  purl: "pkg:bundler/public_suffix@4.0.5"
+  purl: "pkg:gem/public_suffix@4.0.5"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -260,7 +260,7 @@ packages:
     revision: "v4.0.5"
     path: ""
 - id: "Bundler::rack:2.2.3"
-  purl: "pkg:bundler/rack@2.2.3"
+  purl: "pkg:gem/rack@2.2.3"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -291,7 +291,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::rspec-core:3.7.1"
-  purl: "pkg:bundler/rspec-core@3.7.1"
+  purl: "pkg:gem/rspec-core@3.7.1"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -319,7 +319,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::rspec-expectations:3.7.0"
-  purl: "pkg:bundler/rspec-expectations@3.7.0"
+  purl: "pkg:gem/rspec-expectations@3.7.0"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -348,7 +348,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::rspec-mocks:3.7.0"
-  purl: "pkg:bundler/rspec-mocks@3.7.0"
+  purl: "pkg:gem/rspec-mocks@3.7.0"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -376,7 +376,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::rspec-support:3.7.1"
-  purl: "pkg:bundler/rspec-support@3.7.1"
+  purl: "pkg:gem/rspec-support@3.7.1"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -404,7 +404,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::rspec:3.7.0"
-  purl: "pkg:bundler/rspec@3.7.0"
+  purl: "pkg:gem/rspec@3.7.0"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -432,7 +432,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::signet:0.8.1"
-  purl: "pkg:bundler/signet@0.8.1"
+  purl: "pkg:gem/signet@0.8.1"
   declared_licenses:
   - "Apache-2.0"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
@@ -39,7 +39,7 @@ project:
         - id: "Bundler::rspec-support:3.7.1"
 packages:
 - id: "Bundler::diff-lcs:1.3"
-  purl: "pkg:bundler/diff-lcs@1.3"
+  purl: "pkg:gem/diff-lcs@1.3"
   declared_licenses:
   - "Artistic-2.0"
   - "GPL-2.0+"
@@ -77,7 +77,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::mini_portile2:2.4.0"
-  purl: "pkg:bundler/mini_portile2@2.4.0"
+  purl: "pkg:gem/mini_portile2@2.4.0"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -107,7 +107,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::nokogiri:1.10.8"
-  purl: "pkg:bundler/nokogiri@1.10.8"
+  purl: "pkg:gem/nokogiri@1.10.8"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -136,7 +136,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::rack:2.1.4"
-  purl: "pkg:bundler/rack@2.1.4"
+  purl: "pkg:gem/rack@2.1.4"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -168,7 +168,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::rspec-core:3.7.1"
-  purl: "pkg:bundler/rspec-core@3.7.1"
+  purl: "pkg:gem/rspec-core@3.7.1"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -196,7 +196,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::rspec-expectations:3.7.0"
-  purl: "pkg:bundler/rspec-expectations@3.7.0"
+  purl: "pkg:gem/rspec-expectations@3.7.0"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -225,7 +225,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::rspec-mocks:3.7.0"
-  purl: "pkg:bundler/rspec-mocks@3.7.0"
+  purl: "pkg:gem/rspec-mocks@3.7.0"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -253,7 +253,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::rspec-support:3.7.1"
-  purl: "pkg:bundler/rspec-support@3.7.1"
+  purl: "pkg:gem/rspec-support@3.7.1"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -281,7 +281,7 @@ packages:
     revision: ""
     path: ""
 - id: "Bundler::rspec:3.7.0"
-  purl: "pkg:bundler/rspec@3.7.0"
+  purl: "pkg:gem/rspec@3.7.0"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/glide-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/glide-expected-output.yml
@@ -24,7 +24,7 @@ project:
       linkage: "STATIC"
 packages:
 - id: "GoDep::github.com/mattn/go-isatty:v0.0.12"
-  purl: "pkg:godep/github.com%2Fmattn%2Fgo-isatty@v0.0.12"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.12"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -50,7 +50,7 @@ packages:
     revision: "7b513a986450394f7bbf1476909911b3aa3a55ce"
     path: ""
 - id: "GoDep::golang.org/x/sys:05986578812163b26672dabd9b425240ae2bb0ad"
-  purl: "pkg:godep/golang.org%2Fx%2Fsys@05986578812163b26672dabd9b425240ae2bb0ad"
+  purl: "pkg:golang/golang.org%2Fx%2Fsys@05986578812163b26672dabd9b425240ae2bb0ad"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/godep-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/godep-expected-output.yml
@@ -28,7 +28,7 @@ project:
       linkage: "STATIC"
 packages:
 - id: "GoDep::github.com/fatih/color:v1.9.0"
-  purl: "pkg:godep/github.com%2Ffatih%2Fcolor@v1.9.0"
+  purl: "pkg:golang/github.com%2Ffatih%2Fcolor@v1.9.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -54,7 +54,7 @@ packages:
     revision: "daf2830f2741ebb735b21709a520c5f37d642d85"
     path: ""
 - id: "GoDep::github.com/mattn/go-colorable:v0.1.6"
-  purl: "pkg:godep/github.com%2Fmattn%2Fgo-colorable@v0.1.6"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-colorable@v0.1.6"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -80,7 +80,7 @@ packages:
     revision: "68e95eba382c972aafde02ead2cd2426a8a92480"
     path: ""
 - id: "GoDep::github.com/mattn/go-isatty:v0.0.12"
-  purl: "pkg:godep/github.com%2Fmattn%2Fgo-isatty@v0.0.12"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.12"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -106,7 +106,7 @@ packages:
     revision: "7b513a986450394f7bbf1476909911b3aa3a55ce"
     path: ""
 - id: "GoDep::golang.org/x/sys:05986578812163b26672dabd9b425240ae2bb0ad"
-  purl: "pkg:godep/golang.org%2Fx%2Fsys@05986578812163b26672dabd9b425240ae2bb0ad"
+  purl: "pkg:golang/golang.org%2Fx%2Fsys@05986578812163b26672dabd9b425240ae2bb0ad"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/godeps-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/godeps-expected-output.yml
@@ -24,7 +24,7 @@ project:
       linkage: "STATIC"
 packages:
 - id: "GoDep::github.com/mattn/go-isatty:v0.0.12"
-  purl: "pkg:godep/github.com%2Fmattn%2Fgo-isatty@v0.0.12"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.12"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -50,7 +50,7 @@ packages:
     revision: "7b513a986450394f7bbf1476909911b3aa3a55ce"
     path: ""
 - id: "GoDep::golang.org/x/sys:8d3cce7afc34617998104db7c4b58c2de9e77215"
-  purl: "pkg:godep/golang.org%2Fx%2Fsys@8d3cce7afc34617998104db7c4b58c2de9e77215"
+  purl: "pkg:golang/golang.org%2Fx%2Fsys@8d3cce7afc34617998104db7c4b58c2de9e77215"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
@@ -69,7 +69,7 @@ project:
         linkage: "PROJECT_STATIC"
 packages:
 - id: "GoMod::cloud.google.com/go:v0.34.0"
-  purl: "pkg:gomod/cloud.google.com%2Fgo@v0.34.0"
+  purl: "pkg:golang/cloud.google.com%2Fgo@v0.34.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -95,7 +95,7 @@ packages:
     revision: ""
     path: ""
 - id: "GoMod::github.com/fatih/color:v1.7.0"
-  purl: "pkg:gomod/github.com%2Ffatih%2Fcolor@v1.7.0"
+  purl: "pkg:golang/github.com%2Ffatih%2Fcolor@v1.7.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -121,7 +121,7 @@ packages:
     revision: ""
     path: ""
 - id: "GoMod::github.com/golang/protobuf:v1.2.0"
-  purl: "pkg:gomod/github.com%2Fgolang%2Fprotobuf@v1.2.0"
+  purl: "pkg:golang/github.com%2Fgolang%2Fprotobuf@v1.2.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -147,7 +147,7 @@ packages:
     revision: ""
     path: ""
 - id: "GoMod::github.com/hashicorp/errwrap:v1.0.0"
-  purl: "pkg:gomod/github.com%2Fhashicorp%2Ferrwrap@v1.0.0"
+  purl: "pkg:golang/github.com%2Fhashicorp%2Ferrwrap@v1.0.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -173,7 +173,7 @@ packages:
     revision: ""
     path: ""
 - id: "GoMod::github.com/hashicorp/go-multierror:v1.0.0"
-  purl: "pkg:gomod/github.com%2Fhashicorp%2Fgo-multierror@v1.0.0"
+  purl: "pkg:golang/github.com%2Fhashicorp%2Fgo-multierror@v1.0.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -199,7 +199,7 @@ packages:
     revision: ""
     path: ""
 - id: "GoMod::github.com/mattn/go-colorable:v0.1.4"
-  purl: "pkg:gomod/github.com%2Fmattn%2Fgo-colorable@v0.1.4"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-colorable@v0.1.4"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -225,7 +225,7 @@ packages:
     revision: ""
     path: ""
 - id: "GoMod::github.com/mattn/go-isatty:v0.0.10"
-  purl: "pkg:gomod/github.com%2Fmattn%2Fgo-isatty@v0.0.10"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.10"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -251,7 +251,7 @@ packages:
     revision: ""
     path: ""
 - id: "GoMod::github.com/mattn/go-isatty:v0.0.8"
-  purl: "pkg:gomod/github.com%2Fmattn%2Fgo-isatty@v0.0.8"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.8"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -277,7 +277,7 @@ packages:
     revision: ""
     path: ""
 - id: "GoMod::golang.org/x/net:v0.0.0-20180724234803-3673e40ba225"
-  purl: "pkg:gomod/golang.org%2Fx%2Fnet@v0.0.0-20180724234803-3673e40ba225"
+  purl: "pkg:golang/golang.org%2Fx%2Fnet@v0.0.0-20180724234803-3673e40ba225"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -303,7 +303,7 @@ packages:
     revision: ""
     path: ""
 - id: "GoMod::golang.org/x/net:v0.0.0-20190108225652-1e06a53dbb7e"
-  purl: "pkg:gomod/golang.org%2Fx%2Fnet@v0.0.0-20190108225652-1e06a53dbb7e"
+  purl: "pkg:golang/golang.org%2Fx%2Fnet@v0.0.0-20190108225652-1e06a53dbb7e"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -329,7 +329,7 @@ packages:
     revision: ""
     path: ""
 - id: "GoMod::golang.org/x/oauth2:v0.0.0-20190226205417-e64efc72b421"
-  purl: "pkg:gomod/golang.org%2Fx%2Foauth2@v0.0.0-20190226205417-e64efc72b421"
+  purl: "pkg:golang/golang.org%2Fx%2Foauth2@v0.0.0-20190226205417-e64efc72b421"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -355,7 +355,7 @@ packages:
     revision: ""
     path: ""
 - id: "GoMod::golang.org/x/sync:v0.0.0-20181221193216-37e7f081c4d4"
-  purl: "pkg:gomod/golang.org%2Fx%2Fsync@v0.0.0-20181221193216-37e7f081c4d4"
+  purl: "pkg:golang/golang.org%2Fx%2Fsync@v0.0.0-20181221193216-37e7f081c4d4"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -381,7 +381,7 @@ packages:
     revision: ""
     path: ""
 - id: "GoMod::golang.org/x/sys:v0.0.0-20190222072716-a9d3bda3a223"
-  purl: "pkg:gomod/golang.org%2Fx%2Fsys@v0.0.0-20190222072716-a9d3bda3a223"
+  purl: "pkg:golang/golang.org%2Fx%2Fsys@v0.0.0-20190222072716-a9d3bda3a223"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -407,7 +407,7 @@ packages:
     revision: ""
     path: ""
 - id: "GoMod::golang.org/x/sys:v0.0.0-20191008105621-543471e840be"
-  purl: "pkg:gomod/golang.org%2Fx%2Fsys@v0.0.0-20191008105621-543471e840be"
+  purl: "pkg:golang/golang.org%2Fx%2Fsys@v0.0.0-20191008105621-543471e840be"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -433,7 +433,7 @@ packages:
     revision: ""
     path: ""
 - id: "GoMod::golang.org/x/text:v0.3.0"
-  purl: "pkg:gomod/golang.org%2Fx%2Ftext@v0.3.0"
+  purl: "pkg:golang/golang.org%2Fx%2Ftext@v0.3.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -459,7 +459,7 @@ packages:
     revision: ""
     path: ""
 - id: "GoMod::google.golang.org/appengine:v1.4.0"
-  purl: "pkg:gomod/google.golang.org%2Fappengine@v1.4.0"
+  purl: "pkg:golang/google.golang.org%2Fappengine@v1.4.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -599,4 +599,5 @@ analyzer:
           comment: "Declared license in pom.xml is wrong."
     has_issues: true
 scanner: null
+advisor: null
 evaluator: null

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -580,4 +580,5 @@ analyzer:
       curations: []
     has_issues: true
 scanner: null
+advisor: null
 evaluator: null

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -119,6 +119,7 @@ repositories {
 }
 
 dependencies {
+    implementation(project(":advisor"))
     implementation(project(":analyzer"))
     implementation(project(":downloader"))
     implementation(project(":evaluator"))

--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -119,6 +119,7 @@ class OrtMain : CliktCommand(name = ORT_NAME, epilog = "* denotes required optio
         }
 
         subcommands(
+            AdvisorCommand(),
             AnalyzerCommand(),
             DownloaderCommand(),
             EvaluatorCommand(),

--- a/cli/src/main/kotlin/commands/AdvisorCommand.kt
+++ b/cli/src/main/kotlin/commands/AdvisorCommand.kt
@@ -36,6 +36,7 @@ import com.github.ajalt.clikt.parameters.types.file
 
 import org.ossreviewtoolkit.GlobalOptions
 import org.ossreviewtoolkit.advisor.Advisor
+import org.ossreviewtoolkit.advisor.advisors.NexusIq
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
 import org.ossreviewtoolkit.model.config.NexusIqConfiguration
@@ -84,7 +85,7 @@ class AdvisorCommand : CliktCommand(name = "advise", help = "Run vulnerability d
     ).convert { advisorName ->
         Advisor.ALL.find { it.advisorName.equals(advisorName, ignoreCase = true) }
             ?: throw BadParameterValue("Advisor '$advisorName' is not one of ${Advisor.ALL}")
-    }
+    }.default(NexusIq.Factory())
 
     private val skipExcluded by option(
         "--skip-excluded",
@@ -99,7 +100,7 @@ class AdvisorCommand : CliktCommand(name = "advise", help = "Run vulnerability d
             )
         }
 
-        val advisor = advisorFactory?.create(config) ?: throw IllegalArgumentException("No advisor specified.")
+        val advisor = advisorFactory.create(config)
         println("Using advisor '${advisor.advisorName}'.")
 
         return advisor
@@ -118,7 +119,7 @@ class AdvisorCommand : CliktCommand(name = "advise", help = "Run vulnerability d
         }
 
         val config = globalOptionsForSubcommands.config
-        val advisorConfig = config.advisor?.get(advisorFactory?.advisorName?.toLowerCase())
+        val advisorConfig = config.advisor?.get(advisorFactory.advisorName.toLowerCase())
         val advisor = configureAdvisor(advisorConfig)
 
         val ortResult = advisor.retrieveVulnerabilityInformation(input, skipExcluded).mergeLabels(labels)

--- a/cli/src/main/kotlin/commands/AdvisorCommand.kt
+++ b/cli/src/main/kotlin/commands/AdvisorCommand.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.commands
+
+import com.github.ajalt.clikt.core.BadParameterValue
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.ProgramResult
+import com.github.ajalt.clikt.core.UsageError
+import com.github.ajalt.clikt.core.requireObject
+import com.github.ajalt.clikt.parameters.options.associate
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.options.split
+import com.github.ajalt.clikt.parameters.types.enum
+import com.github.ajalt.clikt.parameters.types.file
+
+import org.ossreviewtoolkit.GlobalOptions
+import org.ossreviewtoolkit.advisor.Advisor
+import org.ossreviewtoolkit.model.FileFormat
+import org.ossreviewtoolkit.model.config.AdvisorConfiguration
+import org.ossreviewtoolkit.model.config.NexusIqConfiguration
+import org.ossreviewtoolkit.model.mapper
+import org.ossreviewtoolkit.model.utils.mergeLabels
+import org.ossreviewtoolkit.utils.ORT_CONFIG_FILENAME
+import org.ossreviewtoolkit.utils.expandTilde
+import org.ossreviewtoolkit.utils.ortConfigDirectory
+import org.ossreviewtoolkit.utils.safeMkdirs
+
+class AdvisorCommand : CliktCommand(name = "advise", help = "Run vulnerability detector") {
+    private val input by option(
+        "--ort-file", "-i",
+        help = "An ORT result file with an analyzer result to use."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val outputDir by option(
+        "--output-dir", "-o",
+        help = "The directory to write the advisor results as ORT result file(s) to."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = false, canBeDir = true, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+        .outputGroup()
+
+    private val outputFormats by option(
+        "--output-formats", "-f",
+        help = "The list of output formats to be used for the ORT result file(s)."
+    ).enum<FileFormat>().split(",").default(listOf(FileFormat.YAML)).outputGroup()
+
+    private val labels by option(
+        "--label", "-l",
+        help = "Add a label to the ORT result. Can be used multiple times. If an ORT result is used as input for the" +
+                "advisor, any existing label with the same key is overwritten. For example: " +
+                "--label distribution=external"
+    ).associate()
+
+    private val globalOptionsForSubcommands by requireObject<GlobalOptions>()
+
+    private val advisorFactory by option(
+        "--advisor", "-a",
+        help = "The advisor to use, one of ${Advisor.ALL}"
+    ).convert { advisorName ->
+        Advisor.ALL.find { it.advisorName.equals(advisorName, ignoreCase = true) }
+            ?: throw BadParameterValue("Advisor '$advisorName' is not one of ${Advisor.ALL}")
+    }
+
+    private val skipExcluded by option(
+        "--skip-excluded",
+        help = "Do not check excluded projects or packages."
+    ).flag()
+
+    private fun configureAdvisor(advisorConfiguration: AdvisorConfiguration?): Advisor {
+        val config = when (advisorConfiguration) {
+            is NexusIqConfiguration -> advisorConfiguration
+            null -> throw IllegalArgumentException(
+                "No advisor configuration found in ${ortConfigDirectory.resolve(ORT_CONFIG_FILENAME)}"
+            )
+        }
+
+        val advisor = advisorFactory?.create(config) ?: throw IllegalArgumentException("No advisor specified.")
+        println("Using advisor '${advisor.advisorName}'.")
+
+        return advisor
+    }
+
+    override fun run() {
+        val outputFiles = outputFormats.mapTo(mutableSetOf()) { format ->
+            outputDir.resolve("advisor-result.${format.fileExtension}")
+        }
+
+        if (!globalOptionsForSubcommands.forceOverwrite) {
+            val existingOutputFiles = outputFiles.filter { it.exists() }
+            if (existingOutputFiles.isNotEmpty()) {
+                throw UsageError("None of the output files $existingOutputFiles must exist yet.", statusCode = 2)
+            }
+        }
+
+        val config = globalOptionsForSubcommands.config
+        val advisorConfig = config.advisor?.get(advisorFactory?.advisorName?.toLowerCase())
+        val advisor = configureAdvisor(advisorConfig)
+
+        val ortResult = advisor.retrieveVulnerabilityInformation(input, skipExcluded).mergeLabels(labels)
+
+        outputFiles.forEach { file ->
+            println("Writing advisor result to '$file'.")
+            outputDir.safeMkdirs()
+            file.mapper().writerWithDefaultPrettyPrinter().writeValue(file, ortResult)
+        }
+
+        val advisorResults = ortResult.advisor?.results
+
+        if (advisorResults == null) {
+            println("There was an error creating the advisor results.")
+            throw ProgramResult(1)
+        }
+
+        if (advisorResults.hasIssues) {
+            throw ProgramResult(2)
+        }
+    }
+}

--- a/clients/nexus-iq/build.gradle.kts
+++ b/clients/nexus-iq/build.gradle.kts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+val jacksonVersion: String by project
+val retrofitVersion: String by project
+
+plugins {
+    // Apply core plugins.
+    `java-library`
+}
+
+dependencies {
+    api("com.squareup.retrofit2:retrofit:$retrofitVersion")
+
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    implementation("com.squareup.retrofit2:converter-jackson:$retrofitVersion")
+}

--- a/detekt-rules/src/main/kotlin/OrtPackageNaming.kt
+++ b/detekt-rules/src/main/kotlin/OrtPackageNaming.kt
@@ -60,6 +60,7 @@ class OrtPackageNaming : Rule() {
             "cli" -> ""
             "detekt-rules" -> ".detekt"
             "helper-cli" -> ".helper"
+            "nexus-iq" -> ".nexusiq"
             "spdx-utils" -> ".spdx"
             "test-utils" -> ".utils.test"
             else -> ".$projectDir"

--- a/model/src/main/kotlin/AdvisorDetails.kt
+++ b/model/src/main/kotlin/AdvisorDetails.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+/**
+ * Details about the used provider of vulnerability information.
+ */
+data class AdvisorDetails(
+    /**
+     * The name of the used advisor.
+     */
+    val name: String
+) {
+    companion object {
+        val EMPTY = AdvisorDetails(
+            name = ""
+        )
+    }
+}

--- a/model/src/main/kotlin/AdvisorRecord.kt
+++ b/model/src/main/kotlin/AdvisorRecord.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import java.util.SortedSet
+
+/**
+ * A record of a single run of the advisor tool, containing the input and the [Vulnerability] for every checked package.
+ */
+data class AdvisorRecord(
+    /**
+     * The [AdvisorResult]s for all [Package]s.
+     */
+    val advisorResults: SortedSet<AdvisorResultContainer>
+) {
+    fun collectIssues(): Map<Identifier, Set<OrtIssue>> {
+        val collectedIssues = mutableMapOf<Identifier, MutableSet<OrtIssue>>()
+
+        advisorResults.forEach { container ->
+            container.results.forEach { result ->
+                collectedIssues.getOrPut(container.id) { mutableSetOf() } += result.summary.issues
+            }
+        }
+
+        return collectedIssues
+    }
+
+    /**
+     * True if any of the [advisorResults] contain [OrtIssue]s.
+     */
+    val hasIssues by lazy {
+        advisorResults.any { advisorResultContainer ->
+            advisorResultContainer.results.any { it.summary.issues.isNotEmpty() }
+        }
+    }
+}

--- a/model/src/main/kotlin/AdvisorResult.kt
+++ b/model/src/main/kotlin/AdvisorResult.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+/**
+ * The result of a single vulnerability check of a single package.
+ */
+data class AdvisorResult(
+    /**
+     * The found vulnerabilities.
+     */
+    val vulnerability: List<Vulnerability>,
+
+    /**
+     * Details about the used advisor.
+     */
+    val advisor: AdvisorDetails,
+
+    /**
+     * A summary of the advisor results.
+     */
+    val summary: AdvisorSummary
+)

--- a/model/src/main/kotlin/AdvisorResultContainer.kt
+++ b/model/src/main/kotlin/AdvisorResultContainer.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+/**
+ * A container for [AdvisorResult]s for the package identified by [id].
+ */
+data class AdvisorResultContainer(
+    /**
+     * The [Identifier] of the package these [results] belong to.
+     */
+    val id: Identifier,
+
+    /**
+     * The list of [AdvisorResult]s from potentially multiple advisors.
+     */
+    val results: List<AdvisorResult>
+) : Comparable<AdvisorResultContainer> {
+    /**
+     * A comparison function to sort the advisor result containers by their identifier.
+     */
+    override fun compareTo(other: AdvisorResultContainer): Int = id.compareTo(other.id)
+}

--- a/model/src/main/kotlin/AdvisorRun.kt
+++ b/model/src/main/kotlin/AdvisorRun.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import java.time.Instant
+
+import org.ossreviewtoolkit.model.config.AdvisorConfiguration
+
+/**
+ * The summary of a single run of the advisor.
+ */
+data class AdvisorRun(
+    /**
+     * The [Instant] the advisor was started.
+     */
+    val startTime: Instant,
+
+    /**
+     * The [Instant] the advisor has finished.
+     */
+    val endTime: Instant,
+
+    /**
+     * The [Environment] in which the advisor was executed.
+     */
+    val environment: Environment,
+
+    /**
+     * The [AdvisorConfiguration] used for this run.
+     */
+    val config: AdvisorConfiguration,
+
+    /**
+     * The result of the [AdvisorRun].
+     */
+    val results: AdvisorRecord
+)

--- a/model/src/main/kotlin/AdvisorSummary.kt
+++ b/model/src/main/kotlin/AdvisorSummary.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+import java.time.Instant
+
+/**
+ * A short summary of the advisor result.
+ */
+data class AdvisorSummary(
+    /**
+     * The time when the advisor started.
+     */
+    val startTime: Instant,
+
+    /**
+     * The time when the advisor finished.
+     */
+    val endTime: Instant,
+
+    /**
+     * The list of issues that occurred during the advisor run.
+     * This property is not serialized if the list is empty to reduce the size of the result file. If there are no
+     * issues at all, [AdvisorRecord.hasIssues] already contains that information.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val issues: List<OrtIssue> = emptyList()
+)

--- a/model/src/main/kotlin/Identifier.kt
+++ b/model/src/main/kotlin/Identifier.kt
@@ -121,14 +121,18 @@ data class Identifier(
 
     /**
      * Create the canonical [package URL](https://github.com/package-url/purl-spec) ("purl") based on the properties of
-     * the [Identifier].
+     * the [Identifier]. Some issues remain with this specification
+     * (see e.g. https://github.com/package-url/purl-spec/issues/33).
+     *
+     * This implementation uses the package type as 'type' purl element as it is used
+     * [in the documentation](https://github.com/package-url/purl-spec/blob/master/README.rst#purl).
+     * E.g. 'maven' for Gradle projects.
      */
-    // TODO: This is a preliminary implementation as some open questions remain, see e.g.
-    //       https://github.com/package-url/purl-spec/issues/33.
     fun toPurl() = "".takeIf { this == EMPTY }
         ?: buildString {
             append("pkg:")
-            append(type.toLowerCase())
+            val purlType = getPurlType()?.toString() ?: type.toLowerCase()
+            append(purlType)
 
             if (namespace.isNotEmpty()) {
                 append('/')
@@ -141,4 +145,47 @@ data class Identifier(
             append('@')
             append(version.percentEncode())
         }
+
+    /**
+     * Map a package manager type as to a package url using the package type.
+     * Returns null when package manager cannot be mapped to a package type.
+     */
+    fun getPurlType() = when (type.toLowerCase()) {
+        "bower" -> PurlType.BOWER
+        "bundler" -> PurlType.GEM
+        "cargo" -> PurlType.CARGO
+        "carthage", "pub", "spdx", "stack" -> null
+        "composer" -> PurlType.COMPOSER
+        "conan" -> PurlType.CONAN
+        "dep", "glide", "godep", "gomod" -> PurlType.GOLANG
+        "dotnet", "nuget" -> PurlType.NUGET
+        "gradle", "maven", "sbt" -> PurlType.MAVEN
+        "npm", "yarn" -> PurlType.NPM
+        "pip", "pipenv" -> PurlType.PYPI
+        else -> null
+    }
+
+    enum class PurlType(private val value: String) {
+        ALPINE("alpine"),
+        A_NAME("a-name"),
+        BOWER("bower"),
+        CARGO("cargo"),
+        COCOAPODS("cocoapods"),
+        COMPOSER("composer"),
+        CONAN("conan"),
+        CONDA("conda"),
+        CRAN("cran"),
+        DEBIAN("debian"),
+        DRUPAL("drupal"),
+        GEM("gem"),
+        GOLANG("golang"),
+        MAVEN("maven"),
+        NPM("npm"),
+        NUGET("nuget"),
+        PECOFF("pecoff"),
+        PYPI("pypi"),
+        RPM("rpm");
+
+        override fun toString() = value
+    }
 }

--- a/model/src/main/kotlin/Vulnerability.kt
+++ b/model/src/main/kotlin/Vulnerability.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+/**
+ * Base model for all vulnerability providers supported by the advisor.
+ */
+interface Vulnerability {
+    /**
+     * The ID of a vulnerability. Most likely a CVE identifier.
+     */
+    val id: String
+
+    /**
+     * Severity of the vulnerability. Most likely expressed using the CVSS.
+     * See: https://www.first.org/cvss/
+     */
+    val severity: Float
+}

--- a/model/src/main/kotlin/config/AdvisorConfiguration.kt
+++ b/model/src/main/kotlin/config/AdvisorConfiguration.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.config
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+
+/**
+ * The base configuration model of the advisor.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS)
+@JsonSubTypes(
+    JsonSubTypes.Type(NexusIqConfiguration::class)
+)
+sealed class AdvisorConfiguration
+
+/**
+ * The configuration for the Nexus IQ Server security vulnerability provider.
+ */
+data class NexusIqConfiguration(
+    /**
+     * The base URL of the provider.
+     */
+    val serverUrl: String,
+
+    /**
+     * Username of the provider. Used without authentication if no password or username is given.
+     */
+    val username: String?,
+
+    /**
+     * Password of the provider. Used without authentication if no password or username is given.
+     */
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    val password: String?
+) : AdvisorConfiguration()

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -38,7 +38,12 @@ data class OrtConfiguration(
     /**
      * The configuration of the scanner.
      */
-    val scanner: ScannerConfiguration? = null
+    val scanner: ScannerConfiguration? = null,
+
+    /**
+     * The configuration of the advisors, using the advisor's name as the key.
+     */
+    val advisor: Map<String, AdvisorConfiguration>? = null
 ) {
     companion object {
         /**

--- a/model/src/test/kotlin/IdentifierTest.kt
+++ b/model/src/test/kotlin/IdentifierTest.kt
@@ -123,6 +123,12 @@ class IdentifierTest : WordSpec({
             purl shouldNotContain "%"
         }
 
+        "ignore case in type" {
+            val purl = Identifier("MaVeN", "namespace", "name", "version").toPurl()
+
+            purl shouldBe purl.toLowerCase()
+        }
+
         "not use '/' for empty namespaces" {
             val purl = Identifier("type", "", "name", "version").toPurl()
 

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -213,7 +213,7 @@
     "id" : "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0",
     "is_project" : true,
     "definition_file_path" : "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle",
-    "purl" : "pkg:gradle/org.ossreviewtoolkit.gradle.example/lib@1.0.0",
+    "purl" : "pkg:maven/org.ossreviewtoolkit.gradle.example/lib@1.0.0",
     "declared_licenses_processed" : { },
     "detected_licenses" : [ 0, 1, 2, 3, 4 ],
     "binary_artifact" : {
@@ -308,7 +308,7 @@
     "id" : "Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0",
     "is_project" : true,
     "definition_file_path" : "project/build.gradle",
-    "purl" : "pkg:gradle/org.ossreviewtoolkit/nested-fake-project@1.0.0",
+    "purl" : "pkg:maven/org.ossreviewtoolkit/nested-fake-project@1.0.0",
     "declared_licenses" : [ 5 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "GPL-3.0-only WITH GCC-exception-3.1 AND CC-BY-NC-3.0",

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -169,7 +169,7 @@ packages:
   id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
   is_project: true
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
-  purl: "pkg:gradle/org.ossreviewtoolkit.gradle.example/lib@1.0.0"
+  purl: "pkg:maven/org.ossreviewtoolkit.gradle.example/lib@1.0.0"
   declared_licenses_processed: {}
   detected_licenses:
   - 0
@@ -256,7 +256,7 @@ packages:
   id: "Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0"
   is_project: true
   definition_file_path: "project/build.gradle"
-  purl: "pkg:gradle/org.ossreviewtoolkit/nested-fake-project@1.0.0"
+  purl: "pkg:maven/org.ossreviewtoolkit/nested-fake-project@1.0.0"
   declared_licenses:
   - 5
   declared_licenses_processed:

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -320,4 +320,5 @@ scanner:
       num_reads: 5
       num_hits: 0
     has_issues: true
+advisor: null
 evaluator: null

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,6 +45,7 @@ pluginManagement {
 
 rootProject.name = "oss-review-toolkit"
 
+include(":advisor")
 include(":analyzer")
 include(":cli")
 include(":clients:clearly-defined")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
  * Copyright (C) 2019 Bosch Software Innovations GmbH
+ * Copyright (C) 2020 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +48,7 @@ rootProject.name = "oss-review-toolkit"
 include(":analyzer")
 include(":cli")
 include(":clients:clearly-defined")
+include(":clients:nexus-iq")
 include(":detekt-rules")
 include(":downloader")
 include(":evaluator")


### PR DESCRIPTION
This PR adds the advisor module and a first implementation of it for [Sonatype Nexus IQ Server](https://help.sonatype.com/iqserver).

Resolves #3268.