### PR TITLE
Oheger bosch/scanner/#3091 out of memory

### DIFF
--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -44,6 +44,7 @@ import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.mapper
 import org.ossreviewtoolkit.model.utils.mergeLabels
+import org.ossreviewtoolkit.scanner.InMemoryScannerResultBuilder
 import org.ossreviewtoolkit.scanner.LocalScanner
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.scanner.Scanner
@@ -171,12 +172,15 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run existing copyrigh
         val scanner = configureScanner(config.scanner)
 
         val ortResult = if (input.isFile) {
+            val builder = InMemoryScannerResultBuilder()
             scanner.scanOrtResult(
+                builder = builder,
                 ortResultFile = input,
                 outputDirectory = nativeOutputDir,
                 downloadDirectory = downloadDir ?: outputDir.resolve("downloads"),
                 skipExcluded = skipExcluded
             )
+            builder.result()
         } else {
             require(scanner is LocalScanner) {
                 "To scan local files the chosen scanner must be a local scanner."

--- a/reporter/src/funTest/kotlin/reporters/ExcelReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/ExcelReporterFunTest.kt
@@ -46,7 +46,7 @@ class ExcelReporterFunTest : WordSpec({
             val outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile().apply { deleteOnExit() }
             val ortResult = readOrtResult(
                 "../scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml"
-            )
+            ).copy(labels = emptyMap())
 
             val report = ExcelReporter().generateReport(ReporterInput(ortResult), outputDir).single()
             val actualWorkbook = WorkbookFactory.create(report)

--- a/scanner/src/funTest/assets/analyzer-result.yml
+++ b/scanner/src/funTest/assets/analyzer-result.yml
@@ -191,3 +191,5 @@ analyzer:
     has_issues: false
 scanner: null
 evaluator: null
+labels:
+  analyzed: "complete"

--- a/scanner/src/funTest/assets/test-scanner-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/test-scanner-expected-output-for-analyzer-result.yml
@@ -15,7 +15,7 @@ analyzer:
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
   environment:
-    ort_version: "HEAD"
+    ort_version: "<REPLACE_REVISION>"
     java_version: "<REPLACE_JAVA>"
     os: "Linux"
     processors: "<REPLACE_PROCESSORS>"
@@ -196,12 +196,16 @@ scanner:
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
   environment:
-    ort_version: "HEAD"
+    ort_version: "<REPLACE_REVISION>"
     java_version: "<REPLACE_JAVA>"
     os: "<REPLACE_OS>"
     processors: "<REPLACE_PROCESSORS>"
     max_memory: "<REPLACE_MAX_MEMORY>"
-    variables: {}
+    variables:
+      SHELL: "/bin/bash"
+      http_proxy: "http://127.0.0.1:3128/"
+      https_proxy: "http://127.0.0.1:3128/"
+      JAVA_HOME: "/opt/jdk-11.0.2"
     tool_versions: {}
   config:
     archive: null
@@ -216,9 +220,9 @@ scanner:
       - provenance:
           download_time: "1970-01-01T00:00:00Z"
         scanner:
-          name: "FileCounter"
-          version: "1.0"
-          configuration: ""
+          name: "TestScanner"
+          version: "1.0.0"
+          configuration: "testScannerConfig"
         summary:
           start_time: "1970-01-01T00:00:00Z"
           end_time: "1970-01-01T00:00:00Z"
@@ -228,7 +232,7 @@ scanner:
           copyrights: []
           issues:
           - timestamp: "1970-01-01T00:00:00Z"
-            source: "FileCounter"
+            source: "TestScanner"
             message: "Could not download 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0':\
               \ DownloadException: Download failed for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\n\
               Suppressed: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\
@@ -246,16 +250,32 @@ scanner:
               value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
               algorithm: "SHA-1"
         scanner:
-          name: "FileCounter"
-          version: "1.0"
-          configuration: ""
+          name: "TestScanner"
+          version: "1.0.0"
+          configuration: "testScannerConfig"
         summary:
           start_time: "1970-01-01T00:00:00Z"
           end_time: "1970-01-01T00:00:00Z"
-          file_count: 234
-          package_verification_code: "a86513854c8896d354a2d84f51beeaf9b378c233"
-          licenses: []
-          copyrights: []
+          file_count: 1
+          package_verification_code: ""
+          licenses:
+          - license: "ASL-2"
+            location:
+              path: "/tmp/ort-ScannerFunTest-download5339913367497143930/Maven/junit/junit/4.12"
+              start_line: 1
+              end_line: 8
+          copyrights:
+          - statement: "(C) 4.12"
+            location:
+              path: "/tmp/ort-ScannerFunTest-download5339913367497143930/Maven/junit/junit/4.12"
+              start_line: 3
+              end_line: 4
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "NoStorage"
+            message: "Not storing scan result for 'Maven:junit:junit:4.12' because\
+              \ the raw result is null."
+            severity: "WARNING"
     - id: "Maven:org.apache.commons:commons-lang3:3.5"
       results:
       - provenance:
@@ -266,16 +286,32 @@ scanner:
               value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
               algorithm: "SHA-1"
         scanner:
-          name: "FileCounter"
-          version: "1.0"
-          configuration: ""
+          name: "TestScanner"
+          version: "1.0.0"
+          configuration: "testScannerConfig"
         summary:
           start_time: "1970-01-01T00:00:00Z"
           end_time: "1970-01-01T00:00:00Z"
-          file_count: 168
-          package_verification_code: "bff2d5982a9b1985295c372b3ae2f90a7a860747"
-          licenses: []
-          copyrights: []
+          file_count: 1
+          package_verification_code: ""
+          licenses:
+          - license: "ASL-2"
+            location:
+              path: "/tmp/ort-ScannerFunTest-download5339913367497143930/Maven/org.apache.commons/commons-lang3/3.5"
+              start_line: 1
+              end_line: 8
+          copyrights:
+          - statement: "(C) 3.5"
+            location:
+              path: "/tmp/ort-ScannerFunTest-download5339913367497143930/Maven/org.apache.commons/commons-lang3/3.5"
+              start_line: 3
+              end_line: 4
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "NoStorage"
+            message: "Not storing scan result for 'Maven:org.apache.commons:commons-lang3:3.5'\
+              \ because the raw result is null."
+            severity: "WARNING"
     - id: "Maven:org.apache.commons:commons-text:1.1"
       results:
       - provenance:
@@ -286,16 +322,32 @@ scanner:
               value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
               algorithm: "SHA-1"
         scanner:
-          name: "FileCounter"
-          version: "1.0"
-          configuration: ""
+          name: "TestScanner"
+          version: "1.0.0"
+          configuration: "testScannerConfig"
         summary:
           start_time: "1970-01-01T00:00:00Z"
           end_time: "1970-01-01T00:00:00Z"
-          file_count: 80
-          package_verification_code: "78daf07d29c2b84b09766a98c1728b2daeeb59e6"
-          licenses: []
-          copyrights: []
+          file_count: 1
+          package_verification_code: ""
+          licenses:
+          - license: "ASL-2"
+            location:
+              path: "/tmp/ort-ScannerFunTest-download5339913367497143930/Maven/org.apache.commons/commons-text/1.1"
+              start_line: 1
+              end_line: 8
+          copyrights:
+          - statement: "(C) 1.1"
+            location:
+              path: "/tmp/ort-ScannerFunTest-download5339913367497143930/Maven/org.apache.commons/commons-text/1.1"
+              start_line: 3
+              end_line: 4
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "NoStorage"
+            message: "Not storing scan result for 'Maven:org.apache.commons:commons-text:1.1'\
+              \ because the raw result is null."
+            severity: "WARNING"
     - id: "Maven:org.hamcrest:hamcrest-core:1.3"
       results:
       - provenance:
@@ -306,16 +358,32 @@ scanner:
               value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
               algorithm: "SHA-1"
         scanner:
-          name: "FileCounter"
-          version: "1.0"
-          configuration: ""
+          name: "TestScanner"
+          version: "1.0.0"
+          configuration: "testScannerConfig"
         summary:
           start_time: "1970-01-01T00:00:00Z"
           end_time: "1970-01-01T00:00:00Z"
-          file_count: 47
-          package_verification_code: "a42897bec728695ae0e3ecdcc891ced065dae355"
-          licenses: []
-          copyrights: []
+          file_count: 1
+          package_verification_code: ""
+          licenses:
+          - license: "ASL-2"
+            location:
+              path: "/tmp/ort-ScannerFunTest-download5339913367497143930/Maven/org.hamcrest/hamcrest-core/1.3"
+              start_line: 1
+              end_line: 8
+          copyrights:
+          - statement: "(C) 1.3"
+            location:
+              path: "/tmp/ort-ScannerFunTest-download5339913367497143930/Maven/org.hamcrest/hamcrest-core/1.3"
+              start_line: 3
+              end_line: 4
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "NoStorage"
+            message: "Not storing scan result for 'Maven:org.hamcrest:hamcrest-core:1.3'\
+              \ because the raw result is null."
+            severity: "WARNING"
     storage_stats:
       num_reads: 5
       num_hits: 0
@@ -324,3 +392,5 @@ advisor: null
 evaluator: null
 labels:
   analyzed: "complete"
+  test: "true"
+  scan: "full"

--- a/scanner/src/funTest/kotlin/ScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/ScannerFunTest.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner
+
+import com.fasterxml.jackson.databind.JsonNode
+
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+import java.io.File
+import java.time.Instant
+
+import kotlin.io.path.createTempDirectory
+
+import org.ossreviewtoolkit.model.AccessStatistics
+import org.ossreviewtoolkit.model.CopyrightFinding
+import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.yamlMapper
+import org.ossreviewtoolkit.utils.ORT_NAME
+import org.ossreviewtoolkit.utils.safeDeleteRecursively
+import org.ossreviewtoolkit.utils.test.patchActualResult
+import org.ossreviewtoolkit.utils.test.patchExpectedResult
+
+class ScannerFunTest : StringSpec() {
+    private lateinit var downloadDir: File
+
+    private lateinit var outputDir: File
+
+    override fun beforeSpec(spec: Spec) {
+        downloadDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}-download").toFile()
+        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}-output").toFile()
+    }
+
+    override fun afterSpec(spec: Spec) {
+        outputDir.safeDeleteRecursively(force = true)
+        downloadDir.safeDeleteRecursively(force = true)
+        ScanResultsStorage.storage.stats.reset()
+    }
+
+    init {
+        "Scanner should scan an OrtResult in memory" {
+            val analyzerResult = assetsDir.resolve("analyzer-result.yml")
+            val builder = InMemoryScannerResultBuilder()
+            val scanner = createScanner()
+
+            scanner.scanOrtResult(builder, analyzerResult, outputDir, downloadDir, labels = labels)
+
+            checkResult(builder.result())
+        }
+    }
+
+    /**
+     * Create a scanner implementation for executing test scans that returns very simple, deterministic results.
+     */
+    private fun createScanner(): LocalScanner =
+        object : LocalScanner("TestScanner", ScannerConfiguration()) {
+            override val resultFileExt: String
+                get() = "tst"
+            override val expectedVersion: String
+                get() = version
+
+            override fun getConfiguration(): String = "testScannerConfig"
+
+            override fun scanPathInternal(path: File, resultsFile: File): ScanResult {
+                val provenance = Provenance()
+                val licenseFinding = LicenseFinding(
+                    "ASL-2",
+                    TextLocation(path.absolutePath, 1, 8)
+                )
+                val copyrightFinding = CopyrightFinding(
+                    "(C) ${path.name}",
+                    TextLocation(path.absolutePath, 3, 4)
+                )
+                val summary = ScanSummary(
+                    startTime = Instant.now(),
+                    endTime = Instant.now(),
+                    packageVerificationCode = "",
+                    fileCount = 1,
+                    licenseFindings = sortedSetOf(licenseFinding),
+                    copyrightFindings = sortedSetOf(copyrightFinding)
+                )
+
+                return ScanResult(provenance, getDetails(), summary)
+            }
+
+            override fun command(workingDir: File?): String {
+                throw UnsupportedOperationException("Unexpected call")
+            }
+
+            override fun getRawResult(resultsFile: File): JsonNode {
+                return yamlMapper.nullNode()
+            }
+
+            override val version: String
+                get() = "1.0.0"
+        }
+}
+
+/** Name of the file holding the expected scan result. */
+private const val EXPECTED_RESULT_FILE_NAME = "test-scanner-expected-output-for-analyzer-result.yml"
+
+/** Path to test files. */
+private val assetsDir = File("src/funTest/assets")
+
+/**
+ * Regular expression to match temporary download paths in a scan result. As these paths change on each test run,
+ * they have to be dealt with when comparing results.
+ */
+private val DOWNLOAD_PATH_REGEX = Regex("-download(\\d+)/")
+
+/**
+ * Regular expression to match the *variables* element in a scan result. Variables depend on the current
+ * environment; so they have to be deleted when comparing results.
+ */
+private val VARIABLES_REGEX = Regex("variables:.*?tool_versions:", RegexOption.DOT_MATCHES_ALL)
+
+/** Some labels to assign to the test result. */
+private val labels = mapOf(
+    "test" to "true",
+    "scan" to "full"
+)
+
+/** Stores a result object with the expected scanner result to compare to in tests. */
+private var expectedScannerResult = constructExpectedResult()
+
+/**
+ * Patch the given [scan result][result] by replacing variables part, so that it can be compared.
+ */
+private fun patchResult(result: String): String =
+    stripTempPaths(stripVariables(result))
+
+/**
+ * Replace temporary path names in the given [result].
+ */
+private fun stripTempPaths(result: String): String =
+    result.replace(DOWNLOAD_PATH_REGEX, "/")
+
+/**
+ * Remove the section with environment variables from the given [result].
+ */
+private fun stripVariables(result: String): String =
+    result.replace(VARIABLES_REGEX, "tool_versions:")
+
+/**
+ * Read the file with the expected scanner result, replace variable parts, and convert it to an [OrtResult] object.
+ */
+private fun constructExpectedResult(): OrtResult {
+    val expectedResultYaml = patchResult(
+        patchExpectedResult(
+            assetsDir.resolve("test-scanner-expected-output-for-analyzer-result.yml"),
+            revision = "HEAD"
+        )
+    )
+
+    return deserializeResult(expectedResultYaml)
+}
+
+/**
+ * Compares the [result] specified against the expected scanner result. Note that comparison needs to be done on
+ * object level, as the raw YAML representation may differ. The [result] passed in needs to be patched first to
+ * deal with variable parts. Also, access statistics cannot be compared directly.
+ */
+private fun checkResult(result: OrtResult) {
+    val patchedYaml = patchResult(
+        patchActualResult(
+            yamlMapper.writeValueAsString(result),
+            patchDownloadTime = true,
+            patchStartAndEndTime = true
+        )
+    )
+    val patchedResult = deserializeResult(patchedYaml)
+    val statistics = patchedResult.statistics()
+    val expectedStatistics = expectedScannerResult.statistics()
+    statistics.numHits.get() shouldBe expectedStatistics.numHits.get()
+    statistics.numReads.get() shouldBe expectedStatistics.numReads.get()
+    // AtomicInteger does not implement equals(); so copy objects to make comparison succeed.
+    statistics.numHits = expectedStatistics.numHits
+    statistics.numReads = expectedStatistics.numReads
+
+    patchedResult shouldBe expectedScannerResult
+}
+
+/**
+ * Convert a [serialized YAML result][resultYaml] to an [OrtResult] object.
+ */
+private fun deserializeResult(resultYaml: String): OrtResult =
+    yamlMapper.readValue(resultYaml, OrtResult::class.java)
+
+/**
+ * Convenience function to return a result's statistics for accessing the scan results storage.
+ */
+private fun OrtResult.statistics(): AccessStatistics =
+    scanner?.results?.storageStats ?: AccessStatistics()

--- a/scanner/src/funTest/kotlin/scanners/FileCounterScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/FileCounterScannerFunTest.kt
@@ -28,6 +28,7 @@ import kotlin.io.path.createTempDirectory
 
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.yamlMapper
+import org.ossreviewtoolkit.scanner.InMemoryScannerResultBuilder
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
@@ -48,9 +49,10 @@ class FileCounterScannerFunTest : StringSpec() {
                 assetsDir.resolve("file-counter-expected-output-for-analyzer-result.yml")
             )
 
+            val builder = InMemoryScannerResultBuilder()
             val scanner = FileCounter("FileCounter", ScannerConfiguration())
-            val ortResult = scanner.scanOrtResult(analyzerResultFile, outputDir, outputDir.resolve("downloads"))
-            val result = yamlMapper.writeValueAsString(ortResult)
+            scanner.scanOrtResult(builder, analyzerResultFile, outputDir, outputDir.resolve("downloads"))
+            val result = yamlMapper.writeValueAsString(builder.result())
 
             patchActualResult(result, patchDownloadTime = true, patchStartAndEndTime = true) shouldBe expectedResult
 

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -35,6 +35,7 @@ import kotlin.time.measureTimedValue
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 
@@ -189,33 +190,38 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
      */
     fun getDetails() = ScannerDetails(scannerName, version, getConfiguration())
 
-    override suspend fun scanPackages(packages: List<Package>, outputDirectory: File, downloadDirectory: File):
-            Map<Package, List<ScanResult>> {
-
+    override suspend fun scanPackages(
+        channel: Channel<Pair<Package, List<ScanResult>>>,
+        packages: List<Package>,
+        outputDirectory: File,
+        downloadDirectory: File) {
         val storageDispatcher =
             Executors.newFixedThreadPool(5, NamedThreadFactory(ScanResultsStorage.storage.name)).asCoroutineDispatcher()
         val scanDispatcher = Executors.newSingleThreadExecutor(NamedThreadFactory(scannerName)).asCoroutineDispatcher()
 
-        return try {
+        try {
             coroutineScope {
                 packages.withIndex().map { (index, pkg) ->
                     val packageIndex = "(${index + 1} of ${packages.size})"
 
                     async {
-                        pkg to scanPackage(
-                            pkg,
-                            packageIndex,
-                            downloadDirectory,
-                            outputDirectory,
-                            storageDispatcher,
-                            scanDispatcher
+                        channel.send(
+                            pkg to scanPackage(
+                                pkg,
+                                packageIndex,
+                                downloadDirectory,
+                                outputDirectory,
+                                storageDispatcher,
+                                scanDispatcher
+                            )
                         )
                     }
-                }.associate { it.await() }
+                }
             }
         } finally {
             storageDispatcher.close()
             scanDispatcher.close()
+            channel.close()
         }
     }
 

--- a/scanner/src/main/kotlin/ScannerResultBuilder.kt
+++ b/scanner/src/main/kotlin/ScannerResultBuilder.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner
+
+import java.time.Instant
+
+import org.ossreviewtoolkit.model.AccessStatistics
+import org.ossreviewtoolkit.model.Environment
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.ScanRecord
+import org.ossreviewtoolkit.model.ScanResultContainer
+import org.ossreviewtoolkit.model.ScannerRun
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+
+/**
+ * Definition of an interface that allows a scanner to construct an [OrtResult] with a scanner result without
+ * having to know about details.
+ *
+ * This interface supports a more efficient handling of large scanner results. The basic idea is that a scanner
+ * adds results for single packages when they become available and does not have to care how these results are
+ * combined to a full [OrtResult].
+ *
+ * Concrete implementations handle the result construction differently: A naive implementation can collect all
+ * results in memory, while a more efficient one streams the data to a file reducing the memory consumption.
+ */
+interface ScannerResultBuilder : AutoCloseable {
+    /**
+     * Initialize this builder from the [OrtResult][analyzerResult] produced by the analyzer. The result produced by
+     * this builder is then based on the result passed to this function. This function must be called initially.
+     */
+    fun initFromAnalyzerResult(analyzerResult: OrtResult)
+
+    /**
+     * Add a [resultContainer] to the result managed by this builder. This function should be called when scan
+     * results for a package become available.
+     */
+    fun addScanResult(resultContainer: ScanResultContainer)
+
+    /**
+     * Notify the builder about the completion of the scan operation passing in metadata to add to the result: the
+     * [startTime] and [endTime] of the operation, the [environment] and the [config] passed to the scanner,
+     * [statistics][storageStats] of the results storage, and arbitrary [labels] to add to the result. After
+     * this function has been called, the builder has all the information required to produce a valid [OrtResult]
+     * instance.
+     */
+    fun complete(
+        startTime: Instant,
+        endTime: Instant,
+        environment: Environment,
+        config: ScannerConfiguration,
+        storageStats: AccessStatistics,
+        labels: Map<String, String>
+    )
+}
+
+/**
+ * A straight-forward implementation of [ScannerResultBuilder] that constructs the [OrtResult] with scanner results
+ * in memory.
+ *
+ * This implementation is easy, but it is limited to scan results that do not exceed the amount of heap space
+ * available.
+ */
+class InMemoryScannerResultBuilder : ScannerResultBuilder {
+    /** Stores the base result to build upon. */
+    private lateinit var ortResult: OrtResult
+
+    /** Collects the incoming scan results for packages. */
+    private val scanResults = sortedSetOf<ScanResultContainer>()
+
+    override fun initFromAnalyzerResult(analyzerResult: OrtResult) {
+        ortResult = analyzerResult
+    }
+
+    override fun addScanResult(resultContainer: ScanResultContainer) {
+        scanResults.add(resultContainer)
+    }
+
+    /**
+     * Record the metadata specified and assemble an [OrtResult] object with the data gathered so far.
+     */
+    override fun complete(
+        startTime: Instant,
+        endTime: Instant,
+        environment: Environment,
+        config: ScannerConfiguration,
+        storageStats: AccessStatistics,
+        labels: Map<String, String>
+    ) {
+        val scanRecord = ScanRecord(scanResults, storageStats)
+        val scannerRun = ScannerRun(startTime, endTime, environment, config, scanRecord)
+        ortResult = ortResult.copy(
+            scanner = scannerRun,
+            labels = ortResult.labels + labels
+        )
+    }
+
+    override fun close() {
+        // Nothing to do here.
+    }
+
+    /**
+     * Return the [OrtResult] produced by this builder. Call this method after invoking *complete()* to obtain the
+     * final result.
+     */
+    fun result(): OrtResult = ortResult
+}

--- a/scanner/src/test/kotlin/ScannerResultBuilderTest.kt
+++ b/scanner/src/test/kotlin/ScannerResultBuilderTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2020 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+import java.io.File
+import java.nio.file.Files
+import java.time.Instant
+
+import kotlin.io.path.createTempDirectory
+
+import org.ossreviewtoolkit.model.AccessStatistics
+import org.ossreviewtoolkit.model.Environment
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.Repository
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.utils.ORT_NAME
+import org.ossreviewtoolkit.utils.safeDeleteRecursively
+
+class ScannerResultBuilderTest : WordSpec({
+    "StreamingScannerResultBuilder" should {
+        "handle null fields in the result from the analyzer" {
+            val outputFile = Files.createTempFile("scan-result", ".yml").toFile()
+            outputFile.deleteOnExit()
+            val analyzerResult = OrtResult(
+                Repository(
+                    VcsInfo(VcsType.CVS, "someUri", "someRevision")
+                )
+            )
+
+            StreamingScannerResultBuilder(outputFile).use { builder ->
+                builder.initFromAnalyzerResult(analyzerResult)
+                builder.complete(
+                    Instant.now(),
+                    Instant.now(),
+                    Environment(),
+                    ScannerConfiguration(),
+                    AccessStatistics(),
+                    emptyMap()
+                )
+            }
+
+            val result = outputFile.readText()
+            result shouldContain "analyzer: null"
+            result shouldContain "advisor: null"
+            result shouldContain "evaluator: null"
+        }
+
+        "create the output folder if it does not exist yet" {
+            val outputDir = createTempDirectory("$ORT_NAME-scanner-builder").toFile()
+            val outputFile = File(outputDir, "sub/folder/scan-result.yml")
+
+            StreamingScannerResultBuilder(outputFile).use { builder ->
+                builder.initFromAnalyzerResult(OrtResult.EMPTY)
+                builder.complete(
+                    Instant.now(),
+                    Instant.now(),
+                    Environment(),
+                    ScannerConfiguration(),
+                    AccessStatistics(),
+                    emptyMap()
+                )
+            }
+
+            outputFile.isFile shouldBe true
+
+            outputDir.safeDeleteRecursively(force = true)
+        }
+    }
+})


### PR DESCRIPTION
This PR proposes a solution to reduce the memory consumed by the scanner when scanning many packages.

The basic idea is, to not collect all the scan results for the single packages and write them to a result file at the very end, but to use the Jackson streaming API to write incoming results to the output file immediately, not keeping them in memory.