### PR TITLE
ScanCode: Drop support for debug command line options

### DIFF
--- a/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
@@ -28,7 +28,7 @@ import org.ossreviewtoolkit.model.config.ScannerConfiguration
 class ScanCodeTest : WordSpec({
     val scanner = ScanCode("ScanCode", ScannerConfiguration())
 
-    "getConfiguration()" should {
+    "configuration()" should {
         "return the default values if the scanner configuration is empty" {
             scanner.configuration shouldBe "--copyright --license --info --strip-root --timeout 300 --json-pp"
         }
@@ -39,22 +39,20 @@ class ScanCodeTest : WordSpec({
                     options = mapOf(
                         "ScanCode" to mapOf(
                             "commandLine" to "--command --line",
-                            "commandLineNonConfig" to "--commandLineNonConfig",
-                            "debugCommandLine" to "--debug --commandLine",
-                            "debugCommandLineNonConfig" to "--debugCommandLineNonConfig"
+                            "commandLineNonConfig" to "--commandLineNonConfig"
                         )
                     )
                 )
             )
 
-            scannerWithConfig.configuration shouldBe "--command --line --json-pp --debug --commandLine"
+            scannerWithConfig.configuration shouldBe "--command --line --json-pp"
         }
     }
 
     "commandLineOptions" should {
         "contain the default values if the scanner configuration is empty" {
             scanner.commandLineOptions.joinToString(" ") shouldMatch
-                    "--copyright --license --info --strip-root --timeout 300 --processes \\d+ --verbose"
+                    "--copyright --license --info --strip-root --timeout 300 --processes \\d+"
         }
 
         "contain the values from the scanner configuration" {
@@ -63,16 +61,14 @@ class ScanCodeTest : WordSpec({
                     options = mapOf(
                         "ScanCode" to mapOf(
                             "commandLine" to "--command --line",
-                            "commandLineNonConfig" to "--commandLineNonConfig",
-                            "debugCommandLine" to "--debug --commandLine",
-                            "debugCommandLineNonConfig" to "--debugCommandLineNonConfig"
+                            "commandLineNonConfig" to "--commandLineNonConfig"
                         )
                     )
                 )
             )
 
             scannerWithConfig.commandLineOptions.joinToString(" ") shouldBe
-                    "--command --line --commandLineNonConfig --debug --commandLine --debugCommandLineNonConfig"
+                    "--command --line --commandLineNonConfig"
         }
     }
 })


### PR DESCRIPTION
The feature to pass additional options to the command line of ScanCode
when ORT is running in debug mode does not bring much benefit (the
same effect can be achieved manually by temporarily changing the ORT
configuration), but complicates the handling of scanner options and
checks for their compatibility.

While at it, fix some warnings about wrong references in KDoc comments
(which have been caused by changes of the 'configuration' property.

