### PR TITLE
Change NexusIqService to use suspend functions

### DIFF
--- a/advisor/src/main/kotlin/advisors/NexusIq.kt
+++ b/advisor/src/main/kotlin/advisors/NexusIq.kt
@@ -22,11 +22,6 @@ package org.ossreviewtoolkit.advisor.advisors
 import java.io.IOException
 import java.net.URI
 import java.time.Instant
-import java.util.concurrent.Executors
-
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.withContext
 
 import org.ossreviewtoolkit.advisor.AbstractAdvisorFactory
 import org.ossreviewtoolkit.advisor.Advisor
@@ -42,13 +37,12 @@ import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.model.utils.PurlType
 import org.ossreviewtoolkit.model.utils.getPurlType
 import org.ossreviewtoolkit.model.utils.toPurl
-import org.ossreviewtoolkit.utils.NamedThreadFactory
 import org.ossreviewtoolkit.utils.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.showStackTrace
 
-import retrofit2.Call
+import retrofit2.HttpException
 
 /**
  * The number of packages to request from Nexus IQ in one request.
@@ -76,78 +70,69 @@ class NexusIq(
             OkHttpClientHelper.buildClient()
         )
 
-        val advisorDispatcher =
-            Executors.newSingleThreadExecutor(NamedThreadFactory(advisorName)).asCoroutineDispatcher()
+        val startTime = Instant.now()
 
-        return coroutineScope {
-            val startTime = Instant.now()
+        val components = packages.map { pkg ->
+            val packageUrl = buildString {
+                append(pkg.purl)
 
-            val components = packages.map { pkg ->
-                val packageUrl = buildString {
-                    append(pkg.purl)
-
-                    when (pkg.id.getPurlType()) {
-                        PurlType.MAVEN.toString() -> append("?type=jar")
-                        PurlType.PYPI.toString() -> append("?extension=tar.gz")
-                    }
+                when (pkg.id.getPurlType()) {
+                    PurlType.MAVEN.toString() -> append("?type=jar")
+                    PurlType.PYPI.toString() -> append("?extension=tar.gz")
                 }
-
-                NexusIqService.Component(packageUrl)
             }
 
-            try {
-                val componentDetails = mutableMapOf<String, NexusIqService.ComponentDetails>()
+            NexusIqService.Component(packageUrl)
+        }
 
-                components.chunked(REQUEST_CHUNK_SIZE).forEach { component ->
-                    val serviceCall = withContext(advisorDispatcher) {
-                        service.getComponentDetails(NexusIqService.ComponentsWrapper(component))
-                    }
+        return try {
+            val componentDetails = mutableMapOf<String, NexusIqService.ComponentDetails>()
 
-                    val requestResults = execute(serviceCall).componentDetails.associateBy {
-                        it.component.packageUrl.substringBefore("?")
-                    }
-
-                    componentDetails += requestResults
+            components.chunked(REQUEST_CHUNK_SIZE).forEach { component ->
+                val requestResults = getComponentDetails(service, component).componentDetails.associateBy {
+                    it.component.packageUrl.substringBefore("?")
                 }
 
-                val endTime = Instant.now()
+                componentDetails += requestResults
+            }
 
-                packages.mapNotNullTo(mutableListOf()) { pkg ->
-                    componentDetails[pkg.id.toPurl()]?.takeUnless {
-                        it.securityData.securityIssues.isEmpty()
-                    }?.let { details ->
-                        pkg to listOf(
-                            AdvisorResult(
-                                details.securityData.securityIssues.map { it.toVulnerability() },
-                                AdvisorDetails(advisorName),
-                                AdvisorSummary(startTime, endTime)
-                            )
-                        )
-                    }
-                }.toMap()
-            } catch (e: IOException) {
-                e.showStackTrace()
+            val endTime = Instant.now()
 
-                val now = Instant.now()
-                packages.associateWith {
-                    listOf(
+            packages.mapNotNullTo(mutableListOf()) { pkg ->
+                componentDetails[pkg.id.toPurl()]?.takeUnless {
+                    it.securityData.securityIssues.isEmpty()
+                }?.let { details ->
+                    pkg to listOf(
                         AdvisorResult(
-                            vulnerabilities = emptyList(),
-                            advisor = AdvisorDetails(advisorName),
-                            summary = AdvisorSummary(
-                                startTime = now,
-                                endTime = now,
-                                issues = listOf(
-                                    createAndLogIssue(
-                                        source = advisorName,
-                                        message = "Failed to retrieve security vulnerabilities from $advisorName: " +
-                                                e.collectMessagesAsString()
-                                    )
+                            details.securityData.securityIssues.map { it.toVulnerability() },
+                            AdvisorDetails(advisorName),
+                            AdvisorSummary(startTime, endTime)
+                        )
+                    )
+                }
+            }.toMap()
+        } catch (e: IOException) {
+            e.showStackTrace()
+
+            val now = Instant.now()
+            packages.associateWith {
+                listOf(
+                    AdvisorResult(
+                        vulnerabilities = emptyList(),
+                        advisor = AdvisorDetails(advisorName),
+                        summary = AdvisorSummary(
+                            startTime = now,
+                            endTime = now,
+                            issues = listOf(
+                                createAndLogIssue(
+                                    source = advisorName,
+                                    message = "Failed to retrieve security vulnerabilities from $advisorName: " +
+                                            e.collectMessagesAsString()
                                 )
                             )
                         )
                     )
-                }
+                )
             }
         }
     }
@@ -163,23 +148,17 @@ class NexusIq(
     }
 
     /**
-     * Execute an HTTP request specified by the given [call]. The response status is checked. If everything went
-     * well, the marshalled body of the request is returned; otherwise, the function throws an exception.
+     * Invoke the [NexusIQ service][service] to request detail information for the given [components]. Catch HTTP
+     * exceptions thrown by the service and re-throw them as [IOException].
      */
