### PR TITLE
OrtResult: Add getAdvisorResultsForId()

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -388,6 +388,11 @@ data class OrtResult(
         }
 
     /**
+     * Return the list of [AdvisorResult]s for the given [id].
+     */
+    fun getAdvisorResultsForId(id: Identifier): List<AdvisorResult> = advisorResultsById[id].orEmpty()
+
+    /**
      * Return all [RuleViolation]s contained in this [OrtResult].
      */
     @JsonIgnore


### PR DESCRIPTION
Previously, the private property advisorResultsById was unused and thus
could be removed. However, add a function to make use of that property
for consistency with getScanResultsForId().
