### PR TITLE
ScanCode: Align the debug configuration options with non-debug ones

### DIFF
--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -100,11 +100,6 @@ class ScanCode(
         )
 
         /**
-         * Debug configuration options that are relevant for [getConfiguration] because they change the result file.
-         */
-        private val DEFAULT_DEBUG_CONFIGURATION_OPTIONS = listOf("--license-diag")
-
-        /**
          * Debug configuration options that are not relevant for [getConfiguration] because they do not change the
          * result file.
          */
@@ -138,7 +133,7 @@ class ScanCode(
     private val nonConfigurationOptions = scanCodeConfiguration["commandLineNonConfig"]?.split(" ")
         ?: DEFAULT_NON_CONFIGURATION_OPTIONS
     private val debugConfigurationOptions = scanCodeConfiguration["debugCommandLine"]?.split(" ")
-        ?: DEFAULT_DEBUG_CONFIGURATION_OPTIONS
+        ?: emptyList()
     private val debugNonConfigurationOptions = scanCodeConfiguration["debugCommandLineNonConfig"]?.split(" ")
         ?: DEFAULT_DEBUG_NON_CONFIGURATION_OPTIONS
 

--- a/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
@@ -30,9 +30,7 @@ class ScanCodeTest : WordSpec({
 
     "getConfiguration()" should {
         "return the default values if the scanner configuration is empty" {
-            scanner.configuration shouldBe
-                    "--copyright --license --info --strip-root --timeout 300 " +
-                    "--json-pp --license-diag"
+            scanner.configuration shouldBe "--copyright --license --info --strip-root --timeout 300 --json-pp"
         }
 
         "return the non-config values from the scanner configuration" {
@@ -56,8 +54,7 @@ class ScanCodeTest : WordSpec({
     "commandLineOptions" should {
         "contain the default values if the scanner configuration is empty" {
             scanner.commandLineOptions.joinToString(" ") shouldMatch
-                    "--copyright --license --info --strip-root --timeout 300 " +
-                        "--processes \\d+ --license-diag --verbose"
+                    "--copyright --license --info --strip-root --timeout 300 --processes \\d+ --verbose"
         }
 
         "contain the values from the scanner configuration" {


### PR DESCRIPTION
When the configuration options differ between debug and non-debug mode
the scan results cannot be re-used across these two modes. Align them
so that the scan storage entries do actually get re-used across modes.

Note that the option `--license-diag´ doesn't have any effect anymore
anyway as of [1].

[1] https://github.com/nexB/scancode-toolkit/commit/4087bba0eded214435e6e83297e7cb8fcc5415d3
