### PR TITLE
More explicit configuration of scanner-specific options

### DIFF
--- a/model/src/main/kotlin/config/ScannerCompatibilityConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerCompatibilityConfiguration.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.config
+
+/**
+ * A data class storing configuration options related to the compatibility of scan results.
+ *
+ * The options defined in this class are evaluated when scan results are looked up from a scan results storage. It
+ * then has to be checked whether the results from the storage has been produced by a compatible scanner version with
+ * compatible command line options. Per default, this check is rather strict. By specifying some of these options of
+ * this class, it can be configured that scan results are reused even if their parameters do not exactly match the
+ * current scanner settings.
+ */
+data class ScannerCompatibilityConfiguration(
+    /**
+     * A regular expression pattern to match the name of the scanner. A result loaded from a storage is accepted only
+     * if the name of the scanner that produced it is matched by this expression. Defaults to the name of the current
+     * scanner if unspecified.
+     */
+    val namePattern: String? = null,
+
+    /**
+     * The minimum scanner version of a scan result to be considered compatible. A result loaded from a storage is
+     * accepted only if its scanner version is greater than or equal to this version. Defaults to the current scanner
+     * version if unspecified.
+     */
+    val minVersion: String? = null,
+
+    /**
+     * The maximum scanner version of a scan result to be considered compatible. A result loaded from a storage is
+     * accepted only if its scanner version is less than to this version. (This bound of the version range is
+     * excluding.) Defaults to the next minor version of [minVersion] if unspecified; so patch level updates do not
+     * cause the compatibility check to fail.
+     */
+    val maxVersion: String? = null
+)

--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -37,10 +37,10 @@ data class ScannerConfiguration(
 
     /**
      * Scanner specific configuration options. The key needs to match the name of the scanner class, e.g. "ScanCode"
-     * for the ScanCode wrapper. See the documentation of the scanner for available options.
+     * for the ScanCode wrapper.
      */
     @JsonAlias("scanner")
-    val options: Map<String, Map<String, String>>? = null,
+    val options: Map<String, ScannerOptions>? = null,
 
     /**
      * A map with the configurations of the scan result storages available. Based on this information the actual
@@ -68,4 +68,24 @@ data class ScannerConfiguration(
         "**/*.ort.yml",
         "**/META-INF/DEPENDENCIES"
     )
+)
+
+/**
+ * A class defining scanner-specific option.
+ *
+ * In the global [ScannerConfiguration], the _options_ map allows assigning an instance of this class to each
+ * scanner. That way, this scanner can be configured in a special way. The options consist of a part that is common to
+ * all scanners, and a generic map of properties to be evaluated by specific scanner implementations.
+ */
+data class ScannerOptions(
+    /**
+     * The configuration of the criteria when a scan result loaded from a results storage is considered compatible with
+     * the current scanner version.
+     */
+    val compatibility: ScannerCompatibilityConfiguration? = null,
+
+    /**
+     * Scanner specific configuration options. See the documentation of the scanner for available options.
+     */
+    val properties: Map<String, String>? = null
 )

