### PR TITLE
Adjust the log level to be "info" for Maven source packages

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -486,7 +486,8 @@ class MavenSupport(workspaceReader: WorkspaceReader) {
             }
         }
 
-        log.warn { "Unable to find '$artifact' in any of ${remoteRepositories.map { it.url }}." }
+        val level = if (artifact.classifier == "sources") Level.DEBUG else Level.WARN
+        log.log(level) { "Unable to find '$artifact' in any of ${remoteRepositories.map { it.url }}." }
 
         return RemoteArtifact.EMPTY.also {
             log.debug { "Writing empty remote artifact for '$artifact' to disk cache." }


### PR DESCRIPTION
When a Maven sources package cannot be downloaded, we should log with an "INFO" level instead of "WARN".

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>
