### PR TITLE
Oheger bosch/analyzer/dependency representation

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-cli.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-cli.yml
@@ -15,222 +15,95 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/external/multi-kotlin-project/cli"
   homepage_url: ""
-  scopes:
-  - name: "annotationProcessor"
-    dependencies: []
-  - name: "apiDependenciesMetadata"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+  dependency_graph:
+    packages:
+    - "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+    - "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+    - "Maven:org.jetbrains:annotations:13.0"
+    - "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
+    scope_roots:
+    - dependencies:
+      - pkg: 1
+        dependencies:
+        - pkg: 2
+        - pkg: 3
       linkage: "PROJECT_DYNAMIC"
+    - pkg: 4
       dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      - pkg: 1
         dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        - pkg: 2
+        - pkg: 3
+      - pkg: 5
+      - pkg: 6
         dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "compileOnly"
-    dependencies: []
-  - name: "compileOnlyDependenciesMetadata"
-    dependencies: []
-  - name: "default"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "implementationDependenciesMetadata"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "kapt"
-    dependencies: []
-  - name: "kaptTest"
-    dependencies: []
-  - name: "kotlinCompilerClasspath"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        - pkg: 1
           dependencies:
-          - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-          - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "kotlinCompilerPluginClasspath"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
-  - name: "kotlinNativeCompilerPluginClasspath"
-    dependencies: []
-  - name: "kotlinScriptDef"
-    dependencies: []
-  - name: "runtime"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "runtimeOnlyDependenciesMetadata"
-    dependencies: []
-  - name: "testAnnotationProcessor"
-    dependencies: []
-  - name: "testApiDependenciesMetadata"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "testCompile"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "testCompileOnly"
-    dependencies: []
-  - name: "testCompileOnlyDependenciesMetadata"
-    dependencies: []
-  - name: "testImplementationDependenciesMetadata"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "testKotlinScriptDef"
-    dependencies: []
-  - name: "testRuntime"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "testRuntimeOnlyDependenciesMetadata"
-    dependencies: []
+          - pkg: 2
+          - pkg: 3
+    - pkg: 7
+    scopes:
+      annotationProcessor: []
+      apiDependenciesMetadata:
+      - root: 0
+      - root: 1
+      archives: []
+      compile:
+      - root: 0
+      - root: 1
+      compileClasspath:
+      - root: 0
+      - root: 1
+      compileOnly: []
+      compileOnlyDependenciesMetadata: []
+      default:
+      - root: 0
+      - root: 1
+      implementationDependenciesMetadata:
+      - root: 0
+      - root: 1
+      kapt: []
+      kaptTest: []
+      kotlinCompilerClasspath:
+      - root: 4
+      kotlinCompilerPluginClasspath:
+      - root: 7
+      kotlinNativeCompilerPluginClasspath: []
+      kotlinScriptDef: []
+      runtime:
+      - root: 0
+      - root: 1
+      runtimeClasspath:
+      - root: 0
+      - root: 1
+      runtimeOnlyDependenciesMetadata: []
+      testAnnotationProcessor: []
+      testApiDependenciesMetadata:
+      - root: 0
+      - root: 1
+      testCompile:
+      - root: 0
+      - root: 1
+      testCompileClasspath:
+      - root: 0
+      - root: 1
+      testCompileOnly: []
+      testCompileOnlyDependenciesMetadata: []
+      testImplementationDependenciesMetadata:
+      - root: 0
+      - root: 1
+      testKotlinScriptDef: []
+      testRuntime:
+      - root: 0
+      - root: 1
+      testRuntimeClasspath:
+      - root: 0
+      - root: 1
+      testRuntimeOnlyDependenciesMetadata: []
 packages:
 - id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
   purl: "pkg:maven/org.jetbrains.kotlin/kotlin-compiler-embeddable@1.3.11"

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-core.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-core.yml
@@ -15,131 +15,73 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/external/multi-kotlin-project/core"
   homepage_url: ""
-  scopes:
-  - name: "annotationProcessor"
-    dependencies: []
-  - name: "apiDependenciesMetadata"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+  dependency_graph:
+    packages:
+    - "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+    - "Maven:org.jetbrains:annotations:13.0"
+    - "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
+    scope_roots:
+    - pkg: 3
       dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "compileOnly"
-    dependencies: []
-  - name: "compileOnlyDependenciesMetadata"
-    dependencies: []
-  - name: "default"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "implementationDependenciesMetadata"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "kapt"
-    dependencies: []
-  - name: "kaptTest"
-    dependencies: []
-  - name: "kotlinCompilerClasspath"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
+      - dependencies:
+        - pkg: 1
+        - pkg: 2
+      - pkg: 4
+      - pkg: 5
         dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-          dependencies:
-          - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-          - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "kotlinCompilerPluginClasspath"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
-  - name: "kotlinNativeCompilerPluginClasspath"
-    dependencies: []
-  - name: "kotlinScriptDef"
-    dependencies: []
-  - name: "runtime"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "runtimeOnlyDependenciesMetadata"
-    dependencies: []
-  - name: "testAnnotationProcessor"
-    dependencies: []
-  - name: "testApiDependenciesMetadata"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "testCompile"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "testCompileOnly"
-    dependencies: []
-  - name: "testCompileOnlyDependenciesMetadata"
-    dependencies: []
-  - name: "testImplementationDependenciesMetadata"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "testKotlinScriptDef"
-    dependencies: []
-  - name: "testRuntime"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "testRuntimeOnlyDependenciesMetadata"
-    dependencies: []
+        - dependencies:
+          - pkg: 1
+          - pkg: 2
+    - pkg: 6
+    scopes:
+      annotationProcessor: []
+      apiDependenciesMetadata:
+      - root: 0
+      archives: []
+      compile:
+      - root: 0
+      compileClasspath:
+      - root: 0
+      compileOnly: []
+      compileOnlyDependenciesMetadata: []
+      default:
+      - root: 0
+      implementationDependenciesMetadata:
+      - root: 0
+      kapt: []
+      kaptTest: []
+      kotlinCompilerClasspath:
+      - root: 3
+      kotlinCompilerPluginClasspath:
+      - root: 6
+      kotlinNativeCompilerPluginClasspath: []
+      kotlinScriptDef: []
+      runtime:
+      - root: 0
+      runtimeClasspath:
+      - root: 0
+      runtimeOnlyDependenciesMetadata: []
+      testAnnotationProcessor: []
+      testApiDependenciesMetadata:
+      - root: 0
+      testCompile:
+      - root: 0
+      testCompileClasspath:
+      - root: 0
+      testCompileOnly: []
+      testCompileOnlyDependenciesMetadata: []
+      testImplementationDependenciesMetadata:
+      - root: 0
+      testKotlinScriptDef: []
+      testRuntime:
+      - root: 0
+      testRuntimeClasspath:
+      - root: 0
+      testRuntimeOnlyDependenciesMetadata: []
 packages:
 - id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
   purl: "pkg:maven/org.jetbrains.kotlin/kotlin-compiler-embeddable@1.3.11"

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-root.yml
@@ -15,32 +15,32 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/external/multi-kotlin-project"
   homepage_url: ""
-  scopes:
-  - name: "archives"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:cli:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-        linkage: "PROJECT_DYNAMIC"
+  dependency_graph:
+    packages:
+    - "Gradle:org.gradle.kotlin.dsl.samples.multiproject:cli:1.0"
+    - "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+    - "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+    - "Maven:org.jetbrains:annotations:13.0"
+    scope_roots:
+    - dependencies:
+      - pkg: 1
         dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        - pkg: 2
           dependencies:
-          - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-          - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+          - pkg: 3
+          - pkg: 4
+        linkage: "PROJECT_DYNAMIC"
+      - pkg: 2
         dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+        - pkg: 3
+        - pkg: 4
       linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-        - id: "Maven:org.jetbrains:annotations:13.0"
-  - name: "default"
-    dependencies: []
+    scopes:
+      archives:
+      - root: 0
+      - root: 1
+      default: []
 packages:
 - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
   purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib-common@1.3.11"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -66,7 +66,10 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
       homepage_url: ""
-      scopes: []
+      dependency_graph:
+        packages: []
+        scope_roots: []
+        scopes: {}
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:app:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
       declared_licenses: []
@@ -82,98 +85,43 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
       homepage_url: ""
-      scopes:
-      - name: "annotationProcessor"
-        dependencies: []
-      - name: "archives"
-        dependencies: []
-      - name: "compile"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependency_graph:
+        packages:
+        - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+        - "Maven:org.apache.commons:commons-text:1.1"
+        - "Maven:org.apache.commons:commons-lang3:3.5"
+        - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+        scope_roots:
+        - dependencies:
+          - pkg: 1
             dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "compileClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+            - pkg: 2
+          - pkg: 3
           linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "compileOnly"
-        dependencies: []
-      - name: "default"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtime"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtimeClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testAnnotationProcessor"
-        dependencies: []
-      - name: "testCompile"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompileClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompileOnly"
-        dependencies: []
-      - name: "testRuntime"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testRuntimeClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+        scopes:
+          annotationProcessor: []
+          archives: []
+          compile:
+          - root: 0
+          compileClasspath:
+          - root: 0
+          compileOnly: []
+          default:
+          - root: 0
+          runtime:
+          - root: 0
+          runtimeClasspath:
+          - root: 0
+          testAnnotationProcessor: []
+          testCompile:
+          - root: 0
+          testCompileClasspath:
+          - root: 0
+          testCompileOnly: []
+          testRuntime:
+          - root: 0
+          testRuntimeClasspath:
+          - root: 0
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo/build.gradle"
       declared_licenses: []
@@ -189,135 +137,53 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
       homepage_url: ""
-      scopes:
-      - name: "annotationProcessor"
-        dependencies: []
-      - name: "archives"
-        dependencies: []
-      - name: "compile"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
+      dependency_graph:
+        packages:
+        - "Unknown:org.apache.commons:commons-text:1.1"
+        - "Unknown:junit:junit:4.12"
+        scope_roots:
+        - issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
             severity: "ERROR"
-      - name: "compileClasspath"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "compileOnly"
-        dependencies: []
-      - name: "default"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "runtime"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "runtimeClasspath"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testAnnotationProcessor"
-        dependencies: []
-      - name: "testCompile"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
+        - pkg: 1
           issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
             severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testCompileClasspath"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testCompileOnly"
-        dependencies: []
-      - name: "testRuntime"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testRuntimeClasspath"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
+        scopes:
+          annotationProcessor: []
+          archives: []
+          compile:
+          - root: 0
+          compileClasspath:
+          - root: 0
+          compileOnly: []
+          default:
+          - root: 0
+          runtime:
+          - root: 0
+          runtimeClasspath:
+          - root: 0
+          testAnnotationProcessor: []
+          testCompile:
+          - root: 0
+          - root: 1
+          testCompileClasspath:
+          - root: 0
+          - root: 1
+          testCompileOnly: []
+          testRuntime:
+          - root: 0
+          - root: 1
+          testRuntimeClasspath:
+          - root: 0
+          - root: 1
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
       declared_licenses: []
@@ -333,83 +199,57 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
       homepage_url: ""
-      scopes:
-      - name: "annotationProcessor"
-        dependencies: []
-      - name: "archives"
-        dependencies: []
-      - name: "compile"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependency_graph:
+        packages:
+        - "Maven:org.apache.commons:commons-text:1.1"
+        - "Maven:org.apache.commons:commons-lang3:3.5"
+        - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+        - "Maven:junit:junit:4.12"
+        - "Maven:org.hamcrest:hamcrest-core:1.3"
+        scope_roots:
+        - dependencies:
+          - pkg: 1
+        - pkg: 2
+        - pkg: 3
           dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "compileClasspath"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "compileOnly"
-        dependencies: []
-      - name: "default"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtime"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtimeClasspath"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testAnnotationProcessor"
-        dependencies: []
-      - name: "testCompile"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompileClasspath"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompileOnly"
-        dependencies: []
-      - name: "testRuntime"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testRuntimeClasspath"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+          - pkg: 4
+        scopes:
+          annotationProcessor: []
+          archives: []
+          compile:
+          - root: 0
+          - root: 2
+          compileClasspath:
+          - root: 0
+          - root: 2
+          compileOnly: []
+          default:
+          - root: 0
+          - root: 2
+          runtime:
+          - root: 0
+          - root: 2
+          runtimeClasspath:
+          - root: 0
+          - root: 2
+          testAnnotationProcessor: []
+          testCompile:
+          - root: 0
+          - root: 2
+          - root: 3
+          testCompileClasspath:
+          - root: 0
+          - root: 2
+          - root: 3
+          testCompileOnly: []
+          testRuntime:
+          - root: 0
+          - root: 2
+          - root: 3
+          testRuntimeClasspath:
+          - root: 0
+          - root: 2
+          - root: 3
     packages:
     - package:
         id: "Maven:junit:junit:4.12"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -66,7 +66,10 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
       homepage_url: ""
-      scopes: []
+      dependency_graph:
+        packages: []
+        scope_roots: []
+        scopes: {}
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:app:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
       declared_licenses: []
@@ -82,98 +85,43 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
       homepage_url: ""
-      scopes:
-      - name: "annotationProcessor"
-        dependencies: []
-      - name: "archives"
-        dependencies: []
-      - name: "compile"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependency_graph:
+        packages:
+        - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+        - "Maven:org.apache.commons:commons-text:1.1"
+        - "Maven:org.apache.commons:commons-lang3:3.5"
+        - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+        scope_roots:
+        - dependencies:
+          - pkg: 1
             dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "compileClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+            - pkg: 2
+          - pkg: 3
           linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "compileOnly"
-        dependencies: []
-      - name: "default"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtime"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtimeClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testAnnotationProcessor"
-        dependencies: []
-      - name: "testCompile"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompileClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompileOnly"
-        dependencies: []
-      - name: "testRuntime"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testRuntimeClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+        scopes:
+          annotationProcessor: []
+          archives: []
+          compile:
+          - root: 0
+          compileClasspath:
+          - root: 0
+          compileOnly: []
+          default:
+          - root: 0
+          runtime:
+          - root: 0
+          runtimeClasspath:
+          - root: 0
+          testAnnotationProcessor: []
+          testCompile:
+          - root: 0
+          testCompileClasspath:
+          - root: 0
+          testCompileOnly: []
+          testRuntime:
+          - root: 0
+          testRuntimeClasspath:
+          - root: 0
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo/build.gradle"
       declared_licenses: []
@@ -189,135 +137,53 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
       homepage_url: ""
