### PR TITLE
helper-cli: Support working with package configurations

### DIFF
--- a/helper-cli/src/main/kotlin/HelperMain.kt
+++ b/helper-cli/src/main/kotlin/HelperMain.kt
@@ -54,6 +54,7 @@ import org.ossreviewtoolkit.helper.commands.RemoveConfigurationEntriesCommand
 import org.ossreviewtoolkit.helper.commands.SortRepositoryConfigurationCommand
 import org.ossreviewtoolkit.helper.commands.SubtractScanResultsCommand
 import org.ossreviewtoolkit.helper.commands.VerifySourceArtifactCurationsCommand
+import org.ossreviewtoolkit.helper.commands.packageconfig.PackageConfigurationCommand
 import org.ossreviewtoolkit.helper.common.ORTH_NAME
 import org.ossreviewtoolkit.utils.printStackTrace
 
@@ -98,6 +99,7 @@ internal class HelperMain : CliktCommand(name = ORTH_NAME, epilog = "* denotes r
             ListStoredScanResultsCommand(),
             MapCopyrightsCommand(),
             MergeRepositoryConfigurationsCommand(),
+            PackageConfigurationCommand(),
             RemoveConfigurationEntriesCommand(),
             SortRepositoryConfigurationCommand(),
             SubtractScanResultsCommand(),

--- a/helper-cli/src/main/kotlin/commands/packageconfig/FindCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/FindCommand.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands.packageconfig
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.file
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.config.PackageConfiguration
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider.Companion.findPackageConfigurationFiles
+import org.ossreviewtoolkit.utils.expandTilde
+
+internal class FindCommand : CliktCommand(
+    help = "Searches the given directory for a package configuration file matching the given identifier." +
+            "If found the absolute path is written to the output."
+) {
+    private val packageId by option(
+        "--package-id",
+        help = "The target package for which the package configurations shall be searched."
+    ).convert { Identifier(it) }
+        .required()
+
+    private val packageConfigurationDir by option(
+        "--package-configuration-dir",
+        help = "The package configurations directory."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = false, canBeDir = true, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    override fun run() {
+        // TODO: There could be multiple package configurations matching the given identifier which is not handled.
+        findPackageConfigurationFiles(packageConfigurationDir).find {
+            it.readValue<PackageConfiguration>().id == packageId
+        }?.let {
+            println(it.absolutePath)
+        }
+    }
+}

--- a/helper-cli/src/main/kotlin/commands/packageconfig/FormatCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/FormatCommand.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands.packageconfig
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.convert
+import com.github.ajalt.clikt.parameters.types.file
+
+import org.ossreviewtoolkit.helper.common.writeAsYaml
+import org.ossreviewtoolkit.model.config.PackageConfiguration
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.utils.expandTilde
+
+internal class FormatCommand : CliktCommand(
+    help = "Applies the formatting used by all ort-helper commands and strips all YAML comments. The output is " +
+            "written to the given package configuration file."
+) {
+    private val packageConfigurationFile by argument(
+        "package-configuration-file",
+        help = "The package configuration file to be formatted."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+
+    override fun run() {
+        packageConfigurationFile
+            .readValue<PackageConfiguration>()
+            .writeAsYaml(packageConfigurationFile)
+    }
+}

--- a/helper-cli/src/main/kotlin/commands/packageconfig/ImportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/ImportLicenseFindingCurationsCommand.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands.packageconfig
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.file
+
+import org.ossreviewtoolkit.helper.common.getScanResultFor
+import org.ossreviewtoolkit.helper.common.importLicenseFindingCurations
+import org.ossreviewtoolkit.helper.common.mergeLicenseFindingCurations
+import org.ossreviewtoolkit.helper.common.sortLicenseFindingCurations
+import org.ossreviewtoolkit.helper.common.writeAsYaml
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.config.PackageConfiguration
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
+import org.ossreviewtoolkit.utils.expandTilde
+
+class ImportLicenseFindingCurationsCommand : CliktCommand(
+    help = "Import license finding curations from a license finding curations file and merge them into the given "
+            + "package configuration."
+) {
+    private val licenseFindingCurationsFile by option(
+        "--license-finding-curations-file",
+        help = "The input license finding curations file."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val ortResultFile by option(
+        "--ort-result-file",
+        help = "The ORT file containing the findings the imported curations need to match against."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val packageConfigurationFile by option(
+        "--package-configuration-file",
+        help = "The package configuration file where the imported curations are to be merged into."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val sourceCodeDir by option(
+        "--source-code-dir",
+        help = "A directory containing the sources for the provenance matching the given package configuration."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = false, canBeDir = true, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val updateOnlyExisting by option(
+        "--update-only-existing",
+        help = "If enabled, only entries are imported for which an entry already exists which differs only in terms " +
+                "of its concluded license, comment or reason."
+    ).flag()
+
+    private val findingCurationMatcher = FindingCurationMatcher()
+
+    override fun run() {
+        val ortResult = ortResultFile.readValue<OrtResult>()
+        val packageConfiguration = packageConfigurationFile.readValue<PackageConfiguration>()
+
+        val allLicenseFindings = ortResult.getScanResultFor(packageConfiguration)?.summary?.licenseFindings.orEmpty()
+
+        val importedCurations = importLicenseFindingCurations(sourceCodeDir, licenseFindingCurationsFile)
+            .filter { curation ->
+                allLicenseFindings.any { finding ->
+                    findingCurationMatcher.matches(finding, curation)
+                }
+            }
+
+        val existingCurations = packageConfiguration.licenseFindingCurations
+        val curations = existingCurations
+            .mergeLicenseFindingCurations(importedCurations, updateOnlyExisting)
+            .sortLicenseFindingCurations()
+
+        packageConfiguration
+            .copy(licenseFindingCurations = curations)
+            .writeAsYaml(packageConfigurationFile)
+    }
+}

--- a/helper-cli/src/main/kotlin/commands/packageconfig/ImportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/ImportPathExcludesCommand.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands.packageconfig
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.file
+
+import org.ossreviewtoolkit.helper.common.findFilesRecursive
+import org.ossreviewtoolkit.helper.common.importPathExcludes
+import org.ossreviewtoolkit.helper.common.mergePathExcludes
+import org.ossreviewtoolkit.helper.common.sortPathExcludes
+import org.ossreviewtoolkit.helper.common.writeAsYaml
+import org.ossreviewtoolkit.model.config.PackageConfiguration
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.utils.expandTilde
+
+class ImportPathExcludesCommand : CliktCommand(
+    help = "Import path excludes by repository from a file into the given package configuration."
+) {
+    private val pathExcludesFile by option(
+        "--path-excludes-file",
+        help = "The input path excludes file."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val packageConfigurationFile by option(
+        "--package-configuration-file",
+        help = "The package configuration."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = true, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val sourceCodeDir by option(
+        "--source-code-dir",
+        help = "A directory containing the sources for the provenance matching the given package configuration."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = false, canBeDir = true, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val updateOnlyExisting by option(
+        "--update-only-existing",
+        help = "If enabled, only entries are imported for which an entry with the same pattern already exists."
+    ).flag()
+
+    override fun run() {
+        val allFiles = findFilesRecursive(sourceCodeDir)
+
+        val packageConfiguration = packageConfigurationFile.readValue<PackageConfiguration>()
+
+        val existingPathExcludes = packageConfiguration.pathExcludes
+        val importedPathExcludes = importPathExcludes(sourceCodeDir, pathExcludesFile).filter { pathExclude ->
+            allFiles.any { pathExclude.matches(it) }
+        }
+
+        val pathExcludes = existingPathExcludes
+            .mergePathExcludes(importedPathExcludes, updateOnlyExisting)
+            .sortPathExcludes()
+
+        packageConfiguration
+            .copy(pathExcludes = pathExcludes)
+            .writeAsYaml(packageConfigurationFile)
+    }
+}

--- a/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
@@ -29,6 +29,7 @@ internal class PackageConfigurationCommand : CliktCommand(
         subcommands(
             FindCommand(),
             FormatCommand(),
+            ImportPathExcludesCommand(),
             SortCommand(),
             RemoveEntriesCommand()
         )

--- a/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
@@ -28,7 +28,8 @@ internal class PackageConfigurationCommand : CliktCommand(
     init {
         subcommands(
             FindCommand(),
-            FormatCommand()
+            FormatCommand(),
+            SortCommand()
         )
     }
 

--- a/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands.packageconfig
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.subcommands
+
+internal class PackageConfigurationCommand : CliktCommand(
+    help = "Commands for working with package configurations."
+) {
+    init {
+        subcommands(
+            FindCommand()
+        )
+    }
+
+    override fun run() {
+        // Intentionally empty, because all logic is implemented inside the sub commands..
+    }
+}

--- a/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
@@ -27,7 +27,8 @@ internal class PackageConfigurationCommand : CliktCommand(
 ) {
     init {
         subcommands(
-            FindCommand()
+            FindCommand(),
+            FormatCommand()
         )
     }
 

--- a/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
@@ -29,7 +29,8 @@ internal class PackageConfigurationCommand : CliktCommand(
         subcommands(
             FindCommand(),
             FormatCommand(),
-            SortCommand()
+            SortCommand(),
+            RemoveEntriesCommand()
         )
     }
 

--- a/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
@@ -29,6 +29,7 @@ internal class PackageConfigurationCommand : CliktCommand(
         subcommands(
             FindCommand(),
             FormatCommand(),
+            ImportLicenseFindingCurationsCommand(),
             ImportPathExcludesCommand(),
             SortCommand(),
             RemoveEntriesCommand()

--- a/helper-cli/src/main/kotlin/commands/packageconfig/RemoveEntriesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/RemoveEntriesCommand.kt
@@ -25,6 +25,7 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
+import org.ossreviewtoolkit.helper.common.getScanResultFor
 import org.ossreviewtoolkit.helper.common.writeAsYaml
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.ScanResult
@@ -34,7 +35,7 @@ import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.utils.expandTilde
 
 internal class RemoveEntriesCommand : CliktCommand(
-    help = "Removes all non-matching path excludes and license finding curations."
+    help = "Removes all path excludes and license finding curations which do not match any files or license findings."
 ) {
     private val packageConfigurationFile by option(
         "--package-configuration-file",
@@ -92,11 +93,6 @@ internal class RemoveEntriesCommand : CliktCommand(
         }.let { println(it) }
     }
 }
-
-private fun OrtResult.getScanResultFor(packageConfiguration: PackageConfiguration): ScanResult? =
-    getScanResultsForId(packageConfiguration.id).find { scanResult ->
-        packageConfiguration.matches(packageConfiguration.id, scanResult.provenance)
-    }
 
 private fun ScanResult.getAllFiles(): List<String> =
     with(summary) {

--- a/helper-cli/src/main/kotlin/commands/packageconfig/RemoveEntriesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/RemoveEntriesCommand.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands.packageconfig
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.file
+
+import org.ossreviewtoolkit.helper.common.writeAsYaml
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.config.PackageConfiguration
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
+import org.ossreviewtoolkit.utils.expandTilde
+
+internal class RemoveEntriesCommand : CliktCommand(
+    help = "Removes all non-matching path excludes and license finding curations."
+) {
+    private val packageConfigurationFile by option(
+        "--package-configuration-file",
+        help = "The package configuration."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = true, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val ortResultFile by option(
+        "--ort-result-file",
+        help = "The ORT result file to read as input which should contain a scan result to which the given " +
+                "package configuration applies to."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val findingsMatcher = FindingCurationMatcher()
+
+    override fun run() {
+        val packageConfiguration = packageConfigurationFile.readValue<PackageConfiguration>()
+        val ortResult = ortResultFile.readValue<OrtResult>()
+        val scanResult = ortResult.getScanResultFor(packageConfiguration)
+
+        if (scanResult == null) {
+            println("No scan result found for the given provenance matching id '${packageConfiguration.id}'.")
+            return
+        }
+
+        val allFiles = scanResult.getAllFiles()
+
+        val pathExcludes = packageConfiguration.pathExcludes.filter { pathExclude ->
+            allFiles.any { pathExclude.matches(it) }
+        }
+
+        val licenseFindingCurations = packageConfiguration.licenseFindingCurations.filter { curation ->
+            scanResult.summary.licenseFindings.any { finding -> findingsMatcher.matches(finding, curation) }
+        }
+
+        packageConfiguration.copy(
+            pathExcludes = pathExcludes,
+            licenseFindingCurations = licenseFindingCurations
+        ).writeAsYaml(packageConfigurationFile)
+
+        buildString {
+            val removedPathExcludes = packageConfiguration.pathExcludes.size - pathExcludes.size
+            val removedLicenseFindingCurations = packageConfiguration.licenseFindingCurations.size -
+                    licenseFindingCurations.size
+
+            appendLine("Removed entries:")
+            appendLine()
+            appendLine("  path excludes             : $removedPathExcludes")
+            appendLine("  license finding curations : $removedLicenseFindingCurations")
+        }.let { println(it) }
+    }
+}
+
+private fun OrtResult.getScanResultFor(packageConfiguration: PackageConfiguration): ScanResult? =
+    getScanResultsForId(packageConfiguration.id).find { scanResult ->
+        packageConfiguration.matches(packageConfiguration.id, scanResult.provenance)
+    }
+
+private fun ScanResult.getAllFiles(): List<String> =
+    with(summary) {
+        licenseFindings.map { it.location.path } + copyrightFindings.map { it.location.path }
+    }.distinct()

--- a/helper-cli/src/main/kotlin/commands/packageconfig/SortCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/SortCommand.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands.packageconfig
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.convert
+import com.github.ajalt.clikt.parameters.types.file
+
+import org.ossreviewtoolkit.helper.common.sortEntries
+import org.ossreviewtoolkit.helper.common.writeAsYaml
+import org.ossreviewtoolkit.model.config.PackageConfiguration
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.utils.expandTilde
+
+internal class SortCommand : CliktCommand(
+    help = "Sorts all exclude and curation entries of the given package configuration alphabetically. The output " +
+            "is written to the given package configuration file."
+) {
+    private val packageConfigurationFile by argument(
+        "package-configuration-file",
+        help = "The package configuration file to be sorted."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+
+    override fun run() {
+        packageConfigurationFile
+            .readValue<PackageConfiguration>()
+            .sortEntries()
+            .writeAsYaml(packageConfigurationFile)
+    }
+}

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -45,6 +45,7 @@ import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Repository
 import org.ossreviewtoolkit.model.RuleViolation
+import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
@@ -787,3 +788,11 @@ internal fun importPathExcludes(sourceCodeDir: File, pathExcludesFile: File): Li
 
     return result
 }
+
+/**
+ * Return the scan result matching the given package configuration if any or null otherwise.
+ */
+internal fun OrtResult.getScanResultFor(packageConfiguration: PackageConfiguration): ScanResult? =
+    getScanResultsForId(packageConfiguration.id).find { scanResult ->
+        packageConfiguration.matches(packageConfiguration.id, scanResult.provenance)
+    }

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -498,9 +498,7 @@ internal fun RepositoryConfiguration.sortEntries(): RepositoryConfiguration =
 internal fun RepositoryConfiguration.sortLicenseFindingCurations(): RepositoryConfiguration =
     copy(
         curations = curations.copy(
-            licenseFindings = curations.licenseFindings.sortedBy { curation ->
-                curation.path.removePrefix("*").removePrefix("*")
-            }
+            licenseFindings = curations.licenseFindings.sortLicenseFindingCurations()
         )
     )
 
@@ -654,6 +652,14 @@ internal fun Collection<LicenseFindingCuration>.mergeLicenseFindingCurations(
 
     return result.values.toList()
 }
+
+/**
+ * Return a copy with the [LicenseFindingCuration]s sorted.
+ */
+internal fun Collection<LicenseFindingCuration>.sortLicenseFindingCurations(): List<LicenseFindingCuration> =
+    sortedBy { curation ->
+        curation.path.removePrefix("*").removePrefix("*")
+    }
 
 private data class LicenseFindingCurationHashKey(
     val path: String,

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -789,6 +789,33 @@ internal fun importPathExcludes(sourceCodeDir: File, pathExcludesFile: File): Li
     return result
 }
 
+internal fun importLicenseFindingCurations(
+    sourceCodeDir: File,
+    licenseFindingCurationsFile: File
+): List<LicenseFindingCuration> {
+    println("Analyzing $sourceCodeDir...")
+    val repositoryPaths = findRepositoryPaths(sourceCodeDir)
+    println("Found ${repositoryPaths.size} repositories in ${repositoryPaths.values.sumBy { it.size }} locations.")
+
+    println("Loading $licenseFindingCurationsFile...")
+    val curations = licenseFindingCurationsFile.readValue<RepositoryLicenseFindingCurations>()
+    println("Found ${curations.values.sumBy { it.size }} curations for ${curations.size} repositories.")
+
+    val result = mutableListOf<LicenseFindingCuration>()
+
+    repositoryPaths.forEach { (vcsUrl, relativePaths) ->
+        curations[vcsUrl]?.let { curationsForRepository ->
+            curationsForRepository.forEach { curation ->
+                relativePaths.forEach { path ->
+                    result += curation.copy(path = path + '/' + curation.path)
+                }
+            }
+        }
+    }
+
+    return result
+}
+
 /**
  * Return the scan result matching the given package configuration if any or null otherwise.
  */

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -455,6 +455,15 @@ fun OrtResult.replaceConfig(respositoryConfigurationFile: File?): OrtResult =
     } ?: this
 
 /**
+ * Return a copy with sorting applied to all entry types which are to be sorted.
+ */
+internal fun PackageConfiguration.sortEntries(): PackageConfiguration =
+    copy(
+        pathExcludes = pathExcludes.sortPathExcludes(),
+        licenseFindingCurations = licenseFindingCurations.sortLicenseFindingCurations()
+    )
+
+/**
  * Return a copy with the [IssueResolution]s replaced by the given [issueResolutions].
  */
 internal fun RepositoryConfiguration.replaceIssueResolutions(

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -510,9 +510,7 @@ internal fun RepositoryConfiguration.sortLicenseFindingCurations(): RepositoryCo
 internal fun RepositoryConfiguration.sortPathExcludes(): RepositoryConfiguration =
     copy(
         excludes = excludes.copy(
-            paths = excludes.paths.sortedBy { pathExclude ->
-                pathExclude.pattern.removePrefix("*").removePrefix("*")
-            }
+            paths = excludes.paths.sortPathExcludes()
         )
     )
 
@@ -688,6 +686,12 @@ internal fun Collection<PathExclude>.mergePathExcludes(
 
     return result.values.toList()
 }
+
+/**
+ * Return a copy with the [PathExclude]s sorted.
+ */
+internal fun Collection<PathExclude>.sortPathExcludes(): List<PathExclude> =
+    sortedBy { it.pattern.removePrefix("*").removePrefix("*") }
 
 /**
  * Merge the given [ScopeExclude]s replacing entries with equal [ScopeExclude.pattern].

--- a/model/src/main/kotlin/utils/SimplePackageConfigurationProvider.kt
+++ b/model/src/main/kotlin/utils/SimplePackageConfigurationProvider.kt
@@ -48,18 +48,19 @@ class SimplePackageConfigurationProvider(
          * configuration per [Identifier] and [Provenance].
          */
         fun forDirectory(directory: File): SimplePackageConfigurationProvider {
-            val entries = directory.walkBottomUp()
-                .filter { !it.isHidden && it.isFile }
-                .mapTo(mutableListOf()) { file ->
-                    try {
-                        file.readValue<PackageConfiguration>()
-                    } catch (e: IOException) {
-                        throw IOException("Error reading package configuration from '${file.absoluteFile}'.", e)
-                    }
+            val entries = findPackageConfigurationFiles(directory).mapTo(mutableListOf()) { file ->
+                try {
+                    file.readValue<PackageConfiguration>()
+                } catch (e: IOException) {
+                    throw IOException("Error reading package configuration from '${file.absoluteFile}'.", e)
                 }
+            }
 
             return SimplePackageConfigurationProvider(entries)
         }
+
+        fun findPackageConfigurationFiles(directory: File): List<File> =
+            directory.walkBottomUp().filter { !it.isHidden && it.isFile }.toList()
 
         /**
          * Return a [SimplePackageConfigurationProvider] which provides all [PackageConfiguration]s found in the given


### PR DESCRIPTION
Provide commands analog (but with slight differences) to the ones for the repository configurations.
Therefore introduce a dedicated Kotline package and add one level of sub command nesting.

Note: A following PR will clean-up the package configuration command and move the repository config commands also into a separate package and sub commend.
