### PR TITLE
ClearlyDefinedStorageTest: Avoid an unnecessary lateinit

### DIFF
--- a/scanner/src/test/kotlin/storages/ClearlyDefinedStorageTest.kt
+++ b/scanner/src/test/kotlin/storages/ClearlyDefinedStorageTest.kt
@@ -195,14 +195,13 @@ private fun assertCurrentTime(time: Instant) {
 }
 
 class ClearlyDefinedStorageTest : WordSpec({
-    lateinit var wiremock: WireMockServer
+    val wiremock = WireMockServer(
+        WireMockConfiguration.options()
+            .dynamicPort()
+            .usingFilesUnderDirectory("src/test/assets/")
+    )
 
     beforeSpec {
-        wiremock = WireMockServer(
-            WireMockConfiguration.options()
-                .dynamicPort()
-                .usingFilesUnderDirectory("src/test/assets/")
-        )
         wiremock.start()
         WireMock.configureFor(wiremock.port())
     }


### PR DESCRIPTION
With lateinit there is always the theoretical risk that the variable is
accessed before it is being initialized, so avoid lateinit where not
strictly needed.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>