### PR TITLE
ScanResult: Remove raw result

### DIFF
--- a/helper-cli/src/main/kotlin/commands/ImportScanResultsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportScanResultsCommand.kt
@@ -25,7 +25,6 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.model.EMPTY_JSON_NODE
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.scanner.storages.FileBasedStorage
@@ -58,7 +57,7 @@ internal class ImportScanResultsCommand : CliktCommand(
 
         ids.forEach { id ->
             ortResult.getScanResultsForId(id).forEach { scanResult ->
-                scanResultsStorage.add(id, scanResult.copy(rawResult = EMPTY_JSON_NODE))
+                scanResultsStorage.add(id, scanResult)
             }
         }
     }

--- a/model/src/main/kotlin/ScanResult.kt
+++ b/model/src/main/kotlin/ScanResult.kt
@@ -19,15 +19,14 @@
 
 package org.ossreviewtoolkit.model
 
-import com.fasterxml.jackson.annotation.JsonAlias
-import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
 
 /**
  * The result of a single scan of a single package.
  */
+@JsonIgnoreProperties("raw_result")
 data class ScanResult(
     /**
      * Provenance information about the scanned source code.
@@ -42,15 +41,7 @@ data class ScanResult(
     /**
      * A summary of the scan results.
      */
-    val summary: ScanSummary,
-
-    /**
-     * The raw output of the scanner. Can be null if the raw result shall not be included. If the raw result is
-     * empty it must not be null but [EMPTY_JSON_NODE].
-     */
-    @JsonAlias("rawResult")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    val rawResult: JsonNode? = null
+    val summary: ScanSummary
 ) {
     /**
      * Filter all detected licenses and copyrights from the [summary] which are underneath [path], and set the [path]
@@ -84,6 +75,6 @@ data class ScanResult(
             copyrightFindings = copyrightFindings
         )
 
-        return ScanResult(newProvenance, scanner, summary, rawResult)
+        return ScanResult(newProvenance, scanner, summary)
     }
 }

--- a/model/src/test/assets/expected-scan-results.yml
+++ b/model/src/test/assets/expected-scan-results.yml
@@ -48,7 +48,6 @@ results:
       source: "source-12"
       message: "issue-12"
       severity: "ERROR"
-  raw_result: "key 1"
 - provenance:
     download_time: "1970-01-03T00:00:00Z"
     vcs_info:
@@ -97,4 +96,3 @@ results:
       source: "source-22"
       message: "issue-22"
       severity: "ERROR"
-  raw_result: "key 2"

--- a/model/src/test/kotlin/ScanResultContainerTest.kt
+++ b/model/src/test/kotlin/ScanResultContainerTest.kt
@@ -108,13 +108,8 @@ class ScanResultContainerTest : WordSpec() {
         mutableListOf(issue21, issue22)
     )
 
-    private val rawResult1 = jsonMapper.readTree("\"key 1\": \"value 1\"")
-    private val rawResult2 = jsonMapper.readTree("\"key 2\": \"value 2\"")
-
-    private val scanResult1 =
-        ScanResult(provenance1, scannerDetails1, scanSummary1, rawResult1)
-    private val scanResult2 =
-        ScanResult(provenance2, scannerDetails2, scanSummary2, rawResult2)
+    private val scanResult1 = ScanResult(provenance1, scannerDetails1, scanSummary1)
+    private val scanResult2 = ScanResult(provenance2, scannerDetails2, scanSummary2)
 
     private val scanResults = ScanResultContainer(id, listOf(scanResult1, scanResult2))
 

--- a/scanner/src/main/kotlin/ScanResultsStorage.kt
+++ b/scanner/src/main/kotlin/ScanResultsStorage.kt
@@ -239,25 +239,16 @@ abstract class ScanResultsStorage {
     }
 
     /**
-     * Add the given [scanResult], which must include a [ScanResult.rawResult], to the [ScanResultContainer] for the
-     * scanned [Package] with the provided [id]. Depending on the storage implementation this might first read any
-     * existing [ScanResultContainer] and write the new [ScanResultContainer] to the storage again, implicitly deleting
-     * the original storage entry by overwriting it. Return a [Result] describing whether the operation was successful.
+     * Add the given [scanResult] to the [ScanResultContainer] for the scanned [Package] with the provided [id].
+     * Depending on the storage implementation this might first read any existing [ScanResultContainer] and write the
+     * new [ScanResultContainer] to the storage again, implicitly deleting the original storage entry by overwriting it.
+     * Return a [Result] describing whether the operation was successful.
      */
     fun add(id: Identifier, scanResult: ScanResult): Result<Unit> {
         // Do not store empty scan results. It is likely that something went wrong when they were created, and if not,
         // it is cheap to re-create them.
         if (scanResult.summary.fileCount == 0) {
             val message = "Not storing scan result for '${id.toCoordinates()}' because no files were scanned."
-            log.info { message }
-
-            return Failure(message)
-        }
-
-        // Do not store scan results without raw result. The raw result can be set to null for other usages, but in the
-        // storage it must never be null.
-        if (scanResult.rawResult == null) {
-            val message = "Not storing scan result for '${id.toCoordinates()}' because the raw result is null."
             log.info { message }
 
             return Failure(message)

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -122,7 +122,7 @@ class Askalono(name: String, config: ScannerConfiguration) : LocalScanner(name, 
                 stdoutFile.copyTo(resultsFile)
                 val result = getRawResult(resultsFile)
                 val summary = generateSummary(startTime, endTime, path, result)
-                return ScanResult(Provenance(), getDetails(), summary, result)
+                return ScanResult(Provenance(), getDetails(), summary)
             } else {
                 throw ScanException(errorMessage)
             }

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -130,7 +130,7 @@ class BoyterLc(name: String, config: ScannerConfiguration) : LocalScanner(name, 
             if (isSuccess) {
                 val result = getRawResult(resultsFile)
                 val summary = generateSummary(startTime, endTime, path, result)
-                return ScanResult(Provenance(), getDetails(), summary, result)
+                return ScanResult(Provenance(), getDetails(), summary)
             } else {
                 throw ScanException(errorMessage)
             }

--- a/scanner/src/main/kotlin/scanners/FileCounter.kt
+++ b/scanner/src/main/kotlin/scanners/FileCounter.kt
@@ -65,7 +65,7 @@ class FileCounter(name: String, config: ScannerConfiguration) : LocalScanner(nam
 
         val result = getRawResult(resultsFile)
         val summary = generateSummary(startTime, endTime, path, result)
-        return ScanResult(Provenance(), getDetails(), summary, result)
+        return ScanResult(Provenance(), getDetails(), summary)
     }
 
     override fun getRawResult(resultsFile: File) =

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -109,7 +109,7 @@ class Licensee(name: String, config: ScannerConfiguration) : LocalScanner(name, 
                 stdoutFile.copyTo(resultsFile)
                 val result = getRawResult(resultsFile)
                 val summary = generateSummary(startTime, endTime, path, result)
-                return ScanResult(Provenance(), getDetails(), summary, result)
+                return ScanResult(Provenance(), getDetails(), summary)
             } else {
                 throw ScanException(errorMessage)
             }

--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -259,6 +259,5 @@ class ScanCode(
             }
         }
 
-    override fun getRawResult(resultsFile: File) =
-        parseScanCodeResult(resultsFile)
+    override fun getRawResult(resultsFile: File) = parseScanCodeResult(resultsFile)
 }

--- a/scanner/src/main/kotlin/scanners/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/ScanCode.kt
@@ -240,7 +240,7 @@ class ScanCode(
 
         with(process) {
             if (isSuccess || hasOnlyMemoryErrors || hasOnlyTimeoutErrors) {
-                return ScanResult(Provenance(), getDetails(), summary.copy(issues = issues), result)
+                return ScanResult(Provenance(), getDetails(), summary.copy(issues = issues))
             } else {
                 throw ScanException(errorMessage)
             }

--- a/scanner/src/main/kotlin/storages/PostgresStorage.kt
+++ b/scanner/src/main/kotlin/storages/PostgresStorage.kt
@@ -70,7 +70,7 @@ class PostgresStorage(
         private const val VERSION_EXPRESSION = "$VERSION_ARRAY::int[]"
 
         /**
-         * The null character "\u0000" can appear in raw scan results, for example in ScanCode if the matched text for a
+         * The null character "\u0000" can appear in scan results, for example in ScanCode if the matched text for a
          * license or copyright contains this character. Since it is not allowed in PostgreSQL JSONB columns we need to
          * escape it before writing a string to the database.
          * See: [https://www.postgresql.org/docs/11/datatype-json.html]

--- a/scanner/src/test/kotlin/storages/CompositeStorageTest.kt
+++ b/scanner/src/test/kotlin/storages/CompositeStorageTest.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.scanner.storages
 
-import com.fasterxml.jackson.databind.node.TextNode
 import com.vdurmont.semver4j.Semver
 
 import io.kotest.assertions.fail
@@ -88,7 +87,7 @@ private fun createScanResult(resultCount: Int): ScanResult {
     )
     val provenance = Provenance(sourceArtifact = RemoteArtifact.EMPTY)
     val scanner = ScannerDetails("scanner$resultCount", "v$resultCount", "testConfig")
-    return ScanResult(provenance, scanner, summary, TextNode("some result"))
+    return ScanResult(provenance, scanner, summary)
 }
 
 class CompositeStorageTest : WordSpec({


### PR DESCRIPTION
Remove the `rawResult` field from the `ScanResult`. The property
contained the raw data from the license scanner. The idea behind this
property was that it might be useful to have the raw data, but in
practice it turned out it is very rarely used. The raw result could be
much larger than the `ScanSummary` which contains the extracted data
from the raw result. This significantly increased the space required for
storing scan results and also slowed down storing and reading scan
results from a storage, for no practical use. This change also reduces
the amount of memory used by the scanner, because raw results are kept
in memory for a shorter time when scanning packages, and not at all when
downloading scan results from the storage.

Fixes #3403: As part of this also an old workaround that stored the raw
results in separate files is removed.
