### PR TITLE
Create a single CycloneDX BOM by default

### DIFF
--- a/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
+++ b/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
@@ -44,7 +44,7 @@ import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.spdx.SpdxLicense
 import org.ossreviewtoolkit.utils.ORT_NAME
-import org.ossreviewtoolkit.utils.isTrue
+import org.ossreviewtoolkit.utils.isFalse
 
 private const val REPORT_BASE_FILENAME = "CycloneDX-BOM"
 private const val REPORT_EXTENSION = "xml"
@@ -54,7 +54,8 @@ private const val REPORT_EXTENSION = "xml"
  * contained in the ORT result a separate SBOM is created.
  *
  * This reporter supports the following options:
- * - *single.bom*: If set, a single SBOM for all projects is created instead of separate SBOMs for each project.
+ * - *single.bom*: If true (the default), a single SBOM for all projects is created; if set to false, separate SBOMs are
+ *                 created for each project.
  *
  * [1]: https://cyclonedx.org
  */
@@ -100,7 +101,7 @@ class CycloneDxReporter : Reporter {
     ): List<File> {
         val outputFiles = mutableListOf<File>()
         val projects = input.ortResult.getProjects(omitExcluded = true)
-        val createSingleBom = options["single.bom"].isTrue()
+        val createSingleBom = !options["single.bom"].isFalse()
 
         if (createSingleBom && projects.size > 1) {
             val reportFilename = "$REPORT_BASE_FILENAME.$REPORT_EXTENSION"

--- a/utils/src/main/kotlin/Extensions.kt
+++ b/utils/src/main/kotlin/Extensions.kt
@@ -313,6 +313,11 @@ fun String.fileSystemEncode() =
         .take(255)
 
 /**
+ * Return true if the string represents a false value, otherwise return false.
+ */
+fun String?.isFalse() = this?.toBoolean()?.not() ?: false
+
+/**
  * Return true if the string represents a true value, otherwise return false.
  */
 fun String?.isTrue() = this?.toBoolean() ?: false


### PR DESCRIPTION
All other reporters also default to create a single file for all
projects, and for large multi-projects the number of files can become
confusing, so change the default to create a single file.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>