### PR TITLE
Fix null/empty vulnerability URLs in the vulnerability_report template

### DIFF
--- a/reporter/src/main/resources/templates/asciidoc/vulnerability_report.ftl
+++ b/reporter/src/main/resources/templates/asciidoc/vulnerability_report.ftl
@@ -19,7 +19,8 @@ Package: *${advisorResult.id.toCoordinates()}*
 
 [#list result.vulnerabilities as vulnerability]
 
-** ${vulnerability.url}[${vulnerability.id}], Severity: ${vulnerability.severity}
+** [#if vulnerability.url??]${vulnerability.url}[${vulnerability.id}][#else]${vulnerability.id}[/#if],
+    Severity: ${vulnerability.severity}
 
 [/#list]
 


### PR DESCRIPTION
This PR fixes the issue with the vulnerability_report template when there are no vulnerability URLs and an external link can not be generated. 