### PR TITLE
LocalScanner: Make `scanPackage` a public function

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -354,7 +354,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
      *
      * Return the [ScanResult], if the package could not be scanned a [ScanException] is thrown.
      */
-    private fun scanPackage(
+    fun scanPackage(
         scannerDetails: ScannerDetails,
         pkg: Package,
         outputDirectory: File,


### PR DESCRIPTION
When using ORT programmatically it is useful to have access to this
function to scan a single package.