### PR TITLE
NoticeTemplateReporter: Add an option for treating projects like packages

### DIFF
--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -44,7 +44,7 @@ class LicenseInfoResolver(
     val provider: LicenseInfoProvider,
     val copyrightGarbage: CopyrightGarbage,
     val archiver: FileArchiver?,
-    licenseFilenamePatterns: LicenseFilenamePatterns = LicenseFilenamePatterns.DEFAULT
+    val licenseFilenamePatterns: LicenseFilenamePatterns = LicenseFilenamePatterns.DEFAULT
 ) {
     private val resolvedLicenseInfo: ConcurrentMap<Identifier, ResolvedLicenseInfo> = ConcurrentHashMap()
     private val resolvedLicenseFiles: ConcurrentMap<Identifier, ResolvedLicenseFileInfo> = ConcurrentHashMap()

--- a/reporter/src/main/kotlin/reporters/AsciiDocTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AsciiDocTemplateReporter.kt
@@ -56,6 +56,7 @@ import org.ossreviewtoolkit.utils.safeDeleteRecursively
  *              fake backend is used to indicate that no backend should be used but the AsciiDoc files should be kept.
  * - *pdf.theme.file*: A path to an AsciiDoc PDF theme file. Only used with the "pdf" backend.
  * - *pdf.fonts.dir*: A path to a directory containing custom fonts. Only used with the "pdf" backend.
+ * - *project-types-as-packages: A comma-separated list of project types to be handled as packages.
  *
  * [1]: https://freemarker.apache.org
  * [2]: https://asciidoc.org/

--- a/reporter/src/main/kotlin/reporters/NoticeTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/NoticeTemplateReporter.kt
@@ -35,6 +35,7 @@ import org.ossreviewtoolkit.reporter.utils.FreemarkerTemplateProcessor
  * - *template.id*: A comma-separated list of IDs of templates provided by ORT. Currently only the "default"
  *                  and "summary" templates are available.
  * - *template.path*: A comma-separated list of paths to template files provided by the user.
+ * - *project-types-as-packages: A comma-separated list of project types to be handled as packages.
  *
  * [1]: https://freemarker.apache.org
  */

--- a/reporter/src/test/kotlin/utils/FreeMarkerTemplateProcessorTest.kt
+++ b/reporter/src/test/kotlin/utils/FreeMarkerTemplateProcessorTest.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.reporter.utils
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+
+import java.time.Instant
+
+import org.ossreviewtoolkit.model.AccessStatistics
+import org.ossreviewtoolkit.model.AnalyzerResult
+import org.ossreviewtoolkit.model.AnalyzerRun
+import org.ossreviewtoolkit.model.CopyrightFinding
+import org.ossreviewtoolkit.model.Environment
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.Project
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.Repository
+import org.ossreviewtoolkit.model.ScanRecord
+import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.ScanResultContainer
+import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.ScannerDetails
+import org.ossreviewtoolkit.model.ScannerRun
+import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.config.RepositoryConfiguration
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+
+private fun scanResultContainer(
+    id: String,
+    vcsInfo: VcsInfo,
+    findingsPaths: Collection<String>
+): ScanResultContainer {
+    val licenseFindings = findingsPaths.mapTo(sortedSetOf()) { LicenseFinding("MIT", TextLocation(it, 1)) }
+    val copyrightFindings = findingsPaths.mapTo(sortedSetOf()) { CopyrightFinding("(c)", TextLocation(it, 1)) }
+
+    return ScanResultContainer(
+        id = Identifier(id),
+        results = listOf(
+            ScanResult(
+                provenance = Provenance(vcsInfo = vcsInfo),
+                scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
+                summary = ScanSummary(
+                    startTime = Instant.EPOCH,
+                    endTime = Instant.EPOCH,
+                    fileCount = 0,
+                    packageVerificationCode = "",
+                    licenseFindings = licenseFindings,
+                    copyrightFindings = copyrightFindings,
+                )
+            )
+        )
+    )
+}
+
+private val PROJECT_VCS_INFO = VcsInfo(
+    type = VcsType.GIT_REPO,
+    url = "ssh://git@host/manifests/repo",
+    path = "path/to/manifest.xml",
+    revision = "deadbeaf44444444333333332222222211111111",
+    resolvedRevision = "deadbeaf44444444333333332222222211111111"
+)
+private val NESTED_VCS_INFO = VcsInfo(
+    type = VcsType.GIT,
+    url = "ssh://git@host/project/repo",
+    path = "",
+    revision = "0000000000000000000000000000000000000000",
+    resolvedRevision = "0000000000000000000000000000000000000000"
+)
+
+private val ORT_RESULT = OrtResult(
+    repository = Repository(
+        vcs = PROJECT_VCS_INFO,
+        config = RepositoryConfiguration(),
+        nestedRepositories = mapOf("nested-vcs-dir" to NESTED_VCS_INFO)
+    ),
+    analyzer = AnalyzerRun(
+        environment = Environment(),
+        config = DEFAULT_ANALYZER_CONFIGURATION,
+        result = AnalyzerResult.EMPTY.copy(
+            projects = sortedSetOf(
+                Project.EMPTY.copy(
+                    id = Identifier("NPM:@ort:project-in-root-dir:1.0"),
+                    definitionFilePath = "package.json",
+                    vcsProcessed = PROJECT_VCS_INFO
+                ),
+                Project.EMPTY.copy(
+                    id = Identifier("SpdxDocumentFile:@ort:project-in-sub-dir:1.0"),
+                    definitionFilePath = "sub-dir/project.spdx.yml",
+                    vcsProcessed = PROJECT_VCS_INFO
+                ),
+                Project.EMPTY.copy(
+                    id = Identifier("SpdxDocumentFile:@ort:project-in-nested-vcs:1.0"),
+                    definitionFilePath = "nested-vcs-dir/project.spdx.yml",
+                    vcsProcessed = NESTED_VCS_INFO
+                )
+            )
+        )
+    ),
+    scanner = ScannerRun(
+        environment = Environment(),
+        config = ScannerConfiguration(),
+        results = ScanRecord(
+            scanResults = sortedSetOf(
+                scanResultContainer(
+                    id = "NPM:@ort:project-in-root-dir:1.0",
+                    vcsInfo = PROJECT_VCS_INFO,
+                    findingsPaths = listOf(
+                        "src/main.js",
+                        "sub-dir/src/main.cpp",
+                        "nested-vcs-dir/src/main.cpp"
+                    )
+                ),
+                scanResultContainer(
+                    id = "SpdxDocumentFile:@ort:project-in-sub-dir:1.0",
+                    vcsInfo = PROJECT_VCS_INFO,
+                    findingsPaths = listOf(
+                        "sub-dir/src/main.cpp"
+                    )
+                ),
+                scanResultContainer(
+                    id = "SpdxDocumentFile:@ort:project-in-nested-vcs:1.0",
+                    vcsInfo = NESTED_VCS_INFO,
+                    findingsPaths = listOf(
+                        "src/main.cpp"
+                    )
+                )
+            ),
+            storageStats = AccessStatistics()
+        )
+    )
+)
+
+class FreeMarkerTemplateProcessorTest : WordSpec({
+    "deduplicateProjectScanResults" should {
+        val targetProjects = setOf(
+            Identifier("SpdxDocumentFile:@ort:project-in-sub-dir:1.0"),
+            Identifier("SpdxDocumentFile:@ort:project-in-nested-vcs:1.0")
+        )
+
+        val ortResult = ORT_RESULT.deduplicateProjectScanResults(targetProjects)
+
+        "keep the findings of all target projects" {
+            targetProjects.forAll { targetProject ->
+                ortResult.getScanResultsForId(targetProject) shouldBe ORT_RESULT.getScanResultsForId(targetProject)
+            }
+        }
+
+        "remove the findings of all target projects from the root project" {
+            val scanResult = ortResult.getScanResultsForId(Identifier("NPM:@ort:project-in-root-dir:1.0")).single()
+
+            with(scanResult.summary) {
+                copyrightFindings.map { it.location.path } shouldContainExactlyInAnyOrder listOf(
+                    "src/main.js"
+                )
+
+                licenseFindings.map { it.location.path } shouldContainExactlyInAnyOrder listOf(
+                    "src/main.js"
+                )
+            }
+        }
+    }
+})


### PR DESCRIPTION
ORT has two different notice reporter templates. The notice summary
template just lists all licenses in one large list. The default
template has one joint list for the licenses of all projects and
separate lists for the licenses of each package.

In some cases it makes sense to also list the licenses separetly for (some
of the) projects. In particular, listing the licenses for
SpdxDocumentFile projects separately is interresting, because this
allows to create a notice by package report also in cases where no
package manager is involved and the source code of the project dependencies
is just included in the source tree of the analyzed project.

In order to support that use case the scan results have to be
deduplicated for the projects which are to be reported separately in the
notices, because the scan results of projects may overlap - which would
in turn result in licenses being reported twice, in the list for the
respective package and in the joint licenses list for the projects.
