### PR TITLE
AsciiDocTemplateReporter: Add pdf-fontsdir option

### DIFF
--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -155,7 +155,7 @@ class ExamplesFunTest : StringSpec() {
             val report = AsciiDocTemplateReporter().generateReport(
                 ReporterInput(OrtResult.EMPTY),
                 outputDir,
-                mapOf("pdf-theme.path" to examplesDir.resolve("asciidoctor-pdf-theme.yml").path)
+                mapOf("pdf.theme.file" to examplesDir.resolve("asciidoctor-pdf-theme.yml").path)
             )
 
             report shouldHaveSize 1

--- a/docs/reporters/AsciiDocTemplateReporter.md
+++ b/docs/reporters/AsciiDocTemplateReporter.md
@@ -20,7 +20,7 @@ the theme file does not exist, an in-built theme of AsciidoctorJ PDF is used.
 * `template.path`: A comma-separated list of paths to template files provided by the user.
 * `backend`: The name of the AsciiDoc backend to use, like "html". Defaults to "pdf". As a special case, the "adoc"
              fake backend is used to indicate that no backend should be used but the AsciiDoc files should be kept.
-* `pdf-theme.path`: A path to an AsciiDoc PDF theme file. Only used with the "pdf" backend.
+* `pdf.theme.file`: A path to an AsciiDoc PDF theme file. Only used with the "pdf" backend.
 
 ## Command Line
 
@@ -33,7 +33,7 @@ cli/build/install/ort/bin/ort report
   -o [reporter-output-dir]
   -f AsciiDoc
   --report-option AsciiDocTemplate=template.id=[template-id]
-  --report-option AsciiDocTemplate=pdf-theme.path=pdf-theme.yml
+  --report-option AsciiDocTemplate=pdf.theme.file=pdf-theme.yml
 ```
 
 [1]: https://freemarker.apache.org

--- a/docs/reporters/AsciiDocTemplateReporter.md
+++ b/docs/reporters/AsciiDocTemplateReporter.md
@@ -4,7 +4,7 @@ The AsciiDocTemplateReporter creates PDF files using a combination of [Apache Fr
 with [AsciidoctorJ][3] as Java interface and [AsciidoctorJ PDF][4] as PDF file generator.
 For each Freemarker template provided using the options described below a separate intermediate file is created that can be
 processed by AsciidoctorJ. If no options are provided, the "disclosure_document" template is used, and if security
-vulnerability information is available also the "vulerability_report" template.
+vulnerability information is available also the "vulernability_report" template.
 
 After the intermediate files are generated, they are processed by AsciidoctorJ or to be more precise by its PDF
 implementation AsciidoctorJ PDF. A PDF theme can be handed over to AsciidoctorJ PDF in which properties like fonts or
@@ -16,7 +16,7 @@ the theme file does not exist, an in-built theme of AsciidoctorJ PDF is used.
 ## Report options
 
 * `template.id`: A comma-separated list of IDs of templates provided by ORT. Currently, the "disclosure_document" and
-                 "vulerability_report" templates are available.
+                 "vulnerability_report" templates are available.
 * `template.path`: A comma-separated list of paths to template files provided by the user.
 * `backend`: The name of the AsciiDoc backend to use, like "html". Defaults to "pdf". As a special case, the "adoc"
              fake backend is used to indicate that no backend should be used but the AsciiDoc files should be kept.

--- a/docs/reporters/AsciiDocTemplateReporter.md
+++ b/docs/reporters/AsciiDocTemplateReporter.md
@@ -21,6 +21,7 @@ the theme file does not exist, an in-built theme of AsciidoctorJ PDF is used.
 * `backend`: The name of the AsciiDoc backend to use, like "html". Defaults to "pdf". As a special case, the "adoc"
              fake backend is used to indicate that no backend should be used but the AsciiDoc files should be kept.
 * `pdf.theme.file`: A path to an AsciiDoc PDF theme file. Only used with the "pdf" backend.
+* `pdf.fonts.dir`: A path to a directory containing custom fonts. Only used with the "pdf" backend.
 
 ## Command Line
 
@@ -36,8 +37,16 @@ cli/build/install/ort/bin/ort report
   --report-option AsciiDocTemplate=pdf.theme.file=pdf-theme.yml
 ```
 
+If you want to add your own custom fonts in the AsciiDoc PDF theme file using a [relative path][6],
+you need to add the directory in which the fonts are located as a report-specific option like
+
+    --report-option AsciiDocTemplate=pdf.fonts.dir=path/to/fonts/
+
+where `path/to/fonts` is the relative path to the font directory from the base execution directory.
+
 [1]: https://freemarker.apache.org
 [2]: https://asciidoc.org/
 [3]: https://github.com/asciidoctor/asciidoctorj
 [4]: https://github.com/asciidoctor/asciidoctorj-pdf
 [5]: https://github.com/asciidoctor/asciidoctor-pdf/blob/master/docs/theming-guide.adoc
+[6]: https://github.com/asciidoctor/asciidoctor-pdf/blob/master/docs/theming-guide.adoc#configuring-the-font-search-path

--- a/reporter/src/funTest/kotlin/reporters/AsciiDocTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/AsciiDocTemplateReporterFunTest.kt
@@ -43,7 +43,7 @@ class AsciiDocTemplateReporterFunTest : StringSpec({
 
     "Report generation is aborted when path to non-existing pdf-them file is given" {
         shouldThrow<IllegalArgumentException> {
-            generateReport(ORT_RESULT, mapOf("pdf-theme.path" to "dummy.file"))
+            generateReport(ORT_RESULT, mapOf("pdf.theme.file" to "dummy.file"))
         }
     }
 })

--- a/reporter/src/funTest/kotlin/reporters/AsciiDocTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/AsciiDocTemplateReporterFunTest.kt
@@ -46,6 +46,12 @@ class AsciiDocTemplateReporterFunTest : StringSpec({
             generateReport(ORT_RESULT, mapOf("pdf.theme.file" to "dummy.file"))
         }
     }
+
+    "PDF output is aborted when a non-existent PDF fonts directory is given" {
+        shouldThrow<IllegalArgumentException> {
+            generateReport(ORT_RESULT, mapOf("pdf.fonts.dir" to "fake.path"))
+        }
+    }
 })
 
 private fun generateReport(

--- a/reporter/src/main/kotlin/reporters/AsciiDocTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AsciiDocTemplateReporter.kt
@@ -54,6 +54,7 @@ import org.ossreviewtoolkit.utils.safeDeleteRecursively
  * - *backend*: The name of the AsciiDoc backend to use, like "html". Defaults to "pdf". As a special case, the "adoc"
  *              fake backend is used to indicate that no backend should be used but the AsciiDoc files should be kept.
  * - *pdf.theme.file*: A path to an AsciiDoc PDF theme file. Only used with the "pdf" backend.
+ * - *pdf.fonts.dir*: A path to a directory containing custom fonts. Only used with the "pdf" backend.
  *
  * [1]: https://freemarker.apache.org
  * [2]: https://asciidoc.org/
@@ -72,6 +73,7 @@ class AsciiDocTemplateReporter : Reporter {
 
         private const val OPTION_BACKEND = "backend"
         private const val OPTION_PDF_THEME_FILE = "pdf.theme.file"
+        private const val OPTION_PDF_FONTS_DIR = "pdf.fonts.dir"
 
         private const val BACKEND_PDF = "pdf"
     }
@@ -99,6 +101,14 @@ class AsciiDocTemplateReporter : Reporter {
                 require(pdfThemeFile.isFile) { "Could not find PDF theme file at '$pdfThemeFile'." }
 
                 asciidoctorAttributes.attribute("pdf-theme", pdfThemeFile.toString())
+            }
+
+            templateOptions.remove(OPTION_PDF_FONTS_DIR)?.let {
+                val pdfFontsDir = File(it).absoluteFile
+
+                require(pdfFontsDir.isDirectory) { "Could not find PDF fonts directory at '$pdfFontsDir'." }
+
+                asciidoctorAttributes.attribute("pdf-fontsdir", "$pdfFontsDir,GEM_FONTS_DIR")
             }
         }
 

