### PR TITLE
LicenseInfoResolver: Properly determine the root license files

### DIFF
--- a/model/src/main/kotlin/ScanResult.kt
+++ b/model/src/main/kotlin/ScanResult.kt
@@ -50,7 +50,7 @@ data class ScanResult(
     fun filterPath(path: String): ScanResult {
         if (path.isBlank()) return this
 
-        val applicableLicenseFiles = RootLicenseMatcher().getApplicableLicenseFilesForDirectories(
+        val applicableLicenseFiles = RootLicenseMatcher().getApplicableRootLicenseFindingsForDirectories(
             licenseFindings = summary.licenseFindings,
             directories = listOf(path)
         ).values.flatten().mapTo(mutableSetOf()) { it.location.path }

--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -162,7 +162,7 @@ class FindingsMatcher(
         licenseFindings: Set<LicenseFinding>,
         copyrightFindings: Set<CopyrightFinding>
     ): Map<LicenseFinding, Set<CopyrightFinding>> {
-        val rootLicensesForDirectories = rootLicenseMatcher.getApplicableLicenseFilesForDirectories(
+        val rootLicensesForDirectories = rootLicenseMatcher.getApplicableRootLicenseFindingsForDirectories(
             licenseFindings = licenseFindings,
             directories = copyrightFindings.map { it.location.directory() }
         )

--- a/model/src/main/kotlin/utils/RootLicenseMatcher.kt
+++ b/model/src/main/kotlin/utils/RootLicenseMatcher.kt
@@ -54,7 +54,7 @@ class RootLicenseMatcher(
      * applicable to the respective directory. These values of the map entries are subsets of the given
      * [licenseFindings].
      */
-    fun getApplicableLicenseFilesForDirectories(
+    fun getApplicableRootLicenseFindingsForDirectories(
         licenseFindings: Collection<LicenseFinding>,
         directories: Collection<String>
     ): Map<String, Set<LicenseFinding>> {

--- a/model/src/main/kotlin/utils/RootLicenseMatcher.kt
+++ b/model/src/main/kotlin/utils/RootLicenseMatcher.kt
@@ -51,7 +51,7 @@ class RootLicenseMatcher(
 
     /**
      * Return a mapping from the given relative [directories] to the licenses findings for the (root) license files
-     * applicable to the respective directory. These values of the map entries are subsets of the given
+     * applicable to the respective directory. The values of the map entries are subsets of the given
      * [licenseFindings].
      */
     fun getApplicableRootLicenseFindingsForDirectories(
@@ -69,7 +69,7 @@ class RootLicenseMatcher(
 
     /**
      * Return a mapping from the given relative [directories] to the relative paths of the (root) licenses files
-     * applicable to that respective directory. These values of the map entries are subsets of the given
+     * applicable to that respective directory. The values of the map entries are subsets of the given
      * [relativeFilePaths].
      */
     fun getApplicableLicenseFilesForDirectories(

--- a/model/src/test/kotlin/RootLicenseMatcherTest.kt
+++ b/model/src/test/kotlin/RootLicenseMatcherTest.kt
@@ -46,7 +46,7 @@ private val COMMONLY_USED_LICENSE_FILE_NAMES = listOf(
 class RootLicenseMatcherTest : WordSpec({
     "getApplicableLicenseFilesForDirectories" should {
         "override license files of ancestors as expected" {
-            RootLicenseMatcher().getApplicableLicenseFilesForDirectories(
+            RootLicenseMatcher().getApplicableRootLicenseFindingsForDirectories(
                 licenseFindings = licenseFindings(
                     "README",
                     "PATENTS",
@@ -66,7 +66,7 @@ class RootLicenseMatcherTest : WordSpec({
         }
 
         "not use the readme if there is a license file" {
-            RootLicenseMatcher().getApplicableLicenseFilesForDirectories(
+            RootLicenseMatcher().getApplicableRootLicenseFindingsForDirectories(
                 licenseFindings = licenseFindings(
                     "README",
                     "LICENSE"
@@ -76,7 +76,7 @@ class RootLicenseMatcherTest : WordSpec({
         }
 
         "use the readme if there is no license but a patents file" {
-            RootLicenseMatcher().getApplicableLicenseFilesForDirectories(
+            RootLicenseMatcher().getApplicableRootLicenseFindingsForDirectories(
                 licenseFindings = licenseFindings(
                     "README",
                     "PATENTS"
@@ -87,7 +87,7 @@ class RootLicenseMatcherTest : WordSpec({
 
         "match commonly used license file paths in upper-case" {
             COMMONLY_USED_LICENSE_FILE_NAMES.map { it.toUpperCase() }.forAll {
-                RootLicenseMatcher().getApplicableLicenseFilesForDirectories(
+                RootLicenseMatcher().getApplicableRootLicenseFindingsForDirectories(
                     licenseFindings = licenseFindings(it),
                     directories = listOf("")
                 ).paths() shouldBe mapOf("" to setOf(it))
@@ -96,7 +96,7 @@ class RootLicenseMatcherTest : WordSpec({
 
         "match commonly used license file paths in lower-case" {
             COMMONLY_USED_LICENSE_FILE_NAMES.map { it.toLowerCase() }.forAll {
-                RootLicenseMatcher().getApplicableLicenseFilesForDirectories(
+                RootLicenseMatcher().getApplicableRootLicenseFindingsForDirectories(
                     licenseFindings = licenseFindings(it),
                     directories = listOf("")
                 ).paths() shouldBe mapOf("" to setOf(it))
@@ -105,7 +105,7 @@ class RootLicenseMatcherTest : WordSpec({
 
         "match commonly used license file paths in capital (case)" {
             COMMONLY_USED_LICENSE_FILE_NAMES.map { it.capitalize() }.forAll {
-                RootLicenseMatcher().getApplicableLicenseFilesForDirectories(
+                RootLicenseMatcher().getApplicableRootLicenseFindingsForDirectories(
                     licenseFindings = licenseFindings(it),
                     directories = listOf("")
                 ).paths() shouldBe mapOf("" to setOf(it))


### PR DESCRIPTION
The current implementation of the license info resolver considers any
file that has been archived and is matching the currently configured
archiver pattern as a root license file.

In recent month an improved heuristic for determining the root license
has been implemented, but it's not yet been take into use by this license
info resolver. That heuristic also considers the actual project / VCS path
and is no limited to matching only files residing in the root directory
anymore. For consistency it also should be applied here.

Doing so makes it possible to broaden the archiver patterns without
affecting the generated notices. Further, it eliminates the need to create
a separate archives per VCS path (for same revision and VCS URL). Finally
it simplifies the (planned) removal of sparse checkouts.
