### PR TITLE
Remove the mention of HERE_NOTICE from test data

### DIFF
--- a/cli/src/funTest/assets/semver4j-analyzer-result.yml
+++ b/cli/src/funTest/assets/semver4j-analyzer-result.yml
@@ -222,7 +222,7 @@ scanner:
               name: "ScanCode"
               version: "3.2.1-rc2"
               configuration: "--copyright --license --ignore *.ort.yml --info --strip-root\
-            \ --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+            \ --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
             summary:
               start_time: "2020-09-30T09:27:12.023451Z"
               end_time: "2020-09-30T09:28:20.525647Z"
@@ -274,7 +274,7 @@ scanner:
               name: "ScanCode"
               version: "3.2.1-rc2"
               configuration: "--copyright --license --ignore *.ort.yml --info --strip-root\
-            \ --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+            \ --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
             summary:
               start_time: "2020-09-30T09:28:32.817956Z"
               end_time: "2020-09-30T09:29:02.889213Z"

--- a/reporter-web-app/public/index.html
+++ b/reporter-web-app/public/index.html
@@ -1800,7 +1800,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-29T12:40:38.089704Z",
               "end_time" : "2020-04-29T12:40:46.392337Z",
@@ -1827,7 +1827,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-09-08T18:07:46.674346Z",
               "end_time" : "2020-09-08T18:08:03.488173Z",
@@ -1854,7 +1854,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-08-17T12:41:53.318556Z",
               "end_time" : "2020-08-17T12:42:03.503803Z",
@@ -1881,7 +1881,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-08-25T05:17:39.918231Z",
               "end_time" : "2020-08-25T05:17:48.619537Z",
@@ -1908,7 +1908,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-08-26T17:28:37.268671Z",
               "end_time" : "2020-08-26T17:28:57.646330Z",
@@ -1935,7 +1935,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-28T09:47:05.163116Z",
               "end_time" : "2020-01-28T09:47:16.371391Z",
@@ -1962,7 +1962,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T16:25:50.627895Z",
               "end_time" : "2020-03-19T16:25:59.568311Z",
@@ -1989,7 +1989,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T10:45:21.988971Z",
               "end_time" : "2020-01-23T10:45:29.961989Z",
@@ -2016,7 +2016,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T10:45:11.771290Z",
               "end_time" : "2020-01-23T10:45:19.955365Z",
@@ -2043,7 +2043,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T15:20:45.589077Z",
               "end_time" : "2020-03-13T15:20:57.320490Z",
@@ -2070,7 +2070,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T10:45:53.842211Z",
               "end_time" : "2020-01-23T10:46:03.806584Z",
@@ -2097,7 +2097,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T15:20:59.442556Z",
               "end_time" : "2020-03-13T15:21:11.568076Z",
@@ -2124,7 +2124,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T16:05:38.661829Z",
               "end_time" : "2020-01-27T16:05:48.135008Z",
@@ -2151,7 +2151,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:16:53.953974Z",
               "end_time" : "2020-03-24T07:17:04.151353Z",
@@ -2178,7 +2178,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T16:19:57.271240Z",
               "end_time" : "2020-01-27T16:20:08.763780Z",
@@ -2205,7 +2205,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T10:46:36.088368Z",
               "end_time" : "2020-01-23T10:46:50.843452Z",
@@ -2232,7 +2232,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-17T10:38:29.638639Z",
               "end_time" : "2020-03-17T10:38:40.376902Z",
@@ -2259,7 +2259,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-17T10:38:42.102821Z",
               "end_time" : "2020-03-17T10:38:52.755834Z",
@@ -2286,7 +2286,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T10:47:27.305172Z",
               "end_time" : "2020-01-23T10:47:35.479082Z",
@@ -2313,7 +2313,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-30T08:40:07.934594Z",
               "end_time" : "2020-03-30T08:40:16.184941Z",
@@ -2340,7 +2340,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-05-27T11:30:02.593312Z",
               "end_time" : "2020-05-27T11:30:11.297933Z",
@@ -2367,7 +2367,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-21T14:15:06.155157Z",
               "end_time" : "2020-07-21T14:15:14.899794Z",
@@ -2394,7 +2394,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T10:50:07.656134Z",
               "end_time" : "2020-01-23T10:50:17.819668Z",
@@ -2421,7 +2421,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T17:00:24.558751Z",
               "end_time" : "2020-01-27T17:00:37.133824Z",
@@ -2448,7 +2448,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T10:51:00.634168Z",
               "end_time" : "2020-01-23T10:51:08.350220Z",
@@ -2475,7 +2475,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:19:02.042179Z",
               "end_time" : "2020-03-24T07:19:10.471333Z",
@@ -2502,7 +2502,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T17:08:08.334930Z",
               "end_time" : "2020-01-27T17:08:19.545049Z",
@@ -2529,7 +2529,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T17:09:24.920610Z",
               "end_time" : "2020-01-27T17:09:35.013085Z",
@@ -2556,7 +2556,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:24:08.941942Z",
               "end_time" : "2020-01-23T11:24:22.572477Z",
@@ -2583,7 +2583,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-21T14:17:19.893675Z",
               "end_time" : "2020-07-21T14:17:30.096807Z",
@@ -2610,7 +2610,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-27T15:03:31.385628Z",
               "end_time" : "2020-03-27T15:03:39.760879Z",
@@ -2637,7 +2637,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-27T15:03:17.865591Z",
               "end_time" : "2020-03-27T15:03:28.761846Z",
@@ -2664,7 +2664,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-27T15:03:41.504727Z",
               "end_time" : "2020-03-27T15:03:49.939893Z",
@@ -2691,7 +2691,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T10:53:17.749890Z",
               "end_time" : "2020-01-23T10:53:33.392079Z",
@@ -2718,7 +2718,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:19:12.140757Z",
               "end_time" : "2020-03-24T07:19:22.693988Z",
@@ -2745,7 +2745,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T17:16:28.257344Z",
               "end_time" : "2020-01-27T17:16:37.885981Z",
@@ -2772,7 +2772,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T17:16:52.782759Z",
               "end_time" : "2020-01-27T17:17:02.557005Z",
@@ -2799,7 +2799,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-21T14:18:36.288203Z",
               "end_time" : "2020-07-21T14:18:44.434742Z",
@@ -2826,7 +2826,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T17:18:23.352128Z",
               "end_time" : "2020-01-27T17:18:40.682763Z",
@@ -2853,7 +2853,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:19:24.588870Z",
               "end_time" : "2020-03-24T07:19:33.325328Z",
@@ -2880,7 +2880,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-30T08:41:53.960565Z",
               "end_time" : "2020-03-30T08:42:02.358482Z",
