### PR TITLE
Oheger bosch/analyzer/#3321 memory consumption

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
@@ -15,445 +15,169 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/app"
   homepage_url: ""
-  scopes:
-  - name: "amazonDemoDebugAndroidTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonDemoDebugAndroidTestCompileClasspath"
+  scopes: []
+  dependency_graph:
     dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
     - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
       dependencies:
       - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoDebugAndroidTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoDebugAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonDemoDebugCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoDebugRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoDebugUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonDemoDebugUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonDemoDebugUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonDemoDebugWearBundling"
-    dependencies: []
-  - name: "amazonDemoReleaseAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonDemoReleaseCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoReleaseRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoReleaseUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonDemoReleaseUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonDemoReleaseUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonDemoReleaseWearBundling"
-    dependencies: []
-  - name: "amazonFullDebugAndroidTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonFullDebugAndroidTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullDebugAndroidTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullDebugAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonFullDebugCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullDebugRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullDebugUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonFullDebugUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonFullDebugUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonFullDebugWearBundling"
-    dependencies: []
-  - name: "amazonFullReleaseAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonFullReleaseCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullReleaseRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullReleaseUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonFullReleaseUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonFullReleaseUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonFullReleaseWearBundling"
-    dependencies: []
-  - name: "androidTestUtil"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
-    dependencies: []
-  - name: "default"
-    dependencies: []
-  - name: "googleDemoDebugAndroidTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleDemoDebugAndroidTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleDemoDebugAndroidTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleDemoDebugAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleDemoDebugCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleDemoDebugRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleDemoDebugUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleDemoDebugUnitTestCompileClasspath"
-    dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       linkage: "PROJECT_DYNAMIC"
     - id: "Maven:junit:junit:4.12"
       dependencies:
       - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleDemoDebugUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleDemoDebugWearBundling"
-    dependencies: []
-  - name: "googleDemoReleaseAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleDemoReleaseCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleDemoReleaseRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleDemoReleaseUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleDemoReleaseUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleDemoReleaseUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleDemoReleaseWearBundling"
-    dependencies: []
-  - name: "googleFullDebugAndroidTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleFullDebugAndroidTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleFullDebugAndroidTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleFullDebugAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleFullDebugCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleFullDebugRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleFullDebugUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleFullDebugUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleFullDebugUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleFullDebugWearBundling"
-    dependencies: []
-  - name: "googleFullReleaseAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleFullReleaseCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleFullReleaseRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleFullReleaseUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleFullReleaseUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleFullReleaseUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleFullReleaseWearBundling"
-    dependencies: []
-  - name: "lintChecks"
-    dependencies: []
-  - name: "lintClassPath"
-    dependencies: []
-  - name: "testCompile"
-    dependencies: []
+    scope_mapping:
+      amazonDemoDebugAndroidTestAnnotationProcessorClasspath: []
+      amazonDemoDebugAndroidTestCompileClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      amazonDemoDebugAndroidTestRuntimeClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      amazonDemoDebugAnnotationProcessorClasspath: []
+      amazonDemoDebugCompileClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      amazonDemoDebugRuntimeClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      amazonDemoDebugUnitTestAnnotationProcessorClasspath: []
+      amazonDemoDebugUnitTestCompileClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      - "Maven:junit:junit:4.12"
+      amazonDemoDebugUnitTestRuntimeClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      - "Maven:junit:junit:4.12"
+      amazonDemoDebugWearBundling: []
+      amazonDemoReleaseAnnotationProcessorClasspath: []
+      amazonDemoReleaseCompileClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      amazonDemoReleaseRuntimeClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      amazonDemoReleaseUnitTestAnnotationProcessorClasspath: []
+      amazonDemoReleaseUnitTestCompileClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      - "Maven:junit:junit:4.12"
+      amazonDemoReleaseUnitTestRuntimeClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      - "Maven:junit:junit:4.12"
+      amazonDemoReleaseWearBundling: []
+      amazonFullDebugAndroidTestAnnotationProcessorClasspath: []
+      amazonFullDebugAndroidTestCompileClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      amazonFullDebugAndroidTestRuntimeClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      amazonFullDebugAnnotationProcessorClasspath: []
+      amazonFullDebugCompileClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      amazonFullDebugRuntimeClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      amazonFullDebugUnitTestAnnotationProcessorClasspath: []
+      amazonFullDebugUnitTestCompileClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      - "Maven:junit:junit:4.12"
+      amazonFullDebugUnitTestRuntimeClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      - "Maven:junit:junit:4.12"
+      amazonFullDebugWearBundling: []
+      amazonFullReleaseAnnotationProcessorClasspath: []
+      amazonFullReleaseCompileClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      amazonFullReleaseRuntimeClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      amazonFullReleaseUnitTestAnnotationProcessorClasspath: []
+      amazonFullReleaseUnitTestCompileClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      - "Maven:junit:junit:4.12"
+      amazonFullReleaseUnitTestRuntimeClasspath:
+      - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      - "Maven:junit:junit:4.12"
+      amazonFullReleaseWearBundling: []
+      androidTestUtil: []
+      archives: []
+      compile: []
+      default: []
+      googleDemoDebugAndroidTestAnnotationProcessorClasspath: []
+      googleDemoDebugAndroidTestCompileClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      googleDemoDebugAndroidTestRuntimeClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      googleDemoDebugAnnotationProcessorClasspath: []
+      googleDemoDebugCompileClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      googleDemoDebugRuntimeClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      googleDemoDebugUnitTestAnnotationProcessorClasspath: []
+      googleDemoDebugUnitTestCompileClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      - "Maven:junit:junit:4.12"
+      googleDemoDebugUnitTestRuntimeClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      - "Maven:junit:junit:4.12"
+      googleDemoDebugWearBundling: []
+      googleDemoReleaseAnnotationProcessorClasspath: []
+      googleDemoReleaseCompileClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      googleDemoReleaseRuntimeClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      googleDemoReleaseUnitTestAnnotationProcessorClasspath: []
+      googleDemoReleaseUnitTestCompileClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      - "Maven:junit:junit:4.12"
+      googleDemoReleaseUnitTestRuntimeClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      - "Maven:junit:junit:4.12"
+      googleDemoReleaseWearBundling: []
+      googleFullDebugAndroidTestAnnotationProcessorClasspath: []
+      googleFullDebugAndroidTestCompileClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      googleFullDebugAndroidTestRuntimeClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      googleFullDebugAnnotationProcessorClasspath: []
+      googleFullDebugCompileClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      googleFullDebugRuntimeClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      googleFullDebugUnitTestAnnotationProcessorClasspath: []
+      googleFullDebugUnitTestCompileClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      - "Maven:junit:junit:4.12"
+      googleFullDebugUnitTestRuntimeClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      - "Maven:junit:junit:4.12"
+      googleFullDebugWearBundling: []
+      googleFullReleaseAnnotationProcessorClasspath: []
+      googleFullReleaseCompileClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      googleFullReleaseRuntimeClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      googleFullReleaseUnitTestAnnotationProcessorClasspath: []
+      googleFullReleaseUnitTestCompileClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      - "Maven:junit:junit:4.12"
+      googleFullReleaseUnitTestRuntimeClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      - "Maven:junit:junit:4.12"
+      googleFullReleaseWearBundling: []
+      lintChecks: []
+      lintClassPath: []
+      testCompile: []
 packages:
 - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
   purl: "pkg:maven/com.squareup.okhttp3/okhttp@3.10.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
