### PR TITLE
CycloneDxReporter: Fix the processing of copyright statements

### DIFF
--- a/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
+++ b/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
@@ -43,6 +43,7 @@ import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.spdx.SpdxLicense
+import org.ossreviewtoolkit.utils.CopyrightStatementsProcessor
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.isFalse
 
@@ -225,8 +226,9 @@ class CycloneDxReporter : Reporter {
 
             // TODO: Find a way to associate copyrights to the license they belong to, see
             //       https://github.com/CycloneDX/cyclonedx-core-java/issues/58
-            copyright = resolvedLicenseInfo.flatMap { it.getCopyrights(process = true) }.joinToString()
-                .takeUnless { it.isEmpty() }
+            copyright = resolvedLicenseInfo.flatMapTo(mutableSetOf()) { it.getCopyrights() }.let {
+                CopyrightStatementsProcessor().process(it).getAllStatements()
+            }.joinToString().takeUnless { it.isEmpty() }
 
             purl = pkg.purl + purlQualifier
             isModified = pkg.isModified


### PR DESCRIPTION
One important aspect of the copyright statements processing is the
merging of multiple copyright statements into single ones. Thus, collect
all copyright statements to be included first and then pass them to the
processing.

Previously, the processing was called once per license which hinders the
merging from doing its job.

Note: In a following change the call to the copyright statements
processor will be moved into a function of the resolved licenses API.
