### PR TITLE
Gradle: Upgrade Kotlin to version 1.4.20

### DIFF
--- a/analyzer/src/funTest/kotlin/GitRepoFunTest.kt
+++ b/analyzer/src/funTest/kotlin/GitRepoFunTest.kt
@@ -25,6 +25,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.analyzer.managers.toYaml
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.downloader.vcs.GitRepo
@@ -48,7 +50,7 @@ class GitRepoFunTest : StringSpec() {
     override fun beforeSpec(spec: Spec) {
         // Do not use the class name as a suffix here to shorten the path. Otherwise the path will get too long for
         // Windows to handle.
-        outputDir = createTempDir(ORT_NAME)
+        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
 
         val vcs = VcsInfo(VcsType.GIT_REPO, REPO_URL, REPO_REV, path = REPO_MANIFEST)
         val pkg = Package.EMPTY.copy(vcsProcessed = vcs)

--- a/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
+++ b/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
@@ -32,6 +32,8 @@ import io.kotest.matchers.shouldNot
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.analyzer.ManagedProjectFiles
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.downloader.Downloader
@@ -81,7 +83,7 @@ abstract class AbstractIntegrationSpec : StringSpec() {
     override fun beforeSpec(spec: Spec) {
         // Do not use the usual simple class name as the suffix here to shorten the path which otherwise gets too long
         // on Windows for SimpleFormIntegrationTest.
-        outputDir = createTempDir(ORT_NAME)
+        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
         downloadResult = Downloader.download(pkg, outputDir)
     }
 

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -26,6 +26,8 @@ import java.io.IOException
 import java.net.URI
 import java.nio.file.Paths
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.downloader.VersionControlSystem
@@ -94,7 +96,7 @@ class GoDep(
     override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val projectDir = resolveProjectRoot(definitionFile)
         val projectVcs = processProjectVcs(projectDir)
-        val gopath = createTempDir(ORT_NAME, "${projectDir.name}-gopath")
+        val gopath = createTempDirectory("$ORT_NAME-${projectDir.name}-gopath").toFile()
         val workingDir = setUpWorkspace(projectDir, projectVcs, gopath)
 
         GO_LEGACY_MANIFESTS[definitionFile.name]?.let { lockfileName ->

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -31,6 +31,8 @@ import java.lang.NumberFormatException
 import java.net.HttpURLConnection
 import java.util.SortedSet
 
+import kotlin.io.path.createTempDirectory
+
 import okhttp3.Request
 
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
@@ -486,7 +488,7 @@ class Pip(
     }
 
     private fun createVirtualEnv(workingDir: File, pythonVersion: Int): File {
-        val virtualEnvDir = createTempDir(ORT_NAME, "${workingDir.name}-virtualenv")
+        val virtualEnvDir = createTempDirectory("$ORT_NAME-${workingDir.name}-virtualenv").toFile()
 
         val pythonInterpreter = PythonVersion.getPythonInterpreter(pythonVersion)
         ProcessCapture(workingDir, "virtualenv", virtualEnvDir.path, "-p", pythonInterpreter).requireSuccess()

--- a/analyzer/src/main/kotlin/managers/Sbt.kt
+++ b/analyzer/src/main/kotlin/managers/Sbt.kt
@@ -26,6 +26,8 @@ import java.io.File
 import java.io.IOException
 import java.util.Properties
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
@@ -87,7 +89,10 @@ class Sbt(
 
         // Avoid newer Sbt versions to warn about "Neither build.sbt nor a 'project' directory in the current directory"
         // and prompt the user to continue or quit on Windows where the "-batch" option is not supported.
-        val dummyProjectDir = createTempDir(ORT_NAME, managerName).also { it.resolve("build.sbt").createNewFile() }
+        val dummyProjectDir = createTempDirectory("$ORT_NAME-$managerName").toFile().apply {
+            resolve("build.sbt").createNewFile()
+        }
+
         return super.getVersion(dummyProjectDir).also { dummyProjectDir.safeDeleteRecursively() }
     }
 

--- a/analyzer/src/test/kotlin/managers/utils/NodeSupportTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/NodeSupportTest.kt
@@ -33,6 +33,8 @@ import io.kotest.matchers.shouldBe
 import java.io.File
 import java.net.InetSocketAddress
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.ProtocolProxyMap
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
@@ -264,7 +266,7 @@ class NodeSupportTest : WordSpec() {
 
     override fun beforeTest(testCase: TestCase) {
         super.beforeTest(testCase)
-        tempDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        tempDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
         definitionFiles.clear()
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -216,7 +216,11 @@ subprojects {
     }
 
     tasks.withType<KotlinCompile>().configureEach {
-        val customCompilerArgs = listOf("-Xallow-result-return-type", "-Xopt-in=kotlin.time.ExperimentalTime")
+        val customCompilerArgs = listOf(
+            "-Xallow-result-return-type",
+            "-Xopt-in=kotlin.io.path.ExperimentalPathApi",
+            "-Xopt-in=kotlin.time.ExperimentalTime"
+        )
 
         kotlinOptions {
             allWarningsAsErrors = true

--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -35,6 +35,8 @@ import java.io.File
 import java.io.IOException
 import java.time.Instant
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.evaluator.Evaluator
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
@@ -143,9 +145,9 @@ class ExamplesFunTest : StringSpec() {
         }
 
         "PDF files are valid Antenna templates" {
-            val outputDir = createTempDir(
-                ORT_NAME, ExamplesFunTest::class.simpleName
-            ).apply { deleteOnExit() }
+            val outputDir = createTempDirectory("$ORT_NAME-${ExamplesFunTest::class.simpleName}").toFile().apply {
+                deleteOnExit()
+            }
 
             takeExampleFile("back.pdf")
             takeExampleFile("content.pdf")

--- a/cli/src/funTest/kotlin/OrtMainFunTest.kt
+++ b/cli/src/funTest/kotlin/OrtMainFunTest.kt
@@ -31,6 +31,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.normalizeVcsUrl
@@ -51,7 +53,7 @@ class OrtMainFunTest : StringSpec() {
     private lateinit var outputDir: File
 
     override fun beforeTest(testCase: TestCase) {
-        outputDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {

--- a/downloader/src/funTest/kotlin/BabelFunTest.kt
+++ b/downloader/src/funTest/kotlin/BabelFunTest.kt
@@ -28,6 +28,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
@@ -43,7 +45,7 @@ class BabelFunTest : StringSpec() {
     private lateinit var outputDir: File
 
     override fun beforeTest(testCase: TestCase) {
-        outputDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {

--- a/downloader/src/funTest/kotlin/BeanUtilsFunTest.kt
+++ b/downloader/src/funTest/kotlin/BeanUtilsFunTest.kt
@@ -27,6 +27,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.RemoteArtifact
@@ -40,7 +42,7 @@ class BeanUtilsFunTest : StringSpec() {
     private lateinit var outputDir: File
 
     override fun beforeTest(testCase: TestCase) {
-        outputDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {

--- a/downloader/src/funTest/kotlin/DownloaderFunTest.kt
+++ b/downloader/src/funTest/kotlin/DownloaderFunTest.kt
@@ -28,6 +28,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
@@ -43,7 +45,7 @@ class DownloaderFunTest : StringSpec() {
     private lateinit var outputDir: File
 
     override fun beforeTest(testCase: TestCase) {
-        outputDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {

--- a/downloader/src/funTest/kotlin/vcs/CvsDownloadFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/CvsDownloadFunTest.kt
@@ -28,6 +28,8 @@ import io.kotest.matchers.string.contain
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.VcsInfo
@@ -47,7 +49,7 @@ class CvsDownloadFunTest : StringSpec() {
     private lateinit var outputDir: File
 
     override fun beforeTest(testCase: TestCase) {
-        outputDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {

--- a/downloader/src/funTest/kotlin/vcs/CvsWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/CvsWorkingTreeFunTest.kt
@@ -28,6 +28,8 @@ import io.kotest.matchers.shouldNotBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.Ci
@@ -43,7 +45,7 @@ class CvsWorkingTreeFunTest : StringSpec() {
     override fun beforeSpec(spec: Spec) {
         val zipFile = File("src/funTest/assets/jhove-2019-12-11-cvs.zip")
 
-        zipContentDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        zipContentDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
 
         println("Extracting '$zipFile' to '$zipContentDir'...")
         zipFile.unpack(zipContentDir)

--- a/downloader/src/funTest/kotlin/vcs/GitDownloadFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitDownloadFunTest.kt
@@ -27,6 +27,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.downloader.DownloadException
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
@@ -50,7 +52,7 @@ class GitDownloadFunTest : StringSpec() {
     private lateinit var outputDir: File
 
     override fun beforeTest(testCase: TestCase) {
-        outputDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {

--- a/downloader/src/funTest/kotlin/vcs/GitRepoDownloadFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitRepoDownloadFunTest.kt
@@ -26,6 +26,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
@@ -43,7 +45,7 @@ class GitRepoDownloadFunTest : StringSpec() {
     override fun beforeTest(testCase: TestCase) {
         // Do not use the class name as a suffix here to shorten the path. Otherwise the path will get too long for
         // Windows to handle.
-        outputDir = createTempDir(ORT_NAME)
+        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {

--- a/downloader/src/funTest/kotlin/vcs/GitWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitWorkingTreeFunTest.kt
@@ -29,6 +29,8 @@ import io.kotest.matchers.shouldNotBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
@@ -44,7 +46,7 @@ class GitWorkingTreeFunTest : StringSpec() {
     override fun beforeSpec(spec: Spec) {
         val zipFile = File("src/funTest/assets/pipdeptree-2018-01-03-git.zip")
 
-        zipContentDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        zipContentDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
 
         println("Extracting '$zipFile' to '$zipContentDir'...")
         zipFile.unpack(zipContentDir)

--- a/downloader/src/funTest/kotlin/vcs/MercurialDownloadFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/MercurialDownloadFunTest.kt
@@ -26,6 +26,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.VcsInfo
@@ -48,7 +50,7 @@ class MercurialDownloadFunTest : StringSpec() {
     private lateinit var outputDir: File
 
     override fun beforeTest(testCase: TestCase) {
-        outputDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {

--- a/downloader/src/funTest/kotlin/vcs/MercurialWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/MercurialWorkingTreeFunTest.kt
@@ -28,6 +28,8 @@ import io.kotest.matchers.shouldNotBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.ORT_NAME
@@ -42,7 +44,7 @@ class MercurialWorkingTreeFunTest : StringSpec() {
     override fun beforeSpec(spec: Spec) {
         val zipFile = File("src/funTest/assets/lz4revlog-2018-01-03-hg.zip")
 
-        zipContentDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        zipContentDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
 
         println("Extracting '$zipFile' to '$zipContentDir'...")
         zipFile.unpack(zipContentDir)

--- a/downloader/src/funTest/kotlin/vcs/SubversionDownloadFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/SubversionDownloadFunTest.kt
@@ -26,6 +26,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.VcsInfo
@@ -48,7 +50,7 @@ class SubversionDownloadFunTest : StringSpec() {
     private lateinit var outputDir: File
 
     override fun beforeTest(testCase: TestCase) {
-        outputDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {

--- a/downloader/src/funTest/kotlin/vcs/SubversionWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/SubversionWorkingTreeFunTest.kt
@@ -28,6 +28,8 @@ import io.kotest.matchers.shouldNotBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.ORT_NAME
@@ -42,7 +44,7 @@ class SubversionWorkingTreeFunTest : StringSpec() {
     override fun beforeSpec(spec: Spec) {
         val zipFile = File("src/funTest/assets/docutils-2018-01-03-svn-trunk.zip")
 
-        zipContentDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        zipContentDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
 
         print("Extracting '$zipFile' to '$zipContentDir'... ")
         zipFile.unpack(zipContentDir)

--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -24,6 +24,8 @@ import java.io.IOException
 import java.net.URI
 import java.time.Instant
 
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.createTempFile
 import kotlin.time.TimeSource
 
 import okhttp3.Request
@@ -365,7 +367,7 @@ object Downloader {
                         ArchiveType.getType(it) != ArchiveType.NONE
                     } ?: candidateNames.first()
 
-                    createTempFile(ORT_NAME, tempFileName).also { tempFile ->
+                    createTempFile(ORT_NAME, tempFileName).toFile().also { tempFile ->
                         tempFile.sink().buffer().use { it.writeAll(body.source()) }
                         tempFile.deleteOnExit()
                     }
@@ -390,7 +392,7 @@ object Downloader {
         try {
             if (sourceArchive.extension == "gem") {
                 // Unpack the nested data archive for Ruby Gems.
-                val gemDirectory = createTempDir(ORT_NAME, "gem")
+                val gemDirectory = createTempDirectory("$ORT_NAME-gem").toFile()
                 val dataFile = gemDirectory.resolve("data.tar.gz")
 
                 try {

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@
 detektPluginVersion = 1.14.2
 dokkaPluginVersion = 1.4.10.2
 ideaExtPluginVersion = 0.9
-kotlinPluginVersion = 1.4.10
+kotlinPluginVersion = 1.4.20
 svntoolsPluginVersion = 3.1
 versionsPluginVersion = 0.36.0
 

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -23,6 +23,10 @@ package org.ossreviewtoolkit.helper.common
 
 import java.io.File
 import java.io.IOException
+import java.nio.file.Paths
+
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.createTempFile
 
 import okhttp3.Request
 
@@ -102,7 +106,7 @@ internal fun download(url: String): File {
 
         // Use the filename from the request for the last redirect.
         val tempFileName = response.request.url.pathSegments.last()
-        return createTempFile(ORT_NAME, tempFileName).also { tempFile ->
+        return createTempFile(ORT_NAME, tempFileName).toFile().also { tempFile ->
             tempFile.sink().buffer().use { it.writeAll(body.source()) }
             tempFile.deleteOnExit()
         }
@@ -183,7 +187,7 @@ internal fun List<ScopeExclude>.minimize(projectScopes: List<String>): List<Scop
  * the given [id] depending on whether a scan result is present with matching [Provenance].
  */
 internal fun OrtResult.fetchScannedSources(id: Identifier): File {
-    val tempDir = createTempDir(ORTH_NAME, directory = File("."))
+    val tempDir = createTempDirectory(Paths.get("."), ORTH_NAME).toFile()
 
     val pkg = getPackageOrProject(id)!!.let {
         if (getProvenance(id)!!.sourceArtifact != null) {

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -22,6 +22,8 @@ package org.ossreviewtoolkit.model.licenses
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.CopyrightFinding
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseSource
@@ -206,7 +208,7 @@ class LicenseInfoResolver(
         licenseInfo.flatMapTo(mutableSetOf()) { resolvedLicense ->
             resolvedLicense.locations.map { it.provenance }
         }.forEach { provenance ->
-            val archiveDir = createTempDir(ORT_NAME, "archive").also { it.deleteOnExit() }
+            val archiveDir = createTempDirectory("$ORT_NAME-archive").toFile().apply { deleteOnExit() }
 
             val path = "${id.toPath()}/${provenance.hash()}"
             if (archiver.unarchive(archiveDir, path)) {

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -34,6 +34,8 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import java.io.File
 import java.lang.IllegalArgumentException
 
+import kotlin.io.path.createTempFile
+
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.test.containExactly as containExactlyEntries
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
@@ -231,7 +233,7 @@ class OrtConfigurationTest : WordSpec({
  * Create a test configuration with the [data] specified.
  */
 private fun createTestConfig(data: String): File =
-    createTempFile(ORT_NAME, ".conf").apply {
+    createTempFile(ORT_NAME, ".conf").toFile().apply {
         writeText(data)
         deleteOnExit()
     }

--- a/model/src/test/kotlin/config/ScannerConfigurationTest.kt
+++ b/model/src/test/kotlin/config/ScannerConfigurationTest.kt
@@ -26,6 +26,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempFile
+
 import org.ossreviewtoolkit.model.mapper
 import org.ossreviewtoolkit.model.readValue
 
@@ -34,9 +36,7 @@ class ScannerConfigurationTest : WordSpec({
         "support a serialization round-trip via an ObjectMapper" {
             val refConfig = File("src/test/assets/reference.conf")
             val ortConfig = OrtConfiguration.load(configFile = refConfig)
-            val file = createTempFile(suffix = ".yml").apply {
-                deleteOnExit()
-            }
+            val file = createTempFile(suffix = ".yml").toFile().apply { deleteOnExit() }
 
             file.mapper().writeValue(file, ortConfig.scanner)
             val loadedConfig = file.readValue<ScannerConfiguration>()

--- a/reporter/src/funTest/kotlin/reporters/AntennaAttributionDocumentReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/AntennaAttributionDocumentReporterFunTest.kt
@@ -24,6 +24,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.ORT_NAME
@@ -47,9 +49,8 @@ class AntennaAttributionDocumentReporterFunTest : StringSpec({
 })
 
 private fun generateReport(ortResult: OrtResult): List<File> {
-    val outputDir = createTempDir(
-        ORT_NAME, AntennaAttributionDocumentReporterFunTest::class.simpleName
-    ).apply { deleteOnExit() }
+    val outputDir = createTempDirectory("$ORT_NAME-${AntennaAttributionDocumentReporterFunTest::class.simpleName}")
+        .toFile().apply { deleteOnExit() }
 
     return AntennaAttributionDocumentReporter().generateReport(ReporterInput(ortResult), outputDir)
 }

--- a/reporter/src/funTest/kotlin/reporters/CycloneDxReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/CycloneDxReporterFunTest.kt
@@ -29,6 +29,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.cyclonedx.CycloneDxSchema
 import org.cyclonedx.model.ExternalReference
 import org.cyclonedx.parsers.XmlParser
@@ -45,7 +47,7 @@ class CycloneDxReporterFunTest : WordSpec({
 
     "A generated BOM" should {
         "be valid according to schema version 1.1" {
-            val outputDir = createTempDir(ORT_NAME, javaClass.simpleName).apply { deleteOnExit() }
+            val outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile().apply { deleteOnExit() }
             val bomFile = CycloneDxReporter().generateReport(ReporterInput(ORT_RESULT), outputDir, options).single()
 
             XmlParser().validate(bomFile, CycloneDxSchema.Version.VERSION_11) should beEmpty()
@@ -62,7 +64,7 @@ class CycloneDxReporterFunTest : WordSpec({
                 )
             )
 
-            val outputDir = createTempDir(ORT_NAME, javaClass.simpleName).apply { deleteOnExit() }
+            val outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile().apply { deleteOnExit() }
             val bomFileFromReporter = CycloneDxReporter().generateReport(
                 ReporterInput(ortResult),
                 outputDir,

--- a/reporter/src/funTest/kotlin/reporters/EvaluatedModelReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/EvaluatedModelReporterFunTest.kt
@@ -24,6 +24,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
@@ -68,7 +70,9 @@ private fun generateReport(reporter: EvaluatedModelReporter, ortResult: OrtResul
         howToFixTextProvider = HOW_TO_FIX_TEXT_PROVIDER
     )
 
-    val outputDir = createTempDir(ORT_NAME, EvaluatedModelReporterFunTest::class.simpleName).apply { deleteOnExit() }
+    val outputDir = createTempDirectory("$ORT_NAME-${EvaluatedModelReporterFunTest::class.simpleName}").toFile().apply {
+        deleteOnExit()
+    }
 
     return reporter.generateReport(input, outputDir).single().readText()
 }

--- a/reporter/src/funTest/kotlin/reporters/ExcelReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/ExcelReporterFunTest.kt
@@ -28,6 +28,8 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
 
+import kotlin.io.path.createTempDirectory
+
 import org.apache.poi.ss.usermodel.Cell
 import org.apache.poi.ss.usermodel.Row
 import org.apache.poi.ss.usermodel.Sheet
@@ -41,7 +43,7 @@ import org.ossreviewtoolkit.utils.test.readOrtResult
 class ExcelReporterFunTest : WordSpec({
     "ExcelReporter" should {
         "successfully export to an Excel sheet" {
-            val outputDir = createTempDir(ORT_NAME, javaClass.simpleName).apply { deleteOnExit() }
+            val outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile().apply { deleteOnExit() }
             val ortResult = readOrtResult(
                 "../scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml"
             )

--- a/reporter/src/funTest/kotlin/reporters/GitLabLicenseModelReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/GitLabLicenseModelReporterFunTest.kt
@@ -24,6 +24,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.AnalyzerRun
 import org.ossreviewtoolkit.model.CuratedPackage
@@ -71,9 +73,8 @@ private fun expectedOutput(assetName: String): String = File("src/funTest/assets
 private fun generateReport(ortResult: OrtResult, skipExcluded: Boolean): String =
     GitLabLicenseModelReporter().generateReport(
         input = ReporterInput(ortResult = ortResult),
-        outputDir = createTempDir(ORT_NAME, GitLabLicenseModelReporterFunTest::class.simpleName).apply {
-            deleteOnExit()
-        },
+        outputDir = createTempDirectory("$ORT_NAME-${GitLabLicenseModelReporterFunTest::class.simpleName}").toFile()
+            .apply { deleteOnExit() },
         options = mapOf(GitLabLicenseModelReporter.OPTION_SKIP_EXCLUDED to skipExcluded.toString())
     ).single().readText().normalizeLineBreaks()
 

--- a/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterFunTest.kt
@@ -24,6 +24,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.FileArchiverConfiguration
@@ -99,7 +101,9 @@ private fun generateReport(
         licenseConfiguration = createLicenseConfiguration()
     )
 
-    val outputDir = createTempDir(ORT_NAME, NoticeTemplateReporterFunTest::class.simpleName).apply { deleteOnExit() }
+    val outputDir = createTempDirectory("$ORT_NAME-${NoticeTemplateReporterFunTest::class.simpleName}").toFile().apply {
+        deleteOnExit()
+    }
 
     return NoticeTemplateReporter().generateReport(input, outputDir, options).single().readText()
 }

--- a/reporter/src/funTest/kotlin/reporters/SpdxDocumentReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/SpdxDocumentReporterFunTest.kt
@@ -25,6 +25,8 @@ import io.kotest.matchers.shouldBe
 import java.io.File
 import java.time.Instant
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.AccessStatistics
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.AnalyzerRun
@@ -101,7 +103,9 @@ private fun generateReport(ortResult: OrtResult, format: FileFormat): String {
         licenseTextProvider = DefaultLicenseTextProvider()
     )
 
-    val outputDir = createTempDir(ORT_NAME, SpdxDocumentReporterFunTest::class.simpleName).apply { deleteOnExit() }
+    val outputDir = createTempDirectory("$ORT_NAME-${SpdxDocumentReporterFunTest::class.simpleName}").toFile().apply {
+        deleteOnExit()
+    }
 
     val reportOptions = mapOf(
         SpdxDocumentReporter.OPTION_CREATION_INFO_COMMENT to "some creation info comment",

--- a/reporter/src/funTest/kotlin/reporters/StaticHtmlReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/StaticHtmlReporterFunTest.kt
@@ -26,6 +26,8 @@ import java.io.File
 
 import javax.xml.transform.TransformerFactory
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.Environment
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
@@ -77,7 +79,9 @@ private fun generateReport(ortResult: OrtResult): String {
         howToFixTextProvider = HOW_TO_FIX_TEXT_PROVIDER
     )
 
-    val outputDir = createTempDir(ORT_NAME, StaticHtmlReporterFunTest::class.simpleName).apply { deleteOnExit() }
+    val outputDir = createTempDirectory("$ORT_NAME-${StaticHtmlReporterFunTest::class.simpleName}").toFile().apply {
+        deleteOnExit()
+    }
 
     return StaticHtmlReporter().generateReport(input, outputDir).single().readText()
 }

--- a/reporter/src/funTest/kotlin/reporters/WebAppReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/WebAppReporterFunTest.kt
@@ -22,6 +22,8 @@ package org.ossreviewtoolkit.reporter.reporters
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.longs.shouldBeGreaterThan
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.test.readOrtResult
@@ -33,7 +35,7 @@ class WebAppReporterFunTest : WordSpec({
                 "../scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml"
             )
 
-            val outputDir = createTempDir(ORT_NAME, javaClass.simpleName).apply { deleteOnExit() }
+            val outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile().apply { deleteOnExit() }
 
             val report = WebAppReporter().generateReport(ReporterInput(ortResult), outputDir).single()
 

--- a/reporter/src/main/kotlin/reporters/AntennaAttributionDocumentReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AntennaAttributionDocumentReporter.kt
@@ -23,6 +23,8 @@ import java.io.File
 import java.net.URL
 import java.net.URLClassLoader
 
+import kotlin.io.path.createTempDirectory
+
 import org.eclipse.sw360.antenna.attribution.document.core.AttributionDocumentGeneratorImpl
 import org.eclipse.sw360.antenna.attribution.document.core.DocumentValues
 import org.eclipse.sw360.antenna.attribution.document.core.model.LicenseInfo
@@ -35,6 +37,7 @@ import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.utils.AttributionDocumentPdfModel
 import org.ossreviewtoolkit.spdx.SpdxLicense
 import org.ossreviewtoolkit.utils.CopyrightStatementsProcessor
+import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.toHexString
 
@@ -187,7 +190,7 @@ class AntennaAttributionDocumentReporter : Reporter {
                     input.licenseInfoResolver.resolveLicenseInfo(project.id).filter(LicenseView.CONCLUDED_OR_REST)
                 )
 
-                val workingDir = createTempDir()
+                val workingDir = createTempDirectory("$ORT_NAME-antenna-reporter").toFile()
 
                 val generator = AttributionDocumentGeneratorImpl(
                     reportFilename,

--- a/scanner/src/funTest/kotlin/scanners/AbstractScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/AbstractScannerFunTest.kt
@@ -31,6 +31,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.LocalScanner
 import org.ossreviewtoolkit.spdx.SpdxExpression
@@ -53,7 +55,7 @@ abstract class AbstractScannerFunTest(testTags: Set<Tag> = emptySet()) : StringS
 
     override fun beforeSpec(spec: Spec) {
         super.beforeSpec(spec)
-        inputDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        inputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
 
         // Copy our own root license under different names to a temporary directory so we have something to operate on.
         val ortLicense = File("../LICENSE")
@@ -62,7 +64,7 @@ abstract class AbstractScannerFunTest(testTags: Set<Tag> = emptySet()) : StringS
 
     override fun beforeTest(testCase: TestCase) {
         super.beforeTest(testCase)
-        outputDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {

--- a/scanner/src/funTest/kotlin/scanners/FileCounterScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/FileCounterScannerFunTest.kt
@@ -24,6 +24,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
@@ -39,7 +41,7 @@ class FileCounterScannerFunTest : StringSpec() {
 
     init {
         "Gradle project scan results for a given analyzer result are correct".config(invocations = 3) {
-            outputDir = createTempDir(ORT_NAME, javaClass.simpleName)
+            outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
 
             val analyzerResultFile = assetsDir.resolve("analyzer-result.yml")
             val expectedResult = patchExpectedResult(

--- a/scanner/src/funTest/kotlin/storages/FileBasedStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/FileBasedStorageFunTest.kt
@@ -19,10 +19,16 @@
 
 package org.ossreviewtoolkit.scanner.storages
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.storage.LocalFileStorage
 
 class FileBasedStorageFunTest : AbstractStorageFunTest() {
     override fun createStorage() =
-        FileBasedStorage(LocalFileStorage(createTempDir(ORT_NAME, javaClass.simpleName).apply { deleteOnExit() }))
+        FileBasedStorage(
+            LocalFileStorage(
+                createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile().apply { deleteOnExit() }
+            )
+        )
 }

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -26,6 +26,8 @@ import java.io.IOException
 import java.net.HttpURLConnection
 import java.time.Instant
 
+import kotlin.io.path.createTempDirectory
+
 import okhttp3.Request
 
 import org.ossreviewtoolkit.model.EMPTY_JSON_NODE
@@ -88,7 +90,9 @@ class Askalono(name: String, config: ScannerConfiguration) : LocalScanner(name, 
                 log.info { "Retrieved $scannerName from local cache." }
             }
 
-            val unpackDir = createTempDir(ORT_NAME, "$scannerName-$expectedVersion").apply { deleteOnExit() }
+            val unpackDir = createTempDirectory("$ORT_NAME-$scannerName-$expectedVersion").toFile().apply {
+                deleteOnExit()
+            }
 
             log.info { "Unpacking '$archive' to '$unpackDir'... " }
             body.bytes().unpackZip(unpackDir)

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -26,6 +26,8 @@ import java.io.IOException
 import java.net.HttpURLConnection
 import java.time.Instant
 
+import kotlin.io.path.createTempDirectory
+
 import okhttp3.Request
 
 import org.ossreviewtoolkit.model.EMPTY_JSON_NODE
@@ -95,7 +97,9 @@ class BoyterLc(name: String, config: ScannerConfiguration) : LocalScanner(name, 
                 log.info { "Retrieved $scannerName from local cache." }
             }
 
-            val unpackDir = createTempDir(ORT_NAME, "$scannerName-$expectedVersion").apply { deleteOnExit() }
+            val unpackDir = createTempDirectory("$ORT_NAME-$scannerName-$expectedVersion").toFile().apply {
+                deleteOnExit()
+            }
 
             log.info { "Unpacking '$archive' to '$unpackDir'... " }
             body.bytes().unpackZip(unpackDir)

--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -24,6 +24,8 @@ import java.io.IOException
 import java.net.HttpURLConnection
 import java.time.Instant
 
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.createTempFile
 import kotlin.math.max
 
 import okhttp3.Request
@@ -183,10 +185,12 @@ class ScanCode(
                 log.info { "Retrieved $scannerName from local cache." }
             }
 
-            val scannerArchive = createTempFile(ORT_NAME, "$scannerName-${url.substringAfterLast("/")}")
+            val scannerArchive = createTempFile(ORT_NAME, "$scannerName-${url.substringAfterLast("/")}").toFile()
             scannerArchive.sink().buffer().use { it.writeAll(body.source()) }
 
-            val unpackDir = createTempDir(ORT_NAME, "$scannerName-$expectedVersion").apply { deleteOnExit() }
+            val unpackDir = createTempDirectory("$ORT_NAME-$scannerName-$expectedVersion").toFile().apply {
+                deleteOnExit()
+            }
 
             log.info { "Unpacking '$scannerArchive' to '$unpackDir'... " }
             scannerArchive.unpack(unpackDir)

--- a/spdx-utils/src/test/kotlin/SpdxUtilsTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxUtilsTest.kt
@@ -33,13 +33,15 @@ import io.kotest.matchers.string.startWith
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.utils.ORT_NAME
 
 class SpdxUtilsTest : WordSpec() {
     private lateinit var tempDir: File
 
     override fun beforeTest(testCase: TestCase) {
-        tempDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        tempDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {

--- a/utils/src/main/kotlin/DirectoryStash.kt
+++ b/utils/src/main/kotlin/DirectoryStash.kt
@@ -25,6 +25,8 @@ import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
+import kotlin.io.path.createTempDirectory
+
 /**
  * A convenience function that stashes directories using a [DirectoryStash] instance.
  */
@@ -44,7 +46,7 @@ private class DirectoryStash(directories: Set<File>) : Closeable {
             // directories.
             if (originalDir.isDirectory) {
                 // Create a temporary directory to move directories as-is into.
-                val stashDir = createTempDir(ORT_NAME, "stash", originalDir.parentFile)
+                val stashDir = createTempDirectory(originalDir.parentFile.toPath(), "$ORT_NAME-stash").toFile()
 
                 // Use a non-existing directory as the target to ensure the directory can be moved atomically.
                 val tempDir = stashDir.resolve(originalDir.name)

--- a/utils/src/main/kotlin/ProcessCapture.kt
+++ b/utils/src/main/kotlin/ProcessCapture.kt
@@ -22,6 +22,8 @@ package org.ossreviewtoolkit.utils
 import java.io.File
 import java.io.IOException
 
+import kotlin.io.path.createTempDirectory
+
 /**
  * An (almost) drop-in replacement for ProcessBuilder that is able to capture huge outputs to the standard output and
  * standard error streams by redirecting output to temporary files.
@@ -54,7 +56,7 @@ class ProcessCapture(vararg command: String, workingDir: File? = null, environme
         }
     }
 
-    private val tempDir = createTempDir(ORT_NAME, "process").apply { deleteOnExit() }
+    private val tempDir = createTempDirectory("$ORT_NAME-process").toFile().apply { deleteOnExit() }
     private val tempPrefix = command.first().substringAfterLast(File.separatorChar)
 
     val stdoutFile = tempDir.resolve("$tempPrefix.stdout").apply { deleteOnExit() }

--- a/utils/src/main/kotlin/Redirection.kt
+++ b/utils/src/main/kotlin/Redirection.kt
@@ -23,8 +23,10 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.PrintStream
 
+import kotlin.io.path.createTempFile
+
 private fun redirectOutput(originalOutput: PrintStream, setOutput: (PrintStream) -> Unit, block: () -> Unit): String {
-    val tempFile = createTempFile(ORT_NAME, "redirect").apply { deleteOnExit() }
+    val tempFile = createTempFile(ORT_NAME, "redirect").toFile().apply { deleteOnExit() }
     val fileStream = FileOutputStream(tempFile)
 
     try {

--- a/utils/src/main/kotlin/storage/FileArchiver.kt
+++ b/utils/src/main/kotlin/storage/FileArchiver.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.utils.storage
 import java.io.File
 import java.io.IOException
 
+import kotlin.io.path.createTempFile
 import kotlin.time.measureTime
 import kotlin.time.measureTimedValue
 
@@ -82,7 +83,7 @@ class FileArchiver(
      * are zipped in the file '[storagePath]/[ARCHIVE_FILE_NAME]'.
      */
     fun archive(directory: File, storagePath: String) {
-        val zipFile = createTempFile(ORT_NAME, ".zip")
+        val zipFile = createTempFile(ORT_NAME, ".zip").toFile()
         zipFile.deleteOnExit()
 
         val zipDuration = measureTime {

--- a/utils/src/test/kotlin/ArchiveUtilsTest.kt
+++ b/utils/src/test/kotlin/ArchiveUtilsTest.kt
@@ -26,11 +26,13 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 class ArchiveUtilsTest : StringSpec() {
     private lateinit var outputDir: File
 
     override fun beforeTest(testCase: TestCase) {
-        outputDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
     }
 
     override fun afterTest(testCase: TestCase, result: TestResult) {

--- a/utils/src/test/kotlin/DirectoryStashTest.kt
+++ b/utils/src/test/kotlin/DirectoryStashTest.kt
@@ -30,6 +30,8 @@ import io.kotest.matchers.shouldNot
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 class DirectoryStashTest : StringSpec() {
     private lateinit var sandboxDir: File
     private lateinit var a: File
@@ -38,7 +40,7 @@ class DirectoryStashTest : StringSpec() {
     private lateinit var b1: File
 
     override fun beforeTest(testCase: TestCase) {
-        sandboxDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        sandboxDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
         a = sandboxDir.resolve("a")
         a1 = a.resolve("a1")
         b = sandboxDir.resolve("b")

--- a/utils/src/test/kotlin/ExtensionsTest.kt
+++ b/utils/src/test/kotlin/ExtensionsTest.kt
@@ -31,6 +31,9 @@ import io.kotest.matchers.shouldBe
 import java.io.File
 import java.io.IOException
 
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.createTempFile
+
 import org.ossreviewtoolkit.utils.test.containExactly
 
 class ExtensionsTest : WordSpec({
@@ -52,7 +55,7 @@ class ExtensionsTest : WordSpec({
 
     "File.hash" should {
         "calculate the correct SHA1" {
-            val file = createTempFile(ORT_NAME, javaClass.simpleName).apply {
+            val file = createTempFile(ORT_NAME, javaClass.simpleName).toFile().apply {
                 writeText("test")
                 deleteOnExit()
             }
@@ -62,7 +65,7 @@ class ExtensionsTest : WordSpec({
     }
 
     "File.isSymbolicLink" should {
-        val tempDir = createTempDir(ORT_NAME, javaClass.simpleName)
+        val tempDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
         val file = tempDir.resolve("file").apply { createNewFile() }
         val directory = tempDir.resolve("directory").apply { safeMkdirs() }
 
@@ -155,7 +158,7 @@ class ExtensionsTest : WordSpec({
 
     "File.safeMkDirs" should {
         "succeed if directory already exists" {
-            val directory = createTempDir(ORT_NAME, javaClass.simpleName).apply { deleteOnExit() }
+            val directory = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile().apply { deleteOnExit() }
 
             directory.isDirectory shouldBe true
             shouldNotThrow<IOException> { directory.safeMkdirs() }
@@ -163,7 +166,7 @@ class ExtensionsTest : WordSpec({
         }
 
         "succeed if directory could be created" {
-            val parent = createTempDir(ORT_NAME, javaClass.simpleName).apply { deleteOnExit() }
+            val parent = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile().apply { deleteOnExit() }
             val child = File(parent, "child").apply { deleteOnExit() }
 
             parent.isDirectory shouldBe true
@@ -175,7 +178,7 @@ class ExtensionsTest : WordSpec({
             // Test case for an unexpected behaviour of File.mkdirs() which returns false for
             // File(File("parent1/parent2"), "/").mkdirs() if both "parent" directories do not exist, even when the
             // directory was successfully created.
-            val parent = createTempDir(ORT_NAME, javaClass.simpleName).apply { deleteOnExit() }
+            val parent = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile().apply { deleteOnExit() }
             val nonExistingParent = File(parent, "parent1/parent2").apply { deleteOnExit() }
             val child = File(nonExistingParent, "/").apply { deleteOnExit() }
 
@@ -187,7 +190,7 @@ class ExtensionsTest : WordSpec({
         }
 
         "throw exception if file is not a directory" {
-            val file = createTempFile(ORT_NAME, javaClass.simpleName).apply { deleteOnExit() }
+            val file = createTempFile(ORT_NAME, javaClass.simpleName).toFile().apply { deleteOnExit() }
 
             file.isFile shouldBe true
             shouldThrow<IOException> { file.safeMkdirs() }
@@ -269,7 +272,7 @@ class ExtensionsTest : WordSpec({
         }
 
         "create a valid file name" {
-            val tempDir = createTempDir(ORT_NAME, javaClass.simpleName)
+            val tempDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
             val fileFromStr = tempDir.resolve(str.fileSystemEncode()).apply { writeText("dummy") }
 
             fileFromStr.isFile shouldBe true

--- a/utils/src/test/kotlin/storage/FileArchiverTest.kt
+++ b/utils/src/test/kotlin/storage/FileArchiverTest.kt
@@ -26,6 +26,8 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.safeMkdirs
@@ -38,9 +40,9 @@ class FileArchiverTest : StringSpec() {
     private lateinit var storage: LocalFileStorage
 
     override fun beforeTest(testCase: TestCase) {
-        workingDir = createTempDir(ORT_NAME, "${javaClass.simpleName}-workingDir")
-        storageDir = createTempDir(ORT_NAME, "${javaClass.simpleName}-storageDir")
-        targetDir = createTempDir(ORT_NAME, "${javaClass.simpleName}-targetDir")
+        workingDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}-workingDir").toFile()
+        storageDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}-storageDir").toFile()
+        targetDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}-targetDir").toFile()
         storage = LocalFileStorage(storageDir)
     }
 

--- a/utils/src/test/kotlin/storage/LocalFileStorageTest.kt
+++ b/utils/src/test/kotlin/storage/LocalFileStorageTest.kt
@@ -28,13 +28,16 @@ import java.io.BufferedReader
 import java.io.File
 import java.io.FileNotFoundException
 
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.createTempFile
+
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.safeMkdirs
 
 class LocalFileStorageTest : WordSpec() {
     private fun storage(block: (LocalFileStorage, File) -> Unit) {
-        val directory = createTempDir(ORT_NAME, javaClass.simpleName)
+        val directory = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
         val storage = LocalFileStorage(directory)
         block(storage, directory)
         directory.safeDeleteRecursively()
@@ -44,12 +47,12 @@ class LocalFileStorageTest : WordSpec() {
         "Creating the storage" should {
             "succeed if the directory exists" {
                 shouldNotThrowAny {
-                    LocalFileStorage(createTempDir(ORT_NAME, javaClass.simpleName))
+                    LocalFileStorage(createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile())
                 }
             }
 
             "succeed if the directory does not exist and must be created" {
-                val directory = createTempDir(ORT_NAME, javaClass.simpleName)
+                val directory = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
                 val storageDirectory = directory.resolve("create/storage")
 
                 LocalFileStorage(storageDirectory)
@@ -58,7 +61,7 @@ class LocalFileStorageTest : WordSpec() {
             }
 
             "fail if the directory is a file" {
-                val storageDirectory = createTempFile(ORT_NAME, javaClass.simpleName).apply { deleteOnExit() }
+                val storageDirectory = createTempFile(ORT_NAME, javaClass.simpleName).toFile().apply { deleteOnExit() }
 
                 shouldThrow<IllegalArgumentException> {
                     LocalFileStorage(storageDirectory)

--- a/utils/src/test/kotlin/storage/XZCompressedLocalFileStorageTest.kt
+++ b/utils/src/test/kotlin/storage/XZCompressedLocalFileStorageTest.kt
@@ -25,12 +25,14 @@ import io.kotest.matchers.shouldBe
 import java.io.BufferedReader
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
 
 class XZCompressedLocalFileStorageTest : StringSpec() {
     private fun storage(block: (XZCompressedLocalFileStorage, File) -> Unit) {
-        val directory = createTempDir(ORT_NAME, javaClass.simpleName)
+        val directory = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
         val storage = XZCompressedLocalFileStorage(directory)
         block(storage, directory)
         directory.safeDeleteRecursively()


### PR DESCRIPTION
See https://blog.jetbrains.com/kotlin/2020/11/kotlin-1-4-20-released/.

Interestingly, the createTemp{Dir,File}() functions that return Files have
been deprecated (and their use triggers a compiler warning, which we do
not allow in ORT), but only in favor of an experimental Path-based API,
whose use also triggers a warning to explicitly enable that API. So
migrate the code and do enable the experimental use.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>