@@ -16,4 +16,7 @@ project:
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android"
   homepage_url: ""
   scopes: []
+  dependency_graph:
+    dependencies: []
+    scope_mapping: {}
 packages: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -15,12 +15,8 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
   homepage_url: ""
-  scopes:
-  - name: "annotationProcessor"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
+  scopes: []
+  dependency_graph:
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       linkage: "PROJECT_DYNAMIC"
@@ -29,84 +25,30 @@ project:
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.5"
       - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileOnly"
-    dependencies: []
-  - name: "default"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testAnnotationProcessor"
-    dependencies: []
-  - name: "testCompile"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileOnly"
-    dependencies: []
-  - name: "testRuntime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    scope_mapping:
+      annotationProcessor: []
+      archives: []
+      compile:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      compileClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      compileOnly: []
+      default:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      runtime:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      runtimeClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      testAnnotationProcessor: []
+      testCompile:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      testCompileClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      testCompileOnly: []
+      testRuntime:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      testRuntimeClasspath:
+      - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
 packages:
 - id: "Maven:org.apache.commons:commons-lang3:3.5"
   purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -15,12 +15,8 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
   homepage_url: ""
-  scopes:
-  - name: "annotationProcessor"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
+  scopes: []
+  dependency_graph:
     dependencies:
     - id: "Unknown:org.apache.commons:commons-text:1.1"
       issues:
@@ -30,52 +26,6 @@ project:
           \ dependency org.apache.commons:commons-text:1.1 because no repositories\
           \ are defined."
         severity: "ERROR"
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "compileOnly"
-    dependencies: []
-  - name: "default"
-    dependencies:
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "runtime"
-    dependencies:
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "testAnnotationProcessor"
-    dependencies: []
-  - name: "testCompile"
-    dependencies:
     - id: "Unknown:junit:junit:4.12"
       issues:
       - timestamp: "1970-01-01T00:00:00Z"
@@ -83,65 +33,32 @@ project:
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
           \ dependency junit:junit:4.12 because no repositories are defined."
         severity: "ERROR"
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Unknown:junit:junit:4.12"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency junit:junit:4.12 because no repositories are defined."
-        severity: "ERROR"
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "testCompileOnly"
-    dependencies: []
-  - name: "testRuntime"
-    dependencies:
-    - id: "Unknown:junit:junit:4.12"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency junit:junit:4.12 because no repositories are defined."
-        severity: "ERROR"
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Unknown:junit:junit:4.12"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency junit:junit:4.12 because no repositories are defined."
-        severity: "ERROR"
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
+    scope_mapping:
+      annotationProcessor: []
+      archives: []
+      compile:
+      - "Unknown:org.apache.commons:commons-text:1.1"
+      compileClasspath:
+      - "Unknown:org.apache.commons:commons-text:1.1"
+      compileOnly: []
+      default:
+      - "Unknown:org.apache.commons:commons-text:1.1"
+      runtime:
+      - "Unknown:org.apache.commons:commons-text:1.1"
+      runtimeClasspath:
+      - "Unknown:org.apache.commons:commons-text:1.1"
+      testAnnotationProcessor: []
+      testCompile:
+      - "Unknown:org.apache.commons:commons-text:1.1"
+      - "Unknown:junit:junit:4.12"
+      testCompileClasspath:
+      - "Unknown:org.apache.commons:commons-text:1.1"
+      - "Unknown:junit:junit:4.12"
+      testCompileOnly: []
+      testRuntime:
+      - "Unknown:org.apache.commons:commons-text:1.1"
+      - "Unknown:junit:junit:4.12"
+      testRuntimeClasspath:
+      - "Unknown:org.apache.commons:commons-text:1.1"
+      - "Unknown:junit:junit:4.12"
 packages: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -15,83 +15,53 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
   homepage_url: ""
