### PR TITLE
GitRepoFunTest: Do like the comment says and keep the shortened path

### DIFF
--- a/analyzer/src/funTest/kotlin/GitRepoFunTest.kt
+++ b/analyzer/src/funTest/kotlin/GitRepoFunTest.kt
@@ -50,7 +50,7 @@ class GitRepoFunTest : StringSpec() {
     override fun beforeSpec(spec: Spec) {
         // Do not use the class name as a suffix here to shorten the path. Otherwise the path will get too long for
         // Windows to handle.
-        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
+        outputDir = createTempDirectory(ORT_NAME).toFile()
 
         val vcs = VcsInfo(VcsType.GIT_REPO, REPO_URL, REPO_REV, path = REPO_MANIFEST)
         val pkg = Package.EMPTY.copy(vcsProcessed = vcs)


### PR DESCRIPTION
This reverts a change from 97561f6 and makes the test run again on
Windows.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>