### PR TITLE
LicenseClassifications: Refactor the API a bit for usability

### DIFF
--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -26,7 +26,6 @@ import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.shouldContain
@@ -54,6 +53,7 @@ import org.ossreviewtoolkit.reporter.reporters.AsciiDocTemplateReporter
 import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.ORT_REPO_CONFIG_FILENAME
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class ExamplesFunTest : StringSpec() {
     private val examplesDir = File("../examples")
@@ -98,9 +98,10 @@ class ExamplesFunTest : StringSpec() {
 
                 classifications.categories.filter { it.description.isNotEmpty() } shouldNot beEmpty()
                 classifications.categoryNames shouldContain "public-domain"
-                val licMIT = classifications["MIT".toSpdx()]
-                licMIT.shouldNotBeNull()
-                licMIT.categories shouldContain "permissive"
+                val classificationsForMit = classifications["MIT".toSpdx()]
+                classificationsForMit shouldNotBeNull {
+                    shouldContain("permissive")
+                }
             }
         }
 

--- a/examples/rules.kts
+++ b/examples/rules.kts
@@ -29,16 +29,13 @@
  * Import the license classifications from license-classifications.yml.
  */
 
-fun getLicenseCategory(categoryId: String) =
-    licenseClassifications.getLicensesForCategory(categoryId).map { it.id }.toSet()
+val permissiveLicenses = licenseClassifications.licensesByCategory["permissive"].orEmpty()
 
-val permissiveLicenses = getLicenseCategory("permissive")
+val copyleftLicenses = licenseClassifications.licensesByCategory["copyleft"].orEmpty()
 
-val copyleftLicenses = getLicenseCategory("copyleft")
+val copyleftLimitedLicenses = licenseClassifications.licensesByCategory["copyleft-limited"].orEmpty()
 
-val copyleftLimitedLicenses = getLicenseCategory("copyleft-limited")
-
-val publicDomainLicenses = getLicenseCategory("public-domain")
+val publicDomainLicenses = licenseClassifications.licensesByCategory["public-domain"].orEmpty()
 
 // The complete set of licenses covered by policy rules.
 val handledLicenses = listOf(

--- a/model/src/test/kotlin/licenses/LicenseClassificationsTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseClassificationsTest.kt
@@ -23,15 +23,16 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 
-import java.lang.IllegalStateException
 import java.util.Collections.emptySortedSet
 
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class LicenseClassificationsTest : WordSpec({
     "init()" should {
@@ -87,8 +88,8 @@ class LicenseClassificationsTest : WordSpec({
         }
     }
 
-    "getLicensesForCategory()" should {
-        "fetch all licenses for a specific category" {
+    "licensesByCategory" should {
+        "contain all licenses for a specific category" {
             val cat1 = LicenseCategory("permissive", "Permissive licenses")
             val cat2 = LicenseCategory("non permissive", "Strict licenses")
             val lic1 = LicenseCategorization(
@@ -105,35 +106,38 @@ class LicenseClassificationsTest : WordSpec({
                 categorizations = listOf(lic1, lic2, lic3)
             )
 
-            val permissiveLicenses = licenseClassifications.getLicensesForCategory(cat1.name)
+            val permissiveLicenses = licenseClassifications.licensesByCategory[cat1.name]
 
-            permissiveLicenses should containExactlyInAnyOrder(lic1, lic2)
+            permissiveLicenses shouldNotBeNull {
+                permissiveLicenses should containExactlyInAnyOrder(lic1.id, lic2.id)
+            }
         }
 
-        "throw an exception when querying the licenses for an unknown category" {
+        "return null when querying the licenses for an unknown category" {
             val cat = LicenseCategory("oneAndOnlyCategory")
             val lic = LicenseCategorization(
                 SpdxSingleLicenseExpression.parse("LICENSE"), sortedSetOf(cat.name)
             )
             val licenseClassifications = LicenseClassifications(categorizations = listOf(lic), categories = listOf(cat))
 
-            shouldThrow<IllegalStateException> {
-                licenseClassifications.getLicensesForCategory("nonExistingCategory")
-            }
+            licenseClassifications.licensesByCategory["nonExistingCategory"] should beNull()
         }
     }
 
-    "LicenseClassifications" should {
-        "allow querying a license by ID" {
-            val lic1 = LicenseCategorization(
-                SpdxSingleLicenseExpression.parse("ASL-1"), emptySortedSet()
-            )
-            val lic2 = LicenseCategorization(
-                SpdxSingleLicenseExpression.parse("ASL-2"), emptySortedSet()
-            )
-            val licenseClassifications = LicenseClassifications(categorizations = listOf(lic1, lic2))
+    "categoriesByLicense" should {
+        "contain all categories for a specific license" {
+            val asl1 = SpdxSingleLicenseExpression.parse("ASL-1")
+            val asl2 = SpdxSingleLicenseExpression.parse("ASL-2")
 
-            licenseClassifications[SpdxSingleLicenseExpression.parse("ASL-2")] shouldBe lic2
+            val lic1 = LicenseCategorization(asl1, setOf("hot"))
+            val lic2 = LicenseCategorization(asl2, setOf("cold"))
+
+            val licenseClassifications = LicenseClassifications(
+                categories = listOf(LicenseCategory("hot"), LicenseCategory("cold")),
+                categorizations = listOf(lic1, lic2)
+            )
+
+            licenseClassifications[asl2] shouldBe setOf("cold")
         }
     }
 

--- a/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
@@ -188,7 +188,7 @@ class FreemarkerTemplateProcessor(
         @Suppress("UNUSED") // This function is used in the templates.
         fun filterForCategory(licenses: Collection<ResolvedLicense>, category: String): List<ResolvedLicense> =
             licenses.filter { resolvedLicense ->
-                licenseClassifications[resolvedLicense.license]?.categories?.contains(category) ?: true
+                licenseClassifications[resolvedLicense.license]?.contains(category) ?: true
             }
 
         /**


### PR DESCRIPTION
Instead of returning the LicenseCategorization, just return the licenses
contained in the category or the names of the categories, respectively,
as that is what is mostly needed. Adjust variable names, docs and tests
accordingly.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>