### PR TITLE
Utils: Add some fault tolerance to normalizeVcsUr()

### DIFF
--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -192,7 +192,7 @@ fun joinNonBlank(vararg strings: String, separator: String = " - ") =
  * Normalize a string representing a [VCS URL][vcsUrl] to a common string form.
  */
 fun normalizeVcsUrl(vcsUrl: String): String {
-    var url = vcsUrl.trimEnd('/')
+    var url = vcsUrl.trim().trimEnd('/')
 
     if (url.startsWith(":pserver:") || url.startsWith(":ext:")) {
         // Do not touch CVS URLs for now.


### PR DESCRIPTION
When a VCS Url with a leading white space is passed to that function, it
runs into so fallback handling implemented inside the catch block for
the URISyntaxException. The result of normalizing [1] is [2] whereas
${CWD} is the current working directory.

On the one hand the input was just wrong and thus it doesn't need to be
handled, but on the other hand finding the root cause of this issue was
quite time consuming. Thus, add this fault tolerance to avoid such time
consuming investigation in the future.

[1] " https://github.com/oss-review-toolkit/ort.git"
[2] "file:///${CWD}%20https:/github.com/oss-review-toolkit/ort.git

Signed-off-by: Frank Viernau <frank.viernau@here.com>