### PR TITLE
Raise the Java requirement to 11 from 1.8 to be able to simplify code

### DIFF
--- a/.jitpack.yml
+++ b/.jitpack.yml
@@ -1,5 +1,5 @@
 jdk:
-  - openjdk8
+  - openjdk11
 
 install:
   # Exclude dokkaJavadoc tasks to save build time.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 &nbsp;
 
-| Linux (OpenJDK 11)             | Windows (Oracle JDK 11)         | JitPack (OpenJDK 8)             |
+| Linux (OpenJDK 11)             | Windows (Oracle JDK 11)         | JitPack (OpenJDK 11)            |
 | :----------------------------- | :------------------------------ | :------------------------------ |
 | [![Linux build status][1]][2]  | [![Windows build status][3]][4] | [![JitPack build status][5]][6] |
 | [![Linux code coverage][7]][8] |                                 |                                 |
@@ -83,8 +83,7 @@ Change into the directory with ORT's source code and run `docker build -t ort .`
 
 Install these additional prerequisites:
 
-* OpenJDK 8 or Oracle JDK 8u161 or later (not the JRE as you need the `javac` compiler); also remember to set the
-  `JAVA_HOME` environment variable accordingly.
+* Java Development Kit (JDK) version 11 or later; also remember to set the `JAVA_HOME` environment variable accordingly.
 
 Change into the directory with ORT's source code and run `./gradlew installDist` (on the first run this will bootstrap
 Gradle and download all required dependencies).
@@ -575,10 +574,9 @@ ORT is being continuously used on Linux, Windows and macOS by the
 [core development team](https://github.com/orgs/oss-review-toolkit/people), so these operating systems are
 considered to be well supported.
 
-To run the ORT binaries (also see [Installation from binaries](#from-binaries)) at least a Java Runtime Environment
-(JRE) version 8 is required, but using version 11 is recommended. Memory and CPU requirements vary depending on the size
-and type of project(s) to analyze / scan, but the general recommendation is to configure the JRE with 8 GiB of memory
-(`-Xmx=8g`) and to use a CPU with at least 4 cores.
+To run the ORT binaries (also see [Installation from binaries](#from-binaries)) at least Java 11 is required. Memory and
+CPU requirements vary depending on the size and type of project(s) to analyze / scan, but the general recommendation is
+to configure Java with 8 GiB of memory (`-Xmx=8g`) and to use a CPU with at least 4 cores.
 
 If ORT requires external tools in order to analyze a project, these tools are listed by the `ort requirements` command.
 If a package manager is not list listed there, support for it is integrated directly into ORT and does not require any

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,14 @@ plugins {
     id("org.jetbrains.gradle.plugin.idea-ext")
 }
 
+// TODO: Replace this with Gradle's toolchain mechanism [1] once the Kotlin plugin supports it [2].
+// [1] https://blog.gradle.org/java-toolchains
+// [2] https://youtrack.jetbrains.com/issue/KT-43095
+val javaVersion = JavaVersion.current()
+if (!javaVersion.isCompatibleWith(JavaVersion.VERSION_11)) {
+    throw GradleException("At least Java 11 is required, but Java $javaVersion is being used.")
+}
+
 reckon {
     scopeFromProp()
     snapshotFromProp()
@@ -199,7 +207,7 @@ subprojects {
 
         kotlinOptions {
             allWarningsAsErrors = true
-            jvmTarget = "1.8"
+            jvmTarget = "11"
             apiVersion = "1.4"
             freeCompilerArgs = freeCompilerArgs + customCompilerArgs
         }

--- a/downloader/src/main/kotlin/vcs/Subversion.kt
+++ b/downloader/src/main/kotlin/vcs/Subversion.kt
@@ -32,7 +32,6 @@ import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.downloader.WorkingTree
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
-import org.ossreviewtoolkit.utils.OrtAuthenticator
 import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.installAuthenticatorAndProxySelector
 import org.ossreviewtoolkit.utils.log
@@ -251,7 +250,6 @@ private class OrtSVNAuthenticationManager : DefaultSVNAuthenticationManager(
     /* passphrase = */ charArrayOf()
 ) {
     private val ortProxySelector = installAuthenticatorAndProxySelector()
-    private val ortAuthenticator = OrtAuthenticator.getDefaultAuthenticator()
 
     init {
         authenticationProvider = object : ISVNAuthenticationProvider {
@@ -265,7 +263,7 @@ private class OrtSVNAuthenticationManager : DefaultSVNAuthenticationManager(
             ): SVNAuthentication? {
                 val url = URL(svnurl.toString())
 
-                val auth = ortAuthenticator?.requestPasswordAuthenticationInstance(
+                val auth = Authenticator.getDefault()?.requestPasswordAuthenticationInstance(
                     svnurl.host, null, svnurl.port, svnurl.protocol, null, null, url, Authenticator.RequestorType.SERVER
                 ) ?: return null
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ dokkaPluginVersion = 1.4.10.2
 ideaExtPluginVersion = 0.9
 kotlinPluginVersion = 1.4.10
 reckonPluginVersion = 0.13.0
-svntoolsPluginVersion = 2.2.1
+svntoolsPluginVersion = 3.1
 versionsPluginVersion = 0.36.0
 
 antennaVersion = 1.0.0-weekly-2020-29

--- a/utils/src/main/kotlin/OrtAuthenticator.kt
+++ b/utils/src/main/kotlin/OrtAuthenticator.kt
@@ -33,19 +33,12 @@ import org.apache.logging.log4j.Level
  */
 class OrtAuthenticator(private val original: Authenticator? = null) : Authenticator() {
     companion object {
-        fun getDefaultAuthenticator(): Authenticator? {
-            // The getDefault() method is only available as of Java 9, see
-            // https://docs.oracle.com/javase/9/docs/api/java/net/Authenticator.html#getDefault--
-            val method = runCatching { Authenticator::class.java.getMethod("getDefault") }.getOrNull()
-            return method?.invoke(null) as? Authenticator
-        }
-
         /**
          * Install this authenticator as the global default.
          */
         @Synchronized
         fun install(): OrtAuthenticator {
-            val current = getDefaultAuthenticator()
+            val current = getDefault()
             return if (current is OrtAuthenticator) {
                 logOnce(Level.INFO) { "Authenticator is already installed." }
                 current
@@ -62,7 +55,7 @@ class OrtAuthenticator(private val original: Authenticator? = null) : Authentica
          */
         @Synchronized
         fun uninstall(): Authenticator? {
-            val current = getDefaultAuthenticator()
+            val current = getDefault()
             return if (current is OrtAuthenticator) {
                 current.original.also {
                     setDefault(it)


### PR DESCRIPTION
And to be able to use the requestPasswordAuthenticationInstance() method
from the Java Authenticator.

Fixes #3322.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>