### PR TITLE
Oheger bosch/licenses/#2624 rework license configuration

### DIFF
--- a/cli/src/funTest/assets/semver4j-analyzer-result.yml
+++ b/cli/src/funTest/assets/semver4j-analyzer-result.yml
@@ -1,0 +1,344 @@
+---
+repository:
+  vcs:
+    type: "Git"
+    url: "https://github.com/vdurmont/semver4j.git"
+    revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/vdurmont/semver4j.git"
+    revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+    path: ""
+  config: {}
+analyzer:
+  start_time: "2020-10-26T20:00:07.677878Z"
+  end_time: "2020-10-26T20:00:39.307607Z"
+  environment:
+    ort_version: "0.1.0-SNAPSHOT"
+    java_version: "11.0.6"
+    os: "Linux"
+    processors: 6
+    max_memory: 6274678784
+    variables:
+      http_proxy: "http://172.17.0.1:3128"
+      https_proxy: "http://172.17.0.1:3128"
+      JAVA_HOME: "/opt/java/openjdk"
+      ANDROID_HOME: "/opt/android-sdk"
+      GOPATH: "/go"
+    tool_versions: {}
+  config:
+    ignore_tool_versions: false
+    allow_dynamic_versions: false
+  result:
+    projects:
+      - id: "Maven:com.vdurmont:semver4j:3.1.0"
+        definition_file_path: "pom.xml"
+        declared_licenses:
+          - "The MIT License"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+          mapped:
+            The MIT License: "MIT"
+        vcs:
+          type: "Git"
+          url: "git@github.com:vdurmont/semver4j.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/vdurmont/semver4j.git"
+          revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+          path: ""
+        homepage_url: "https://github.com/vdurmont/semver4j"
+        scopes:
+          - name: "test"
+            dependencies:
+              - id: "Maven:junit:junit:4.12"
+                dependencies:
+                  - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+              - id: "Maven:org.mockito:mockito-all:1.10.19"
+    packages:
+      - package:
+          id: "Maven:junit:junit:4.12"
+          purl: "pkg:maven/junit/junit@4.12"
+          declared_licenses:
+            - "Eclipse Public License 1.0"
+          declared_licenses_processed:
+            spdx_expression: "EPL-1.0"
+            mapped:
+              Eclipse Public License 1.0: "EPL-1.0"
+          description: "JUnit is a unit testing framework for Java, created by Erich\
+          \ Gamma and Kent Beck."
+          homepage_url: "http://junit.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
+            hash:
+              value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+            hash:
+              value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/junit-team/junit.git"
+            revision: "r4.12"
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/junit-team/junit.git"
+            revision: "r4.12"
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.hamcrest:hamcrest-core:1.3"
+          purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
+          declared_licenses:
+            - "BSD-3-Clause"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+          description: "This is the core API of hamcrest matcher framework to be used\
+          \ by third-party framework providers. This includes the a foundation set\
+          \ of matcher implementations for common operations."
+          homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
+            hash:
+              value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+            hash:
+              value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:hamcrest/JavaHamcrest.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
+            revision: ""
+            path: ""
+        curations:
+          - base:
+              declared_licenses:
+                - "New BSD License"
+            curation:
+              declared_licenses:
+                - "BSD-3-Clause"
+              comment: "Provided by ClearlyDefined."
+      - package:
+          id: "Maven:org.mockito:mockito-all:1.10.19"
+          purl: "pkg:maven/org.mockito/mockito-all@1.10.19"
+          declared_licenses:
+            - "MIT"
+          declared_licenses_processed:
+            spdx_expression: "MIT"
+          description: "Mock objects library for java"
+          homepage_url: "http://www.mockito.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/mockito/mockito-all/1.10.19/mockito-all-1.10.19.jar"
+            hash:
+              value: "539df70269cc254a58cccc5d8e43286b4a73bf30"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/mockito/mockito-all/1.10.19/mockito-all-1.10.19-sources.jar"
+            hash:
+              value: "8269667b73d9616600359a9b0ba1b1c7d0cf7a97"
+              algorithm: "SHA-1"
+          vcs:
+            type: ""
+            url: ""
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: ""
+            url: ""
+            revision: ""
+            path: ""
+        curations:
+          - base:
+              declared_licenses:
+                - "The MIT License"
+            curation:
+              declared_licenses:
+                - "MIT"
+              comment: "Provided by ClearlyDefined."
+    has_issues: false
+scanner:
+  start_time: "2020-10-26T20:00:50.163356Z"
+  end_time: "2020-10-26T20:00:59.349366Z"
+  environment:
+    ort_version: "0.1.0-SNAPSHOT"
+    java_version: "11.0.6"
+    os: "Linux"
+    processors: 6
+    max_memory: 6274678784
+    variables:
+      http_proxy: "http://172.17.0.1:3128"
+      https_proxy: "http://172.17.0.1:3128"
+      JAVA_HOME: "/opt/java/openjdk"
+      ANDROID_HOME: "/opt/android-sdk"
+      GOPATH: "/go"
+    tool_versions: {}
+  config:
+    archive: null
+    options: null
+    storages:
+      postgresStorage: !<.PostgresStorageConfiguration>
+        url: "jdbc:postgresql://172.17.0.1:5432/ort"
+        schema: "scan_storage"
+        username: "ort"
+        sslmode: "disable"
+        sslcert: null
+        sslkey: null
+        sslrootcert: null
+    storage_readers:
+      - "postgresStorage"
+    storage_writers:
+      - "postgresStorage"
+  results:
+    scan_results:
+      - id: "Maven:com.vdurmont:semver4j:3.1.0"
+        results:
+          - provenance:
+              download_time: "2020-09-30T09:27:08.894485Z"
+              vcs_info:
+                type: "Git"
+                url: "https://github.com/vdurmont/semver4j.git"
+                revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+                resolved_revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+                path: ""
+              original_vcs_info:
+                type: "Git"
+                url: "https://github.com/vdurmont/semver4j.git"
+                revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+                path: ""
+            scanner:
+              name: "ScanCode"
+              version: "3.2.1-rc2"
+              configuration: "--copyright --license --ignore *.ort.yml --info --strip-root\
+            \ --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+            summary:
+              start_time: "2020-09-30T09:27:12.023451Z"
+              end_time: "2020-09-30T09:28:20.525647Z"
+              file_count: 16
+              package_verification_code: "48ba11487d53ce933b5d4db1d069b70a803ff19b"
+              licenses:
+                - license: "BSD-3-Clause"
+                  location:
+                    path: "pom.xml"
+                    start_line: 28
+                    end_line: 34
+                - license: "MIT"
+                  location:
+                    path: "LICENSE.md"
+                    start_line: 1
+                    end_line: 1
+                - license: "MIT"
+                  location:
+                    path: "LICENSE.md"
+                    start_line: 5
+                    end_line: 21
+                - license: "MIT"
+                  location:
+                    path: "pom.xml"
+                    start_line: 30
+                    end_line: 31
+              copyrights:
+                - statement: "Copyright (c) 2015-present Vincent DURMONT <vdurmont@gmail.com>"
+                  location:
+                    path: "LICENSE.md"
+                    start_line: 3
+                    end_line: 3
+      - id: "Maven:junit:junit:4.12"
+        results:
+          - provenance:
+              download_time: "2020-09-30T09:28:22.219996Z"
+              vcs_info:
+                type: "Git"
+                url: "https://github.com/junit-team/junit.git"
+                revision: "r4.12"
+                resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
+                path: ""
+              original_vcs_info:
+                type: "Git"
+                url: "https://github.com/junit-team/junit.git"
+                revision: "r4.12"
+                path: ""
+            scanner:
+              name: "ScanCode"
+              version: "3.2.1-rc2"
+              configuration: "--copyright --license --ignore *.ort.yml --info --strip-root\
+            \ --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+            summary:
+              start_time: "2020-09-30T09:28:32.817956Z"
+              end_time: "2020-09-30T09:29:02.889213Z"
+              file_count: 478
+              package_verification_code: "2acb4f0b06b706fa94e9159c2f9abc1397c46ba0"
+              licenses:
+                - license: "Apache-2.0"
+                  location:
+                    path: "pom.xml"
+                    start_line: 19
+                    end_line: 23
+                - license: "Apache-2.0"
+                  location:
+                    path: "src/site/resources/css/hopscotch-0.1.2.min.css"
+                    start_line: 5
+                    end_line: 15
+                - license: "Apache-2.0"
+                  location:
+                    path: "src/site/resources/scripts/hopscotch-0.1.2.min.js"
+                    start_line: 5
+                    end_line: 15
+                - license: "EPL-1.0"
+                  location:
+                    path: "LICENSE-junit.txt"
+                    start_line: 3
+                    end_line: 213
+                - license: "EPL-1.0"
+                  location:
+                    path: "epl-v10.html"
+                    start_line: 7
+                    end_line: 257
+                - license: "EPL-1.0"
+                  location:
+                    path: "pom.xml"
+                    start_line: 18
+                    end_line: 20
+                - license: "EPL-1.0"
+                  location:
+                    path: "src/site/fml/faq.fml"
+                    start_line: 157
+                    end_line: 157
+                - license: "EPL-2.0"
+                  location:
+                    path: "pom.xml"
+                    start_line: 19
+                    end_line: 23
+                - license: "NOASSERTION"
+                  location:
+                    path: "src/site/fml/faq.fml"
+                    start_line: 156
+                    end_line: 156
+              copyrights:
+                - statement: "Copyright 2013 LinkedIn Corp."
+                  location:
+                    path: "src/site/resources/css/hopscotch-0.1.2.min.css"
+                    start_line: 3
+                    end_line: 3
+                - statement: "Copyright 2013 LinkedIn Corp."
+                  location:
+                    path: "src/site/resources/scripts/hopscotch-0.1.2.min.js"
+                    start_line: 3
+                    end_line: 3
+    storage_stats:
+      num_reads: 4
+      num_hits: 4
+    has_issues: false
+evaluator: null

