### PR TITLE
ArchiveUtils: Gracefully unpack malicious Zip file entries

### DIFF
--- a/utils/src/main/kotlin/ArchiveUtils.kt
+++ b/utils/src/main/kotlin/ArchiveUtils.kt
@@ -90,7 +90,7 @@ fun File.unpack7Zip(targetDirectory: File) {
         while (true) {
             val entry = zipFile.nextEntry ?: break
 
-            if (entry.isDirectory || entry.isAntiItem) {
+            if (entry.isDirectory || entry.isAntiItem || File(entry.name).isAbsolute) {
                 continue
             }
 
@@ -157,7 +157,7 @@ fun File.packZip(
 fun InputStream.unpackTar(targetDirectory: File) =
     TarArchiveInputStream(this).unpack(
         targetDirectory,
-        { entry -> !(entry as TarArchiveEntry).isFile },
+        { entry -> !(entry as TarArchiveEntry).isFile || File(entry.name).isAbsolute },
         { entry -> (entry as TarArchiveEntry).mode }
     )
 
@@ -168,7 +168,7 @@ fun InputStream.unpackTar(targetDirectory: File) =
 fun InputStream.unpackZip(targetDirectory: File) =
     ZipArchiveInputStream(this).unpack(
         targetDirectory,
-        { entry -> (entry as ZipArchiveEntry).let { it.isDirectory || it.isUnixSymlink } },
+        { entry -> (entry as ZipArchiveEntry).let { it.isDirectory || it.isUnixSymlink || File(it.name).isAbsolute } },
         { entry -> (entry as ZipArchiveEntry).unixMode }
     )
 
@@ -226,7 +226,7 @@ private fun ZipFile.unpack(targetDirectory: File) =
         while (entries.hasMoreElements()) {
             val entry = entries.nextElement()
 
-            if (entry.isDirectory || entry.isUnixSymlink) {
+            if (entry.isDirectory || entry.isUnixSymlink || File(entry.name).isAbsolute) {
                 continue
             }
 


### PR DESCRIPTION
 ArchiveUtils: Gracefully unpack malicious Zip file entries

Normally all entries of a Zip file are associated with a relatve file
path. However, it is also possible to have entries with an absolute
path, see e.g. [1]. When the downloader unpacks such source artifact
archives it tries to create the respective absolute directories, which
fails in case of lacking file system privileges.

Skip all entries with absolute paths to fix that. Apply the same fix to
all other unpack functions for consistency.

[1] https://repo.maven.apache.org/maven2/org/liquibase/liquibase-core/3.8.9/liquibase-core-3.8.9-sources.jar
