### PR TITLE
Stop filtering scan results by VCS path for Git Repo

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -56,6 +56,7 @@ import org.ossreviewtoolkit.model.ScannerRun
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.Success
 import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.model.mapper
@@ -520,7 +521,7 @@ private fun ScanResultContainer.deduplicateScanResults(): ScanResultContainer {
 }
 
 private fun ScanResult.filterByVcsPath(): ScanResult {
-    val path = provenance.vcsInfo?.path.orEmpty()
+    val path = provenance.vcsInfo?.takeIf { it.type != VcsType.GIT_REPO }?.path.orEmpty()
 
     return filterPath(path)
 }

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -357,9 +357,9 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
 
         archiveFiles(downloadResult.downloadDirectory, pkg.id, provenance)
 
-        val scanResult = scanPathInternal(downloadResult.downloadDirectory, resultsFile).let { scanResult ->
-            provenance.vcsInfo?.let { scanResult.filterPath(it.path) } ?: scanResult
-        }.copy(provenance = provenance)
+        val scanResult = scanPathInternal(downloadResult.downloadDirectory, resultsFile)
+            .copy(provenance = provenance)
+            .let { scanResult -> provenance.vcsInfo?.let { scanResult.filterPath(it.path) } ?: scanResult }
 
         return when (val storageResult = ScanResultsStorage.storage.add(pkg.id, scanResult)) {
             is Success -> scanResult

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -157,7 +157,6 @@ abstract class Scanner(val scannerName: String, protected val config: ScannerCon
         if (parentPath != null) {
             filteredResults = resultContainer.results.map { result ->
                 if (result.provenance.sourceArtifact != null) {
-                    // Do not filter the result if a source artifact was scanned.
                     result
                 } else {
                     result.filterPath(parentPath)


### PR DESCRIPTION
Since this leads to empty scan results as the VCS path points to the manifest.