### PR TITLE
Add withResolvedScopes() function to Project class

### DIFF
--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -121,6 +121,16 @@ data class Project(
     }
 
     /**
+     * Return a [Project] instance that has its scope information directly available. A project can be constructed
+     * either with a set of [Scope] objects or with a [DependencyGraph]. In the latter case, the graph has to be
+     * converted first into the scope representation. This function ensures that this step was done: If the project
+     * has a [DependencyGraph], it returns a new instance with the converted scope information (and the dependency
+     * graph removed to save memory); otherwise, it returns this same object.
+     */
+    fun withResolvedScopes(): Project =
+        takeUnless { dependencyGraph != null } ?: copy(scopeDependencies = scopes, dependencyGraph = null)
+
+    /**
      * Return the set of package [Identifier]s of all transitive dependencies of this [Project], up to and including a
      * depth of [maxDepth] where counting starts at 0 (for the [Project] itself) and 1 are direct dependencies etc. A
      * value below 0 means to not limit the depth. If the given [filterPredicate] is false for a specific

--- a/model/src/test/kotlin/ProjectTest.kt
+++ b/model/src/test/kotlin/ProjectTest.kt
@@ -25,8 +25,10 @@ import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.beTheSameInstanceAs
 
 import java.io.File
 import java.time.Instant
@@ -57,7 +59,7 @@ private fun projectWithDependencyGraph(): Project =
         declaredLicenses = sortedSetOf(),
         vcs = VcsInfo.EMPTY,
         homepageUrl = "https//www.test-project.org",
-        scopeDependencies = sortedSetOf(),
+        scopeDependencies = null,
         dependencyGraph = createDependencyGraph()
     )
 
@@ -200,6 +202,25 @@ class ProjectTest : WordSpec({
             )
 
             project.scopes.shouldBeEmpty()
+        }
+    }
+
+    "withResolvedScopes" should {
+        "return the same instance if no dependency graph is available" {
+            val project = readAnalyzerResult("maven-expected-output-app.yml")
+
+            val resolvedProject = project.withResolvedScopes()
+
+            resolvedProject should beTheSameInstanceAs(project)
+        }
+
+        "return an instance with scope information extracted from the dependency graph" {
+            val project = projectWithDependencyGraph()
+
+            val resolvedProject = project.withResolvedScopes()
+
+            resolvedProject.dependencyGraph.shouldBeNull()
+            resolvedProject.scopes shouldBe project.scopes
         }
     }
 


### PR DESCRIPTION
Projects now support two different ways to store information about
their scopes and dependencies. This function makes sure that the
traditional format - the map with scopes - has been initialized, which
ensures compatibility with some use cases.
