### PR TITLE
analyzer: Remove the Bundler version from test lockfiles

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/bundler/gemspec/Gemfile.lock
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler/gemspec/Gemfile.lock
@@ -44,6 +44,3 @@ PLATFORMS
 DEPENDENCIES
   rspec
   test-project!
-
-BUNDLED WITH
-   1.17.3

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler/lockfile/Gemfile.lock
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler/lockfile/Gemfile.lock
@@ -30,6 +30,3 @@ DEPENDENCIES
   nokogiri
   rack (~> 2.1)
   rspec
-
-BUNDLED WITH
-   1.17.1


### PR DESCRIPTION
This way the tests work with both Bundler 1 and Bundler 2. Also see
https://bundler.io/guides/bundler_2_upgrade.html#version-autoswitch.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>