### PR TITLE
Map a declared license that refers to "LICENSE.txt" to NONE

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -299,6 +299,7 @@
 "LGPL, version 3.0": LGPL-2.1-only
 "LGPL/MIT": LGPL-3.0-only OR MIT
 "LGPLv3 or later": LGPL-3.0-or-later
+"LICENSE.txt": NONE
 "LPGL, see LICENSE file.": LGPL-3.0-only
 "Lesser General Public License (LGPL)": LGPL-2.1-only
 "Lesser General Public License, version 3 or greater": LGPL-3.0-or-later


### PR DESCRIPTION
The string "LICENSE.txt" is not a declared license, and the contents of
"LICENSE.txt" would be scanned by the scanner, so map it to NONE here.

Seen in https://github.com/Knio/dominate/blob/2.3.1/setup.py#L46.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>