### PR TITLE
Scanner: Generalize the ignore file list and make it configurable

### DIFF
--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -22,7 +22,6 @@ package org.ossreviewtoolkit.model.config
 import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
-import org.ossreviewtoolkit.spdx.NON_LICENSE_FILENAMES
 import org.ossreviewtoolkit.utils.storage.FileArchiver
 import org.ossreviewtoolkit.utils.storage.FileStorage
 
@@ -65,5 +64,8 @@ data class ScannerConfiguration(
     /**
      * A list of glob expressions that match file paths which are to be excluded from scan results.
      */
-    val ignorePatterns: List<String> = NON_LICENSE_FILENAMES
+    val ignorePatterns: List<String> = listOf(
+        "**/HERE_NOTICE",
+        "**/META-INF/DEPENDENCIES"
+    )
 )

--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.model.config
 import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
+import org.ossreviewtoolkit.spdx.NON_LICENSE_FILENAMES
 import org.ossreviewtoolkit.utils.storage.FileArchiver
 import org.ossreviewtoolkit.utils.storage.FileStorage
 
@@ -59,5 +60,10 @@ data class ScannerConfiguration(
      * A list with the IDs of scan storages that are called to persist scan results. The strings in this list
      * must match keys in the storages map.
      */
-    val storageWriters: List<String>? = null
+    val storageWriters: List<String>? = null,
+
+    /**
+     * A list of glob expressions that match file paths which are to be excluded from scan results.
+     */
+    val ignorePatterns: List<String> = NON_LICENSE_FILENAMES
 )

--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -65,7 +65,6 @@ data class ScannerConfiguration(
      * A list of glob expressions that match file paths which are to be excluded from scan results.
      */
     val ignorePatterns: List<String> = listOf(
-        "**/HERE_NOTICE",
         "**/META-INF/DEPENDENCIES"
     )
 )

--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -65,6 +65,7 @@ data class ScannerConfiguration(
      * A list of glob expressions that match file paths which are to be excluded from scan results.
      */
     val ignorePatterns: List<String> = listOf(
+        "**/*.ort.yml",
         "**/META-INF/DEPENDENCIES"
     )
 )