@@ -2907,7 +2907,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T10:55:12.202143Z",
               "end_time" : "2020-01-23T10:55:21.846326Z",
@@ -2934,7 +2934,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T15:26:52.882653Z",
               "end_time" : "2020-03-13T15:27:06.327593Z",
@@ -2961,7 +2961,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T10:55:02.222595Z",
               "end_time" : "2020-01-23T10:55:09.942892Z",
@@ -2988,7 +2988,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T17:21:32.999520Z",
               "end_time" : "2020-01-27T17:21:41.214988Z",
@@ -3015,7 +3015,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T17:24:31.631878Z",
               "end_time" : "2020-01-27T17:24:40.680971Z",
@@ -3042,7 +3042,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T10:56:48.899491Z",
               "end_time" : "2020-01-23T10:56:56.755364Z",
@@ -3063,7 +3063,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T17:27:14.382683Z",
               "end_time" : "2020-01-27T17:27:24.522245Z",
@@ -3090,7 +3090,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T16:14:10.796502Z",
               "end_time" : "2020-03-13T16:14:19.698873Z",
@@ -3117,7 +3117,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T17:37:39.301826Z",
               "end_time" : "2020-01-27T17:37:56.082455Z",
@@ -3144,7 +3144,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-06-03T06:38:37.482195Z",
               "end_time" : "2020-06-03T06:38:48.311452Z",
@@ -3171,7 +3171,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T10:59:59.456188Z",
               "end_time" : "2020-01-23T11:00:09.610163Z",
@@ -3198,7 +3198,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T17:47:25.743667Z",
               "end_time" : "2020-01-27T17:47:35.987689Z",
@@ -3225,7 +3225,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:46:52.206202Z",
               "end_time" : "2020-01-23T12:47:01.913497Z",
@@ -3252,7 +3252,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:47:16.011013Z",
               "end_time" : "2020-01-23T12:47:24.818482Z",
@@ -3279,7 +3279,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:01:09.342651Z",
               "end_time" : "2020-01-23T11:01:17.422634Z",
@@ -3306,7 +3306,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:22:02.032200Z",
               "end_time" : "2020-03-24T07:22:10.565877Z",
@@ -3333,7 +3333,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:47:27.119372Z",
               "end_time" : "2020-01-23T12:47:35.520348Z",
@@ -3360,7 +3360,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:01:19.510216Z",
               "end_time" : "2020-01-23T11:01:34.004453Z",
@@ -3387,7 +3387,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T17:53:16.812106Z",
               "end_time" : "2020-01-27T17:53:29.091931Z",
@@ -3414,7 +3414,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T17:53:01.994057Z",
               "end_time" : "2020-01-27T17:53:14.803368Z",
@@ -3441,7 +3441,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:03:47.430001Z",
               "end_time" : "2020-01-23T11:03:56.104514Z",
@@ -3468,7 +3468,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T18:00:44.381295Z",
               "end_time" : "2020-01-27T18:00:55.606654Z",
@@ -3495,7 +3495,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:04:17.747839Z",
               "end_time" : "2020-01-23T11:04:27.087294Z",
@@ -3522,7 +3522,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-06-16T13:58:01.460470Z",
               "end_time" : "2020-06-16T13:58:24.387120Z",
@@ -3549,7 +3549,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T15:32:15.393549Z",
               "end_time" : "2020-03-13T15:32:26.293737Z",
@@ -3576,7 +3576,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T18:06:35.726024Z",
               "end_time" : "2020-01-27T18:06:45.824968Z",
@@ -3603,7 +3603,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:04:52.722456Z",
               "end_time" : "2020-01-23T11:05:00.690973Z",
@@ -3630,7 +3630,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-05-10T16:47:38.546590Z",
               "end_time" : "2020-05-10T16:47:47.098389Z",
@@ -3657,7 +3657,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-06-18T11:46:16.383955Z",
               "end_time" : "2020-06-18T11:46:33.533554Z",
@@ -3678,7 +3678,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-01T11:46:44.227103Z",
               "end_time" : "2020-04-01T11:46:56.820827Z",
@@ -3705,7 +3705,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-08-26T17:38:08.549516Z",
               "end_time" : "2020-08-26T17:38:21.637521Z",
@@ -3732,7 +3732,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-04T11:33:55.858658Z",
               "end_time" : "2020-04-04T11:34:12.034022Z",
@@ -3759,7 +3759,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-05-10T16:48:05.804957Z",
               "end_time" : "2020-05-10T16:48:15.437220Z",
@@ -3786,7 +3786,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-05-10T16:47:49.439935Z",
               "end_time" : "2020-05-10T16:48:03.861639Z",
@@ -3807,7 +3807,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-01T11:47:13.260748Z",
               "end_time" : "2020-04-01T11:47:24.748682Z",
@@ -3834,7 +3834,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-01T11:46:58.878024Z",
               "end_time" : "2020-04-01T11:47:11.442869Z",
@@ -3861,7 +3861,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-06-16T13:59:45.844446Z",
               "end_time" : "2020-06-16T13:59:56.829564Z",
@@ -3888,7 +3888,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T16:41:23.587259Z",
               "end_time" : "2020-03-19T16:41:33.817803Z",
@@ -3915,7 +3915,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-06-16T14:00:09.383699Z",
               "end_time" : "2020-06-16T14:00:19.892495Z",
@@ -3942,7 +3942,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-21T14:34:03.791997Z",
               "end_time" : "2020-07-21T14:34:13.090167Z",
@@ -3969,7 +3969,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T16:40:07.463474Z",
               "end_time" : "2020-03-19T16:41:21.139154Z",
@@ -3996,7 +3996,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T16:41:46.841502Z",
               "end_time" : "2020-03-19T16:46:43.569991Z",
@@ -4023,7 +4023,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:06:35.990473Z",
               "end_time" : "2020-01-23T11:09:59.992684Z",
@@ -4050,7 +4050,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-21T12:56:37.446418Z",
               "end_time" : "2020-04-21T12:56:49.318080Z",
@@ -4077,7 +4077,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-09-02T08:36:49.400468Z",
               "end_time" : "2020-09-02T08:36:57.073875Z",
@@ -4104,7 +4104,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T18:35:16.209282Z",
               "end_time" : "2020-01-27T18:35:28.040537Z",
@@ -4131,7 +4131,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-08-17T12:48:45.843310Z",
               "end_time" : "2020-08-17T12:48:58.378382Z",
@@ -4158,7 +4158,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:52:45.149065Z",
               "end_time" : "2020-01-23T12:52:53.923146Z",
@@ -4185,7 +4185,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:17:19.796236Z",
               "end_time" : "2020-01-23T11:17:30.672401Z",
@@ -4212,7 +4212,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T18:40:46.861905Z",
               "end_time" : "2020-01-27T18:40:58.165193Z",
