### PR TITLE
analyzer: Add support for the Conda package manager

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,7 @@ environment:
   FLUTTER_HOME: C:\flutter
   FLUTTER_VERSION: v1.12.13+hotfix.9-stable
   GO_DEP_VERSION: 0.5.0
+  MINICONDA: C:\Miniconda3-x64
   NPM_VERSION: 6.14.1
   PHP_VERSION: 7.4.3
   PYTHON_PIPENV_VERSION: 2018.11.26
@@ -57,6 +58,10 @@ install:
   - flutter config --no-analytics
   - flutter doctor
   - pip install pipenv==%PYTHON_PIPENV_VERSION%
+  # Install Conda.
+  - set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%MINICONDA%\\Library\\bin;%PATH%
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
   # Work around an issue with GPG failing to connect to its agent in GitRepoTest
   # as seen at https://ci.appveyor.com/project/heremaps/oss-review-toolkit/builds/30228453#L3030.
   - mv C:\msys64\usr\bin\gpg.exe C:\msys64\usr\bin\gpg.exe.orig

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - ANDROID_SDK_VERSION="6609375"
     - BOWER_VERSION="1.8.8"
     - CONAN_VERSION="1.18.0"
+    - CONDA_VERSION="4.7.12.1"
     - FLUTTER_HOME="/opt/flutter"
     - FLUTTER_VERSION="v1.12.13+hotfix.9-stable"
     - GIMME_GO_VERSION="1.13" # Used internally by Travis.
@@ -75,6 +76,11 @@ install:
   - conan user # Create the conan data directory. Automatic detection of your arch, compiler, etc.
   - pyenv global system 3.6
   - pip3 install --user reuse
+  - wget https://repo.continuum.io/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -O miniconda.sh
+  - ./miniconda.sh -b -p $HOME/miniconda
+  - source "$HOME/miniconda/etc/profile.d/conda.sh"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
 
 before_script:
   - reuse lint