-  scopes:
-  - name: "annotationProcessor"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
+  scopes: []
+  dependency_graph:
     dependencies:
     - id: "Maven:org.apache.commons:commons-text:1.1"
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.5"
     - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileOnly"
-    dependencies: []
-  - name: "default"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtime"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testAnnotationProcessor"
-    dependencies: []
-  - name: "testCompile"
-    dependencies:
     - id: "Maven:junit:junit:4.12"
       dependencies:
       - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileOnly"
-    dependencies: []
-  - name: "testRuntime"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    scope_mapping:
+      annotationProcessor: []
+      archives: []
+      compile:
+      - "Maven:org.apache.commons:commons-text:1.1"
+      - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      compileClasspath:
+      - "Maven:org.apache.commons:commons-text:1.1"
+      - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      compileOnly: []
+      default:
+      - "Maven:org.apache.commons:commons-text:1.1"
+      - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      runtime:
+      - "Maven:org.apache.commons:commons-text:1.1"
+      - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      runtimeClasspath:
+      - "Maven:org.apache.commons:commons-text:1.1"
+      - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      testAnnotationProcessor: []
+      testCompile:
+      - "Maven:org.apache.commons:commons-text:1.1"
+      - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - "Maven:junit:junit:4.12"
+      testCompileClasspath:
+      - "Maven:org.apache.commons:commons-text:1.1"
+      - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - "Maven:junit:junit:4.12"
+      testCompileOnly: []
+      testRuntime:
+      - "Maven:org.apache.commons:commons-text:1.1"
+      - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - "Maven:junit:junit:4.12"
+      testRuntimeClasspath:
+      - "Maven:org.apache.commons:commons-text:1.1"
+      - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - "Maven:junit:junit:4.12"
 packages:
 - id: "Maven:junit:junit:4.12"
   purl: "pkg:maven/junit/junit@4.12"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
@@ -16,4 +16,7 @@ project:
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   homepage_url: ""
   scopes: []
+  dependency_graph:
+    dependencies: []
+    scope_mapping: {}
 packages: []

--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -237,7 +237,7 @@ class Bower(
                 vcs = projectPackage.vcs,
                 vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, projectPackage.homepageUrl),
                 homepageUrl = projectPackage.homepageUrl,
-                scopes = sortedSetOf(dependenciesScope, devDependenciesScope)
+                scopeDependencies = sortedSetOf(dependenciesScope, devDependenciesScope)
             )
 
             return listOf(ProjectAnalyzerResult(project, packages.values.toSortedSet()))

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -116,7 +116,7 @@ class Bundler(
                 vcs = VcsInfo.EMPTY,
                 vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY, homepageUrl),
                 homepageUrl = homepageUrl,
-                scopes = scopes.toSortedSet()
+                scopeDependencies = scopes.toSortedSet()
             )
 
             return listOf(ProjectAnalyzerResult(project, packages, issues))

--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -288,7 +288,7 @@ class Cargo(
             vcs = projectPkg.vcs,
             vcsProcessed = processProjectVcs(workingDir, projectPkg.vcs, homepageUrl),
             homepageUrl = homepageUrl,
-            scopes = scopes.toSortedSet()
+            scopeDependencies = scopes.toSortedSet()
         )
 
         val nonProjectPackages = packages

--- a/analyzer/src/main/kotlin/managers/Carthage.kt
+++ b/analyzer/src/main/kotlin/managers/Carthage.kt
@@ -83,7 +83,7 @@ class Carthage(
                     declaredLicenses = sortedSetOf(),
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY),
-                    scopes = sortedSetOf(),
+                    scopeDependencies = sortedSetOf(),
                     homepageUrl = ""
                 ),
                 packages = parseCarthageDependencies(definitionFile)

--- a/analyzer/src/main/kotlin/managers/Composer.kt
+++ b/analyzer/src/main/kotlin/managers/Composer.kt
@@ -236,7 +236,7 @@ class Composer(
             vcs = vcs,
             vcsProcessed = processProjectVcs(definitionFile.parentFile, vcs, homepageUrl),
             homepageUrl = homepageUrl,
-            scopes = scopes
+            scopeDependencies = scopes
         )
     }
 

--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -132,7 +132,7 @@ class Conan(
                             projectPackage.homepageUrl
                         ),
                         homepageUrl = projectPackage.homepageUrl,
