### PR TITLE
Gradle: Add the taskinfo plugin for listing task dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ plugins {
 
     id("com.github.ben-manes.versions")
     id("io.gitlab.arturbosch.detekt")
+    id("org.barfuin.gradle.taskinfo")
     id("org.jetbrains.dokka")
     id("org.jetbrains.gradle.plugin.idea-ext")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,6 +22,7 @@ dokkaPluginVersion = 1.4.10.2
 ideaExtPluginVersion = 0.9
 kotlinPluginVersion = 1.4.20
 svntoolsPluginVersion = 3.1
+taskinfoPluginVersion = 1.0.3
 versionsPluginVersion = 0.36.0
 
 antennaVersion = 1.0.0-weekly-2020-29


### PR DESCRIPTION
This can be useful for debugging / optimizing builds. See
https://gitlab.com/barfuin/gradle-taskinfo.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>