### PR TITLE
Align on using canonicalPath for checking a provided ORT result file

### DIFF
--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -61,8 +61,7 @@ abstract class Advisor(val advisorName: String, protected val config: AdvisorCon
         val ortResult = ortResultFile.readValue<OrtResult>()
 
         requireNotNull(ortResult.analyzer) {
-            "The provided ORT result file '${ortResultFile.invariantSeparatorsPath}' does not contain an analyzer " +
-                    "result."
+            "The provided ORT result file '${ortResultFile.canonicalPath}' does not contain an analyzer result."
         }
 
         val packages = ortResult.getPackages(skipExcluded).map { it.pkg }

--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -175,16 +175,18 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
 
         when (input) {
             is FileType -> {
-                val ortFile = (input as FileType).file
-                val (analyzerResult, duration) = measureTimedValue { ortFile.readValue<OrtResult>().analyzer?.result }
+                val ortResultFile = (input as FileType).file
+                val (analyzerResult, duration) = measureTimedValue {
+                    ortResultFile.readValue<OrtResult>().analyzer?.result
+                }
 
                 log.perf {
-                    "Read ORT result from '${ortFile.name}' (${ortFile.formatSizeInMib}) in " +
+                    "Read ORT result from '${ortResultFile.name}' (${ortResultFile.formatSizeInMib}) in " +
                             "${duration.inMilliseconds}ms."
                 }
 
                 requireNotNull(analyzerResult) {
-                    "The provided ORT result file '$ortFile' does not contain an analyzer result."
+                    "The provided ORT result file '${ortResultFile.canonicalPath}' does not contain an analyzer result."
                 }
 
                 val packages = mutableListOf<Package>().apply {

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -103,8 +103,7 @@ abstract class Scanner(val scannerName: String, protected val config: ScannerCon
         }
 
         requireNotNull(ortResult.analyzer) {
-            "The provided ORT result file '${ortResultFile.invariantSeparatorsPath}' does not contain an analyzer " +
-                    "result."
+            "The provided ORT result file '${ortResultFile.canonicalPath}' does not contain an analyzer result."
         }
 
         // Add the projects as packages to scan.


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>