### PR TITLE
OkHttpClientHelper: Base all clients on the same base client

### DIFF
--- a/utils/src/main/kotlin/OkHttpClientHelper.kt
+++ b/utils/src/main/kotlin/OkHttpClientHelper.kt
@@ -36,7 +36,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 
-private typealias BuilderConfiguration = OkHttpClient.Builder.() -> Unit
+typealias BuilderConfiguration = OkHttpClient.Builder.() -> Unit
 
 /**
  * A helper class to manage OkHttp instances backed by distinct cache directories.
@@ -59,7 +59,7 @@ object OkHttpClientHelper {
      * Build a preconfigured client that uses a cache directory inside the [ORT data directory][ortDataDirectory].
      * Proxy environment variables are by default respected, but the client can further be configured via the [block].
      */
-    fun buildClient(block: OkHttpClient.Builder.() -> Unit = {}): OkHttpClient =
+    fun buildClient(block: BuilderConfiguration = {}): OkHttpClient =
         clients.getOrPut(block) {
             val cacheDirectory = ortDataDirectory.resolve("cache/http")
             val cache = Cache(cacheDirectory, MAX_CACHE_SIZE_IN_BYTES)
@@ -83,14 +83,14 @@ object OkHttpClientHelper {
     /**
      * Execute a [request] using the client for the specified [builder configuration][block].
      */
-    fun execute(request: Request, block: OkHttpClient.Builder.() -> Unit = {}): Response =
+    fun execute(request: Request, block: BuilderConfiguration = {}): Response =
         buildClient(block).newCall(request).execute()
 
     /**
      * Asynchronously enqueue a [request] using the client for the specified [builder configuration][block] and await
      * its response.
      */
-    suspend fun await(request: Request, block: OkHttpClient.Builder.() -> Unit = {}): Response =
+    suspend fun await(request: Request, block: BuilderConfiguration = {}): Response =
         buildClient(block).newCall(request).await()
 }
 

--- a/utils/src/main/kotlin/OkHttpClientHelper.kt
+++ b/utils/src/main/kotlin/OkHttpClientHelper.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.utils
 
 import java.io.IOException
 import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
 
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -45,7 +46,7 @@ object OkHttpClientHelper {
     private const val MAX_CACHE_SIZE_IN_BYTES = 1024L * 1024L * 1024L
 
     private val client = buildClient()
-    private val clients = mutableMapOf<BuilderConfiguration, OkHttpClient>()
+    private val clients = ConcurrentHashMap<BuilderConfiguration, OkHttpClient>()
 
     /**
      * A constant for the "too many requests" HTTP code as HttpURLConnection has none.

--- a/utils/src/main/kotlin/OkHttpClientHelper.kt
+++ b/utils/src/main/kotlin/OkHttpClientHelper.kt
@@ -43,7 +43,9 @@ typealias BuilderConfiguration = OkHttpClient.Builder.() -> Unit
  * A helper class to manage OkHttp instances backed by distinct cache directories.
  */
 object OkHttpClientHelper {
+    private const val CACHE_DIRECTORY = "cache/http"
     private const val MAX_CACHE_SIZE_IN_BYTES = 1024L * 1024L * 1024L
+    private const val READ_TIMEOUT_IN_SECONDS = 30L
 
     private val client = buildClient()
     private val clients = ConcurrentHashMap<BuilderConfiguration, OkHttpClient>()
@@ -58,7 +60,7 @@ object OkHttpClientHelper {
     }
 
     private fun buildClient(): OkHttpClient {
-        val cacheDirectory = ortDataDirectory.resolve("cache/http")
+        val cacheDirectory = ortDataDirectory.resolve(CACHE_DIRECTORY)
         val cache = Cache(cacheDirectory, MAX_CACHE_SIZE_IN_BYTES)
         val specs = listOf(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS, ConnectionSpec.CLEARTEXT)
 
@@ -70,7 +72,7 @@ object OkHttpClientHelper {
         return OkHttpClient.Builder()
             .cache(cache)
             .connectionSpecs(specs)
-            .readTimeout(Duration.ofSeconds(30))
+            .readTimeout(Duration.ofSeconds(READ_TIMEOUT_IN_SECONDS))
             .authenticator(Authenticator.JAVA_NET_AUTHENTICATOR)
             .proxyAuthenticator(Authenticator.JAVA_NET_AUTHENTICATOR)
             .build()

--- a/utils/src/test/kotlin/OkHttpClientHelperTest.kt
+++ b/utils/src/test/kotlin/OkHttpClientHelperTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.utils
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+
+import java.time.Duration
+
+class OkHttpClientHelperTest : StringSpec({
+    "Passing no lambda blocks should return the same client" {
+        val clientA = OkHttpClientHelper.buildClient()
+        val clientB = OkHttpClientHelper.buildClient()
+
+        clientA shouldBeSameInstanceAs clientB
+    }
+
+    "Passing the same lambda blocks should return the same client" {
+        val timeout: BuilderConfiguration = { readTimeout(Duration.ofSeconds(100)) }
+        val clientA = OkHttpClientHelper.buildClient(timeout)
+        val clientB = OkHttpClientHelper.buildClient(timeout)
+
+        clientA shouldBeSameInstanceAs clientB
+    }
+})


### PR DESCRIPTION
This way a common connection pool is shared across all clients.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>