### PR TITLE
analyzer: Relax strict version requirements on external tools

### DIFF
--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -59,9 +59,6 @@ class Bower(
     repoConfig: RepositoryConfiguration
 ) : PackageManager(name, analysisRoot, analyzerConfig, repoConfig), CommandLineTool {
     companion object {
-        // We do not actually depend on any features specific to this Bower version, but we still want to
-        // stick to fixed versions to be sure to get consistent results.
-        private const val REQUIRED_BOWER_VERSION = "1.8.8"
         private const val SCOPE_NAME_DEPENDENCIES = "dependencies"
         private const val SCOPE_NAME_DEV_DEPENDENCIES = "devDependencies"
 
@@ -211,7 +208,7 @@ class Bower(
 
     override fun command(workingDir: File?) = if (Os.isWindows) "bower.cmd" else "bower"
 
-    override fun getVersionRequirement(): Requirement = Requirement.buildStrict(REQUIRED_BOWER_VERSION)
+    override fun getVersionRequirement(): Requirement = Requirement.buildIvy("[1.8.8,)")
 
     override fun beforeResolution(definitionFiles: List<File>) = checkVersion(analyzerConfig.ignoreToolVersions)
 

--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -64,8 +64,6 @@ class Conan(
     repoConfig: RepositoryConfiguration
 ) : PackageManager(name, analysisRoot, analyzerConfig, repoConfig), CommandLineTool {
     companion object {
-        private const val REQUIRED_CONAN_VERSION = "1.18.0"
-
         private const val SCOPE_NAME_DEPENDENCIES = "requires"
         private const val SCOPE_NAME_DEV_DEPENDENCIES = "build_requires"
     }
@@ -90,7 +88,7 @@ class Conan(
         // Conan version 1.18.0
         output.removePrefix("Conan version ")
 
-    override fun getVersionRequirement(): Requirement = Requirement.buildStrict(REQUIRED_CONAN_VERSION)
+    override fun getVersionRequirement(): Requirement = Requirement.buildIvy("[1.18.0,)")
 
     override fun beforeResolution(definitionFiles: List<File>) = checkVersion(analyzerConfig.ignoreToolVersions)
 


### PR DESCRIPTION
Instead of requiring a strict version, use that version as the minimum
to avoid frequent updates for newer versions. An upper bound could quickly
be set if incompatibility with a newer version is reported that cannot
immediately be fixed.

Resolves #3440.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>