### PR TITLE
Stop archiving the local Maven repository in CI builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,6 @@ cache:
   - $(HOME)\.gradle\caches
   - $(HOME)\.gradle\wrapper\dists -> gradle\wrapper\gradle-wrapper.properties
   - $(HOME)\.ivy2
-  - $(HOME)\.m2\repository
   - $(HOME)\.ort\cache
 
 clone_depth: 50

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/dists/
     - $HOME/.ivy2/
-    - $HOME/.m2/repository/
     - $HOME/.ort/cache/
 
 env:


### PR DESCRIPTION
This fortunately has no benefit anymore as of [1], and not archiving the
local Maven repository should speed up CI builds.

[1] https://github.com/oss-review-toolkit/ort/pull/3445

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>