### PR TITLE
Downloader: Support dynamic remote default branches

### DIFF
--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -242,7 +242,7 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
                 } else {
                     val vcs = VersionControlSystem.forUrl(projectUrl)
                     val vcsType = vcsTypeOption?.let { VcsType(it) } ?: (vcs?.type ?: VcsType.UNKNOWN)
-                    val vcsRevision = vcsRevisionOption ?: vcs?.defaultBranchName.orEmpty()
+                    val vcsRevision = vcsRevisionOption ?: vcs?.getDefaultBranchName(projectUrl).orEmpty()
 
                     val vcsInfo = VcsInfo(
                         type = vcsType,

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -151,11 +151,6 @@ abstract class VersionControlSystem {
     protected open val priority: Int = 0
 
     /**
-     * The name of the remote branch that gets checked out by default if none if specified.
-     */
-    abstract val defaultBranchName: String
-
-    /**
      * A list of symbolic names that point to the latest revision.
      */
     protected abstract val latestRevisionNames: List<String>
@@ -164,6 +159,11 @@ abstract class VersionControlSystem {
      * Return the VCS command's version string, or an empty string if the version cannot be determined.
      */
     abstract fun getVersion(): String
+
+    /**
+     * Return the name of the default branch for the repository at [url], or null if there is no default remote branch.
+     */
+    abstract fun getDefaultBranchName(url: String): String?
 
     /**
      * Return a working tree instance for this VCS.

--- a/downloader/src/main/kotlin/vcs/Cvs.kt
+++ b/downloader/src/main/kotlin/vcs/Cvs.kt
@@ -39,12 +39,13 @@ class Cvs : VersionControlSystem(), CommandLineTool {
     private val versionRegex = Pattern.compile("Concurrent Versions System \\(CVS\\) (?<version>[\\d.]+).+")
 
     override val type = VcsType.CVS
-    override val defaultBranchName = ""
     override val latestRevisionNames = emptyList<String>()
 
     override fun command(workingDir: File?) = "cvs"
 
     override fun getVersion() = getVersion(null)
+
+    override fun getDefaultBranchName(url: String) = null
 
     override fun transformVersion(output: String) =
         versionRegex.matcher(output.lineSequence().first()).let {

--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -35,6 +35,7 @@ import java.util.regex.Pattern
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.LsRemoteCommand
 import org.eclipse.jgit.api.errors.GitAPIException
+import org.eclipse.jgit.lib.SymbolicRef
 import org.eclipse.jgit.transport.JschConfigSessionFactory
 import org.eclipse.jgit.transport.OpenSshConfig
 import org.eclipse.jgit.transport.SshSessionFactory
@@ -97,12 +98,16 @@ class Git : VersionControlSystem(), CommandLineTool {
 
     override val type = VcsType.GIT
     override val priority = 100
-    override val defaultBranchName = "master"
     override val latestRevisionNames = listOf("HEAD", "@")
 
     override fun command(workingDir: File?) = "git"
 
     override fun getVersion() = getVersion(null)
+
+    override fun getDefaultBranchName(url: String): String {
+        val refs = Git.lsRemoteRepository().setRemote(url).callAsMap()
+        return (refs["HEAD"] as? SymbolicRef)?.target?.name?.removePrefix("refs/heads/") ?: "master"
+    }
 
     override fun transformVersion(output: String) =
         versionRegex.matcher(output.lineSequence().first()).let {

--- a/downloader/src/main/kotlin/vcs/Mercurial.kt
+++ b/downloader/src/main/kotlin/vcs/Mercurial.kt
@@ -41,12 +41,13 @@ class Mercurial : VersionControlSystem(), CommandLineTool {
 
     override val type = VcsType.MERCURIAL
     override val priority = 20
-    override val defaultBranchName = "default"
     override val latestRevisionNames = listOf("tip")
 
     override fun command(workingDir: File?) = "hg"
 
     override fun getVersion() = getVersion(null)
+
+    override fun getDefaultBranchName(url: String) = "default"
 
     override fun transformVersion(output: String) =
         versionRegex.matcher(output.lineSequence().first()).let {

--- a/downloader/src/main/kotlin/vcs/Subversion.kt
+++ b/downloader/src/main/kotlin/vcs/Subversion.kt
@@ -60,10 +60,11 @@ class Subversion : VersionControlSystem() {
 
     override val type = VcsType.SUBVERSION
     override val priority = 10
-    override val defaultBranchName = "trunk"
     override val latestRevisionNames = listOf("HEAD")
 
     override fun getVersion() = Version.getVersionString()
+
+    override fun getDefaultBranchName(url: String) = "trunk"
 
     override fun getWorkingTree(vcsDirectory: File) =
         object : WorkingTree(vcsDirectory, type) {


### PR DESCRIPTION
In some VCS, like Git, the remote default branch can be configured. As Git
(and GitHub) recently changed the default name of the remote (and local)
default branch from "master" to "main", extend ORT's logic to dynamically
determine the remote default branch name per repository.

Resolves #3590.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>