### PR TITLE
Apply license choices to SPDX expressions

### DIFF
--- a/spdx-utils/src/main/kotlin/SpdxException.kt
+++ b/spdx-utils/src/main/kotlin/SpdxException.kt
@@ -19,7 +19,7 @@
 
 package org.ossreviewtoolkit.spdx
 
-class SpdxException : RuntimeException {
+open class SpdxException : RuntimeException {
     constructor(message: String?, cause: Throwable?) : super(message, cause)
     constructor(message: String?) : super(message)
     constructor(cause: Throwable?) : super(cause)

--- a/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2020-2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -364,6 +365,113 @@ class SpdxExpressionTest : WordSpec() {
                 spdxExpression.isValidChoice("a AND b AND c".toSpdx()) shouldBe false
                 spdxExpression.isValidChoice("a AND b AND d".toSpdx()) shouldBe false
                 spdxExpression.isValidChoice("a AND b AND c AND d".toSpdx()) shouldBe false
+            }
+        }
+
+        "applyChoice()" should {
+            "return the choice for a simple expression" {
+                val expression = "a".toSpdx()
+                val choice = "a".toSpdx()
+
+                val result = expression.applyChoice(choice)
+
+                result shouldBe "a".toSpdx()
+            }
+
+            "throw an exception if the user chose a wrong license for a simple expression" {
+                val expression = "a".toSpdx()
+                val choice = "b".toSpdx()
+
+                shouldThrow<InvalidLicenseChoiceException> { expression.applyChoice(choice) }
+            }
+
+            "return the new expression if only a part of the expression is matched by the subExpression" {
+                val expression = "a OR b OR c".toSpdx()
+                val choice = "b".toSpdx()
+                val subExpression = "a OR b".toSpdx()
+
+                val result = expression.applyChoice(choice, subExpression)
+
+                result shouldBe "b OR c".toSpdx()
+            }
+
+            "work with choices that itself are a choice" {
+                val expression = "a OR b OR c OR d".toSpdx()
+                val choice = "a OR b".toSpdx()
+                val subExpression = "a OR b OR c".toSpdx()
+
+                val result = expression.applyChoice(choice, subExpression)
+
+                result shouldBe "a OR b OR d".toSpdx()
+            }
+
+            "apply the choice if the expression contains multiple choices" {
+                val expression = "a OR b OR c".toSpdx()
+                val choice = "b".toSpdx()
+
+                val result = expression.applyChoice(choice)
+
+                result shouldBe "b".toSpdx()
+            }
+
+            "throw an exception if the chosen license is not a valid option" {
+                val expression = "a OR b".toSpdx()
+                val choice = "c".toSpdx()
+
+                shouldThrow<InvalidLicenseChoiceException> { expression.applyChoice(choice) }
+            }
+
+            "apply the choice if the expression is not in DNF" {
+                val expression = "(a OR b) AND c".toSpdx()
+                val choice = "a AND c".toSpdx()
+
+                val result = expression.applyChoice(choice)
+
+                result shouldBe "a AND c".toSpdx()
+            }
+
+            "return the reduced subExpression in DNF if the choice was valid" {
+                val expression = "(a OR b) AND c AND (d OR e)".toSpdx()
+                val choice = "a AND c AND d".toSpdx()
+                val subExpression = "a AND c AND d OR a AND c AND e".toSpdx()
+
+                val result = expression.applyChoice(choice, subExpression)
+
+                result shouldBe "a AND c AND d OR b AND c AND d OR b AND c AND e".toSpdx()
+            }
+
+            "throw an exception if the subExpression does not match the simple expression" {
+                val expression = "a".toSpdx()
+                val choice = "x".toSpdx()
+                val subExpression = "x OR y".toSpdx()
+
+                shouldThrow<InvalidSubExpressionException> { expression.applyChoice(choice, subExpression) }
+            }
+
+            "throw an exception if the subExpression does not match the expression" {
+                val expression = "a OR b OR c".toSpdx()
+                val choice = "x".toSpdx()
+                val subExpression = "x OR y OR z".toSpdx()
+
+                shouldThrow<InvalidSubExpressionException> { expression.applyChoice(choice, subExpression) }
+            }
+
+            "throw an exception if the subExpression does not match and needs to be converted to a DNF" {
+                val expression = "(a OR b) AND c AND (d OR e)".toSpdx()
+                val choice = "a AND c AND d".toSpdx()
+                val subExpression = "(a AND c AND d) OR (x AND y AND z)".toSpdx()
+
+                shouldThrow<InvalidSubExpressionException> { expression.applyChoice(choice, subExpression) }
+            }
+
+            "apply the choice when the subExpression matches only a part of the expression" {
+                val expression = "(a OR b) AND c".toSpdx()
+                val choice = "a".toSpdx()
+                val subExpression = "a OR b".toSpdx()
+
+                val result = expression.applyChoice(choice, subExpression)
+
+                result shouldBe "a AND c".toSpdx()
             }
         }
 


### PR DESCRIPTION
This is a draft how license choices should be applied.
The signature of the tested function looks like this:
`fun applyChoice(choice: SpdxExpression, subtreeMatcher: SpdxExpression = this): SpdxExpression`

See #3396 and #2610