-      scopes:
-      - name: "annotationProcessor"
-        dependencies: []
-      - name: "archives"
-        dependencies: []
-      - name: "compile"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
+      dependency_graph:
+        packages:
+        - "Unknown:org.apache.commons:commons-text:1.1"
+        - "Unknown:junit:junit:4.12"
+        scope_roots:
+        - issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
             severity: "ERROR"
-      - name: "compileClasspath"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "compileOnly"
-        dependencies: []
-      - name: "default"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "runtime"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "runtimeClasspath"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testAnnotationProcessor"
-        dependencies: []
-      - name: "testCompile"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
+        - pkg: 1
           issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
             severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testCompileClasspath"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testCompileOnly"
-        dependencies: []
-      - name: "testRuntime"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testRuntimeClasspath"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
+        scopes:
+          annotationProcessor: []
+          archives: []
+          compile:
+          - root: 0
+          compileClasspath:
+          - root: 0
+          compileOnly: []
+          default:
+          - root: 0
+          runtime:
+          - root: 0
+          runtimeClasspath:
+          - root: 0
+          testAnnotationProcessor: []
+          testCompile:
+          - root: 0
+          - root: 1
+          testCompileClasspath:
+          - root: 0
+          - root: 1
+          testCompileOnly: []
+          testRuntime:
+          - root: 0
+          - root: 1
+          testRuntimeClasspath:
+          - root: 0
+          - root: 1
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
       declared_licenses: []
@@ -333,83 +199,57 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
       homepage_url: ""
-      scopes:
-      - name: "annotationProcessor"
-        dependencies: []
-      - name: "archives"
-        dependencies: []
-      - name: "compile"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependency_graph:
+        packages:
+        - "Maven:org.apache.commons:commons-text:1.1"
+        - "Maven:org.apache.commons:commons-lang3:3.5"
+        - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+        - "Maven:junit:junit:4.12"
+        - "Maven:org.hamcrest:hamcrest-core:1.3"
+        scope_roots:
+        - dependencies:
+          - pkg: 1
+        - pkg: 2
+        - pkg: 3
           dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "compileClasspath"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "compileOnly"
-        dependencies: []
-      - name: "default"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtime"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtimeClasspath"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testAnnotationProcessor"
-        dependencies: []
-      - name: "testCompile"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompileClasspath"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompileOnly"
-        dependencies: []
-      - name: "testRuntime"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testRuntimeClasspath"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+          - pkg: 4
+        scopes:
+          annotationProcessor: []
+          archives: []
+          compile:
+          - root: 0
+          - root: 2
+          compileClasspath:
+          - root: 0
+          - root: 2
+          compileOnly: []
+          default:
+          - root: 0
+          - root: 2
+          runtime:
+          - root: 0
+          - root: 2
+          runtimeClasspath:
+          - root: 0
+          - root: 2
+          testAnnotationProcessor: []
+          testCompile:
+          - root: 0
+          - root: 2
+          - root: 3
+          testCompileClasspath:
+          - root: 0
+          - root: 2
+          - root: 3
+          testCompileOnly: []
+          testRuntime:
+          - root: 0
+          - root: 2
+          - root: 3
+          testRuntimeClasspath:
+          - root: 0
+          - root: 2
+          - root: 3
     packages:
     - package:
         id: "Maven:junit:junit:4.12"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
@@ -15,445 +15,213 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/app"
   homepage_url: ""
-  scopes:
-  - name: "amazonDemoDebugAndroidTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonDemoDebugAndroidTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+  dependency_graph:
+    packages:
+    - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+    - "Maven:com.squareup.okio:okio:1.14.0"
+    - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+    - "Maven:org.apache.commons:commons-text:1.2"
+    - "Maven:org.apache.commons:commons-lang3:3.7"
+    - "Maven:org.apache.commons:commons-compress:1.17"
+    - "Maven:junit:junit:4.12"
+    - "Maven:org.hamcrest:hamcrest-core:1.3"
+    - "Maven:org.apache.commons:commons-text:1.3"
+    scope_roots:
+    - dependencies:
+      - pkg: 1
+    - pkg: 2
       linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+    - pkg: 2
+      fragment: 1
       dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoDebugAndroidTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
+      - pkg: 3
         dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoDebugAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonDemoDebugCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+        - pkg: 4
+      - pkg: 5
       linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+    - pkg: 6
       dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoDebugRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
+      - pkg: 7
+    - pkg: 2
+      fragment: 2
       dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
+      - pkg: 5
+      - pkg: 8
         dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoDebugUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonDemoDebugUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+        - pkg: 4
       linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonDemoDebugUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonDemoDebugWearBundling"
-    dependencies: []
-  - name: "amazonDemoReleaseAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonDemoReleaseCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoReleaseRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoReleaseUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonDemoReleaseUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonDemoReleaseUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonDemoReleaseWearBundling"
-    dependencies: []
-  - name: "amazonFullDebugAndroidTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonFullDebugAndroidTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullDebugAndroidTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullDebugAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonFullDebugCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullDebugRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullDebugUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonFullDebugUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonFullDebugUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonFullDebugWearBundling"
-    dependencies: []
-  - name: "amazonFullReleaseAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonFullReleaseCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullReleaseRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullReleaseUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "amazonFullReleaseUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonFullReleaseUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonFullReleaseWearBundling"
-    dependencies: []
-  - name: "androidTestUtil"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
-    dependencies: []
-  - name: "default"
-    dependencies: []
-  - name: "googleDemoDebugAndroidTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleDemoDebugAndroidTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleDemoDebugAndroidTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleDemoDebugAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleDemoDebugCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleDemoDebugRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleDemoDebugUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleDemoDebugUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleDemoDebugUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleDemoDebugWearBundling"
-    dependencies: []
-  - name: "googleDemoReleaseAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleDemoReleaseCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleDemoReleaseRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleDemoReleaseUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleDemoReleaseUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleDemoReleaseUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleDemoReleaseWearBundling"
-    dependencies: []
-  - name: "googleFullDebugAndroidTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleFullDebugAndroidTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleFullDebugAndroidTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleFullDebugAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleFullDebugCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleFullDebugRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleFullDebugUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleFullDebugUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleFullDebugUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleFullDebugWearBundling"
-    dependencies: []
-  - name: "googleFullReleaseAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleFullReleaseCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleFullReleaseRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleFullReleaseUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "googleFullReleaseUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleFullReleaseUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleFullReleaseWearBundling"
-    dependencies: []
-  - name: "lintChecks"
-    dependencies: []
-  - name: "lintClassPath"
-    dependencies: []
-  - name: "testCompile"
-    dependencies: []
+    scopes:
+      amazonDemoDebugAndroidTestAnnotationProcessorClasspath: []
+      amazonDemoDebugAndroidTestCompileClasspath:
+      - root: 0
+      - root: 2
+      amazonDemoDebugAndroidTestRuntimeClasspath:
+      - root: 0
+      - root: 2
+        fragment: 1
+      amazonDemoDebugAnnotationProcessorClasspath: []
+      amazonDemoDebugCompileClasspath:
+      - root: 0
+      - root: 2
+      amazonDemoDebugRuntimeClasspath:
+      - root: 0
+      - root: 2
+        fragment: 1
+      amazonDemoDebugUnitTestAnnotationProcessorClasspath: []
+      amazonDemoDebugUnitTestCompileClasspath:
+      - root: 0
+      - root: 2
+      - root: 6
+      amazonDemoDebugUnitTestRuntimeClasspath:
+      - root: 0
+      - root: 2
+        fragment: 1
+      - root: 6
+      amazonDemoDebugWearBundling: []
+      amazonDemoReleaseAnnotationProcessorClasspath: []
+      amazonDemoReleaseCompileClasspath:
+      - root: 0
+      - root: 2
+      amazonDemoReleaseRuntimeClasspath:
+      - root: 0
+      - root: 2
+        fragment: 1
+      amazonDemoReleaseUnitTestAnnotationProcessorClasspath: []
+      amazonDemoReleaseUnitTestCompileClasspath:
+      - root: 0
+      - root: 2
+      - root: 6
+      amazonDemoReleaseUnitTestRuntimeClasspath:
+      - root: 0
+      - root: 2
+        fragment: 1
+      - root: 6
+      amazonDemoReleaseWearBundling: []
+      amazonFullDebugAndroidTestAnnotationProcessorClasspath: []
+      amazonFullDebugAndroidTestCompileClasspath:
+      - root: 0
+      - root: 2
+      amazonFullDebugAndroidTestRuntimeClasspath:
+      - root: 0
+      - root: 2
+        fragment: 2
+      amazonFullDebugAnnotationProcessorClasspath: []
+      amazonFullDebugCompileClasspath:
+      - root: 0
+      - root: 2
+      amazonFullDebugRuntimeClasspath:
+      - root: 0
+      - root: 2
+        fragment: 2
+      amazonFullDebugUnitTestAnnotationProcessorClasspath: []
+      amazonFullDebugUnitTestCompileClasspath:
+      - root: 0
+      - root: 2
+      - root: 6
+      amazonFullDebugUnitTestRuntimeClasspath:
+      - root: 0
+      - root: 2
+        fragment: 2
+      - root: 6
+      amazonFullDebugWearBundling: []
+      amazonFullReleaseAnnotationProcessorClasspath: []
+      amazonFullReleaseCompileClasspath:
+      - root: 0
+      - root: 2
+      amazonFullReleaseRuntimeClasspath:
+      - root: 0
+      - root: 2
+        fragment: 2
+      amazonFullReleaseUnitTestAnnotationProcessorClasspath: []
+      amazonFullReleaseUnitTestCompileClasspath:
+      - root: 0
+      - root: 2
+      - root: 6
+      amazonFullReleaseUnitTestRuntimeClasspath:
+      - root: 0
+      - root: 2
+        fragment: 2
+      - root: 6
+      amazonFullReleaseWearBundling: []
+      androidTestUtil: []
+      archives: []
+      compile: []
+      default: []
+      googleDemoDebugAndroidTestAnnotationProcessorClasspath: []
+      googleDemoDebugAndroidTestCompileClasspath:
+      - root: 2
+      googleDemoDebugAndroidTestRuntimeClasspath:
+      - root: 2
+        fragment: 1
+      googleDemoDebugAnnotationProcessorClasspath: []
+      googleDemoDebugCompileClasspath:
+      - root: 2
+      googleDemoDebugRuntimeClasspath:
+      - root: 2
+        fragment: 1
+      googleDemoDebugUnitTestAnnotationProcessorClasspath: []
+      googleDemoDebugUnitTestCompileClasspath:
+      - root: 2
+      - root: 6
+      googleDemoDebugUnitTestRuntimeClasspath:
+      - root: 2
+        fragment: 1
+      - root: 6
+      googleDemoDebugWearBundling: []
+      googleDemoReleaseAnnotationProcessorClasspath: []
+      googleDemoReleaseCompileClasspath:
+      - root: 2
+      googleDemoReleaseRuntimeClasspath:
+      - root: 2
+        fragment: 1
+      googleDemoReleaseUnitTestAnnotationProcessorClasspath: []
+      googleDemoReleaseUnitTestCompileClasspath:
+      - root: 2
+      - root: 6
+      googleDemoReleaseUnitTestRuntimeClasspath:
+      - root: 2
+        fragment: 1
+      - root: 6
+      googleDemoReleaseWearBundling: []
+      googleFullDebugAndroidTestAnnotationProcessorClasspath: []
+      googleFullDebugAndroidTestCompileClasspath:
+      - root: 2
+      googleFullDebugAndroidTestRuntimeClasspath:
+      - root: 2
+        fragment: 2
+      googleFullDebugAnnotationProcessorClasspath: []
+      googleFullDebugCompileClasspath:
+      - root: 2
+      googleFullDebugRuntimeClasspath:
+      - root: 2
+        fragment: 2
+      googleFullDebugUnitTestAnnotationProcessorClasspath: []
+      googleFullDebugUnitTestCompileClasspath:
+      - root: 2
+      - root: 6
+      googleFullDebugUnitTestRuntimeClasspath:
+      - root: 2
+        fragment: 2
+      - root: 6
+      googleFullDebugWearBundling: []
+      googleFullReleaseAnnotationProcessorClasspath: []
+      googleFullReleaseCompileClasspath:
+      - root: 2
+      googleFullReleaseRuntimeClasspath:
+      - root: 2
+        fragment: 2
+      googleFullReleaseUnitTestAnnotationProcessorClasspath: []
+      googleFullReleaseUnitTestCompileClasspath:
+      - root: 2
+      - root: 6
+      googleFullReleaseUnitTestRuntimeClasspath:
+      - root: 2
+        fragment: 2
+      - root: 6
+      googleFullReleaseWearBundling: []
+      lintChecks: []
+      lintClassPath: []
+      testCompile: []
 packages:
 - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
   purl: "pkg:maven/com.squareup.okhttp3/okhttp@3.10.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
@@ -15,161 +15,97 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/lib"
   homepage_url: ""
-  scopes:
-  - name: "androidTestUtil"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
-    dependencies: []
-  - name: "default"
-    dependencies: []
-  - name: "demoDebugAndroidTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "demoDebugAndroidTestCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
+  dependency_graph:
+    packages:
+    - "Maven:org.apache.commons:commons-text:1.2"
+    - "Maven:org.apache.commons:commons-lang3:3.7"
+    - "Maven:org.apache.commons:commons-compress:1.17"
+    - "Maven:org.apache.commons:commons-text:1.3"
+    scope_roots:
+    - dependencies:
+      - pkg: 1
+    - pkg: 2
+    - pkg: 3
       dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoDebugAndroidTestRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoDebugAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "demoDebugCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoDebugRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoDebugUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "demoDebugUnitTestCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoDebugUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoReleaseAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "demoReleaseCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoReleaseRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoReleaseUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "demoReleaseUnitTestCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoReleaseUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullDebugAndroidTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "fullDebugAndroidTestCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullDebugAndroidTestRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullDebugAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "fullDebugCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullDebugRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullDebugUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "fullDebugUnitTestCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullDebugUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullReleaseAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "fullReleaseCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullReleaseRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullReleaseUnitTestAnnotationProcessorClasspath"
