### PR TITLE
Add a wrapper for FossID scanner

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/Extensions.kt
+++ b/clients/fossid-webapp/src/main/kotlin/Extensions.kt
@@ -30,15 +30,21 @@ private const val PROJECT_GROUP = "projects"
  * Verify that a request for the given [operation] was successful. [operation] is a free label describing the operation.
  * If [withDataCheck] is true, also the payload data is checked, otherwise that check is skipped.
  */
-fun EntityPostResponseBody<*>.checkResponse(operation: String, withDataCheck: Boolean = true) {
+fun <B : EntityPostResponseBody<T>, T> B?.checkResponse(operation: String, withDataCheck: Boolean = true): B {
+    // The null check is here to avoid the caller to wrap the call of this function in a null check.
+    requireNotNull(this)
+
     require(error == null) {
         "Could not '$operation'. Additional information : $error"
     }
+
     if (withDataCheck) {
         requireNotNull(data) {
             "No Payload received for '$operation'. Additional information: $error"
         }
     }
+
+    return this
 }
 
 /**

--- a/clients/fossid-webapp/src/main/kotlin/Extensions.kt
+++ b/clients/fossid-webapp/src/main/kotlin/Extensions.kt
@@ -21,9 +21,6 @@
 
 package org.ossreviewtoolkit.clients.fossid
 
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-
 import kotlin.reflect.KClass
 
 private const val SCAN_GROUP = "scans"
@@ -111,12 +108,11 @@ suspend fun FossIdRestService.createScan(
     user: String,
     apiKey: String,
     projectCode: String,
+    scanCode: String,
     gitRepoUrl: String,
     gitBranch: String
-): MapResponseBody<String> {
-    val formatter = DateTimeFormatter.ofPattern("'$projectCode'_yyyyMMdd_HHmmss")
-    val scanCode = formatter.format(LocalDateTime.now())
-    return createScan(
+): MapResponseBody<String> =
+    createScan(
         PostRequestBody(
             "create",
             SCAN_GROUP,
@@ -129,7 +125,6 @@ suspend fun FossIdRestService.createScan(
             "git_branch" to gitBranch
         )
     )
-}
 
 /**
  * Trigger a scan with the given [scanCode].

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
@@ -113,6 +113,7 @@ class FossIdClientNewProjectTest : StringSpec({
         service.createScan(
             "", "",
             PROJECT_CODE,
+            SCAN_CODE,
             "https://github.com/gundy/semver4j.git",
             "671aa533f7e33c773bf620b9f466650c3b9ab26e"
         ) shouldNotBeNull {

--- a/scanner/build.gradle.kts
+++ b/scanner/build.gradle.kts
@@ -25,6 +25,7 @@ val kotlinxCoroutinesVersion: String by project
 val mockkVersion: String by project
 val postgresVersion: String by project
 val postgresEmbeddedVersion: String by project
+val retrofitVersion: String by project
 val sw360ClientVersion: String by project
 val wiremockVersion: String by project
 
@@ -49,10 +50,12 @@ dependencies {
     api(project(":model"))
 
     implementation(project(":clients:clearly-defined"))
+    implementation(project(":clients:fossid-webapp"))
     implementation(project(":downloader"))
     implementation(project(":utils"))
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    implementation("com.squareup.retrofit2:converter-jackson:$retrofitVersion")
     implementation("com.zaxxer:HikariCP:$hikariVersion")
     implementation("org.eclipse.sw360:client:$sw360ClientVersion")
     implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -1,0 +1,357 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.fossid
+
+import java.io.File
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+import kotlin.time.measureTimedValue
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeoutOrNull
+
+import org.ossreviewtoolkit.clients.fossid.FossIdRestService
+import org.ossreviewtoolkit.clients.fossid.checkDownloadStatus
+import org.ossreviewtoolkit.clients.fossid.checkResponse
+import org.ossreviewtoolkit.clients.fossid.checkScanStatus
+import org.ossreviewtoolkit.clients.fossid.createProject
+import org.ossreviewtoolkit.clients.fossid.createScan
+import org.ossreviewtoolkit.clients.fossid.downloadFromGit
+import org.ossreviewtoolkit.clients.fossid.listIdentifiedFiles
+import org.ossreviewtoolkit.clients.fossid.listIgnoredFiles
+import org.ossreviewtoolkit.clients.fossid.listMarkedAsIdentifiedFiles
+import org.ossreviewtoolkit.clients.fossid.model.identification.ignored.IgnoredFile
+import org.ossreviewtoolkit.clients.fossid.model.identification.markedAsIdentified.MarkedAsIdentifiedFile
+import org.ossreviewtoolkit.clients.fossid.model.status.DownloadStatus
+import org.ossreviewtoolkit.clients.fossid.model.status.ScanState
+import org.ossreviewtoolkit.clients.fossid.runScan
+import org.ossreviewtoolkit.clients.fossid.toList
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.scanner.AbstractScannerFactory
+import org.ossreviewtoolkit.scanner.RemoteScanner
+import org.ossreviewtoolkit.utils.OkHttpClientHelper
+import org.ossreviewtoolkit.utils.log
+
+import retrofit2.Retrofit
+import retrofit2.converter.jackson.JacksonConverterFactory
+
+/**
+ * A wrapper for [FossID](https://fossid.com/).
+ *
+ * This scanner can be configured in [ScannerConfiguration.options] using the key "FossId". It offers the following
+ * configuration options:
+ *
+ * * **"serverUrl":** The URL of the FossID server.
+ * * **"user":** The user to connect to the FossID server.
+ * * **"apiKey":** The API key of the user which connects to the FossID server.
+ */
+class FossId(name: String, config: ScannerConfiguration) : RemoteScanner(name, config) {
+    class Factory : AbstractScannerFactory<FossId>("FossId") {
+        override fun create(config: ScannerConfiguration) = FossId(scannerName, config)
+    }
+
+    companion object {
+        @JvmStatic
+        private val PROJECT_NAME_REGEX = Regex("""^.*\/([\w-]+)\.git$""")
+
+        @JvmStatic
+        private val GIT_FETCH_DONE_REGEX = Regex("-> FETCH_HEAD")
+
+        @JvmStatic
+        private val WAIT_INTERVAL_MS = 10000L
+
+        @JvmStatic
+        private val WAIT_REPETITION = 50
+
+        /**
+         * Convert a Git repository URL to a valid project name, e.g.
+         * https://github.com/jshttp/mime-types.git -> mime-types
+         */
+        fun convertGitUrlToProjectName(gitRepoUrl: String): String {
+            val projectNameMatcher = PROJECT_NAME_REGEX.matchEntire(gitRepoUrl)
+
+            requireNotNull(projectNameMatcher) { "Git repository URL '$gitRepoUrl' does not contain a project name." }
+
+            val projectName = projectNameMatcher.groupValues[1]
+
+            log.info { "Found project name in '$projectName' in URL '$gitRepoUrl'." }
+
+            return projectName
+        }
+    }
+
+    private val serverUrl: String
+    private val apiKey: String
+    private val user: String
+
+    private val secretKeys = listOf("serverUrl", "apiKey", "user")
+
+    private val service: FossIdRestService
+
+    // TODO: Parse the version from the FossID login page.
+    override val version = ""
+
+    override val configuration = ""
+
+    init {
+        val fossIdScannerOptions = config.options?.get("FossId")
+
+        requireNotNull(fossIdScannerOptions) { "No FossId Scanner configuration found." }
+
+        serverUrl = fossIdScannerOptions["serverUrl"]
+            ?: throw IllegalArgumentException("No FossId server URL configuration found.")
+        apiKey = fossIdScannerOptions["apiKey"]
+            ?: throw IllegalArgumentException("No FossId API Key configuration found.")
+        user = fossIdScannerOptions["user"]
+            ?: throw IllegalArgumentException("No FossId User configuration found.")
+
+        val client = OkHttpClientHelper.buildClient()
+
+        val retrofit = Retrofit.Builder()
+            .client(client)
+            .baseUrl(serverUrl)
+            .addConverterFactory(JacksonConverterFactory.create(FossIdRestService.JSON_MAPPER))
+            .build()
+
+        service = retrofit.create(FossIdRestService::class.java)
+    }
+
+    override fun filterOptionsForResult(options: Map<String, String>) =
+        options.mapValues { (k, v) ->
+            v.takeUnless { k in secretKeys }.orEmpty()
+        }
+
+    override suspend fun scanPackages(
+        packages: List<Package>,
+        outputDirectory: File,
+        downloadDirectory: File
+    ): Map<Package, List<ScanResult>> {
+        val (results, duration) = measureTimedValue {
+            val results = mutableMapOf<Package, MutableList<ScanResult>>()
+
+            packages.forEach { pkg: Package ->
+                val startTime = Instant.now()
+
+                // TODO: Continue the processing of other packages and add an issue to the scan result.
+                require(pkg.vcsProcessed.type == VcsType.GIT) { "FossID only supports Git repositories." }
+
+                val url = pkg.vcsProcessed.url
+                val revision = pkg.vcsProcessed.revision.ifEmpty { "HEAD" }
+                val projectCode = convertGitUrlToProjectName(url)
+
+                log.info { "Creating project '$projectCode' ..." }
+
+                service.createProject(user, apiKey, projectCode, projectCode)
+                    .checkResponse("create project")
+
+                log.info { "Creating scan for URL $url and revision $revision ..." }
+
+                val scanCode = createScan(projectCode, url, revision)
+
+                log.info { "Initiating download from Git repository ..." }
+
+                service.downloadFromGit(user, apiKey, scanCode)
+                    .checkResponse("download data from Git", false)
+
+                checkScan(scanCode)
+
+                val rawResults = getRawResults(scanCode)
+                val resultsSummary = createResultSummary(startTime, rawResults)
+
+                results.getOrPut(pkg) { mutableListOf() } += resultsSummary
+            }
+
+            results
+        }
+
+        log.info { "Scan has been performed. Total time was ${duration.inSeconds}s." }
+
+        return results
+    }
+
+    /**
+     * Create a new scan in the FossID server and return the scan code.
+     */
+    private suspend fun createScan(projectCode: String, url: String, revision: String): String {
+        val formatter = DateTimeFormatter.ofPattern("'$projectCode'_yyyyMMdd_HHmmss")
+        val scanCode = formatter.format(LocalDateTime.now())
+
+        val response = service.createScan(user, apiKey, projectCode, scanCode, url, revision)
+            .checkResponse("create scan")
+
+        val scanId = response.data?.get("scan_id")
+
+        requireNotNull(scanId) { "Scan could not be created. The response was: ${response.message}." }
+
+        log.info { "Scan has been created with ID $scanId." }
+
+        return scanCode
+    }
+
+    /**
+     * Check the repository has been downloaded and the scan has completed. The latter will be triggered if needed.
+     */
+    private suspend fun checkScan(scanCode: String) {
+        waitDownloadComplete(scanCode)
+
+        val response = service.checkScanStatus(user, apiKey, scanCode)
+            .checkResponse("check scan status", false)
+
+        if (response.data?.state == ScanState.NOT_STARTED) {
+            log.info { "Triggering scan as it has not yet been started." }
+
+            service.runScan(user, apiKey, scanCode)
+                .checkResponse("trigger scan", false)
+
+            waitScanComplete(scanCode)
+        }
+    }
+
+    /**
+     * Wait for the lambda [waitLoop] to return true, waiting [loopDelay] between each invocation.
+     * [waitLoop] should return true if the wait must be interrupted, false otherwise.
+     *
+     * A [timeout] will be honored and null will be returned if the timeout has been reached.
+     */
+    private suspend fun wait(timeout: Long, loopDelay: Long, waitLoop: suspend () -> Boolean) =
+        withTimeoutOrNull(timeout) {
+            while (!waitLoop()) {
+                delay(loopDelay)
+            }
+        }
+
+    /**
+     * Wait until the repository of a scan with [scanCode] has been downloaded.
+     */
+    private suspend fun waitDownloadComplete(scanCode: String) {
+        val result = wait(WAIT_INTERVAL_MS * WAIT_REPETITION, WAIT_INTERVAL_MS) {
+            FossId.log.info { "Checking download status for scan code '$scanCode'." }
+
+            val response = service.checkDownloadStatus(user, apiKey, scanCode)
+                .checkResponse("check download status")
+
+            if (response.data == DownloadStatus.FINISHED) return@wait true
+
+            // There is a bug with the FossId server version < 20.2: Sometimes the download is complete but it stays in
+            // state "NOT FINISHED". Therefore we check the output of the Git fetch to find out whether the download is
+            // actually done.
+            val message = response.message
+            if (message == null || !GIT_FETCH_DONE_REGEX.containsMatchIn(message)) return@wait false
+
+            FossId.log.warn { "The download is not finished but Git Fetch has completed. Carrying on..." }
+
+            return@wait true
+        }
+
+        requireNotNull(result) { "Timeout while waiting for the download to complete" }
+
+        log.info { "Data download has been completed." }
+    }
+
+    /**
+     * Wait until a scan with [scanCode] has completed.
+     */
+    private suspend fun waitScanComplete(scanCode: String) {
+        val result = wait(WAIT_INTERVAL_MS * WAIT_REPETITION, WAIT_INTERVAL_MS) {
+            FossId.log.info { "Waiting for scan='$scanCode' to complete." }
+
+            val response = service.checkScanStatus(user, apiKey, scanCode)
+                .checkResponse("check scan status", false)
+
+            response.data?.let {
+                if (it.state == ScanState.FINISHED) {
+                    FossId.log.info { "Scan finished with response: ${response.data?.comment}." }
+                    true
+                } else {
+                    FossId.log.info {
+                        "Scan status for scan code '$scanCode' is '${response.data?.state}'. Waiting ..."
+                    }
+
+                    false
+                }
+            } ?: false
+        }
+
+        requireNotNull(result) { "Timeout while waiting for the scan to complete" }
+
+        log.info { "Scan has been completed." }
+    }
+
+    /**
+     * Get the different kind of results from the scan with [scanCode]
+     */
+    private suspend fun getRawResults(scanCode: String): RawResults {
+        val responseIdentifiedFiles = service.listIdentifiedFiles(user, apiKey, scanCode)
+            .checkResponse("list identified files", false)
+
+        // TODO: Replace the return type of listIdentifiedFiles to Call<EntityPostResponseBody<Any>> and use toList().
+        val identifiedFiles = responseIdentifiedFiles.data?.values?.toList().orEmpty()
+
+        log.info { "${identifiedFiles.size} identified files have been returned for scan code $scanCode." }
+
+        val responseMarkedAsIdentified = service.listMarkedAsIdentifiedFiles(user, apiKey, scanCode)
+            .checkResponse("list marked as identified files", false)
+        val markedAsIdentifiedFiles = responseMarkedAsIdentified.toList(MarkedAsIdentifiedFile::class)
+
+        log.info {
+            "${markedAsIdentifiedFiles.size} marked as identified files have been returned for scan code $scanCode."
+        }
+
+        // The "match_type=ignore" info is already in the ScanResult, but here we also get the ignore reason.
+        val responseListIgnoredFiles = service.listIgnoredFiles(user, apiKey, scanCode)
+            .checkResponse("list ignored files", false)
+
+        val listIgnoredFiles = responseListIgnoredFiles.toList(IgnoredFile::class)
+        return RawResults(identifiedFiles, markedAsIdentifiedFiles, listIgnoredFiles)
+    }
+
+    /**
+     * Construct the [ScanSummary] for this FossId scan.
+     */
+    private fun createResultSummary(startTime: Instant, rawResults: RawResults): ScanResult {
+        val associate = rawResults.listIgnoredFiles.associateBy { it.path }
+
+        val (filesCount, licenseFindings, copyrightFindings) = if (rawResults.markedAsIdentifiedFiles.isEmpty()) {
+            rawResults.identifiedFiles
+        } else {
+            rawResults.markedAsIdentifiedFiles
+        }.mapSummary(associate)
+
+        val summary = ScanSummary(
+            startTime = startTime,
+            endTime = Instant.now(),
+            fileCount = filesCount,
+            packageVerificationCode = "",
+            licenseFindings = licenseFindings.toSortedSet(),
+            copyrightFindings = copyrightFindings.toSortedSet(),
+            // TODO: Maybe get issues from FossId (see has_failed_scan_files, get_failed_files and maybe get_scan_log).
+            issues = emptyList()
+        )
+
+        return ScanResult(Provenance(), details, summary)
+    }
+}

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdScanResults.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdScanResults.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.fossid
+
+import org.ossreviewtoolkit.clients.fossid.model.identification.identifiedFiles.IdentifiedFile
+import org.ossreviewtoolkit.clients.fossid.model.identification.ignored.IgnoredFile
+import org.ossreviewtoolkit.clients.fossid.model.identification.markedAsIdentified.MarkedAsIdentifiedFile
+import org.ossreviewtoolkit.clients.fossid.model.summary.Summarizable
+import org.ossreviewtoolkit.model.CopyrightFinding
+import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.TextLocation
+
+/**
+ * A simple data class to hold FossId raw results.
+ */
+internal data class RawResults(
+    val identifiedFiles: List<IdentifiedFile>,
+    val markedAsIdentifiedFiles: List<MarkedAsIdentifiedFile>,
+    val listIgnoredFiles: List<IgnoredFile>
+)
+
+/**
+ * A simple Triple data class to hold FossId mapped results.
+ */
+internal data class FindingsContainer(
+    val filesCount: Int,
+    val licenseFindings: MutableList<LicenseFinding>,
+    val copyrightFindings: MutableList<CopyrightFinding>
+)
+
+/**
+ * Map a fossId Raw result to sections that can be included in a [org.ossreviewtoolkit.model.ScanSummary].
+ */
+internal fun <T : Summarizable> List<T>.mapSummary(ignoredFiles: Map<String, IgnoredFile>): FindingsContainer {
+    val licenseFindings = mutableListOf<LicenseFinding>()
+    val copyrightFindings = mutableListOf<CopyrightFinding>()
+
+    val files = filterNot { ignoredFiles.contains(it.getFileName()) }
+    files.forEach { summarizable ->
+        val summary = summarizable.toSummary()
+        val location = TextLocation(summary.path, -1, -1)
+
+        summary.licences.forEach {
+            val finding = LicenseFinding(it.identifier, location)
+            licenseFindings += finding
+        }
+
+        summarizable.getCopyright()?.let {
+            if (it.isNotEmpty()) {
+                copyrightFindings += CopyrightFinding(it, location)
+            }
+        }
+    }
+
+    return FindingsContainer(
+        filesCount = files.size,
+        licenseFindings = licenseFindings,
+        copyrightFindings = copyrightFindings
+    )
+}

--- a/scanner/src/main/resources/META-INF/services/org.ossreviewtoolkit.scanner.ScannerFactory
+++ b/scanner/src/main/resources/META-INF/services/org.ossreviewtoolkit.scanner.ScannerFactory
@@ -2,4 +2,5 @@ org.ossreviewtoolkit.scanner.scanners.Askalono$Factory
 org.ossreviewtoolkit.scanner.scanners.BoyterLc$Factory
 org.ossreviewtoolkit.scanner.scanners.FileCounter$Factory
 org.ossreviewtoolkit.scanner.scanners.Licensee$Factory
+org.ossreviewtoolkit.scanner.scanners.fossid.FossId$Factory
 org.ossreviewtoolkit.scanner.scanners.scancode.ScanCode$Factory


### PR DESCRIPTION
This scanner communicates with the FossID API client that
was previously contributed.
In this first implementation, the scanner creates a
project, a scan, runs the scan and fetches the scan
results.

- Add a parameter to FossIdRestService.createScan to be
able to configure scan name before scan's creation.

- Allow a scanner to modify its configuration before
putting the latter in the ScannerRun.

The FossId server configuration is passed through ort.conf :

```
options {
       FossId {
             serverUrl="https://xxx"
             apiKey="xxx"
             user="xxx"
       }
}
```


[1]: https://fossid.com/

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>
