### PR TITLE
Add a declared license mapping for "CDDL-1.1 OR GPL 2.0 only WITH Classpath exception 2.0"

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -1,6 +1,3 @@
-# Sort the entries below via IntelliJ's "Edit" -> "Sort Lines".
-# Map a declared license string to "NONE" in order to discard it.
----
 "(MIT-style) netCDF C library license": NetCDF
 "2-clause BSD license": BSD-2-Clause
 "2-clause BSDL": BSD-2-Clause
@@ -114,6 +111,7 @@
 "CDDL+GPL License": CDDL-1.0 AND GPL-2.0-only
 "CDDL+GPL": CDDL-1.0 AND GPL-2.0-only
 "CDDL+GPLv2": CDDL-1.0 AND GPL-2.0-only
+"CDDL-1.1 OR GPL 2.0 only WITH Classpath exception 2.0": CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
 "CDDL/GPLv2 dual license": CDDL-1.0 OR GPL-2.0-only
 "CDDL/GPLv2+CE": CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 "CEA CNRS Inria Logiciel Libre License, version 2.1 (CeCILL-2.1)": CECILL-2.1
@@ -521,3 +519,6 @@
 "zope 2.1": ZPL-2.1
 "zope license": ZPL-2.1
 "zope v2.1": ZPL-2.1
+# Map a declared license string to "NONE" in order to discard it.
+# Sort the entries below via IntelliJ's "Edit" -> "Sort Lines".
+---


### PR DESCRIPTION
Found in https://repo1.maven.org/maven2/com/sun/mail/javax.mail/1.6.1/javax.mail-1.6.1.pom

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>