### PR TITLE
reporter: Filter out excluded license findings by default

### DIFF
--- a/reporter/src/funTest/kotlin/reporters/AsciidocTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/AsciidocTemplateReporterFunTest.kt
@@ -37,7 +37,7 @@ class AsciidocTemplateReporterFunTest : StringSpec({
     "PDF output is created successfully from an existing result and default template" {
         val report = generateReport(ORT_RESULT)
 
-        report.single().length() shouldBe 84514L
+        report.single().length() shouldBe 82361L
     }
 
     "Report generation is aborted when path to non-existing pdf-them file is given" {

--- a/reporter/src/main/kotlin/reporters/AmazonOssAttributionBuilderReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AmazonOssAttributionBuilderReporter.kt
@@ -104,7 +104,7 @@ class AmazonOssAttributionBuilderReporter : Reporter {
                 // URL passed into the Amazon Oss Attribution Builder needs to be reachable!
                 val pkgUrl = pkg.homepageUrl.takeUnless { it.isEmpty() } ?: "https://github.com/404"
 
-                val licenseInfo = input.licenseInfoResolver.resolveLicenseInfo(pkg.id)
+                val licenseInfo = input.licenseInfoResolver.resolveLicenseInfo(pkg.id).filterExcluded()
 
                 val allCopyrights = licenseInfo.filter(LicenseView.ONLY_DETECTED).flatMapTo(mutableSetOf()) {
                     it.getCopyrights()

--- a/reporter/src/main/kotlin/reporters/AntennaAttributionDocumentReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AntennaAttributionDocumentReporter.kt
@@ -173,8 +173,8 @@ class AntennaAttributionDocumentReporter : Reporter {
                 }
 
                 val artifacts = packages.map { pkg ->
-                    val resolvedLicense =
-                        input.licenseInfoResolver.resolveLicenseInfo(pkg.id).filter(LicenseView.CONCLUDED_OR_REST)
+                    val resolvedLicense = input.licenseInfoResolver.resolveLicenseInfo(pkg.id)
+                        .filterExcluded().filter(LicenseView.CONCLUDED_OR_REST)
 
                     AttributionDocumentPdfModel(
                         purl = pkg.purl,
@@ -187,7 +187,8 @@ class AntennaAttributionDocumentReporter : Reporter {
                 }.toList()
 
                 val projectCopyright = createCopyrightStatement(
-                    input.licenseInfoResolver.resolveLicenseInfo(project.id).filter(LicenseView.CONCLUDED_OR_REST)
+                    input.licenseInfoResolver.resolveLicenseInfo(project.id)
+                        .filterExcluded().filter(LicenseView.CONCLUDED_OR_REST)
                 )
 
                 val workingDir = createTempDirectory("$ORT_NAME-antenna-reporter").toFile()

--- a/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
+++ b/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
@@ -149,7 +149,7 @@ class CycloneDxReporter : Reporter {
 
                 bom.addExternalReference(ExternalReference.Type.WEBSITE, project.homepageUrl)
 
-                val licenseNames = input.licenseInfoResolver.resolveLicenseInfo(project.id)
+                val licenseNames = input.licenseInfoResolver.resolveLicenseInfo(project.id).filterExcluded()
                     .getLicenseNames(LicenseSource.DECLARED, LicenseSource.DETECTED)
 
                 bom.addExternalReference(ExternalReference.Type.LICENSE, licenseNames.joinToString(", "))
@@ -182,7 +182,7 @@ class CycloneDxReporter : Reporter {
     }
 
     private fun addPackageToBom(input: ReporterInput, pkg: Package, bom: Bom, dependencyType: String) {
-        val resolvedLicenseInfo = input.licenseInfoResolver.resolveLicenseInfo(pkg.id)
+        val resolvedLicenseInfo = input.licenseInfoResolver.resolveLicenseInfo(pkg.id).filterExcluded()
 
         val concludedLicenseNames = resolvedLicenseInfo.getLicenseNames(LicenseSource.CONCLUDED)
         val declaredLicenseNames = resolvedLicenseInfo.getLicenseNames(LicenseSource.DECLARED)

--- a/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
@@ -146,7 +146,7 @@ class FreemarkerTemplateProcessor(
          * The resolved license information for the package.
          */
         val license: ResolvedLicenseInfo by lazy {
-            val resolved = input.licenseInfoResolver.resolveLicenseInfo(id)
+            val resolved = input.licenseInfoResolver.resolveLicenseInfo(id).filterExcluded()
             resolved.copy(licenses = resolved.licenses.sortedBy { it.license.toString() })
         }
 

--- a/reporter/src/main/resources/templates/asciidoc/default.ftl
+++ b/reporter/src/main/resources/templates/asciidoc/default.ftl
@@ -51,14 +51,15 @@ The applicable license information is listed below:
 == Project Licenses
 [#list mergedLicenses as resolvedLicense]
 
-* <<${resolvedLicense.license}, ${resolvedLicense.license}>>
+* License: <<${resolvedLicense.license}, ${resolvedLicense.license}>>
 
 [#assign copyrights = resolvedLicense.getCopyrights(true)]
 [#list copyrights as copyright]
-
-** ${copyright}
-
+** +${copyright}+
+[#else]
+** No copyright found
 [/#list]
+
 [/#list]
 [/#if]
 <<<
@@ -79,21 +80,15 @@ Package: [#if package.id.namespace?has_content]${package.id.namespace}:[/#if]${p
 [#-- List the content of archived license files and associated copyrights. --]
 [#list package.licenseFiles.files as licenseFile]
 
-License File:
-
-* <<${licenseFile.path}, ${licenseFile.path}>>
-
-* Copyrights:
+License File: <<${licenseFile.path}, ${licenseFile.path}>>
 
 [#assign copyrights = licenseFile.getCopyrights()]
-[#if copyrights?has_content]
-
 [#list copyrights as copyright]
-
 ** +${copyright}+
-
+[#else]
+** No copyright found
 [/#list]
-[/#if]
+
 [/#list]
 [#--
 Filter the licenses of the package using LicenseView.CONCLUDED_OR_REST. This is the default view which ignores declared
@@ -106,23 +101,20 @@ resolvedLicenses =
 ]
 [#if resolvedLicenses?has_content]
 
-The following copyrights and licenses were found in the source code of this package:
+The following licenses and copyrights were found in the source code of this package:
 [/#if]
 
 [#list resolvedLicenses as resolvedLicense]
 
-License:
-
-* <<${resolvedLicense.license}, ${resolvedLicense.license}>>
-
-* Copyrights:
+* License: <<${resolvedLicense.license}, ${resolvedLicense.license}>>
 
 [#assign copyrights = resolvedLicense.getCopyrights(true)]
 [#list copyrights as copyright]
-
 ** +${copyright}+
-
+[#else]
+** No copyright found
 [/#list]
+
 [/#list]
 [/#if]
 [/#list]
@@ -143,9 +135,7 @@ Append the text of all licenses that have been listed in the above lists for lic
 
 [#assign copyrights = resolvedLicense.getCopyrights(true)]
 [#list copyrights as copyright]
-
 ${copyright}
-
 [/#list]
 
 ${licenseText}
@@ -171,9 +161,7 @@ ${exceptionText}
 [#assign copyrights = licenseFile.getCopyrights()]
 [#if copyrights?has_content]
 [#list copyrights as copyright]
-
 ${copyright}
-
 [/#list]
 
 ${licenseFile.readFile()}


### PR DESCRIPTION
For those reporters that to dot display excluded license findings in a
special way, align on filtering them out, as that is what users usually
expect.

Fixes #3363.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>