### PR TITLE
Gradle/Docker: Do not quote version strings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,7 @@ if (version == Project.DEFAULT_VERSION) {
     }
 }
 
-logger.quiet("Building ORT version '$version'.")
+logger.quiet("Building ORT version $version.")
 
 // TODO: Replace this with Gradle's toolchain mechanism [1] once the Kotlin plugin supports it [2].
 // [1] https://blog.gradle.org/java-toolchains

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -20,5 +20,5 @@
 GIT_ROOT=$(git rev-parse --show-toplevel)
 GIT_VERSION=$(git describe --abbrev=7 --always --tags --dirty)
 
-echo "Setting ORT_VERSION to '$GIT_VERSION'."
+echo "Setting ORT_VERSION to $GIT_VERSION."
 docker build -f $GIT_ROOT/Dockerfile -t ort --build-arg ORT_VERSION=$GIT_VERSION $GIT_ROOT


### PR DESCRIPTION
We usually do not quote version strings, so also do not do this here.
This is a fixup for b0e5263.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>