-                        scopes = sortedSetOf(dependenciesScope, devDependenciesScope)
+                        scopeDependencies = sortedSetOf(dependenciesScope, devDependenciesScope)
                     ),
                     packages = packages.values.toSortedSet()
                 )

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -176,7 +176,7 @@ class GoDep(
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = projectVcs,
                     homepageUrl = "",
-                    scopes = sortedSetOf(scope)
+                    scopeDependencies = sortedSetOf(scope)
                 ),
                 packages = packages
             )

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -136,7 +136,7 @@ class GoMod(
                         vcs = projectVcs,
                         vcsProcessed = projectVcs,
                         homepageUrl = "",
-                        scopes = scopes
+                        scopeDependencies = scopes
                     ),
                     packages = packages
                 )

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -253,7 +253,7 @@ class Gradle(
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = processProjectVcs(definitionFile.parentFile),
                     homepageUrl = "",
-                    scopes = scopes.toSortedSet()
+                    scopeDependencies = scopes.toSortedSet()
                 )
 
                 val issues = mutableListOf<OrtIssue>()

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -168,7 +168,7 @@ class Maven(
             vcs = vcsFromPackage,
             vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, *vcsFallbackUrls),
             homepageUrl = homepageUrl.orEmpty(),
-            scopes = scopes.values.toSortedSet()
+            scopeDependencies = scopes.values.toSortedSet()
         )
 
         return listOf(ProjectAnalyzerResult(project, packages.values.toSortedSet()))

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -529,7 +529,7 @@ open class Npm(
             vcs = vcsFromPackage,
             vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, homepageUrl),
             homepageUrl = homepageUrl,
-            scopes = scopes
+            scopeDependencies = scopes
         )
 
         return ProjectAnalyzerResult(project, packages)

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -380,7 +380,7 @@ class Pip(
             vcs = VcsInfo.EMPTY,
             vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY, setupHomepage),
             homepageUrl = setupHomepage,
-            scopes = scopes
+            scopeDependencies = scopes
         )
 
         // Remove the virtualenv by simply deleting the directory.

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -369,7 +369,7 @@ class Pub(
             vcs = vcs,
             vcsProcessed = processProjectVcs(definitionFile.parentFile, vcs, homepageUrl),
             homepageUrl = homepageUrl,
-            scopes = scopes
+            scopeDependencies = scopes
         )
     }
 

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -195,7 +195,7 @@ class SpdxDocumentFile(
                 vcs = VcsInfo.EMPTY,
                 vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY, projectPackage.homepage),
                 homepageUrl = projectPackage.homepage.mapNotPresentToEmpty(),
-                scopes = scopes
+                scopeDependencies = scopes
             )
         } else {
             // TODO: Add support for "package.spdx.yml" files. How to deal with relationships between SPDX packages if

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -167,7 +167,7 @@ class Stack(
             vcs = projectPackage.vcs,
             vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, projectPackage.homepageUrl),
             homepageUrl = projectPackage.homepageUrl,
-            scopes = scopes
+            scopeDependencies = scopes
         )
 
         return listOf(ProjectAnalyzerResult(project, allPackages.values.toSortedSet()))

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -111,7 +111,7 @@ class Unmanaged(
             vcs = VcsInfo.EMPTY,
             vcsProcessed = vcsInfo,
             homepageUrl = "",
-            scopes = sortedSetOf()
+            scopeDependencies = sortedSetOf()
         )
 
         return listOf(ProjectAnalyzerResult(project, packages = sortedSetOf()))

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -295,7 +295,7 @@ fun PackageManager.resolveNuGetDependencies(
         vcs = VcsInfo.EMPTY,
         vcsProcessed = PackageManager.processProjectVcs(workingDir),
         homepageUrl = "",
-        scopes = sortedSetOf(scope)
+        scopeDependencies = sortedSetOf(scope)
     )
 
     return ProjectAnalyzerResult(project, packages, issues)