@@ -4239,7 +4239,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-06-16T14:00:21.622768Z",
               "end_time" : "2020-06-16T14:00:30.724444Z",
@@ -4266,7 +4266,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T16:29:30.895926Z",
               "end_time" : "2020-03-13T16:29:41.739564Z",
@@ -4293,7 +4293,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:19:15.913546Z",
               "end_time" : "2020-01-23T11:19:24.850847Z",
@@ -4320,7 +4320,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T16:48:02.799476Z",
               "end_time" : "2020-03-19T16:48:11.639075Z",
@@ -4347,7 +4347,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T18:45:51.446650Z",
               "end_time" : "2020-01-27T18:46:00.609787Z",
@@ -4374,7 +4374,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T18:49:18.987342Z",
               "end_time" : "2020-01-27T18:49:29.020183Z",
@@ -4401,7 +4401,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T16:48:25.129444Z",
               "end_time" : "2020-03-19T16:48:33.191449Z",
@@ -4428,7 +4428,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T18:51:02.669368Z",
               "end_time" : "2020-01-27T18:51:10.931302Z",
@@ -4455,7 +4455,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T18:50:52.286657Z",
               "end_time" : "2020-01-27T18:51:00.547253Z",
@@ -4482,7 +4482,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T18:51:36.529739Z",
               "end_time" : "2020-01-27T18:51:45.967683Z",
@@ -4509,7 +4509,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T18:53:25.772557Z",
               "end_time" : "2020-01-27T18:53:35.603792Z",
@@ -4536,7 +4536,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T15:36:14.746624Z",
               "end_time" : "2020-03-13T15:36:23.235995Z",
@@ -4563,7 +4563,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-01T11:48:35.142543Z",
               "end_time" : "2020-04-01T11:48:57.566954Z",
@@ -4590,7 +4590,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:23:08.186876Z",
               "end_time" : "2020-03-24T07:23:17.131544Z",
@@ -4617,7 +4617,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-08-26T17:38:23.463122Z",
               "end_time" : "2020-08-26T17:38:31.265050Z",
@@ -4644,7 +4644,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:22:04.985716Z",
               "end_time" : "2020-01-23T11:22:13.405410Z",
@@ -4671,7 +4671,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:58:07.281855Z",
               "end_time" : "2020-01-23T12:58:15.936883Z",
@@ -4692,7 +4692,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:21:46.413465Z",
               "end_time" : "2020-01-23T11:21:57.059009Z",
@@ -4713,7 +4713,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-18T16:56:47.551330Z",
               "end_time" : "2020-03-18T16:56:57.363220Z",
@@ -4740,7 +4740,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T18:59:57.446544Z",
               "end_time" : "2020-01-27T19:00:05.701774Z",
@@ -4767,7 +4767,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-06-03T15:08:53.573949Z",
               "end_time" : "2020-06-03T15:09:02.675660Z",
@@ -4794,7 +4794,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:24:56.326153Z",
               "end_time" : "2020-03-24T07:25:05.260423Z",
@@ -4821,7 +4821,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:24:05.499866Z",
               "end_time" : "2020-01-23T11:24:20.070284Z",
@@ -4848,7 +4848,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T14:31:33.179889Z",
               "end_time" : "2020-03-13T14:31:48.878869Z",
@@ -4875,7 +4875,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:02:22.425802Z",
               "end_time" : "2020-01-23T13:02:32.816063Z",
@@ -4902,7 +4902,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T16:49:42.022754Z",
               "end_time" : "2020-03-19T16:49:52.853123Z",
@@ -4929,7 +4929,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-05-05T21:05:21.168231Z",
               "end_time" : "2020-05-05T21:05:30.431715Z",
@@ -4956,7 +4956,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:24:40.622236Z",
               "end_time" : "2020-01-23T11:24:50.369408Z",
@@ -4983,7 +4983,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:26:29.140827Z",
               "end_time" : "2020-01-23T11:26:38.607560Z",
@@ -5010,7 +5010,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T15:40:59.368103Z",
               "end_time" : "2020-03-13T15:41:09.944867Z",
@@ -5037,7 +5037,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T15:40:48.189590Z",
               "end_time" : "2020-03-13T15:40:57.815194Z",
@@ -5064,7 +5064,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:06:38.734331Z",
               "end_time" : "2020-01-23T13:06:46.754608Z",
@@ -5091,7 +5091,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:25:17.054152Z",
               "end_time" : "2020-03-24T07:25:25.884184Z",
@@ -5118,7 +5118,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T19:09:39.967109Z",
               "end_time" : "2020-01-27T19:09:56.209295Z",
@@ -5145,7 +5145,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-17T10:56:26.992210Z",
               "end_time" : "2020-03-17T10:56:37.133762Z",
@@ -5172,7 +5172,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-01T11:48:59.397314Z",
               "end_time" : "2020-04-01T11:49:10.591582Z",
@@ -5199,7 +5199,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:28:49.195816Z",
               "end_time" : "2020-01-23T11:29:04.279132Z",
@@ -5226,7 +5226,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T19:19:13.542058Z",
               "end_time" : "2020-01-27T19:19:23.182646Z",
@@ -5253,7 +5253,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-06-02T14:05:11.455690Z",
               "end_time" : "2020-06-02T14:05:21.234088Z",
@@ -5280,7 +5280,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T16:55:25.673314Z",
               "end_time" : "2020-03-19T16:55:34.730575Z",
@@ -5307,7 +5307,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:29:23.956231Z",
               "end_time" : "2020-01-23T11:29:31.952187Z",
@@ -5334,7 +5334,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T16:46:15.531618Z",
               "end_time" : "2020-03-13T16:46:27.703317Z",
@@ -5361,7 +5361,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:29:33.939802Z",
               "end_time" : "2020-01-23T11:29:41.826049Z",
@@ -5388,7 +5388,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:08:41.646539Z",
               "end_time" : "2020-01-23T13:08:50.243721Z",
@@ -5415,7 +5415,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-30T08:56:17.356332Z",
               "end_time" : "2020-07-30T08:56:29.459428Z",
@@ -5442,7 +5442,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-27T15:13:41.701807Z",
               "end_time" : "2020-03-27T15:13:50.009155Z",
@@ -5469,7 +5469,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-27T15:13:31.810094Z",
               "end_time" : "2020-03-27T15:13:40.120271Z",
@@ -5496,7 +5496,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:31:05.051326Z",
               "end_time" : "2020-01-23T11:31:15.104843Z",
@@ -5523,7 +5523,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T19:25:47.288615Z",
               "end_time" : "2020-01-27T19:25:56.039235Z",
@@ -5550,7 +5550,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:10:50.301441Z",
               "end_time" : "2020-01-23T13:10:58.990845Z",