-    dependencies: []
-  - name: "fullReleaseUnitTestCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullReleaseUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "lintChecks"
-    dependencies: []
-  - name: "lintClassPath"
-    dependencies: []
-  - name: "testCompile"
-    dependencies: []
+      - pkg: 1
+    scopes:
+      androidTestUtil: []
+      archives: []
+      compile: []
+      default: []
+      demoDebugAndroidTestAnnotationProcessorClasspath: []
+      demoDebugAndroidTestCompileClasspath:
+      - root: 0
+      - root: 2
+      demoDebugAndroidTestRuntimeClasspath:
+      - root: 0
+      - root: 2
+      demoDebugAnnotationProcessorClasspath: []
+      demoDebugCompileClasspath:
+      - root: 0
+      - root: 2
+      demoDebugRuntimeClasspath:
+      - root: 0
+      - root: 2
+      demoDebugUnitTestAnnotationProcessorClasspath: []
+      demoDebugUnitTestCompileClasspath:
+      - root: 0
+      - root: 2
+      demoDebugUnitTestRuntimeClasspath:
+      - root: 0
+      - root: 2
+      demoReleaseAnnotationProcessorClasspath: []
+      demoReleaseCompileClasspath:
+      - root: 0
+      - root: 2
+      demoReleaseRuntimeClasspath:
+      - root: 0
+      - root: 2
+      demoReleaseUnitTestAnnotationProcessorClasspath: []
+      demoReleaseUnitTestCompileClasspath:
+      - root: 0
+      - root: 2
+      demoReleaseUnitTestRuntimeClasspath:
+      - root: 0
+      - root: 2
+      fullDebugAndroidTestAnnotationProcessorClasspath: []
+      fullDebugAndroidTestCompileClasspath:
+      - root: 3
+      - root: 2
+      fullDebugAndroidTestRuntimeClasspath:
+      - root: 3
+      - root: 2
+      fullDebugAnnotationProcessorClasspath: []
+      fullDebugCompileClasspath:
+      - root: 3
+      - root: 2
+      fullDebugRuntimeClasspath:
+      - root: 3
+      - root: 2
+      fullDebugUnitTestAnnotationProcessorClasspath: []
+      fullDebugUnitTestCompileClasspath:
+      - root: 3
+      - root: 2
+      fullDebugUnitTestRuntimeClasspath:
+      - root: 3
+      - root: 2
+      fullReleaseAnnotationProcessorClasspath: []
+      fullReleaseCompileClasspath:
+      - root: 3
+      - root: 2
+      fullReleaseRuntimeClasspath:
+      - root: 3
+      - root: 2
+      fullReleaseUnitTestAnnotationProcessorClasspath: []
+      fullReleaseUnitTestCompileClasspath:
+      - root: 3
+      - root: 2
+      fullReleaseUnitTestRuntimeClasspath:
+      - root: 3
+      - root: 2
+      lintChecks: []
+      lintClassPath: []
+      testCompile: []
 packages:
 - id: "Maven:org.apache.commons:commons-compress:1.17"
   purl: "pkg:maven/org.apache.commons/commons-compress@1.17"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
@@ -15,5 +15,8 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android"
   homepage_url: ""
-  scopes: []
+  dependency_graph:
+    packages: []
+    scope_roots: []
+    scopes: {}
 packages: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
@@ -15,72 +15,35 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
   homepage_url: ""
-  scopes:
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
+  dependency_graph:
+    identifier_list:
+    - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+    - "Maven:org.apache.commons:commons-text:1.1"
+    - "Maven:org.apache.commons:commons-lang3:3.5"
+    - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    scope-roots:
+    - dependencies:
+      - pkg: 1
         dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileOnly"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+        - pkg: 2
+      - pkg: 3
       linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "default"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompile"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileOnly"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testRuntime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    scopes:
+      archives: []
+      compile:
+      - root: 0
+      compileOnly:
+      - root: 0
+      default:
+      - root: 0
+      runtime:
+      - root: 0
+      testCompile:
+      - root: 0
+      testCompileOnly:
+      - root: 0
+      testRuntime:
+      - root: 0
 packages:
 - id: "Maven:org.apache.commons:commons-lang3:3.5"
   purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
@@ -15,58 +15,34 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
   homepage_url: ""
-  scopes:
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
+  dependency_graph:
+    packages:
+    - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+    - "Maven:org.apache.commons:commons-text:1.1"
+    - "Maven:org.apache.commons:commons-lang3:3.5"
+    - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    scope-roots:
+    - dependencies:
+      - pkg: 1
         dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileOnly"
-    dependencies: []
-  - name: "default"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+        - pkg: 2
+      - pkg: 3
       linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompile"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileOnly"
-    dependencies: []
-  - name: "testRuntime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    scopes:
+      archives: []
+      compile:
+      - root: 0
+      compileOnly: []
+      default:
+      - root: 0
+      runtime:
+      - root: 0
+      testCompile:
+      - root: 0
+      testCompileOnly: []
+      testRuntime:
+      - root: 0
+    manager_name: "Gradle"
 packages:
 - id: "Maven:org.apache.commons:commons-lang3:3.5"
   purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -15,98 +15,43 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
   homepage_url: ""
-  scopes:
-  - name: "annotationProcessor"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
+  dependency_graph:
+    packages:
+    - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+    - "Maven:org.apache.commons:commons-text:1.1"
+    - "Maven:org.apache.commons:commons-lang3:3.5"
+    - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    scope_roots:
+    - dependencies:
+      - pkg: 1
         dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+        - pkg: 2
+      - pkg: 3
       linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileOnly"
-    dependencies: []
-  - name: "default"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testAnnotationProcessor"
-    dependencies: []
-  - name: "testCompile"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileOnly"
-    dependencies: []
-  - name: "testRuntime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    scopes:
+      annotationProcessor: []
+      archives: []
+      compile:
+      - root: 0
+      compileClasspath:
+      - root: 0
+      compileOnly: []
+      default:
+      - root: 0
+      runtime:
+      - root: 0
+      runtimeClasspath:
+      - root: 0
+      testAnnotationProcessor: []
+      testCompile:
+      - root: 0
+      testCompileClasspath:
+      - root: 0
+      testCompileOnly: []
+      testRuntime:
+      - root: 0
+      testRuntimeClasspath:
+      - root: 0
 packages:
 - id: "Maven:org.apache.commons:commons-lang3:3.5"
   purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -15,133 +15,51 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
   homepage_url: ""
-  scopes:
-  - name: "annotationProcessor"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
-    dependencies:
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
+  dependency_graph:
+    packages:
+    - "Unknown:org.apache.commons:commons-text:1.1"
+    - "Unknown:junit:junit:4.12"
+    scope_roots:
+    - issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
           \ dependency org.apache.commons:commons-text:1.1 because no repositories\
           \ are defined."
         severity: "ERROR"
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "compileOnly"
-    dependencies: []
-  - name: "default"
-    dependencies:
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "runtime"
-    dependencies:
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "testAnnotationProcessor"
-    dependencies: []
-  - name: "testCompile"
-    dependencies:
-    - id: "Unknown:junit:junit:4.12"
+    - pkg: 1
       issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
           \ dependency junit:junit:4.12 because no repositories are defined."
         severity: "ERROR"
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Unknown:junit:junit:4.12"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency junit:junit:4.12 because no repositories are defined."
-        severity: "ERROR"
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "testCompileOnly"
-    dependencies: []
-  - name: "testRuntime"
-    dependencies:
-    - id: "Unknown:junit:junit:4.12"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency junit:junit:4.12 because no repositories are defined."
-        severity: "ERROR"
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Unknown:junit:junit:4.12"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency junit:junit:4.12 because no repositories are defined."
-        severity: "ERROR"
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
+    scopes:
+      annotationProcessor: []
+      archives: []
+      compile:
+      - root: 0
+      compileClasspath:
+      - root: 0
+      compileOnly: []
+      default:
+      - root: 0
+      runtime:
+      - root: 0
+      runtimeClasspath:
+      - root: 0
+      testAnnotationProcessor: []
+      testCompile:
+      - root: 0
+      - root: 1
+      testCompileClasspath:
+      - root: 0
+      - root: 1
+      testCompileOnly: []
+      testRuntime:
+      - root: 0
+      - root: 1
+      testRuntimeClasspath:
+      - root: 0
+      - root: 1
 packages: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -15,83 +15,57 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
   homepage_url: ""
-  scopes:
-  - name: "annotationProcessor"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
+  dependency_graph:
+    packages:
+    - "Maven:org.apache.commons:commons-text:1.1"
+    - "Maven:org.apache.commons:commons-lang3:3.5"
+    - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    - "Maven:junit:junit:4.12"
+    - "Maven:org.hamcrest:hamcrest-core:1.3"
+    scope_roots:
+    - dependencies:
+      - pkg: 1
+    - pkg: 2
+    - pkg: 3
       dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileOnly"
-    dependencies: []
-  - name: "default"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtime"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testAnnotationProcessor"
-    dependencies: []
-  - name: "testCompile"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileOnly"
-    dependencies: []
-  - name: "testRuntime"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - pkg: 4
+    scopes:
+      annotationProcessor: []
+      archives: []
+      compile:
+      - root: 0
+      - root: 2
+      compileClasspath:
+      - root: 0
+      - root: 2
+      compileOnly: []
+      default:
+      - root: 0
+      - root: 2
+      runtime:
+      - root: 0
+      - root: 2
+      runtimeClasspath:
+      - root: 0
+      - root: 2
+      testAnnotationProcessor: []
+      testCompile:
+      - root: 0
+      - root: 2
+      - root: 3
+      testCompileClasspath:
+      - root: 0
+      - root: 2
+      - root: 3
+      testCompileOnly: []
+      testRuntime:
+      - root: 0
+      - root: 2
+      - root: 3
+      testRuntimeClasspath:
+      - root: 0
+      - root: 2
+      - root: 3
 packages:
 - id: "Maven:junit:junit:4.12"
   purl: "pkg:maven/junit/junit@4.12"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
@@ -15,5 +15,8 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   homepage_url: ""
-  scopes: []
+  dependency_graph:
+    packages: []
+    scope_roots: []
+    scopes: {}
 packages: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
@@ -15,96 +15,51 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/app"
   homepage_url: ""
-  scopes:
-  - name: "annotationProcessor"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
+  dependency_graph:
+    packages:
+    - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+    - "Maven:org.apache.commons:commons-text:1.1"
+    - "Maven:org.apache.commons:commons-lang3:3.5"
+    - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    scope_roots:
+    - dependencies:
+      - pkg: 1
         dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+        - pkg: 2
+      - pkg: 3
       linkage: "PROJECT_DYNAMIC"
+    - fragment: 1
       dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
+      - pkg: 1
         dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-  - name: "compileOnly"
-    dependencies: []
-  - name: "default"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+        - pkg: 2
       linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testAnnotationProcessor"
-    dependencies: []
-  - name: "testCompile"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-  - name: "testCompileOnly"
-    dependencies: []
-  - name: "testRuntime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    scopes:
+      annotationProcessor: []
+      archives: []
+      compile:
+      - root: 0
+      compileClasspath:
+      - root: 0
+        fragment: 1
+      compileOnly: []
+      default:
+      - root: 0
+      runtime:
+      - root: 0
+      runtimeClasspath:
+      - root: 0
+      testAnnotationProcessor: []
+      testCompile:
+      - root: 0
+      testCompileClasspath:
+      - root: 0
+        fragment: 1
+      testCompileOnly: []
+      testRuntime:
+      - root: 0
+      testRuntimeClasspath:
+      - root: 0
 packages:
 - id: "Maven:org.apache.commons:commons-lang3:3.5"
   purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
@@ -15,61 +15,47 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/lib"
   homepage_url: ""
-  scopes:
-  - name: "annotationProcessor"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
-    dependencies: []
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
+  dependency_graph:
+    packages:
+    - "Maven:org.apache.commons:commons-text:1.1"
+    - "Maven:org.apache.commons:commons-lang3:3.5"
+    - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    - "Maven:junit:junit:4.12"
+    - "Maven:org.hamcrest:hamcrest-core:1.3"
+    scope_roots:
+    - dependencies:
+      - pkg: 1
+    - pkg: 2
+    - pkg: 3
       dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileOnly"
-    dependencies: []
-  - name: "default"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtime"
-    dependencies: []
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testAnnotationProcessor"
-    dependencies: []
-  - name: "testCompile"
-    dependencies: []
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileOnly"
-    dependencies: []
-  - name: "testRuntime"
-    dependencies: []
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - pkg: 4
+    scopes:
+      annotationProcessor: []
+      archives: []
+      compile: []
+      compileClasspath:
+      - root: 0
+      - root: 2
+      compileOnly: []
+      default:
+      - root: 0
+      - root: 2
+      runtime: []
+      runtimeClasspath:
+      - root: 0
+      - root: 2
+      testAnnotationProcessor: []
+      testCompile: []
+      testCompileClasspath:
+      - root: 0
+      - root: 2
+      - root: 3
+      testCompileOnly: []
+      testRuntime: []
+      testRuntimeClasspath:
+      - root: 0
+      - root: 2
+      - root: 3
 packages:
 - id: "Maven:junit:junit:4.12"
   purl: "pkg:maven/junit/junit@4.12"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-root.yml
@@ -15,5 +15,8 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library"
   homepage_url: ""
-  scopes: []
+  dependency_graph:
+    packages: []
+    scope_roots: []
+    scopes: {}
 packages: []

--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -237,7 +237,7 @@ class Bower(
                 vcs = projectPackage.vcs,
                 vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, projectPackage.homepageUrl),
                 homepageUrl = projectPackage.homepageUrl,
-                scopes = sortedSetOf(dependenciesScope, devDependenciesScope)
+                scopeDependencies = sortedSetOf(dependenciesScope, devDependenciesScope)
             )
 
             return listOf(ProjectAnalyzerResult(project, packages.values.toSortedSet()))

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -116,7 +116,7 @@ class Bundler(
                 vcs = VcsInfo.EMPTY,
                 vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY, homepageUrl),
                 homepageUrl = homepageUrl,
-                scopes = scopes.toSortedSet()
+                scopeDependencies = scopes.toSortedSet()
             )
 
             return listOf(ProjectAnalyzerResult(project, packages, issues))

--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -288,7 +288,7 @@ class Cargo(
             vcs = projectPkg.vcs,
             vcsProcessed = processProjectVcs(workingDir, projectPkg.vcs, homepageUrl),
             homepageUrl = homepageUrl,
-            scopes = scopes.toSortedSet()
+            scopeDependencies = scopes.toSortedSet()
         )
 
         val nonProjectPackages = packages