--- a/model/src/test/assets/reference.conf
+++ b/model/src/test/assets/reference.conf
@@ -89,5 +89,9 @@ ort {
     storageWriters: [
       "postgres"
     ]
+
+    ignorePatterns: [
+      "**/META-INF/DEPENDENCIES"
+    ]
   }
 }

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -101,6 +101,8 @@ class OrtConfigurationTest : WordSpec({
                 options.shouldNotBeNull()
                 storageReaders shouldContainExactly listOf("local", "postgres", "http", "clearlyDefined")
                 storageWriters shouldContainExactly listOf("postgres")
+
+                ignorePatterns shouldContainExactly listOf("**/META-INF/DEPENDENCIES")
             }
 
             ortConfig.licenseFilePatterns shouldNotBeNull {

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -209,6 +209,9 @@ scanner:
     storages: null
     storage_readers: null
     storage_writers: null
+    ignore_patterns:
+    - "**/HERE_NOTICE"
+    - "**/META-INF/DEPENDENCIES"
   results:
     scan_results:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -210,6 +210,7 @@ scanner:
     storage_readers: null
     storage_writers: null
     ignore_patterns:
+    - "**/*.ort.yml"
     - "**/META-INF/DEPENDENCIES"
   results:
     scan_results:

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -210,7 +210,6 @@ scanner:
     storage_readers: null
     storage_writers: null
     ignore_patterns:
-    - "**/HERE_NOTICE"
     - "**/META-INF/DEPENDENCIES"
   results:
     scan_results:

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -63,7 +63,6 @@ import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.scanner.storages.PostgresStorage
-import org.ossreviewtoolkit.spdx.NON_LICENSE_FILENAMES
 import org.ossreviewtoolkit.utils.CommandLineTool
 import org.ossreviewtoolkit.utils.NamedThreadFactory
 import org.ossreviewtoolkit.utils.Os
@@ -273,7 +272,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
                 // Due to a temporary bug that has been fixed by now the scan results for packages were not properly
                 // filtered by VCS path. Filter them again to fix the problem.
                 // TODO: This filtering can be removed after a while.
-                storedResults.map { it.filterByVcsPath().filterByIgnorePatterns(NON_LICENSE_FILENAMES) }
+                storedResults.map { it.filterByVcsPath().filterByIgnorePatterns(config.ignorePatterns) }
             } else {
                 withContext(scanDispatcher) {
                     log.info {
@@ -404,7 +403,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
         }
 
         val storageResult = ScanResultsStorage.storage.add(pkg.id, scanResult)
-        val filteredResult = scanResult.filterByIgnorePatterns(NON_LICENSE_FILENAMES)
+        val filteredResult = scanResult.filterByIgnorePatterns(config.ignorePatterns)
 
         return when (storageResult) {
             is Success -> filteredResult
@@ -469,7 +468,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
                 log.info {
                     "Detected licenses for path '$absoluteInputPath': ${it.summary.licenses.joinToString()}"
                 }
-            }.filterByIgnorePatterns(NON_LICENSE_FILENAMES)
+            }.filterByIgnorePatterns(config.ignorePatterns)
         } catch (e: ScanException) {
             e.showStackTrace()
 

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -270,7 +270,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
                 }
 
                 // Due to a temporary bug that has been fixed by now the scan results for packages were not properly
-                // filtered. Filter them again to fix the problem also scan storage entries which exhibit that problem.
+                // filtered by VCS path. Filter them again to fix the problem.
                 // TODO: This filtering can be removed after a while.
                 storedResults.map { it.filterByVcsPath() }
             } else {

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -43,7 +43,6 @@ import org.ossreviewtoolkit.scanner.AbstractScannerFactory
 import org.ossreviewtoolkit.scanner.LocalScanner
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
-import org.ossreviewtoolkit.spdx.NON_LICENSE_FILENAMES
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.ORT_REPO_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.OkHttpClientHelper
@@ -92,7 +91,7 @@ class ScanCode(
             "--info",
             "--strip-root",
             "--timeout", TIMEOUT.toString()
-        ) + NON_LICENSE_FILENAMES.flatMap { listOf("--ignore", it) }
+        )
 
         /**
          * Configuration options that are not relevant for [getConfiguration] because they do not change the result

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -44,7 +44,6 @@ import org.ossreviewtoolkit.scanner.LocalScanner
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.utils.ORT_NAME
-import org.ossreviewtoolkit.utils.ORT_REPO_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.Os
 import org.ossreviewtoolkit.utils.ProcessCapture
@@ -87,7 +86,6 @@ class ScanCode(
         private val DEFAULT_CONFIGURATION_OPTIONS = listOf(
             "--copyright",
             "--license",
-            "--ignore", "*$ORT_REPO_CONFIG_FILENAME",
             "--info",
             "--strip-root",
             "--timeout", TIMEOUT.toString()

--- a/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
@@ -33,7 +33,7 @@ class ScanCodeTest : WordSpec({
         "return the default values if the scanner configuration is empty" {
             scanner.configuration shouldBe
                     "--copyright --license --ignore *$ORT_REPO_CONFIG_FILENAME --info --strip-root --timeout 300 " +
-                    "--ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp --license-diag"
+                    "--json-pp --license-diag"
         }
 
         "return the non-config values from the scanner configuration" {
@@ -58,8 +58,7 @@ class ScanCodeTest : WordSpec({
         "contain the default values if the scanner configuration is empty" {
             scanner.commandLineOptions.joinToString(" ") shouldMatch
                     "--copyright --license --ignore \\*$ORT_REPO_CONFIG_FILENAME --info --strip-root --timeout 300 " +
-                        "--ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --processes \\d+ --license-diag " +
-                        "--verbose"
+                        "--processes \\d+ --license-diag --verbose"
         }
 
         "contain the values from the scanner configuration" {

--- a/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
@@ -24,7 +24,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldMatch
 
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.utils.ORT_REPO_CONFIG_FILENAME
 
 class ScanCodeTest : WordSpec({
     val scanner = ScanCode("ScanCode", ScannerConfiguration())
@@ -32,7 +31,7 @@ class ScanCodeTest : WordSpec({
     "getConfiguration()" should {
         "return the default values if the scanner configuration is empty" {
             scanner.configuration shouldBe
-                    "--copyright --license --ignore *$ORT_REPO_CONFIG_FILENAME --info --strip-root --timeout 300 " +
+                    "--copyright --license --info --strip-root --timeout 300 " +
                     "--json-pp --license-diag"
         }
 
@@ -57,7 +56,7 @@ class ScanCodeTest : WordSpec({
     "commandLineOptions" should {
         "contain the default values if the scanner configuration is empty" {
             scanner.commandLineOptions.joinToString(" ") shouldMatch
-                    "--copyright --license --ignore \\*$ORT_REPO_CONFIG_FILENAME --info --strip-root --timeout 300 " +
+                    "--copyright --license --info --strip-root --timeout 300 " +
                         "--processes \\d+ --license-diag --verbose"
         }
 

--- a/spdx-utils/src/main/kotlin/SpdxUtils.kt
+++ b/spdx-utils/src/main/kotlin/SpdxUtils.kt
@@ -32,14 +32,6 @@ import java.util.EnumSet
 import org.ossreviewtoolkit.spdx.SpdxExpression.Strictness
 
 /**
- * A list of globs that match file names which are not license files but typically trigger false-positives.
- */
-val NON_LICENSE_FILENAMES = listOf(
-    "**/HERE_NOTICE",
-    "**/META-INF/DEPENDENCIES"
-)
-
-/**
  * A list of directories used by version control systems to store metadata.
  */
 val VCS_DIRECTORIES = listOf(

--- a/spdx-utils/src/main/kotlin/SpdxUtils.kt
+++ b/spdx-utils/src/main/kotlin/SpdxUtils.kt
@@ -35,8 +35,8 @@ import org.ossreviewtoolkit.spdx.SpdxExpression.Strictness
  * A list of globs that match file names which are not license files but typically trigger false-positives.
  */
 val NON_LICENSE_FILENAMES = listOf(
-    "HERE_NOTICE",
-    "META-INF/DEPENDENCIES"
+    "**/HERE_NOTICE",
+    "**/META-INF/DEPENDENCIES"
 )
 
 /**


### PR DESCRIPTION
Remove the filtering of 'non-license-files' from ScanCode in favor of a  configurable 'ignore file path' list which is applied consistently across all (local) scanner implementations. This makes things simpler and more general. Furthermore it allows for changing the configuration option in the future without invalidating the already existing scan cache entries - as the filtering is applied only after the scan results are stored.

**Migrating the Postgres scan results database**

This PR changes the scanner details which has the effect that entries stored in the scan results database do no match anymore.
This can be fixed by updating the `configuration` property of the scan results. Here's how this can be done in PostgreSQL

1. Determine the value(s) of the `scanner.configuration` property of the stored scan results
```
SELECT
  scan_result->'scanner'->>'configuration', 
  COUNT(*)
FROM 
  scan_results 
GROUP BY 
  scan_result->'scanner'->>'configuration'
```
In my case this yields:
 ```
--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp
```

2. Duplicate all entries in `scan_results` table, which have `scanner.configuration` equal to the one determined in step 1,
    Updating the value to the value the configuration property will hold after this PR is merged.
```
INSERT INTO 
  scan_results (identifier, scan_result)
SELECT 
  identifier, 
  jsonb_set(scan_result, '{scanner,configuration}', jsonb('"--copyright --license --info --strip-root --timeout 300 --json-pp"')) as scan_result
FROM 
  scan_results 
WHERE 
  scan_result->'scanner'->>'configuration' = '--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp'
```

3. Verify that it works by running a scan and check if cached scan results get picked up

4. Merge this PR / upgrade infrastructure to use latest ORT

5. Delete the original entries (the ones with `scanner.configuration` equal to the one determined in step 1.
```
DELETE FROM 
  scan_results 
WHERE
  scan_result->'scanner'->>'configuration' = '--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp'
```

6. Actually free disk space
```
VACUUM FULL scan_results;
```
 