### PR TITLE
Fix not persisted has_issues in AdvisorResult

### DIFF
--- a/cli/src/main/kotlin/commands/AdvisorCommand.kt
+++ b/cli/src/main/kotlin/commands/AdvisorCommand.kt
@@ -138,6 +138,7 @@ class AdvisorCommand : CliktCommand(name = "advise", help = "Run vulnerability d
         }
 
         if (advisorResults.hasIssues) {
+            println("The advisor result contains issues.")
             throw ProgramResult(2)
         }
     }

--- a/model/src/main/kotlin/AdvisorRecord.kt
+++ b/model/src/main/kotlin/AdvisorRecord.kt
@@ -26,7 +26,7 @@ import java.util.SortedSet
 /**
  * A record of a single run of the advisor tool, containing the input and the [Vulnerability] for every checked package.
  */
-@JsonIgnoreProperties(value = ["has_issues"])
+@JsonIgnoreProperties(value = ["has_issues"], allowGetters = true)
 data class AdvisorRecord(
     /**
      * The [AdvisorResult]s for all [Package]s.


### PR DESCRIPTION
This PR fixes the issue that the advisor result does not contain the `has_issues` flag if there are any issues present.