### PR TITLE
Account for "ort.analyzer.allowDynamicVersions" now being a global option

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -91,10 +91,10 @@ Writing analyzer result to '[analyzer-output-dir]/analyzer-result.yml'.
 
 This happens because `mime-types` does not have `package-lock.json` file. Without this file the versions of (transitive)
 dependencies that are defined with version ranges could change at any time, leading to different results of the
-analyzer. To override this check, use the `-P ort.analyzer.allowDynamicVersions=true` option:
+analyzer. To override this check, use the global `-P ort.analyzer.allowDynamicVersions=true` option:
 
 ```bash
-$ cli/build/install/ort/bin/ort analyze -i [mime-types-dir] -o [analyzer-output-dir] -P ort.analyzer.allowDynamicVersions=true
+$ cli/build/install/ort/bin/ort -P ort.analyzer.allowDynamicVersions=true analyze -i [mime-types-dir] -o [analyzer-output-dir]
 The following package managers are activated:
         Bundler, Composer, GoDep, Gradle, Maven, NPM, PIP, SBT, Stack, Yarn
 Analyzing project path:

--- a/integrations/Jenkinsfile
+++ b/integrations/Jenkinsfile
@@ -298,7 +298,7 @@ pipeline {
                         fi
 
                         rm -fr out/results
-                        /opt/ort/bin/ort $LOG_LEVEL $STACKTRACE_OPTION analyze -P ort.analyzer.allowDynamicVersions=$ALLOW_DYNAMIC_VERSIONS $USE_CLEARLY_DEFINED_CURATIONS_OPTION -i $PROJECT_DIR/source -o out/results/analyzer
+                        /opt/ort/bin/ort $LOG_LEVEL $STACKTRACE_OPTION -P ort.analyzer.allowDynamicVersions=$ALLOW_DYNAMIC_VERSIONS analyze $USE_CLEARLY_DEFINED_CURATIONS_OPTION -i $PROJECT_DIR/source -o out/results/analyzer
                     '''
 
                     if (status >= ORT_FAILURE_STATUS_CODE) unstable('Analyzer issues found.')


### PR DESCRIPTION
This is a fixup for 533c5fd.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>