### PR TITLE
Ignore leading './' in path exclude patterns

### DIFF
--- a/model/src/main/kotlin/config/PathExclude.kt
+++ b/model/src/main/kotlin/config/PathExclude.kt
@@ -46,7 +46,9 @@ data class PathExclude(
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val comment: String = ""
 ) {
-    private val glob by lazy { FileSystems.getDefault().getPathMatcher("glob:$pattern") }
+    private val glob by lazy {
+        FileSystems.getDefault().getPathMatcher("glob:${pattern.removePrefix("./")}")
+    }
 
     fun matches(path: String) = glob.matches(Paths.get(path))
 }

--- a/model/src/test/kotlin/config/PathExcludeTest.kt
+++ b/model/src/test/kotlin/config/PathExcludeTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.config
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * This class tests [PathExclude] members functions
+ */
+class PathExcludeTest : WordSpec() {
+    private val pathExcludeWithLeadingDot = PathExclude("./path1", PathExcludeReason.BUILD_TOOL_OF, "")
+
+    init {
+        "isPathExcluded" should {
+            "ignore leading './' in the matching path" {
+                pathExcludeWithLeadingDot.matches("path1") shouldBe true
+                pathExcludeWithLeadingDot.matches("path2") shouldBe false
+            }
+        }
+    }
+}


### PR DESCRIPTION
When `.ort.yml `contains a exclude path pattern with leading "./" , the match is not done.
With this commit, the leading "./" is ignored for matching.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>