### PR TITLE
Add support for external document reference to SPDX document

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
@@ -52,12 +52,12 @@ packages:
     type: "Git"
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
-    path: "analyzer/src/funTest/assets/projects/synthetic/spdx/project/libs/curl"
+    path: "analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl"
   vcs_processed:
     type: "Git"
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
-    path: "analyzer/src/funTest/assets/projects/synthetic/spdx/project/libs/curl"
+    path: "analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl"
 - id: "SpdxDocumentFile::zlib:1.2.11"
   purl: "pkg:spdxdocumentfile/zlib@1.2.11"
   declared_licenses:

--- a/analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl/package.spdx.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl/package.spdx.yml
@@ -18,10 +18,11 @@ packages:
      IMAP, SMTP, POP3, RTSP and RTMP. libcurl offers a myriad of powerful features."
   copyrightText: "Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many
     contributors, see the THANKS file."
-  downloadLocation: "git+https://github.com/curl/curl.git@53cdc2c963e33bc0cc1a51ad2df79396202e07f8"
+  downloadLocation: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
   filesAnalyzed: false
   homepage: "https://curl.haxx.se/"
   licenseConcluded: "NOASSERTION"
   licenseDeclared: "curl"
   name: "curl"
   versionInfo: "7.70.0"
+  originator: "Person: Daniel Stenberg (daniel@haxx.se)"

--- a/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
@@ -11,6 +11,12 @@ dataLicense: "CC0-1.0"
 documentNamespace: "http://spdx.org/spdxdocs/spdx-document-xyz"
 documentDescribes:
 - "SPDXRef-Package-xyz"
+externalDocumentRefs:
+- externalDocumentId: "DocumentRef-curl-7.70.0"
+  checksum:
+    algorithm: "SHA1"
+    checksumValue: "a2ab98f8e10bad892313ccc573b3820369551dcb"
+  spdxDocument: "../package/libs/curl/package.spdx.yml"
 packages:
 - SPDXID: "SPDXRef-Package-xyz"
   description: "Awesome product created by Example Inc."
@@ -23,21 +29,6 @@ packages:
   name: "xyz"
   versionInfo: "0.1.0"
   originator: "Person: Thomas Steenbergen"
-- SPDXID: "SPDXRef-Package-curl"
-  description: "A command line tool and library for transferring data with URL syntax, supporting \
-     HTTP, HTTPS, FTP, FTPS, GOPHER, TFTP, SCP, SFTP, SMB, TELNET, DICT, LDAP, LDAPS, MQTT, FILE, \
-     IMAP, SMTP, POP3, RTSP and RTMP. libcurl offers a myriad of powerful features."
-  copyrightText: "Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many
-    contributors, see the THANKS file."
-  downloadLocation: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
-  filesAnalyzed: false
-  homepage: "https://curl.haxx.se/"
-  licenseConcluded: "NOASSERTION"
-  licenseDeclared: "curl"
-  name: "curl"
-  packageFileName: "./libs/curl"
-  versionInfo: "7.70.0"
-  originator: "Person: Daniel Stenberg (daniel@haxx.se)"
 - SPDXID: "SPDXRef-Package-openssl"
   description: "OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit for the Transport Layer Security (TLS) protocol formerly known as the Secure Sockets Layer (SSL) protocol. The protocol implementation is based on a full-strength general purpose cryptographic library, which can also be used stand-alone."
   copyrightText: "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
@@ -78,14 +69,14 @@ packages:
   versionInfo: "1.2.11"
   originator: "Person: Mark Adler, Jean-loup Gailly"
 relationships:
-- spdxElementId: "SPDXRef-Package-curl"
+- spdxElementId: "DocumentRef-curl-7.70.0:SPDXRef-ToolsElement"
   relatedSpdxElement: "SPDXRef-Package-xyz"
   relationshipType: "TEST_DEPENDENCY_OF"
 - spdxElementId: "SPDXRef-Package-xyz"
   relatedSpdxElement: "SPDXRef-Package-openssl"
   relationshipType: "DEPENDS_ON"
 - spdxElementId: "SPDXRef-Package-xyz"
-  relatedSpdxElement: "SPDXRef-Package-curl"
+  relatedSpdxElement: "DocumentRef-curl-7.70.0:SPDXRef-ToolsElement"
   relationshipType: "DYNAMIC_LINK"
 - spdxElementId: "SPDXRef-Package-xyz"
   relatedSpdxElement: "SPDXRef-Package-zlib"

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -73,6 +73,13 @@ private val SPDX_VCS_PREFIXES = mapOf(
 )
 
 /**
+ * Return the [SpdxPackage] in the [SpdxDocument] that denotes a project, or null if no project but only packages are
+ * defined.
+ */
+private fun SpdxDocument.projectPackage(): SpdxPackage? =
+    packages.takeIf { it.size > 1 }?.singleOrNull { it.packageFilename.isEmpty() || it.packageFilename == "." }
+
+/**
  * Return the organization from an "originator", "supplier", or "annotator" string, or null if no organization is
  * specified.
  */
@@ -353,8 +360,7 @@ class SpdxDocumentFile(
 
         // Distinguish whether we have a project-style SPDX document that describes a project and its dependencies, or a
         // package-style SPDX document that describes a single (dependency-)package.
-        val projectPackage = spdxDocument.packages.takeIf { it.size > 1 }
-            ?.singleOrNull { it.packageFilename.isEmpty() || it.packageFilename == "." }
+        val projectPackage = spdxDocument.projectPackage()
 
         val packages = mutableSetOf<Package>()
 

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -353,7 +353,8 @@ class SpdxDocumentFile(
 
         // Distinguish whether we have a project-style SPDX document that describes a project and its dependencies, or a
         // package-style SPDX document that describes a single (dependency-)package.
-        val projectPackage = spdxDocument.packages.singleOrNull { it.packageFilename.isEmpty() }
+        val projectPackage = spdxDocument.packages.takeIf { it.size > 1 }
+            ?.singleOrNull { it.packageFilename.isEmpty() || it.packageFilename == "." }
 
         val packages = mutableSetOf<Package>()
 


### PR DESCRIPTION
Introduce the integration of external document references that
refer to package spdx documents.

External references only get loaded when there is a relationship
referencing to the external document reference id, to avoid
unnecessary loading and parsing.

Resolves #3402.