### PR TITLE
Configurable license filename patterns

### DIFF
--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -42,8 +42,8 @@ import org.apache.logging.log4j.core.config.Configurator
 
 import org.ossreviewtoolkit.commands.*
 import org.ossreviewtoolkit.model.Environment
+import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.model.config.OrtConfiguration
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.ORT_CONFIG_DIR_ENV_NAME
 import org.ossreviewtoolkit.utils.ORT_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ORT_DATA_DIR_ENV_NAME

--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -43,6 +43,7 @@ import org.apache.logging.log4j.core.config.Configurator
 import org.ossreviewtoolkit.commands.*
 import org.ossreviewtoolkit.model.Environment
 import org.ossreviewtoolkit.model.config.OrtConfiguration
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.ORT_CONFIG_DIR_ENV_NAME
 import org.ossreviewtoolkit.utils.ORT_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ORT_DATA_DIR_ENV_NAME
@@ -145,13 +146,10 @@ class OrtMain : CliktCommand(name = ORT_NAME, epilog = "* denotes required optio
         // Make the parameter globally available.
         printStackTrace = stacktrace
 
-        // Make options available to subcommands.
-        currentContext.findOrSetObject {
-            GlobalOptions(
-                OrtConfiguration.load(configArguments, configFile),
-                forceOverwrite
-            )
-        }
+        // Make options available to subcommands and apply static configuration.
+        val ortConfiguration = OrtConfiguration.load(configArguments, configFile)
+        currentContext.findOrSetObject { GlobalOptions(ortConfiguration, forceOverwrite) }
+        applyStaticConfiguration(ortConfiguration)
 
         println(getVersionHeader(env.ortVersion))
     }
@@ -186,6 +184,10 @@ class OrtMain : CliktCommand(name = ORT_NAME, epilog = "* denotes required optio
 
         return header.joinToString("\n", postfix = "\n")
     }
+}
+
+private fun applyStaticConfiguration(ortConfiguration: OrtConfiguration) {
+    ortConfiguration.licenseFilePatterns?.let { LicenseFilenamePatterns.configure(it) }
 }
 
 /**

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -48,6 +48,7 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
+import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.config.orEmpty
 import org.ossreviewtoolkit.model.licenses.DefaultLicenseInfoProvider
 import org.ossreviewtoolkit.model.licenses.LicenseClassifications
@@ -67,7 +68,6 @@ import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.ortConfigDirectory
 import org.ossreviewtoolkit.utils.perf
 import org.ossreviewtoolkit.utils.safeMkdirs
-import org.ossreviewtoolkit.utils.storage.FileArchiver
 
 class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate rules on ORT result files.") {
     private val ortFile by option(
@@ -257,7 +257,7 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate rules 
         val licenseInfoResolver = LicenseInfoResolver(
             provider = DefaultLicenseInfoProvider(finalOrtResult, packageConfigurationProvider),
             copyrightGarbage = copyrightGarbage,
-            archiver = globalOptionsForSubcommands.config.scanner?.archive?.createFileArchiver() ?: FileArchiver.DEFAULT
+            archiver = globalOptionsForSubcommands.config.scanner?.archive.createFileArchiver()
         )
 
         val licenseClassifications =

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -43,6 +43,7 @@ import org.ossreviewtoolkit.GlobalOptions
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.Resolutions
+import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.config.orEmpty
 import org.ossreviewtoolkit.model.licenses.DefaultLicenseInfoProvider
 import org.ossreviewtoolkit.model.licenses.LicenseClassifications
@@ -70,7 +71,6 @@ import org.ossreviewtoolkit.utils.ortConfigDirectory
 import org.ossreviewtoolkit.utils.perf
 import org.ossreviewtoolkit.utils.safeMkdirs
 import org.ossreviewtoolkit.utils.showStackTrace
-import org.ossreviewtoolkit.utils.storage.FileArchiver
 
 class ReporterCommand : CliktCommand(
     name = "report",
@@ -219,7 +219,7 @@ class ReporterCommand : CliktCommand(
         val licenseInfoResolver = LicenseInfoResolver(
             provider = DefaultLicenseInfoProvider(ortResult, packageConfigurationProvider),
             copyrightGarbage = copyrightGarbage,
-            archiver = globalOptionsForSubcommands.config.scanner?.archive?.createFileArchiver() ?: FileArchiver.DEFAULT
+            archiver = globalOptionsForSubcommands.config.scanner?.archive.createFileArchiver()
         )
 
         val licenseClassifications =

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.CommandLineTool
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.ALL_LICENSE_FILENAMES
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.showStackTrace
@@ -134,7 +134,7 @@ abstract class VersionControlSystem {
          * Return glob patterns matching all potential license or patent files.
          */
         internal fun getLicenseFileGlobPatterns(): List<String> =
