### PR TITLE
reporter: Replaced repository for com.github.everit-org.json-schema:org.everit.json.schema

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -105,15 +105,6 @@ repositories {
 
         filter {
             includeGroup("com.github.ralfstuckert.pdfbox-layout")
-        }
-    }
-
-    exclusiveContent {
-        forRepository {
-            maven("https://repository.mulesoft.org/nexus/content/repositories/public/")
-        }
-
-        filter {
             includeGroup("com.github.everit-org.json-schema")
         }
     }

--- a/reporter/build.gradle.kts
+++ b/reporter/build.gradle.kts
@@ -63,16 +63,7 @@ repositories {
 
         filter {
             includeGroup("com.github.ralfstuckert.pdfbox-layout")
-        }
-    }
-
-    exclusiveContent {
-        forRepository {
-            maven("https://repository.mulesoft.org/nexus/content/repositories/public/")
-        }
-
-        filter {
-            includeGroup("com.github.everit-org.json-schema")
+			includeGroup("com.github.everit-org.json-schema")
         }
     }
 }


### PR DESCRIPTION
As mentioned here https://github.com/oss-review-toolkit/ort/issues/3470 build fails on trying to find required for bom generation `com.github.everit-org.json-schema:org.everit.json.schema:1.12.1`
```
-----------
* What went wrong:
Execution failed for task ':reporter:compileKotlin'.
> Could not resolve all files for configuration ':reporter:compileClasspath'.
   > Could not find com.github.everit-org.json-schema:org.everit.json.schema:1.12.1.
     Searched in the following locations:
       - https://repository.mulesoft.org/nexus/content/repositories/public/com/github/everit-org/json-schema/org.everit.json.schema/1.12.1/org.everit.json.schema-1.12.1.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository
 declaration.
     Required by:
         project :reporter > org.cyclonedx:cyclonedx-core-java:3.0.7
```
