### PR TITLE
Maven: Fix the issue for auto-generated POMs to be a hint

### DIFF
--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -178,7 +178,7 @@ class Maven(
                 createAndLogIssue(
                     managerName,
                     "Package '${pkg.id.toCoordinates()}' seem to use an auto-generated POM which might lack metadata.",
-                    Severity.WARNING
+                    Severity.HINT
                 )
             } else {
                 null


### PR DESCRIPTION
This is a fixup for 539d00a where only the commit messages was adjusted
to refer to a hint.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>