### PR TITLE
RemoteScanner: Fix a leaking "this" in constructor

### DIFF
--- a/scanner/src/main/kotlin/RemoteScanner.kt
+++ b/scanner/src/main/kotlin/RemoteScanner.kt
@@ -40,5 +40,5 @@ abstract class RemoteScanner(name: String, config: ScannerConfiguration) : Scann
     /**
      * Return the [ScannerDetails] of this [RemoteScanner].
      */
-    val details = ScannerDetails(scannerName, version, configuration)
+    val details by lazy { ScannerDetails(scannerName, version, configuration) }
 }


### PR DESCRIPTION
Fix this inspection hint by turning "details" into a lazy property, like
it is in LocalScanner.

This is a fixup for a2a2b71.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>