--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -55,11 +55,11 @@ class AnalyzerResultBuilderTest : WordSpec() {
 
     private val project1 = Project.EMPTY.copy(
         id = Identifier("type-1", "namespace-1", "project-1", "version-1"),
-        scopes = sortedSetOf(scope1)
+        scopeDependencies = sortedSetOf(scope1)
     )
     private val project2 = Project.EMPTY.copy(
         id = Identifier("type-2", "namespace-2", "project-2", "version-2"),
-        scopes = sortedSetOf(scope1, scope2)
+        scopeDependencies = sortedSetOf(scope1, scope2)
     )
 
     private val analyzerResult1 = ProjectAnalyzerResult(

--- a/analyzer/src/test/kotlin/managers/GradleDependencyGraphBuilderTest.kt
+++ b/analyzer/src/test/kotlin/managers/GradleDependencyGraphBuilderTest.kt
@@ -1,0 +1,259 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers
+
+import Dependency
+
+import io.kotest.assertions.fail
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.maps.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+
+import org.eclipse.aether.artifact.DefaultArtifact
+import org.eclipse.aether.repository.RemoteRepository
+
+import org.ossreviewtoolkit.analyzer.managers.utils.MavenSupport
+import org.ossreviewtoolkit.model.DependencyGraph
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageReference
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.VcsInfo
+
+class GradleDependencyGraphBuilderTest : WordSpec({
+    "GradleDependencyGraphBuilder" should {
+        "collect the direct dependencies of scopes" {
+            val scope1 = "compile"
+            val scope2 = "test"
+            val dep1 = createDependency("org.apache.commons", "commons-lang3", "3.11")
+            val dep2 = createDependency("org.apache.commons", "commons-collections4", "4.4")
+            val dep3 = createDependency("my-project", "my-module", "1.0", path = "subPath")
+            val maven = createMavenSupport()
+            val builder = GradleDependencyGraphBuilder(NAME, maven)
+
+            builder.addDependency(scope1, dep1, remoteRepositories)
+            builder.addDependency(scope1, dep3, remoteRepositories)
+            builder.addDependency(scope2, dep2, remoteRepositories)
+            builder.addDependency(scope2, dep1, remoteRepositories)
+            val graph = builder.build()
+
+            graph.dependencies shouldHaveSize 3
+            val dependencyIds = graph.dependencies.map { ref -> ref.id }
+            dependencyIds shouldContainExactlyInAnyOrder listOf(dep1.toId(), dep2.toId(), dep3.toId())
+            graph.dependencies.forEach {
+                it.dependencies.shouldBeEmpty()
+            }
+
+            graph.scopeMapping.keys shouldContainExactlyInAnyOrder setOf(scope1, scope2)
+            graph.scopeMapping[scope1] shouldContainExactlyInAnyOrder setOf(dep1.toId(), dep3.toId())
+            graph.scopeMapping[scope2] shouldContainExactlyInAnyOrder setOf(dep2.toId(), dep1.toId())
+        }
+
+        "collect information about packages" {
+            val dep1 = createDependency("org.apache.commons", "commons-lang3", "3.11")
+            val dep2 = createDependency("org.apache.commons", "commons-collections4", "4.4")
+            val dep3 = createDependency("my-project", "my-module", "1.0", path = "foo")
+            val maven = createMavenSupport()
+            val builder = GradleDependencyGraphBuilder(NAME, maven)
+
+            builder.addDependency("s1", dep1, remoteRepositories)
+            builder.addDependency("s2", dep2, remoteRepositories)
+            builder.addDependency("s3", dep3, remoteRepositories)
+
+            val packageIds = builder.packages().map { it.id }
+            packageIds shouldContainExactlyInAnyOrder setOf(dep1.toId(), dep2.toId())
+        }
+
+        "deal with transitive dependencies correctly" {
+            val scope1 = "compile"
+            val scope2 = "test"
+            val dep1 = createDependency("org.apache.commons", "commons-lang3", "3.11")
+            val dep2 = createDependency("org.apache.commons", "commons-collections4", "4.4")
+            val dep3 = createDependency(
+                "org.apache.commons",
+                "commons-configuration2",
+                "2.7",
+                dependencies = listOf(dep1, dep2)
+            )
+            val dep4 = createDependency("org.apache.commons", "commons-csv", "1.5", dependencies = listOf(dep1))
+            val dep5 = createDependency("com.acme", "dep", "0.7", dependencies = listOf(dep3))
+            val maven = createMavenSupport()
+            val builder = GradleDependencyGraphBuilder(NAME, maven)
+
+            builder.addDependency(scope1, dep1, remoteRepositories)
+            builder.addDependency(scope2, dep1, remoteRepositories)
+            builder.addDependency(scope2, dep2, remoteRepositories)
+            builder.addDependency(scope1, dep5, remoteRepositories)
+            builder.addDependency(scope1, dep3, remoteRepositories)
+            builder.addDependency(scope2, dep4, remoteRepositories)
+            val graph = builder.build()
+
+            graph.dependencies shouldHaveSize 2
+            val dependencyIds = graph.dependencies.map { ref -> ref.id }
+            dependencyIds shouldContainExactlyInAnyOrder listOf(dep4.toId(), dep5.toId())
+
+            val refMapping = mutableMapOf<Identifier, PackageReference>()
+            graph.dependencies.forEach {
+                traverse(it, refMapping)
+            }
+
+            refMapping shouldHaveSize 5
+            val refConfig = refMapping[dep3.toId()] ?: fail("Could not resolve dependency.")
+            refConfig.dependencies.map { it.id } shouldContainExactlyInAnyOrder setOf(dep2.toId(), dep1.toId())
+            val scopeDependencies1 = scopeDependencies(graph, scope1, refMapping)
+            scopeDependencies1 shouldContainExactlyInAnyOrder setOf(
+                refMapping[dep1.toId()],
+                refMapping[dep3.toId()], refMapping[dep5.toId()]
+            )
+            val scopeDependencies2 = scopeDependencies(graph, scope2, refMapping)
+            scopeDependencies2 shouldContainExactlyInAnyOrder setOf(
+                refMapping[dep1.toId()],
+                refMapping[dep2.toId()],
+                refMapping[dep4.toId()]
+            )
+        }
+
+        "support scopes without dependencies" {
+            val scope = "EmptyScope"
+            val builder = GradleDependencyGraphBuilder(NAME, createMavenSupport())
+
+            builder.addScope(scope)
+            val graph = builder.build()
+
+            graph.dependencies.shouldBeEmpty()
+            graph.scopeMapping.keys shouldContainExactly setOf(scope)
+            val scopeDependencies = graph.scopeMapping[scope]
+            scopeDependencies.shouldNotBeNull()
+            scopeDependencies.shouldBeEmpty()
+        }
+
+        "not override a scope's dependencies when adding it again" {
+            val scope = "compile"
+            val dep = createDependency("org.apache.commons", "commons-lang3", "3.11")
+            val builder = GradleDependencyGraphBuilder(NAME, createMavenSupport())
+
+            builder.addDependency(scope, dep, remoteRepositories)
+            builder.addScope(scope)
+            val graph = builder.build()
+            val scopeDependencies = graph.scopeMapping[scope]
+            scopeDependencies.shouldNotBeNull()
+            scopeDependencies shouldContainExactly setOf(dep.toId())
+        }
+    }
+})
+
+/** The name of the package manager. */
+private const val NAME = "GradleTest"
+
+/** Remote repositories used by the test. */
+private val remoteRepositories = listOf(mockk<RemoteRepository>())
+
+/**
+ * Create a mock dependency with the properties provided.
+ */
+private fun createDependency(
+    group: String,
+    artifact: String,
+    version: String,
+    path: String? = null,
+    dependencies: List<Dependency> = emptyList()
+): Dependency {
+    val dependency = mockk<Dependency>()
+    every { dependency.groupId } returns group
+    every { dependency.artifactId } returns artifact
+    every { dependency.version } returns version
+    every { dependency.localPath } returns path
+    every { dependency.pomFile } returns "pom.xml"
+    every { dependency.dependencies } returns dependencies
+    every { dependency.warning } returns null
+    every { dependency.error } returns null
+    every { dependency.classifier } returns "jar"
+    every { dependency.extension } returns ""
+    return dependency
+}
+
+/**
+ * Create a [MavenSupport] mock object which is prepared to convert arbitrary artifacts to [Package] objects.
+ */
+private fun createMavenSupport(): MavenSupport {
+    val maven = mockk<MavenSupport>()
+    val slotArtifact = slot<DefaultArtifact>()
+    every { maven.parsePackage(capture(slotArtifact), remoteRepositories) } answers {
+        val artifact = slotArtifact.captured
+        val id = Identifier("Maven", artifact.groupId, artifact.artifactId, artifact.version)
+        Package(
+            id,
+            declaredLicenses = sortedSetOf(),
+            binaryArtifact = RemoteArtifact.EMPTY,
+            sourceArtifact = RemoteArtifact.EMPTY,
+            homepageUrl = "www.${artifact.artifactId}.org",
+            description = "Description of $artifact",
+            vcs = VcsInfo.EMPTY
+        )
+    }
+
+    return maven
+}
+
+/**
+ * Determine the type of the [Identifier] for this dependency.
+ */
+private fun Dependency.type(): String =
+    if (localPath != null) {
+        NAME
+    } else {
+        "Maven"
+    }
+
+/**
+ * Returns an [Identifier] for this [Dependency].
+ */
+private fun Dependency.toId() =
+    Identifier(type(), groupId, artifactId, version)
+
+/**
+ * Construct a [mapping] of package references to their IDs starting with the given [ref].
+ */
+private fun traverse(ref: PackageReference, mapping: MutableMap<Identifier, PackageReference>) {
+    val validRef = !mapping.containsKey(ref.id) || mapping[ref.id] === ref
+    validRef shouldBe true
+    mapping[ref.id] = ref
+    ref.dependencies.forEach { traverse(it, mapping) }
+}
+
+/**
+ * Return the package references from the given [graph] associated with the scope with the given [scopeName]
+ * using the specified [refMapping].
+ */
+private fun scopeDependencies(
+    graph: DependencyGraph,
+    scopeName: String,
+    refMapping: Map<Identifier, PackageReference>
+): List<PackageReference> =
+    graph.scopeMapping[scopeName].orEmpty().mapNotNull { refMapping[it] }

--- a/evaluator/src/test/kotlin/TestData.kt
+++ b/evaluator/src/test/kotlin/TestData.kt
@@ -121,7 +121,7 @@ val scopeExcluded = Scope(
 val projectExcluded = Project.EMPTY.copy(
     id = Identifier("Maven:org.ossreviewtoolkit:project-excluded:1.0"),
     definitionFilePath = "excluded/pom.xml",
-    scopes = sortedSetOf(scopeExcluded)
+    scopeDependencies = sortedSetOf(scopeExcluded)
 )
 
 val packageRefDynamicallyLinked = packageDynamicallyLinked.toReference(PackageLinkage.DYNAMIC)
@@ -143,7 +143,7 @@ val scopeIncluded = Scope(
 val projectIncluded = Project.EMPTY.copy(
     id = Identifier("Maven:org.ossreviewtoolkit:project-included:1.0"),
     definitionFilePath = "included/pom.xml",
-    scopes = sortedSetOf(scopeIncluded)
+    scopeDependencies = sortedSetOf(scopeIncluded)
 )
 
 val allProjects = listOf(

--- a/model/src/main/kotlin/DependencyGraph.kt
+++ b/model/src/main/kotlin/DependencyGraph.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+/**
+ * A data class that represents the graph of dependencies of a project.
+ *
+ * This class holds information about a project's scopes and their dependencies in a format that minimizes the
+ * consumption of memory. In projects with many scopes there is often a high degree of duplication in the
+ * dependencies of the single scopes. To avoid this, this class separates the storage of the dependencies from the
+ * storage of the scopes. The packages and their (transitive) dependencies are stored only once; an additional
+ * mapping then associates the scopes with their (direct) dependencies.
+ */
+data class DependencyGraph(
+    /**
+     * A set with [PackageReference] objects serving as the entry points into the dependency graph. By traversing the
+     * dependency trees contained in this set, each dependency of the represented project can be reached exactly once.
+     */
+    val dependencies: Set<PackageReference>,
+
+    /**
+     * A mapping from scope names to the direct dependencies of the scopes. Based on this information, the set of
+     * [Scope]s of a project can be constructed from the serialized form.
+     */
+    val scopeMapping: Map<String, Set<Identifier>>
+)

--- a/model/src/test/kotlin/ProjectTest.kt
+++ b/model/src/test/kotlin/ProjectTest.kt
@@ -19,13 +19,20 @@
 
 package org.ossreviewtoolkit.model
 
+import io.kotest.assertions.fail
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 
 import java.io.File
 import java.time.Instant
+import java.util.*
+
+import kotlin.io.path.createTempFile
 
 import org.ossreviewtoolkit.utils.test.containExactly
 
@@ -33,6 +40,58 @@ private fun readAnalyzerResult(analyzerResultFilename: String): Project =
     File("../analyzer/src/funTest/assets/projects/synthetic")
         .resolve(analyzerResultFilename)
         .readValue<ProjectAnalyzerResult>().project
+
+private val exampleId = Identifier("Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0")
+private val textId = Identifier("Maven:org.apache.commons:commons-text:1.1")
+private val langId = Identifier("Maven:org.apache.commons:commons-lang3:3.5")
+private val strutsId = Identifier("Maven:org.apache.struts:struts2-assembly:2.5.14.1")
+private val csvId = Identifier("Maven:org.apache.commons:commons-csv:1.4")
+
+/**
+ * Create a [Project] whose dependencies are represented as a [DependencyGraph].
+ */
+private fun projectWithDependencyGraph(): Project =
+    Project(
+        id = Identifier.EMPTY,
+        definitionFilePath = "/some/path",
+        declaredLicenses = sortedSetOf(),
+        vcs = VcsInfo.EMPTY,
+        homepageUrl = "https//www.test-project.org",
+        scopeDependencies = sortedSetOf(),
+        dependencyGraph = createDependencyGraph()
+    )
+
+/**
+ * Create a [DependencyGraph] containing some test dependencies.
+ */
+private fun createDependencyGraph(): DependencyGraph {
+    val langRef = PackageReference(langId)
+    val textRef = PackageReference(textId, dependencies = sortedSetOf(langRef))
+    val strutsRef = PackageReference(strutsId)
+    val csvRef = PackageReference(csvId, dependencies = sortedSetOf(langRef))
+    val exampleRef = PackageReference(exampleId, dependencies = sortedSetOf(textRef, strutsRef))
+
+    val scopeMapping = mapOf(
+        "default" to setOf(exampleId),
+        "compile" to setOf(exampleId),
+        "test" to setOf(exampleId, csvId),
+        "partial" to setOf(textId)
+    )
+
+    return DependencyGraph(setOf(exampleRef, csvRef), scopeMapping)
+}
+
+/**
+ * Lookup the scope with the given [name] in the set of [scopes].
+ */
+private fun findScope(scopes: SortedSet<Scope>, name: String): Scope =
+    scopes.find { it.name == name } ?: fail("Could not resolve scope $name.")
+
+/**
+ * Return a set with the identifiers of the (direct) dependencies of the given [scope].
+ */
+private fun scopeDependencies(scope: Scope): Set<Identifier> =
+    scope.dependencies.map { it.id }.toSet()
 
 class ProjectTest : WordSpec({
     "collectDependencies" should {
@@ -95,6 +154,41 @@ class ProjectTest : WordSpec({
                     )
                 )
             )
+        }
+    }
+
+    "scopes" should {
+        "be initialized from scope dependencies" {
+            val project = readAnalyzerResult("gradle-expected-output-lib-without-repo.yml")
+
+            project.scopes shouldBe project.scopeDependencies
+        }
+
+        "be initialized from a dependency graph" {
+            val project = projectWithDependencyGraph()
+            val scopes = project.scopes
+            scopes.map { it.name } shouldContainExactly listOf("compile", "default", "partial", "test")
+
+            val defaultScope = findScope(scopes, "default")
+            scopeDependencies(defaultScope) should containExactly(exampleId)
+            val testScope = findScope(scopes, "test")
+            scopeDependencies(testScope) should containExactlyInAnyOrder(exampleId, csvId)
+            val partialScope = findScope(scopes, "partial")
+            scopeDependencies(partialScope) should containExactly(textId)
+        }
+    }
+
+    "Project" should {
+        "be serializable with a dependency graph" {
+            val outputFile = createTempFile(prefix = "project", suffix = ".yml").toFile().apply {
+                deleteOnExit()
+            }
+
+            val project = projectWithDependencyGraph()
+            jsonMapper.writeValue(outputFile, project)
+
+            val projectCopy = jsonMapper.readValue(outputFile, Project::class.java)
+            projectCopy.scopes shouldBe project.scopes
         }
     }
 })

--- a/model/src/test/kotlin/config/ExcludesTest.kt
+++ b/model/src/test/kotlin/config/ExcludesTest.kt
@@ -147,7 +147,7 @@ class ExcludesTest : WordSpec() {
         "isExcluded" should {
             "return false if the project is not found" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1))
                 )
 
                 ortResult.isExcluded(project2.id) shouldBe false
@@ -163,7 +163,7 @@ class ExcludesTest : WordSpec() {
 
             "return false if the package is not excluded" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1))
                 )
 
                 ortResult.isExcluded(id) shouldBe false
