### PR TITLE
model: Add a new field for authors

### DIFF
--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -99,6 +99,8 @@ class Bower(
         private fun extractPackage(node: JsonNode) =
             Package(
                 id = extractPackageId(node),
+                // TODO: Find a way to track authors.
+                authors = sortedSetOf(),
                 declaredLicenses = extractDeclaredLicenses(node),
                 description = node["pkgMeta"]["description"].textValueOrEmpty(),
                 homepageUrl = node["pkgMeta"]["homepage"].textValueOrEmpty(),
@@ -233,6 +235,8 @@ class Bower(
             val project = Project(
                 id = projectPackage.id,
                 definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+                // TODO: Find a way to track authors.
+                authors = sortedSetOf(),
                 declaredLicenses = projectPackage.declaredLicenses,
                 vcs = projectPackage.vcs,
                 vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, projectPackage.homepageUrl),

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -112,6 +112,8 @@ class Bundler(
             val project = Project(
                 id = projectId,
                 definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+                // TODO: Find a way to track authors.
+                authors = sortedSetOf(),
                 declaredLicenses = declaredLicenses.toSortedSet(),
                 vcs = VcsInfo.EMPTY,
                 vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY, homepageUrl),
@@ -162,6 +164,8 @@ class Bundler(
 
                 packages += Package(
                     id = gemId,
+                    // TODO: Find a way to track authors.
+                    authors = sortedSetOf(),
                     declaredLicenses = gemSpec.declaredLicenses,
                     description = gemSpec.description,
                     homepageUrl = gemSpec.homepageUrl,

--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -117,6 +117,8 @@ class Cargo(
     private fun extractPackage(node: JsonNode, hashes: Map<String, String>) =
         Package(
             id = extractPackageId(node),
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = extractDeclaredLicenses(node),
             description = node["description"].textValueOrEmpty(),
             binaryArtifact = RemoteArtifact.EMPTY,
@@ -284,6 +286,8 @@ class Cargo(
         val project = Project(
             id = projectPkg.id,
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = projectPkg.declaredLicenses,
             vcs = projectPkg.vcs,
             vcsProcessed = processProjectVcs(workingDir, projectPkg.vcs, homepageUrl),

--- a/analyzer/src/main/kotlin/managers/Carthage.kt
+++ b/analyzer/src/main/kotlin/managers/Carthage.kt
@@ -80,6 +80,8 @@ class Carthage(
                         version = projectInfo.revision.orEmpty()
                     ),
                     definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+                    // TODO: Find a way to track authors.
+                    authors = sortedSetOf(),
                     declaredLicenses = sortedSetOf(),
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY),
@@ -187,6 +189,8 @@ class Carthage(
                 name = vcsHost?.getProject(projectUrl).orEmpty(),
                 version = revision
             ),
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = sortedSetOf(),
             description = "",
             homepageUrl = projectUrl.removeSuffix(".git"),
@@ -210,6 +214,8 @@ class Carthage(
                 name = fileUrl.substringAfterLast("/"),
                 version = revision
             ),
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = sortedSetOf(),
             description = "",
             homepageUrl = "",
@@ -227,6 +233,8 @@ class Carthage(
                 name = id.substringAfterLast("/").removeSuffix(".json"),
                 version = revision
             ),
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = sortedSetOf(),
             description = "",
             homepageUrl = "",

--- a/analyzer/src/main/kotlin/managers/Composer.kt
+++ b/analyzer/src/main/kotlin/managers/Composer.kt
@@ -232,6 +232,8 @@ class Composer(
                 version = json["version"].textValueOrEmpty()
             ),
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = parseDeclaredLicenses(json),
             vcs = vcs,
             vcsProcessed = processProjectVcs(definitionFile.parentFile, vcs, homepageUrl),
@@ -263,6 +265,8 @@ class Composer(
                         name = rawName.substringAfter('/'),
                         version = version
                     ),
+                    // TODO: Find a way to track authors.
+                    authors = sortedSetOf(),
                     declaredLicenses = parseDeclaredLicenses(pkgInfo),
                     description = pkgInfo["description"].textValueOrEmpty(),
                     homepageUrl = homepageUrl,

--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -124,6 +124,8 @@ class Conan(
                     project = Project(
                         id = projectPackage.id,
                         definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+                        // TODO: Find a way to track authors.
+                        authors = sortedSetOf(),
                         declaredLicenses = projectPackage.declaredLicenses,
                         vcs = projectPackage.vcs,
                         vcsProcessed = processProjectVcs(
@@ -217,6 +219,8 @@ class Conan(
     private fun extractPackage(node: JsonNode, workingDir: File) =
         Package(
             id = extractPackageId(node, workingDir),
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = extractDeclaredLicenses(node),
             description = extractPackageField(node, workingDir, "description"),
             homepageUrl = node["homepage"].textValueOrEmpty(),
@@ -309,6 +313,8 @@ class Conan(
                 name = runInspectRawField(definitionFile.name, workingDir, "name"),
                 version = runInspectRawField(definitionFile.name, workingDir, "version")
             ),
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = extractDeclaredLicenses(node),
             description = runInspectRawField(definitionFile.name, workingDir, "description"),
             homepageUrl = node["homepage"].textValueOrEmpty(),
@@ -328,6 +334,8 @@ class Conan(
                 name = node["reference"].textValueOrEmpty(),
                 version = ""
             ),
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = extractDeclaredLicenses(node),
             description = "",
             homepageUrl = node["homepage"].textValueOrEmpty(),

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -131,6 +131,8 @@ class GoDep(
 
             val pkg = Package(
                 id = Identifier(managerName, "", name, version),
+                // TODO: Find a way to track authors.
+                authors = sortedSetOf(),
                 declaredLicenses = sortedSetOf(),
                 description = "",
                 homepageUrl = "",
@@ -172,6 +174,8 @@ class GoDep(
                         version = projectVcs.revision
                     ),
                     definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+                    // TODO: Find a way to track authors.
+                    authors = sortedSetOf(),
                     declaredLicenses = sortedSetOf(),
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = projectVcs,

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -132,6 +132,8 @@ class GoMod(
                             version = projectVcs.revision
                         ),
                         definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+                        // TODO: Find a way to track authors.
+                        authors = sortedSetOf(),
                         declaredLicenses = sortedSetOf(), // Go mod doesn't support declared licenses.
                         vcs = projectVcs,
                         vcsProcessed = projectVcs,
@@ -196,6 +198,8 @@ class GoMod(
 
         return Package(
             id = Identifier(managerName, "", id.name, id.version),
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = sortedSetOf(), // Go mod doesn't support declared licenses.
             description = "",
             homepageUrl = "",

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -240,6 +240,8 @@ class Gradle(
                         version = dependencyTreeModel.version
                     ),
                     definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+                    // TODO: Find a way to track authors.
+                    authors = sortedSetOf(),
                     declaredLicenses = sortedSetOf(),
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = processProjectVcs(definitionFile.parentFile),

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -137,6 +137,8 @@ class Maven(
                 version = mavenProject.version
             ),
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = MavenSupport.parseLicenses(mavenProject),
             vcs = vcsFromPackage,
             vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, *vcsFallbackUrls),

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -295,6 +295,8 @@ open class Npm(
                     name = name,
                     version = version
                 ),
+                // TODO: Find a way to track authors.
+                authors = sortedSetOf(),
                 declaredLicenses = declaredLicenses,
                 description = description,
                 homepageUrl = homepageUrl,
@@ -525,6 +527,8 @@ open class Npm(
                 version = version
             ),
             definitionFilePath = VersionControlSystem.getPathInfo(packageJson).path,
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = declaredLicenses,
             vcs = vcsFromPackage,
             vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, homepageUrl),

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -376,6 +376,8 @@ class Pip(
                 version = projectVersion
             ),
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = declaredLicenses,
             vcs = VcsInfo.EMPTY,
             vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY, setupHomepage),
@@ -557,6 +559,7 @@ class Pip(
                     name = dependency["package_name"].textValue(),
                     version = dependency["installed_version"].textValue()
                 ),
+                authors = sortedSetOf(),
                 declaredLicenses = sortedSetOf(),
                 description = "",
                 homepageUrl = "",
@@ -619,6 +622,8 @@ class Pip(
                     id = id,
                     homepageUrl = homepageUrl,
                     description = pkgInfo["summary"]?.textValue().orEmpty(),
+                    // TODO: Find a way to track authors.
+                    authors = sortedSetOf(),
                     declaredLicenses = getDeclaredLicenses(pkgInfo),
                     binaryArtifact = getBinaryArtifact(pkgRelease),
                     sourceArtifact = getSourceArtifact(pkgRelease),
@@ -709,6 +714,8 @@ class Pip(
             ),
             description = map["Summary"]?.single().orEmpty(),
             homepageUrl = map["Home-page"]?.single().orEmpty(),
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = declaredLicenses,
             binaryArtifact = RemoteArtifact.EMPTY,
             sourceArtifact = RemoteArtifact.EMPTY,
@@ -723,6 +730,7 @@ private fun Package.enrichWith(other: Package?): Package =
             id = id,
             homepageUrl = homepageUrl.takeUnless { it.isBlank() } ?: other.homepageUrl,
             description = description.takeUnless { it.isBlank() } ?: other.description,
+            authors = authors.takeUnless { it.isEmpty() } ?: other.authors,
             declaredLicenses = declaredLicenses.takeUnless { it.isEmpty() } ?: other.declaredLicenses,
             binaryArtifact = binaryArtifact.takeUnless { it == RemoteArtifact.EMPTY } ?: other.binaryArtifact,
             sourceArtifact = sourceArtifact.takeUnless { it == RemoteArtifact.EMPTY } ?: other.sourceArtifact,

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -364,6 +364,8 @@ class Pub(
                 version = pubspec["version"].textValueOrEmpty()
             ),
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             // Pub does not declare any licenses in the pubspec files, therefore we keep this empty.
             declaredLicenses = sortedSetOf(),
             vcs = vcs,
@@ -433,6 +435,8 @@ class Pub(
 
                 packages[id] = Package(
                     id,
+                    // TODO: Find a way to track authors.
+                    authors = sortedSetOf(),
                     // Pub does not declare any licenses in the pubspec files, therefore we keep this empty.
                     declaredLicenses = sortedSetOf(),
                     description = description,

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -191,6 +191,8 @@ class SpdxDocumentFile(
             Project(
                 id = projectPackage.toIdentifier(),
                 definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+                // TODO: Find a way to track authors.
+                authors = sortedSetOf(),
                 declaredLicenses = sortedSetOf(projectPackage.licenseDeclared),
                 vcs = VcsInfo.EMPTY,
                 vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY, projectPackage.homepage),
@@ -215,6 +217,8 @@ class SpdxDocumentFile(
 
             Package(
                 id = pkg.toIdentifier(),
+                // TODO: Find a way to track authors.
+                authors = sortedSetOf(),
                 declaredLicenses = sortedSetOf(pkg.licenseDeclared),
                 concludedLicense = getConcludedLicense(pkg),
                 description = packageDescription,

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -163,6 +163,8 @@ class Stack(
         val project = Project(
             id = projectId,
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = projectPackage.declaredLicenses,
             vcs = projectPackage.vcs,
             vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, projectPackage.homepageUrl),
@@ -345,6 +347,8 @@ class Stack(
 
         return Package(
             id = id,
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = map["license"]?.let { sortedSetOf(it) } ?: sortedSetOf(),
             description = map["description"].orEmpty(),
             homepageUrl = homepageUrl,

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -107,6 +107,8 @@ class Unmanaged(
         val project = Project(
             id = id,
             definitionFilePath = "",
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = sortedSetOf(),
             vcs = VcsInfo.EMPTY,
             vcsProcessed = vcsInfo,

--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -644,6 +644,8 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
                 name = mavenProject.artifactId,
                 version = mavenProject.version
             ),
+            // TODO: Find a way to track authors.
+            authors = sortedSetOf(),
             declaredLicenses = parseLicenses(mavenProject),
             description = mavenProject.description.orEmpty(),
             homepageUrl = homepageUrl.orEmpty(),

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -190,6 +190,8 @@ class NuGetSupport(serviceIndexUrls: List<String> = listOf(DEFAULT_SERVICE_INDEX
         return with(all.details) {
             Package(
                 id = getIdentifier(id, version),
+                // TODO: Find a way to track authors.
+                authors = sortedSetOf(),
                 declaredLicenses = setOfNotNull(license).toSortedSet(),
                 description = description.orEmpty(),
                 homepageUrl = projectUrl.orEmpty(),
@@ -291,6 +293,8 @@ fun PackageManager.resolveNuGetDependencies(
             version = ""
         ),
         definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
+        // TODO: Find a way to track authors.
+        authors = sortedSetOf(),
         declaredLicenses = sortedSetOf(),
         vcs = VcsInfo.EMPTY,
         vcsProcessed = PackageManager.processProjectVcs(workingDir),

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -53,6 +53,15 @@ data class Package(
     val purl: String = id.toPurl(),
 
     /**
+     * The list of authors declared for this package.
+     *
+     * TODO: The annotation can be removed after all package manager implementations have filled the field [authors]
+     *       accordingly.
+     */
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    val authors: SortedSet<String> = sortedSetOf(),
+
+    /**
      * The list of licenses the authors have declared for this package. This does not necessarily correspond to the
      * licenses as detected by a scanner. Both need to be taken into account for any conclusions.
      */
@@ -125,6 +134,7 @@ data class Package(
         val EMPTY = Package(
             id = Identifier.EMPTY,
             purl = "",
+            authors = sortedSetOf(),
             declaredLicenses = sortedSetOf(),
             declaredLicensesProcessed = ProcessedDeclaredLicense.EMPTY,
             concludedLicense = null,
@@ -153,6 +163,7 @@ data class Package(
         }
 
         return PackageCurationData(
+            authors = authors.takeIf { it != other.authors },
             declaredLicenses = declaredLicenses.takeIf { it != other.declaredLicenses },
             description = description.takeIf { it != other.description },
             homepageUrl = homepageUrl.takeIf { it != other.homepageUrl },

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -34,6 +34,11 @@ import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class PackageCurationData(
     /**
+     * The list of authors of this package.
+     */
+    val authors: SortedSet<String>? = null,
+
+    /**
      * The list of licenses the authors have declared for this package. This does not necessarily correspond to the
      * licenses as detected by a scanner. Both need to be taken into account for any conclusions.
      */
@@ -118,12 +123,14 @@ private fun applyCurationToPackage(targetPackage: CuratedPackage, curation: Pack
         )
     } ?: base.vcs
 
+    val authors = curation.authors ?: base.authors
     val declaredLicenses = curation.declaredLicenses ?: base.declaredLicenses
     val declaredLicenseMapping = targetPackage.getDeclaredLicenseMapping() + curation.declaredLicenseMapping
     val declaredLicensesProcessed = DeclaredLicenseProcessor.process(declaredLicenses, declaredLicenseMapping)
 
     val pkg = Package(
         id = base.id,
+        authors = authors,
         declaredLicenses = declaredLicenses,
         declaredLicensesProcessed = declaredLicensesProcessed,
         concludedLicense = curation.concludedLicense ?: base.concludedLicense,

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -51,6 +51,15 @@ data class Project(
     val definitionFilePath: String,
 
     /**
+     * The list of authors declared for this package.
+     *
+     * TODO: The annotation can be removed after all package manager implementations have filled the field [authors]
+     *       accordingly.
+     */
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    val authors: SortedSet<String> = sortedSetOf(),
+
+    /**
      * The list of licenses the authors have declared for this package. This does not necessarily correspond to the
      * licenses as detected by a scanner. Both need to be taken into account for any conclusions.
      */
@@ -102,6 +111,7 @@ data class Project(
         val EMPTY = Project(
             id = Identifier.EMPTY,
             definitionFilePath = "",
+            authors = sortedSetOf(),
             declaredLicenses = sortedSetOf(),
             declaredLicensesProcessed = ProcessedDeclaredLicense.EMPTY,
             vcs = VcsInfo.EMPTY,
@@ -198,6 +208,7 @@ data class Project(
     fun toPackage() =
         Package(
             id = id,
+            authors = authors,
             declaredLicenses = declaredLicenses,
             description = "",
             homepageUrl = homepageUrl,

--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -39,6 +39,7 @@ class PackageCurationTest : WordSpec({
                     name = "hamcrest-core",
                     version = "1.3"
                 ),
+                authors = sortedSetOf(),
                 declaredLicenses = sortedSetOf(),
                 description = "",
                 homepageUrl = "",
@@ -52,6 +53,7 @@ class PackageCurationTest : WordSpec({
             val curation = PackageCuration(
                 id = pkg.id,
                 data = PackageCurationData(
+                    authors = sortedSetOf("author 1", "author 2"),
                     declaredLicenses = sortedSetOf("license a", "license b"),
                     declaredLicenseMapping = mapOf("license a" to "Apache-2.0".toSpdx()),
                     concludedLicense = "license1 OR license2".toSpdx(),
@@ -81,6 +83,7 @@ class PackageCurationTest : WordSpec({
 
             with(curatedPkg.pkg) {
                 id.toCoordinates() shouldBe pkg.id.toCoordinates()
+                authors shouldBe curation.data.authors
                 declaredLicenses shouldBe curation.data.declaredLicenses
                 declaredLicensesProcessed.spdxExpression shouldBe "Apache-2.0".toSpdx()
                 declaredLicensesProcessed.unmapped should containExactlyInAnyOrder("license b")
@@ -107,6 +110,7 @@ class PackageCurationTest : WordSpec({
                     name = "hamcrest-core",
                     version = "1.3"
                 ),
+                authors = sortedSetOf("author 1", "author 2"),
                 declaredLicenses = sortedSetOf("license a", "license b"),
                 description = "description",
                 homepageUrl = "homepageUrl",
@@ -137,6 +141,7 @@ class PackageCurationTest : WordSpec({
 
             with(curatedPkg.pkg) {
                 id.toCoordinates() shouldBe pkg.id.toCoordinates()
+                authors shouldBe pkg.authors
                 declaredLicenses shouldBe pkg.declaredLicenses
                 concludedLicense shouldBe pkg.concludedLicense
                 description shouldBe pkg.description
@@ -167,6 +172,7 @@ class PackageCurationTest : WordSpec({
                     name = "hamcrest-core",
                     version = "1.3"
                 ),
+                authors = sortedSetOf("author 1", "author 2"),
                 declaredLicenses = sortedSetOf("license a", "license b"),
                 description = "description",
                 homepageUrl = "homepageUrl",
@@ -206,6 +212,7 @@ class PackageCurationTest : WordSpec({
                     name = "hamcrest-core",
                     version = "1.3"
                 ),
+                authors = sortedSetOf(),
                 declaredLicenses = sortedSetOf(),
                 description = "",
                 homepageUrl = "",
@@ -239,6 +246,7 @@ class PackageCurationTest : WordSpec({
                     name = "hamcrest-core",
                     version = "1.3"
                 ),
+                authors = sortedSetOf(),
                 declaredLicenses = sortedSetOf(),
                 description = "",
                 homepageUrl = "",
@@ -268,6 +276,7 @@ class PackageCurationTest : WordSpec({
                     name = "hamcrest-core",
                     version = "1.3"
                 ),
+                authors = sortedSetOf(),
                 declaredLicenses = sortedSetOf(),
                 description = "",
                 homepageUrl = "",
@@ -362,6 +371,7 @@ class PackageCurationTest : WordSpec({
         "accumulate the map entries and override the entries with same key" {
             val pkg = Package(
                 id = Identifier("type", "namespace", "name", "version"),
+                authors = sortedSetOf(),
                 declaredLicenses = sortedSetOf("license a", "license b", "license c"),
                 description = "",
                 homepageUrl = "",

--- a/model/src/test/kotlin/PackageTest.kt
+++ b/model/src/test/kotlin/PackageTest.kt
@@ -43,6 +43,7 @@ class PackageTest : StringSpec({
                 name = "name",
                 version = "version"
             ),
+            authors = sortedSetOf("author"),
             declaredLicenses = sortedSetOf("declared license"),
             description = "description",
             homepageUrl = "homepageUrl",
@@ -59,6 +60,7 @@ class PackageTest : StringSpec({
                 name = "name",
                 version = "version"
             ),
+            authors = sortedSetOf("other author"),
             declaredLicenses = sortedSetOf("other declared license"),
             description = "other description",
             homepageUrl = "other homepageUrl",
@@ -72,6 +74,7 @@ class PackageTest : StringSpec({
 
         diff.binaryArtifact shouldBe pkg.binaryArtifact
         diff.comment should beNull()
+        diff.authors shouldBe pkg.authors
         diff.declaredLicenses shouldBe pkg.declaredLicenses
         diff.homepageUrl shouldBe pkg.homepageUrl
         diff.sourceArtifact shouldBe pkg.sourceArtifact
@@ -87,6 +90,7 @@ class PackageTest : StringSpec({
                 name = "name",
                 version = "version"
             ),
+            authors = sortedSetOf("author"),
             declaredLicenses = sortedSetOf("declared license"),
             description = "description",
             homepageUrl = "homepageUrl",
@@ -99,6 +103,7 @@ class PackageTest : StringSpec({
 
         diff.binaryArtifact should beNull()
         diff.comment should beNull()
+        diff.authors should beNull()
         diff.declaredLicenses should beNull()
         diff.homepageUrl should beNull()
         diff.sourceArtifact should beNull()


### PR DESCRIPTION
This is a preparation for solving #3400 and making copyright holder
curations possible. A new field declaredAuthors is added to
Package, PackageCuration and Project in order to be able to track
fields like authors from various package managers. These changes
don't include the adaptation of the package managers.