### PR TITLE
Add a declared license mapping for http://json.codeplex.com/license

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
@@ -57,8 +57,9 @@ packages:
   declared_licenses:
   - "http://json.codeplex.com/license"
   declared_licenses_processed:
-    unmapped:
-    - "http://json.codeplex.com/license"
+    spdx_expression: "MIT"
+    mapped:
+      http://json.codeplex.com/license: "MIT"
   description: "Json.NET is a popular high-performance JSON framework for .NET"
   homepage_url: "http://james.newtonking.com/projects/json-net.aspx"
   binary_artifact:

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
@@ -57,8 +57,9 @@ packages:
   declared_licenses:
   - "http://json.codeplex.com/license"
   declared_licenses_processed:
-    unmapped:
-    - "http://json.codeplex.com/license"
+    spdx_expression: "MIT"
+    mapped:
+      http://json.codeplex.com/license: "MIT"
   description: "Json.NET is a popular high-performance JSON framework for .NET"
   homepage_url: "http://james.newtonking.com/projects/json-net.aspx"
   binary_artifact:

--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -462,6 +462,7 @@
 "http://creativecommons.org/publicdomain/zero/1.0/legalcode": CC0-1.0
 "http://go.microsoft.com/fwlink/?LinkId=329770": LicenseRef-scancode-ms-net-library-2018-11
 "http://go.microsoft.com/fwlink/?LinkId=529443": LicenseRef-scancode-ms-net-library-2018-11
+"http://json.codeplex.com/license": MIT
 "http://polymer.github.io/LICENSE.txt": BSD-3-Clause
 "http://svnkit.com/license.html": TMate
 "http://www.apache.org/licenses/LICENSE-2.0": Apache-2.0


### PR DESCRIPTION
The homepage lists being liensed under "MIT License" as a feature.

Also see the discussion at [1].

[1] https://github.com/oss-review-toolkit/ort/issues/3324#issuecomment-729163021

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>