### PR TITLE
Add @MarcelBochtler and @oheger-bosch as advisor code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 * @sschuberth @mnonnenmacher @fviernau
 *.md @sschuberth @mnonnenmacher @fviernau @tsteenbe
+/advisor/ @MarcelBochtler @oheger-bosch
 /reporter-web-app/ @tsteenbe
 /spdx-utils/src/main/ @sschuberth @mnonnenmacher @fviernau @tsteenbe


### PR DESCRIPTION
Both have contributed significantly to the advisor and should be
consulted for future changes.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>