### PR TITLE
helper-cli: Start indexing scan results

### DIFF
--- a/helper-cli/src/main/kotlin/HelperMain.kt
+++ b/helper-cli/src/main/kotlin/HelperMain.kt
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.core.config.Configurator
 import org.ossreviewtoolkit.helper.commands.ExportLicenseFindingCurationsCommand
 import org.ossreviewtoolkit.helper.commands.ExportPathExcludesCommand
 import org.ossreviewtoolkit.helper.commands.ExtractRepositoryConfigurationCommand
+import org.ossreviewtoolkit.helper.commands.ImportScanResultsCommand
 import org.ossreviewtoolkit.helper.commands.FormatRepositoryConfigurationCommand
 import org.ossreviewtoolkit.helper.commands.GeneratePackageConfigurationsCommand
 import org.ossreviewtoolkit.helper.commands.GenerateProjectExcludesCommand
@@ -89,6 +90,7 @@ internal class HelperMain : CliktCommand(name = ORTH_NAME, epilog = "* denotes r
             ImportCopyrightGarbageCommand(),
             ImportLicenseFindingCurationsCommand(),
             ImportPathExcludesCommand(),
+            ImportScanResultsCommand(),
             ListCopyrightsCommand(),
             ListLicenseCategoriesCommand(),
             ListLicensesCommand(),

--- a/helper-cli/src/main/kotlin/HelperMain.kt
+++ b/helper-cli/src/main/kotlin/HelperMain.kt
@@ -33,7 +33,6 @@ import org.apache.logging.log4j.core.config.Configurator
 import org.ossreviewtoolkit.helper.commands.ExportLicenseFindingCurationsCommand
 import org.ossreviewtoolkit.helper.commands.ExportPathExcludesCommand
 import org.ossreviewtoolkit.helper.commands.ExtractRepositoryConfigurationCommand
-import org.ossreviewtoolkit.helper.commands.ImportScanResultsCommand
 import org.ossreviewtoolkit.helper.commands.FormatRepositoryConfigurationCommand
 import org.ossreviewtoolkit.helper.commands.GeneratePackageConfigurationsCommand
 import org.ossreviewtoolkit.helper.commands.GenerateProjectExcludesCommand
@@ -43,6 +42,7 @@ import org.ossreviewtoolkit.helper.commands.GenerateTimeoutErrorResolutionsComma
 import org.ossreviewtoolkit.helper.commands.ImportCopyrightGarbageCommand
 import org.ossreviewtoolkit.helper.commands.ImportLicenseFindingCurationsCommand
 import org.ossreviewtoolkit.helper.commands.ImportPathExcludesCommand
+import org.ossreviewtoolkit.helper.commands.ImportScanResultsCommand
 import org.ossreviewtoolkit.helper.commands.ListCopyrightsCommand
 import org.ossreviewtoolkit.helper.commands.ListLicenseCategoriesCommand
 import org.ossreviewtoolkit.helper.commands.ListLicensesCommand

--- a/helper-cli/src/main/kotlin/commands/ImportScanResultsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportScanResultsCommand.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.file
+
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.scanner.storages.FileBasedStorage
+import org.ossreviewtoolkit.utils.expandTilde
+import org.ossreviewtoolkit.utils.storage.LocalFileStorage
+
+internal class ImportScanResultsCommand : CliktCommand(
+    help = "Import all scan results from the given ORT result file to the file based scan results storage directory."
+) {
+    private val ortResultFile by option(
+        "--ort-result-file",
+        help = "The input ORT file from which repository configuration shall be extracted."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val scanResultsStorageDir by option(
+        "--scan-results-storage-dir",
+        help = "The scan results storage to import the scan results to."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = false, canBeDir = true, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    override fun run() {
+        val ortResult = ortResultFile.readValue<OrtResult>()
+        val scanResultsStorage = FileBasedStorage(LocalFileStorage(scanResultsStorageDir))
+        val ids = ortResult.getProjects().map { it.id } + ortResult.getPackages().map { it.pkg.id }
+
+        ids.forEach { id ->
+            ortResult.getScanResultsForId(id).forEach { scanResult ->
+                scanResultsStorage.add(id, scanResult)
+            }
+        }
+    }
+}


### PR DESCRIPTION
To allow the (future) implementation of commands taking scan results from that storage as input.
Adjust a first command to do so already to illustrate the idea and to speed-up that command.
