### PR TITLE
OrtAuthenticator : in .netrc, raise 'machine' precedence

### DIFF
--- a/utils/src/main/kotlin/OrtAuthenticator.kt
+++ b/utils/src/main/kotlin/OrtAuthenticator.kt
@@ -146,10 +146,12 @@ fun getNetrcAuthentication(contents: String, machine: String): PasswordAuthentic
     }
 
     credentialsPerMachine[machine]?.let {
+        OrtAuthenticator.log.debug { "Found .netrc entry for $machine." }
         return PasswordAuthentication(it.first, it.second.toCharArray())
     }
 
     return credentialsPerMachine["default"]?.let {
+        OrtAuthenticator.log.debug { "Using default .netrc entry for $machine." }
         PasswordAuthentication(it.first, it.second.toCharArray())
     }
 }

--- a/utils/src/test/kotlin/OrtAuthenticatorTest.kt
+++ b/utils/src/test/kotlin/OrtAuthenticatorTest.kt
@@ -61,6 +61,19 @@ class OrtAuthenticatorTest : WordSpec({
             authentication.password shouldBe "bar".toCharArray()
         }
 
+        "prefer machine-specific entries over the default" {
+            val authentication = getNetrcAuthentication("""
+                default login foo password bar
+                machine github.com
+                login git
+                password hub
+            """.trimIndent(), "github.com")
+
+            authentication.shouldNotBeNull()
+            authentication.userName shouldBe "git"
+            authentication.password shouldBe "hub".toCharArray()
+        }
+
         "ignore superfluous statements" {
             val authentication = getNetrcAuthentication("""
                 machine "# A funky way to add comments."


### PR DESCRIPTION
When parsing the .netrc, the entry with the 'machine'
name has higher precedence than the 'default' one.
Current implementation always wrongly returns the first entry.

Also : the regex has been moved to a static field because compilation is expensive.
Maybe it would be worthwhile to make getNetrcAuthentication() an instance function
of OrtAuthenticator ? Thus we could make the regex private.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>