### PR TITLE
Rename license configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ A file that contains user-defined categorization of licenses.
 
 | Format | Scope | Default location | Default value |
 | ------ | ----- | ---------------- | ------------- |
-| YAML / JSON | Global | `$ORT_CONFIG_DIR/licenses.yml` | Empty (n/a) |
+| YAML / JSON | Global | `$ORT_CONFIG_DIR/license-classifications.yml` | Empty (n/a) |
 
 #### [Resolution file](./docs/config-file-resolutions-yml.md)
 

--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -86,9 +86,9 @@ class ExamplesFunTest : StringSpec() {
             }
         }
 
-        "licenses.yml can be deserialized" {
+        "license-classifications.yml can be deserialized" {
             shouldNotThrow<IOException> {
-                takeExampleFile("licenses.yml").readValue<LicenseConfiguration>()
+                takeExampleFile("license-classifications.yml").readValue<LicenseConfiguration>()
             }
         }
 

--- a/docs/config-file-curations-yml.md
+++ b/docs/config-file-curations-yml.md
@@ -107,7 +107,7 @@ cli/build/install/ort/bin/ort evaluate
   -i [scanner-output-dir]/scan-result.yml
   -o [evaluator-output-dir]
   --output-formats YAML
-  --license-configuration-file $ORT_CONFIG_DIR/licenses.yml
+  --license-configuration-file $ORT_CONFIG_DIR/license-classifications.yml
   --package-curations-file $ORT_CONFIG_DIR/curations.yml
   --rules-file $ORT_CONFIG_DIR/rules.kts
 ```

--- a/docs/config-file-licenses-yml.md
+++ b/docs/config-file-licenses-yml.md
@@ -1,8 +1,9 @@
-# The `licenses.yml` file
+# The `license-classifications.yml` file
 
-The `licenses.yml` file holds a user-defined categorization of licenses.
+The `license-classifications.yml` file holds a user-defined categorization of licenses.
 
-You can use the [licenses.yml example](../examples/licenses.yml) as the base configuration file for your scans.
+You can use the [license-classifications.yml example](../examples/license-classifications.yml) as the base configuration
+file for your scans.
 
 ### When to Use
 
@@ -13,15 +14,15 @@ Licenses can be assigned to license sets like "permissive" or "public domain" wh
 
 ## Command Line
 
-To use the `licenses.yml` file put it to `$ORT_CONFIG_DIR/licenses.yml` or pass it to the `--license-configuration-file`
-option of the _evaluator_:
+To use the `license-classifications.yml` file put it to `$ORT_CONFIG_DIR/license-classifications.yml` or pass it to the
+`--license-configuration-file` option of the _evaluator_:
 
 ```bash
 cli/build/install/ort/bin/ort evaluate
   -i [scanner-output-dir]/scan-result.yml
   -o [evaluator-output-dir]
   --output-formats YAML
-  --license-configuration-file $ORT_CONFIG_DIR/licenses.yml
+  --license-configuration-file $ORT_CONFIG_DIR/license-classifications.yml
   --package-curations-file $ORT_CONFIG_DIR/curations.yml
   --rules-file $ORT_CONFIG_DIR/rules.kts
 ```

--- a/docs/config-file-package-configuration-yml.md
+++ b/docs/config-file-package-configuration-yml.md
@@ -83,7 +83,7 @@ cli/build/install/ort/bin/ort evaluate
   -i [scanner-output-dir]/scan-result.yml
   -o [evaluator-output-dir]
   --output-formats YAML
-  --license-configuration-file $ORT_CONFIG_DIR/licenses.yml
+  --license-configuration-file $ORT_CONFIG_DIR/license-classifications.yml
   --package-curations-file $ORT_CONFIG_DIR/curations.yml
   --package-configuration-dir $ORT_CONFIG_DIR/packages
   --rules-file $ORT_CONFIG_DIR/rules.kts
@@ -96,7 +96,7 @@ cli/build/install/ort/bin/ort report
   -i [evaluator-output-dir]/evaluation-result.yml
   -o [reporter-output-dir]
   --report-formats NoticeTemplate,WebApp
-  --license-configuration-file $ORT_CONFIG_DIR/licenses.yml
+  --license-configuration-file $ORT_CONFIG_DIR/license-classifications.yml
   --package-configuration-dir $ORT_CONFIG_DIR/packages
 ```
  
@@ -110,7 +110,7 @@ cli/build/install/ort/bin/ort evaluate
   -i [scanner-output-dir]/scan-result.yml
   -o [evaluator-output-dir]
   --output-formats YAML
-  --license-configuration-file $ORT_CONFIG_DIR/licenses.yml
+  --license-configuration-file $ORT_CONFIG_DIR/license-classifications.yml
   --package-curations-file $ORT_CONFIG_DIR/curations.yml
   --package-configuration-file $ORT_CONFIG_DIR/packages.yml
   --rules-file $ORT_CONFIG_DIR/rules.kts
@@ -123,7 +123,7 @@ cli/build/install/ort/bin/ort report
   -i [evaluator-output-dir]/evaluation-result.yml
   -o [reporter-output-dir]
   --report-formats NoticeTemplate,WebApp
-  --license-configuration-file $ORT_CONFIG_DIR/licenses.yml
+  --license-configuration-file $ORT_CONFIG_DIR/license-classifications.yml
   --package-configuration-file $ORT_CONFIG_DIR/packages.yml
 ```
 

--- a/docs/config-file-resolutions-yml.md
+++ b/docs/config-file-resolutions-yml.md
@@ -94,6 +94,6 @@ cli/build/install/ort/bin/ort report
   -i [evaluator-output-dir]/evaluation-result.yml
   -o [reporter-output-dir]
   --report-formats NoticeTemplate,StaticHtml,WebApp
-  --license-configuration-file $ORT_CONFIG_DIR/licenses.yml
+  --license-configuration-file $ORT_CONFIG_DIR/license-classifications.yml
   --resolutions-file $ORT_CONFIG_DIR/resolutions.yml
 ```

--- a/docs/file-rules-kts.md
+++ b/docs/file-rules-kts.md
@@ -7,8 +7,9 @@ For each policy rule violation, you can define 'How to fix' follow-up actions to
 violations by themselves.
 
 You can use the [rules.kts example](../examples/rules.kts) as the base script file for your policy rules. Note that this
-example depends on the licenses categorizations defined in the [licenses.yml example](../examples/licenses.yml), see the
-[licenses.yml docs](config-file-licenses-yml.md).
+example depends on the licenses categorizations defined in the 
+[license-classifications.yml example](../examples/license-classifications.yml), see the
+[license-classifications.yml docs](config-file-licenses-yml.md).
 
 ## Command Line
 
@@ -20,7 +21,7 @@ cli/build/install/ort/bin/ort evaluate \
   -i [scanner-output-dir]/scan-result.yml
   -o [evaluator-output-dir] \
   --output-formats YAML \
-  --license-configuration-file $ORT_CONFIG_DIR/licenses.yml \
+  --license-configuration-file $ORT_CONFIG_DIR/license-classifications.yml \
   --package-curations-file $ORT_CONFIG_DIR/curations.yml  \
   --rules-file $ORT_CONFIG_DIR/rules.kts
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -304,7 +304,7 @@ on a bigger project you will see that `ScanCode` often finds more licenses than 
 
 The evaluator can apply a set of rules against the scan result created above.
 ORT provides examples for the policy rules file [(rules.kts)](../examples/rules.kts),
-[user-defined categorization of licenses (licenses.yml)](../examples/licenses.yml) and
+[user-defined categorization of licenses (license-classifications.yml)](../examples/license-classifications.yml) and
 [user-defined package curations (curations.yml)](../examples/curations.yml) that can be used for testing the
 _evaluator_. 
 
@@ -314,14 +314,14 @@ To run the example rules use:
 cli/build/install/ort/bin/ort evaluate
   --package-curations-file curations.yml
   --rules-file rules.kts
-  --license-configuration-file licenses.yml
+  --license-configuration-file license-classifications.yml
   -i [scanner-output-dir]/scan-result.yml
   -o [evaluator-output-dir]/mime-types
 ```
 
 See the [curations.yml documentation](config-file-curations-yml.md) to learn more about using curations to correct
-invalid or missing package metadata and the [licenses.yml documentation](config-file-licenses-yml.md) on how you can
-classify licenses to simplify writing the policy rules.
+invalid or missing package metadata and the [license-classifications.yml documentation](config-file-licenses-yml.md) on
+how you can classify licenses to simplify writing the policy rules.
 
 It is possible to write your own evaluator rules as a Kotlin script and pass it to the _evaluator_ using `--rules-file`.
 Note that detailed documentation for writing custom rules is not yet available.

--- a/examples/license-classifications.yml
+++ b/examples/license-classifications.yml
@@ -1,5 +1,5 @@
 ---
-# Example licenses.yml based on categorization from
+# Example license-classifications.yml based on categorization from
 # https://github.com/nexB/scancode-toolkit/commit/ed644e4
 #
 # To demonstrate how one can insert a custom written offer

--- a/examples/rules.kts
+++ b/examples/rules.kts
@@ -26,7 +26,7 @@
  *******************************************************/
 
 /**
- * Import license configuration from licenses.yml.
+ * Import license configuration from license-classifications.yml.
  */
 
 fun getLicenseSet(setId: String) = licenseConfiguration.getLicensesForSet(setId).map { it.id }.toSet()

--- a/utils/src/main/kotlin/Constants.kt
+++ b/utils/src/main/kotlin/Constants.kt
@@ -68,7 +68,7 @@ const val ORT_HOW_TO_FIX_TEXT_PROVIDER_FILENAME = "how-to-fix-text-provider.kts"
 /**
  * The name of the ORT license configuration file.
  */
-const val ORT_LICENSE_CONFIGURATION_FILENAME = "licenses.yml"
+const val ORT_LICENSE_CONFIGURATION_FILENAME = "license-classifications.yml"
 
 /**
  * The name of the ORT package configurations directory.


### PR DESCRIPTION
Rename the file from licenses.yml to license-classifications.yml. The
new name expresses the intention of this file better: to give the user
a possibility to group licenses into a customizable set of categories.

I hope I spotted all references to the file name, including the ones in the documentation. At least IntelliJ's "find in path" feature did not find any hits any more.