### PR TITLE
Gradle: Generally disable configure-on-demand

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN --mount=type=cache,target=/root/.gradle/ \
     scripts/import_proxy_certs.sh && \
     scripts/set_gradle_proxy.sh && \
     sed -i -r 's,(^distributionUrl=)(.+)-all\.zip$,\1\2-bin.zip,' gradle/wrapper/gradle-wrapper.properties && \
-    ./gradlew --no-daemon --stacktrace --no-configure-on-demand :cli:distTar
+    ./gradlew --no-daemon --stacktrace :cli:distTar
 
 FROM adoptopenjdk:11-jre-hotspot-bionic
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -64,7 +64,6 @@ xalanVersion = 2.7.2
 xzVersion = 1.8
 
 org.gradle.caching = true
-org.gradle.configureondemand = true
 org.gradle.parallel = true
 
 buildCacheRetentionDays = 7


### PR DESCRIPTION
This is a more general follow-up fix to [1] so that also users with a
custom Dockerfile benefit from it.

[1] https://github.com/oss-review-toolkit/ort/pull/3302

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>