### PR TITLE
Vulnerability: Add a function to get the rating based on the score

### DIFF
--- a/model/src/main/kotlin/Vulnerability.kt
+++ b/model/src/main/kotlin/Vulnerability.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Bosch.IO GmbH
+ * Copyright (C) 2020-2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,4 +43,32 @@ data class Vulnerability(
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val url: URL? = null
-)
+) {
+    /**
+     * The rating attaches human-readable semantics to the score number, see
+     * https://www.first.org/cvss/specification-document#Qualitative-Severity-Rating-Scale.
+     */
+    enum class Rating(private val upperBound: Float) {
+        NONE(0.0f),
+        LOW(4.0f),
+        MEDIUM(7.0f),
+        HIGH(9.0f),
+        CRITICAL(10.0f);
+
+        companion object {
+            private val bounds = enumValues<Rating>().asIterable().zipWithNext()
+            private val limits = listOf(bounds.first().first, bounds.last().second)
+
+            /**
+             * Get the [Rating] from a [score], or null if the [score] does not map to any [Rating].
+             */
+            fun fromCvssScore(score: Float): Rating? {
+                return limits.find { score == it.upperBound } ?: run {
+                    bounds.find { (a, b) -> a.upperBound <= score && score < b.upperBound }?.second
+                }
+            }
+        }
+    }
+
+    val rating = Rating.fromCvssScore(severity)
+}

--- a/model/src/test/kotlin/VulnerabilityTest.kt
+++ b/model/src/test/kotlin/VulnerabilityTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+class VulnerabilityTest : StringSpec({
+    "The rating should be correct for a given severity" {
+        Vulnerability("", -0.1f).rating should beNull()
+
+        Vulnerability("", 0.0f).rating shouldBe Vulnerability.Rating.NONE
+
+        Vulnerability("", 0.1f).rating shouldBe Vulnerability.Rating.LOW
+        Vulnerability("", 3.9f).rating shouldBe Vulnerability.Rating.LOW
+
+        Vulnerability("", 4.0f).rating shouldBe Vulnerability.Rating.MEDIUM
+        Vulnerability("", 6.9f).rating shouldBe Vulnerability.Rating.MEDIUM
+
+        Vulnerability("", 7.0f).rating shouldBe Vulnerability.Rating.HIGH
+        Vulnerability("", 8.9f).rating shouldBe Vulnerability.Rating.HIGH
+
+        Vulnerability("", 9.0f).rating shouldBe Vulnerability.Rating.CRITICAL
+        Vulnerability("", 10.0f).rating shouldBe Vulnerability.Rating.CRITICAL
+
+        Vulnerability("", 10.1f).rating should beNull()
+    }
+})


### PR DESCRIPTION
The rating attaches human-readable semantics to the score number.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>