### PR TITLE
Remove optional trailing commas from the code base

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/NuGetAllPackageData.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetAllPackageData.kt
@@ -63,7 +63,7 @@ internal class NuGetAllPackageData(
         // Optional fields.
         val description: String? = null,
         val projectUrl: String? = null,
-        val dependencyGroups: List<DependencyGroup> = emptyList(),
+        val dependencyGroups: List<DependencyGroup> = emptyList()
     )
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -94,7 +94,7 @@ internal class NuGetAllPackageData(
         // See https://docs.microsoft.com/en-us/nuget/reference/nuspec#optional-metadata-elements.
         val licenseUrl: String? = null,
         val license: License? = null,
-        val repository: Repository? = null,
+        val repository: Repository? = null
     )
 
     data class License(

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -159,7 +159,7 @@ class ReporterCommand : CliktCommand(
         ).convert { it.expandTilde() }
             .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
             .convert { PackageConfigurationOption.File(it.absoluteFile.normalize()) },
-        name = OPTION_GROUP_CONFIGURATION,
+        name = OPTION_GROUP_CONFIGURATION
     ).single()
 
     private val repositoryConfigurationFile by option(

--- a/helper-cli/src/main/kotlin/commands/SubtractScanResultsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/SubtractScanResultsCommand.kt
@@ -97,7 +97,7 @@ private operator fun ScanSummary.minus(other: ScanSummary?): ScanSummary {
 
     return copy(
         licenseFindings = (licenseFindings - other.licenseFindings).toSortedSet(),
-        copyrightFindings = (copyrightFindings - other.copyrightFindings).toSortedSet(),
+        copyrightFindings = (copyrightFindings - other.copyrightFindings).toSortedSet()
     )
 }
 

--- a/model/src/test/kotlin/RootLicenseMatcherTest.kt
+++ b/model/src/test/kotlin/RootLicenseMatcherTest.kt
@@ -61,7 +61,7 @@ class RootLicenseMatcherTest : WordSpec({
                 "a" to setOf("a/LICENSE", "PATENTS"),
                 "a/a" to setOf("a/LICENSE", "PATENTS"),
                 "a/a/a" to setOf("a/a/a/LICENSE", "PATENTS"),
-                "a/a/a/a" to setOf("a/a/a/LICENSE", "a/a/a/a/PATENTS"),
+                "a/a/a/a" to setOf("a/a/a/LICENSE", "a/a/a/a/PATENTS")
             )
         }
 


### PR DESCRIPTION
Trailing commas have their benefits [1], but using them inconsistenly
might be confusing as it can make the code look incomplete. So remove
our few (probably accidental) usages manually until we can suppress them
[2].

[1] https://kotlinlang.org/docs/reference/coding-conventions.html#trailing-commas
[2] https://github.com/detekt/detekt/issues/2398

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>