### PR TITLE
Logger: Ensure logging is done on ORT classes

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -467,11 +467,11 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
             artifactDownload.isExistenceCheck = true
             artifactDownload.listener = object : AbstractTransferListener() {
                 override fun transferFailed(event: TransferEvent?) {
-                    log.debug { "Transfer failed: $event" }
+                    MavenSupport.log.debug { "Transfer failed: $event" }
                 }
 
                 override fun transferSucceeded(event: TransferEvent?) {
-                    log.debug { "Transfer succeeded: $event" }
+                    MavenSupport.log.debug { "Transfer succeeded: $event" }
                 }
             }
 

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -255,7 +255,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
 
         return try {
             val storedResults = withContext(storageDispatcher) {
-                log.info {
+                LocalScanner.log.info {
                     "Looking for stored scan results for ${pkg.id.toCoordinates()} and " +
                             "$scannerCriteria $packageIndex."
                 }
@@ -275,7 +275,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
                 storedResults.map { it.filterByVcsPath().filterByIgnorePatterns(config.ignorePatterns) }
             } else {
                 withContext(scanDispatcher) {
-                    log.info {
+                    LocalScanner.log.info {
                         "No stored result found for ${pkg.id.toCoordinates()} and $scannerCriteria, " +
                                 "scanning package in thread '${Thread.currentThread().name}' " +
                                 "$packageIndex."
@@ -283,7 +283,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
 
                     listOf(
                         scanPackage(details, pkg, outputDirectory, downloadDirectory).also {
-                            log.info {
+                            LocalScanner.log.info {
                                 "Finished scanning ${pkg.id.toCoordinates()} in thread " +
                                         "'${Thread.currentThread().name}' $packageIndex."
                             }

--- a/utils/src/main/kotlin/Logger.kt
+++ b/utils/src/main/kotlin/Logger.kt
@@ -39,7 +39,15 @@ val loggerOfClass = ConcurrentHashMap<Any, KotlinLogger>()
  * An extension property for adding a log instance to any (unique) class.
  */
 val <reified T : Any> T.log: KotlinLogger
-    inline get() = loggerOfClass.getOrPut(T::class.java) { loggerOf(T::class.java) }
+    inline get() = loggerOfClass.getOrPut(T::class.java) {
+        T::class.qualifiedName?.let { name ->
+            require(name.startsWith("org.ossreviewtoolkit.")) {
+                "Logging is only allowed on ORT classes, but '$name' is used."
+            }
+        }
+
+        loggerOf(T::class.java)
+    }
 
 val KotlinLogger.statements by lazy { mutableSetOf<Triple<Any, Level, String>>() }
 

--- a/utils/src/test/kotlin/LoggerTest.kt
+++ b/utils/src/test/kotlin/LoggerTest.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.utils
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.kotest.matchers.types.shouldNotBeSameInstanceAs
@@ -48,6 +49,12 @@ class LoggerTest : WordSpec({
             val b = OtherClass().log
 
             a shouldNotBeSameInstanceAs b
+        }
+
+        "refuse to be used on a non-ORT class" {
+            shouldThrow<IllegalArgumentException> {
+                String().log.info { "Hello from a String." }
+            }
         }
     }
 

--- a/utils/src/test/kotlin/LoggerTest.kt
+++ b/utils/src/test/kotlin/LoggerTest.kt
@@ -29,28 +29,29 @@ import io.mockk.verify
 import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.kotlin.KotlinLogger
 
+private class DummyClass
+private class OtherClass
+
+private const val LOG_ONCE_MESSAGE = "This message should be logged only once."
+
 class LoggerTest : WordSpec({
     "A logger instance" should {
         "be shared between different instances of the same class" {
-            val a = String().log
-            val b = String().log
+            val a = DummyClass().log
+            val b = DummyClass().log
 
             a shouldBeSameInstanceAs b
         }
 
         "not be shared between instances of different classes" {
-            val a = String().log
-            val b = this.log
+            val a = DummyClass().log
+            val b = OtherClass().log
 
             a shouldNotBeSameInstanceAs b
         }
     }
 
     "Asking to log a statement only once" should {
-        class DummyClass
-
-        val message = "This message should be logged only once."
-
         "log the statement only once for the same instance and level" {
             val dummyInstance = DummyClass()
 
@@ -58,8 +59,8 @@ class LoggerTest : WordSpec({
             loggerOfClass[DummyClass::class.java] = mockedLogger
 
             // Log the same message at the same level for the same instance twice.
-            dummyInstance.logOnce(Level.WARN) { message }
-            dummyInstance.logOnce(Level.WARN) { message }
+            dummyInstance.logOnce(Level.WARN) { LOG_ONCE_MESSAGE }
+            dummyInstance.logOnce(Level.WARN) { LOG_ONCE_MESSAGE }
 
             dummyInstance.log shouldBeSameInstanceAs mockedLogger
             verify(exactly = 1) { mockedLogger.log(any(), any<String>()) }
@@ -72,8 +73,8 @@ class LoggerTest : WordSpec({
             loggerOfClass[DummyClass::class.java] = mockedLogger
 
             // Log the same message at the different levels for the same instance.
-            dummyInstance.logOnce(Level.WARN) { message }
-            dummyInstance.logOnce(Level.ERROR) { message }
+            dummyInstance.logOnce(Level.WARN) { LOG_ONCE_MESSAGE }
+            dummyInstance.logOnce(Level.ERROR) { LOG_ONCE_MESSAGE }
 
             dummyInstance.log shouldBeSameInstanceAs mockedLogger
             verify(exactly = 2) { mockedLogger.log(any(), any<String>()) }
@@ -87,8 +88,8 @@ class LoggerTest : WordSpec({
             loggerOfClass[DummyClass::class.java] = mockedLogger
 
             // Log the same message at the same level for different instances.
-            dummyInstance1.logOnce(Level.WARN) { message }
-            dummyInstance2.logOnce(Level.WARN) { message }
+            dummyInstance1.logOnce(Level.WARN) { LOG_ONCE_MESSAGE }
+            dummyInstance2.logOnce(Level.WARN) { LOG_ONCE_MESSAGE }
 
             dummyInstance1.log shouldBeSameInstanceAs mockedLogger
             dummyInstance2.log shouldBeSameInstanceAs mockedLogger


### PR DESCRIPTION
This helps to avoid logging accidentally being done on nested lambdas,
resulting in probably unexpected class names in the log.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>