### PR TITLE
Fix processing of copyrights along with its performance issues

### DIFF
--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -254,7 +254,10 @@ internal fun OrtResult.processAllCopyrightStatements(
         licenseInfoResolver.resolveLicenseInfo(id).forEach innerForEach@{ resolvedLicense ->
             if (omitExcluded && resolvedLicense.isDetectedExcluded) return@innerForEach
 
-            val copyrights = resolvedLicense.getResolvedCopyrights(omitExcluded).flatMap { resolvedCopyright ->
+            val copyrights = resolvedLicense.getResolvedCopyrights(
+                process = false,
+                omitExcluded = omitExcluded
+            ).flatMap { resolvedCopyright ->
                 resolvedCopyright.findings.map { it.statement }
             }
 

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -36,7 +36,6 @@ import org.ossreviewtoolkit.model.utils.FindingsMatcher
 import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
 import org.ossreviewtoolkit.model.utils.prependPath
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
-import org.ossreviewtoolkit.utils.CopyrightStatementsProcessor
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.storage.FileArchiver
 
@@ -240,21 +239,3 @@ private class ResolvedLicenseBuilder(val license: SpdxSingleLicenseExpression) {
 
     fun build() = ResolvedLicense(license, sources, originalDeclaredLicenses, locations)
 }
-
-internal fun Collection<ResolvedCopyrightFinding>.toResolvedCopyrights(process: Boolean): List<ResolvedCopyright> {
-    val allStatements = map { it.statement }
-    val processedStatements = if (process) {
-        CopyrightStatementsProcessor().process(allStatements).toMap()
-    } else {
-        allStatements.associateBy({ it }, { mutableSetOf(it) })
-    }
-
-    return processedStatements.mapValues { (_, originalStatements) ->
-        filter { it.statement in originalStatements }
-    }.filterValues { it.isNotEmpty() }.entries.map() { (statement, findings) ->
-        ResolvedCopyright(statement, findings.toSet())
-    }
-}
-
-private fun CopyrightStatementsProcessor.Result.toMap(): Map<String, Set<String>> =
-    processedStatements + unprocessedStatements.associateWith { setOf(it) }

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -192,11 +192,7 @@ class LicenseInfoResolver(
                 it.matches(finding.location.prependPath(relativeFindingsPath))
             }
 
-            ResolvedCopyrightFinding(
-                finding.statement,
-                finding.location,
-                matchingPathExcludes = matchingPathExcludes
-            )
+            ResolvedCopyrightFinding(finding.statement, finding.location, matchingPathExcludes)
         }
 
         return processCopyrights(resolvedCopyrightFindings)

--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -162,7 +162,7 @@ data class ResolvedLicense(
     fun filterExcludedCopyrights(): ResolvedLicense =
         copy(locations = locations.mapTo(mutableSetOf()) { location ->
             val findings = location.copyrights.flatMap { it.findings }.filter { it.matchingPathExcludes.isEmpty() }
-            location.copy(copyrights = processCopyrights(findings))
+            location.copy(copyrights = findings.toResolvedCopyrights(process = true))
         })
 }
 

--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -66,11 +66,11 @@ data class ResolvedLicenseInfo(
 
     /**
      * Return all copyright statements associated to this license info. Copyright findings that are excluded by
-     * [PathExclude]s are [omitted][omitExcluded] by default. The copyrights can optionally be [processed][process]
+     * [PathExclude]s are [omitted][omitExcluded] by default. The copyrights are [processed][process] by default
      * using the [CopyrightStatementsProcessor].
      */
     @JvmOverloads
-    fun getCopyrights(process: Boolean = false, omitExcluded: Boolean = true): Set<String> {
+    fun getCopyrights(process: Boolean = true, omitExcluded: Boolean = true): Set<String> {
         val copyrightStatements = licenses.flatMapTo(mutableSetOf()) { license ->
             license.getCopyrights(process = false, omitExcluded = omitExcluded)
         }
@@ -139,10 +139,10 @@ data class ResolvedLicense(
 
     /**
      * Return all resolved copyrights for this license. Copyright findings that are excluded by [PathExclude]s are
-     * [omitted][omitExcluded] by default. The copyrights can optionally be [processed][process]
-     * using the [CopyrightStatementsProcessor].
+     * [omitted][omitExcluded] by default. The copyrights are [processed][process] by default using the
+     * [CopyrightStatementsProcessor].
      */
-    fun getResolvedCopyrights(process: Boolean = false, omitExcluded: Boolean = true): List<ResolvedCopyright> {
+    fun getResolvedCopyrights(process: Boolean = true, omitExcluded: Boolean = true): List<ResolvedCopyright> {
         val resolvedCopyrightFindings = locations.flatMap { location ->
             location.copyrights.filter { copyright ->
                 !omitExcluded || copyright.matchingPathExcludes.isEmpty()
@@ -154,11 +154,11 @@ data class ResolvedLicense(
 
     /**
      * Return all copyright statements associated to this license. Copyright findings that are excluded by
-     * [PathExclude]s are [omitted][omitExcluded] by default. The copyrights can optionally be [processed][process]
+     * [PathExclude]s are [omitted][omitExcluded] by default. The copyrights are [processed][process] by default
      * using the [CopyrightStatementsProcessor].
      */
     @JvmOverloads
-    fun getCopyrights(process: Boolean = false, omitExcluded: Boolean = true): Set<String> =
+    fun getCopyrights(process: Boolean = true, omitExcluded: Boolean = true): Set<String> =
         getResolvedCopyrights(process, omitExcluded).mapTo(mutableSetOf()) { it.statement }
 
     /**

--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -191,7 +191,7 @@ data class ResolvedLicenseLocation(
     val matchingPathExcludes: List<PathExclude>,
 
     /**
-     * All copyright findings associated to this license location.
+     * All copyright findings associated to this license location, excluding copyright garbage.
      */
     val copyrights: Set<ResolvedCopyright>
 )

--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -65,6 +65,21 @@ data class ResolvedLicenseInfo(
     operator fun get(license: SpdxSingleLicenseExpression): ResolvedLicense? = find { it.license == license }
 
     /**
+     * Return all copyright statements associated to this license info. Copyright findings that are excluded by
+     * [PathExclude]s are [omitted][omitExcluded] by default. The copyrights can optionally be [processed][process]
+     * using the [CopyrightStatementsProcessor].
+     */
+    @JvmOverloads
+    fun getCopyrights(process: Boolean = false, omitExcluded: Boolean = true): Set<String> {
+        val copyrightStatements = licenses.flatMapTo(mutableSetOf()) { license ->
+            license.getCopyrights(process = false, omitExcluded = omitExcluded)
+        }
+
+        return copyrightStatements.takeIf { !process }
+            ?: CopyrightStatementsProcessor().process(copyrightStatements).getAllStatements()
+    }
+
+    /**
      * Call [LicenseView.filter] on this [ResolvedLicenseInfo].
      */
     @JvmOverloads

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -627,7 +627,7 @@ fun containCopyrightStatementsForLicenseExactly(
 ): Matcher<ResolvedLicenseInfo?> =
     neverNullMatcher { value ->
         val expected = copyrights.toSet()
-        val actual = value[SpdxSingleLicenseExpression.parse(license)]?.getCopyrights().orEmpty()
+        val actual = value[SpdxSingleLicenseExpression.parse(license)]?.getCopyrights(process = false).orEmpty()
 
         MatcherResult(
             expected == actual,

--- a/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
+++ b/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
@@ -229,7 +229,7 @@ class CycloneDxReporter : Reporter {
 
             // TODO: Find a way to associate copyrights to the license they belong to, see
             //       https://github.com/CycloneDX/cyclonedx-core-java/issues/58
-            copyright = resolvedLicenseInfo.getCopyrights(process = true).joinToString().takeUnless { it.isEmpty() }
+            copyright = resolvedLicenseInfo.getCopyrights().joinToString().takeUnless { it.isEmpty() }
 
             purl = pkg.purl + purlQualifier
             isModified = pkg.isModified

--- a/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
+++ b/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
@@ -43,7 +43,6 @@ import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.spdx.SpdxLicense
-import org.ossreviewtoolkit.utils.CopyrightStatementsProcessor
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.isFalse
 
@@ -230,9 +229,7 @@ class CycloneDxReporter : Reporter {
 
             // TODO: Find a way to associate copyrights to the license they belong to, see
             //       https://github.com/CycloneDX/cyclonedx-core-java/issues/58
-            copyright = resolvedLicenseInfo.flatMapTo(mutableSetOf()) { it.getCopyrights() }.let {
-                CopyrightStatementsProcessor().process(it).getAllStatements()
-            }.joinToString().takeUnless { it.isEmpty() }
+            copyright = resolvedLicenseInfo.getCopyrights(process = true).joinToString().takeUnless { it.isEmpty() }
 
             purl = pkg.purl + purlQualifier
             isModified = pkg.isModified


### PR DESCRIPTION
Previously, `CopyrightStatements.process()` was called once per license finding file location by the `LicenseInfoResolver`.
This does not make sense and leads to poor performance as the `process()` function is not super fast (but fast enough if called only reasonably often). Once more, the license API was designed to hold the pre-processed copyright statements. This does not make any sense because the processing is different depending on the use case.

Do the processing properly, thereby reduce the number of calls to `process()` tremendously and change the design such that copyright statements are always processed on-the-fly. This fixes #3511.