--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Currently, the following package managers are supported:
 * [Composer](https://getcomposer.org/) (PHP)
 * [Conan](https://conan.io/) (C / C++, *experimental* as the VCS locations often times do not contain the actual source
   code, see [issue #2037](https://github.com/oss-review-toolkit/ort/issues/2037))
+* [Conda](https://docs.conda.io/en/latest/miniconda.html) (Python)
 * [dep](https://golang.github.io/dep/) (Go)
 * [DotNet](https://docs.microsoft.com/en-us/dotnet/core/tools/) (.NET, with currently some
   [limitations](https://github.com/oss-review-toolkit/ort/pull/1303#issue-253860146))

--- a/analyzer/src/funTest/assets/projects/synthetic/conda-django-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/conda-django-expected-output.yml
@@ -1,0 +1,181 @@
+---
+project:
+  id: "Conda::src/funTest/assets/projects/synthetic/python3-django/environment.yml:<REPLACE_REVISION>"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/python3-django/environment.yml"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scopes:
+  - name: "install"
+    dependencies:
+    - id: "PyPI::Django:2.2.1"
+      dependencies:
+      - id: "PyPI::pytz:2019.1"
+      - id: "PyPI::sqlparse:0.3.0"
+    - id: "PyPI::certifi:2019.9.11"
+    - id: "PyPI::wincertstore:0.2"
+packages:
+- package:
+    id: "PyPI::Django:2.2.1"
+    purl: "pkg:pypi/Django@2.2.1"
+    declared_licenses:
+    - "BSD"
+    declared_licenses_processed:
+      spdx_expression: "BSD-3-Clause"
+    description: "A high-level Python Web framework that encourages rapid development\
+      \ and clean, pragmatic design."
+    homepage_url: "https://www.djangoproject.com/"
+    binary_artifact:
+      url: "https://files.pythonhosted.org/packages/b1/1d/2476110614367adfb079a9bc718621f9fc8351e9214e1750cae1832d4090/Django-2.2.1-py3-none-any.whl"
+      hash:
+        value: "8a2f51f779351edcbceda98719e07254"
+        algorithm: "MD5"
+    source_artifact:
+      url: "https://files.pythonhosted.org/packages/fd/70/36c08f4c3b22523173b3a5e21fbdaa137bdb1722b76f356e0e2d5d8aa645/Django-2.2.1.tar.gz"
+      hash:
+        value: "3b1721c1b5014316e1af8b10613c7592"
+        algorithm: "MD5"
+    vcs:
+      type: ""
+      url: ""
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: ""
+      url: ""
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "PyPI::certifi:2019.9.11"
+    purl: "pkg:pypi/certifi@2019.9.11"
+    declared_licenses:
+    - "MPL-2.0"
+    - "Mozilla Public License 2.0 (MPL 2.0)"
+    declared_licenses_processed:
+      spdx_expression: "MPL-2.0"
+    description: "Python package for providing Mozilla's CA Bundle."
+    homepage_url: "https://certifi.io/"
+    binary_artifact:
+      url: "https://files.pythonhosted.org/packages/18/b0/8146a4f8dd402f60744fa380bc73ca47303cccf8b9190fd16a827281eac2/certifi-2019.9.11-py2.py3-none-any.whl"
+      hash:
+        value: "c6eec42e5b000580fb096b892ea1e2b5"
+        algorithm: "MD5"
+    source_artifact:
+      url: "https://files.pythonhosted.org/packages/62/85/7585750fd65599e88df0fed59c74f5075d4ea2fe611deceb95dd1c2fb25b/certifi-2019.9.11.tar.gz"
+      hash:
+        value: "cadd4e373fc08f649fa39b82aed9ad96"
+        algorithm: "MD5"
+    vcs:
+      type: ""
+      url: ""
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: ""
+      url: ""
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "PyPI::pytz:2019.1"
+    purl: "pkg:pypi/pytz@2019.1"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "World timezone definitions, modern and historical"
+    homepage_url: "http://pythonhosted.org/pytz"
+    binary_artifact:
+      url: "https://files.pythonhosted.org/packages/3d/73/fe30c2daaaa0713420d0382b16fbb761409f532c56bdcc514bf7b6262bb6/pytz-2019.1-py2.py3-none-any.whl"
+      hash:
+        value: "9494cbd701404080e83cbb316e692891"
+        algorithm: "MD5"
+    source_artifact:
+      url: "https://files.pythonhosted.org/packages/df/d5/3e3ff673e8f3096921b3f1b79ce04b832e0100b4741573154b72b756a681/pytz-2019.1.tar.gz"
+      hash:
+        value: "8b2860a161bfb0a6165798b1a2d8c40c"
+        algorithm: "MD5"
+    vcs:
+      type: ""
+      url: ""
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: ""
+      url: ""
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "PyPI::sqlparse:0.3.0"
+    purl: "pkg:pypi/sqlparse@0.3.0"
+    declared_licenses:
+    - "BSD"
+    declared_licenses_processed:
+      spdx_expression: "BSD-3-Clause"
+    description: "Non-validating SQL parser"
+    homepage_url: "https://github.com/andialbrecht/sqlparse"
+    binary_artifact:
+      url: "https://files.pythonhosted.org/packages/ef/53/900f7d2a54557c6a37886585a91336520e5539e3ae2423ff1102daf4f3a7/sqlparse-0.3.0-py2.py3-none-any.whl"
+      hash:
+        value: "19aaa5c1cdb4fcae4fd0717f104c524d"
+        algorithm: "MD5"
+    source_artifact:
+      url: "https://files.pythonhosted.org/packages/63/c8/229dfd2d18663b375975d953e2bdc06d0eed714f93dcb7732f39e349c438/sqlparse-0.3.0.tar.gz"
+      hash:
+        value: "2ce34181d6b7b234c9f3c0ecd1ffb93e"
+        algorithm: "MD5"
+    vcs:
+      type: ""
+      url: ""
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/andialbrecht/sqlparse.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "PyPI::wincertstore:0.2"
+    purl: "pkg:pypi/wincertstore@0.2"
+    declared_licenses:
+    - "PSFL"
+    - "Python Software Foundation"
+    declared_licenses_processed:
+      spdx_expression: "Python-2.0"
+    description: "Python module to extract CA and CRL certs from Windows' cert store\
+      \ (ctypes based)."
+    homepage_url: "https://bitbucket.org/tiran/wincertstore"
+    binary_artifact:
+      url: "https://files.pythonhosted.org/packages/d1/67/12f477fa1cc8cbcdc78027c9fb0933ad41daf2e95a29d1cc8f34fe80c692/wincertstore-0.2-py2.py3-none-any.whl"
+      hash:
+        value: "03510657cf5ed292c9debe22c16edbe0"
+        algorithm: "MD5"
+    source_artifact:
+      url: "https://files.pythonhosted.org/packages/df/e1/765f9abdd57610b1c6251e4853edddcac60f929cf6c9029200887dde0f9e/wincertstore-0.2.zip"
+      hash:
+        value: "ae728f2f007185648d0c7a8679b361e2"
+        algorithm: "MD5"
+    vcs:
+      type: ""
+      url: ""
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Mercurial"
+      url: "https://bitbucket.org/tiran/wincertstore"
+      revision: ""
+      path: ""
+  curations: []

--- a/analyzer/src/funTest/assets/projects/synthetic/pipenv-python3/environment.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pipenv-python3/environment.yml
@@ -1,0 +1,11 @@
+name: ort
+channels:
+  - defaults
+dependencies:
+  - python=3.7
+  - django==2.2.1
+  - certifi==2019.9.11
+  - pytz==2019.1
+  - sqlparse==0.3.0
+  - pip:
+    - wincertstore==0.2

--- a/analyzer/src/funTest/kotlin/managers/CondaTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/CondaTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.analyzer.managers
+
+import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.yamlMapper
+import com.here.ort.utils.normalizeVcsUrl
+import com.here.ort.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+import com.here.ort.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
+import com.here.ort.utils.test.USER_DIR
+import com.here.ort.utils.test.patchExpectedResult
+
+import io.kotlintest.matchers.string.shouldContain
+import io.kotlintest.matchers.string.shouldStartWith
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.WordSpec
+
+import java.io.File
+
+class CondaTest : WordSpec() {
+    private val projectsDir = File("src/funTest/assets/projects").absoluteFile
+    private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
+    private val vcsUrl = vcsDir.getRemoteUrl()
+    private val vcsRevision = vcsDir.getRevision()
+
+    init {
+        "conda executable" should {
+            "find the environment" {
+                val definitionFile = File(projectsDir, "synthetic/python3-django/environment.yml")
+                val conda = createConda()
+
+                val envDir = conda.createEnv(definitionFile)
+
+                envDir.path.toLowerCase() shouldContain "conda"
+                envDir.name shouldStartWith "ort"
+                conda.runInEnv(envDir, "python", "--version").stdout shouldStartWith "Python 3"
+                conda.runInEnv(envDir, "pip", "--version").stdout.toLowerCase() shouldContain "conda"
+            }
+        }
+
+        "Python dependencies" should {
+            "resolve dependencies correctly for python-django" {
+                val definitionFile = File(projectsDir, "synthetic/python3-django/environment.yml")
+                val vcsPath = vcsDir.getPathToRoot(definitionFile.parentFile)
+
+                val result = createConda().resolveDependencies(listOf(definitionFile))[definitionFile]
+                val expectedResultFile = File(projectsDir, "synthetic/conda-django-expected-output.yml")
+                val expectedResult = patchExpectedResult(
+                    expectedResultFile,
+                    url = normalizeVcsUrl(vcsUrl),
+                    revision = vcsRevision,
+                    path = vcsPath
+                )
+
+                yamlMapper.writeValueAsString(result) shouldBe expectedResult
+            }
+        }
+    }
+
+    private fun createConda() =
+        Conda("Conda", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+}

--- a/analyzer/src/main/kotlin/managers/Conda.kt
+++ b/analyzer/src/main/kotlin/managers/Conda.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.analyzer.managers
+
+import com.here.ort.analyzer.AbstractPackageManagerFactory
+import com.here.ort.analyzer.PackageManager
+import com.here.ort.analyzer.managers.utils.PythonSupport
+import com.here.ort.model.ProjectAnalyzerResult
+import com.here.ort.model.config.AnalyzerConfiguration
+import com.here.ort.model.config.RepositoryConfiguration
+import com.here.ort.model.jsonMapper
+import com.here.ort.utils.CommandLineTool
+import com.here.ort.utils.ProcessCapture
+import com.here.ort.utils.log
+import com.here.ort.utils.safeDeleteRecursively
+
+import java.io.File
+import java.io.IOException
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * The [Conda](https://docs.conda.io/en/latest/) package manager for Python.
+ */
+class Conda(
+    name: String,
+    analyzerRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) : PackageManager(name, analyzerRoot, analyzerConfig, repoConfig), CommandLineTool {
+    class Factory : AbstractPackageManagerFactory<Conda>("Conda") {
+        override val globsForDefinitionFiles = listOf("environment.yml")
+
+        override fun create(
+            analysisRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) = Conda(managerName, analysisRoot, analyzerConfig, repoConfig)
+    }
+
+    // Create an environment with Conda named "ort<datetime>".
+    private val envName = run {
+        val formatter = DateTimeFormatter.ofPattern("yyyyMMddhhmmss")
+        val formattedDate = LocalDateTime.now().format(formatter)
+        "ort$formattedDate"
+    }
+
+    override fun command(workingDir: File?) = "conda"
+
+    /**
+     * Run [commandName] with arguments [commandArgs] in environment at directory [envDir].
+     */
+    fun runInEnv(envDir: File, commandName: String, vararg commandArgs: String): ProcessCapture =
+        ProcessCapture(command(), "run", "--name", envDir.name, commandName, *commandArgs).requireSuccess()
+
+    override fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+        val workingDir = definitionFile.parentFile
+        val envDir = setupEnv(definitionFile)
+
+        val support = object : PythonSupport(managerName, analysisRoot, command(workingDir), envDir) {
+            override fun runInEnv(workingDir: File, commandName: String, vararg commandArgs: String): ProcessCapture =
+                this@Conda.runInEnv(envDir, commandName, *commandArgs)
+        }
+
+        val result = support.resolveDependencies(definitionFile)
+
+        // Remove the env by simply deleting the directory.
+        envDir.safeDeleteRecursively()
+
+        return result
+    }
+
+    private fun setupEnv(definitionFile: File): File {
+        // Create an out-of-tree environment.
+        log.info { "Creating a Conda env for $definitionFile..." }
+        val envDir = createEnv(definitionFile)
+        val install = installDependencies(definitionFile, envDir)
+
+        if (install.isError) {
+            log.debug {
+                // Pip writes the real error message to stdout instead of stderr.
+                "First try to install dependencies using Conda failed with:\n${install.stdout}"
+            }
+
+            if (install.isError) {
+                // pip writes the real error message to stdout instead of stderr.
+                throw IOException("setupEnv (in $envDir) error: ${install.stdout}")
+            }
+        }
+
+        log.info {
+            "Successfully installed dependencies for project '$definitionFile' using Conda."
+        }
+
+        return envDir
+    }
+
+    /**
+     * Create a Conda environment given the environment.yml or requirements.txt.
+     */
+    fun createEnv(envDefinition: File): File {
+        if (envDefinition.name.endsWith(".py")) {
+            // Python install script is not an environment definition.
+            ProcessCapture(
+                "conda", "create",
+                "-y",
+                "--name", envName,
+                "python"
+            ).requireSuccess()
+        } else {
+            ProcessCapture(
+                "conda", "env", "create",
+                "--force",
+                "--name", envName,
+                "--file", envDefinition.absolutePath
+            ).requireSuccess()
+        }
+
+        // Load the list of Conda environments and find the one we created.
+        val jsonString: String = ProcessCapture("conda", "env", "list", "--json").requireSuccess().stdout
+        val rootNode = jsonMapper.readTree(jsonString)
+        val envsNodes = rootNode.path("envs").elements().asSequence().toList()
+        return File(envsNodes.single { File(it.textValue()).name == envName }.textValue())
+    }
+
+    private fun installDependencies(definitionFile: File, envDir: File): ProcessCapture {
+        // Install pipdeptree inside the Conda environment as that is the only way to make it report only the project's
+        // dependencies instead of those of all (globally) installed packages, see
+        // https://github.com/naiquevin/pipdeptree#known-issues.
+        // We only depend on pipdeptree to be at least version 0.5.0 for JSON output, but we stick to a fixed
+        // version to be sure to get consistent results.
+        runInEnv(envDir, "pip", *Pip.TRUSTED_HOSTS, "install", "pipdeptree==$PIPDEPTREE_VERSION").requireSuccess()
+
+        // Use the yml that defines the environment.
+        val conda = ProcessCapture(
+            "conda",
+            "env",
+            "update",
+            "--name", envName,
+            "--file", definitionFile.absolutePath
+        ).requireSuccess()
+
+        return conda
+    }
+}

--- a/analyzer/src/main/kotlin/managers/utils/PythonSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/PythonSupport.kt
@@ -1,0 +1,378 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.ort.analyzer.managers.utils
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
+
+import com.here.ort.analyzer.HTTP_CACHE_PATH
+import com.here.ort.analyzer.PackageManager
+import com.here.ort.analyzer.managers.Pip
+import com.here.ort.downloader.VersionControlSystem
+import com.here.ort.model.EMPTY_JSON_NODE
+import com.here.ort.model.Hash
+import com.here.ort.model.Identifier
+import com.here.ort.model.Package
+import com.here.ort.model.PackageReference
+import com.here.ort.model.Project
+import com.here.ort.model.ProjectAnalyzerResult
+import com.here.ort.model.RemoteArtifact
+import com.here.ort.model.Scope
+import com.here.ort.model.VcsInfo
+import com.here.ort.model.jsonMapper
+import com.here.ort.utils.OkHttpClientHelper
+import com.here.ort.utils.Os
+import com.here.ort.utils.ProcessCapture
+import com.here.ort.utils.collectMessagesAsString
+import com.here.ort.utils.log
+import com.here.ort.utils.showStackTrace
+import com.here.ort.utils.stripLeadingZerosFromVersion
+import com.here.ort.utils.textValueOrEmpty
+
+import java.io.File
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.util.SortedSet
+
+import okhttp3.Request
+
+abstract class PythonSupport(val managerName: String, val analysisRoot: File, val command: String, val envDir: File) {
+    companion object {
+        private const val PYDEP_REVISION = "license-and-classifiers"
+        private const val PYDEP_URL = "git+https://github.com/heremaps/pydep@$PYDEP_REVISION"
+
+        private val PHONY_DEPENDENCIES = mapOf(
+            "pipdeptree" to "", // A dependency of pipdeptree itself.
+            "pkg-resources" to "0.0.0", // Added by a bug with some Ubuntu distributions.
+            "setuptools" to "", // A dependency of pipdeptree itself.
+            "wheel" to "" // A dependency of pipdeptree itself.
+        )
+
+        private fun isPhonyDependency(name: String, version: String): Boolean =
+            PHONY_DEPENDENCIES[name].orEmpty().let { ignoredVersion ->
+                PHONY_DEPENDENCIES.containsKey(name) && (ignoredVersion.isEmpty() || version == ignoredVersion)
+            }
+    }
+
+    abstract fun runInEnv(
+        workingDir: File,
+        commandName: String,
+        vararg commandArgs: String
+    ): ProcessCapture
+
+    fun resolveDependencies(definitionFile: File): ProjectAnalyzerResult? {
+        // For an overview, dependency resolution involves the following steps:
+        // 1. Install dependencies via pip (inside a virtualenv, for isolation from globally installed packages).
+        // 2. Get meta-data about the local project via pydep (only for setup.py-based projects).
+        // 3. Get the hierarchy of dependencies via pipdeptree.
+        // 4. Get additional remote package meta-data via PyPIJSON.
+
+        val workingDir = definitionFile.parentFile
+
+        // List all packages installed locally in the virtualenv.
+        val pipdeptree = runInEnv(workingDir, "pipdeptree", "-l", "--json-tree")
+
+        // Install pydep after running any other command but before looking at the dependencies because it
+        // downgrades pip to version 7.1.2. Use it to get meta-information from about the project from setup.py. As
+        // pydep is not on PyPI, install it from Git instead.
+        val pip = if (Os.isWindows) {
+            // On Windows, in-place pip up-/downgrades require pip to be wrapped by "python -m", see
+            // https://github.com/pypa/pip/issues/1299.
+            runInEnv(
+                workingDir, "python", "-m", command,
+                *Pip.TRUSTED_HOSTS, "install", PYDEP_URL
+            )
+        } else {
+            runInEnv(workingDir, "pip", *Pip.TRUSTED_HOSTS, "install", PYDEP_URL)
+        }
+        pip.requireSuccess()
+
+        var declaredLicenses: SortedSet<String> = sortedSetOf<String>()
+
+        // First try to get meta-data from "setup.py" in any case, even for "requirements.txt" projects.
+        val (setupName, setupVersion, setupHomepage) = if (File(workingDir, "setup.py").isFile) {
+            val pydep = if (Os.isWindows) {
+                // On Windows, the script itself is not executable, so we need to wrap the call by "python".
+                runInEnv(workingDir, "python", envDir.path + "\\Scripts\\pydep-run.py", "info", ".")
+            } else {
+                runInEnv(workingDir, "pydep-run.py", "info", ".")
+            }
+            pydep.requireSuccess()
+
+            // What pydep actually returns as "repo_url" is either setup.py's
+            // - "url", denoting the "home page for the package", or
+            // - "download_url", denoting the "location where the package may be downloaded".
+            // So the best we can do is to map this the project's homepage URL.
+            jsonMapper.readTree(pydep.stdout).let {
+                declaredLicenses = getDeclaredLicenses(it)
+                listOf(
+                    it["project_name"].textValue(), it["version"].textValueOrEmpty(),
+                    it["repo_url"].textValueOrEmpty()
+                )
+            }
+        } else {
+            listOf("", "", "")
+        }
+
+        // Try to get additional information from any "requirements.txt" file.
+        val (requirementsName, requirementsVersion, requirementsSuffix) = if (definitionFile.name != "setup.py") {
+            val pythonVersionLines = definitionFile.readLines().filter { it.contains("python_version") }
+            if (pythonVersionLines.isNotEmpty()) {
+                log.debug {
+                    "Some dependencies have Python version requirements:\n$pythonVersionLines"
+                }
+            }
+
+            // In case of "requirements*.txt" there is no meta-data at all available, so use the parent directory name
+            // plus what "*" expands to as the project name and the VCS revision, if any, as the project version.
+            val suffix = definitionFile.name.removePrefix("requirements").removeSuffix(".txt")
+            val name = definitionFile.parentFile.name + suffix
+
+            val version = VersionControlSystem.getCloneInfo(workingDir).revision
+
+            listOf(name, version, suffix)
+        } else {
+            listOf("", "", "")
+        }
+
+        // Amend information from "setup.py" with that from "requirements.txt".
+        val projectName = when (Pair(setupName.isNotEmpty(), requirementsName.isNotEmpty())) {
+            Pair(true, false) -> setupName
+            // In case of only a requirements file without further meta-data, use the relative path to the analyzer
+            // root as a unique project name.
+            Pair(false, true) -> definitionFile.relativeTo(analysisRoot).invariantSeparatorsPath
+            Pair(true, true) -> "$setupName-requirements$requirementsSuffix"
+            else -> throw IllegalArgumentException("Unable to determine a project name for '$definitionFile'.")
+        }
+        val projectVersion = setupVersion.takeIf { it.isNotEmpty() } ?: requirementsVersion
+
+        val packages = sortedSetOf<Package>()
+        val installDependencies = sortedSetOf<PackageReference>()
+
+        if (pipdeptree.isSuccess) {
+            val fullDependencyTree = jsonMapper.readTree(pipdeptree.stdout)
+
+            val projectDependencies = if (definitionFile.name == "setup.py") {
+                // The tree contains a root node for the project itself and pipdeptree's dependencies are also at the
+                // root next to it, as siblings.
+                fullDependencyTree.find {
+                    it["package_name"].textValue() == projectName
+                }?.get("dependencies") ?: run {
+                    log.info { "The '$projectName' project does not declare any dependencies." }
+                    EMPTY_JSON_NODE
+                }
+            } else {
+                // The tree does not contain a node for the project itself. Its dependencies are on the root level
+                // together with the dependencies of pipdeptree itself, which we need to filter out.
+                fullDependencyTree.filterNot {
+                    isPhonyDependency(it["package_name"].textValue(), it["installed_version"].textValueOrEmpty())
+                }
+            }
+
+            val packageTemplates = sortedSetOf<Package>()
+            parseDependencies(projectDependencies, packageTemplates, installDependencies)
+
+            // Enrich the package templates with additional meta-data from PyPI.
+            packageTemplates.mapTo(packages) { pkg ->
+                // See https://wiki.python.org/moin/PyPIJSON.
+                val pkgRequest = Request.Builder()
+                    .get()
+                    .url("https://pypi.org/pypi/${pkg.id.name}/${pkg.id.version}/json")
+                    .build()
+
+                OkHttpClientHelper.execute(HTTP_CACHE_PATH, pkgRequest).use { response ->
+                    val body = response.body?.string()?.trim()
+
+                    if (response.code != HttpURLConnection.HTTP_OK || body.isNullOrEmpty()) {
+                        log.warn { "Unable to retrieve PyPI meta-data for package '${pkg.id.toCoordinates()}'." }
+                        if (body != null) {
+                            log.warn { "The response was '$body' (code ${response.code})." }
+                        }
+
+                        // Fall back to returning the original package data.
+                        return@use pkg
+                    }
+
+                    val pkgData = try {
+                        jsonMapper.readTree(body)!!
+                    } catch (e: IOException) {
+                        e.showStackTrace()
+
+                        log.warn {
+                            "Unable to parse PyPI meta-data for package '${pkg.id.toCoordinates()}': " +
+                                    e.collectMessagesAsString()
+                        }
+
+                        // Fall back to returning the original package data.
+                        return@use pkg
+                    }
+
+                    pkgData["info"]?.let { pkgInfo ->
+                        val pkgDescription = pkgInfo["summary"]?.textValue() ?: pkg.description
+                        val pkgHomepage = pkgInfo["home_page"]?.textValue() ?: pkg.homepageUrl
+
+                        val pkgRelease = pkgData["releases"]?.let { pkgReleases ->
+                            val pkgVersion = pkgReleases.fieldNames().asSequence().find {
+                                stripLeadingZerosFromVersion(it) == pkg.id.version
+                            }
+
+                            pkgReleases[pkgVersion]
+                        } as? ArrayNode
+
+                        // Amend package information with more details.
+                        Package(
+                            id = pkg.id,
+                            declaredLicenses = getDeclaredLicenses(pkgInfo),
+                            description = pkgDescription,
+                            homepageUrl = pkgHomepage,
+                            binaryArtifact = if (pkgRelease != null) {
+                                getBinaryArtifact(pkg, pkgRelease)
+                            } else {
+                                pkg.binaryArtifact
+                            },
+                            sourceArtifact = if (pkgRelease != null) {
+                                getSourceArtifact(pkgRelease)
+                            } else {
+                                pkg.sourceArtifact
+                            },
+                            vcs = pkg.vcs,
+                            vcsProcessed = PackageManager.processPackageVcs(pkg.vcs, pkgHomepage)
+                        )
+                    } ?: run {
+                        log.warn {
+                            "PyPI meta-data for package '${pkg.id.toCoordinates()}' does not provide any information."
+                        }
+
+                        // Fall back to returning the original package data.
+                        pkg
+                    }
+                }
+            }
+        } else {
+            log.error {
+                "Unable to determine dependencies for project in directory '$workingDir':\n${pipdeptree.stderr}"
+            }
+        }
+
+        // TODO: Handle "extras" and "tests" dependencies.
+        val scopes = sortedSetOf(
+            Scope("install", installDependencies)
+        )
+
+        val project = Project(
+            id = Identifier(
+                type = managerName,
+                namespace = "",
+                name = projectName,
+                version = projectVersion
+            ),
+            definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+            declaredLicenses = declaredLicenses,
+            vcs = VcsInfo.EMPTY,
+            vcsProcessed = PackageManager.processProjectVcs(workingDir, homepageUrl = setupHomepage),
+            homepageUrl = setupHomepage,
+            scopes = scopes
+        )
+
+        return ProjectAnalyzerResult(project, packages.mapTo(sortedSetOf()) { it.toCuratedPackage() })
+    }
+
+    /**
+     * Get declared licenses from PIP package JSON metadata.
+     */
+    fun getDeclaredLicenses(pkgInfo: JsonNode): SortedSet<String> {
+        val declaredLicenses = sortedSetOf<String>()
+
+        // Use the top-level license field as well as the license classifiers as the declared licenses.
+        setOf(pkgInfo["license"]).mapNotNullTo(declaredLicenses) { license ->
+            license?.textValue()?.removeSuffix(" License")?.takeUnless { it.isBlank() || it == "UNKNOWN" }
+        }
+
+        // Example license classifier:
+        // "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)"
+        pkgInfo["classifiers"]?.mapNotNullTo(declaredLicenses) { it ->
+            val classifier = it.textValue().split(" :: ")
+            classifier.takeIf { it.first() == "License" }?.last()?.removeSuffix(" License")
+        }
+
+        return declaredLicenses
+    }
+
+    fun parseDependencies(
+        dependencies: Iterable<JsonNode>,
+        allPackages: SortedSet<Package>,
+        installDependencies: SortedSet<PackageReference>
+    ) {
+        dependencies.forEach { dependency ->
+            val name = dependency["package_name"].textValue()
+            val version = dependency["installed_version"].textValue()
+
+            val pkg = Package(
+                id = Identifier(
+                    type = "PyPI",
+                    namespace = "",
+                    name = name,
+                    version = version
+                ),
+                declaredLicenses = sortedSetOf(),
+                description = "",
+                homepageUrl = "",
+                binaryArtifact = RemoteArtifact.EMPTY,
+                sourceArtifact = RemoteArtifact.EMPTY,
+                vcs = VcsInfo.EMPTY
+            )
+            allPackages += pkg
+
+            val packageRef = pkg.toReference()
+            installDependencies += packageRef
+
+            parseDependencies(dependency["dependencies"], allPackages, packageRef.dependencies)
+        }
+    }
+
+    fun getBinaryArtifact(pkg: Package, releaseNode: ArrayNode): RemoteArtifact {
+        // Prefer python wheels and fall back to the first entry (probably a sdist).
+        val binaryArtifact = releaseNode.asSequence().find {
+            it["packagetype"].textValue() == "bdist_wheel"
+        } ?: releaseNode[0]
+
+        val url = binaryArtifact["url"]?.textValue() ?: pkg.binaryArtifact.url
+        val hash = binaryArtifact["md5_digest"]?.textValue()?.let { Hash.create(it) } ?: pkg.binaryArtifact.hash
+
+        return RemoteArtifact(url, hash)
+    }
+
+    fun getSourceArtifact(releaseNode: ArrayNode): RemoteArtifact {
+        val sourceArtifacts = releaseNode.asSequence().filter {
+            it["packagetype"].textValue() == "sdist"
+        }
+
+        if (sourceArtifacts.count() == 0) return RemoteArtifact.EMPTY
+
+        val sourceArtifact = sourceArtifacts.find {
+            it["filename"].textValue().endsWith(".tar.bz2")
+        } ?: sourceArtifacts.elementAt(0)
+
+        val url = sourceArtifact["url"]?.textValue() ?: return RemoteArtifact.EMPTY
+        val hash = sourceArtifact["md5_digest"]?.textValue() ?: return RemoteArtifact.EMPTY
+
+        return RemoteArtifact(url, Hash.create(hash))
+    }
+}

--- a/utils/src/main/kotlin/Extensions.kt
+++ b/utils/src/main/kotlin/Extensions.kt
@@ -28,6 +28,7 @@ import com.vdurmont.semver4j.Semver
 
 import java.io.File
 import java.io.IOException
+import java.lang.NumberFormatException
 import java.net.URI
 import java.net.URISyntaxException
 import java.net.URL
@@ -403,3 +404,15 @@ fun Throwable.showStackTrace() {
  * Check whether the URI has a fragment that looks like a VCS revision.
  */
 fun URI.hasRevisionFragment() = fragment?.let { Regex("[a-fA-F0-9]{7,}$").matches(it) } == true
+
+/**
+ * Return a version string with leading zeros of components stripped.
+ */
+fun stripLeadingZerosFromVersion(version: String) =
+    version.split(".").joinToString(".") {
+        try {
+            it.toInt().toString()
+        } catch (e: NumberFormatException) {
+            it
+        }
+    }


### PR DESCRIPTION
Implement support for the Python package manager Conda [1].
Code that this implementation shares with the existing Pip
implementation is moved to a `PythonSupport` class.

[1] https://docs.conda.io/en/latest/

Co-authored-by: Martin Nonnenmacher <martin.nonnenmacher@here.com>
Signed-off-by: Bryan K. Woods <bryan.woods@here.com>