### PR TITLE
Prevent download of binaries when analyzing a Maven project

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -287,7 +287,10 @@ class MavenSupport(workspaceReader: WorkspaceReader) {
             aetherRepositorySystem
         )
 
-        return DefaultRepositorySystemSession(session).setWorkspaceReader(workspaceReader).apply {
+        val skipDownloadWorkspaceReader = SkipBinaryDownloadsWorkspaceReader(workspaceReader)
+
+        return DefaultRepositorySystemSession(session).apply {
+            setWorkspaceReader(skipDownloadWorkspaceReader)
             installAuthenticatorAndProxySelector()
             proxySelector = JreProxySelector()
         }
@@ -669,5 +672,38 @@ class HttpsMirrorSelector(private val originalMirrorSelector: MirrorSelector?) :
             setReleasePolicy(repository.getPolicy(false))
             setMirroredRepositories(listOf(repository))
         }.build()
+    }
+}
+
+/**
+ * A specialized [WorkspaceReader] implementation used when building a Maven project that prevents unnecessary
+ * downloads of binary artifacts.
+ *
+ * When building a Maven project from a POM using Maven's [ProjectBuilder] API clients have no control over the
+ * downloads of dependencies: If dependencies are to be resolved, all the artifacts of these dependencies are
+ * automatically downloaded. For the purpose of just constructing the dependency tree, this is not needed and only
+ * costs time and bandwidth.
+ *
+ * Unfortunately, there is no official API to prevent the download of dependencies. However, Maven can be tricked to
+ * believe that the artifacts are already present on the local disk - then the download is skipped. This is what
+ * this implementation does. It reports that all binary artifacts are available locally, and only treats POMs
+ * correctly, as they may be required for the dependency analysis.
+ */
+private class SkipBinaryDownloadsWorkspaceReader(
+    /** The real workspace reader to delegate to. */
+    val delegate: WorkspaceReader
+) : WorkspaceReader by delegate {
+    /**
+     * Locate the given artifact on the local disk. This implementation does a correct location only for POM files;
+     * for all other artifacts it returns a non-null file. Note: For the purpose of analyzing the project's
+     * dependencies the artifact files are never accessed. Therefore, the concrete file returned here does not
+     * actually matter; it just have to be non-null to indicate that the artifact is present locally.
+     */
+    override fun findArtifact(artifact: Artifact): File? {
+        return if (artifact.extension == "pom") {
+            delegate.findArtifact(artifact)
+        } else {
+            File(artifact.artifactId)
+        }
     }
 }


### PR DESCRIPTION
MavenSupport.buildMavenProject() used to download all the artifacts
for the dependencies of the project to build, which is unnecessary for
the analysis. There is no official way in the Maven API to prevent
this.

Therefore, implement a custom WorkspaceReader that claims binary
artifacts to be present locally; they are then no longer downloaded.
Further details can be found in this ticket:
https://github.com/oss-review-toolkit/ort/issues/2115.

Resolves #2115.

Signed-off-by: Oliver Heger <oliver.heger@bosch.io>

Please ensure that your pull request adheres to our [contribution guidelines](../CONTRIBUTING.md). Thank you!
