### PR TITLE
Change PURL fallback to package manager type

### DIFF
--- a/advisor/src/main/kotlin/advisors/NexusIq.kt
+++ b/advisor/src/main/kotlin/advisors/NexusIq.kt
@@ -77,9 +77,11 @@ class NexusIq(
             val components = packages.map { pkg ->
                 val packageUrl = buildString {
                     append(pkg.purl)
-                    val purlType = pkg.id.getPurlType()
-                    if (purlType == Identifier.PurlType.MAVEN) append("?type=jar")
-                    if (purlType == Identifier.PurlType.PYPI) append("?extension=tar.gz")
+
+                    when (pkg.id.getPurlType()) {
+                        Identifier.PurlType.MAVEN.toString() -> append("?type=jar")
+                        Identifier.PurlType.PYPI.toString() -> append("?extension=tar.gz")
+                    }
                 }
 
                 NexusIqService.Component(packageUrl)

--- a/clients/nexus-iq/src/main/kotlin/NexusIqService.kt
+++ b/clients/nexus-iq/src/main/kotlin/NexusIqService.kt
@@ -95,7 +95,7 @@ interface NexusIqService {
     data class SecurityIssue(
         val reference: String,
         val severity: Float,
-        val url: URL
+        val url: URL?
     )
 
     data class ComponentsWrapper(

--- a/model/src/main/kotlin/Identifier.kt
+++ b/model/src/main/kotlin/Identifier.kt
@@ -131,8 +131,7 @@ data class Identifier(
     fun toPurl() = "".takeIf { this == EMPTY }
         ?: buildString {
             append("pkg:")
-            val purlType = getPurlType()?.toString() ?: type.toLowerCase()
-            append(purlType)
+            append(getPurlType())
 
             if (namespace.isNotEmpty()) {
                 append('/')
@@ -147,23 +146,25 @@ data class Identifier(
         }
 
     /**
-     * Map a package manager type as to a package url using the package type.
-     * Returns null when package manager cannot be mapped to a package type.
+     * Map a package manager type to the String representation of the respective [PurlType].
+     * Falls back to the lower case package manager type if the [PurlType] cannot be determined.
+     *
+     * E.g. PIP to [PurlType.PYPI] or Gradle to [PurlType.MAVEN].
      */
-    fun getPurlType() = when (type.toLowerCase()) {
-        "bower" -> PurlType.BOWER
-        "bundler" -> PurlType.GEM
-        "cargo" -> PurlType.CARGO
-        "carthage", "pub", "spdx", "stack" -> null
-        "composer" -> PurlType.COMPOSER
-        "conan" -> PurlType.CONAN
-        "dep", "glide", "godep", "gomod" -> PurlType.GOLANG
-        "dotnet", "nuget" -> PurlType.NUGET
-        "gradle", "maven", "sbt" -> PurlType.MAVEN
-        "npm", "yarn" -> PurlType.NPM
-        "pip", "pipenv" -> PurlType.PYPI
-        else -> null
-    }
+    fun getPurlType() =
+        when (val lowerType = type.toLowerCase()) {
+            "bower" -> PurlType.BOWER
+            "bundler" -> PurlType.GEM
+            "cargo" -> PurlType.CARGO
+            "composer" -> PurlType.COMPOSER
+            "conan" -> PurlType.CONAN
+            "dep", "glide", "godep", "gomod" -> PurlType.GOLANG
+            "dotnet", "nuget" -> PurlType.NUGET
+            "gradle", "maven", "sbt" -> PurlType.MAVEN
+            "npm", "yarn" -> PurlType.NPM
+            "pip", "pipenv" -> PurlType.PYPI
+            else -> lowerType
+        }.toString()
 
     enum class PurlType(private val value: String) {
         ALPINE("alpine"),

--- a/model/src/test/kotlin/IdentifierTest.kt
+++ b/model/src/test/kotlin/IdentifierTest.kt
@@ -129,6 +129,18 @@ class IdentifierTest : WordSpec({
             purl shouldBe purl.toLowerCase()
         }
 
+        "Use PURL type instead of package manager type" {
+            val purl = Identifier("gradle", "namespace", "name", "version").toPurl()
+
+            purl shouldStartWith "pkg:maven"
+        }
+
+        "Use given type if it is not a known package manager" {
+            val purl = Identifier("PyPI", "namespace", "name", "version").toPurl()
+
+            purl shouldStartWith "pkg:pypi"
+        }
+
         "not use '/' for empty namespaces" {
             val purl = Identifier("type", "", "name", "version").toPurl()
 


### PR DESCRIPTION
This PR fixes an issue with PIP that [uses PyPi](https://github.com/oss-review-toolkit/ort/blob/master/analyzer/src/main/kotlin/managers/Pip.kt#L553) as the type within `Identity` as opposed to Gradle that uses `gradle` instead of `maven`.

Also Security Vulnerability URLs need to be nullable within Nexus IQ security issues.