### PR TITLE
declared-license-mapping: Add an entry for `MIT`

### DIFF
--- a/downloader/src/funTest/kotlin/vcs/GitWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitWorkingTreeFunTest.kt
@@ -93,6 +93,7 @@ class GitWorkingTreeFunTest : StringSpec() {
                 "debug-test-failures",
                 "drop-py2.6",
                 "fixing-test-setups",
+                "idiot-z-add_extra_require",
                 "master",
                 "release-0.10.1",
                 "reverse-mode",

--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -413,6 +413,7 @@
 "Zlib/Libpng License": zlib-acknowledgement
 "Zope Public License": ZPL-2.1
 "Zope Public": ZPL-2.1
+"['MIT']": MIT
 "artistic license v2.0": Artistic-2.0
 "bsd 4-clause": BSD-3-Clause
 "bzip2 license": bzip2-1.0.6


### PR DESCRIPTION
As found in [1].

[1] https://github.com/mapado/haversine/blob/9fe596116a3d2f13208953f4a0f7bc7225ae0ac9/setup.py#L18

Signed-off-by: Frank Viernau <frank.viernau@here.com>