--- a/analyzer/src/main/kotlin/managers/Carthage.kt
+++ b/analyzer/src/main/kotlin/managers/Carthage.kt
@@ -83,7 +83,7 @@ class Carthage(
                     declaredLicenses = sortedSetOf(),
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY),
-                    scopes = sortedSetOf(),
+                    scopeDependencies = sortedSetOf(),
                     homepageUrl = ""
                 ),
                 packages = parseCarthageDependencies(definitionFile)

--- a/analyzer/src/main/kotlin/managers/Composer.kt
+++ b/analyzer/src/main/kotlin/managers/Composer.kt
@@ -236,7 +236,7 @@ class Composer(
             vcs = vcs,
             vcsProcessed = processProjectVcs(definitionFile.parentFile, vcs, homepageUrl),
             homepageUrl = homepageUrl,
-            scopes = scopes
+            scopeDependencies = scopes
         )
     }
 

--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -132,7 +132,7 @@ class Conan(
                             projectPackage.homepageUrl
                         ),
                         homepageUrl = projectPackage.homepageUrl,
-                        scopes = sortedSetOf(dependenciesScope, devDependenciesScope)
+                        scopeDependencies = sortedSetOf(dependenciesScope, devDependenciesScope)
                     ),
                     packages = packages.values.toSortedSet()
                 )

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -176,7 +176,7 @@ class GoDep(
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = projectVcs,
                     homepageUrl = "",
-                    scopes = sortedSetOf(scope)
+                    scopeDependencies = sortedSetOf(scope)
                 ),
                 packages = packages
             )

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -136,7 +136,7 @@ class GoMod(
                         vcs = projectVcs,
                         vcsProcessed = projectVcs,
                         homepageUrl = "",
-                        scopes = scopes
+                        scopeDependencies = scopes
                     ),
                     packages = packages
                 )

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -252,7 +252,7 @@ class Gradle(
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = processProjectVcs(definitionFile.parentFile),
                     homepageUrl = "",
-                    scopes = scopes.toSortedSet()
+                    scopeDependencies = scopes.toSortedSet()
                 )
 
                 val issues = mutableListOf<OrtIssue>()

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.analyzer.managers
 
-import Dependency
 import DependencyTreeModel
 
 import java.io.ByteArrayOutputStream
@@ -27,10 +26,7 @@ import java.io.File
 import java.util.Properties
 import java.util.concurrent.TimeUnit
 
-import org.apache.maven.project.ProjectBuildingException
-
 import org.eclipse.aether.artifact.Artifact
-import org.eclipse.aether.artifact.DefaultArtifact
 import org.eclipse.aether.repository.RemoteRepository
 import org.eclipse.aether.repository.WorkspaceReader
 import org.eclipse.aether.repository.WorkspaceRepository
@@ -40,26 +36,21 @@ import org.gradle.tooling.internal.consumer.DefaultGradleConnector
 
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
+import org.ossreviewtoolkit.analyzer.managers.utils.GradleDependencyGraphBuilder
 import org.ossreviewtoolkit.analyzer.managers.utils.MavenSupport
 import org.ossreviewtoolkit.analyzer.managers.utils.identifier
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
-import org.ossreviewtoolkit.model.Package
-import org.ossreviewtoolkit.model.PackageLinkage
-import org.ossreviewtoolkit.model.PackageReference
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
-import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.utils.Os
-import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.log
-import org.ossreviewtoolkit.utils.showStackTrace
 import org.ossreviewtoolkit.utils.temporaryProperties
 
 /**
@@ -231,13 +222,14 @@ class Gradle(
                     "The Gradle project '$projectName' uses the following Maven repositories: $repositories"
                 }
 
-                val packages = mutableMapOf<String, Package>()
-                val scopes = dependencyTreeModel.configurations.map { configuration ->
-                    val dependencies = configuration.dependencies.map { dependency ->
-                        parseDependency(dependency, packages, repositories)
+                val graphBuilder = GradleDependencyGraphBuilder(managerName, maven)
+                dependencyTreeModel.configurations.forEach { configuration ->
+                    configuration.dependencies.forEach { dependency ->
+                        graphBuilder.addDependency(configuration.name, dependency, repositories)
                     }
 
-                    Scope(configuration.name, dependencies.toSortedSet())
+                    // Make sure that scopes without dependencies are recorded.
+                    graphBuilder.addScope(configuration.name)
                 }
 
                 val project = Project(
@@ -252,7 +244,8 @@ class Gradle(
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = processProjectVcs(definitionFile.parentFile),
                     homepageUrl = "",
-                    scopeDependencies = scopes.toSortedSet()
+                    scopeDependencies = null,
+                    dependencyGraph = graphBuilder.build()
                 )
 
                 val issues = mutableListOf<OrtIssue>()
@@ -265,75 +258,8 @@ class Gradle(
                     createAndLogIssue(source = managerName, message = it, severity = Severity.WARNING)
                 }
 
-                listOf(ProjectAnalyzerResult(project, packages.values.toSortedSet(), issues))
+                listOf(ProjectAnalyzerResult(project, graphBuilder.packages().toSortedSet(), issues))
             }
-        }
-    }
-
-    private fun parseDependency(
-        dependency: Dependency, packages: MutableMap<String, Package>,
-        repositories: List<RemoteRepository>
-    ): PackageReference {
-        val issues = mutableListOf<OrtIssue>()
-
-        dependency.error?.let {
-            issues += createAndLogIssue(
-                source = managerName,
-                message = it,
-                severity = Severity.ERROR
-            )
-        }
-
-        dependency.warning?.let {
-            issues += createAndLogIssue(
-                source = managerName,
-                message = it,
-                severity = Severity.WARNING
-            )
-        }
-
-        // Only look for a package if there was no error resolving the dependency and it is no project dependency.
-        if (dependency.error == null && dependency.localPath == null) {
-            val identifier = "${dependency.groupId}:${dependency.artifactId}:${dependency.version}"
-
-            packages.getOrPut(identifier) {
-                try {
-                    val artifact = DefaultArtifact(
-                        dependency.groupId, dependency.artifactId, dependency.classifier,
-                        dependency.extension, dependency.version
-                    )
-
-                    maven.parsePackage(artifact, repositories)
-                } catch (e: ProjectBuildingException) {
-                    e.showStackTrace()
-
-                    issues += createAndLogIssue(
-                        source = managerName,
-                        message = "Could not get package information for dependency '$identifier': " +
-                                e.collectMessagesAsString()
-                    )
-
-                    Package.EMPTY.copy(
-                        id = Identifier(
-                            type = "Maven",
-                            namespace = dependency.groupId,
-                            name = dependency.artifactId,
-                            version = dependency.version
-                        )
-                    )
-                }
-            }
-        }
-
-        val transitiveDependencies = dependency.dependencies.map { parseDependency(it, packages, repositories) }
-
-        return if (dependency.localPath != null) {
-            val id = Identifier(managerName, dependency.groupId, dependency.artifactId, dependency.version)
-            PackageReference(id, PackageLinkage.PROJECT_DYNAMIC, transitiveDependencies.toSortedSet(), issues)
-        } else {
-            val type = dependency.pomFile?.let { "Maven" } ?: "Unknown"
-            val id = Identifier(type, dependency.groupId, dependency.artifactId, dependency.version)
-            PackageReference(id, dependencies = transitiveDependencies.toSortedSet(), issues = issues)
         }
     }
 }

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -141,7 +141,7 @@ class Maven(
             vcs = vcsFromPackage,
             vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, *vcsFallbackUrls),
             homepageUrl = homepageUrl.orEmpty(),
-            scopes = scopesByName.values.toSortedSet()
+            scopeDependencies = scopesByName.values.toSortedSet()
         )
 
         val packages = packagesById.values.toSortedSet()

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -529,7 +529,7 @@ open class Npm(
             vcs = vcsFromPackage,
             vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, homepageUrl),
             homepageUrl = homepageUrl,
-            scopes = scopes
+            scopeDependencies = scopes
         )
 
         return ProjectAnalyzerResult(project, packages)

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -380,7 +380,7 @@ class Pip(
             vcs = VcsInfo.EMPTY,
             vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY, setupHomepage),
             homepageUrl = setupHomepage,
-            scopes = scopes
+            scopeDependencies = scopes
         )
 
         // Remove the virtualenv by simply deleting the directory.

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -369,7 +369,7 @@ class Pub(
             vcs = vcs,
             vcsProcessed = processProjectVcs(definitionFile.parentFile, vcs, homepageUrl),
             homepageUrl = homepageUrl,
-            scopes = scopes
+            scopeDependencies = scopes
         )
     }
 

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -195,7 +195,7 @@ class SpdxDocumentFile(
                 vcs = VcsInfo.EMPTY,
                 vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY, projectPackage.homepage),
                 homepageUrl = projectPackage.homepage.mapNotPresentToEmpty(),
-                scopes = scopes
+                scopeDependencies = scopes
             )
         } else {
             // TODO: Add support for "package.spdx.yml" files. How to deal with relationships between SPDX packages if

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -167,7 +167,7 @@ class Stack(
             vcs = projectPackage.vcs,
             vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, projectPackage.homepageUrl),
             homepageUrl = projectPackage.homepageUrl,
-            scopes = scopes
+            scopeDependencies = scopes
         )
 
         return listOf(ProjectAnalyzerResult(project, allPackages.values.toSortedSet()))

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -111,7 +111,7 @@ class Unmanaged(
             vcs = VcsInfo.EMPTY,
             vcsProcessed = vcsInfo,
             homepageUrl = "",
-            scopes = sortedSetOf()
+            scopeDependencies = sortedSetOf()
         )
 
         return listOf(ProjectAnalyzerResult(project, packages = sortedSetOf()))

--- a/analyzer/src/main/kotlin/managers/utils/GradleDependencyGraphBuilder.kt
+++ b/analyzer/src/main/kotlin/managers/utils/GradleDependencyGraphBuilder.kt
@@ -1,0 +1,431 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers.utils
+
+import Dependency
+
+import org.apache.maven.project.ProjectBuildingException
+
+import org.eclipse.aether.artifact.DefaultArtifact
+import org.eclipse.aether.repository.RemoteRepository
+
+import org.ossreviewtoolkit.model.DependencyGraph
+import org.ossreviewtoolkit.model.DependencyReference
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageLinkage
+import org.ossreviewtoolkit.model.RootDependencyIndex
+import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.model.createAndLogIssue
+import org.ossreviewtoolkit.utils.collectMessagesAsString
+import org.ossreviewtoolkit.utils.showStackTrace
+
+/**
+ * Internal class to represent the result of a search in the dependency graph. The outcome of the search determines
+ * how to integrate a specific dependency into the dependency graph.
+ */
+private sealed class GraphSearchResult
+
+/**
+ * A specialized [GraphSearchResult] that indicates that the dependency that was searched for is already present in
+ * the dependency graph. This is the easiest case, as the [DependencyReference] that was found can directly be
+ * reused.
+ */
+private data class GraphSearchResultFound(
+    /** The reference to the dependency that was searched in the graph. */
+    val ref: DependencyReference
+) : GraphSearchResult()
+
+/**
+ * A specialized [GraphSearchResult] that indicates that the dependency that was searched for was not found in the
+ * dependency graph, but a fragment has been detected, to which it can be added.
+ */
+private data class GraphSearchResultNotFound(
+    /** The index of the fragment to which to add the dependency. */
+    val fragmentIndex: Int
+) : GraphSearchResult()
+
+/**
+ * A specialized [GraphSearchResult] that indicates that the dependency that was searched for in its current form
+ * cannot be added to any of the existing fragments. This means that either there are no fragments yet or each
+ * fragment contains a variant of the dependency with an incompatible dependency tree. In this case, a new fragment
+ * has to be added to the graph to host this special variant of this dependency.
+ */
+private object GraphSearchResultIncompatible : GraphSearchResult()
+
+/**
+ * A class that can construct a [DependencyGraph] from a set of Gradle dependencies that provides an efficient storage
+ * format for large dependency sets in many scopes.
+ *
+ * Especially in Android projects, it is common habit to have many scopes that all define their own sets of (often
+ * identical) dependencies. Duplicating the dependency trees for the different scopes leads to a high consumption of
+ * memory. This class addresses this problem by sharing the components of the dependency graph between the scopes as
+ * far as possible.
+ *
+ * This builder class provides the _addDependency()_ function, which has to be called for all the direct dependencies
+ * of the different scopes. From these dependencies it constructs a single, optimized graph that is referenced by all
+ * scopes. To reduce the amount of memory required even further, package identifiers are replaced by numeric indices,
+ * so that references in the graph are just numbers.
+ *
+ * Ideally, the resulting dependency graph contains each dependency exactly once. There are, however, cases, in which
+ * packages occur multiple times in the project's dependency graph with different dependencies. Such cases are
+ * detected, and the corresponding packages form different nodes in the graph, so that they can be distinguished
+ * correctly.
+ */
+class GradleDependencyGraphBuilder(
+    /** The name of the dependency manager to use as type of identifiers. */
+    private val managerName: String,
+
+    /** The helper object to resolve packages via Maven. */
+    private val maven: MavenSupport
+) {
+    /**
+     * A list storing the identifiers of all dependencies added to this builder. This list is then used to resolve
+     * dependencies based on their indices.
+     */
+    private val dependencyIds = mutableListOf<String>()
+
+    /**
+     * A map listing the dependencies known to this builder and their numeric indices. This is used for a fast
+     * calculation of the index for a specific dependency.
+     */
+    private val dependencyIndexMapping = mutableMapOf<String, Int>()
+
+    /**
+     * Stores all the references to dependencies that have been added so far. Each element of the list represents a
+     * fragment of the dependency graph. For each fragment, there is a mapping from a dependency index to the
+     * reference pointing to the corresponding dependency tree.
+     */
+    private val referenceMappings = mutableListOf<MutableMap<Int, DependencyReference>>()
+
+    /** The mapping from scopes to dependencies constructed by this builder. */
+    private val scopeMapping = mutableMapOf<String, List<RootDependencyIndex>>()
+
+    /** Stores all packages encountered in the dependency tree. */
+    private val resolvedPackages = mutableSetOf<Package>()
+
+    /**
+     * A set storing the packages that are direct dependencies of one of the scopes. These are the entry points into
+     * the dependency graph.
+     */
+    private val directDependencies = mutableSetOf<DependencyReference>()
+
+    /**
+     * Add the scope with the given [scopeName] to this builder. In most cases, it is not necessary to add scopes
+     * explicitly, as they are recorded automatically by _addDependency()_. However, if there are scopes without
+     * dependencies, this function can be used to include them into the builder result.
+     */
+    fun addScope(scopeName: String) {
+        scopeMapping.putIfAbsent(scopeName, emptyList())
+    }
+
+    /**
+     * Add the given [dependency] for the scope with the given [scopeName] to this builder. Use the provided
+     * [repositories] to resolve the package if necessary.
+     */
+    fun addDependency(scopeName: String, dependency: Dependency, repositories: List<RemoteRepository>) {
+        addDependencyToGraph(scopeName, dependency, repositories, transitive = false)
+    }
+
+    /**
+     * Construct the [DependencyGraph] from the dependencies passed to this builder so far.
+     */
+    fun build(): DependencyGraph = DependencyGraph(dependencyIds, directDependencies, scopeMapping)
+
+    /**
+     * Return a set with all the packages that have been encountered for the current project.
+     */
+    fun packages(): Set<Package> = resolvedPackages
+
+    /**
+     * Update the dependency graph by adding the given [dependency], which may be [transitive], for the scope with name
+     * [scopeName]. Use the provided [repositories] to resolve the package if necessary. All the dependencies of this
+     * dependency are processed recursively.
+     */
+    private fun addDependencyToGraph(
+        scopeName: String,
+        dependency: Dependency,
+        repositories: List<RemoteRepository>,
+        transitive: Boolean
+    ): DependencyReference {
+        val identifier = identifierFor(dependency)
+        val issues = issuesForDependency(dependency)
+        val index = updateDependencyMappingAndPackages(identifier, dependency, repositories, issues)
+
+        val ref = when (val result = findDependencyInGraph(index, dependency)) {
+            is GraphSearchResultFound -> result.ref
+            is GraphSearchResultNotFound ->
+                insertIntoGraph(
+                    RootDependencyIndex(index, result.fragmentIndex),
+                    scopeName,
+                    dependency,
+                    repositories,
+                    issues,
+                    transitive
+                )
+            is GraphSearchResultIncompatible ->
+                insertIntoNewFragment(index, scopeName, dependency, repositories, issues, transitive)
+        }
+
+        return updateScopeMapping(scopeName, ref, transitive)
+    }
+
+    /**
+     * Update internal state for the given dependency [id]. Check whether this ID is already known. If not, add it
+     * to the data managed by this instance, resolve the package, and update the [issues] if necessary. Return the
+     * numeric index for this dependency.
+     */
+    private fun updateDependencyMappingAndPackages(
+        id: String,
+        dependency: Dependency,
+        repositories: List<RemoteRepository>,
+        issues: MutableList<OrtIssue>
+    ): Int {
+        val dependencyIndex = dependencyIndexMapping[id]
+        if (dependencyIndex != null) return dependencyIndex
+
+        updateResolvedPackages(id, dependency, repositories, issues)
+        return dependencyIds.size.also {
+            dependencyIds += id
+            dependencyIndexMapping[id] = it
+        }
+    }
+
+    /**
+     * Search for the [dependency] with the given [index] in the fragments of the dependency graph. Return a
+     * [GraphSearchResult] that indicates how to proceed with this dependency.
+     */
+    private fun findDependencyInGraph(index: Int, dependency: Dependency): GraphSearchResult {
+        val mappingForCompatibleFragment = referenceMappings.find { mapping ->
+            mapping[index]?.takeIf { dependencyTreeEquals(it, dependency) } != null
+        }
+
+        val compatibleReference = mappingForCompatibleFragment?.let { it[index] }
+        return compatibleReference?.let { GraphSearchResultFound(it) } ?: handleNoCompatibleDependencyInGraph(index)
+    }
+
+    /**
+     * Determine how to deal with the dependency with the given [index], for which no compatible variant was found
+     * in the dependency graph. Try to find a fragment, in which the dependency can be inserted. If this fails, a new
+     * fragment has to be added.
+     */
+    private fun handleNoCompatibleDependencyInGraph(index: Int): GraphSearchResult {
+        val mappingToInsert = referenceMappings.withIndex().find { index !in it.value }
+        return mappingToInsert?.let { GraphSearchResultNotFound(it.index) } ?: GraphSearchResultIncompatible
+    }
+
+    /**
+     * Check whether the dependency tree spawned by [dependency] matches the one [ref] points to. Using this function,
+     * packages are identified that occur multiple times in the dependency graph with different sets of dependencies;
+     * these have to be placed in separate fragments of the dependency graph.
+     */
+    private fun dependencyTreeEquals(ref: DependencyReference, dependency: Dependency): Boolean {
+        if (ref.dependencies.size != dependency.dependencies.size) return false
+
+        val dependencies1 = ref.dependencies.map { dependencyIds[it.pkg] }
+        val dependencies2 = dependency.dependencies.associateBy(::identifierFor)
+        if (!dependencies2.keys.containsAll(dependencies1)) return false
+
+        return ref.dependencies.all { refDep ->
+            dependencies2[dependencyIds[refDep.pkg]]?.let { dependencyTreeEquals(refDep, it) } ?: false
+        }
+    }
+
+    /**
+     * Add a new fragment to the dependency graph for the [dependency] with the given [index], which may be
+     * [transitive] and belongs to the scope with the given [scopeName]. This function is called for dependencies that
+     * cannot be added to already existing fragments. Therefore, create a new fragment and add the [dependency] to it,
+     * together with its own dependencies. Store the given [issues] for the dependency and use the given
+     * [repositories] to resolve packages.
+     */
+    private fun insertIntoNewFragment(
+        index: Int, scopeName: String,
+        dependency: Dependency,
+        repositories: List<RemoteRepository>,
+        issues: List<OrtIssue>,
+        transitive: Boolean
+    ): DependencyReference {
+        val fragmentMapping = mutableMapOf<Int, DependencyReference>()
+        val dependencyIndex = RootDependencyIndex(index, referenceMappings.size)
+        referenceMappings += fragmentMapping
+        return insertIntoGraph(dependencyIndex, scopeName, dependency, repositories, issues, transitive)
+    }
+
+    /**
+     * Insert the [dependency] with the given [RootDependencyIndex][index], which belongs to the scope with the given
+     * [scopeName] and may be [transitive] into the dependency graph. Insert the dependencies of this [dependency]
+     * recursively and use the [repositories] to resolve packages. Create a new [DependencyReference] for the
+     * dependency and initialize it with the list of [issues].
+     */
+    private fun insertIntoGraph(
+        index: RootDependencyIndex,
+        scopeName: String,
+        dependency: Dependency,
+        repositories: List<RemoteRepository>,
+        issues: List<OrtIssue>,
+        transitive: Boolean
+    ): DependencyReference {
+        val transitiveDependencies = dependency.dependencies.map {
+            addDependencyToGraph(scopeName, it, repositories, transitive = true)
+        }
+
+        val fragmentMapping = referenceMappings[index.fragment]
+        val ref = DependencyReference(
+            pkg = index.root,
+            fragment = index.fragment,
+            dependencies = transitiveDependencies.toSortedSet(),
+            linkage = dependency.linkage(),
+            issues = issues
+        )
+
+        fragmentMapping[index.root] = ref
+        return updateDirectDependencies(ref, transitive)
+    }
+
+    /**
+     * Return a list of issues that is initially populated with errors or warnings from the given [dependency].
+     */
+    private fun issuesForDependency(dependency: Dependency): MutableList<OrtIssue> {
+        val issues = mutableListOf<OrtIssue>()
+
+        dependency.error?.let {
+            issues += createAndLogIssue(
+                source = managerName,
+                message = it,
+                severity = Severity.ERROR
+            )
+        }
+
+        dependency.warning?.let {
+            issues += createAndLogIssue(
+                source = managerName,
+                message = it,
+                severity = Severity.WARNING
+            )
+        }
+
+        return issues
+    }
+
+    /**
+     * Construct a [Package] for the given [dependency] using the [repositories] provided. Add the new package to the
+     * set managed by this object. If this fails, record a corresponding message in [issues].
+     */
+    private fun updateResolvedPackages(
+        identifier: String,
+        dependency: Dependency,
+        repositories: List<RemoteRepository>,
+        issues: MutableList<OrtIssue>
+    ) {
+        // Only look for a package if there was no error resolving the dependency and it is no project dependency.
+        if (dependency.error != null || dependency.isProjectDependency()) return
+
+        val pkg = try {
+            val artifact = DefaultArtifact(
+                dependency.groupId, dependency.artifactId, dependency.classifier,
+                dependency.extension, dependency.version
+            )
+
+            maven.parsePackage(artifact, repositories)
+        } catch (e: ProjectBuildingException) {
+            e.showStackTrace()
+
+            issues += createAndLogIssue(
+                source = managerName,
+                message = "Could not get package information for dependency '$identifier': " +
+                        e.collectMessagesAsString()
+            )
+
+            Package.EMPTY.copy(
+                id = Identifier(
+                    type = "Maven",
+                    namespace = dependency.groupId,
+                    name = dependency.artifactId,
+                    version = dependency.version
+                )
+            )
+        }
+
+        resolvedPackages += pkg
+    }
+
+    /**
+     * Add the given [dependency reference][ref] to the set of direct dependencies if it is not [transitive]. If one of
+     * the direct dependencies of this package is in this set, it is removed, as it is obviously no direct dependency.
+     * Because this function is called for all dependencies, all transitive dependencies are eventually removed.
+     */
+    private fun updateDirectDependencies(ref: DependencyReference, transitive: Boolean): DependencyReference {
+        directDependencies.removeAll(ref.dependencies)
+        if (!transitive) directDependencies += ref
+        return ref
+    }
+
+    /**
+     * Update the scope mapping for the given [scopeName] to depend on [ref], which may be a [transitive] dependency.
+     * The scope mapping records all the direct dependencies of scopes.
+     */
+    private fun updateScopeMapping(
+        scopeName: String, ref: DependencyReference, transitive: Boolean
+    ): DependencyReference {
+        if (!transitive) {
+            val index = RootDependencyIndex(ref.pkg, ref.fragment)
+            scopeMapping.compute(scopeName) { _, ids ->
+                ids?.let { it + index } ?: listOf(index)
+            }
+        }
+
+        return ref
+    }
+
+    /**
+     * Generate a string that uniquely identifies this [dependency]. This string is also used to construct an
+     * [Identifier] for this package.
+     */
+    private fun identifierFor(dependency: Dependency): String =
+        "${dependencyType(dependency)}:${dependency.groupId}:${dependency.artifactId}:${dependency.version}"
+
+    /**
+     * Determine the type of the given [dependency]. This manager implementation uses Maven to resolve packages, so
+     * the type of dependencies to packages is typically _Maven_ unless no pom is available. Only for module
+     * dependencies, the type of this manager is used.
+     */
+    private fun dependencyType(dependency: Dependency): String =
+        if (dependency.isProjectDependency()) {
+            managerName
+        } else {
+            dependency.pomFile?.let { "Maven" } ?: "Unknown"
+        }
+}
+
+/**
+ * Determine the [PackageLinkage] for this [Dependency].
+ */
+private fun Dependency.linkage() =
+    if (isProjectDependency()) {
+        PackageLinkage.PROJECT_DYNAMIC
+    } else {
+        PackageLinkage.DYNAMIC
+    }
+
+/**
+ * Return a flag whether this dependency references another project in the current build.
+ */
+private fun Dependency.isProjectDependency() = localPath != null

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -295,7 +295,7 @@ fun PackageManager.resolveNuGetDependencies(
         vcs = VcsInfo.EMPTY,
         vcsProcessed = PackageManager.processProjectVcs(workingDir),
         homepageUrl = "",
-        scopes = sortedSetOf(scope)
+        scopeDependencies = sortedSetOf(scope)
     )
 
     return ProjectAnalyzerResult(project, packages, issues)