-            ALL_LICENSE_FILENAMES.generateCapitalizationVariants().map { "**/$it" }
+            LicenseFilenamePatterns.DEFAULT.allLicenseFilenames.generateCapitalizationVariants().map { "**/$it" }
 
         private fun Collection<String>.generateCapitalizationVariants() =
             flatMap { listOf(it, it.toUpperCase(), it.capitalize()) }

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -28,8 +28,8 @@ import java.util.ServiceLoader
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.CommandLineTool
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.showStackTrace

--- a/model/src/main/kotlin/config/FileArchiverConfiguration.kt
+++ b/model/src/main/kotlin/config/FileArchiverConfiguration.kt
@@ -19,8 +19,10 @@
 
 package org.ossreviewtoolkit.model.config
 
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.storage.FileArchiver
 import org.ossreviewtoolkit.utils.storage.FileStorage
+import org.ossreviewtoolkit.utils.storage.LocalFileStorage
 
 /**
  * The configuration model for a [FileArchiver].
@@ -35,9 +37,17 @@ data class FileArchiverConfiguration(
      * Configuration of the [FileStorage] used for archiving the files.
      */
     val storage: FileStorageConfiguration
-) {
-    /**
-     * Create a [FileArchiver] based on this configuration.
-     */
-    fun createFileArchiver() = FileArchiver(patterns, storage.createFileStorage())
-}
+)
+
+/**
+ * Create a [FileArchiver] based on this configuration.
+ */
+fun FileArchiverConfiguration?.createFileArchiver(): FileArchiver =
+    if (this != null) {
+        FileArchiver(patterns, storage.createFileStorage())
+    } else {
+        FileArchiver(
+            LicenseFilenamePatterns.ALL_LICENSE_FILENAMES,
+            LocalFileStorage(FileArchiver.DEFAULT_ARCHIVE_DIR)
+        )
+    }

--- a/model/src/main/kotlin/config/FileArchiverConfiguration.kt
+++ b/model/src/main/kotlin/config/FileArchiverConfiguration.kt
@@ -19,6 +19,8 @@
 
 package org.ossreviewtoolkit.model.config
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
 import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.storage.FileArchiver
 import org.ossreviewtoolkit.utils.storage.FileStorage
@@ -27,12 +29,8 @@ import org.ossreviewtoolkit.utils.storage.LocalFileStorage
 /**
  * The configuration model for a [FileArchiver].
  */