@@ -5577,7 +5577,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T15:42:44.766669Z",
               "end_time" : "2020-03-13T15:42:53.805686Z",
@@ -5604,7 +5604,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-06-03T10:07:51.400216Z",
               "end_time" : "2020-06-03T10:08:00.143052Z",
@@ -5631,7 +5631,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T15:43:07.779235Z",
               "end_time" : "2020-03-13T15:43:18.285954Z",
@@ -5658,7 +5658,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-27T15:13:51.518576Z",
               "end_time" : "2020-03-27T15:13:59.872302Z",
@@ -5685,7 +5685,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:12:36.535389Z",
               "end_time" : "2020-01-23T13:12:44.668152Z",
@@ -5712,7 +5712,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:30:25.560049Z",
               "end_time" : "2020-01-23T11:30:33.520319Z",
@@ -5739,7 +5739,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T19:27:28.871307Z",
               "end_time" : "2020-01-27T19:27:37.083307Z",
@@ -5766,7 +5766,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:12:49.010191Z",
               "end_time" : "2020-01-23T13:12:57.207096Z",
@@ -5793,7 +5793,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-27T15:14:01.378952Z",
               "end_time" : "2020-03-27T15:14:09.787828Z",
@@ -5820,7 +5820,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T19:29:51.569860Z",
               "end_time" : "2020-01-27T19:30:00.212935Z",
@@ -5847,7 +5847,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:31:29.769482Z",
               "end_time" : "2020-01-23T11:31:38.321557Z",
@@ -5874,7 +5874,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-08-10T09:42:20.890211Z",
               "end_time" : "2020-08-10T09:42:29.156444Z",
@@ -5901,7 +5901,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-18T16:58:23.235478Z",
               "end_time" : "2020-03-18T16:58:31.674166Z",
@@ -5928,7 +5928,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-17T10:57:44.685486Z",
               "end_time" : "2020-03-17T10:57:53.016901Z",
@@ -5955,7 +5955,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T15:44:02.372963Z",
               "end_time" : "2020-03-13T15:44:12.011074Z",
@@ -5982,7 +5982,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:46:55.765996Z",
               "end_time" : "2020-01-23T11:47:03.332525Z",
@@ -6009,7 +6009,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-30T08:53:56.940639Z",
               "end_time" : "2020-03-30T08:54:05.061535Z",
@@ -6036,7 +6036,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:14:52.517844Z",
               "end_time" : "2020-01-23T13:15:00.526095Z",
@@ -6063,7 +6063,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-30T08:54:16.125174Z",
               "end_time" : "2020-03-30T08:54:24.445075Z",
@@ -6090,7 +6090,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:47:35.331524Z",
               "end_time" : "2020-01-23T11:47:43.359155Z",
@@ -6117,7 +6117,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:47:25.579517Z",
               "end_time" : "2020-01-23T11:47:33.379970Z",
@@ -6144,7 +6144,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-18T16:58:34.006180Z",
               "end_time" : "2020-03-18T16:58:43.210387Z",
@@ -6171,7 +6171,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:26:59.585719Z",
               "end_time" : "2020-03-24T07:27:08.839718Z",
@@ -6198,7 +6198,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-05-10T16:48:17.745588Z",
               "end_time" : "2020-05-10T16:48:27.531394Z",
@@ -6225,7 +6225,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:27:21.918480Z",
               "end_time" : "2020-03-24T07:27:31.296407Z",
@@ -6252,7 +6252,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:27:10.930920Z",
               "end_time" : "2020-03-24T07:27:20.370770Z",
@@ -6279,7 +6279,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:27:46.698854Z",
               "end_time" : "2020-03-24T07:27:56.149156Z",
@@ -6306,7 +6306,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-05-07T08:04:59.422824Z",
               "end_time" : "2020-05-07T08:05:10.883172Z",
@@ -6333,7 +6333,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:16:15.862686Z",
               "end_time" : "2020-01-23T13:16:25.923821Z",
@@ -6360,7 +6360,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:48:25.772267Z",
               "end_time" : "2020-01-23T11:48:57.740797Z",
@@ -6387,7 +6387,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-05-27T14:03:24.832777Z",
               "end_time" : "2020-05-27T14:03:52.302394Z",
@@ -6414,7 +6414,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:16:27.910998Z",
               "end_time" : "2020-01-23T13:16:36.222013Z",
@@ -6441,7 +6441,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:50:12.628495Z",
               "end_time" : "2020-01-23T11:50:21.226769Z",
@@ -6468,7 +6468,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:49:45.898712Z",
               "end_time" : "2020-01-23T11:49:55.938541Z",
@@ -6495,7 +6495,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-16T08:33:41.380625Z",
               "end_time" : "2020-04-16T08:33:51.667130Z",
@@ -6522,7 +6522,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:51:02.148989Z",
               "end_time" : "2020-01-23T11:51:12.120891Z",
@@ -6549,7 +6549,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T20:42:55.281903Z",
               "end_time" : "2020-01-27T20:43:03.129625Z",
@@ -6576,7 +6576,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T20:44:05.358478Z",
               "end_time" : "2020-01-27T20:44:13.323676Z",
@@ -6603,7 +6603,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T20:43:55.300967Z",
               "end_time" : "2020-01-27T20:44:03.292759Z",
@@ -6630,7 +6630,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T20:43:42.449824Z",
               "end_time" : "2020-01-27T20:43:50.648653Z",
@@ -6651,7 +6651,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T20:51:03.277023Z",
               "end_time" : "2020-01-27T20:51:11.582176Z",
@@ -6678,7 +6678,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-08-14T08:56:46.545405Z",
               "end_time" : "2020-08-14T08:57:30.891330Z",
@@ -6705,7 +6705,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T15:57:34.298533Z",
               "end_time" : "2020-03-13T15:57:44.091160Z",
@@ -6732,7 +6732,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-29T12:40:14.746973Z",
               "end_time" : "2020-04-29T12:40:23.778197Z",
@@ -6759,7 +6759,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-30T08:57:34.902543Z",
               "end_time" : "2020-03-30T08:57:43.306570Z",
@@ -6786,7 +6786,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-29T12:40:25.543638Z",
               "end_time" : "2020-04-29T12:40:36.469963Z",
@@ -6813,7 +6813,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T21:26:25.959328Z",
               "end_time" : "2020-01-27T21:26:34.233669Z",
@@ -6840,7 +6840,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:57:45.220409Z",
               "end_time" : "2020-01-23T11:57:56.997643Z",
@@ -6867,7 +6867,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-18T10:52:46.964277Z",
               "end_time" : "2020-03-18T10:52:56.902528Z",
@@ -6894,7 +6894,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-18T10:52:58.516619Z",
               "end_time" : "2020-03-18T10:53:09.350009Z",
