### PR TITLE
Consistently use the configured license filename patterns

### DIFF
--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -48,6 +48,7 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
+import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.config.orEmpty
 import org.ossreviewtoolkit.model.licenses.DefaultLicenseInfoProvider
@@ -257,7 +258,8 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate rules 
         val licenseInfoResolver = LicenseInfoResolver(
             provider = DefaultLicenseInfoProvider(finalOrtResult, packageConfigurationProvider),
             copyrightGarbage = copyrightGarbage,
-            archiver = globalOptionsForSubcommands.config.scanner?.archive.createFileArchiver()
+            archiver = globalOptionsForSubcommands.config.scanner?.archive.createFileArchiver(),
+            licenseFilenamePatterns = LicenseFilenamePatterns.getInstance()
         )
 
         val licenseClassifications =

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -42,6 +42,7 @@ import kotlin.time.measureTimedValue
 import org.ossreviewtoolkit.GlobalOptions
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
+import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.model.config.Resolutions
 import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.config.orEmpty
@@ -219,7 +220,8 @@ class ReporterCommand : CliktCommand(
         val licenseInfoResolver = LicenseInfoResolver(
             provider = DefaultLicenseInfoProvider(ortResult, packageConfigurationProvider),
             copyrightGarbage = copyrightGarbage,
-            archiver = globalOptionsForSubcommands.config.scanner?.archive.createFileArchiver()
+            archiver = globalOptionsForSubcommands.config.scanner?.archive.createFileArchiver(),
+            licenseFilenamePatterns = LicenseFilenamePatterns.getInstance()
         )
 
         val licenseClassifications =

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -134,7 +134,7 @@ abstract class VersionControlSystem {
          * Return glob patterns matching all potential license or patent files.
          */
         internal fun getLicenseFileGlobPatterns(): List<String> =
-            LicenseFilenamePatterns.DEFAULT.allLicenseFilenames.generateCapitalizationVariants().map { "**/$it" }
+            LicenseFilenamePatterns.getInstance().allLicenseFilenames.generateCapitalizationVariants().map { "**/$it" }
 
         private fun Collection<String>.generateCapitalizationVariants() =
             flatMap { listOf(it, it.toUpperCase(), it.capitalize()) }

--- a/model/src/main/kotlin/ScanResult.kt
+++ b/model/src/main/kotlin/ScanResult.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
+import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
 
 /**
@@ -50,7 +51,8 @@ data class ScanResult(
     fun filterByPath(path: String): ScanResult {
         if (path.isBlank()) return this
 
-        val applicableLicenseFiles = RootLicenseMatcher().getApplicableRootLicenseFindingsForDirectories(
+        val rootLicenseMatcher = RootLicenseMatcher(LicenseFilenamePatterns.getInstance())
+        val applicableLicenseFiles = rootLicenseMatcher.getApplicableRootLicenseFindingsForDirectories(
             licenseFindings = summary.licenseFindings,
             directories = listOf(path)
         ).values.flatten().mapTo(mutableSetOf()) { it.location.path }

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -49,6 +49,7 @@ class LicenseInfoResolver(
     private val resolvedLicenseFiles: ConcurrentMap<Identifier, ResolvedLicenseFileInfo> = ConcurrentHashMap()
     private val rootLicenseMatcher =
         RootLicenseMatcher(LicenseFilenamePatterns.DEFAULT.copy(rootLicenseFilenames = emptyList()))
+    private val findingsMatcher = FindingsMatcher()
 
     /**
      * Get the [ResolvedLicenseInfo] for the project or package identified by [id].
@@ -142,7 +143,7 @@ class LicenseInfoResolver(
             //       resolved license for completeness, e.g. to show in a report that a license finding was marked as
             //       false positive.
             val curatedLicenseFindings = licenseCurationResults.keys.filterNotNull().toSet()
-            val matchResult = FindingsMatcher().match(curatedLicenseFindings, findings.copyrights)
+            val matchResult = findingsMatcher.match(curatedLicenseFindings, findings.copyrights)
 
             matchResult.matchedFindings.forEach { (licenseFinding, copyrightFindings) ->
                 val resolvedCopyrightFindings = resolveCopyrights(

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -43,13 +43,15 @@ import org.ossreviewtoolkit.utils.storage.FileArchiver
 class LicenseInfoResolver(
     val provider: LicenseInfoProvider,
     val copyrightGarbage: CopyrightGarbage,
-    val archiver: FileArchiver?
+    val archiver: FileArchiver?,
+    licenseFilenamePatterns: LicenseFilenamePatterns = LicenseFilenamePatterns.DEFAULT
 ) {
     private val resolvedLicenseInfo: ConcurrentMap<Identifier, ResolvedLicenseInfo> = ConcurrentHashMap()
     private val resolvedLicenseFiles: ConcurrentMap<Identifier, ResolvedLicenseFileInfo> = ConcurrentHashMap()
-    private val rootLicenseMatcher =
-        RootLicenseMatcher(LicenseFilenamePatterns.DEFAULT.copy(rootLicenseFilenames = emptyList()))
-    private val findingsMatcher = FindingsMatcher()
+    private val rootLicenseMatcher = RootLicenseMatcher(
+        licenseFilenamePatterns = licenseFilenamePatterns.copy(rootLicenseFilenames = emptyList())
+    )
+    private val findingsMatcher = FindingsMatcher(RootLicenseMatcher(licenseFilenamePatterns))
 
     /**
      * Get the [ResolvedLicenseInfo] for the project or package identified by [id].

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -29,6 +29,7 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
+import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.FindingsMatcher
@@ -46,7 +47,8 @@ class LicenseInfoResolver(
 ) {
     private val resolvedLicenseInfo: ConcurrentMap<Identifier, ResolvedLicenseInfo> = ConcurrentHashMap()
     private val resolvedLicenseFiles: ConcurrentMap<Identifier, ResolvedLicenseFileInfo> = ConcurrentHashMap()
-    private val rootLicenseMatcher = RootLicenseMatcher(rootLicenseFilenamePatterns = emptyList())
+    private val rootLicenseMatcher =
+        RootLicenseMatcher(LicenseFilenamePatterns.DEFAULT.copy(rootLicenseFilenames = emptyList()))
 
     /**
      * Get the [ResolvedLicenseInfo] for the project or package identified by [id].

--- a/model/src/main/kotlin/utils/OrtResultExtensions.kt
+++ b/model/src/main/kotlin/utils/OrtResultExtensions.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.model.utils
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
+import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.model.licenses.DefaultLicenseInfoProvider
 import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
 import org.ossreviewtoolkit.utils.storage.FileArchiver
@@ -60,7 +61,7 @@ fun OrtResult.createLicenseInfoResolver(
     archiver: FileArchiver? = null
 ): LicenseInfoResolver {
     val licenseInfoProvider = DefaultLicenseInfoProvider(this, packageConfigurationProvider)
-    return LicenseInfoResolver(licenseInfoProvider, copyrightGarbage, archiver)
+    return LicenseInfoResolver(licenseInfoProvider, copyrightGarbage, archiver, LicenseFilenamePatterns.getInstance())
 }
 
 /**

--- a/model/src/main/kotlin/utils/RootLicenseMatcher.kt
+++ b/model/src/main/kotlin/utils/RootLicenseMatcher.kt
@@ -29,25 +29,23 @@ import org.ossreviewtoolkit.utils.getAllAncestorDirectories
 /**
  * A heuristic for determining which (root) license files apply to any file or directory.
  *
- * For any given directory the heuristic tries to assign license files by utilizing [licenseFilenamePatterns] and
- * patent files by utilizing [patentFilenamePatterns] independently from one another. The [rootLicenseFilenamePatterns]
- * serve only as fallback to find license files if there isn't any match for [licenseFilenamePatterns].
+ * For any given directory the heuristic tries to assign license files by utilizing
+ * [LicenseFilenamePatterns.licenseFilenames] and patent files by utilizing [LicenseFilenamePatterns.patentFilenames]
+ * independently from one another. The [LicenseFilenamePatterns.rootLicenseFilenames] serve only as fallback to find
+ * license files if there isn't any match for [LicenseFilenamePatterns.licenseFilenames].
  *
  * To determine the (root) license files applicable for a specific directory, all filenames in that directory are
- * matched against [licenseFilenamePatterns]. If there are matches then these are used as result, otherwise that search
- * is repeated recursively in the parent directory. If there is no parent directory (because the root was already
- * searched but no result was found) then start from scratch using the fallback pattern [rootLicenseFilenamePatterns].
+ * matched against [LicenseFilenamePatterns.licenseFilenames]. If there are matches then these are used as result,
+ * otherwise that search is repeated recursively in the parent directory. If there is no parent directory (because the
+ * root was already searched but no result was found) then start from scratch using the fallback pattern
+ * [LicenseFilenamePatterns.rootLicenseFilenames].
  *
  * Patent files are assigned in an analog way, but without any fallback pattern.
  */
-class RootLicenseMatcher(
-    licenseFilenamePatterns: List<String> = LicenseFilenamePatterns.DEFAULT.licenseFilenames,
-    patentFilenamePatterns: List<String> = LicenseFilenamePatterns.DEFAULT.patentFilenames,
-    rootLicenseFilenamePatterns: List<String> = LicenseFilenamePatterns.DEFAULT.rootLicenseFilenames
-) {
-    private val licenseFileMatcher = createFileMatcher(licenseFilenamePatterns)
-    private val patentFileMatcher = createFileMatcher(patentFilenamePatterns)
-    private val rootLicenseFileMatcher = createFileMatcher(rootLicenseFilenamePatterns)
+class RootLicenseMatcher(licenseFilenamePatterns: LicenseFilenamePatterns = LicenseFilenamePatterns.DEFAULT) {
+    private val licenseFileMatcher = createFileMatcher(licenseFilenamePatterns.licenseFilenames)
+    private val patentFileMatcher = createFileMatcher(licenseFilenamePatterns.patentFilenames)
+    private val rootLicenseFileMatcher = createFileMatcher(licenseFilenamePatterns.rootLicenseFilenames)
 
     /**
      * Return a mapping from the given relative [directories] to the licenses findings for the (root) license files

--- a/reporter/src/main/kotlin/ReporterInput.kt
+++ b/reporter/src/main/kotlin/ReporterInput.kt
@@ -23,6 +23,7 @@ import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
+import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.createFileArchiver
@@ -74,7 +75,8 @@ data class ReporterInput(
     val licenseInfoResolver: LicenseInfoResolver = LicenseInfoResolver(
         provider = DefaultLicenseInfoProvider(ortResult, packageConfigurationProvider),
         copyrightGarbage = copyrightGarbage,
-        archiver = ortConfig.scanner?.archive.createFileArchiver()
+        archiver = ortConfig.scanner?.archive.createFileArchiver(),
+        licenseFilenamePatterns = ortConfig.licenseFilePatterns ?: LicenseFilenamePatterns.DEFAULT
     ),
 
     /**

--- a/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
@@ -31,12 +31,14 @@ import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.IssueResolution
+import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.config.RuleViolationResolution
 import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.FindingsMatcher
+import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.utils.StatisticsCalculator
@@ -62,7 +64,8 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     private val ruleViolationResolutions = mutableListOf<RuleViolationResolution>()
 
     private val curationsMatcher = FindingCurationMatcher()
-    private val findingsMatcher = FindingsMatcher()
+    private val findingsMatcher =
+        FindingsMatcher(RootLicenseMatcher(input.ortConfig.licenseFilePatterns ?: LicenseFilenamePatterns.DEFAULT))
 
     private data class PackageExcludeInfo(
         var id: Identifier,


### PR DESCRIPTION
This PR ensures that the configured license filename patterns are consistently used all over the place, except for the tests.

It is basically taking https://github.com/oss-review-toolkit/ort/pull/3462 into use and thus has to be merged after it.