--- a/reporter/src/main/kotlin/reporters/AsciiDocTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AsciiDocTemplateReporter.kt
@@ -93,12 +93,12 @@ class AsciiDocTemplateReporter : Reporter {
         val backend = templateOptions.remove(OPTION_BACKEND) ?: BACKEND_PDF
 
         if (backend.equals(BACKEND_PDF, ignoreCase = true)) {
-            templateOptions.remove(OPTION_PDF_THEME_FILE)?.let { pdfThemeFile ->
-                File(pdfThemeFile).also {
-                    require(it.isFile) { "Could not find PDF theme file at '${it.absolutePath}'." }
-                }
+            templateOptions.remove(OPTION_PDF_THEME_FILE)?.let {
+                val pdfThemeFile = File(it).absoluteFile
 
-                asciidoctorAttributes.attribute("pdf-theme", pdfThemeFile)
+                require(pdfThemeFile.isFile) { "Could not find PDF theme file at '$pdfThemeFile'." }
+
+                asciidoctorAttributes.attribute("pdf-theme", pdfThemeFile.toString())
             }
         }
 

--- a/reporter/src/main/kotlin/reporters/AsciiDocTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AsciiDocTemplateReporter.kt
@@ -53,7 +53,7 @@ import org.ossreviewtoolkit.utils.safeDeleteRecursively
  * - *template.path*: A comma-separated list of paths to template files provided by the user.
  * - *backend*: The name of the AsciiDoc backend to use, like "html". Defaults to "pdf". As a special case, the "adoc"
  *              fake backend is used to indicate that no backend should be used but the AsciiDoc files should be kept.
- * - *pdf-theme.path*: A path to an AsciiDoc PDF theme file. Only used with the "pdf" backend.
+ * - *pdf.theme.file*: A path to an AsciiDoc PDF theme file. Only used with the "pdf" backend.
  *
  * [1]: https://freemarker.apache.org
  * [2]: https://asciidoc.org/
@@ -71,7 +71,7 @@ class AsciiDocTemplateReporter : Reporter {
         private const val VULNERABILITY_TEMPLATE_ID = "vulnerability_report"
 
         private const val OPTION_BACKEND = "backend"
-        private const val OPTION_PDF_THEME_PATH = "pdf-theme.path"
+        private const val OPTION_PDF_THEME_FILE = "pdf.theme.file"
 
         private const val BACKEND_PDF = "pdf"
     }
@@ -93,12 +93,12 @@ class AsciiDocTemplateReporter : Reporter {
         val backend = templateOptions.remove(OPTION_BACKEND) ?: BACKEND_PDF
 
         if (backend.equals(BACKEND_PDF, ignoreCase = true)) {
-            templateOptions.remove(OPTION_PDF_THEME_PATH)?.let { themePath ->
-                File(themePath).also {
-                    require(it.isFile) { "Could not find pdf-theme file at '${it.absolutePath}'." }
+            templateOptions.remove(OPTION_PDF_THEME_FILE)?.let { pdfThemeFile ->
+                File(pdfThemeFile).also {
+                    require(it.isFile) { "Could not find PDF theme file at '${it.absolutePath}'." }
                 }
 
-                asciidoctorAttributes.attribute("pdf-theme", themePath)
+                asciidoctorAttributes.attribute("pdf-theme", pdfThemeFile)
             }
         }
 

--- a/reporter/src/main/kotlin/reporters/AsciiDocTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AsciiDocTemplateReporter.kt
@@ -38,7 +38,7 @@ import org.ossreviewtoolkit.utils.safeDeleteRecursively
  * with [AsciidoctorJ][3] as Java interface and [AsciidoctorJ PDF][4] as PDF file generator.
  * For each Freemarker template provided using the options described below a separate intermediate file is created
  * that can be processed by AsciidoctorJ. If no options are provided, the "disclosure_document" template is used, and if
- * security vulnerability information is available also the "vulerability_report" template.
+ * security vulnerability information is available also the "vulernability_report" template.
  *
  * After the intermediate files are generated, they are processed by  AsciidoctorJ PDF.
  * A PDF theme can be handed over to AsciidoctorJ PDF in which properties like fonts or images displayed in the PDF can
@@ -49,7 +49,7 @@ import org.ossreviewtoolkit.utils.safeDeleteRecursively
  *
  * This reporter supports the following options:
  * - *template.id*: A comma-separated list of IDs of templates provided by ORT. Currently, the "disclosure_document" and
- *                  "vulerability_report" templates are available.
+ *                  "vulernability_report" templates are available.
  * - *template.path*: A comma-separated list of paths to template files provided by the user.
  * - *backend*: The name of the AsciiDoc backend to use, like "html". Defaults to "pdf". As a special case, the "adoc"
  *              fake backend is used to indicate that no backend should be used but the AsciiDoc files should be kept.


### PR DESCRIPTION
To be able to refer to fonts without an absolute path in the
theme yaml, the attribute `pdf-fontsdir` was added.

As described in the [asciidoctor-pdf documentation][1]

In order to support both custom fonts and the location of
bundled fonts the [`GEM_FONTS_DIR` was added in the attribute
by default][1].

[1]: https://github.com/asciidoctor/asciidoctor-pdf/blob/master/docs/theming-guide.adoc#configuring-the-font-search-path

