### PR TITLE
FossIdRestService: Change functions to use suspend

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/Extensions.kt
+++ b/clients/fossid-webapp/src/main/kotlin/Extensions.kt
@@ -26,8 +26,6 @@ import java.time.format.DateTimeFormatter
 
 import kotlin.reflect.KClass
 
-import retrofit2.Call
-
 private const val SCAN_GROUP = "scans"
 private const val PROJECT_GROUP = "projects"
 
@@ -67,7 +65,7 @@ fun <T : Any> EntityPostResponseBody<Any>.toList(cls: KClass<T>): List<T> =
  * @param apiKey the key to query the API
  * @param projectCode the code of the project
  */
-fun FossIdRestService.getProject(user: String, apiKey: String, projectCode: String) =
+suspend fun FossIdRestService.getProject(user: String, apiKey: String, projectCode: String) =
     getProject(
         PostRequestBody("get_information", PROJECT_GROUP, user, apiKey, "project_code" to projectCode)
     )
@@ -78,7 +76,7 @@ fun FossIdRestService.getProject(user: String, apiKey: String, projectCode: Stri
  * @param apiKey the key to query the API
  * @param projectCode the code of the project
  */
-fun FossIdRestService.listScansForProject(user: String, apiKey: String, projectCode: String) =
+suspend fun FossIdRestService.listScansForProject(user: String, apiKey: String, projectCode: String) =
     listScansForProject(
         PostRequestBody("get_all_scans", PROJECT_GROUP, user, apiKey, "project_code" to projectCode)
     )
@@ -91,7 +89,7 @@ fun FossIdRestService.listScansForProject(user: String, apiKey: String, projectC
  * @param projectName the name of the project
  * @param comment the comment of the project
  */
-fun FossIdRestService.createProject(
+suspend fun FossIdRestService.createProject(
     user: String,
     apiKey: String,
     projectCode: String,
@@ -118,13 +116,13 @@ fun FossIdRestService.createProject(
  * @param gitRepoUrl the URL of the GIT repository
  * @param gitBranch the branch of the GIT repository
  */
-fun FossIdRestService.createScan(
+suspend fun FossIdRestService.createScan(
     user: String,
     apiKey: String,
     projectCode: String,
     gitRepoUrl: String,
     gitBranch: String
-): Call<MapResponseBody<String>> {
+): MapResponseBody<String> {
     val formatter = DateTimeFormatter.ofPattern("'$projectCode'_yyyyMMdd_HHmmss")
     val scanCode = formatter.format(LocalDateTime.now())
     return createScan(
@@ -148,7 +146,7 @@ fun FossIdRestService.createScan(
  * @param apiKey the key to query the API
  * @param scanCode the code of the scan
  */
-fun FossIdRestService.runScan(user: String, apiKey: String, scanCode: String) =
+suspend fun FossIdRestService.runScan(user: String, apiKey: String, scanCode: String) =
     runScan(
         PostRequestBody(
             "run",
@@ -167,7 +165,7 @@ fun FossIdRestService.runScan(user: String, apiKey: String, scanCode: String) =
  * @param apiKey the key to query the API
  * @param scanCode the code of the scan
  */
-fun FossIdRestService.downloadFromGit(user: String, apiKey: String, scanCode: String) =
+suspend fun FossIdRestService.downloadFromGit(user: String, apiKey: String, scanCode: String) =
     downloadFromGit(
         PostRequestBody(
             "download_content_from_git",
@@ -184,7 +182,7 @@ fun FossIdRestService.downloadFromGit(user: String, apiKey: String, scanCode: St
  * @param apiKey the key to query the API
  * @param scanCode the code of the scan
  */
-fun FossIdRestService.checkScanStatus(user: String, apiKey: String, scanCode: String) =
+suspend fun FossIdRestService.checkScanStatus(user: String, apiKey: String, scanCode: String) =
     checkScanStatus(
         PostRequestBody("check_status", SCAN_GROUP, user, apiKey, "scan_code" to scanCode)
     )
@@ -195,7 +193,7 @@ fun FossIdRestService.checkScanStatus(user: String, apiKey: String, scanCode: St
  * @param apiKey the key to query the API
  * @param scanCode the code of the scan
  */
-fun FossIdRestService.checkDownloadStatus(user: String, apiKey: String, scanCode: String) =
+suspend fun FossIdRestService.checkDownloadStatus(user: String, apiKey: String, scanCode: String) =
     checkDownloadStatus(
         PostRequestBody(
             "check_status_download_content_from_git", SCAN_GROUP, user, apiKey, "scan_code" to scanCode
@@ -208,7 +206,7 @@ fun FossIdRestService.checkDownloadStatus(user: String, apiKey: String, scanCode
  * @param apiKey the key to query the API
  * @param scanCode the code of the scan
  */
-fun FossIdRestService.listScanResults(user: String, apiKey: String, scanCode: String) =
+suspend fun FossIdRestService.listScanResults(user: String, apiKey: String, scanCode: String) =
     listScanResults(
         PostRequestBody("get_results", SCAN_GROUP, user, apiKey, "scan_code" to scanCode)
     )
@@ -219,7 +217,7 @@ fun FossIdRestService.listScanResults(user: String, apiKey: String, scanCode: St
  * @param apiKey the key to query the API
  * @param scanCode the code of the scan
  */
-fun FossIdRestService.listMarkedAsIdentifiedFiles(user: String, apiKey: String, scanCode: String) =
+suspend fun FossIdRestService.listMarkedAsIdentifiedFiles(user: String, apiKey: String, scanCode: String) =
     listMarkedAsIdentifiedFiles(
         PostRequestBody(
             "get_marked_as_identified_files",
@@ -236,7 +234,7 @@ fun FossIdRestService.listMarkedAsIdentifiedFiles(user: String, apiKey: String, 
  * @param apiKey the key to query the API
  * @param scanCode the code of the scan
  */
-fun FossIdRestService.listIdentifiedFiles(user: String, apiKey: String, scanCode: String) =
+suspend fun FossIdRestService.listIdentifiedFiles(user: String, apiKey: String, scanCode: String) =
     listIdentifiedFiles(
         PostRequestBody(
             "get_identified_files", SCAN_GROUP, user, apiKey, "scan_code" to scanCode
@@ -249,7 +247,7 @@ fun FossIdRestService.listIdentifiedFiles(user: String, apiKey: String, scanCode
  * @param apiKey the key to query the API
  * @param scanCode the code of the scan
  */
-fun FossIdRestService.listIgnoredFiles(user: String, apiKey: String, scanCode: String) =
+suspend fun FossIdRestService.listIgnoredFiles(user: String, apiKey: String, scanCode: String) =
     listIgnoredFiles(
         PostRequestBody(
             "get_ignored_files", SCAN_GROUP, user, apiKey, "scan_code" to scanCode

--- a/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
+++ b/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
@@ -34,7 +34,6 @@ import org.ossreviewtoolkit.clients.fossid.model.result.FossIdScanResult
 import org.ossreviewtoolkit.clients.fossid.model.status.DownloadStatus
 import org.ossreviewtoolkit.clients.fossid.model.status.ScanStatus
 
-import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.jackson.JacksonConverterFactory
 import retrofit2.http.Body
@@ -63,41 +62,41 @@ interface FossIdRestService {
     }
 
     @POST("api.php")
-    fun getProject(@Body body: PostRequestBody): Call<EntityPostResponseBody<Project>>
+    suspend fun getProject(@Body body: PostRequestBody): EntityPostResponseBody<Project>
 
     @POST("api.php")
-    fun listScansForProject(@Body body: PostRequestBody): Call<EntityPostResponseBody<Any>>
+    suspend fun listScansForProject(@Body body: PostRequestBody): EntityPostResponseBody<Any>
 
     @POST("api.php")
-    fun createProject(@Body body: PostRequestBody): Call<MapResponseBody<String>>
+    suspend fun createProject(@Body body: PostRequestBody): MapResponseBody<String>
 
     @POST("api.php")
-    fun createScan(@Body body: PostRequestBody): Call<MapResponseBody<String>>
+    suspend fun createScan(@Body body: PostRequestBody): MapResponseBody<String>
 
     @POST("api.php")
-    fun runScan(@Body body: PostRequestBody): Call<EntityPostResponseBody<Nothing>>
+    suspend fun runScan(@Body body: PostRequestBody): EntityPostResponseBody<Nothing>
 
     @POST("api.php")
-    fun downloadFromGit(@Body body: PostRequestBody): Call<EntityPostResponseBody<Nothing>>
+    suspend fun downloadFromGit(@Body body: PostRequestBody): EntityPostResponseBody<Nothing>
 
     @POST("api.php")
-    fun checkDownloadStatus(@Body body: PostRequestBody): Call<EntityPostResponseBody<DownloadStatus>>
+    suspend fun checkDownloadStatus(@Body body: PostRequestBody): EntityPostResponseBody<DownloadStatus>
 
     @POST("api.php")
-    fun checkScanStatus(@Body body: PostRequestBody): Call<EntityPostResponseBody<ScanStatus>>
+    suspend fun checkScanStatus(@Body body: PostRequestBody): EntityPostResponseBody<ScanStatus>
 
     @POST("api.php")
-    fun listScanResults(@Body body: PostRequestBody): Call<MapResponseBody<FossIdScanResult>>
+    suspend fun listScanResults(@Body body: PostRequestBody): MapResponseBody<FossIdScanResult>
 
     @POST("api.php")
-    fun listIdentifiedFiles(@Body body: PostRequestBody): Call<MapResponseBody<IdentifiedFile>>
+    suspend fun listIdentifiedFiles(@Body body: PostRequestBody): MapResponseBody<IdentifiedFile>
 
     @POST("api.php")
-    fun listMarkedAsIdentifiedFiles(@Body body: PostRequestBody): Call<EntityPostResponseBody<Any>>
+    suspend fun listMarkedAsIdentifiedFiles(@Body body: PostRequestBody): EntityPostResponseBody<Any>
 
     @POST("api.php")
-    fun listIgnoredFiles(@Body body: PostRequestBody): Call<EntityPostResponseBody<Any>>
+    suspend fun listIgnoredFiles(@Body body: PostRequestBody): EntityPostResponseBody<Any>
 
     @GET("index.php?form=login")
-    fun getLoginPage(): Call<ResponseBody>
+    suspend fun getLoginPage(): ResponseBody
 }

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
@@ -80,20 +80,20 @@ class FossIdClientNewProjectTest : StringSpec({
     }
 
     "Version can be extracted from index" {
-        service.getLoginPage().execute().body() shouldNotBeNull {
+        service.getLoginPage() shouldNotBeNull {
             string() shouldContain "cli.  3.1.16 (build 5634934d, RELEASE)"
         }
     }
 
     "Projects can be listed when there is none" {
-        service.getProject("", "", PROJECT_CODE).execute().body() shouldNotBeNull {
+        service.getProject("", "", PROJECT_CODE) shouldNotBeNull {
             status shouldBe 0
             data should beNull()
         }
     }
 
     "Project can be created" {
-        service.createProject("", "", PROJECT_CODE, PROJECT_CODE).execute().body() shouldNotBeNull {
+        service.createProject("", "", PROJECT_CODE, PROJECT_CODE) shouldNotBeNull {
             checkResponse("create project")
             data shouldNotBeNull {
                 shouldContain("project_id", "405")
@@ -102,7 +102,7 @@ class FossIdClientNewProjectTest : StringSpec({
     }
 
     "Scans for project can be listed when there is no scan" {
-        service.listScansForProject("", "", PROJECT_CODE).execute().body() shouldNotBeNull {
+        service.listScansForProject("", "", PROJECT_CODE) shouldNotBeNull {
             checkResponse("list scans")
             toList(Scan::class) should beEmpty()
         }
@@ -114,7 +114,7 @@ class FossIdClientNewProjectTest : StringSpec({
             PROJECT_CODE,
             "https://github.com/gundy/semver4j.git",
             "671aa533f7e33c773bf620b9f466650c3b9ab26e"
-        ).execute().body() shouldNotBeNull {
+        ) shouldNotBeNull {
             data shouldNotBeNull {
                 shouldContain("scan_id", "4920")
             }
@@ -122,26 +122,26 @@ class FossIdClientNewProjectTest : StringSpec({
     }
 
     "Download from Git can be triggered" {
-        service.downloadFromGit("", "", SCAN_CODE).execute().body() shouldNotBeNull {
+        service.downloadFromGit("", "", SCAN_CODE) shouldNotBeNull {
             checkResponse("download data from Git", false)
         }
     }
 
     "Download status can be queried" {
-        service.checkDownloadStatus("", "", SCAN_CODE).execute().body() shouldNotBeNull {
+        service.checkDownloadStatus("", "", SCAN_CODE) shouldNotBeNull {
             checkResponse("check download status")
             data shouldBe DownloadStatus.FINISHED
         }
     }
 
     "A scan can be run" {
-        service.runScan("", "", SCAN_CODE).execute().body() shouldNotBeNull {
+        service.runScan("", "", SCAN_CODE) shouldNotBeNull {
             checkResponse("trigger scan", false)
         }
     }
 
     "Scan status can be queried" {
-        service.checkScanStatus("", "", SCAN_CODE).execute().body() shouldNotBeNull {
+        service.checkScanStatus("", "", SCAN_CODE) shouldNotBeNull {
             checkResponse("get scan status", false)
 
             data shouldNotBeNull {
@@ -151,7 +151,7 @@ class FossIdClientNewProjectTest : StringSpec({
     }
 
     "Scan results can be listed" {
-        service.listScanResults("", "", SCAN_CODE).execute().body() shouldNotBeNull {
+        service.listScanResults("", "", SCAN_CODE) shouldNotBeNull {
             checkResponse("list scan results")
 
             data shouldNotBeNull {
@@ -162,7 +162,7 @@ class FossIdClientNewProjectTest : StringSpec({
     }
 
     "Identified files can be listed" {
-        service.listIdentifiedFiles("", "", SCAN_CODE).execute().body() shouldNotBeNull {
+        service.listIdentifiedFiles("", "", SCAN_CODE) shouldNotBeNull {
             checkResponse("list identified files")
 
             data shouldNotBeNull {
@@ -183,14 +183,14 @@ class FossIdClientNewProjectTest : StringSpec({
     }
 
     "Marked files can be listed when there are none" {
-        service.listMarkedAsIdentifiedFiles("", "", SCAN_CODE).execute().body() shouldNotBeNull {
+        service.listMarkedAsIdentifiedFiles("", "", SCAN_CODE) shouldNotBeNull {
             checkResponse("list marked as identified files")
             toList(MarkedAsIdentifiedFile::class) should beEmpty()
         }
     }
 
     "Ignored files can be listed" {
-        service.listIgnoredFiles("", "", SCAN_CODE).execute().body() shouldNotBeNull {
+        service.listIgnoredFiles("", "", SCAN_CODE) shouldNotBeNull {
             checkResponse("list ignored files")
 
             val files = toList(IgnoredFile::class)


### PR DESCRIPTION
Use the built-in support for coroutines of Retrofit for this service.

This PR converts the last remaining Retrofit service to use the built-in coroutines support.