--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -23,6 +23,8 @@ import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
@@ -46,6 +48,7 @@ import org.ossreviewtoolkit.model.utils.createLicenseInfoResolver
 import org.ossreviewtoolkit.reporter.HowToFixTextProvider
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.reporters.AntennaAttributionDocumentReporter
+import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.ORT_REPO_CONFIG_FILENAME
 
@@ -88,7 +91,13 @@ class ExamplesFunTest : StringSpec() {
 
         "license-classifications.yml can be deserialized" {
             shouldNotThrow<IOException> {
-                takeExampleFile("license-classifications.yml").readValue<LicenseConfiguration>()
+                val config = takeExampleFile("license-classifications.yml").readValue<LicenseConfiguration>()
+
+                config.categories.filter { it.description.isNotEmpty() } shouldNot beEmpty()
+                config.categoryNames shouldContain "public-domain"
+                val licMIT = config["MIT".toSpdx()]
+                licMIT.shouldNotBeNull()
+                licMIT.categories shouldContain "permissive"
             }
         }
 

--- a/docs/config-file-licenses-yml.md
+++ b/docs/config-file-licenses-yml.md
@@ -5,12 +5,36 @@ The `license-classifications.yml` file holds a user-defined categorization of li
 You can use the [license-classifications.yml example](../examples/license-classifications.yml) as the base configuration
 file for your scans.
 
+The file consists of two sections: The first one, _categories_, allows defining arbitrary categories for grouping
+licenses. Categories have a name and an optional description; the names must be unique.
+
+The second section, _categorizations_, assigns licenses to the categories defined before. Licenses are identified
+using SPDX identifiers. Each license can be assigned an arbitrary number of categories by listing the names of these
+categories. Note that only names can be used that reference one of the categories from the first section.
+
 ### When to Use
 
-Set *include\_in_notice_file* if the license does not require attribution. Similarly, setting
-*include_source_code_offer_in_notice_file* to `true` will ensure a written source code offer is included in the notices.
-Licenses can be assigned to license sets like "permissive" or "public domain" which can be used by the
-[rules](file-rules-kts.md) to determine how to handle the license.
+The mechanism of assigning categories to licenses is rather generic and can be customized for specific use cases.
+The information from the `license-classifications.yml` is evaluated by the following components:
+
+* [Rules](file-rules-kts.md): By defining categories like "permissive" or "public domain", rules can determine how
+  to handle specific licenses and issue warning or error messages if problems are detected.
+* [Notice templates](notice-templates.md): Based on their associated categories, the templates can decide, which
+  licenses to include into the generated notice file.
+
+The [license-classifications.yml example](../examples/license-classifications.yml) demonstrates the intended use
+cases. It defines some categories that specify whether licenses are applicable to development projects. The
+[rules.kts example](../examples/rules.kts) checks ORT results against these categories and generates issues if the
+rules detect a misuse.
+
+In addition, there are some other categories to be evaluated by the templates for the notice file: The
+*include-in-notice-file* category controls whether or not the license requires attribution. Similarly, assigning the
+*include-source-code-offer-in-notice-file* category will ensure a written source code offer is included in the notices.
+
+The point to take is that users can freely choose their license classifications and define their rule sets and
+templates accordingly to achieve the desired results. ORT does not enforce any semantics on categories; it is fully
+up to concrete use cases how they are interpreted. It is therefore well possible that licenses are assigned to
+multiple orthogonal, partly overlapping sets of categories with different meanings.
 
 ## Command Line
 

--- a/examples/license-classifications.yml
+++ b/examples/license-classifications.yml
@@ -5,374 +5,375 @@
 # To demonstrate how one can insert a custom written offer
 # include_source_code_offer_in_notice_file has been set to
 # true for all licenses of the GPL family.
-license_sets:
-- id: "copyleft"
-- id: "copyleft-limited"
-- id: "permissive"
-- id: "public-domain"
-licenses:
+categories:
+- name: "copyleft"
+- name: "strong-copyleft"
+- name: "copyleft-limited"
+- name: "permissive"
+- name: "public-domain"
+categorizations:
 - id: "AGPL-1.0"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "AGPL-1.0-only"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "AGPL-1.0-or-later"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "AGPL-3.0"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "AGPL-3.0-only"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "AGPL-3.0-or-later"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "Apache-2.0"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false 
+  include_source_code_offer_in_notice_file: false
 - id: "Artistic-1.0"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "Artistic-2.0"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "BSD-1-Clause"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "BSD-2-Clause"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "BSD-2-Clause-FreeBSD"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "BSD-2-Clause-NetBSD"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "BSD-3-Clause"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "BSD-4-Clause"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "BSD-4-Clause-UC"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "CC-BY-1.0"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "CC-BY-2.0"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "CC-BY-2.5"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "CC-BY-3.0"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "CC-BY-4.0"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "CC0-1.0"
-  sets:
+  categories:
   - "public-domain"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "CDDL-1.0"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "CDDL-1.1"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "EPL-1.0"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "EPL-2.0"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "EUPL-1.1"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "EUPL-1.2"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "GPL-1.0+"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "GPL-1.0-only"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "GPL-1.0-or-later"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "GPL-2.0"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "GPL-2.0+"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "GPL-2.0-only"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "GPL-2.0-only WITH Classpath-exception-2.0"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "GPL-2.0-only WITH Font-exception-2.0"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "GPL-2.0-or-later"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "GPL-3.0"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "GPL-3.0+"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "GPL-3.0-only"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "GPL-3.0-or-later"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "JSON"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "LGPL-2.0-only"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "LGPL-2.0-or-later"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "LGPL-2.1-only"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "LGPL-2.1-or-later"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "LGPL-3.0-only"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "LGPL-3.0-or-later"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: true
 - id: "Libpng"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "MIT"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "MIT-0"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "MIT-feh"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "MPL-1.0"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "MPL-1.1"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "MPL-2.0"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "MS-PL"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "MS-RL"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "ODbL-1.0"
-  sets:
+  categories:
   - "copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "OFL-1.0"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "OFL-1.1"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "OpenSSL"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "PSF"
-  sets:
+  categories:
   - "strong-copyleft"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "Python-2.0"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "Ruby"
-  sets:
+  categories:
   - "copyleft-limited"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "SAX-PD"
-  sets:
+  categories:
   - "public-domain"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "Unlicense"
-  sets:
+  categories:
   - "public-domain"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "W3C"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "WTFPL"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "X11"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "Zlib"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "bzip2-1.0.5"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "bzip2-1.0.6"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false
 - id: "curl"
-  sets:
+  categories:
   - "permissive"
   include_in_notice_file: true
   include_source_code_offer_in_notice_file: false

--- a/examples/license-classifications.yml
+++ b/examples/license-classifications.yml
@@ -3,377 +3,338 @@
 # https://github.com/nexB/scancode-toolkit/commit/ed644e4
 #
 # To demonstrate how one can insert a custom written offer
-# include_source_code_offer_in_notice_file has been set to
+# include-source-code-offer-in-notice-file has been set to
 # true for all licenses of the GPL family.
 categories:
 - name: "copyleft"
 - name: "strong-copyleft"
 - name: "copyleft-limited"
 - name: "permissive"
+  description: "Licenses with permissive obligations."
 - name: "public-domain"
+- name: "include-in-notice-file"
+  description: >-
+    This category is checked by templates used by the ORT report generator. The licenses associated with this
+    category are included into NOTICE files.
+- name: "include-source-code-offer-in-notice-file"
+  description: >-
+    A marker category that indicates that the licenses assigned to it require that the source code of the packages
+    needs to be provided.
+
 categorizations:
 - id: "AGPL-1.0"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "AGPL-1.0-only"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "AGPL-1.0-or-later"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "AGPL-3.0"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "AGPL-3.0-only"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "AGPL-3.0-or-later"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "Apache-2.0"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "Artistic-1.0"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "Artistic-2.0"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "BSD-1-Clause"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "BSD-2-Clause"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "BSD-2-Clause-FreeBSD"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "BSD-2-Clause-NetBSD"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "BSD-3-Clause"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "BSD-4-Clause"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "BSD-4-Clause-UC"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "CC-BY-1.0"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "CC-BY-2.0"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "CC-BY-2.5"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "CC-BY-3.0"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "CC-BY-4.0"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "CC0-1.0"
   categories:
   - "public-domain"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "CDDL-1.0"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "CDDL-1.1"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "EPL-1.0"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "EPL-2.0"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "EUPL-1.1"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "EUPL-1.2"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "GPL-1.0+"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "GPL-1.0-only"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "GPL-1.0-or-later"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "GPL-2.0"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "GPL-2.0+"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "GPL-2.0-only"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "GPL-2.0-only WITH Classpath-exception-2.0"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "GPL-2.0-only WITH Font-exception-2.0"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "GPL-2.0-or-later"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "GPL-3.0"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "GPL-3.0+"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "GPL-3.0-only"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "GPL-3.0-or-later"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "JSON"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "LGPL-2.0-only"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "LGPL-2.0-or-later"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "LGPL-2.1-only"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "LGPL-2.1-or-later"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "LGPL-3.0-only"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "LGPL-3.0-or-later"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: true
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "Libpng"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "MIT"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "MIT-0"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "MIT-feh"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "MPL-1.0"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "MPL-1.1"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "MPL-2.0"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "MS-PL"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "MS-RL"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "ODbL-1.0"
   categories:
   - "copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "OFL-1.0"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "OFL-1.1"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "OpenSSL"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "PSF"
   categories:
   - "strong-copyleft"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "Python-2.0"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "Ruby"
   categories:
   - "copyleft-limited"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "SAX-PD"
   categories:
   - "public-domain"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "Unlicense"
   categories:
   - "public-domain"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "W3C"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "WTFPL"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "X11"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "Zlib"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "bzip2-1.0.5"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "bzip2-1.0.6"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"
 - id: "curl"
   categories:
   - "permissive"
-  include_in_notice_file: true
-  include_source_code_offer_in_notice_file: false
+  - "include-in-notice-file"

--- a/examples/rules.kts
+++ b/examples/rules.kts
@@ -29,15 +29,16 @@
  * Import license configuration from license-classifications.yml.
  */
 
-fun getLicenseSet(setId: String) = licenseConfiguration.getLicensesForSet(setId).map { it.id }.toSet()
+fun getLicenseCategory(categoryId: String) =
+    licenseConfiguration.getLicensesForCategory(categoryId).map { it.id }.toSet()
 
-val permissiveLicenses = getLicenseSet("permissive")
+val permissiveLicenses = getLicenseCategory("permissive")
 
-val copyleftLicenses = getLicenseSet("copyleft")
+val copyleftLicenses = getLicenseCategory("copyleft")
 
-val copyleftLimitedLicenses = getLicenseSet("copyleft-limited")
+val copyleftLimitedLicenses = getLicenseCategory("copyleft-limited")
 
-val publicDomainLicenses = getLicenseSet("public-domain")
+val publicDomainLicenses = getLicenseCategory("public-domain")
 
 // The complete set of licenses covered by policy rules.
 val handledLicenses = listOf(

--- a/helper-cli/src/main/kotlin/commands/ListLicenseCategoriesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicenseCategoriesCommand.kt
@@ -89,23 +89,13 @@ class ListLicenseCategoriesCommand : CliktCommand(
         }
 
     private fun License.description(ignoreCategory: String? = null): String {
-        val categories = categories.toMutableList().apply {
-            if (includeInNoticeFile) {
-                add("include-in-notices")
-            }
-
-            if (includeSourceCodeOfferInNoticeFile) {
-                add("include-source-code-offer-in-notices")
-            }
-
-            ignoreCategory?.let { remove(it) }
-        }
+        val filteredCategories = categories.filterNot { it == ignoreCategory }
 
         return buildString {
             append(id)
 
-            if (categories.isNotEmpty()) {
-                append(": [${categories.joinToString()}]")
+            if (filteredCategories.isNotEmpty()) {
+                append(": [${filteredCategories.joinToString()}]")
             }
         }
     }

--- a/helper-cli/src/main/kotlin/commands/ListLicenseCategoriesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicenseCategoriesCommand.kt
@@ -61,16 +61,16 @@ class ListLicenseCategoriesCommand : CliktCommand(
 
     private fun LicenseConfiguration.summary(): String =
         buildString {
-            appendLine("Found ${licenses.size} licenses categorized as:\n")
+            appendLine("Found ${categorizations.size} licenses categorized as:\n")
 
-            licenses.groupByCategory().toList().sortedBy { it.first }.forEach { (category, licenses) ->
+            categorizations.groupByCategory().toList().sortedBy { it.first }.forEach { (category, licenses) ->
                 appendLine("  $category (${licenses.size})")
             }
         }
 
     private fun LicenseConfiguration.licensesByCategory(): String =
         buildString {
-            licenses.groupByCategory().forEach { (category, licenses) ->
+            categorizations.groupByCategory().forEach { (category, licenses) ->
                 appendLine("$category (${licenses.size}):")
                 appendLine()
 
@@ -83,13 +83,13 @@ class ListLicenseCategoriesCommand : CliktCommand(
 
     private fun LicenseConfiguration.licensesList(): String =
         buildString {
-            licenses.sortedBy { it.id.toString() }.forEach { license ->
+            categorizations.sortedBy { it.id.toString() }.forEach { license ->
                 appendLine(license.description())
             }
         }
 
     private fun License.description(ignoreCategory: String? = null): String {
-        val categories = sets.toMutableList().apply {
+        val categories = categories.toMutableList().apply {
             if (includeInNoticeFile) {
                 add("include-in-notices")
             }
@@ -112,6 +112,6 @@ class ListLicenseCategoriesCommand : CliktCommand(
 
     private fun Collection<License>.groupByCategory(): Map<String, List<License>> =
         flatMap { license ->
-            license.sets.map { category -> license to category }
+            license.categories.map { category -> license to category }
         }.groupBy({ it.second }, { it.first })
 }

--- a/model/src/main/kotlin/licenses/License.kt
+++ b/model/src/main/kotlin/licenses/License.kt
@@ -35,10 +35,10 @@ data class License(
     val id: SpdxSingleLicenseExpression,
 
     /**
-     * The identifiers of the [LicenseSet]s this license is assigned to.
+     * The identifiers of the [license categories][LicenseCategory] this license is assigned to.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val sets: SortedSet<String>,
+    val categories: SortedSet<String>,
 
     /**
      * Defines whether the license text should be placed inside the NOTICE file.

--- a/model/src/main/kotlin/licenses/License.kt
+++ b/model/src/main/kotlin/licenses/License.kt
@@ -21,12 +21,14 @@ package org.ossreviewtoolkit.model.licenses
 
 import com.fasterxml.jackson.annotation.JsonInclude
 
-import java.util.SortedSet
-
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 
 /**
  * A class for configuring meta data for a specific license referred to by a SPDX license identifier.
+ *
+ * The meta data consists of assignments to generic categories whose exact meaning is customer specific.
+ * The categories a license belong to can be evaluated by other components, such as rules or templates,
+ * which can decide - based on this information - how to handle a specific license.
  */
 data class License(
     /**
@@ -38,15 +40,5 @@ data class License(
      * The identifiers of the [license categories][LicenseCategory] this license is assigned to.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val categories: SortedSet<String>,
-
-    /**
-     * Defines whether the license text should be placed inside the NOTICE file.
-     */
-    val includeInNoticeFile: Boolean,
-
-    /**
-     * Defines whether a source code offer should be made for this license.
-     */
-    val includeSourceCodeOfferInNoticeFile: Boolean
+    val categories: Set<String>
 )

--- a/model/src/main/kotlin/licenses/LicenseCategory.kt
+++ b/model/src/main/kotlin/licenses/LicenseCategory.kt
@@ -22,27 +22,22 @@ package org.ossreviewtoolkit.model.licenses
 import com.fasterxml.jackson.annotation.JsonInclude
 
 /**
- * A set where [License]s can be assigned to.
+ * A category where [License]s can be assigned to. This does not have any specific semantic, but users are free to
+ * define their own set of categories.
  */
-data class LicenseSet(
+data class LicenseCategory(
     /**
-     * The unique identifier of this [LicenseSet].
+     * The name of this [LicenseCategory]. The name can be chosen freely, but must be unique over all categories.
      */
-    val id: String,
+    val name: String,
 
     /**
-     * The name of this [LicenseSet].
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val name: String = "",
-
-    /**
-     * A description for this [LicenseSet].
+     * A description for this [LicenseCategory].
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val description: String = ""
 ) {
     init {
-        require(id.isNotEmpty()) { "The identifier must not be empty." }
+        require(name.isNotEmpty()) { "The name must not be empty." }
     }
 }

--- a/model/src/test/kotlin/licenses/LicenseConfigurationTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseConfigurationTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.licenses
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+import java.lang.IllegalStateException
+import java.util.Collections.emptySortedSet
+
+import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
+
+class LicenseConfigurationTest : WordSpec({
+    "LicenseConfiguration.init" should {
+        "detect duplicate category names" {
+            val cat1 = LicenseCategory("Category 1")
+            val cat2 = LicenseCategory("Category 2", "Another category")
+            val cat3 = LicenseCategory("Category 1", "Duplicate; should cause a failure")
+
+            shouldThrow<IllegalArgumentException> {
+                LicenseConfiguration(categories = listOf(cat1, cat2, cat3))
+            }
+        }
+
+        "detect duplicate license IDs" {
+            val lic1 = License(
+                SpdxSingleLicenseExpression.parse("ASL-1"), emptySortedSet()
+            )
+            val lic2 = License(
+                SpdxSingleLicenseExpression.parse("ASL-2"), emptySortedSet()
+            )
+            val lic3 = License(
+                SpdxSingleLicenseExpression.parse("ASL-1"), sortedSetOf("permissive")
+            )
+
+            shouldThrow<IllegalArgumentException> {
+                LicenseConfiguration(categorizations = listOf(lic1, lic2, lic3))
+            }
+        }
+
+        "detect licenses referencing non-existing categories" {
+            val cat1 = LicenseCategory("Category 1")
+            val cat2 = LicenseCategory("Category 2")
+            val lic1 = License(
+                SpdxSingleLicenseExpression.parse("ASL-1"), sortedSetOf(cat1.name)
+            )
+            val lic2 = License(
+                SpdxSingleLicenseExpression.parse("ASL-2"), sortedSetOf("unknownCategory")
+            )
+            val lic3 = License(
+                SpdxSingleLicenseExpression.parse("BSD"), sortedSetOf("anotherUnknownCategory")
+            )
+
+            val exception = shouldThrow<IllegalArgumentException> {
+                LicenseConfiguration(categories = listOf(cat1, cat2), categorizations = listOf(lic1, lic2, lic3))
+            }
+            exception.message shouldContain lic2.id.toString()
+            exception.message shouldContain lic3.id.toString()
+            exception.message shouldContain "unknownCategory"
+            exception.message shouldContain "anotherUnknownCategory"
+        }
+    }
+
+    "LicenseConfiguration.getLicensesForCategory" should {
+        "fetch all licenses for a specific category" {
+            val cat1 = LicenseCategory("permissive", "Permissive licenses")
+            val cat2 = LicenseCategory("non permissive", "Strict licenses")
+            val lic1 = License(
+                SpdxSingleLicenseExpression.parse("ASL-1"), sortedSetOf("permissive")
+            )
+            val lic2 = License(
+                SpdxSingleLicenseExpression.parse("ASL-2"), sortedSetOf("permissive")
+            )
+            val lic3 = License(
+                SpdxSingleLicenseExpression.parse("GPL"), sortedSetOf("non permissive")
+            )
+            val licenseConfiguration = LicenseConfiguration(
+                categories = listOf(cat1, cat2),
+                categorizations = listOf(lic1, lic2, lic3)
+            )
+
+            val permissiveLicenses = licenseConfiguration.getLicensesForCategory(cat1.name)
+
+            permissiveLicenses should containExactlyInAnyOrder(lic1, lic2)
+        }
+
+        "throw an exception when querying the licenses for an unknown category" {
+            val cat = LicenseCategory("oneAndOnlyCategory")
+            val lic = License(
+                SpdxSingleLicenseExpression.parse("LICENSE"), sortedSetOf(cat.name)
+            )
+            val licenseConfiguration = LicenseConfiguration(categorizations = listOf(lic), categories = listOf(cat))
+
+            shouldThrow<IllegalStateException> {
+                licenseConfiguration.getLicensesForCategory("nonExistingCategory")
+            }
+        }
+    }
+
+    "LicenseConfiguration" should {
+        "allow querying a license by ID" {
+            val lic1 = License(
+                SpdxSingleLicenseExpression.parse("ASL-1"), emptySortedSet()
+            )
+            val lic2 = License(
+                SpdxSingleLicenseExpression.parse("ASL-2"), emptySortedSet()
+            )
+            val licenseConfiguration = LicenseConfiguration(categorizations = listOf(lic1, lic2))
+
+            licenseConfiguration[SpdxSingleLicenseExpression.parse("ASL-2")] shouldBe lic2
+        }
+    }
+
+    "LicenseConfiguration.categoryNames" should {
+        "contain the expected licenses" {
+            val cat1 = LicenseCategory("permissive", "Permissive licenses")
+            val cat2 = LicenseCategory("non permissive", "Strict licenses")
+            val cat3 = LicenseCategory("other", "Completely different licenses")
+            val licenseConfiguration = LicenseConfiguration(categories = listOf(cat1, cat2, cat3))
+
+            licenseConfiguration.categoryNames should containExactly("non permissive", "other", "permissive")
+        }
+    }
+})

--- a/reporter/src/funTest/assets/notice-template-reporter-expected-results
+++ b/reporter/src/funTest/assets/notice-template-reporter-expected-results
@@ -88,35 +88,6 @@ Package: @ort:declared-license:1.0
 
 The following copyrights and licenses were found in the source code of this package:
 
-Copyright 1
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this list
-of conditions and the following disclaimer.
-
-Redistributions in binary form must reproduce the above copyright notice, this
-list of conditions and the following disclaimer in the documentation and/or
-other materials provided with the distribution.
-
-Neither the name of the ORGANIZATION nor the names of its contributors may be
-used to endorse or promote products derived from this software without specific
-prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
-BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-  --
-
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
 "Software"), to deal in the Software without restriction, including
@@ -141,35 +112,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Package: @ort:license-file-and-additional-licenses:1.0
 
 The following copyrights and licenses were found in the source code of this package:
-
-Copyright 3
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this list
-of conditions and the following disclaimer.
-
-Redistributions in binary form must reproduce the above copyright notice, this
-list of conditions and the following disclaimer in the documentation and/or
-other materials provided with the distribution.
-
-Neither the name of the ORGANIZATION nor the names of its contributors may be
-used to endorse or promote products derived from this software without specific
-prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
-BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-  --
 
 Copyright 1
 Copyright 2

--- a/reporter/src/funTest/assets/notice-template-reporter-expected-results-summary
+++ b/reporter/src/funTest/assets/notice-template-reporter-expected-results-summary
@@ -3,36 +3,6 @@ This project contains or depends on third-party software components pursuant to 
 ----
 
 Copyright 1
-Copyright 3
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this list
-of conditions and the following disclaimer.
-
-Redistributions in binary form must reproduce the above copyright notice, this
-list of conditions and the following disclaimer in the documentation and/or
-other materials provided with the distribution.
-
-Neither the name of the ORGANIZATION nor the names of its contributors may be
-used to endorse or promote products derived from this software without specific
-prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
-BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-----
-
-Copyright 1
 Copyright 2
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/reporter/src/funTest/assets/notice-template-reporter-expected-results-with-license-files
+++ b/reporter/src/funTest/assets/notice-template-reporter-expected-results-with-license-files
@@ -88,35 +88,6 @@ Package: @ort:declared-license:1.0
 
 The following copyrights and licenses were found in the source code of this package:
 
-Copyright 1
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this list
-of conditions and the following disclaimer.
-
-Redistributions in binary form must reproduce the above copyright notice, this
-list of conditions and the following disclaimer in the documentation and/or
-other materials provided with the distribution.
-
-Neither the name of the ORGANIZATION nor the names of its contributors may be
-used to endorse or promote products derived from this software without specific
-prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
-BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-  --
-
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
 "Software"), to deal in the Software without restriction, including
@@ -165,36 +136,6 @@ The following copyright holder information relates to the license(s) above:
 
 Copyright 1
 Copyright 2
-
-The following copyrights and licenses were found in the source code of this package:
-
-Copyright 3
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this list
-of conditions and the following disclaimer.
-
-Redistributions in binary form must reproduce the above copyright notice, this
-list of conditions and the following disclaimer in the documentation and/or
-other materials provided with the distribution.
-
-Neither the name of the ORGANIZATION nor the names of its contributors may be
-used to endorse or promote products derived from this software without specific
-prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
-BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 ----
 
 Package: @ort:license-file:1.0

--- a/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterFunTest.kt
@@ -31,8 +31,12 @@ import org.ossreviewtoolkit.model.config.FileStorageConfiguration
 import org.ossreviewtoolkit.model.config.LocalFileStorageConfiguration
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.licenses.License
+import org.ossreviewtoolkit.model.licenses.LicenseCategory
+import org.ossreviewtoolkit.model.licenses.LicenseConfiguration
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
+import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.LICENSE_FILENAMES
 import org.ossreviewtoolkit.utils.ORT_NAME
 
@@ -91,10 +95,26 @@ private fun generateReport(
     val input = ReporterInput(
         ortResult,
         config,
-        copyrightGarbage = copyrightGarbage
+        copyrightGarbage = copyrightGarbage,
+        licenseConfiguration = createLicenseConfiguration()
     )
 
     val outputDir = createTempDir(ORT_NAME, NoticeTemplateReporterFunTest::class.simpleName).apply { deleteOnExit() }
 
     return NoticeTemplateReporter().generateReport(input, outputDir, options).single().readText()
+}
+
+private fun createLicenseConfiguration(): LicenseConfiguration {
+    val includeNoticeCategory = LicenseCategory("include-in-notice-file")
+    val includeSourceCategory = LicenseCategory("include-source-code-offer-in-notice-file")
+    val mitLicense = License(
+        SpdxSingleLicenseExpression.parse("MIT"), sortedSetOf(includeNoticeCategory.name)
+    )
+    val bsdLicense = License(
+        SpdxSingleLicenseExpression.parse("BSD-3-Clause"), sortedSetOf(includeSourceCategory.name)
+    )
+    return LicenseConfiguration(
+        categories = listOf(includeNoticeCategory, includeSourceCategory),
+        categorizations = listOf(mitLicense, bsdLicense)
+    )
 }

--- a/reporter/src/main/kotlin/reporters/NoticeTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeTemplateReporter.kt
@@ -29,7 +29,6 @@ import kotlin.reflect.full.memberProperties
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtResult
-import org.ossreviewtoolkit.model.licenses.License
 import org.ossreviewtoolkit.model.licenses.LicenseConfiguration
 import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.model.licenses.ResolvedLicense
@@ -183,26 +182,10 @@ class NoticeTemplateReporter : Reporter {
             return packages.filter { pkg -> pkg.id in dependencies }
         }
 
-        /**
-         * Return licenses that are configured to be [included in the notice file][License.includeInNoticeFile] in the
-         * [LicenseConfiguration].
-         */
         @Suppress("UNUSED") // This function is used in the templates.
-        fun filterIncludeInNoticeFile(licenses: Collection<ResolvedLicense>): List<ResolvedLicense> =
+        fun filterForCategory(licenses: Collection<ResolvedLicense>, category: String): List<ResolvedLicense> =
             licenses.filter { resolvedLicense ->
-                licenseConfiguration.categorizations.find { it.id == resolvedLicense.license }?.includeInNoticeFile ?: true
-            }
-
-        /**
-         * Return licenses that are configured to require a
-         * [source code offer in the notice file][License.includeSourceCodeOfferInNoticeFile] in the
-         * [LicenseConfiguration].
-         */
-        @Suppress("UNUSED") // This function is used in the templates.
-        fun filterIncludeSourceCodeOfferInNoticeFile(licenses: Collection<ResolvedLicense>): List<ResolvedLicense> =
-            licenses.filter { resolvedLicense ->
-                licenseConfiguration.categorizations.find { it.id == resolvedLicense.license }
-                    ?.includeSourceCodeOfferInNoticeFile ?: false
+                licenseConfiguration[resolvedLicense.license]?.categories?.contains(category) ?: true
             }
 
         /**

--- a/reporter/src/main/kotlin/reporters/NoticeTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeTemplateReporter.kt
@@ -190,7 +190,7 @@ class NoticeTemplateReporter : Reporter {
         @Suppress("UNUSED") // This function is used in the templates.
         fun filterIncludeInNoticeFile(licenses: Collection<ResolvedLicense>): List<ResolvedLicense> =
             licenses.filter { resolvedLicense ->
-                licenseConfiguration.licenses.find { it.id == resolvedLicense.license }?.includeInNoticeFile ?: true
+                licenseConfiguration.categorizations.find { it.id == resolvedLicense.license }?.includeInNoticeFile ?: true
             }
 
         /**
@@ -201,7 +201,7 @@ class NoticeTemplateReporter : Reporter {
         @Suppress("UNUSED") // This function is used in the templates.
         fun filterIncludeSourceCodeOfferInNoticeFile(licenses: Collection<ResolvedLicense>): List<ResolvedLicense> =
             licenses.filter { resolvedLicense ->
-                licenseConfiguration.licenses.find { it.id == resolvedLicense.license }
+                licenseConfiguration.categorizations.find { it.id == resolvedLicense.license }
                     ?.includeSourceCodeOfferInNoticeFile ?: false
             }
 

--- a/reporter/src/main/resources/template.notice/default.ftl
+++ b/reporter/src/main/resources/template.notice/default.ftl
@@ -36,7 +36,7 @@ Merge the licenses and copyrights of all projects into a single list. The defaul
 projects cannot have a concluded license (compare with the handling of packages below). Also filter all licenses that
 are configured not to be included in notice files.
 --]
-[#assign mergedLicenses = helper.filterIncludeInNoticeFile(helper.mergeLicenses(projects))]
+[#assign mergedLicenses = helper.filterForCategory(helper.mergeLicenses(projects), "include-in-notice-file")]
 [#list mergedLicenses as resolvedLicense]
 [#assign licenseText = licenseTextProvider.getLicenseText(resolvedLicense.license.simpleLicense())!""]
 [#if licenseText?has_content]
@@ -96,8 +96,8 @@ license those statements are kept. Also filter all licenses that are configured 
 filter all licenses that are contained in the license files already printed above.
 --]
 [#assign
-resolvedLicenses = helper.filterIncludeInNoticeFile(
-    helper.licenseView("CONCLUDED_OR_REST").filter(package.licensesNotInLicenseFiles())
+resolvedLicenses = helper.filterForCategory(
+    helper.licenseView("CONCLUDED_OR_REST").filter(package.licensesNotInLicenseFiles()), "include-in-notice-file"
 )
 ]
 [#if resolvedLicenses?has_content]

--- a/reporter/src/main/resources/template.notice/summary.ftl
+++ b/reporter/src/main/resources/template.notice/summary.ftl
@@ -36,7 +36,7 @@ conclusion for a package was made. For projects this is the same as LicenseView.
 concluded licenses. If copyrights were detected for a concluded license those statements are kept. Also filter all
 licenses that are configured not to be included in notice files.
 --]
-[#assign mergedLicenses = helper.filterIncludeInNoticeFile(helper.mergeLicenses(projects + packages, helper.licenseView("CONCLUDED_OR_REST")))]
+[#assign mergedLicenses = helper.filterForCategory(helper.mergeLicenses(projects + packages, helper.licenseView("CONCLUDED_OR_REST")), "include-in-notice-file")]
 [#list mergedLicenses as resolvedLicense]
 [#assign licenseText = licenseTextProvider.getLicenseText(resolvedLicense.license.simpleLicense())!""]
 [#if licenseText?has_content]


### PR DESCRIPTION
This PR reworks the sections of the license_classifications.yml file and introduces a generic mechanism to assign licenses to categories. Refer to the commit messages for detailed information.