--- a/model/src/test/assets/reference.conf
+++ b/model/src/test/assets/reference.conf
@@ -41,7 +41,18 @@ ort {
     }
 
     options {
-      // A map of maps from scanner class names to scanner-specific key-value pairs.
+      // A map from scanner class names to scanner-specific ScannerOption objects.
+      "ScanCode": {
+        compatibility {
+          minVersion = "3.1.0"
+          maxVersion = "3.3"
+        }
+
+        properties: {
+          commandLine = "--copyright --license --info --timeout 300"
+          debugCommandLine = "--license-diag"
+        }
+      }
     }
 
     storages {

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -126,7 +126,7 @@ class ScanCode(
 
     override val resultFileExt = "json"
 
-    private val scanCodeConfiguration = config.options?.get("ScanCode").orEmpty()
+    private val scanCodeConfiguration = config.options?.get("ScanCode")?.properties.orEmpty()
 
     private val configurationOptions = scanCodeConfiguration["commandLine"]?.split(" ")
         ?: DEFAULT_CONFIGURATION_OPTIONS

--- a/scanner/src/test/kotlin/LocalScannerTest.kt
+++ b/scanner/src/test/kotlin/LocalScannerTest.kt
@@ -26,12 +26,14 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import org.ossreviewtoolkit.model.config.ScannerCompatibilityConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.config.ScannerOptions
 
 class LocalScannerTest : WordSpec({
     "getScannerCriteria()" should {
         "obtain default values from the scanner" {
-            val scanner = createScanner(createConfig(emptyMap()))
+            val scanner = createScanner(createConfig(ScannerOptions()))
 
             val criteria = scanner.getScannerCriteria()
 
@@ -41,12 +43,14 @@ class LocalScannerTest : WordSpec({
         }
 
         "obtain values from the configuration" {
-            val config = mapOf(
-                LocalScanner.PROP_CRITERIA_NAME to "foo",
-                LocalScanner.PROP_CRITERIA_MIN_VERSION to "1.2.3",
-                LocalScanner.PROP_CRITERIA_MAX_VERSION to "4.5.6"
+            val options = ScannerOptions(
+                compatibility = ScannerCompatibilityConfiguration(
+                    namePattern = "foo",
+                    minVersion = "1.2.3",
+                    maxVersion = "4.5.6"
+                )
             )
-            val scanner = createScanner(createConfig(config))
+            val scanner = createScanner(createConfig(options))
 
             val criteria = scanner.getScannerCriteria()
 
@@ -56,11 +60,8 @@ class LocalScannerTest : WordSpec({
         }
 
         "parse versions in a lenient way" {
-            val config = mapOf(
-                LocalScanner.PROP_CRITERIA_MIN_VERSION to "1",
-                LocalScanner.PROP_CRITERIA_MAX_VERSION to "3.7"
-            )
-            val scanner = createScanner(createConfig(config))
+            val compatibility = ScannerCompatibilityConfiguration(minVersion = "1", maxVersion = "3.7")
+            val scanner = createScanner(createConfig(ScannerOptions(compatibility)))
 
             val criteria = scanner.getScannerCriteria()
 
@@ -69,7 +70,7 @@ class LocalScannerTest : WordSpec({
         }
 
         "use an exact configuration matcher" {
-            val scanner = createScanner(createConfig(emptyMap()))
+            val scanner = createScanner(createConfig(ScannerOptions()))
 
             val criteria = scanner.getScannerCriteria()
 
@@ -83,11 +84,11 @@ private const val SCANNER_NAME = "TestScanner"
 private const val SCANNER_VERSION = "3.2.1.final"
 
 /**
- * Creates a [ScannerConfiguration] with the given properties for the test scanner.
+ * Creates a [ScannerConfiguration] with the given options for the test scanner.
  */
-private fun createConfig(properties: Map<String, String>): ScannerConfiguration {
-    val options = mapOf(SCANNER_NAME to properties)
-    return ScannerConfiguration(options = options)
+private fun createConfig(options: ScannerOptions): ScannerConfiguration {
+    val scanCodeOptions = mapOf(SCANNER_NAME to options)
+    return ScannerConfiguration(options = scanCodeOptions)
 }
 
 /**

--- a/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
@@ -24,6 +24,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldMatch
 
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.config.ScannerOptions
 
 class ScanCodeTest : WordSpec({
     val scanner = ScanCode("ScanCode", ScannerConfiguration())
@@ -37,11 +38,13 @@ class ScanCodeTest : WordSpec({
             val scannerWithConfig = ScanCode(
                 "ScanCode", ScannerConfiguration(
                     options = mapOf(
-                        "ScanCode" to mapOf(
-                            "commandLine" to "--command --line",
-                            "commandLineNonConfig" to "--commandLineNonConfig",
-                            "debugCommandLine" to "--debug --commandLine",
-                            "debugCommandLineNonConfig" to "--debugCommandLineNonConfig"
+                        "ScanCode" to ScannerOptions(
+                            properties = mapOf(
+                                "commandLine" to "--command --line",
+                                "commandLineNonConfig" to "--commandLineNonConfig",
+                                "debugCommandLine" to "--debug --commandLine",
+                                "debugCommandLineNonConfig" to "--debugCommandLineNonConfig"
+                            )
                         )
                     )
                 )
@@ -61,11 +64,13 @@ class ScanCodeTest : WordSpec({
             val scannerWithConfig = ScanCode(
                 "ScanCode", ScannerConfiguration(
                     options = mapOf(
-                        "ScanCode" to mapOf(
-                            "commandLine" to "--command --line",
-                            "commandLineNonConfig" to "--commandLineNonConfig",
-                            "debugCommandLine" to "--debug --commandLine",
-                            "debugCommandLineNonConfig" to "--debugCommandLineNonConfig"
+                        "ScanCode" to ScannerOptions(
+                            properties = mapOf(
+                                "commandLine" to "--command --line",
+                                "commandLineNonConfig" to "--commandLineNonConfig",
+                                "debugCommandLine" to "--debug --commandLine",
+                                "debugCommandLineNonConfig" to "--debugCommandLineNonConfig"
+                            )
                         )
                     )
                 )


### PR DESCRIPTION
This PR changes the scanner-specific configuration in `ort.conf`. The map of map of properties is replaced by a map to a new `ScannerOptions` class, which holds options common to all scanners and a map with scanner-specific properties.

This is a preparation for changes in the configuration related to the compatibility of scan results (see #3223). In this area, we would like to extend the configuration, and this is not possible with a plain map of options.

Note that there is a potential for merge conflicts with #3510.