@@ -171,8 +171,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all projects depending on a package are excluded by path excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -184,8 +184,8 @@ class ExcludesTest : WordSpec() {
 
             "return false if only part of the projects depending on a package are excluded by path excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -197,8 +197,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all scopes containing the package are excluded by scope excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -210,8 +210,8 @@ class ExcludesTest : WordSpec() {
 
             "return false if only part of the scopes containing the package are excluded by scope excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -223,8 +223,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all dependencies on the package are excluded by path or scope excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -250,7 +250,7 @@ class ExcludesTest : WordSpec() {
             "return true if a project and all dependencies on the project are excluded by path excludes" {
                 setProjects(
                     project1,
-                    project2.copy(scopes = sortedSetOf(scopeProject1))
+                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1))
                 )
 
                 setExcludes(
@@ -263,7 +263,7 @@ class ExcludesTest : WordSpec() {
             "return true if a project is excluded by path excludes and all dependencies on the project are excluded by scope excludes" {
                 setProjects(
                     project1,
-                    project2.copy(scopes = sortedSetOf(scopeProject1))
+                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1))
                 )
 
                 setExcludes(
@@ -277,7 +277,7 @@ class ExcludesTest : WordSpec() {
             "return false if a project is excluded by path excludes but not all dependencies on the project are excluded" {
                 setProjects(
                     project1,
-                    project2.copy(scopes = sortedSetOf(scopeProject1))
+                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1))
                 )
 
                 setExcludes(
@@ -290,7 +290,7 @@ class ExcludesTest : WordSpec() {
             "return false if a project is not excluded but all dependencies on the project are excluded" {
                 setProjects(
                     project1,
-                    project2.copy(scopes = sortedSetOf(scopeProject1))
+                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1))
                 )
 
                 setExcludes(
@@ -312,7 +312,7 @@ class ExcludesTest : WordSpec() {
 
             "return false if the package is not excluded" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1))
                 )
 
                 ortResult.isPackageExcluded(id) shouldBe false
@@ -320,8 +320,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all projects depending on a package are excluded by path excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -333,8 +333,8 @@ class ExcludesTest : WordSpec() {
 
             "return false if only part of the projects depending on a package are excluded by path excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -346,8 +346,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all scopes containing the package are excluded by scope excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -359,8 +359,8 @@ class ExcludesTest : WordSpec() {
 
             "return false if only part of the scopes containing the package are excluded by scope excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -372,8 +372,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all dependencies on the package are excluded by path or scope excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -387,7 +387,7 @@ class ExcludesTest : WordSpec() {
             "return true if all dependencies on the project are excluded" {
                 setProjects(
                     project1,
-                    project2.copy(scopes = sortedSetOf(scopeProject1, scopeProject1.copy(name = "scope")))
+                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1, scopeProject1.copy(name = "scope")))
                 )
 
                 setExcludes(
@@ -400,7 +400,7 @@ class ExcludesTest : WordSpec() {
             "return false if not all dependencies on the project are excluded" {
                 setProjects(
                     project1,
-                    project2.copy(scopes = sortedSetOf(scopeProject1, scopeProject1.copy(name = "scope")))
+                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1, scopeProject1.copy(name = "scope")))
                 )
 
                 setExcludes(
@@ -413,7 +413,7 @@ class ExcludesTest : WordSpec() {
             "return false if no dependencies on the project are excluded" {
                 setProjects(
                     project1,
-                    project2.copy(scopes = sortedSetOf(scopeProject1))
+                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1))
                 )
 
                 ortResult.isPackageExcluded(project1.id) shouldBe false

--- a/model/src/test/kotlin/licenses/TestData.kt
+++ b/model/src/test/kotlin/licenses/TestData.kt
@@ -129,7 +129,7 @@ val scope = Scope(
 val project = Project.EMPTY.copy(
     id = Identifier("Maven:org.ossreviewtoolkit:project-included:1.0"),
     definitionFilePath = "included/pom.xml",
-    scopes = sortedSetOf(scope)
+    scopeDependencies = sortedSetOf(scope)
 )
 
 val provenance = Provenance(sourceArtifact = RemoteArtifact.EMPTY)


### PR DESCRIPTION
This PR addresses #3321 by proposing a more efficient storage format for the dependency representation in analyzer results. The basic idea is to not repeat the dependencies for all scopes, but use a shared dependency graph, which is referenced by scopes.

This is still work in progress. The solution has to be extended to support different sets of dependencies for packages in different scopes.