### PR TITLE
Restore the feature for analyzing a single project file

### DIFF
--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -73,8 +73,9 @@ class Analyzer(private val config: AnalyzerConfiguration) {
 
         // Associate files by the package manager factory that manages them.
         val factoryFiles = if (packageManagers.size == 1 && absoluteProjectPath.isFile) {
-            // If only one package manager is activated, treat the given path as definition file for that package
-            // manager despite its name.
+            // If only one package manager is activated and the project path is in fact a file, assume that the file is
+            // a definition file for that package manager. This is useful to limit analysis to a single project e.g. for
+            // debugging purposes.
             mutableMapOf(packageManagers.first() to listOf(absoluteProjectPath))
         } else {
             PackageManager.findManagedFiles(absoluteProjectPath, packageManagers).toMutableMap()

--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -62,9 +62,10 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
 
     private val inputDir by option(
         "--input-dir", "-i",
-        help = "The project directory to analyze."
+        help = "The project directory to analyze. As a special case, if only one package manager is activated, this " +
+                "may point to a definition file for that package manager to only analyze that single project."
     ).convert { it.expandTilde() }
-        .file(mustExist = true, canBeFile = false, canBeDir = true, mustBeWritable = false, mustBeReadable = true)
+        .file(mustExist = true, canBeFile = true, canBeDir = true, mustBeWritable = false, mustBeReadable = true)
         .convert { it.absoluteFile.normalize() }
         .required()
         .inputGroup()


### PR DESCRIPTION
There used to be an undocumented feature for analyzing a single project
file which got broken in the migration from JCommander to clikt. Restore
that feature and document it.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>