### PR TITLE
LicenseFilenamePatterns: Remove superfluous entries from file patterns

### DIFF
--- a/utils/src/main/kotlin/LicenseFilenamePatterns.kt
+++ b/utils/src/main/kotlin/LicenseFilenamePatterns.kt
@@ -19,8 +19,6 @@
 
 package org.ossreviewtoolkit.utils
 
-import java.io.File
-
 private fun List<String>.generateCapitalizationVariants() = flatMap { listOf(it, it.toUpperCase(), it.capitalize()) }
 
 object LicenseFilenamePatterns {
@@ -60,8 +58,8 @@ object LicenseFilenamePatterns {
     val ALL_LICENSE_FILENAMES = LICENSE_FILENAMES + PATENT_FILENAMES + ROOT_LICENSE_FILENAMES
 
     /**
-     * Return glob patterns which match all files which may contain license information residing recursively within the
-     * given absolute [directory] or in any of its ancestor directories.
+     * Return glob patterns which match all files which may contain license information in [directory] or within its
+     * ancestor directories.
      */
     fun getLicenseFileGlobsForDirectory(directory: String): List<String> =
         getFileGlobsForDirectoryAndAncestors(directory, ALL_LICENSE_FILENAMES)
@@ -90,8 +88,8 @@ object LicenseFilenamePatterns {
     }
 
     /**
-     * Return glob patterns which match files in [directory], in any ancestor directory of [directory] recursively
-     * and in any sub-directory of directory, if the filename matches any of the [filenamePatterns].
+     * Return glob patterns which match files in [directory] and its ancestor directories, if the filename matches any
+     * of the [filenamePatterns].
      */
     internal fun getFileGlobsForDirectoryAndAncestors(
         directory: String,
@@ -99,14 +97,8 @@ object LicenseFilenamePatterns {
     ): List<String> {
         val distinctPatterns = filenamePatterns.toSet()
 
-        val patternsForDir = distinctPatterns.map {
-            getFileGlobForDirectory(File(directory).invariantSeparatorsPath, it, true)
-        }
-
-        val patternsForAncestorDirs = getAllAncestorDirectories(directory).flatMap { dir ->
+        return getAllAncestorDirectories(directory).flatMap { dir ->
             distinctPatterns.map { getFileGlobForDirectory(dir, it, false) }
-        }
-
-        return (patternsForDir + patternsForAncestorDirs).sorted()
+        }.sorted()
     }
 }

--- a/utils/src/test/kotlin/LicenseFilenamePatternsTest.kt
+++ b/utils/src/test/kotlin/LicenseFilenamePatternsTest.kt
@@ -20,9 +20,10 @@
 package org.ossreviewtoolkit.utils
 
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.matchers.collections.containAll
+import io.kotest.matchers.collections.contain
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 
 class LicenseFilenamePatternsTest : WordSpec({
     "globFileInDirectoryOrAncestors" should {
@@ -34,9 +35,7 @@ class LicenseFilenamePatternsTest : WordSpec({
                 "/LICENSE",
                 "/PATENTS",
                 "/some/LICENSE",
-                "/some/PATENTS",
-                "/some/path/**/LICENSE",
-                "/some/path/**/PATENTS"
+                "/some/PATENTS"
             )
         }
 
@@ -44,18 +43,14 @@ class LicenseFilenamePatternsTest : WordSpec({
             LicenseFilenamePatterns.getFileGlobsForDirectoryAndAncestors(
                 directory = "/",
                 filenamePatterns = listOf("LICENSE", "PATENTS")
-            ) should containExactly(
-                "**/LICENSE",
-                "**/PATENTS"
-            )
+            ) shouldBe emptyList()
         }
     }
 
     "getLicenseFileGlobsForDirectory" should {
         "return a list containing the expected patterns for the LICENSE file" {
-            LicenseFilenamePatterns.getLicenseFileGlobsForDirectory("/dir") should containAll(
-                "/LICENSE*",
-                "/dir/**/LICENSE*"
+            LicenseFilenamePatterns.getLicenseFileGlobsForDirectory("/dir") should contain(
+                "/LICENSE*"
             )
         }
     }


### PR DESCRIPTION
As these globs are only used for Git and Mercurial sparse checkouts.
The globs for the current directory are not required, as these files are
already included in the sparse checkout as part of the subproject.

See: https://github.com/oss-review-toolkit/ort/pull/3079#issuecomment-730319812 and https://github.com/oss-review-toolkit/ort/pull/3079#issuecomment-730322531