### PR TITLE
AsciiDocTemplateReporter: Make the PDF theme file naming more consistent

### DIFF
--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -155,7 +155,7 @@ class ExamplesFunTest : StringSpec() {
             val report = AsciiDocTemplateReporter().generateReport(
                 ReporterInput(OrtResult.EMPTY),
                 outputDir,
-                mapOf("pdf-theme.path" to examplesDir.resolve("asciidoctor-pdf-theme.yml").path)
+                mapOf("pdf.theme.file" to examplesDir.resolve("asciidoctor-pdf-theme.yml").path)
             )
 
             report shouldHaveSize 1

--- a/docs/reporters/AsciiDocTemplateReporter.md
+++ b/docs/reporters/AsciiDocTemplateReporter.md
@@ -20,7 +20,7 @@ the theme file does not exist, an in-built theme of AsciidoctorJ PDF is used.
 * `template.path`: A comma-separated list of paths to template files provided by the user.
 * `backend`: The name of the AsciiDoc backend to use, like "html". Defaults to "pdf". As a special case, the "adoc"
              fake backend is used to indicate that no backend should be used but the AsciiDoc files should be kept.
-* `pdf-theme.path`: A path to an AsciiDoc PDF theme file. Only used with the "pdf" backend.
+* `pdf.theme.file`: A path to an AsciiDoc PDF theme file. Only used with the "pdf" backend.
 
 ## Command Line
 
@@ -33,7 +33,7 @@ cli/build/install/ort/bin/ort report
   -o [reporter-output-dir]
   -f AsciiDoc
   --report-option AsciiDocTemplate=template.id=[template-id]
-  --report-option AsciiDocTemplate=pdf-theme.path=pdf-theme.yml
+  --report-option AsciiDocTemplate=pdf.theme.file=pdf-theme.yml
 ```
 
 [1]: https://freemarker.apache.org

--- a/reporter/src/funTest/kotlin/reporters/AsciiDocTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/AsciiDocTemplateReporterFunTest.kt
@@ -43,7 +43,7 @@ class AsciiDocTemplateReporterFunTest : StringSpec({
 
     "Report generation is aborted when path to non-existing pdf-them file is given" {
         shouldThrow<IllegalArgumentException> {
-            generateReport(ORT_RESULT, mapOf("pdf-theme.path" to "dummy.file"))
+            generateReport(ORT_RESULT, mapOf("pdf.theme.file" to "dummy.file"))
         }
     }
 })

--- a/reporter/src/main/kotlin/reporters/AsciiDocTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AsciiDocTemplateReporter.kt
@@ -53,7 +53,7 @@ import org.ossreviewtoolkit.utils.safeDeleteRecursively
  * - *template.path*: A comma-separated list of paths to template files provided by the user.
  * - *backend*: The name of the AsciiDoc backend to use, like "html". Defaults to "pdf". As a special case, the "adoc"
  *              fake backend is used to indicate that no backend should be used but the AsciiDoc files should be kept.
- * - *pdf-theme.path*: A path to an AsciiDoc PDF theme file. Only used with the "pdf" backend.
+ * - *pdf.theme.file*: A path to an AsciiDoc PDF theme file. Only used with the "pdf" backend.
  *
  * [1]: https://freemarker.apache.org
  * [2]: https://asciidoc.org/
@@ -71,7 +71,7 @@ class AsciiDocTemplateReporter : Reporter {
         private const val VULNERABILITY_TEMPLATE_ID = "vulnerability_report"
 
         private const val OPTION_BACKEND = "backend"
-        private const val OPTION_PDF_THEME_PATH = "pdf-theme.path"
+        private const val OPTION_PDF_THEME_FILE = "pdf.theme.file"
 
         private const val BACKEND_PDF = "pdf"
     }
@@ -93,12 +93,12 @@ class AsciiDocTemplateReporter : Reporter {
         val backend = templateOptions.remove(OPTION_BACKEND) ?: BACKEND_PDF
 
         if (backend.equals(BACKEND_PDF, ignoreCase = true)) {
-            templateOptions.remove(OPTION_PDF_THEME_PATH)?.let { themePath ->
-                File(themePath).also {
-                    require(it.isFile) { "Could not find pdf-theme file at '${it.absolutePath}'." }
+            templateOptions.remove(OPTION_PDF_THEME_FILE)?.let { pdfThemeFile ->
+                File(pdfThemeFile).also {
+                    require(it.isFile) { "Could not find PDF theme file at '${it.absolutePath}'." }
                 }
 
-                asciidoctorAttributes.attribute("pdf-theme", themePath)
+                asciidoctorAttributes.attribute("pdf-theme", pdfThemeFile)
             }
         }
 


### PR DESCRIPTION
Only use dots in the property name, and clarify that this is file.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>