### PR TITLE
Support "reactive" authentication for OkHttpClientHelper

### DIFF
--- a/utils/src/main/kotlin/OkHttpClientHelper.kt
+++ b/utils/src/main/kotlin/OkHttpClientHelper.kt
@@ -65,7 +65,7 @@ object OkHttpClientHelper {
             val specs = listOf(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS, ConnectionSpec.CLEARTEXT)
 
             // OkHttp uses Java's global ProxySelector by default, but the Authenticator for a proxy needs to be set
-            // explicitly. Also note that no (non-proxy) authenticator is set here as it is primarily intended for
+            // explicitly. Also note that the (non-proxy) authenticator is set here and is primarily intended for
             // "reactive" authentication, but most often "preemptive" authentication via headers is required. For proxy
             // authentication, OkHttp emulates preemptive authentication by sending a fake "OkHttp-Preemptive" response
             // to the reactive proxy authenticator.
@@ -73,6 +73,7 @@ object OkHttpClientHelper {
                 .cache(cache)
                 .connectionSpecs(specs)
                 .readTimeout(Duration.ofSeconds(30))
+                .authenticator(Authenticator.JAVA_NET_AUTHENTICATOR)
                 .proxyAuthenticator(Authenticator.JAVA_NET_AUTHENTICATOR)
                 .apply(block)
                 .build()


### PR DESCRIPTION
When the jars are in a Maven Artifactory protected by credentials, the downloader part of the Scanner cannot download them.
It does not know the settings.xml.

This commit adds the OrtAuthenticator to the http client of the Downloader to be able to, at least, pass the credentials through .netrc or environment.

Standard use case when there is no need for credentials has also been tested.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>
