### PR TITLE
Gradle: Disable the configure-on-demand option for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN --mount=type=cache,target=/root/.gradle/ \
     scripts/import_proxy_certs.sh && \
     scripts/set_gradle_proxy.sh && \
     sed -i -r 's,(^distributionUrl=)(.+)-all\.zip$,\1\2-bin.zip,' gradle/wrapper/gradle-wrapper.properties && \
-    ./gradlew --no-daemon --stacktrace :cli:distTar
+    ./gradlew --no-daemon --stacktrace --no-configure-on-demand :cli:distTar
 
 FROM adoptopenjdk:11-jre-hotspot-bionic
 


### PR DESCRIPTION
After moving the clearly-defined client to a new "clients" directory in this PR
we started getting error in docker build. Root cause seems to be
gradle/gradle#4823 that is not fixed yet. This change is a workaround that
suitable for docker build in clouds where no gradle files being cached.
Workaround for local development is build with disabled configure-on-demand
option once. For all further build it could be enabled back.

Fixes #3306

Signed-off-by: zhernovs <ext-andriy.zhernovskyi@here.com>