### PR TITLE
Dockerfile: Temporary adaptation for Ubuntu 20.04

### DIFF
--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -103,7 +103,7 @@ class ScanCode(
         }
     }
 
-    override val expectedVersion = "3.2.1-rc2"
+    override val expectedVersion = "21.2.9"
 
     override val configuration by lazy {
         mutableListOf<String>().apply {


### PR DESCRIPTION
Ubuntu 20.04 jumped to python3 mostly, some adaptation are
needed to run basic docker.

This is far to be production ready, as it requires scancode been
compiled from source code instead of releases code but properly
works for Ort been ready to run

TODO:
* Ort requirements test will fail, so it need to be fixe. Commented now
* Dependencies installation inside docker can be done in a smar way,
with independent installation instead of heavily depends on Ubuntu packages

Signed-off-by: Helio Chissini de Castro <helio@kde.org>

Please ensure that your pull request adheres to our [contribution guidelines](../CONTRIBUTING.md). Thank you!
