### PR TITLE
Change ClearlyDefinedService interface to make use of Retrofit's support for coroutines

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -24,6 +24,7 @@ val cliktVersion: String by project
 val config4kVersion: String by project
 val jacksonVersion: String by project
 val kotestVersion: String by project
+val kotlinxCoroutinesVersion: String by project
 val log4jCoreVersion: String by project
 val postgresVersion: String by project
 val reflectionsVersion: String by project
@@ -126,6 +127,7 @@ dependencies {
     implementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jCoreVersion")
     implementation("org.eclipse.sw360.antenna:sw360-client:$antennaVersion")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
     implementation("org.postgresql:postgresql:$postgresVersion")
     implementation("org.reflections:reflections:$reflectionsVersion")
 

--- a/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
+++ b/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
@@ -25,8 +25,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.shouldStartWith
 
-import java.net.HttpURLConnection
-
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionInfo
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionPatch
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Coordinates
@@ -42,19 +40,15 @@ class ClearlyDefinedServiceFunTest : WordSpec({
         "return curation data".config(tags = setOf(ExpensiveTag)) {
             val service = ClearlyDefinedService.create(Server.PRODUCTION)
 
-            val getCall = service.getCuration(
+            val curation = service.getCuration(
                 ComponentType.MAVEN,
                 Provider.MAVEN_CENTRAL,
                 "javax.servlet",
                 "javax.servlet-api",
                 "3.1.0"
             )
-            val response = getCall.execute()
-            val responseCode = response.code()
-            val curation = response.body()
 
-            responseCode shouldBe HttpURLConnection.HTTP_OK
-            curation?.licensed?.declared shouldBe "CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0"
+            curation.licensed?.declared shouldBe "CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0"
         }
     }
 

--- a/clients/clearly-defined/src/main/kotlin/ClearlyDefinedService.kt
+++ b/clients/clearly-defined/src/main/kotlin/ClearlyDefinedService.kt
@@ -430,13 +430,13 @@ interface ClearlyDefinedService {
      * https://api.clearlydefined.io/api-docs/#/curations/get_curations__type___provider___namespace___name___revision_.
      */
     @GET("curations/{type}/{provider}/{namespace}/{name}/{revision}")
-    fun getCuration(
+    suspend fun getCuration(
         @Path("type") type: ComponentType,
         @Path("provider") provider: Provider,
         @Path("namespace") namespace: String,
         @Path("name") name: String,
         @Path("revision") revision: String
-    ): Call<Curation>
+    ): Curation
 
     /**
      * Upload curation [patch] data, see https://api.clearlydefined.io/api-docs/#/curations/patch_curations.

--- a/clients/clearly-defined/src/main/kotlin/ClearlyDefinedService.kt
+++ b/clients/clearly-defined/src/main/kotlin/ClearlyDefinedService.kt
@@ -52,6 +52,11 @@ const val HARVEST_CREATED = "Created"
 interface ClearlyDefinedService {
     companion object {
         /**
+         * The mapper for JSON serialization used by this service.
+         */
+        val JSON_MAPPER = JsonMapper().registerKotlinModule()
+
+        /**
          * Create a ClearlyDefined service instance for communicating with the given [server], optionally using a
          * pre-built OkHttp [client].
          */
@@ -67,7 +72,7 @@ interface ClearlyDefinedService {
                 .apply { if (client != null) client(client) }
                 .baseUrl(url)
                 .addConverterFactory(ScalarsConverterFactory.create())
-                .addConverterFactory(JacksonConverterFactory.create(JsonMapper().registerKotlinModule()))
+                .addConverterFactory(JacksonConverterFactory.create(JSON_MAPPER))
                 .build()
 
             return retrofit.create(ClearlyDefinedService::class.java)
@@ -408,7 +413,7 @@ interface ClearlyDefinedService {
      * https://api.clearlydefined.io/api-docs/#/definitions/post_definitions.
      */
     @POST("definitions")
-    fun getDefinitions(@Body coordinates: Collection<String>): Call<Map<String, Defined>>
+    suspend fun getDefinitions(@Body coordinates: Collection<String>): Map<String, Defined>
 
     /**
      * Search for existing definitions based on the [pattern] string provided, see
@@ -437,7 +442,7 @@ interface ClearlyDefinedService {
      * Upload curation [patch] data, see https://api.clearlydefined.io/api-docs/#/curations/patch_curations.
      */
     @PATCH("curations")
-    fun putCuration(@Body patch: ContributionPatch): Call<ContributionSummary>
+    suspend fun putCuration(@Body patch: ContributionPatch): ContributionSummary
 
     /**
      * [Request][request] the given components to be harvested, see

--- a/clients/clearly-defined/src/main/kotlin/ClearlyDefinedService.kt
+++ b/clients/clearly-defined/src/main/kotlin/ClearlyDefinedService.kt
@@ -32,7 +32,6 @@ import java.net.URI
 import okhttp3.OkHttpClient
 import okhttp3.ResponseBody
 
-import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.jackson.JacksonConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
@@ -423,7 +422,7 @@ interface ClearlyDefinedService {
      * Result is a list with the ClearlyDefined URIs to all the definitions that are matched by the pattern.
      */
     @GET("definitions")
-    fun searchDefinitions(@Query("pattern") pattern: String): Call<List<String>>
+    suspend fun searchDefinitions(@Query("pattern") pattern: String): List<String>
 
     /**
      * Get the curation for the component described by [type], [provider], [namespace], [name] and [revision], see
@@ -449,7 +448,7 @@ interface ClearlyDefinedService {
      * https://api.clearlydefined.io/api-docs/#/harvest/post_harvest.
      */
     @POST("harvest")
-    fun harvest(@Body request: Collection<HarvestRequest>): Call<String>
+    suspend fun harvest(@Body request: Collection<HarvestRequest>): String
 
     /**
      * Get information about the harvest tools that have produced data for the component described by [type],
@@ -458,13 +457,13 @@ interface ClearlyDefinedService {
      * This can be used to quickly find out whether results of a specific tool are already available.
      */
     @GET("harvest/{type}/{provider}/{namespace}/{name}/{revision}?form=list")
-    fun harvestTools(
+    suspend fun harvestTools(
         @Path("type") type: ComponentType,
         @Path("provider") provider: Provider,
         @Path("namespace") namespace: String,
         @Path("name") name: String,
         @Path("revision") revision: String
-    ): Call<List<String>>
+    ): List<String>
 
     /**
      * Get the harvested data for the component described by [type], [provider], [namespace], [name], and [revision]
@@ -472,7 +471,7 @@ interface ClearlyDefinedService {
      * https://api.clearlydefined.io/api-docs/#/harvest/get_harvest__type___provider___namespace___name___revision___tool___toolVersion_
      */
     @GET("harvest/{type}/{provider}/{namespace}/{name}/{revision}/{tool}/{toolVersion}?form=streamed")
-    fun harvestToolData(
+    suspend fun harvestToolData(
         @Path("type") type: ComponentType,
         @Path("provider") provider: Provider,
         @Path("namespace") namespace: String,
@@ -480,5 +479,5 @@ interface ClearlyDefinedService {
         @Path("revision") revision: String,
         @Path("tool") tool: String,
         @Path("toolVersion") toolVersion: String
-    ): Call<ResponseBody>
+    ): ResponseBody
 }

--- a/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
+++ b/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
@@ -23,6 +23,8 @@ import java.io.IOException
 import java.lang.IllegalArgumentException
 import java.time.Instant
 
+import kotlinx.coroutines.runBlocking
+
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService
 import org.ossreviewtoolkit.model.Failure
 import org.ossreviewtoolkit.model.Identifier
@@ -47,7 +49,7 @@ import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.showStackTrace
 
-import retrofit2.Call
+import retrofit2.HttpException
 
 /** The name used by ClearlyDefined for the ScanCode tool. */
 private const val TOOL_SCAN_CODE = "scancode"
@@ -127,7 +129,7 @@ class ClearlyDefinedStorage(
         sourceArtifact: RemoteArtifact?
     ): Result<ScanResultContainer> =
         try {
-            readFromClearlyDefined(id, packageCoordinates(id, vcs, sourceArtifact))
+            runBlocking { readFromClearlyDefined(id, packageCoordinates(id, vcs, sourceArtifact)) }
         } catch (e: IllegalArgumentException) {
             e.showStackTrace()
 
@@ -141,7 +143,7 @@ class ClearlyDefinedStorage(
      * using the given [coordinates] for looking up the data. These may not necessarily be equivalent to the
      * identifier, as we try to lookup source code results if a GitHub repository is known.
      */
-    private fun readFromClearlyDefined(
+    private suspend fun readFromClearlyDefined(
         id: Identifier,
         coordinates: ClearlyDefinedService.Coordinates
     ): Result<ScanResultContainer> {
@@ -149,43 +151,53 @@ class ClearlyDefinedStorage(
         log.info { "Looking up results for '${id.toCoordinates()}'." }
 
         return try {
-            val tools = execute(
-                clearlyDefinedService.harvestTools(
-                    coordinates.type,
-                    coordinates.provider,
-                    coordinates.namespace.orEmpty(),
-                    coordinates.name,
-                    coordinates.revision.orEmpty()
-                )
+            val tools = clearlyDefinedService.harvestTools(
+                coordinates.type,
+                coordinates.provider,
+                coordinates.namespace.orEmpty(),
+                coordinates.name,
+                coordinates.revision.orEmpty()
             )
 
             findScanCodeVersion(tools, coordinates)?.let { version ->
                 loadScanCodeResults(id, coordinates, version, startTime)
             } ?: emptyResult(id)
+        } catch (e: HttpException) {
+            e.response()?.errorBody()?.string()?.let {
+                log.error { "Error response from ClearlyDefined is: $it" }
+            }
+
+            handleException(id, e)
         } catch (e: IOException) {
-            e.showStackTrace()
-
-            log.error { "Error when reading results for package '${id.toCoordinates()}' from ClearlyDefined." }
-
-            Failure(e.collectMessagesAsString())
+            // There are some other exceptions thrown by Retrofit to be handled as well, e.g. ConnectException.
+            handleException(id, e)
         }
+    }
+
+    /**
+     * Log the exception that occurred during a request to ClearlyDefined and construct an error result from it.
+     */
+    private fun handleException(id: Identifier, e: Exception): Result<ScanResultContainer> {
+        e.showStackTrace()
+
+        log.error { "Error when reading results for package '${id.toCoordinates()}' from ClearlyDefined." }
+
+        return Failure(e.collectMessagesAsString())
     }
 
     /**
      * Load the ScanCode results file for the package with the given [id] and [coordinates] from ClearlyDefined.
      * The results have been produced by ScanCode in the given [version]; use the [startTime] for metadata.
      */
-    private fun loadScanCodeResults(
+    private suspend fun loadScanCodeResults(
         id: Identifier,
         coordinates: ClearlyDefinedService.Coordinates,
         version: String,
         startTime: Instant
     ): Result<ScanResultContainer> {
-        val toolResponse = execute(
-            clearlyDefinedService.harvestToolData(
-                coordinates.type, coordinates.provider, coordinates.namespace.orEmpty(), coordinates.name,
-                coordinates.revision.orEmpty(), TOOL_SCAN_CODE, version
-            )
+        val toolResponse = clearlyDefinedService.harvestToolData(
+            coordinates.type, coordinates.provider, coordinates.namespace.orEmpty(), coordinates.name,
+            coordinates.revision.orEmpty(), TOOL_SCAN_CODE, version
         )
 
         return toolResponse.use {
@@ -195,26 +207,5 @@ class ClearlyDefinedStorage(
                 Success(ScanResultContainer(id, listOf(ScanResult(Provenance(), details, summary))))
             } ?: emptyResult(id)
         }
-    }
-
-    /**
-     * Execute an HTTP request specified by the given [call]. The response status is checked. If everything went
-     * well, the marshalled body of the request is returned; otherwise, the function throws an exception.
-     */
-    private fun <T> execute(call: Call<T>): T {
-        val request = "${call.request().method} on ${call.request().url}"
-        log.debug { "Executing HTTP $request." }
-
-        val response = call.execute()
-        log.debug { "HTTP response is (status ${response.code()}): ${response.message()}" }
-
-        val body = response.body()
-        if (!response.isSuccessful || body == null) {
-            throw IOException(
-                "Failed HTTP $request with status ${response.code()} and error: ${response.errorBody()?.string()}."
-            )
-        }
-
-        return body
     }
 }

--- a/scanner/src/test/kotlin/storages/ClearlyDefinedStorageTest.kt
+++ b/scanner/src/test/kotlin/storages/ClearlyDefinedStorageTest.kt
@@ -285,7 +285,7 @@ class ClearlyDefinedStorageTest : WordSpec({
 
             when (val result = storage.read(TEST_IDENTIFIER)) {
                 is Success -> fail("Expected failure, but got $result")
-                is Failure -> result.error shouldContain "IOException"
+                is Failure -> result.error shouldContain "HttpException"
             }
         }
 


### PR DESCRIPTION
Like in previous PRs, the interface is changed to use suspend functions rather than the Call API, and the call sites are changed accordingly.

I split the change into multiple commits because there were different clients for separate groups of functions in the interface; so they could be converted one by one.