### PR TITLE
Vulnerability: Distinguish between CVSS v2 and v3 score mapping

### DIFF
--- a/model/src/main/kotlin/Vulnerability.kt
+++ b/model/src/main/kotlin/Vulnerability.kt
@@ -80,17 +80,19 @@ data class Vulnerability(
         CRITICAL(10.0f);
 
         companion object {
-            private val bounds = enumValues<Cvss3Rating>().asIterable().zipWithNext()
-            private val limits = listOf(bounds.first().first, bounds.last().second)
-
             /**
              * Get the [Cvss3Rating] from a [score], or null if the [score] does not map to any [Cvss3Rating].
              */
-            fun fromScore(score: Float): Cvss3Rating? {
-                return limits.find { score == it.upperBound } ?: run {
-                    bounds.find { (a, b) -> a.upperBound <= score && score < b.upperBound }?.second
+            fun fromScore(score: Float): Cvss3Rating? =
+                when {
+                    score < 0.0f || score > CRITICAL.upperBound -> null
+                    score == NONE.upperBound -> NONE
+                    score < LOW.upperBound -> LOW
+                    score < MEDIUM.upperBound -> MEDIUM
+                    score < HIGH.upperBound -> HIGH
+                    score <= CRITICAL.upperBound -> CRITICAL
+                    else -> null
                 }
-            }
         }
     }
 }

