### PR TITLE
Add and use a string comparison for SpdxExpressions

### DIFF
--- a/model/src/main/kotlin/LicenseFinding.kt
+++ b/model/src/main/kotlin/LicenseFinding.kt
@@ -40,7 +40,7 @@ data class LicenseFinding(
     val location: TextLocation
 ) : Comparable<LicenseFinding> {
     companion object {
-        private val COMPARATOR = compareBy<LicenseFinding> { it.license.toString() }.thenBy(LicenseFinding::location)
+        private val COMPARATOR = compareBy(LicenseFinding::license).thenBy(LicenseFinding::location)
     }
 
     constructor(license: String, location: TextLocation) : this(license.toSpdx(), location)

--- a/spdx-utils/src/main/kotlin/SpdxExpression.kt
+++ b/spdx-utils/src/main/kotlin/SpdxExpression.kt
@@ -33,7 +33,7 @@ import org.antlr.v4.runtime.CommonTokenStream
  * [1]: https://spdx.dev/spdx-specification-21-web-version#h.jxpfx0ykyb60
  */
 @JsonSerialize(using = ToStringSerializer::class)
-sealed class SpdxExpression {
+sealed class SpdxExpression : Comparable<SpdxExpression> {
     /**
      * The level of strictness to apply when validating an [SpdxExpression].
      */
@@ -179,6 +179,11 @@ sealed class SpdxExpression {
      * Concatenate [this][SpdxExpression] and [other] using [SpdxOperator.OR].
      */
     infix fun or(other: SpdxExpression) = SpdxCompoundExpression(this, SpdxOperator.OR, other)
+
+    /**
+     * Compare string representations of [SpdxExpression]s.
+     */
+    override fun compareTo(other: SpdxExpression) = toString().compareTo(other.toString())
 }
 
 /**


### PR DESCRIPTION
This is useful for sorted user-facing output.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>