### PR TITLE
CycloneDxReporter: Change the output name to "CycloneDX-BOM.xml"

### DIFF
--- a/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
+++ b/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
@@ -44,7 +44,7 @@ import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.spdx.SpdxLicense
 import org.ossreviewtoolkit.utils.isTrue
 
-private const val REPORT_BASE_FILENAME = "bom"
+private const val REPORT_BASE_FILENAME = "CycloneDX-BOM"
 private const val REPORT_EXTENSION = "xml"
 
 /**
@@ -101,7 +101,7 @@ class CycloneDxReporter : Reporter {
         val createSingleBom = options["single.bom"].isTrue()
 
         if (createSingleBom && projects.size > 1) {
-            val reportFilename = "bom.xml"
+            val reportFilename = "$REPORT_BASE_FILENAME.$REPORT_EXTENSION"
             val outputFile = outputDir.resolve(reportFilename)
 
             val bom = Bom().apply { serialNumber = "urn:uuid:${UUID.randomUUID()}" }


### PR DESCRIPTION
The previous name "bom.xml" made it sound to users as if this was the one
and only BOM file format that ORT would create, which is not true.
Several other output formats could be regarded as BOMs, too, as "BOM" is
not a well-defined term.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>