--- a/model/src/main/kotlin/Vulnerability.kt
+++ b/model/src/main/kotlin/Vulnerability.kt
@@ -33,8 +33,8 @@ data class Vulnerability(
     val id: String,
 
     /**
-     * Severity of the vulnerability. Most likely expressed using the CVSS in range 0.0 (none) to 10.0 (critical).
-     * See: https://www.first.org/cvss/
+     * Severity of the vulnerability. Most likely expressed using the CVSS version 2 or 3 in range 0.0 to 10.0, see
+     * https://www.first.org/cvss/
      */
     val severity: Float,
 
@@ -45,10 +45,34 @@ data class Vulnerability(
     val url: URL? = null
 ) {
     /**
-     * The rating attaches human-readable semantics to the score number, see
-     * https://www.first.org/cvss/specification-document#Qualitative-Severity-Rating-Scale.
+     * The rating attaches human-readable semantics to the score number according to CVSS version 2, see
+     * https://www.balbix.com/insights/cvss-v2-vs-cvss-v3/#CVSSv3-Scoring-Scale-vs-CVSSv2-6.
      */
-    enum class Rating(private val upperBound: Float) {
+    enum class Cvss2Rating(private val upperBound: Float) {
+        LOW(4.0f),
+        MEDIUM(7.0f),
+        HIGH(10.0f);
+
+        companion object {
+            /**
+             * Get the [Cvss2Rating] from a [score], or null if the [score] does not map to any [Cvss2Rating].
+             */
+            fun fromScore(score: Float): Cvss2Rating? =
+                when {
+                    score < 0.0f || score > HIGH.upperBound -> null
+                    score < LOW.upperBound -> LOW
+                    score < MEDIUM.upperBound -> MEDIUM
+                    score <= HIGH.upperBound -> HIGH
+                    else -> null
+                }
+        }
+    }
+
+    /**
+     * The rating attaches human-readable semantics to the score number according to CVSS version 3, see
+     * https://www.first.org/cvss/v3.0/specification-document#Qualitative-Severity-Rating-Scale.
+     */
+    enum class Cvss3Rating(private val upperBound: Float) {
         NONE(0.0f),
         LOW(4.0f),
         MEDIUM(7.0f),
@@ -56,19 +80,17 @@ data class Vulnerability(
         CRITICAL(10.0f);
 
         companion object {
-            private val bounds = enumValues<Rating>().asIterable().zipWithNext()
+            private val bounds = enumValues<Cvss3Rating>().asIterable().zipWithNext()
             private val limits = listOf(bounds.first().first, bounds.last().second)
 
             /**
-             * Get the [Rating] from a [score], or null if the [score] does not map to any [Rating].
+             * Get the [Cvss3Rating] from a [score], or null if the [score] does not map to any [Cvss3Rating].
              */
-            fun fromCvssScore(score: Float): Rating? {
+            fun fromScore(score: Float): Cvss3Rating? {
                 return limits.find { score == it.upperBound } ?: run {
                     bounds.find { (a, b) -> a.upperBound <= score && score < b.upperBound }?.second
                 }
             }
         }
     }
-
-    val rating = Rating.fromCvssScore(severity)
 }

--- a/model/src/test/kotlin/VulnerabilityTest.kt
+++ b/model/src/test/kotlin/VulnerabilityTest.kt
@@ -24,24 +24,42 @@ import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
+import org.ossreviewtoolkit.model.Vulnerability.Cvss2Rating
+import org.ossreviewtoolkit.model.Vulnerability.Cvss3Rating
+
 class VulnerabilityTest : StringSpec({
-    "The rating should be correct for a given severity" {
-        Vulnerability("", -0.1f).rating should beNull()
+    "The CVSS 2 rating should be correct for a given score" {
+        Cvss2Rating.fromScore(-0.1f) should beNull()
 
-        Vulnerability("", 0.0f).rating shouldBe Vulnerability.Rating.NONE
+        Cvss2Rating.fromScore(0.0f) shouldBe Cvss2Rating.LOW
+        Cvss2Rating.fromScore(3.9f) shouldBe Cvss2Rating.LOW
 
-        Vulnerability("", 0.1f).rating shouldBe Vulnerability.Rating.LOW
-        Vulnerability("", 3.9f).rating shouldBe Vulnerability.Rating.LOW
+        Cvss2Rating.fromScore(4.0f) shouldBe Cvss2Rating.MEDIUM
+        Cvss2Rating.fromScore(6.9f) shouldBe Cvss2Rating.MEDIUM
 
-        Vulnerability("", 4.0f).rating shouldBe Vulnerability.Rating.MEDIUM
-        Vulnerability("", 6.9f).rating shouldBe Vulnerability.Rating.MEDIUM
+        Cvss2Rating.fromScore(7.0f) shouldBe Cvss2Rating.HIGH
+        Cvss2Rating.fromScore(10.0f) shouldBe Cvss2Rating.HIGH
 
-        Vulnerability("", 7.0f).rating shouldBe Vulnerability.Rating.HIGH
-        Vulnerability("", 8.9f).rating shouldBe Vulnerability.Rating.HIGH
+        Cvss2Rating.fromScore(10.1f) should beNull()
+    }
 
-        Vulnerability("", 9.0f).rating shouldBe Vulnerability.Rating.CRITICAL
-        Vulnerability("", 10.0f).rating shouldBe Vulnerability.Rating.CRITICAL
+    "The CVSS 3 rating should be correct for a given score" {
+        Cvss3Rating.fromScore(-0.1f) should beNull()
 
-        Vulnerability("", 10.1f).rating should beNull()
+        Cvss3Rating.fromScore(0.0f) shouldBe Cvss3Rating.NONE
+
+        Cvss3Rating.fromScore(0.1f) shouldBe Cvss3Rating.LOW
+        Cvss3Rating.fromScore(3.9f) shouldBe Cvss3Rating.LOW
+
+        Cvss3Rating.fromScore(4.0f) shouldBe Cvss3Rating.MEDIUM
+        Cvss3Rating.fromScore(6.9f) shouldBe Cvss3Rating.MEDIUM
+
+        Cvss3Rating.fromScore(7.0f) shouldBe Cvss3Rating.HIGH
+        Cvss3Rating.fromScore(8.9f) shouldBe Cvss3Rating.HIGH
+
+        Cvss3Rating.fromScore(9.0f) shouldBe Cvss3Rating.CRITICAL
+        Cvss3Rating.fromScore(10.0f) shouldBe Cvss3Rating.CRITICAL
+
+        Cvss3Rating.fromScore(10.1f) should beNull()
     }
 })


### PR DESCRIPTION
See e.g. [1] for the differences.

Also remove the "rating" variable from the Vulnerability class as it is
up to the Advisor implementation now to choose the correct mapping type.

[1] https://www.balbix.com/insights/cvss-v2-vs-cvss-v3/#CVSSv3-Scoring-Scale-vs-CVSSv2-6

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>