### PR TITLE
getting-started: Fix the directory to change to

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ git clone --recurse-submodules https://github.com/oss-review-toolkit/ort.git
 To build the command line interface run:
 
 ```bash
-cd oss-review-toolkit
+cd ort
 ./gradlew installDist
 ```
 


### PR DESCRIPTION
As the repository is now called "ort", change the directory to change to
accordingly.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>