### PR TITLE
Dockerfile: Switch building to a base image with Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-FROM frolvlad/alpine-java:jdk8-slim AS build
+FROM adoptopenjdk/openjdk11:jdk-11.0.9_11.1-alpine-slim AS build
 
 # Apk install commands.
 RUN apk add --no-cache \


### PR DESCRIPTION
Fixes #3318.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>