@@ -6921,7 +6921,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-15T15:55:38.600450Z",
               "end_time" : "2020-04-15T15:55:48.078876Z",
@@ -6948,7 +6948,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:31:15.230702Z",
               "end_time" : "2020-03-24T07:31:33.201843Z",
@@ -6975,7 +6975,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:59:12.017320Z",
               "end_time" : "2020-01-23T11:59:24.279123Z",
@@ -7002,7 +7002,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:33:33.893113Z",
               "end_time" : "2020-01-23T13:33:42.357295Z",
@@ -7029,7 +7029,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:33:23.602161Z",
               "end_time" : "2020-01-23T13:33:31.953887Z",
@@ -7056,7 +7056,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T21:31:42.634597Z",
               "end_time" : "2020-01-27T21:31:50.913941Z",
@@ -7083,7 +7083,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T11:59:58.155474Z",
               "end_time" : "2020-01-23T12:00:06.236250Z",
@@ -7110,7 +7110,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T21:35:12.558148Z",
               "end_time" : "2020-01-27T21:35:20.862273Z",
@@ -7137,7 +7137,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:32:33.705133Z",
               "end_time" : "2020-03-24T07:32:44.115772Z",
@@ -7164,7 +7164,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:33:11.180529Z",
               "end_time" : "2020-03-24T07:33:20.134820Z",
@@ -7191,7 +7191,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:35:34.000873Z",
               "end_time" : "2020-01-23T13:35:45.874008Z",
@@ -7218,7 +7218,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:36:32.895345Z",
               "end_time" : "2020-01-23T13:36:43.849946Z",
@@ -7245,7 +7245,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-05-07T08:44:28.641381Z",
               "end_time" : "2020-05-07T08:44:39.473949Z",
@@ -7272,7 +7272,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:01:03.294992Z",
               "end_time" : "2020-01-23T12:01:11.877593Z",
@@ -7299,7 +7299,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-06-27T19:07:35.603183Z",
               "end_time" : "2020-06-27T19:07:45.054168Z",
@@ -7326,7 +7326,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:37:57.466437Z",
               "end_time" : "2020-01-23T13:38:06.840734Z",
@@ -7353,7 +7353,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:37:35.742663Z",
               "end_time" : "2020-01-23T13:37:45.330153Z",
@@ -7380,7 +7380,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T16:05:01.875785Z",
               "end_time" : "2020-03-13T16:05:11.709540Z",
@@ -7407,7 +7407,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-17T11:03:06.219806Z",
               "end_time" : "2020-03-17T11:03:15.203565Z",
@@ -7434,7 +7434,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:01:46.914730Z",
               "end_time" : "2020-01-23T12:01:55.210032Z",
@@ -7461,7 +7461,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-08-17T12:53:56.989121Z",
               "end_time" : "2020-08-17T12:54:05.621403Z",
@@ -7488,7 +7488,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T17:54:06.042537Z",
               "end_time" : "2020-03-13T17:54:16.334826Z",
@@ -7515,7 +7515,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:02:09.683767Z",
               "end_time" : "2020-01-23T12:02:19.025590Z",
@@ -7542,7 +7542,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T21:48:25.303599Z",
               "end_time" : "2020-01-27T21:48:33.107011Z",
@@ -7569,7 +7569,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-15T15:56:36.493741Z",
               "end_time" : "2020-04-15T15:56:45.163861Z",
@@ -7596,7 +7596,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T21:48:45.237170Z",
               "end_time" : "2020-01-27T21:48:52.968799Z",
@@ -7623,7 +7623,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T21:48:54.952078Z",
               "end_time" : "2020-01-27T21:49:02.876489Z",
@@ -7650,7 +7650,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T21:49:15.243875Z",
               "end_time" : "2020-01-27T21:49:23.505517Z",
@@ -7677,7 +7677,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-17T19:38:25.991973Z",
               "end_time" : "2020-03-17T19:38:35.504808Z",
@@ -7704,7 +7704,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T21:50:16.916471Z",
               "end_time" : "2020-01-27T21:50:25.302606Z",
@@ -7731,7 +7731,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T21:51:01.184975Z",
               "end_time" : "2020-01-27T21:51:09.286646Z",
@@ -7758,7 +7758,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:34:49.624790Z",
               "end_time" : "2020-03-24T07:35:00.725420Z",
@@ -7785,7 +7785,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T21:52:45.321822Z",
               "end_time" : "2020-01-27T21:52:53.551558Z",
@@ -7812,7 +7812,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T17:05:59.117248Z",
               "end_time" : "2020-03-19T17:06:08.051216Z",
@@ -7839,7 +7839,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:40:32.315641Z",
               "end_time" : "2020-01-23T13:40:41.847442Z",
@@ -7866,7 +7866,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T21:58:17.685874Z",
               "end_time" : "2020-01-27T21:58:25.657452Z",
@@ -7893,7 +7893,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T21:58:27.764572Z",
               "end_time" : "2020-01-27T21:58:36.137590Z",
@@ -7920,7 +7920,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:04:10.594529Z",
               "end_time" : "2020-01-23T12:04:19.466668Z",
@@ -7947,7 +7947,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T21:58:47.496620Z",
               "end_time" : "2020-01-27T21:58:56.078432Z",
@@ -7974,7 +7974,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T17:57:12.611843Z",
               "end_time" : "2020-03-13T17:57:21.150459Z",
@@ -8001,7 +8001,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:42:07.120381Z",
               "end_time" : "2020-01-23T13:42:14.551146Z",
@@ -8028,7 +8028,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T21:58:57.977529Z",
               "end_time" : "2020-01-27T21:59:06.039458Z",
@@ -8055,7 +8055,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:35:53.549636Z",
               "end_time" : "2020-03-24T07:36:08.961366Z",
@@ -8082,7 +8082,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:42:47.684451Z",
               "end_time" : "2020-01-23T13:42:55.704377Z",
@@ -8109,7 +8109,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T22:02:12.093735Z",
               "end_time" : "2020-01-27T22:02:20.073220Z",
@@ -8136,7 +8136,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T22:02:56.650118Z",
               "end_time" : "2020-01-27T22:03:04.823593Z",
@@ -8163,7 +8163,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:05:48.494416Z",
               "end_time" : "2020-01-23T12:06:02.714273Z",
@@ -8190,7 +8190,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:36:10.451765Z",
               "end_time" : "2020-03-24T07:36:18.968362Z",
@@ -8217,7 +8217,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:06:21.858575Z",
               "end_time" : "2020-01-23T12:06:33.536113Z",
@@ -8244,7 +8244,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:10:02.950811Z",
               "end_time" : "2020-01-23T12:10:11.396416Z",