+@JsonIgnoreProperties(value = ["patterns"])
 data class FileArchiverConfiguration(
-    /**
-     * A list of glob patterns that define which files will be archived.
-     */
-    val patterns: List<String>,
-
     /**
      * Configuration of the [FileStorage] used for archiving the files.
      */
@@ -42,12 +40,9 @@ data class FileArchiverConfiguration(
 /**
  * Create a [FileArchiver] based on this configuration.
  */
-fun FileArchiverConfiguration?.createFileArchiver(): FileArchiver =
-    if (this != null) {
-        FileArchiver(patterns, storage.createFileStorage())
-    } else {
-        FileArchiver(
-            LicenseFilenamePatterns.DEFAULT.allLicenseFilenames,
-            LocalFileStorage(FileArchiver.DEFAULT_ARCHIVE_DIR)
-        )
-    }
+fun FileArchiverConfiguration?.createFileArchiver(): FileArchiver {
+    val storage = this?.storage?.createFileStorage() ?: LocalFileStorage(FileArchiver.DEFAULT_ARCHIVE_DIR)
+    val patterns = LicenseFilenamePatterns.getInstance().allLicenseFilenames
+
+    return FileArchiver(patterns, storage)
+}

--- a/model/src/main/kotlin/config/FileArchiverConfiguration.kt
+++ b/model/src/main/kotlin/config/FileArchiverConfiguration.kt
@@ -21,7 +21,6 @@ package org.ossreviewtoolkit.model.config
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.storage.FileArchiver
 import org.ossreviewtoolkit.utils.storage.FileStorage
 import org.ossreviewtoolkit.utils.storage.LocalFileStorage

--- a/model/src/main/kotlin/config/FileArchiverConfiguration.kt
+++ b/model/src/main/kotlin/config/FileArchiverConfiguration.kt
@@ -47,7 +47,7 @@ fun FileArchiverConfiguration?.createFileArchiver(): FileArchiver =
         FileArchiver(patterns, storage.createFileStorage())
     } else {
         FileArchiver(
-            LicenseFilenamePatterns.ALL_LICENSE_FILENAMES,
+            LicenseFilenamePatterns.DEFAULT.allLicenseFilenames,
             LocalFileStorage(FileArchiver.DEFAULT_ARCHIVE_DIR)
         )
     }

--- a/model/src/main/kotlin/config/LicenseFilenamePatterns.kt
+++ b/model/src/main/kotlin/config/LicenseFilenamePatterns.kt
@@ -23,7 +23,7 @@ import org.ossreviewtoolkit.utils.log
 
 data class LicenseFilenamePatterns(
     /**
-     * A list of globs that match default license file names.
+     * A list of globs that match default license file names. The patterns are supposed to be used case-insensitively.
      */
     val licenseFilenames: List<String>,
 

--- a/model/src/main/kotlin/config/LicenseFilenamePatterns.kt
+++ b/model/src/main/kotlin/config/LicenseFilenamePatterns.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.utils
+package org.ossreviewtoolkit.model.config
+
+import org.ossreviewtoolkit.utils.log
 
 data class LicenseFilenamePatterns(
     /**

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -29,6 +29,7 @@ import com.sksamuel.hoplite.parsers.toNode
 
 import java.io.File
 
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.log
 
 /**
@@ -39,6 +40,11 @@ data class OrtConfiguration(
      * The configuration of the scanner.
      */
     val scanner: ScannerConfiguration? = null,
+
+    /**
+     * The license file patterns.
+     */
+    val licenseFilePatterns: LicenseFilenamePatterns? = null,
 
     /**
      * The configuration of the advisors, using the advisor's name as the key.

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -29,7 +29,6 @@ import com.sksamuel.hoplite.parsers.toNode
 
 import java.io.File
 
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.log
 
 /**

--- a/model/src/main/kotlin/utils/RootLicenseMatcher.kt
+++ b/model/src/main/kotlin/utils/RootLicenseMatcher.kt
@@ -22,8 +22,8 @@ package org.ossreviewtoolkit.model.utils
 import java.io.File
 
 import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.FileMatcher
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.getAllAncestorDirectories
 
 /**

--- a/model/src/main/kotlin/utils/RootLicenseMatcher.kt
+++ b/model/src/main/kotlin/utils/RootLicenseMatcher.kt
@@ -41,9 +41,9 @@ import org.ossreviewtoolkit.utils.getAllAncestorDirectories
  * Patent files are assigned in an analog way, but without any fallback pattern.
  */
 class RootLicenseMatcher(
-    licenseFilenamePatterns: List<String> = LicenseFilenamePatterns.LICENSE_FILENAMES,
-    patentFilenamePatterns: List<String> = LicenseFilenamePatterns.PATENT_FILENAMES,
-    rootLicenseFilenamePatterns: List<String> = LicenseFilenamePatterns.ROOT_LICENSE_FILENAMES
+    licenseFilenamePatterns: List<String> = LicenseFilenamePatterns.DEFAULT.licenseFilenames,
+    patentFilenamePatterns: List<String> = LicenseFilenamePatterns.DEFAULT.patentFilenames,
+    rootLicenseFilenamePatterns: List<String> = LicenseFilenamePatterns.DEFAULT.rootLicenseFilenames
 ) {
     private val licenseFileMatcher = createFileMatcher(licenseFilenamePatterns)
     private val patentFileMatcher = createFileMatcher(patentFilenamePatterns)

--- a/model/src/test/assets/reference.conf
+++ b/model/src/test/assets/reference.conf
@@ -9,6 +9,12 @@ ort {
     }
   }
 
+  licenseFilePatterns {
+    licenseFilenames = ["license*"]
+    patentFilenames = ["patents"]
+    rootLicenseFilenames = ["readme*"]
+  }
+
   scanner {
     archive {
       patterns = ["LICENSE*", "COPYING*"]

--- a/model/src/test/assets/reference.conf
+++ b/model/src/test/assets/reference.conf
@@ -17,7 +17,6 @@ ort {
 
   scanner {
     archive {
-      patterns = ["LICENSE*", "COPYING*"]
       storage {
         localFileStorage {
           directory = ~/.ort/scanner/archive

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -22,7 +22,6 @@ package org.ossreviewtoolkit.model.config
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.extensions.system.withEnvironment
-import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.nulls.shouldBeNull
@@ -48,7 +47,6 @@ class OrtConfigurationTest : WordSpec({
 
             ortConfig.scanner shouldNotBeNull {
                 archive shouldNotBeNull {
-                    patterns should containExactly("LICENSE*", "COPYING*")
                     storage.httpFileStorage.shouldBeNull()
                     storage.localFileStorage shouldNotBeNull {
                         directory shouldBe File("~/.ort/scanner/archive")

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -90,6 +90,12 @@ class OrtConfigurationTest : WordSpec({
                 storageReaders shouldContainExactly listOf("local", "postgres", "http", "clearlyDefined")
                 storageWriters shouldContainExactly listOf("postgres")
             }
+
+            ortConfig.licenseFilePatterns shouldNotBeNull {
+                licenseFilenames shouldContainExactly listOf("license*")
+                patentFilenames shouldContainExactly listOf("patents")
+                rootLicenseFilenames shouldContainExactly listOf("readme*")
+            }
         }
 
         "correctly prioritize the sources" {

--- a/model/src/test/kotlin/config/ScannerConfigurationTest.kt
+++ b/model/src/test/kotlin/config/ScannerConfigurationTest.kt
@@ -45,7 +45,6 @@ class ScannerConfigurationTest : WordSpec({
             // Relative paths have been normalized, passwords do not get serialized, etc.
             loadedConfig.storageReaders shouldBe ortConfig.scanner?.storageReaders
             loadedConfig.storageWriters shouldBe ortConfig.scanner?.storageWriters
-            loadedConfig.archive?.patterns shouldBe ortConfig.scanner?.archive?.patterns
             loadedConfig.archive?.storage?.httpFileStorage.shouldBeNull()
 
             val loadedStorages = loadedConfig.storages.orEmpty()

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -57,6 +57,7 @@ import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.storage.FileArchiver
 import org.ossreviewtoolkit.utils.storage.LocalFileStorage
+import org.ossreviewtoolkit.utils.test.createDefault
 
 class LicenseInfoResolverTest : WordSpec() {
     init {
@@ -522,7 +523,7 @@ class LicenseInfoResolverTest : WordSpec() {
     private fun createResolver(
         data: List<LicenseInfo>,
         copyrightGarbage: Set<String> = emptySet(),
-        archiver: FileArchiver = FileArchiver.DEFAULT
+        archiver: FileArchiver = FileArchiver.createDefault()
     ) = LicenseInfoResolver(
         SimpleLicenseInfoProvider(data),
         CopyrightGarbage(copyrightGarbage.toSortedSet()),

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -45,6 +45,7 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
+import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.LicenseFindingCurationReason
 import org.ossreviewtoolkit.model.config.PathExclude
@@ -54,7 +55,6 @@ import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.spdx.getLicenseText
 import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.storage.FileArchiver
 import org.ossreviewtoolkit.utils.storage.LocalFileStorage
 import org.ossreviewtoolkit.utils.test.createDefault

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -54,7 +54,7 @@ import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.spdx.getLicenseText
 import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.LICENSE_FILENAMES
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.storage.FileArchiver
 import org.ossreviewtoolkit.utils.storage.LocalFileStorage
 
@@ -482,7 +482,10 @@ class LicenseInfoResolverTest : WordSpec() {
                 )
 
                 val archiveDir = File("src/test/assets/archive")
-                val archiver = FileArchiver(LICENSE_FILENAMES, LocalFileStorage(archiveDir))
+                val archiver = FileArchiver(
+                    patterns = LicenseFilenamePatterns.DEFAULT.licenseFilenames,
+                    storage = LocalFileStorage(archiveDir)
+                )
                 val resolver = createResolver(licenseInfos, archiver = archiver)
 
                 val result = resolver.resolveLicenseFiles(pkgId)

--- a/model/src/test/kotlin/licenses/LicenseViewTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseViewTest.kt
@@ -36,12 +36,13 @@ import org.ossreviewtoolkit.spdx.SpdxExpression
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.storage.FileArchiver
+import org.ossreviewtoolkit.utils.test.createDefault
 
 class LicenseViewTest : WordSpec() {
     private val licenseInfoResolver = LicenseInfoResolver(
         DefaultLicenseInfoProvider(ortResult, SimplePackageConfigurationProvider.EMPTY),
         CopyrightGarbage(),
-        FileArchiver.DEFAULT
+        FileArchiver.createDefault()
     )
 
     private fun LicenseView.getLicensesWithSources(

--- a/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterFunTest.kt
@@ -39,7 +39,7 @@ import org.ossreviewtoolkit.model.licenses.LicenseClassifications
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.LICENSE_FILENAMES
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.ORT_NAME
 
 class NoticeTemplateReporterFunTest : WordSpec({
@@ -60,7 +60,7 @@ class NoticeTemplateReporterFunTest : WordSpec({
             val config = OrtConfiguration(
                 ScannerConfiguration(
                     archive = FileArchiverConfiguration(
-                        patterns = LICENSE_FILENAMES,
+                        patterns = LicenseFilenamePatterns.DEFAULT.licenseFilenames,
                         storage = FileStorageConfiguration(
                             localFileStorage = LocalFileStorageConfiguration(
                                 directory = archiveDir,

--- a/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterFunTest.kt
@@ -39,7 +39,6 @@ import org.ossreviewtoolkit.model.licenses.LicenseClassifications
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.ORT_NAME
 
 class NoticeTemplateReporterFunTest : WordSpec({
@@ -60,7 +59,6 @@ class NoticeTemplateReporterFunTest : WordSpec({
             val config = OrtConfiguration(
                 ScannerConfiguration(
                     archive = FileArchiverConfiguration(
-                        patterns = LicenseFilenamePatterns.DEFAULT.licenseFilenames,
                         storage = FileStorageConfiguration(
                             localFileStorage = LocalFileStorageConfiguration(
                                 directory = archiveDir,

--- a/reporter/src/main/kotlin/ReporterInput.kt
+++ b/reporter/src/main/kotlin/ReporterInput.kt
@@ -25,6 +25,7 @@ import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.PackageConfiguration
+import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.licenses.DefaultLicenseInfoProvider
 import org.ossreviewtoolkit.model.licenses.LicenseClassifications
 import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
@@ -32,7 +33,6 @@ import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.ResolutionProvider
 import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
-import org.ossreviewtoolkit.utils.storage.FileArchiver
 
 /**
  * A bundle of input to be used by [Reporter] implementations.
@@ -74,7 +74,7 @@ data class ReporterInput(
     val licenseInfoResolver: LicenseInfoResolver = LicenseInfoResolver(
         provider = DefaultLicenseInfoProvider(ortResult, packageConfigurationProvider),
         copyrightGarbage = copyrightGarbage,
-        archiver = ortConfig.scanner?.archive?.createFileArchiver() ?: FileArchiver.DEFAULT
+        archiver = ortConfig.scanner?.archive.createFileArchiver()
     ),
 
     /**

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -60,6 +60,7 @@ import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.Success
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.scanner.storages.PostgresStorage
 import org.ossreviewtoolkit.utils.CommandLineTool
@@ -72,7 +73,6 @@ import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.perf
 import org.ossreviewtoolkit.utils.safeMkdirs
 import org.ossreviewtoolkit.utils.showStackTrace
-import org.ossreviewtoolkit.utils.storage.FileArchiver
 
 /**
  * Abstraction for a [Scanner] that operates locally. Scan results can be stored in a [ScanResultsStorage].
@@ -101,7 +101,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
     }
 
     private val archiver by lazy {
-        config.archive?.createFileArchiver() ?: FileArchiver.DEFAULT
+        config.archive.createFileArchiver()
     }
 
     /**

--- a/test-utils/src/main/kotlin/Extensions.kt
+++ b/test-utils/src/main/kotlin/Extensions.kt
@@ -24,6 +24,10 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import java.net.InetSocketAddress
 import java.net.Proxy
 
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
+import org.ossreviewtoolkit.utils.storage.FileArchiver
+import org.ossreviewtoolkit.utils.storage.LocalFileStorage
+
 fun Proxy.toGenericString() =
     (address() as? InetSocketAddress)?.let { address -> "${type()} @ ${address.hostString}:${address.port}" }
 
@@ -31,3 +35,9 @@ infix fun <T> T?.shouldNotBeNull(block: T.() -> Unit) {
     this.shouldNotBeNull()
     this.block()
 }
+
+fun FileArchiver.Companion.createDefault(): FileArchiver =
+    FileArchiver(
+        patterns = LicenseFilenamePatterns.DEFAULT.allLicenseFilenames.map { "**/$it" },
+        storage = LocalFileStorage(DEFAULT_ARCHIVE_DIR)
+    )

--- a/test-utils/src/main/kotlin/Extensions.kt
+++ b/test-utils/src/main/kotlin/Extensions.kt
@@ -24,7 +24,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import java.net.InetSocketAddress
 import java.net.Proxy
 
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
+import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.storage.FileArchiver
 import org.ossreviewtoolkit.utils.storage.LocalFileStorage
 

--- a/utils/src/main/kotlin/LicenseFilenamePatterns.kt
+++ b/utils/src/main/kotlin/LicenseFilenamePatterns.kt
@@ -61,5 +61,16 @@ data class LicenseFilenamePatterns(
                 "readme*"
             )
         )
+
+        private var instance: LicenseFilenamePatterns = DEFAULT
+
+        @Synchronized
+        fun configure(patterns: LicenseFilenamePatterns) {
+            log.info { "Configuring the license file patterns." }
+            instance = patterns
+        }
+
+        @Synchronized
+        fun getInstance(): LicenseFilenamePatterns = instance
     }
 }

--- a/utils/src/main/kotlin/LicenseFilenamePatterns.kt
+++ b/utils/src/main/kotlin/LicenseFilenamePatterns.kt
@@ -19,39 +19,47 @@
 
 package org.ossreviewtoolkit.utils
 
-object LicenseFilenamePatterns {
+data class LicenseFilenamePatterns(
     /**
      * A list of globs that match default license file names.
      */
-    val LICENSE_FILENAMES = listOf(
-        "copying*",
-        "copyright",
-        "licence*",
-        "license*",
-        "*.licence",
-        "*.license",
-        "unlicence",
-        "unlicense"
-    )
+    val licenseFilenames: List<String>,
 
     /**
      * A list of globs that match default patent file names. The patterns are supposed to be used case-insensitively.
      */
-    val PATENT_FILENAMES = listOf(
-        "patents"
-    )
+    val patentFilenames: List<String>,
 
     /**
      * A list of globs that match files that often define the root license of a project, but are no license files and
-     * are therefore not contained in [LICENSE_FILENAMES]. The patterns are supposed to be used case-insensitively.
+     * are therefore not contained in [licenseFilenames]. The patterns are supposed to be used case-insensitively.
      */
-    val ROOT_LICENSE_FILENAMES = listOf(
-        "readme*"
-    )
-
+    val rootLicenseFilenames: List<String>
+) {
     /**
-     * A list of globs that match all kind of license file names, equaling the union of [LICENSE_FILENAMES],
-     * [PATENT_FILENAMES] and [ROOT_LICENSE_FILENAMES]. The patterns are supposed to be used case-insensitively.
+     * A list of globs that match all kind of license file names, equaling the union of [licenseFilenames],
+     * [patentFilenames] and [rootLicenseFilenames]. The patterns are supposed to be used case-insensitively.
      */
-    val ALL_LICENSE_FILENAMES = LICENSE_FILENAMES + PATENT_FILENAMES + ROOT_LICENSE_FILENAMES
+    val allLicenseFilenames = (licenseFilenames + patentFilenames + rootLicenseFilenames).distinct()
+
+    companion object {
+        val DEFAULT = LicenseFilenamePatterns(
+            licenseFilenames = listOf(
+                "copying*",
+                "copyright",
+                "licence*",
+                "license*",
+                "*.licence",
+                "*.license",
+                "unlicence",
+                "unlicense"
+            ),
+            patentFilenames = listOf(
+                "patents"
+            ),
+            rootLicenseFilenames = listOf(
+                "readme*"
+            )
+        )
+    }
 }

--- a/utils/src/main/kotlin/storage/FileArchiver.kt
+++ b/utils/src/main/kotlin/storage/FileArchiver.kt
@@ -27,8 +27,7 @@ import kotlin.time.measureTime
 import kotlin.time.measureTimedValue
 
 import org.ossreviewtoolkit.utils.FileMatcher
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.LICENSE_FILENAMES
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.PATENT_FILENAMES
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.ALL_LICENSE_FILENAMES
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.log
@@ -62,7 +61,7 @@ class FileArchiver(
          */
         val DEFAULT by lazy {
             FileArchiver(
-                patterns = (LICENSE_FILENAMES + PATENT_FILENAMES).map { "**/$it" },
+                patterns = ALL_LICENSE_FILENAMES.map { "**/$it" },
                 storage = LocalFileStorage(DEFAULT_ARCHIVE_DIR)
             )
         }

--- a/utils/src/main/kotlin/storage/FileArchiver.kt
+++ b/utils/src/main/kotlin/storage/FileArchiver.kt
@@ -27,7 +27,6 @@ import kotlin.time.measureTime
 import kotlin.time.measureTimedValue
 
 import org.ossreviewtoolkit.utils.FileMatcher
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.log
@@ -55,16 +54,6 @@ class FileArchiver(
     companion object {
         private const val ARCHIVE_FILE_NAME = "archive.zip"
         val DEFAULT_ARCHIVE_DIR by lazy { ortDataDirectory.resolve("scanner/archive") }
-
-        /**
-         * A default [FileArchiver] that archives [license files][LICENSE_FILENAMES] in a local directory.
-         */
-        val DEFAULT by lazy {
-            FileArchiver(
-                patterns = LicenseFilenamePatterns.DEFAULT.allLicenseFilenames.map { "**/$it" },
-                storage = LocalFileStorage(DEFAULT_ARCHIVE_DIR)
-            )
-        }
     }
 
     private val matcher = FileMatcher(

--- a/utils/src/main/kotlin/storage/FileArchiver.kt
+++ b/utils/src/main/kotlin/storage/FileArchiver.kt
@@ -27,7 +27,7 @@ import kotlin.time.measureTime
 import kotlin.time.measureTimedValue
 
 import org.ossreviewtoolkit.utils.FileMatcher
-import org.ossreviewtoolkit.utils.LicenseFilenamePatterns.ALL_LICENSE_FILENAMES
+import org.ossreviewtoolkit.utils.LicenseFilenamePatterns
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.log
@@ -61,7 +61,7 @@ class FileArchiver(
          */
         val DEFAULT by lazy {
             FileArchiver(
-                patterns = ALL_LICENSE_FILENAMES.map { "**/$it" },
+                patterns = LicenseFilenamePatterns.DEFAULT.allLicenseFilenames.map { "**/$it" },
                 storage = LocalFileStorage(DEFAULT_ARCHIVE_DIR)
             )
         }

--- a/utils/src/main/kotlin/storage/FileArchiver.kt
+++ b/utils/src/main/kotlin/storage/FileArchiver.kt
@@ -54,7 +54,7 @@ class FileArchiver(
 ) {
     companion object {
         private const val ARCHIVE_FILE_NAME = "archive.zip"
-        internal val DEFAULT_ARCHIVE_DIR by lazy { ortDataDirectory.resolve("scanner/archive") }
+        val DEFAULT_ARCHIVE_DIR by lazy { ortDataDirectory.resolve("scanner/archive") }
 
         /**
          * A default [FileArchiver] that archives [license files][LICENSE_FILENAMES] in a local directory.

--- a/utils/src/test/kotlin/storage/FileArchiverTest.kt
+++ b/utils/src/test/kotlin/storage/FileArchiverTest.kt
@@ -31,6 +31,7 @@ import kotlin.io.path.createTempDirectory
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.safeMkdirs
+import org.ossreviewtoolkit.utils.test.createDefault
 import org.ossreviewtoolkit.utils.unpack
 
 class FileArchiverTest : StringSpec() {
@@ -118,8 +119,9 @@ class FileArchiverTest : StringSpec() {
             createFile("LICENSE")
             createFile("path/LICENSE")
 
-            FileArchiver.DEFAULT.archive(workingDir, "save")
-            FileArchiver.DEFAULT.unarchive(targetDir, "save")
+            val archiver = FileArchiver.createDefault()
+            archiver.archive(workingDir, "save")
+            archiver.unarchive(targetDir, "save")
 
             with(targetDir) {
                 assertFileContent("LICENSE")
@@ -133,8 +135,9 @@ class FileArchiverTest : StringSpec() {
             createFile("c/license")
             createFile("d/LiCeNsE")
 
-            FileArchiver.DEFAULT.archive(workingDir, "save")
-            FileArchiver.DEFAULT.unarchive(targetDir, "save")
+            val archiver = FileArchiver.createDefault()
+            archiver.archive(workingDir, "save")
+            archiver.unarchive(targetDir, "save")
 
             with(targetDir) {
                 assertFileContent("a/LICENSE")


### PR DESCRIPTION
There are several components depending on the license filename patterns, namely
- version control system's sparse checkout implementations
- file archiver
- root license matcher
- license info resolver
- ...

These patterns are currently hard-coded in the code, except for the file archiver which has a single configurable filename pattern
for determining which files to archive. That configuration however needs to be consistent with the hard-coded license filename patterns. Thus, the user can easily setup a wrong config causing inconsistencies and finally issues with the generated notice by package file.

All in all it makes sense to configure the license filename patterns globally and then use these globally configured patterns all over the place. The changes of this PR 
- remove the file archiver specific pattern configuration in favour of a global one and
- make use of it from within the file archiver.

Note: A following PR will migrate all other components to use that new global configuration property.
When done, one can basically configure the heuristic to determine the root license file(s), while it is ensured that the file archiver archives all candidate root license files, the sparse checkout checks out all candidate root license files, and thus also the notice reporter uses the contents of these root license files.