### PR TITLE
Gradle: Get the json-schema artifact from JitPack

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -105,15 +105,6 @@ repositories {
 
         filter {
             includeGroup("com.github.ralfstuckert.pdfbox-layout")
-        }
-    }
-
-    exclusiveContent {
-        forRepository {
-            maven("https://repository.mulesoft.org/nexus/content/repositories/public/")
-        }
-
-        filter {
             includeGroup("com.github.everit-org.json-schema")
         }
     }

--- a/reporter/build.gradle.kts
+++ b/reporter/build.gradle.kts
@@ -63,15 +63,6 @@ repositories {
 
         filter {
             includeGroup("com.github.ralfstuckert.pdfbox-layout")
-        }
-    }
-
-    exclusiveContent {
-        forRepository {
-            maven("https://repository.mulesoft.org/nexus/content/repositories/public/")
-        }
-
-        filter {
             includeGroup("com.github.everit-org.json-schema")
         }
     }


### PR DESCRIPTION
From version 1.6.0 on, the json-schema artifact is primarily distributed
through JitPack [1], so prefer to get the it from there to avoid build
breakages. Fixes #3470.

[1] https://github.com/everit-org/json-schema#maven-installation

Signed-off-by: pctf <baranukis@gmail.com>
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>