@@ -8271,7 +8271,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T22:29:16.256759Z",
               "end_time" : "2020-01-27T22:29:24.243148Z",
@@ -8298,7 +8298,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T22:30:18.077699Z",
               "end_time" : "2020-01-27T22:30:26.110065Z",
@@ -8325,7 +8325,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:37:44.791707Z",
               "end_time" : "2020-03-24T07:37:53.621840Z",
@@ -8352,7 +8352,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T22:35:11.354455Z",
               "end_time" : "2020-01-27T22:35:46.771391Z",
@@ -8379,7 +8379,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-21T13:00:33.776389Z",
               "end_time" : "2020-04-21T13:01:07.238470Z",
@@ -8406,7 +8406,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T22:39:00.323078Z",
               "end_time" : "2020-01-27T22:39:09.146431Z",
@@ -8433,7 +8433,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-30T09:02:24.331603Z",
               "end_time" : "2020-03-30T09:02:39.497989Z",
@@ -8460,7 +8460,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:53:59.492341Z",
               "end_time" : "2020-01-23T13:54:13.053567Z",
@@ -8487,7 +8487,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T22:39:52.841268Z",
               "end_time" : "2020-01-27T22:40:00.899385Z",
@@ -8514,7 +8514,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T22:41:20.299403Z",
               "end_time" : "2020-01-27T22:41:29.306539Z",
@@ -8541,7 +8541,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T22:41:31.492962Z",
               "end_time" : "2020-01-27T22:41:39.253582Z",
@@ -8568,7 +8568,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T22:43:02.757825Z",
               "end_time" : "2020-01-27T22:43:11.129841Z",
@@ -8595,7 +8595,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-17T20:24:43.648763Z",
               "end_time" : "2020-03-17T20:24:52.271346Z",
@@ -8622,7 +8622,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-29T12:42:04.569923Z",
               "end_time" : "2020-04-29T12:42:14.711428Z",
@@ -8649,7 +8649,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T22:44:51.209141Z",
               "end_time" : "2020-01-27T22:44:59.630012Z",
@@ -8676,7 +8676,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:55:10.117345Z",
               "end_time" : "2020-01-23T13:55:19.861030Z",
@@ -8703,7 +8703,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-17T20:25:13.209989Z",
               "end_time" : "2020-03-17T20:25:23.823656Z",
@@ -8730,7 +8730,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-05-05T21:10:17.732341Z",
               "end_time" : "2020-05-05T21:10:25.944056Z",
@@ -8757,7 +8757,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-09-08T18:08:06.180411Z",
               "end_time" : "2020-09-08T18:08:48.814757Z",
@@ -8784,7 +8784,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:20:46.835592Z",
               "end_time" : "2020-01-23T12:20:56.523751Z",
@@ -8811,7 +8811,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:20:35.395387Z",
               "end_time" : "2020-01-23T12:20:44.857630Z",
@@ -8838,7 +8838,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T23:03:17.703953Z",
               "end_time" : "2020-01-27T23:03:27.911121Z",
@@ -8865,7 +8865,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:57:26.597507Z",
               "end_time" : "2020-01-23T13:57:36.940089Z",
@@ -8892,7 +8892,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T13:57:16.970183Z",
               "end_time" : "2020-01-23T13:57:24.579947Z",
@@ -8919,7 +8919,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:22:51.621965Z",
               "end_time" : "2020-01-23T12:23:02.900557Z",
@@ -8946,7 +8946,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T18:06:33.304858Z",
               "end_time" : "2020-03-13T18:06:42.845643Z",
@@ -8973,7 +8973,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:22:39.523794Z",
               "end_time" : "2020-01-23T12:22:49.035714Z",
@@ -9000,7 +9000,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T18:06:22.128824Z",
               "end_time" : "2020-03-13T18:06:31.722086Z",
@@ -9027,7 +9027,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-01T11:50:41.725312Z",
               "end_time" : "2020-04-01T11:50:51.739808Z",
@@ -9054,7 +9054,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:29:14.237568Z",
               "end_time" : "2020-01-23T12:29:24.497044Z",
@@ -9081,7 +9081,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T14:00:07.321362Z",
               "end_time" : "2020-01-23T14:03:11.379451Z",
@@ -9108,7 +9108,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T14:03:58.675284Z",
               "end_time" : "2020-01-23T14:06:59.515294Z",
@@ -9135,7 +9135,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:44:32.130244Z",
               "end_time" : "2020-03-24T07:44:41.701477Z",
@@ -9162,7 +9162,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-05-27T14:22:59.508567Z",
               "end_time" : "2020-05-27T14:23:07.899652Z",
@@ -9189,7 +9189,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-22T07:45:53.916913Z",
               "end_time" : "2020-04-22T07:46:01.320438Z",
@@ -9216,7 +9216,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-05-14T13:02:50.919242Z",
               "end_time" : "2020-05-14T13:03:00.060557Z",
@@ -9243,7 +9243,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T14:07:13.399121Z",
               "end_time" : "2020-01-23T14:07:21.826047Z",
@@ -9270,7 +9270,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T14:07:49.279089Z",
               "end_time" : "2020-01-23T14:07:58.328332Z",
@@ -9297,7 +9297,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-30T09:07:38.264132Z",
               "end_time" : "2020-03-30T09:07:46.538292Z",
@@ -9324,7 +9324,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:36:45.074225Z",
               "end_time" : "2020-01-23T12:36:55.818933Z",
@@ -9351,7 +9351,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:36:34.573392Z",
               "end_time" : "2020-01-23T12:36:43.183792Z",
@@ -9378,7 +9378,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T17:26:48.165741Z",
               "end_time" : "2020-03-19T17:26:56.678699Z",
@@ -9405,7 +9405,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-15T15:58:30.887159Z",
               "end_time" : "2020-04-15T15:58:39.930640Z",
@@ -9432,7 +9432,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-04-15T15:58:41.446868Z",
               "end_time" : "2020-04-15T15:58:50.619495Z",
@@ -9459,7 +9459,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:37:08.796827Z",
               "end_time" : "2020-01-23T12:37:17.352024Z",
@@ -9486,7 +9486,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:38:02.015955Z",
               "end_time" : "2020-01-23T12:38:10.373343Z",
@@ -9513,7 +9513,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T16:22:05.362112Z",
               "end_time" : "2020-03-13T16:22:16.599122Z",
@@ -9540,7 +9540,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T23:24:36.780731Z",
               "end_time" : "2020-01-27T23:24:44.843052Z",
@@ -9567,7 +9567,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:45:01.864248Z",
               "end_time" : "2020-03-24T07:45:10.448775Z",
@@ -9594,7 +9594,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T14:09:38.078111Z",
               "end_time" : "2020-01-23T14:09:45.706752Z",