-    private fun <T> execute(call: Call<T>): T {
-        val request = "${call.request().method} on ${call.request().url}"
-        log.debug { "Executing HTTP $request." }
-
-        val response = call.execute()
-        log.debug { "HTTP response is (status ${response.code()}): ${response.message()}" }
-
-        val body = response.body()
-        if (!response.isSuccessful || body == null) {
-            throw IOException(
-                "Failed HTTP $request with status ${response.code()} and error: ${response.errorBody()?.string()}."
-            )
+    private suspend fun getComponentDetails(
+        service: NexusIqService,
+        components: List<NexusIqService.Component>
+    ): NexusIqService.ComponentDetailsWrapper =
+        try {
+            log.debug { "Querying component details from ${nexusIqConfig.serverUrl}." }
+            service.getComponentDetails(NexusIqService.ComponentsWrapper(components))
+        } catch (e: HttpException) {
+            throw IOException(e)
         }
-
-        return body
-    }
 }

--- a/advisor/src/main/kotlin/advisors/NexusIq.kt
+++ b/advisor/src/main/kotlin/advisors/NexusIq.kt
@@ -115,25 +115,25 @@ class NexusIq(
             e.showStackTrace()
 
             val now = Instant.now()
-            packages.associateWith {
-                listOf(
-                    AdvisorResult(
-                        vulnerabilities = emptyList(),
-                        advisor = AdvisorDetails(advisorName),
-                        summary = AdvisorSummary(
-                            startTime = now,
-                            endTime = now,
-                            issues = listOf(
-                                createAndLogIssue(
-                                    source = advisorName,
-                                    message = "Failed to retrieve security vulnerabilities from $advisorName: " +
-                                            e.collectMessagesAsString()
-                                )
+            val failedResults = listOf(
+                AdvisorResult(
+                    vulnerabilities = emptyList(),
+                    advisor = AdvisorDetails(advisorName),
+                    summary = AdvisorSummary(
+                        startTime = now,
+                        endTime = now,
+                        issues = listOf(
+                            createAndLogIssue(
+                                source = advisorName,
+                                message = "Failed to retrieve security vulnerabilities from $advisorName: " +
+                                        e.collectMessagesAsString()
                             )
                         )
                     )
                 )
-            }
+            )
+
+            packages.associateWith { failedResults }
         }
     }
 

--- a/clients/nexus-iq/src/main/kotlin/NexusIqService.kt
+++ b/clients/nexus-iq/src/main/kotlin/NexusIqService.kt
@@ -29,7 +29,6 @@ import java.util.UUID
 import okhttp3.Credentials
 import okhttp3.OkHttpClient
 
-import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.jackson.JacksonConverterFactory
 import retrofit2.http.Body
@@ -112,5 +111,5 @@ interface NexusIqService {
      * See https://help.sonatype.com/iqserver/automating/rest-apis/component-details-rest-api---v2.
      */
     @POST("api/v2/components/details")
-    fun getComponentDetails(@Body components: ComponentsWrapper): Call<ComponentDetailsWrapper>
+    suspend fun getComponentDetails(@Body components: ComponentsWrapper): ComponentDetailsWrapper
 }


### PR DESCRIPTION
This PR is related #3553. It changes the service interface for NexusIQ to use the coroutines support provided by Retrofit.