### PR TITLE
StaticHtmlReporter: Rework ResolvedLicenseLocation.permalink()

### DIFF
--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -638,35 +638,29 @@ private fun DIV.permalink(permalink: String, count: Int) {
 }
 
 private fun ResolvedLicenseLocation.permalink(id: Identifier): String? {
-    val sourceArtifact = provenance.sourceArtifact
     val vcsInfo = provenance.vcsInfo
+    if (vcsInfo != null && vcsInfo != VcsInfo.EMPTY) {
+        return VcsHost.toPermalink(
+            vcsInfo.copy(path = location.path),
+            location.startLine, location.endLine
+        )
+    }
 
-    return when {
-        sourceArtifact != null && sourceArtifact != RemoteArtifact.EMPTY -> {
-            val mavenCentralPattern = Regex("https?://repo[^/]+maven[^/]+org/.*")
-            when {
-                sourceArtifact.url.matches(mavenCentralPattern) -> {
-                    // At least for source artifacts on Maven Central, use the "proxy" from Sonatype which has the
-                    // Archive Browser plugin installed to link to the files with findings.
-                    with(id) {
-                        val group = namespace.replace('.', '/')
-                        "https://repository.sonatype.org/" +
-                                "service/local/repositories/central-proxy/" +
-                                "archive/$group/$name/$version/$name-$version-sources.jar/" +
-                                "!/${location.path}"
-                    }
-                }
-                else -> null
+    val sourceArtifact = provenance.sourceArtifact
+    if (sourceArtifact != null && sourceArtifact != RemoteArtifact.EMPTY) {
+        val mavenCentralPattern = Regex("https?://repo[^/]+maven[^/]+org/.*")
+        if (sourceArtifact.url.matches(mavenCentralPattern)) {
+            // At least for source artifacts on Maven Central, use the "proxy" from Sonatype which has the
+            // Archive Browser plugin installed to link to the files with findings.
+            return with(id) {
+                val group = namespace.replace('.', '/')
+                "https://repository.sonatype.org/" +
+                        "service/local/repositories/central-proxy/" +
+                        "archive/$group/$name/$version/$name-$version-sources.jar/" +
+                        "!/${location.path}"
             }
         }
-
-        vcsInfo != null && vcsInfo != VcsInfo.EMPTY -> {
-            VcsHost.toPermalink(
-                vcsInfo.copy(path = location.path),
-                location.startLine, location.endLine
-            )
-        }
-
-        else -> null
     }
+
+    return null
 }


### PR DESCRIPTION
While a provenance can only have either sourceArtifact or vcsInfo set,
rewrite the code without taking that convention into account, which
actually makes the code simpler to read. Also check vcsInfo first as we
prefer it, because a sourceArtifact permalink is only supported for
Maven Central.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>