### PR TITLE
ScanResult: Keep the raw result in filterPath()

### DIFF
--- a/model/src/main/kotlin/ScanResult.kt
+++ b/model/src/main/kotlin/ScanResult.kt
@@ -84,6 +84,6 @@ data class ScanResult(
             copyrightFindings = copyrightFindings
         )
 
-        return ScanResult(newProvenance, scanner, summary)
+        return ScanResult(newProvenance, scanner, summary, rawResult)
     }
 }


### PR DESCRIPTION
If a non-empty path was passed to the `filterPath()` function it always
removed the raw scan result. As a result, scan results for packages with
a VCS path were never stored in the scan results storage, because the
storage only stores scan results which contain a raw result.