### PR TITLE
OssAttributionBuilderService: Use suspend functions in interface

### DIFF
--- a/clients/oss-attribution-builder/src/main/kotlin/OssAttributionBuilderService.kt
+++ b/clients/oss-attribution-builder/src/main/kotlin/OssAttributionBuilderService.kt
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 
 import okhttp3.OkHttpClient
 
-import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.jackson.JacksonConverterFactory
 import retrofit2.http.Body
@@ -171,37 +170,37 @@ interface OssAttributionBuilderService {
      * Create a new project in a running instance of the OSS Attribution builder.
      */
     @POST("projects/new")
-    fun createNewProject(
+    suspend fun createNewProject(
         @Body newProject: NewProject,
         @Header("Authorization") credentials: String
-    ): Call<NewProjectResponse>
+    ): NewProjectResponse
 
     /**
      * Attach a new package to an existing project.
      */
     @POST("projects/{projectId}/attach")
-    fun attachPackage(
+    suspend fun attachPackage(
         @Path("projectId") projectId: String,
         @Body newPackage: AttachPackage,
         @Header("Authorization") credentials: String
-    ): Call<AttachPackageResponse>
+    ): AttachPackageResponse
 
     /**
      * Generate an attribution document and store it on the server.
      */
     @POST("projects/{projectId}/build")
-    fun generateAttributionDoc(
+    suspend fun generateAttributionDoc(
         @Path("projectId") projectId: String,
         @Header("Authorization") credentials: String
-    ): Call<DocumentBuildResponse>
+    ): DocumentBuildResponse
 
     /**
      * Fetch a previously generated attribution document.
      */
     @GET("projects/{projectId}/docs/{documentId}")
-    fun fetchAttributionDoc(
+    suspend fun fetchAttributionDoc(
         @Path("projectId") projectId: String,
         @Path("documentId") documentId: String,
         @Header("Authorization") credentials: String
-    ): Call<AttributionDocument>
+    ): AttributionDocument
 }

--- a/reporter/build.gradle.kts
+++ b/reporter/build.gradle.kts
@@ -28,6 +28,7 @@ val flexmarkVersion: String by project
 val freemarkerVersion: String by project
 val hamcrestCoreVersion: String by project
 val jacksonVersion: String by project
+val kotlinxCoroutinesVersion: String by project
 val kotlinxHtmlVersion: String by project
 val retrofitVersion: String by project
 val simpleExcelVersion: String by project
@@ -85,6 +86,7 @@ dependencies {
     implementation("org.asciidoctor:asciidoctorj-pdf:$asciidoctorjPdfVersion")
     implementation("org.cyclonedx:cyclonedx-core-java:$cyclonedxCoreJavaVersion")
     implementation("org.freemarker:freemarker:$freemarkerVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:$kotlinxHtmlVersion")
 
     // This is required to not depend on the version of Apache Xalan bundled with the JDK. Otherwise the formatting of


### PR DESCRIPTION
Use the built-in support for Coroutines in Retrofit rather than the
Call-based API.

Adapt the AmazonOssAttributionBuilderReporter accordingly.

This is part of the work done for #3553.