@@ -9621,7 +9621,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-21T15:51:38.753744Z",
               "end_time" : "2020-07-21T15:52:21.965035Z",
@@ -9648,7 +9648,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T14:09:57.862349Z",
               "end_time" : "2020-01-23T14:10:06.228021Z",
@@ -9675,7 +9675,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T16:22:49.991058Z",
               "end_time" : "2020-03-13T16:23:00.371090Z",
@@ -9702,7 +9702,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-08-31T14:12:32.384140Z",
               "end_time" : "2020-08-31T14:12:41.183137Z",
@@ -9729,7 +9729,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:39:32.389807Z",
               "end_time" : "2020-01-23T12:39:47.170535Z",
@@ -9756,7 +9756,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T07:46:12.568941Z",
               "end_time" : "2020-03-24T07:46:22.117422Z",
@@ -9783,7 +9783,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:38:50.495723Z",
               "end_time" : "2020-01-23T12:38:59.286928Z",
@@ -9810,7 +9810,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T14:21:20.056855Z",
               "end_time" : "2020-01-23T14:21:28.182836Z",
@@ -9837,7 +9837,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:39:49.568721Z",
               "end_time" : "2020-01-23T12:40:06.642959Z",
@@ -9864,7 +9864,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T14:22:01.792967Z",
               "end_time" : "2020-01-23T14:22:09.681531Z",
@@ -9891,7 +9891,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T23:52:53.105027Z",
               "end_time" : "2020-01-27T23:53:01.867964Z",
@@ -9918,7 +9918,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-30T09:08:44.713613Z",
               "end_time" : "2020-03-30T09:08:52.851711Z",
@@ -9939,7 +9939,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-05-11T11:32:15.282965Z",
               "end_time" : "2020-05-11T11:32:22.768684Z",
@@ -9966,7 +9966,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-27T23:55:48.289297Z",
               "end_time" : "2020-01-27T23:55:56.324677Z",
@@ -9993,7 +9993,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-30T09:08:54.294568Z",
               "end_time" : "2020-03-30T09:09:02.987855Z",
@@ -10020,7 +10020,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-05-14T13:03:02.146222Z",
               "end_time" : "2020-05-14T13:03:11.183247Z",
@@ -10047,7 +10047,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T12:40:54.732072Z",
               "end_time" : "2020-01-23T12:41:05.521037Z",
@@ -10074,7 +10074,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T17:31:40.107614Z",
               "end_time" : "2020-03-19T17:31:50.143682Z",
@@ -10101,7 +10101,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-17T21:20:11.118493Z",
               "end_time" : "2020-03-17T21:20:25.179884Z",
@@ -10128,7 +10128,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-28T00:03:38.463100Z",
               "end_time" : "2020-01-28T00:03:46.214194Z",
@@ -10155,7 +10155,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-30T09:09:13.586334Z",
               "end_time" : "2020-03-30T09:09:21.914507Z",
@@ -10182,7 +10182,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-30T09:09:23.441371Z",
               "end_time" : "2020-03-30T09:09:33.210901Z",
@@ -10209,7 +10209,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T17:32:12.151124Z",
               "end_time" : "2020-03-19T17:32:20.587713Z",
@@ -10236,7 +10236,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T17:32:42.317138Z",
               "end_time" : "2020-03-19T17:32:50.419499Z",
@@ -10263,7 +10263,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-28T13:13:13.700498Z",
               "end_time" : "2020-01-28T13:13:21.840907Z",
@@ -10290,7 +10290,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T17:32:32.533106Z",
               "end_time" : "2020-03-19T17:32:40.774505Z",
@@ -10317,7 +10317,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T17:32:54.860120Z",
               "end_time" : "2020-03-19T17:33:03.246194Z",
@@ -10344,7 +10344,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-09-02T10:31:58.488248Z",
               "end_time" : "2020-09-02T10:32:10.056746Z",
@@ -10371,7 +10371,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-12T23:35:43.528966Z",
               "end_time" : "2020-03-12T23:35:54.899909Z",
@@ -10398,7 +10398,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-06-02T14:06:27.954923Z",
               "end_time" : "2020-06-02T14:09:15.308373Z",
@@ -10425,7 +10425,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T14:30:52.541768Z",
               "end_time" : "2020-01-23T14:31:00.657605Z",
@@ -10452,7 +10452,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T17:33:14.644608Z",
               "end_time" : "2020-03-19T17:33:22.633253Z",
@@ -10479,7 +10479,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-28T13:14:53.414303Z",
               "end_time" : "2020-01-28T13:15:01.371688Z",
@@ -10506,7 +10506,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-30T09:10:58.513295Z",
               "end_time" : "2020-03-30T09:11:07.313601Z",
@@ -10533,7 +10533,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-28T13:20:30.863851Z",
               "end_time" : "2020-01-28T13:20:38.660679Z",
@@ -10560,7 +10560,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T14:31:05.387199Z",
               "end_time" : "2020-01-23T14:31:13.956530Z",
@@ -10587,7 +10587,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-18T00:04:21.420473Z",
               "end_time" : "2020-03-18T00:04:30.326205Z",
@@ -10614,7 +10614,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T14:31:38.963699Z",
               "end_time" : "2020-01-23T14:31:47.094977Z",
@@ -10641,7 +10641,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-14T14:09:47.126609Z",
               "end_time" : "2020-03-14T14:09:55.496189Z",
@@ -10668,7 +10668,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-12T23:41:38.821922Z",
               "end_time" : "2020-03-12T23:41:46.919147Z",
@@ -10695,7 +10695,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T08:14:50.664581Z",
               "end_time" : "2020-03-24T08:14:59.016666Z",
@@ -10722,7 +10722,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T14:31:29.351408Z",
               "end_time" : "2020-01-23T14:31:36.945337Z",
@@ -10749,7 +10749,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-24T08:15:00.716197Z",
               "end_time" : "2020-03-24T08:15:09.669978Z",
@@ -10776,7 +10776,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-12T23:41:48.403707Z",
               "end_time" : "2020-03-12T23:41:56.650031Z",
@@ -10797,7 +10797,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-05-11T11:32:23.918514Z",
               "end_time" : "2020-05-11T11:32:31.175678Z",
@@ -10824,7 +10824,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-28T13:29:49.450534Z",
               "end_time" : "2020-01-28T13:29:57.046656Z",
@@ -10851,7 +10851,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-23T14:32:00.120504Z",
               "end_time" : "2020-01-23T14:32:08.003350Z",
@@ -10878,7 +10878,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-01-28T13:29:59.209090Z",
               "end_time" : "2020-01-28T13:30:07.379124Z",
@@ -10905,7 +10905,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T17:36:15.768796Z",
               "end_time" : "2020-03-19T17:36:26.595661Z",
