### PR TITLE
Add Azure Starter Pipeline for ORT run

### DIFF
--- a/integrations/azure/README.md
+++ b/integrations/azure/README.md
@@ -1,0 +1,74 @@
+# Azure ORT Starter Pipeline
+
+The starter pipeline allows you to easily run an ORT scan on [Azure DevOps](https://azure.microsoft.com/services/devops/).
+
+To run the pipeline, simply:
+
+- Create a new YAML-based pipeline in your Azure DevOps project based on [ort-pipeline.yml](./ort-pipeline.yml) in this repository
+- Run the pipeline with the preferred set of parameters
+
+## Directory description
+
+This subdirectory has the following structure:
+```bash
+azure
+├── credentials
+│   ├── write-config-netrc.yml
+│   └── write-downloader-netrc.yml
+├── docker
+│   ├── docker-build-image.yml
+│   └── docker-ort-run.yml
+├── ort-pipeline.yml
+├── README.md
+└── steps
+    └── complete-ort-run.yml
+```
+The folder `credentials` contains templates to write `.netrc` files (see the [specification](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html):
+- `write-config-netrc.yml` converts the parameter group  `ort_config_credentials` to `.netrc` used when downloading the configuration
+- `write-downloader-netrc.yml` converts the parameter group `ort_repo_credentials` to `.netrc` used to download the project
+Exchange those templates with custom templates for different credential handling
+
+The folder `docker` contains files to run ORT in a docker container:
+- `docker-build-image.yml` is a template to build the ORT image based on the [Dockerfile](../../Dockerfile)
+- `docker-ort-run.yml` contains steps to download a configuration repository, download the project and then analyze, scan and evaluate the project, finally creating reports
+
+`ort-pipeline-yml` contains the starter pipeline, consisting of one stage running on a default Ubuntu agent, as well as providing parameters for custom runs.
+
+## Setting up credentials
+
+The pipeline supports using simple credentials (username, password) to download a repository.
+Credentials can be set up in the following way:
+
+- Set the parameter `Use repository credentials as defined in variable group ort_repo_credentials`
+- Add a variable group called `ort_repo_credentials` (via "Library" -> "Variable groups")
+- Add the variables `USERNAME` and `PASSWORD` to this group (for security, make password a secret)
+- Note: The names have to match exactly
+
+This will result in the build using these credentials to download your project.
+
+## Using a different repository for ORT configuration
+
+The pipeline supports using a different repository (with different credentials) to use for a pipeline run.
+Simply fill the two parameters `Config Version Control URL` and optionally change `Config Revision`
+If you need authentication to access the repository, you can do so via login and password:
+
+- Check the parameter `Use credentials for ort as defined in variable group ort_config_credentials`
+- Add a variable group called `ort_config_credentials` (via "Library" -> "Variable groups")
+- Add the variables `ORT_USERNAME` and `ORT_PASSWORD` to this group (for security, make password a secret)
+- Note: The names have to be exactly the ones described above: Azure devops doesn't currently allow dynamic variable groups
+
+If you do not wish to use a config repository, leave `Config Version Control URL` set to `none`.
+
+## Known Limitations
+
+Note that you probably don't want to use this pipeline for your production setup due to the following limitations:
+
+- The pipeline currently runs on hosted agents.
+  This limits pipeline runs to 1 hour (private) and 6 hours (public) repository.
+- In addition, public pipelines don't allow easy Docker image caching between runs, so the Docker image is built within the run.
+- Scan results are stored locally on the agents. 
+  They will not be reused between runs.
+- The pipeline writes credentials to the agent.
+  This can be a major security concern if you do not control the agent and will be fixed in some future version.
+- The version of ORT to use is not configurable.
+  The pipeline will always use ORT master to run.

--- a/integrations/azure/credentials/write-config-netrc.yml
+++ b/integrations/azure/credentials/write-config-netrc.yml
@@ -1,0 +1,26 @@
+# Copyright (C) 2020-2021 Bosch.IO GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+parameters:
+  useCredentials: 'false'
+
+steps:
+  - bash: |
+      if [[ "${{parameters.useCredentials}}" == "True" ]]; then
+        echo "default login $(CONFIG_USERNAME) password $(CONFIG_PASSWORD)" > $(System.DefaultWorkingDirectory)/netrc/.netrc
+      fi
+    displayName: "Write .netrc file for config"

--- a/integrations/azure/credentials/write-downloader-netrc.yml
+++ b/integrations/azure/credentials/write-downloader-netrc.yml
@@ -1,0 +1,26 @@
+# Copyright (C) 2020-2021 Bosch.IO GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+parameters:
+  useCredentials: 'false'
+
+steps:
+  - bash: |
+      if [[ "${{parameters.useCredentials}}" == "True" ]]; then
+        echo "default login $(USERNAME) password $(PASSWORD)" > $(System.DefaultWorkingDirectory)/netrc/.netrc
+      fi
+    displayName: "Write .netrc file for repository"

--- a/integrations/azure/docker/docker-build-image.yml
+++ b/integrations/azure/docker/docker-build-image.yml
@@ -1,0 +1,31 @@
+# Copyright (C) 2020-2021 Bosch.IO GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+parameters:
+  ortUrl: 'https://github.com/oss-review-toolkit/ort.git'
+  branch: 'master'
+
+steps:
+  - bash: git clone "${{parameters.ortUrl}}" --single-branch --branch "${{parameters.branch}}" "$(System.DefaultWorkingDirectory)/ort"
+    displayName: "Clone repository"
+  - bash: DOCKER_BUILDKIT=1 docker build ort/ --tag ort:latest
+    displayName: "Build Dockerfile"
+  - bash: |
+      /usr/bin/docker run \
+        ort:latest \
+        --version
+    displayName: "Check Dockerfile"

--- a/integrations/azure/docker/docker-ort-run.yml
+++ b/integrations/azure/docker/docker-ort-run.yml
@@ -1,0 +1,35 @@
+# Copyright (C) 2020-2021 Bosch.IO GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+parameters:
+  displayName: ''
+  command: ''
+  condition: succeeded()
+
+steps:
+  - bash: |
+      /usr/bin/docker run \
+        -v $(System.DefaultWorkingDirectory)/project:/project \
+        -v $(System.DefaultWorkingDirectory)/.ort:/root/.ort \
+        -v $(System.DefaultWorkingDirectory)/output:/output \
+        -v $(System.DefaultWorkingDirectory)/netrc/.netrc:/root/.netrc \
+        ort:latest \
+        $(logLevel) \
+        $(stacktrace) \
+        ${{ parameters.command }}
+    displayName: ${{ parameters.displayName }}
+    condition: ${{ parameters.condition }}

--- a/integrations/azure/ort-pipeline.yml
+++ b/integrations/azure/ort-pipeline.yml
@@ -1,0 +1,105 @@
+# Copyright (C) 2020-2021 Bosch.IO GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+# ORT starter pipeline: Customize to your need
+
+trigger: none
+
+parameters:
+  - name: project_name
+    displayName: "Project name (for display purposes only)"
+    type: string
+  - name: project_vcs_url
+    displayName: "Project Version Control URL (e.g. github .git address)"
+    type: string
+  - name: project_vcs_revision
+    displayName: "Project Revision (prefix Git tags with 'refs/tags/'), master for last commit"
+    type: string
+    default: master
+  - name: use_credentials
+    displayName: "Use repository credentials as defined in variable group ort_repo_credentials"
+    type: boolean
+    default: false
+
+  - name: ort_project_vcs_url
+    displayName: "Config Version Control URL (e.g. github .git address, use 'none' if the config is already provided)"
+    type: string
+    default: 'none'
+  - name: ort_project_vcs_revision
+    displayName: "Config Revision (prefix Git tags with 'refs/tags/'), master for last commit"
+    type: string
+    default: master
+  - name: ort_use_credentials
+    displayName: "Use credentials for ORT as defined in variable group ort_config_credentials (only necessary when different repository is used)"
+    type: boolean
+    default: false
+
+  - name: log_level
+    displayName: "Log level"
+    type: string
+    default: "default"
+    values: [ "default", "info", "debug" ]
+  - name: stacktrace
+    displayName: "Stacktrace"
+    type: boolean
+    default: false
+
+  - name: allow_dynamic_versions
+    type: boolean
+    displayName: "Allow dynamic versions of dependencies"
+    default: false
+  - name: use_clearly_defined
+    type: boolean
+    displayName: "Use package curation data from ClearlyDefined"
+    default: true
+
+name: ${{parameters.project_name}}_$(Date:yyyyMMdd)
+pool:
+  vmImage: 'Ubuntu-20.04'
+
+variables:
+  - name: DOCKER_BUILDKIT
+    value: 1
+  - ${{ if eq(parameters.use_credentials, True) }}:
+      - group: 'ort_repo_credentials'
+  - ${{ if eq(parameters.ort_use_credentials, True) }}:
+      - group: 'ort_config_credentials'
+
+stages:
+  - stage: run_ort_pipeline
+    displayName: "Run ORT Starter Pipeline"
+    jobs:
+      - job: run_all_steps
+        displayName: "Build and Run ORT"
+        timeoutInMinutes: 0
+        steps:
+          - template: docker/docker-build-image.yml
+          - template: steps/complete-ort-run.yml
+            parameters:
+              projectVcsUrl: ${{parameters.project_vcs_url}}
+              projectVcsRevision: ${{parameters.project_vcs_revision}}
+              useCredentials: ${{parameters.use_credentials}}
+              projectCredentialTemplate: ../credentials/write-config-netrc.yml
+              ortProjectVcsUrl: ${{parameters.ort_project_vcs_url}}
+              ortProjectVcsRevision: ${{parameters.ort_project_vcs_revision}}
+              ortUseCredentials: ${{parameters.ort_use_credentials}}
+              ortConfigCredentialTemplate: ../credentials/write-downloader-netrc.yml
+              logLevel: ${{parameters.log_level}}
+              stacktrace: ${{parameters.stacktrace}}
+              allowDynamicVersions: ${{parameters.allow_dynamic_versions}}
+              useClearlyDefined: ${{parameters.use_clearly_defined}}
+

--- a/integrations/azure/steps/complete-ort-run.yml
+++ b/integrations/azure/steps/complete-ort-run.yml
@@ -1,0 +1,100 @@
+# Copyright (C) 2020-2021 Bosch.IO GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+# This file contains a complete ort run: analyze - scan - evaluate - report
+
+parameters:
+  projectVcsUrl: ''
+  projectVcsRevision: 'master'
+  useCredentials: 'false'
+  projectCredentialTemplate: ''
+
+  ortProjectVcsUrl: 'none'
+  ortProjectVcsRevision: 'master'
+  ortUseCredentials: 'false'
+  ortConfigCredentialTemplate: ''
+
+  logLevel: 'default'
+  stacktrace: 'false'
+  allowDynamicVersions: 'false'
+  useClearlyDefined: 'true'
+
+steps:
+  - script: |
+      if [[ "${{parameters.stacktrace}}" == "True" ]]; then
+        echo '##vso[task.setvariable variable=stacktrace]--stacktrace'
+      else
+        echo '##vso[task.setvariable variable=stacktrace]'
+      fi
+      if [[ "${{parameters.allowDynamicVersions}}" == "True" ]]; then
+        echo '##vso[task.setvariable variable=allowdynamic]--allow-dynamic-versions'
+      else
+        echo '##vso[task.setvariable variable=allowdynamic]'
+      fi
+      if [[ "${{parameters.useClearlyDefined}}" == "True" ]]; then
+        echo '##vso[task.setvariable variable=useclearlydefined]--clearly-defined-curations'
+      else
+        echo '##vso[task.setvariable variable=useclearlydefined]'
+      fi
+      if [[ "${{parameters.logLevel}}" == "default" ]]; then
+        echo '##vso[task.setvariable variable=logLevel]'
+      else
+        echo '##vso[task.setvariable variable=logLevel]--${{parameters.logLevel}}'
+      fi
+    displayName: "Convert variables used in pipeline to CLI flags"
+  - bash: |
+      mkdir $(System.DefaultWorkingDirectory)/project && \
+      mkdir $(System.DefaultWorkingDirectory)/output && \
+      mkdir $(System.DefaultWorkingDirectory)/.ort && \
+      mkdir $(System.DefaultWorkingDirectory)/netrc
+    displayName: "Create shared directories"
+  - template: ${{parameters.ortConfigCredentialTemplate}}
+    parameters:
+      useCredentials: ${{parameters.ortUseCredentials}}
+  - template: ../docker/docker-ort-run.yml
+    parameters:
+      displayName: "Download ORT Configuration"
+      command: download --project-url ${{parameters.ortProjectVcsUrl}} --vcs-revision ${{parameters.ortProjectVcsRevision}} -o /root/.ort/config
+      condition: and(succeeded(), ne('${{parameters.ortProjectVcsUrl}}', 'none'))
+  - template: ${{parameters.projectCredentialTemplate}}
+    parameters:
+      useCredentials: ${{parameters.useCredentials}}
+  - template: ../docker/docker-ort-run.yml
+    parameters:
+      displayName: "Download project"
+      command: download --project-url ${{parameters.projectVcsUrl}} --vcs-revision ${{parameters.projectVcsRevision}} --output-dir /project
+  - template: ../docker/docker-ort-run.yml
+    parameters:
+      displayName: "Analyze project"
+      command: analyze -i /project -o /output/results/analyzer $(allowdynamic)
+  - template: ../docker/docker-ort-run.yml
+    parameters:
+      displayName: "Scan dependencies"
+      command: scan -i /output/results/analyzer/analyzer-result.yml -o /output/results/scanner
+  - template: ../docker/docker-ort-run.yml
+    parameters:
+      displayName: "Evaluate results"
+      command: evaluate -i /output/results/scanner/scan-result.yml -o /output/results/evaluator
+  - template: ../docker/docker-ort-run.yml
+    parameters:
+      displayName: "Create report"
+      command: report -f CycloneDX,NoticeTemplate,SpdxDocument,StaticHTML,WebApp -O NoticeTemplate=template.id=default,summary -i /output/results/evaluator/evaluation-result.yml -o /output/results/report
+  - task: PublishPipelineArtifact@1
+    inputs:
+      artifactName: "reports"
+      targetPath: $(System.DefaultWorkingDirectory)/output/results
+      name: $(Build.BuildNumber)_reports


### PR DESCRIPTION
This adds a starter pipeline to try ORT on Azure. 

To test the pipeline, just select it from the Azure Pipelines GUI and run it with your choice of parameters.

There are several features we would like to contribute later on, but I cut it down to this to simplify reviewing. The pipeline was cut into several pieces to avoid duplication. The general organization will be used for future changes.

The following features are missing and will be contributed in future PRs:
- proper handling of using docker for shared runners: Cleanup output, allow pipeline to run as non-root (this is especially important for file permissions)
- use container registries to not build the pipeline every time
- split into stages to have a nicer view
- better customization