--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -55,11 +55,11 @@ class AnalyzerResultBuilderTest : WordSpec() {
 
     private val project1 = Project.EMPTY.copy(
         id = Identifier("type-1", "namespace-1", "project-1", "version-1"),
-        scopes = sortedSetOf(scope1)
+        scopeDependencies = sortedSetOf(scope1)
     )
     private val project2 = Project.EMPTY.copy(
         id = Identifier("type-2", "namespace-2", "project-2", "version-2"),
-        scopes = sortedSetOf(scope1, scope2)
+        scopeDependencies = sortedSetOf(scope1, scope2)
     )
 
     private val analyzerResult1 = ProjectAnalyzerResult(

--- a/analyzer/src/test/kotlin/managers/utils/GradleDependencyGraphBuilderTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/GradleDependencyGraphBuilderTest.kt
@@ -1,0 +1,399 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers.utils
+
+import Dependency
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.beTheSameInstanceAs
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+
+import java.lang.IllegalArgumentException
+import java.util.SortedSet
+
+import org.eclipse.aether.artifact.DefaultArtifact
+import org.eclipse.aether.repository.RemoteRepository
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageReference
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.RootDependencyIndex
+import org.ossreviewtoolkit.model.Scope
+import org.ossreviewtoolkit.model.VcsInfo
+
+class GradleDependencyGraphBuilderTest : WordSpec({
+    "GradleDependencyGraphBuilder" should {
+        "collect the direct dependencies of scopes" {
+            val scope1 = "compile"
+            val scope2 = "test"
+            val dep1 = createDependency("org.apache.commons", "commons-lang3", "3.11")
+            val dep2 = createDependency("org.apache.commons", "commons-collections4", "4.4")
+            val dep3 = createDependency("my-project", "my-module", "1.0", path = "subPath")
+            val maven = createMavenSupport()
+            val builder = GradleDependencyGraphBuilder(NAME, maven)
+
+            builder.addDependency(scope1, dep1, remoteRepositories)
+            builder.addDependency(scope1, dep3, remoteRepositories)
+            builder.addDependency(scope2, dep2, remoteRepositories)
+            builder.addDependency(scope2, dep1, remoteRepositories)
+            val graph = builder.build()
+
+            graph.scopeRoots shouldHaveSize 3
+            val scopes = graph.createScopes()
+            scopes.map { it.name } should containExactlyInAnyOrder(scope1, scope2)
+
+            val scope1Dependencies = scopeDependencies(scopes, scope1)
+            scope1Dependencies.all { it.dependencies.isEmpty() } shouldBe true
+            scope1Dependencies.identifiers() should containExactlyInAnyOrder(dep1.toId(), dep3.toId())
+
+            val scope2Dependencies = scopeDependencies(scopes, scope2)
+            scope2Dependencies.identifiers() should containExactlyInAnyOrder(dep2.toId(), dep1.toId())
+        }
+
+        "collect a dependency of type Maven" {
+            val scope = "TheScope"
+            val dep = createDependency("org.apache.commons", "commons-lang3", "3.10")
+            val maven = createMavenSupport()
+            val builder = GradleDependencyGraphBuilder(NAME, maven)
+
+            builder.addDependency(scope, dep, remoteRepositories)
+            val graph = builder.build()
+            val scopes = graph.createScopes()
+
+            scopeDependencies(scopes, scope).single { it.id.type == "Maven" }
+        }
+
+        "collect a dependency of type Unknown" {
+            val scope = "TheScope"
+            val dep = createDependency("org.apache.commons", "commons-lang3", "3.10")
+            every { dep.pomFile } returns null
+            val maven = createMavenSupport()
+            val builder = GradleDependencyGraphBuilder(NAME, maven)
+
+            builder.addDependency(scope, dep, remoteRepositories)
+            val graph = builder.build()
+            val scopes = graph.createScopes()
+
+            scopeDependencies(scopes, scope).single { it.id.type == "Unknown" }
+        }
+
+        "collect a project dependency" {
+            val scope = "TheScope"
+            val dep = createDependency("a-project", "a-module", "1.0", path = "p")
+            val maven = createMavenSupport()
+            val builder = GradleDependencyGraphBuilder(NAME, maven)
+
+            builder.addDependency(scope, dep, remoteRepositories)
+            val graph = builder.build()
+            val scopes = graph.createScopes()
+
+            scopeDependencies(scopes, scope).single { it.id.type == NAME }
+        }
+
+        "collect information about packages" {
+            val dep1 = createDependency("org.apache.commons", "commons-lang3", "3.11")
+            val dep2 = createDependency("org.apache.commons", "commons-collections4", "4.4")
+            val dep3 = createDependency("my-project", "my-module", "1.0", path = "foo")
+            val maven = createMavenSupport()
+            val builder = GradleDependencyGraphBuilder(NAME, maven)
+
+            builder.addDependency("s1", dep1, remoteRepositories)
+            builder.addDependency("s2", dep2, remoteRepositories)
+            builder.addDependency("s3", dep3, remoteRepositories)
+
+            val packageIds = builder.packages().map { it.id }
+            packageIds shouldContainExactlyInAnyOrder setOf(dep1.toId(), dep2.toId())
+        }
+
+        "deal with transitive dependencies correctly" {
+            val scope1 = "compile"
+            val scope2 = "test"
+            val dep1 = createDependency("org.apache.commons", "commons-lang3", "3.11")
+            val dep2 = createDependency("org.apache.commons", "commons-collections4", "4.4")
+            val dep3 = createDependency(
+                "org.apache.commons",
+                "commons-configuration2",
+                "2.7",
+                dependencies = listOf(dep1, dep2)
+            )
+            val dep4 = createDependency("org.apache.commons", "commons-csv", "1.5", dependencies = listOf(dep1))
+            val dep5 = createDependency("com.acme", "dep", "0.7", dependencies = listOf(dep3))
+            val maven = createMavenSupport()
+            val builder = GradleDependencyGraphBuilder(NAME, maven)
+
+            builder.addDependency(scope1, dep1, remoteRepositories)
+            builder.addDependency(scope2, dep1, remoteRepositories)
+            builder.addDependency(scope2, dep2, remoteRepositories)
+            builder.addDependency(scope1, dep5, remoteRepositories)
+            builder.addDependency(scope1, dep3, remoteRepositories)
+            builder.addDependency(scope2, dep4, remoteRepositories)
+            val graph = builder.build()
+
+            graph.scopeRoots shouldHaveSize 2
+            graph.scopeRoots.all { it.fragment == 0 } shouldBe true
+            val scopes = graph.createScopes()
+
+            val scopeDependencies1 = scopeDependencies(scopes, scope1)
+            scopeDependencies1.identifiers() should containExactly(dep5.toId(), dep3.toId(), dep1.toId())
+            val dep5Pkg = scopeDependencies1.findDependency(dep5)
+            val dep3Pkg = dep5Pkg.checkDependencies(dep3).findDependency(dep3)
+            dep3Pkg.checkDependencies(dep1, dep2)
+            scopeDependencies1.findDependency(dep3) should beTheSameInstanceAs(dep3Pkg)
+
+            val scopeDependencies2 = scopeDependencies(scopes, scope2)
+            scopeDependencies2.identifiers() should containExactlyInAnyOrder(dep1.toId(), dep2.toId(), dep4.toId())
+            dep3Pkg.dependencies.findDependency(dep2) should beTheSameInstanceAs(
+                scopeDependencies2.findDependency(dep2))
+        }
+
+        "deal with packages that have different dependencies in the same scope" {
+            val scope = "TheScope"
+            val depLang = createDependency("org.apache.commons", "commons-lang3", "3.11")
+            val depLog = createDependency("commons-logging", "commons-logging", "1.2")
+            val depConfig1 = createDependency(
+                "org.apache.commons", "commons-configuration2", "2.7",
+                dependencies = listOf(depLog, depLang)
+            )
+            val depConfig2 = createDependency(
+                "org.apache.commons", "commons-configuration2", "2.7",
+                dependencies = listOf(depLang)
+            )
+            val depAcme = createDependency(
+                "com.acme", "lib-full", "1.0",
+                dependencies = listOf(depConfig1, depLang)
+            )
+            val depAcmeExclude = createDependency(
+                "com.acme", "lib-exclude", "1.1",
+                dependencies = listOf(depConfig2)
+            )
+            val depLib = createDependency("com.business", "lib", "1", dependencies = listOf(depConfig1, depAcmeExclude))
+            val builder = GradleDependencyGraphBuilder(NAME, createMavenSupport())
+
+            builder.addDependency(scope, depAcme, remoteRepositories)
+            builder.addDependency(scope, depLib, remoteRepositories)
+            val graph = builder.build()
+            val scopeDependencies = scopeDependencies(graph.createScopes(), scope)
+
+            scopeDependencies.identifiers() should containExactly(depAcme.toId(), depLib.toId())
+            val refLib = scopeDependencies.findDependency(depLib)
+            refLib.checkDependencies(depConfig1, depAcmeExclude)
+            val refConfigFull = refLib.dependencies.findDependency(depConfig1)
+            refConfigFull.checkDependencies(depLang, depLog)
+            val refAcmeExclude = refLib.dependencies.findDependency(depAcmeExclude)
+            refAcmeExclude.checkDependencies(depConfig1)
+            val refConfigExclude = refAcmeExclude.dependencies.findDependency(depConfig1)
+            refConfigExclude.checkDependencies(depLang)
+            val refAcme = scopeDependencies.findDependency(depAcme)
+            refAcme.checkDependencies(depLang, depConfig1)
+            refAcme.dependencies.findDependency(depConfig1) shouldBeSameInstanceAs refConfigFull
+        }
+
+        "deal with packages that have different dependencies in different scopes" {
+            val scope1 = "OneScope"
+            val scope2 = "AnotherScope"
+            val depLang = createDependency("org.apache.commons", "commons-lang3", "3.11")
+            val depLog = createDependency("commons-logging", "commons-logging", "1.2")
+            val depConfig1 = createDependency(
+                "org.apache.commons", "commons-configuration2", "2.7",
+                dependencies = listOf(depLog, depLang)
+            )
+            val depConfig2 = createDependency(
+                "org.apache.commons", "commons-configuration2", "2.7",
+                dependencies = listOf(depLang)
+            )
+            val depAcmeExclude = createDependency(
+                "com.acme", "lib-exclude", "1.1",
+                dependencies = listOf(depConfig2)
+            )
+            val builder = GradleDependencyGraphBuilder(NAME, createMavenSupport())
+
+            builder.addDependency(scope1, depLog, remoteRepositories)
+            builder.addDependency(scope1, depConfig1, remoteRepositories)
+            builder.addDependency(scope2, depAcmeExclude, remoteRepositories)
+            val graph = builder.build()
+            val scopes = graph.createScopes()
+
+            val scope1Dependencies = scopeDependencies(scopes, scope1)
+            scope1Dependencies.identifiers() should containExactly(depLog.toId(), depConfig1.toId())
+            val scope2Dependencies = scopeDependencies(scopes, scope2)
+            scope2Dependencies.identifiers() should containExactly(depAcmeExclude.toId())
+            val refConfigFull = scope1Dependencies.findDependency(depConfig1)
+            refConfigFull.checkDependencies(depLang, depLog)
+            refConfigFull.dependencies.findDependency(depLog) shouldBeSameInstanceAs scope1Dependencies
+                .findDependency(depLog)
+            val refAcme = scope2Dependencies.findDependency(depAcmeExclude)
+            refAcme.checkDependencies(depConfig2)
+            val refConfigExclude = refAcme.dependencies.findDependency(depConfig2)
+            refConfigExclude.checkDependencies(depLang)
+            refConfigExclude.dependencies.findDependency(depLang) shouldBeSameInstanceAs refConfigFull
+                .dependencies.findDependency(depLang)
+        }
+
+        "support scopes without dependencies" {
+            val scope = "EmptyScope"
+            val builder = GradleDependencyGraphBuilder(NAME, createMavenSupport())
+
+            builder.addScope(scope)
+            val graph = builder.build()
+
+            graph.scopeRoots.shouldBeEmpty()
+            graph.scopes.keys shouldContainExactly setOf(scope)
+            val scopeDependencies = graph.scopes[scope]
+            scopeDependencies.shouldNotBeNull()
+            scopeDependencies.shouldBeEmpty()
+        }
+
+        "not override a scope's dependencies when adding it again" {
+            val scope = "compile"
+            val dep = createDependency("org.apache.commons", "commons-lang3", "3.11")
+            val builder = GradleDependencyGraphBuilder(NAME, createMavenSupport())
+            builder.addDependency(scope, dep, remoteRepositories)
+
+            builder.addScope(scope)
+            val graph = builder.build()
+            val scopeDependencies = graph.scopes[scope]
+            scopeDependencies.shouldNotBeNull()
+            scopeDependencies should containExactly(RootDependencyIndex(0))
+        }
+    }
+})
+
+/** The name of the package manager. */
+private const val NAME = "GradleTest"
+
+/** Remote repositories used by the test. */
+private val remoteRepositories = listOf(mockk<RemoteRepository>())
+
+/**
+ * Create a mock dependency with the properties provided.
+ */
+private fun createDependency(
+    group: String,
+    artifact: String,
+    version: String,
+    path: String? = null,
+    dependencies: List<Dependency> = emptyList()
+): Dependency {
+    val dependency = mockk<Dependency>()
+    every { dependency.groupId } returns group
+    every { dependency.artifactId } returns artifact
+    every { dependency.version } returns version
+    every { dependency.localPath } returns path
+    every { dependency.pomFile } returns "pom.xml"
+    every { dependency.dependencies } returns dependencies
+    every { dependency.warning } returns null
+    every { dependency.error } returns null
+    every { dependency.classifier } returns "jar"
+    every { dependency.extension } returns ""
+    return dependency
+}
+
+/**
+ * Create a [MavenSupport] mock object which is prepared to convert arbitrary artifacts to [Package] objects.
+ */
+private fun createMavenSupport(): MavenSupport {
+    val maven = mockk<MavenSupport>()
+    val slotArtifact = slot<DefaultArtifact>()
+    every { maven.parsePackage(capture(slotArtifact), remoteRepositories) } answers {
+        val artifact = slotArtifact.captured
+        val id = Identifier("Maven", artifact.groupId, artifact.artifactId, artifact.version)
+        Package(
+            id,
+            declaredLicenses = sortedSetOf(),
+            binaryArtifact = RemoteArtifact.EMPTY,
+            sourceArtifact = RemoteArtifact.EMPTY,
+            homepageUrl = "www.${artifact.artifactId}.org",
+            description = "Description of $artifact",
+            vcs = VcsInfo.EMPTY
+        )
+    }
+
+    return maven
+}
+
+/**
+ * Determine the type of the [Identifier] for this dependency.
+ */
+private fun Dependency.type(): String =
+    if (localPath != null) {
+        NAME
+    } else {
+        "Maven"
+    }
+
+/**
+ * Returns an [Identifier] for this [Dependency].
+ */
+private fun Dependency.toId() = Identifier(type(), groupId, artifactId, version)
+
+/**
+ * Return the package references from the given [scopes] associated with the scope with the given [scopeName].
+ */
+private fun scopeDependencies(
+    scopes: SortedSet<Scope>,
+    scopeName: String
+): Set<PackageReference> =
+    scopes.find { it.name == scopeName }?.dependencies.orEmpty()
+
+/**
+ * Extract the identifiers from a collection of package references.
+ */
+private fun Collection<PackageReference>.identifiers(): List<Identifier> = map { it.id }
+
+/**
+ * Find the package corresponding to the given [dependency] in this collection.
+ */
+private fun Collection<PackageReference>.findDependency(dependency: Dependency): PackageReference =
+    findId(dependency.toId())
+
+/**
+ * Find a package with the given [id] in this collection.
+ */
+private fun Collection<PackageReference>.findId(id: Identifier): PackageReference =
+    find { it.id == id } ?: throw IllegalArgumentException("Package with id $id is not contained in $this.")
+
+/**
+ * Return the identifiers of the dependencies of this [PackageReference].
+ */
+private fun PackageReference.dependencyIds(): List<Identifier> = dependencies.identifiers()
+
+/**
+ * Check whether this [PackageReference] contains exactly the given [dependencies][expectedDependencies].
+ */
+private fun PackageReference.checkDependencies(vararg expectedDependencies: Dependency): Set<PackageReference> {
+    dependencies shouldHaveSize expectedDependencies.size
+    val ids = expectedDependencies.map { it.toId() }
+    dependencyIds() should containExactlyInAnyOrder(ids)
+    return dependencies
+}

--- a/evaluator/src/test/kotlin/TestData.kt
+++ b/evaluator/src/test/kotlin/TestData.kt
@@ -121,7 +121,7 @@ val scopeExcluded = Scope(
 val projectExcluded = Project.EMPTY.copy(
     id = Identifier("Maven:org.ossreviewtoolkit:project-excluded:1.0"),
     definitionFilePath = "excluded/pom.xml",
-    scopes = sortedSetOf(scopeExcluded)
+    scopeDependencies = sortedSetOf(scopeExcluded)
 )
 
 val packageRefDynamicallyLinked = packageDynamicallyLinked.toReference(PackageLinkage.DYNAMIC)
@@ -143,7 +143,7 @@ val scopeIncluded = Scope(
 val projectIncluded = Project.EMPTY.copy(
     id = Identifier("Maven:org.ossreviewtoolkit:project-included:1.0"),
     definitionFilePath = "included/pom.xml",
-    scopes = sortedSetOf(scopeIncluded)
+    scopeDependencies = sortedSetOf(scopeIncluded)
 )
 
 val allProjects = listOf(

--- a/model/src/main/kotlin/DependencyGraph.kt
+++ b/model/src/main/kotlin/DependencyGraph.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+import java.lang.IllegalStateException
+import java.util.SortedSet
+
+/**
+ * A data class that represents the graph of dependencies of a project.
+ *
+ * This class holds information about a project's scopes and their dependencies in a format that minimizes the
+ * consumption of memory. In projects with many scopes there is often a high degree of duplication in the
+ * dependencies of the scopes. To avoid this, this class aims to share as many parts of the dependency graph as
+ * possible between the different scopes. Ideally, there is only a single dependency graph containing the dependencies
+ * used by all scopes. This is not always possibles due to inconsistencies in dependency relations, like a package
+ * using different dependencies in different scopes. Then the dependency graph is split into multiple fragments, and
+ * each fragment has a consistent view on the dependencies it contains.
+ *
+ * To further reduce memory consumption, package identifiers are not repeated, but are listed once and then referenced
+ * by indices. The storage format defined by this class is not really human-readable, but it causes a significant
+ * reduction of memory usage. On deserialization, the information stored can be manually converted again to a structure
+ * with [Scope] and [PackageReference] objects (with shared references, so keeping memory consumption low, too), so
+ * that it can be processed in the usual ways.
+ */
+data class DependencyGraph(
+    /**
+     * A list with the identifiers of the packages that appear in the dependency graph. This list is used to resolve
+     * the numeric indices contained in the [DependencyReference] objects.
+     */
+    val packages: List<String>,
+
+    /**
+     * Stores the dependency graph as a list of root nodes for the direct dependencies referenced by scopes. Starting
+     * with these nodes, the whole graph can be traversed. The nodes are constructed from the direct dependencies
+     * declared by scopes that cannot be reached via other paths in the dependency graph.
+     */
+    val scopeRoots: Set<DependencyReference>,
+
+    /**
+     * A mapping from scope names to the direct dependencies of the scopes. Based on this information, the set of
+     * [Scope]s of a project can be constructed from the serialized form.
+     */
+    val scopes: Map<String, List<RootDependencyIndex>>
+) {
+    /**
+     * Transform the data stored in this object to the classical layout of dependency information, which is a set of
+     * [Scope]s referencing the packages they depend on.
+     */
+    fun createScopes(): SortedSet<Scope> {
+        val refMapping = constructReferenceMapping()
+
+        return scopes.mapTo(sortedSetOf()) { entry ->
+            val dependencies = entry.value.mapTo(sortedSetOf()) { index ->
+                refMapping[index.toKey()] ?: throw IllegalStateException("Could not resolve dependency index $index.")
+            }
+
+            Scope(entry.key, dependencies)
+        }
+    }
+
+    /**
+     * Construct a mapping from dependency indices to [PackageReference] objects. Based on this mapping, the
+     * structure with [Scope]s can be generated.
+     */
+    private fun constructReferenceMapping(): Map<String, PackageReference> {
+        val refMapping = mutableMapOf<String, PackageReference>()
+
+        scopeRoots.forEach { tree ->
+            constructReferenceTree(tree, refMapping)
+        }
+
+        return refMapping
+    }
+
+    /**
+     * Construct the tree with [PackageReference]s by navigating the dependency tree starting with [ref] and
+     * populate the given [refMapping].
+     */
+    private fun constructReferenceTree(
+        ref: DependencyReference,
+        refMapping: MutableMap<String, PackageReference>
+    ): PackageReference {
+        val indexKey = RootDependencyIndex.generateKey(ref.pkg, ref.fragment)
+        return refMapping.getOrPut(indexKey) {
+            val dependencies = ref.dependencies.mapTo(sortedSetOf()) {
+                constructReferenceTree(it, refMapping)
+            }
+
+            PackageReference(
+                id = Identifier(packages[ref.pkg]),
+                dependencies = dependencies,
+                linkage = ref.linkage,
+                issues = ref.issues
+            )
+        }
+    }
+}
+
+/**
+ * A data class representing the index of a root dependency of a scope.
+ *
+ * Instances of this class are used to reference the direct dependencies of scopes in the shared dependency graph.
+ * These dependencies form the roots of the dependency trees spawned by scopes.
+ */
+data class RootDependencyIndex(
+    /**
+     * The index of the root dependency referenced by this object. Each package acting as a dependency is assigned a
+     * unique index. Storing an index rather than an identifier reduces the amount of memory consumed by this
+     * representation.
+     */
+    val root: Int,
+
+    /**
+     * The index of the fragment of the dependency graph this reference points to. This is used to distinguish between
+     * packages that occur multiple times in the dependency graph with different dependencies.
+     */
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    val fragment: Int = 0
+) {
+    companion object {
+        /**
+         * Generate a string representation for the given [root] and [fragment] that is used internally as key
+         * in maps.
+         */
+        fun generateKey(root: Int, fragment: Int): String = "$root.$fragment"
+    }
+
+    /**
+     * Generate a string key to represent this index.
+     */
+    fun toKey(): String = generateKey(root, fragment)
+}
+
+/**
+ * A class to model a tree-like structure to represent the dependencies of a project.
+ *
+ * Instances of this class are used to store the relations between dependencies in fragments of dependency trees in an
+ * Analyzer result. The main purpose of this class is to define an efficient serialization format, which avoids
+ * redundancy as far as possible. Therefore, dependencies are represented by numeric indices into an external table.
+ * As a dependency can occur multiple times in the dependency graph with different transitive dependencies, the class
+ * defines another index to distinguish these cases.
+ *
+ * Note: This is by intention no data class. Equality is tested via references and not via the values contained.
+ */
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+class DependencyReference(
+    /**
+     * Stores the numeric index of the package dependency referenced by this object. The package behind this index can
+     * be resolved by evaluating the list of identifiers stored in [DependencyGraph] at this index.
+     */
+    val pkg: Int,
+
+    /**
+     * Stores the index of the fragment in the dependency graph where the referenced dependency is contained. This is
+     * needed to uniquely identify the target if the dependency occurs multiple times in the graph.
+     */
+    val fragment: Int = 0,
+
+    /**
+     * A set with the references to the dependencies of this dependency. That way a tree-like structure is established.
+     */
+    val dependencies: SortedSet<DependencyReference> = sortedSetOf(),
+
+    /**
+     * The type of linkage used for the referred package from its dependent package. As most of our supported
+     * package managers / languages only support dynamic linking or at least default to it, also use that as the
+     * default value here to not blow up our result files.
+     */
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = PackageLinkageValueFilter::class)
+    val linkage: PackageLinkage = PackageLinkage.DYNAMIC,
+
+    /**
+     * A list of [OrtIssue]s that occurred handling this dependency.
+     */
+    val issues: List<OrtIssue> = emptyList()
+) : Comparable<DependencyReference> {
+    /**
+     * Define an order on [DependencyReference] instances. Instances are ordered by their indices and fragment indices.
+     */
+    override fun compareTo(other: DependencyReference): Int =
+        if (pkg != other.pkg) {
+            pkg - other.pkg
+        } else {
+            fragment - other.fragment
+        }
+}

--- a/model/src/test/kotlin/DependencyGraphTest.kt
+++ b/model/src/test/kotlin/DependencyGraphTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import java.util.SortedSet
+
+class DependencyGraphTest : WordSpec({
+    "createScopes()" should {
+        "construct a simple tree with scopes" {
+            val ids = listOf(
+                id("org.apache.commons", "commons-lang3", "3.11"),
+                id("org.apache.commons", "commons-collections4", "4.4"),
+                id(group = "org.junit", artifact = "junit", version = "5")
+            )
+            val fragments =
+                setOf(
+                    DependencyReference(0),
+                    DependencyReference(1),
+                    DependencyReference(2)
+                )
+            val scopeMap = mapOf(
+                "scope1" to listOf(RootDependencyIndex(0), RootDependencyIndex(1)),
+                "scope2" to listOf(RootDependencyIndex(1), RootDependencyIndex(2))
+            )
+
+            val graph = DependencyGraph(ids, fragments, scopeMap)
+            val scopes = graph.createScopes()
+
+            scopes.map { it.name } should containExactly("scope1", "scope2")
+            scopeDependencies(scopes, "scope1") shouldBe "${pkgId(ids[1])}${pkgId(ids[0])}"
+            scopeDependencies(scopes, "scope2") shouldBe "${pkgId(ids[1])}${pkgId(ids[2])}"
+        }
+
+        "construct a tree with multiple levels" {
+            val ids = listOf(
+                id("org.apache.commons", "commons-lang3", "3.11"),
+                id("org.apache.commons", "commons-collections4", "4.4"),
+                id("org.apache.commons", "commons-configuration2", "2.8"),
+                id("org.apache.commons", "commons-csv", "1.5")
+            )
+            val refLang = DependencyReference(0)
+            val refCollections = DependencyReference(1)
+            val refConfig = DependencyReference(2, dependencies = sortedSetOf(refLang, refCollections))
+            val refCsv = DependencyReference(3, dependencies = sortedSetOf(refConfig))
+            val fragments = setOf(refCsv)
+            val scopeMap = mapOf("s" to listOf(RootDependencyIndex(3)))
+            val graph = DependencyGraph(ids, fragments, scopeMap)
+            val scopes = graph.createScopes()
+
+            scopeDependencies(scopes, "s") shouldBe "${pkgId(ids[3])}<${pkgId(ids[2])}<${pkgId(ids[1])}" +
+                    "${pkgId(ids[0])}>>"
+        }
+
+        "construct scopes from different fragments" {
+            val ids = listOf(
+                id("org.apache.commons", "commons-lang3", "3.11"),
+                id("org.apache.commons", "commons-collections4", "4.4"),
+                id("org.apache.commons", "commons-configuration2", "2.8"),
+                id("org.apache.commons", "commons-logging", "1.3")
+            )
+            val refLogging = DependencyReference(3)
+            val refLang = DependencyReference(0)
+            val refCollections1 = DependencyReference(1)
+            val refCollections2 = DependencyReference(1, fragment = 1, dependencies = sortedSetOf(refLogging))
+            val refConfig1 = DependencyReference(2, dependencies = sortedSetOf(refLang, refCollections1))
+            val refConfig2 =
+                DependencyReference(2, fragment = 1, dependencies = sortedSetOf(refLang, refCollections2))
+            val fragments = setOf(refConfig1, refConfig2)
+            val scopeMap = mapOf(
+                "s1" to listOf(RootDependencyIndex(2)),
+                "s2" to listOf(RootDependencyIndex(2, fragment = 1))
+            )
+
+            val graph = DependencyGraph(ids, fragments, scopeMap)
+            val scopes = graph.createScopes()
+
+            scopeDependencies(scopes, "s1") shouldBe "${pkgId(ids[2])}<${pkgId(ids[1])}${pkgId(ids[0])}>"
+            scopeDependencies(scopes, "s2") shouldBe "${pkgId(ids[2])}<${pkgId(ids[1])}<${pkgId(ids[3])}>" +
+                    "${pkgId(ids[0])}>"
+        }
+
+        "deal with attributes of package references" {
+            val ids = listOf(
+                id("org.apache.commons", "commons-lang3", "3.10"),
+                id("org.apache.commons", "commons-collections4", "4.4")
+            )
+            val issue = OrtIssue(source = "analyzer", message = "Could not analyze :-(")
+            val refLang = DependencyReference(0, linkage = PackageLinkage.PROJECT_DYNAMIC)
+            val refCol = DependencyReference(1, issues = listOf(issue), dependencies = sortedSetOf(refLang))
+            val trees = setOf(refCol)
+            val scopeMap = mapOf("s" to listOf(RootDependencyIndex(1)))
+
+            val graph = DependencyGraph(ids, trees, scopeMap)
+            val scopes = graph.createScopes()
+            val scope = scopes.first()
+
+            scope.shouldNotBeNull()
+            scope.dependencies shouldHaveSize 1
+            val pkgRefCol = scope.dependencies.first()
+            pkgRefCol.issues should containExactly(issue)
+            pkgRefCol.dependencies shouldHaveSize 1
+
+            val pkgRefLang = pkgRefCol.dependencies.first()
+            pkgRefLang.linkage shouldBe PackageLinkage.PROJECT_DYNAMIC
+        }
+    }
+})
+
+/** The name of the dependency manager used by tests. */
+private const val MANAGER_NAME = "TestManager"
+
+/**
+ * Create an identifier string with the given [group], [artifact] ID and [version].
+ */
+private fun id(group: String, artifact: String, version: String): String = "$MANAGER_NAME:$group:$artifact:$version"
+
+/**
+ * Create an [Identifier] based on the given [id] string.
+ */
+private fun pkgId(id: String): Identifier = Identifier(id)
+
+/**
+ * Output the dependency tree of the given scope as a string.
+ */
+private fun scopeDependencies(scopes: SortedSet<Scope>, name: String): String = buildString {
+    scopes.find { it.name == name }?.let { scope ->
+        scope.dependencies.forEach { dumpDependencies(it) }
+    }
+}
+
+/**
+ * Transform a dependency tree structure starting at [ref] to a string.
+ */
+private fun StringBuilder.dumpDependencies(ref: PackageReference) {
+    append(ref.id)
+    if (ref.dependencies.isNotEmpty()) {
+        append('<')
+        ref.dependencies.forEach { dumpDependencies(it) }
+        append('>')
+    }
+}

--- a/model/src/test/kotlin/ProjectTest.kt
+++ b/model/src/test/kotlin/ProjectTest.kt
@@ -19,13 +19,18 @@
 
 package org.ossreviewtoolkit.model
 
+import io.kotest.assertions.fail
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 
 import java.io.File
 import java.time.Instant
+import java.util.SortedSet
 
 import org.ossreviewtoolkit.utils.test.containExactly
 
@@ -33,6 +38,71 @@ private fun readAnalyzerResult(analyzerResultFilename: String): Project =
     File("../analyzer/src/funTest/assets/projects/synthetic")
         .resolve(analyzerResultFilename)
         .readValue<ProjectAnalyzerResult>().project
+
+private const val MANAGER = "MyManager"
+
+private val exampleId = Identifier("$MANAGER:org.ossreviewtoolkit.gradle.example:lib:1.0.0")
+private val textId = Identifier("$MANAGER:org.apache.commons:commons-text:1.1")
+private val langId = Identifier("$MANAGER:org.apache.commons:commons-lang3:3.5")
+private val strutsId = Identifier("$MANAGER:org.apache.struts:struts2-assembly:2.5.14.1")
+private val csvId = Identifier("$MANAGER:org.apache.commons:commons-csv:1.4")
+
+/**
+ * Create a [Project] whose dependencies are represented as a [DependencyGraph].
+ */
+private fun projectWithDependencyGraph(): Project =
+    Project(
+        id = Identifier.EMPTY,
+        definitionFilePath = "/some/path",
+        declaredLicenses = sortedSetOf(),
+        vcs = VcsInfo.EMPTY,
+        homepageUrl = "https//www.test-project.org",
+        scopeDependencies = sortedSetOf(),
+        dependencyGraph = createDependencyGraph()
+    )
+
+/**
+ * Create a [DependencyGraph] containing some test dependencies.
+ */
+private fun createDependencyGraph(): DependencyGraph {
+    val dependencies = listOf(
+        langId.toDependencyId(),
+        textId.toDependencyId(),
+        strutsId.toDependencyId(),
+        csvId.toDependencyId(),
+        exampleId.toDependencyId()
+    )
+    val langRef = DependencyReference(0)
+    val textRef = DependencyReference(1, dependencies = sortedSetOf(langRef))
+    val strutsRef = DependencyReference(2)
+    val csvRef = DependencyReference(3, dependencies = sortedSetOf(langRef))
+    val exampleRef = DependencyReference(4, dependencies = sortedSetOf(textRef, strutsRef))
+
+    val scopeMapping = mapOf(
+        "default" to listOf(RootDependencyIndex(4)),
+        "compile" to listOf(RootDependencyIndex(4)),
+        "test" to listOf(RootDependencyIndex(4), RootDependencyIndex(3)),
+        "partial" to listOf(RootDependencyIndex(1))
+    )
+
+    return DependencyGraph(dependencies, setOf(exampleRef, csvRef), scopeMapping)
+}
+
+/**
+ * Construct the short reference from this [Identifier] used internally by the dependency graph.
+ */
+private fun Identifier.toDependencyId() = "$MANAGER:$namespace:$name:$version"
+
+/**
+ * Lookup the scope with the given [name] in the set of [scopes].
+ */
+private fun findScope(scopes: SortedSet<Scope>, name: String): Scope =
+    scopes.find { it.name == name } ?: fail("Could not resolve scope $name.")
+
+/**
+ * Return a set with the identifiers of the (direct) dependencies of the given [scope].
+ */
+private fun scopeDependencies(scope: Scope): Set<Identifier> = scope.dependencies.map { it.id }.toSet()
 
 class ProjectTest : WordSpec({
     "collectDependencies" should {
@@ -95,6 +165,55 @@ class ProjectTest : WordSpec({
                     )
                 )
             )
+        }
+    }
+
+    "scopes" should {
+        "be initialized from scope dependencies" {
+            val project = readAnalyzerResult("maven-expected-output-app.yml")
+
+            project.scopes shouldBe project.scopeDependencies
+        }
+
+        "be initialized from a dependency graph" {
+            val project = projectWithDependencyGraph()
+            val scopes = project.scopes
+            scopes.map { it.name } shouldContainExactly listOf("compile", "default", "partial", "test")
+
+            val defaultScope = findScope(scopes, "default")
+            scopeDependencies(defaultScope) should io.kotest.matchers.collections.containExactly(exampleId)
+            val testScope = findScope(scopes, "test")
+            scopeDependencies(testScope) should containExactlyInAnyOrder(exampleId, csvId)
+            val partialScope = findScope(scopes, "partial")
+            scopeDependencies(partialScope) should io.kotest.matchers.collections.containExactly(textId)
+        }
+
+        "be initialized to an empty set if no information is available" {
+            val project = Project(
+                id = Identifier.EMPTY,
+                definitionFilePath = "/some/path",
+                declaredLicenses = sortedSetOf(),
+                vcs = VcsInfo.EMPTY,
+                homepageUrl = "https//www.test-project.org",
+                scopeDependencies = null,
+                dependencyGraph = null
+            )
+
+            project.scopes.shouldBeEmpty()
+        }
+    }
+
+    "A Project" should {
+        "be serializable with a dependency graph" {
+            val outputFile = kotlin.io.path.createTempFile(prefix = "project", suffix = ".yml").toFile().apply {
+                deleteOnExit()
+            }
+
+            val project = projectWithDependencyGraph()
+            jsonMapper.writeValue(outputFile, project)
+
+            val projectCopy = jsonMapper.readValue(outputFile, Project::class.java)
+            projectCopy.scopes shouldBe project.scopes
         }
     }
 })

--- a/model/src/test/kotlin/config/ExcludesTest.kt
+++ b/model/src/test/kotlin/config/ExcludesTest.kt
@@ -147,7 +147,7 @@ class ExcludesTest : WordSpec() {
         "isExcluded" should {
             "return false if the project is not found" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1))
                 )
 
                 ortResult.isExcluded(project2.id) shouldBe false
@@ -163,7 +163,7 @@ class ExcludesTest : WordSpec() {
 
             "return false if the package is not excluded" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1))
                 )
 
                 ortResult.isExcluded(id) shouldBe false