@@ -10932,7 +10932,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-05-10T16:48:29.187399Z",
               "end_time" : "2020-05-10T16:48:40.896073Z",
@@ -10959,7 +10959,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T16:40:53.389981Z",
               "end_time" : "2020-03-13T16:41:05.475571Z",
@@ -10986,7 +10986,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-19T17:37:05.920794Z",
               "end_time" : "2020-03-19T17:37:17.383923Z",
@@ -11013,7 +11013,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-21T16:35:39.528506Z",
               "end_time" : "2020-07-21T16:35:51.741187Z",
@@ -11040,7 +11040,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-07T13:31:51.155765Z",
               "end_time" : "2020-07-07T13:31:59.080744Z",
@@ -11067,7 +11067,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-09-08T18:08:53.850927Z",
               "end_time" : "2020-09-08T18:09:07.161624Z",
@@ -11094,7 +11094,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-09-04T15:47:19.451745Z",
               "end_time" : "2020-09-04T15:47:38.610656Z",
@@ -11121,7 +11121,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-16T08:07:53.691334Z",
               "end_time" : "2020-07-16T08:08:01.129216Z",
@@ -11148,7 +11148,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-16T08:07:43.670040Z",
               "end_time" : "2020-07-16T08:07:51.086329Z",
@@ -11175,7 +11175,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-08-17T13:11:57.365144Z",
               "end_time" : "2020-08-17T13:12:04.774183Z",
@@ -11202,7 +11202,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-16T08:08:03.982987Z",
               "end_time" : "2020-07-16T08:08:13.028668Z",
@@ -11229,7 +11229,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-08-17T13:11:46.201061Z",
               "end_time" : "2020-08-17T13:11:54.831788Z",
@@ -11256,7 +11256,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-16T08:08:25.835967Z",
               "end_time" : "2020-07-16T08:08:33.288549Z",
@@ -11283,7 +11283,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-16T08:08:47.107192Z",
               "end_time" : "2020-07-16T08:08:54.726837Z",
@@ -11310,7 +11310,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-16T08:09:18.359362Z",
               "end_time" : "2020-07-16T08:09:25.995938Z",
@@ -11337,7 +11337,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-08-17T13:12:17.768531Z",
               "end_time" : "2020-08-17T13:12:25.064318Z",
@@ -11364,7 +11364,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-07T13:32:12.073797Z",
               "end_time" : "2020-07-07T13:32:20.537932Z",
@@ -11391,7 +11391,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-16T08:09:28.671200Z",
               "end_time" : "2020-07-16T08:09:40.404098Z",
@@ -11418,7 +11418,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-07T13:32:01.849723Z",
               "end_time" : "2020-07-07T13:32:09.341582Z",
@@ -11445,7 +11445,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-09-02T10:35:35.573942Z",
               "end_time" : "2020-09-02T10:38:08.996995Z",
@@ -11472,7 +11472,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-07-16T08:12:20.647007Z",
               "end_time" : "2020-07-16T08:12:29.820580Z",
@@ -11499,7 +11499,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-09-02T10:38:56.185790Z",
               "end_time" : "2020-09-02T10:39:08.009030Z",
@@ -11526,7 +11526,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-09-02T10:39:10.843831Z",
               "end_time" : "2020-09-02T10:39:28.675529Z",
@@ -11553,7 +11553,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-06-03T16:16:12.018721Z",
               "end_time" : "2020-06-03T16:16:21.344709Z",
@@ -11580,7 +11580,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-18T18:33:51.428255Z",
               "end_time" : "2020-03-18T18:33:59.850615Z",
@@ -11601,7 +11601,7 @@
               "scanner" : {
                 "name" : "ScanCode",
                 "version" : "3.0.2",
-                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore HERE_NOTICE --ignore META-INF/DEPENDENCIES --json-pp"
+                "configuration" : "--copyright --license --ignore *.ort.yml --info --strip-root --timeout 300 --ignore META-INF/DEPENDENCIES --json-pp"
               },
               "start_time" : "2020-03-13T16:41:53.355417Z",
               "end_time" : "2020-03-13T16:42:00.965731Z",

--- a/scanner/src/test/assets/mime-types-2.1.18_scancode-2.9.7.json
+++ b/scanner/src/test/assets/mime-types-2.1.18_scancode-2.9.7.json
@@ -6,7 +6,6 @@
     "--copyright": true,
     "--ignore": [
       "*.ort.yml",
-      "HERE_NOTICE",
       "META-INF/DEPENDENCIES"
     ],
     "--info": true,

--- a/scanner/src/test/assets/mime-types-2.1.18_scancode-3.0.2.json
+++ b/scanner/src/test/assets/mime-types-2.1.18_scancode-3.0.2.json
@@ -8,7 +8,6 @@
         "--copyright": true,
         "--ignore": [
           "*.ort.yml",
-          "HERE_NOTICE",
           "META-INF/DEPENDENCIES"
         ],
         "--info": true,

--- a/scanner/src/test/kotlin/scanners/scancode/ScanCodeResultParserTest.kt
+++ b/scanner/src/test/kotlin/scanners/scancode/ScanCodeResultParserTest.kt
@@ -50,7 +50,7 @@ class ScanCodeResultParserTest : WordSpec({
             val summary = generateSummary(Instant.now(), Instant.now(), resultFile, result)
 
             summary.fileCount shouldBe 10
-            summary.packageVerificationCode shouldBe "9e3fdffc51568b300a457228055f8dc8a99fc64b"
+            summary.packageVerificationCode shouldBe "875d4d6eabe5bf8cda99be52e28b04cc194de6ea"
         }
     }
 
@@ -65,7 +65,7 @@ class ScanCodeResultParserTest : WordSpec({
             val summary = generateSummary(Instant.now(), Instant.now(), resultFile, result)
 
             summary.fileCount shouldBe 10
-            summary.packageVerificationCode shouldBe "8ec22f05b1a7006ae667901ae0853beff197c576"
+            summary.packageVerificationCode shouldBe "285b79745a96a1c561fef5591586a97176f19457"
         }
     }
 
@@ -623,7 +623,6 @@ class ScanCodeResultParserTest : WordSpec({
             details.version shouldBe "2.9.7"
             details.configuration shouldContain "--copyright true"
             details.configuration shouldContain "--ignore *.ort.yml"
-            details.configuration shouldContain "--ignore HERE_NOTICE"
             details.configuration shouldContain "--ignore META-INF/DEPENDENCIES"
             details.configuration shouldContain "--info true"
         }


### PR DESCRIPTION
As a follow-up to 3410cff, remove this last bit of HERE-specific data
from the code base.

As the SPDX package verification code in simply calculated on the ScanCode
JSON output file for testing, the code needs to be adjusted as the
ScanCode output was modified.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>