### PR TITLE
GitLabLicenseModelMapper: Add a missing dot at the end of a log message

### DIFF
--- a/reporter/src/main/kotlin/gitlab/GitLabLicenseModelMapper.kt
+++ b/reporter/src/main/kotlin/gitlab/GitLabLicenseModelMapper.kt
@@ -119,6 +119,6 @@ private fun Identifier.toPackageManagerName(): String =
         "PIP" -> "pip"
         "Yarn" -> "yarn"
         else -> type.toLowerCase().also {
-            log.info { "No mapping defined for package manager '$type', guessing '$it'" }
+            log.info { "No mapping defined for package manager '$type', guessing '$it'." }
         }
     }


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>