### PR TITLE
Change type of Vulnerability.url from URL to String

### DIFF
--- a/advisor/src/main/kotlin/advisors/NexusIq.kt
+++ b/advisor/src/main/kotlin/advisors/NexusIq.kt
@@ -20,7 +20,7 @@
 package org.ossreviewtoolkit.advisor.advisors
 
 import java.io.IOException
-import java.net.URL
+import java.net.URI
 import java.time.Instant
 import java.util.concurrent.Executors
 
@@ -154,7 +154,7 @@ class NexusIq(
 
     private fun NexusIqService.SecurityIssue.toVulnerability(): Vulnerability {
         val browseUrl = if (url == null && reference.startsWith("sonatype-")) {
-            URL("${nexusIqConfig.browseUrl}/assets/index.html#/vulnerabilities/$reference")
+            URI("${nexusIqConfig.browseUrl}/assets/index.html#/vulnerabilities/$reference")
         } else {
             url
         }

--- a/cli/src/main/kotlin/commands/UploadCurationsCommand.kt
+++ b/cli/src/main/kotlin/commands/UploadCurationsCommand.kt
@@ -31,7 +31,7 @@ import com.github.ajalt.clikt.parameters.types.enum
 import com.github.ajalt.clikt.parameters.types.file
 
 import java.io.IOException
-import java.net.URL
+import java.net.URI
 
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionInfo
@@ -190,7 +190,7 @@ private fun PackageCuration.toContributionPatch(): ContributionPatch? {
     val licenseExpression = data.concludedLicense?.toString() ?: data.declaredLicenses?.joinToString(" AND ")
 
     val described = Described(
-        projectWebsite = data.homepageUrl?.let { URL(it) },
+        projectWebsite = data.homepageUrl?.let { URI(it) },
         sourceLocation = id.toClearlyDefinedSourceLocation(data.vcs, data.sourceArtifact)
     )
 

--- a/clients/clearly-defined/src/main/kotlin/ClearlyDefinedService.kt
+++ b/clients/clearly-defined/src/main/kotlin/ClearlyDefinedService.kt
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 
 import java.io.File
-import java.net.URL
+import java.net.URI
 
 import okhttp3.OkHttpClient
 import okhttp3.ResponseBody
@@ -157,8 +157,8 @@ interface ClearlyDefinedService {
         val facets: Facets? = null,
         val sourceLocation: SourceLocation? = null,
         val urls: URLs? = null,
-        val projectWebsite: URL? = null,
-        val issueTracker: URL? = null,
+        val projectWebsite: URI? = null,
+        val issueTracker: URI? = null,
         val releaseDate: String? = null,
         val hashes: Hashes? = null,
         val files: Int? = null,
@@ -236,9 +236,9 @@ interface ClearlyDefinedService {
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     data class URLs(
-        val registry: URL? = null,
-        val version: URL? = null,
-        val download: URL? = null
+        val registry: URI? = null,
+        val version: URI? = null,
+        val download: URI? = null
     )
 
     /**

--- a/clients/nexus-iq/src/main/kotlin/NexusIqService.kt
+++ b/clients/nexus-iq/src/main/kotlin/NexusIqService.kt
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 
-import java.net.URL
+import java.net.URI
 import java.util.UUID
 
 import okhttp3.Credentials
@@ -95,7 +95,7 @@ interface NexusIqService {
     data class SecurityIssue(
         val reference: String,
         val severity: Float,
-        val url: URL?
+        val url: URI?
     )
 
     data class ComponentsWrapper(

--- a/model/src/main/kotlin/Vulnerability.kt
+++ b/model/src/main/kotlin/Vulnerability.kt
@@ -21,7 +21,7 @@ package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
 
-import java.net.URL
+import java.net.URI
 
 /**
  * Base model for all vulnerability providers supported by the advisor.
@@ -42,7 +42,7 @@ data class Vulnerability(
      * URL pointing to a website with information regarding the vulnerability.
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    val url: URL? = null
+    val url: URI? = null
 ) {
     /**
      * The rating attaches human-readable semantics to the score number according to CVSS version 2, see

--- a/model/src/test/kotlin/AdvisorResultContainerTest.kt
+++ b/model/src/test/kotlin/AdvisorResultContainerTest.kt
@@ -25,15 +25,15 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
-import java.net.URL
+import java.net.URI
 import java.time.Duration
 import java.time.Instant
 
 class AdvisorResultContainerTest : WordSpec() {
     private val id = Identifier("type", "namespace", "name", "version")
 
-    private val vulnerability11 = Vulnerability("CVE-11", 1.1F, URL("https://1.1.com"))
-    private val vulnerability12 = Vulnerability("CVE-12", 1.2F, URL("https://1.2.com"))
+    private val vulnerability11 = Vulnerability("CVE-11", 1.1F, URI("https://1.1.com"))
+    private val vulnerability12 = Vulnerability("CVE-12", 1.2F, URI("https://1.2.com"))
     private val vulnerability21 = Vulnerability("CVE-21", 2.1F)
     private val vulnerability22 = Vulnerability("CVE-22", 2.2F)
 


### PR DESCRIPTION
No specific features of the URL class are used, but it brings in
some additional complexity (e.g. when doing equals checks). Other
parts of the model also use strings to represent URLs, e.g. VcsInfo.
