### PR TITLE
EvaluatedModelMapper: Support empty IDs for rule violations

### DIFF
--- a/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
@@ -334,7 +334,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
 
     private fun addRuleViolation(ruleViolation: RuleViolation) {
         val resolutions = addResolutions(ruleViolation)
-        val pkg = packages.getValue(ruleViolation.pkg)
+        val pkg = packages[ruleViolation.pkg] ?: createEmptyPackage(ruleViolation.pkg)
         val license = ruleViolation.license?.let { licenses.addIfRequired(LicenseId(it.toString())) }
 
         val evaluatedViolation = EvaluatedRuleViolation(
@@ -449,7 +449,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     }
 
     private fun createEmptyPackage(id: Identifier): EvaluatedPackage {
-        val excludeInfo = packageExcludeInfo.getValue(id)
+        val excludeInfo = packageExcludeInfo[id] ?: PackageExcludeInfo(id, isExcluded = false)
 
         val evaluatedPathExcludes = pathExcludes.addIfRequired(excludeInfo.pathExcludes)
         val evaluatedScopeExcludes = scopeExcludes.addIfRequired(excludeInfo.scopeExcludes)


### PR DESCRIPTION
For "global" rule violations that are not triggered by a project or
package it makes sense to set the ID to Identifier.EMPTY. The WebApp
reporter so far failed to be generated for such rule violations as the
underlying mode mapper demanded the ID to by a valid project or package
ID. Relax this requirement to be able to display such "global" rule
violations in the WebApp reporter.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>