### PR TITLE
spdx-utils: Test that we do not map to deprecated SPDX licenses

### DIFF
--- a/spdx-utils/src/test/kotlin/SpdxDeclaredLicenseMappingTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxDeclaredLicenseMappingTest.kt
@@ -39,6 +39,12 @@ class SpdxDeclaredLicenseMappingTest : WordSpec({
 
             keys should beEmpty()
         }
+
+        "not contain any deprecated values" {
+            SpdxDeclaredLicenseMapping.rawMapping.values.forAll {
+                it.isValid(SpdxExpression.Strictness.ALLOW_CURRENT) shouldBe true
+            }
+        }
     }
 
     "The mapping" should {

--- a/spdx-utils/src/test/kotlin/SpdxSimpleLicenseMappingTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxSimpleLicenseMappingTest.kt
@@ -39,6 +39,12 @@ class SpdxSimpleLicenseMappingTest : WordSpec({
 
             keys should beEmpty()
         }
+
+        "not contain any deprecated values" {
+            SpdxSimpleLicenseMapping.customLicenseIdsMap.values.forAll {
+                it.deprecated shouldBe false
+            }
+        }
     }
 
     "The mapping" should {


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>