### PR TITLE
UploadResultToSw360Command: Fix uploaded packages

### DIFF
--- a/cli/src/main/kotlin/commands/UploadResultToSw360Command.kt
+++ b/cli/src/main/kotlin/commands/UploadResultToSw360Command.kt
@@ -172,6 +172,6 @@ class UploadResultToSw360Command : CliktCommand(
 
     private fun getProjectWithPackages(ortResult: OrtResult): Map<Project, List<Package>> =
         ortResult.getProjects(omitExcluded = true).associateWith { project ->
-            project.collectDependencies().mapNotNull { ortResult.getUncuratedPackageById(it) }
+            project.collectDependencies().mapNotNull { ortResult.getPackage(it)?.pkg }
         }
 }


### PR DESCRIPTION
The packages were converted to uncurated packages which removed all
curations applied to them. Instead, upload the packages with curated
metadata.
