### PR TITLE
Gradle: Make also dokka use JDK 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -216,7 +216,7 @@ subprojects {
     tasks.dokkaHtml.configure {
         dokkaSourceSets {
             configureEach {
-                jdkVersion.set(8)
+                jdkVersion.set(11)
 
                 externalDocumentationLink {
                     val baseUrl = "https://codehaus-plexus.github.io/plexus-containers/plexus-container-default/apidocs"


### PR DESCRIPTION
This is a fixup for 48f2b96.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>