### PR TITLE
Add a declared license mapping for "The Apache Software License, Version 1.1"

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -380,6 +380,7 @@
 "The Apache License": Apache-2.0
 "The Apache License, Version 2.0": Apache-2.0
 "The Apache Software Licence, Version 2.0": Apache-2.0
+"The Apache Software License, Version 1.1": Apache-1.1
 "The Apache Software License, Version 2.0": Apache-2.0
 "The BSD 2-Clause License": BSD-2-Clause
 "The BSD 3-Clause License": BSD-3-Clause


### PR DESCRIPTION
As seen in [1].

[1] https://repo.maven.apache.org/maven2/com/caucho/hessian/4.0.38/hessian-4.0.38.pom.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>