### PR TITLE
simple-license-mapping: Add an entry for "Python"

### DIFF
--- a/spdx-utils/src/main/resources/simple-license-mapping.yml
+++ b/spdx-utils/src/main/resources/simple-license-mapping.yml
@@ -44,6 +44,7 @@ MPL: MPL-2.0
 MPLv2.0: MPL-2.0
 MPLv2: MPL-2.0
 ODBL: ODbL-1.0
+Python: Python-2.0
 UNLICENSED: Unlicense
 Vovida: VSL-1.0
 afl-2: AFL-2.0


### PR DESCRIPTION
As found in [1].

[1]: https://bitbucket.org/pypa/distlib/src/17f3f8c6dfd376dad92f4c907629b1452c1e7b06/setup.py#lines-42

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>
