### PR TITLE
Show provenance information for detected licenses in the static HTML report

### DIFF
--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -610,7 +610,7 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
         </thead>
         <tbody>
           <tr class="ort-error " id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-1">
-            <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-1">1</a></td><td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td><td></td><td><em>Detected Licenses:</em>
+            <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-1">1</a></td><td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td><td></td><td><em>Detected Licenses (from <a href="https://github.com/oss-review-toolkit/ort.git">VCS</a>):</em>
               <dl>
                 <dd>
                   <div>BSD-3-Clause (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
@@ -745,7 +745,7 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
                   <div>GPL-3.0-only WITH GCC-exception-3.1</div>
                 </dd>
               </dl>
-              <em>Detected Licenses:</em>
+              <em>Detected Licenses (from <a href="https://example.com/git">VCS</a>):</em>
               <dl>
                 <dd>
                   <div>Apache-2.0</div>

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -534,13 +534,13 @@ class StaticHtmlReporter : Reporter {
                     dl {
                         dd {
                             row.detectedLicenses.forEach { license ->
-                                val firstFinding =
-                                    license.locations.firstOrNull { it.matchingPathExcludes.isEmpty() }
-                                        ?: license.locations.firstOrNull()
+                                val firstFinding = license.locations.firstOrNull { it.matchingPathExcludes.isEmpty() }
+                                    ?: license.locations.firstOrNull()
 
                                 val permalink = firstFinding?.permalink(row.id)
-                                val pathExcludes =
-                                    license.locations.flatMapTo(mutableSetOf()) { it.matchingPathExcludes }
+                                val pathExcludes = license.locations.flatMapTo(mutableSetOf()) {
+                                    it.matchingPathExcludes
+                                }
 
                                 if (!license.isDetectedExcluded) {
                                     div {

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -36,6 +36,7 @@ import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.model.Environment
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Project
+import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.VcsInfo
@@ -530,7 +531,15 @@ class StaticHtmlReporter : Reporter {
                 }
 
                 if (row.detectedLicenses.isNotEmpty()) {
-                    em { +"Detected Licenses:" }
+                    // All license location from a package share the same provenance, so just picking the first is fine.
+                    val firstLicenseLocation = row.detectedLicenses.first().locations.firstOrNull()
+
+                    em {
+                        +"Detected Licenses"
+                        provenanceLink(firstLicenseLocation?.provenance)
+                        +":"
+                    }
+
                     dl {
                         dd {
                             row.detectedLicenses.forEach { license ->
@@ -616,6 +625,18 @@ class StaticHtmlReporter : Reporter {
         val document = markdownParser.parse(markdown)
         val renderer = HtmlRenderer.builder().build()
         unsafe { +renderer.render(document) }
+    }
+}
+
+private fun EM.provenanceLink(provenance: Provenance?) {
+    provenance?.sourceArtifact?.let { artifact ->
+        +" (from "
+        a(href = artifact.url) { +"artifact" }
+        +")"
+    } ?: provenance?.vcsInfo?.let { vcs ->
+        +" (from "
+        a(href = vcs.url) { +"VCS" }
+        +")"
     }
 }
 


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.