### PR TITLE
LocalScanner: Check for archived files if scan results are present

### DIFF
--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -36,6 +36,11 @@ data class ScannerConfiguration(
     val archive: FileArchiverConfiguration? = null,
 
     /**
+     * Create archives for packages that have a stored scan result but no license archive yet.
+     */
+    val createMissingArchives: Boolean = false,
+
+    /**
      * Scanner specific configuration options. The key needs to match the name of the scanner class, e.g. "ScanCode"
      * for the ScanCode wrapper. See the documentation of the scanner for available options.
      */

--- a/model/src/test/assets/reference.conf
+++ b/model/src/test/assets/reference.conf
@@ -41,6 +41,8 @@ ort {
       }
     }
 
+    createMissingArchives = false
+
     options {
       // A map of maps from scanner class names to scanner-specific key-value pairs.
       // At the example of applying custom options for ScanCode, this would look like:

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -205,6 +205,7 @@ scanner:
     tool_versions: {}
   config:
     archive: null
+    create_missing_archives: false
     options: null
     storages: null
     storage_readers: null


### PR DESCRIPTION
The LocalScanner supports both an archive and a storage. So far, if
results of a package are present in the storage, they are skipped,
independent of the presence of results in the archive. Add an additional
check that, in case of absence, downloads the source code and applies the
archiving process.