@@ -171,8 +171,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all projects depending on a package are excluded by path excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -184,8 +184,8 @@ class ExcludesTest : WordSpec() {
 
             "return false if only part of the projects depending on a package are excluded by path excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -197,8 +197,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all scopes containing the package are excluded by scope excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -210,8 +210,8 @@ class ExcludesTest : WordSpec() {
 
             "return false if only part of the scopes containing the package are excluded by scope excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -223,8 +223,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all dependencies on the package are excluded by path or scope excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -250,7 +250,7 @@ class ExcludesTest : WordSpec() {
             "return true if a project and all dependencies on the project are excluded by path excludes" {
                 setProjects(
                     project1,
-                    project2.copy(scopes = sortedSetOf(scopeProject1))
+                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1))
                 )
 
                 setExcludes(
@@ -263,7 +263,7 @@ class ExcludesTest : WordSpec() {
             "return true if a project is excluded by path excludes and all dependencies on the project are excluded by scope excludes" {
                 setProjects(
                     project1,
-                    project2.copy(scopes = sortedSetOf(scopeProject1))
+                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1))
                 )
 
                 setExcludes(
@@ -277,7 +277,7 @@ class ExcludesTest : WordSpec() {
             "return false if a project is excluded by path excludes but not all dependencies on the project are excluded" {
                 setProjects(
                     project1,
-                    project2.copy(scopes = sortedSetOf(scopeProject1))
+                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1))
                 )
 
                 setExcludes(
@@ -290,7 +290,7 @@ class ExcludesTest : WordSpec() {
             "return false if a project is not excluded but all dependencies on the project are excluded" {
                 setProjects(
                     project1,
-                    project2.copy(scopes = sortedSetOf(scopeProject1))
+                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1))
                 )
 
                 setExcludes(
@@ -312,7 +312,7 @@ class ExcludesTest : WordSpec() {
 
             "return false if the package is not excluded" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1))
                 )
 
                 ortResult.isPackageExcluded(id) shouldBe false
@@ -320,8 +320,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all projects depending on a package are excluded by path excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -333,8 +333,8 @@ class ExcludesTest : WordSpec() {
 
             "return false if only part of the projects depending on a package are excluded by path excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -346,8 +346,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all scopes containing the package are excluded by scope excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -359,8 +359,8 @@ class ExcludesTest : WordSpec() {
 
             "return false if only part of the scopes containing the package are excluded by scope excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -372,8 +372,8 @@ class ExcludesTest : WordSpec() {
 
             "return true if all dependencies on the package are excluded by path or scope excludes" {
                 setProjects(
-                    project1.copy(scopes = sortedSetOf(scope1)),
-                    project2.copy(scopes = sortedSetOf(scope2))
+                    project1.copy(scopeDependencies = sortedSetOf(scope1)),
+                    project2.copy(scopeDependencies = sortedSetOf(scope2))
                 )
 
                 setExcludes(
@@ -387,7 +387,7 @@ class ExcludesTest : WordSpec() {
             "return true if all dependencies on the project are excluded" {
                 setProjects(
                     project1,
-                    project2.copy(scopes = sortedSetOf(scopeProject1, scopeProject1.copy(name = "scope")))
+                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1, scopeProject1.copy(name = "scope")))
                 )
 
                 setExcludes(
@@ -400,7 +400,7 @@ class ExcludesTest : WordSpec() {
             "return false if not all dependencies on the project are excluded" {
                 setProjects(
                     project1,
-                    project2.copy(scopes = sortedSetOf(scopeProject1, scopeProject1.copy(name = "scope")))
+                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1, scopeProject1.copy(name = "scope")))
                 )
 
                 setExcludes(
@@ -413,7 +413,7 @@ class ExcludesTest : WordSpec() {
             "return false if no dependencies on the project are excluded" {
                 setProjects(
                     project1,
-                    project2.copy(scopes = sortedSetOf(scopeProject1))
+                    project2.copy(scopeDependencies = sortedSetOf(scopeProject1))
                 )
 
                 ortResult.isPackageExcluded(project1.id) shouldBe false

--- a/model/src/test/kotlin/licenses/TestData.kt
+++ b/model/src/test/kotlin/licenses/TestData.kt
@@ -129,7 +129,7 @@ val scope = Scope(
 val project = Project.EMPTY.copy(
     id = Identifier("Maven:org.ossreviewtoolkit:project-included:1.0"),
     definitionFilePath = "included/pom.xml",
-    scopes = sortedSetOf(scope)
+    scopeDependencies = sortedSetOf(scope)
 )
 
 val provenance = Provenance(sourceArtifact = RemoteArtifact.EMPTY)

--- a/reporter/src/funTest/kotlin/TestData.kt
+++ b/reporter/src/funTest/kotlin/TestData.kt
@@ -81,7 +81,7 @@ val ORT_RESULT = OrtResult(
                     declaredLicenses = sortedSetOf(),
                     vcs = VcsInfo.EMPTY,
                     homepageUrl = "",
-                    scopes = sortedSetOf(
+                    scopeDependencies = sortedSetOf(
                         Scope(
                             name = "dependencies",
                             dependencies = sortedSetOf(
@@ -110,7 +110,7 @@ val ORT_RESULT = OrtResult(
                     declaredLicenses = sortedSetOf(),
                     vcs = VcsInfo.EMPTY,
                     homepageUrl = "",
-                    scopes = sortedSetOf(
+                    scopeDependencies = sortedSetOf(
                         Scope(
                             name = "dependencies",
                             dependencies = sortedSetOf()
@@ -123,7 +123,7 @@ val ORT_RESULT = OrtResult(
                     declaredLicenses = sortedSetOf("BSD-2-Clause"),
                     vcs = VcsInfo.EMPTY,
                     homepageUrl = "",
-                    scopes = sortedSetOf()
+                    scopeDependencies = sortedSetOf()
                 )
             ),
             packages = sortedSetOf(

--- a/reporter/src/funTest/kotlin/reporters/GitLabLicenseModelReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/GitLabLicenseModelReporterFunTest.kt
@@ -100,7 +100,7 @@ private fun createOrtResult(): OrtResult {
                     Project.EMPTY.copy(
                         id = Identifier("Gradle:some-group:some-gradle-project:0.0.1"),
                         definitionFilePath = "some/path/build.gradle",
-                        scopes = sortedSetOf(
+                        scopeDependencies = sortedSetOf(
                             Scope(
                                 name = "compile",
                                 dependencies = sortedSetOf(
@@ -121,7 +121,7 @@ private fun createOrtResult(): OrtResult {
                     ),
                     Project.EMPTY.copy(
                         id = Identifier("PIP::some-pip-project:0.0.2"),
-                        scopes = sortedSetOf(
+                        scopeDependencies = sortedSetOf(
                             Scope(
                                 name = "install",
                                 dependencies = sortedSetOf(

--- a/reporter/src/funTest/kotlin/reporters/SpdxDocumentReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/SpdxDocumentReporterFunTest.kt
@@ -165,7 +165,7 @@ private fun createOrtResult(): OrtResult {
                         declaredLicenses = sortedSetOf("MIT"),
                         definitionFilePath = "",
                         homepageUrl = "first project's homepage",
-                        scopes = sortedSetOf(
+                        scopeDependencies = sortedSetOf(
                             Scope(
                                 name = "compile",
                                 dependencies = sortedSetOf(


### PR DESCRIPTION
This PR addresses #3321 by proposing a more efficient storage format for the dependency representation in Gradle analyzer results. The basic idea is to not repeat the dependency trees for all scopes, but construct an optimized dependency graph, in which dependencies are shared. Ideally, in this graph each dependency occurs once. However, as sometimes packages are referenced from scopes with different sets of dependencies, multiple occurrences are possible.

The most important class of this PR is the new `GradleDependencyGraphBuilder` class that integrates the project's dependencies into a dependency graph (represented by the `DependencyGraph` class). The class is currently specific to Gradle, but it should be possible to make it more generic, so that other analyzer implementations can make use of this optimized format as well.

Here are some numbers to give an impression of the size reduction of the dependency representation. The numbers are based on the [Mozilla Focus Android](https://github.com/mozilla-mobile/focus-android.git) project, which was used for testing. This project uses a large number of scopes causing the dependency graph in the old representation to become really huge:

Original representation:
```
Analyzer execution time: 55:55
Result file size: 1,2 GB
Time to load the result:  111539ms
In-memory representation of analyzer result 1)
byte[]:     45.883.121
String:     45.880.168
Identifier: 11.462.288
PackageRef: 11.461.897
```
New representation:
```
Analyzer execution time: 44:55 2)
Result file size: 46 MB
Time to load the result:  5509ms
In-memory representation of analyzer result 1)
byte[]:         36.154
String:         33.200
DependencyRef: 376.067 3)
DependencyIdx:  10.708
Identifier:        892
PackageRef:        501  4)
```

Remarks:
1) Number of instances of the listed classes, taken from the Memory view of the IntelliJ Debugger.
2) Not sure about the execution time, I actually expected the new approach to take slightly longer because of the additional effort to de-duplicate the dependency graph; however, as this is all done in-memory, it probably does not have a major impact. So the differences in the times could be caused by varying load of our Azure setup.
3) `DependencyRef` is the counter-part of `PackageRef` in the new dependency graph representation. It references dependencies by a numeric index rather than an identifier.
4) From the new dependency graph representation the set of `Scope`s is constructed, but also in an optimized form (shared references to packages). Therefore, the number of `PackageRef` instances is low.
