### PR TITLE
Rename NexusIqConfiguration & serialization test

### DIFF
--- a/advisor/src/main/kotlin/advisors/NexusIq.kt
+++ b/advisor/src/main/kotlin/advisors/NexusIq.kt
@@ -36,7 +36,7 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Vulnerability
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
-import org.ossreviewtoolkit.model.config.NexusIqConfiguration
+import org.ossreviewtoolkit.model.config.BasicAuthConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.nexusiq.NexusIqService
 import org.ossreviewtoolkit.utils.NamedThreadFactory
@@ -58,7 +58,7 @@ class NexusIq(
         override fun create(config: AdvisorConfiguration) = NexusIq(advisorName, config)
     }
 
-    private val nexusIqConfig = config as NexusIqConfiguration
+    private val nexusIqConfig = config as BasicAuthConfiguration
 
     override suspend fun retrievePackageVulnerabilities(packages: List<Package>): Map<Package, List<AdvisorResult>> {
         val service = NexusIqService.create(

--- a/cli/src/main/kotlin/commands/AdvisorCommand.kt
+++ b/cli/src/main/kotlin/commands/AdvisorCommand.kt
@@ -39,7 +39,7 @@ import org.ossreviewtoolkit.advisor.Advisor
 import org.ossreviewtoolkit.advisor.advisors.NexusIq
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
-import org.ossreviewtoolkit.model.config.NexusIqConfiguration
+import org.ossreviewtoolkit.model.config.BasicAuthConfiguration
 import org.ossreviewtoolkit.model.mapper
 import org.ossreviewtoolkit.model.utils.mergeLabels
 import org.ossreviewtoolkit.utils.ORT_CONFIG_FILENAME
@@ -94,7 +94,7 @@ class AdvisorCommand : CliktCommand(name = "advise", help = "Run vulnerability d
 
     private fun configureAdvisor(advisorConfiguration: AdvisorConfiguration?): Advisor {
         val config = when (advisorConfiguration) {
-            is NexusIqConfiguration -> advisorConfiguration
+            is BasicAuthConfiguration -> advisorConfiguration
             null -> throw IllegalArgumentException(
                 "No advisor configuration found in ${ortConfigDirectory.resolve(ORT_CONFIG_FILENAME)}"
             )

--- a/model/src/main/kotlin/config/AdvisorConfiguration.kt
+++ b/model/src/main/kotlin/config/AdvisorConfiguration.kt
@@ -28,14 +28,14 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS)
 @JsonSubTypes(
-    JsonSubTypes.Type(NexusIqConfiguration::class)
+    JsonSubTypes.Type(BasicAuthConfiguration::class)
 )
 sealed class AdvisorConfiguration
 
 /**
- * The configuration for the Nexus IQ Server security vulnerability provider.
+ * The configuration for a security vulnerability provider using basic auth as authentication method.
  */
-data class NexusIqConfiguration(
+data class BasicAuthConfiguration(
     /**
      * The base URL of the provider.
      */

--- a/model/src/test/assets/reference.conf
+++ b/model/src/test/assets/reference.conf
@@ -1,6 +1,14 @@
 // A reference configuration file containing all possible ORT configuration options. Some of those options are mutually
 // exclusive, so this file is only used to show all options and to validate the configuration.
 ort {
+  advisor {
+    nexusiq {
+      serverUrl = "https://your-nexus-iq-server"
+      username = username
+      password = password
+    }
+  }
+
   scanner {
     archive {
       patterns = ["LICENSE*", "COPYING*"]

--- a/model/src/test/kotlin/config/BasicAuthConfigurationTest.kt
+++ b/model/src/test/kotlin/config/BasicAuthConfigurationTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.config
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+import java.io.File
+
+import kotlin.io.path.createTempFile
+
+import org.ossreviewtoolkit.model.mapper
+import org.ossreviewtoolkit.model.readValue
+
+class BasicAuthConfigurationTest : WordSpec({
+    "BasicAuthConfiguration" should {
+        "support a serialization round-trip via an ObjectMapper" {
+            val referenceOrtConfig = OrtConfiguration.load(configFile = File("src/test/assets/reference.conf"))
+            val rereadOrtConfig = createTempFile(suffix = ".yml").toFile().apply {
+                mapper().writeValue(this, referenceOrtConfig)
+                deleteOnExit()
+            }.readValue<OrtConfiguration>()
+
+            val expectedOrtBasicAuthConfig = referenceOrtConfig.advisor?.get("nexusiq")
+            val actualBasicAuthConfiguration = rereadOrtConfig.advisor?.get("nexusiq")
+
+            expectedOrtBasicAuthConfig.shouldBeInstanceOf<BasicAuthConfiguration>()
+            actualBasicAuthConfiguration.shouldBeInstanceOf<BasicAuthConfiguration>()
+            actualBasicAuthConfiguration.serverUrl shouldBe expectedOrtBasicAuthConfig.serverUrl
+            actualBasicAuthConfiguration.username shouldBe expectedOrtBasicAuthConfig.username
+        }
+    }
+})


### PR DESCRIPTION
This PR renames the NexusIqConfiguration to BasicAuthConfiguration as no NexusIq specifics are stored in this configuration.

Added an example configuration to reference.conf and wrote an test case for the (de-) serialization of the configuration