### PR TITLE
Sbt: Improve the mapping of definition files to fix related issues

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/directories-expected-output.yml
@@ -28,7 +28,7 @@ analyzer:
   result:
     projects:
     - id: "SBT:io.github.soc:directories:10"
-      definition_file_path: "target/directories-10.pom"
+      definition_file_path: "target-directories-10.pom"
       declared_licenses:
       - "Mozilla Public License 2.0"
       declared_licenses_processed:
@@ -55,22 +55,6 @@ analyzer:
         - id: "Maven:junit:junit:4.12"
           dependencies:
           - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Unmanaged::directories-jvm:d302b1e93963c81ed511e072a52e95251b5d078b"
-      definition_file_path: ""
-      declared_licenses: []
-      declared_licenses_processed: {}
-      vcs:
-        type: ""
-        url: ""
-        revision: ""
-        path: ""
-      vcs_processed:
-        type: "Git"
-        url: "https://github.com/soc/directories-jvm"
-        revision: "d302b1e93963c81ed511e072a52e95251b5d078b"
-        path: ""
-      homepage_url: ""
-      scopes: []
     packages:
     - package:
         id: "Maven:com.novocode:junit-interface:0.11"

--- a/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
@@ -28,7 +28,7 @@ analyzer:
   result:
     projects:
     - id: "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
-      definition_file_path: "common/target/scala-2.12/common_2.12-0.1-SNAPSHOT.pom"
+      definition_file_path: "common/target-scala-2.12-common_2.12-0.1-SNAPSHOT.pom"
       declared_licenses: []
       declared_licenses_processed: {}
       vcs:
@@ -79,7 +79,7 @@ analyzer:
           - id: "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
           - id: "Maven:org.scalactic:scalactic_2.12:3.0.4"
     - id: "SBT:com.pbassiner:multi1_2.12:0.1-SNAPSHOT"
-      definition_file_path: "multi1/target/scala-2.12/multi1_2.12-0.1-SNAPSHOT.pom"
+      definition_file_path: "multi1/target-scala-2.12-multi1_2.12-0.1-SNAPSHOT.pom"
       declared_licenses: []
       declared_licenses_processed: {}
       vcs:
@@ -138,7 +138,7 @@ analyzer:
           - id: "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
           - id: "Maven:org.scalactic:scalactic_2.12:3.0.4"
     - id: "SBT:com.pbassiner:multi2_2.12:0.1-SNAPSHOT"
-      definition_file_path: "multi2/target/scala-2.12/multi2_2.12-0.1-SNAPSHOT.pom"
+      definition_file_path: "multi2/target-scala-2.12-multi2_2.12-0.1-SNAPSHOT.pom"
       declared_licenses: []
       declared_licenses_processed: {}
       vcs:
@@ -198,7 +198,7 @@ analyzer:
           - id: "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
           - id: "Maven:org.scalactic:scalactic_2.12:3.0.4"
     - id: "SBT:com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT"
-      definition_file_path: "target/scala-2.12/sbt-multi-project-example_2.12-0.1-SNAPSHOT.pom"
+      definition_file_path: "target-scala-2.12-sbt-multi-project-example_2.12-0.1-SNAPSHOT.pom"
       declared_licenses: []
       declared_licenses_processed: {}
       vcs:
@@ -216,22 +216,6 @@ analyzer:
       - name: "compile"
         dependencies:
         - id: "Maven:org.scala-lang:scala-library:2.12.3"
-    - id: "Unmanaged::sbt-multi-project-example:31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
-      definition_file_path: ""
-      declared_licenses: []
-      declared_licenses_processed: {}
-      vcs:
-        type: ""
-        url: ""
-        revision: ""
-        path: ""
-      vcs_processed:
-        type: "Git"
-        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
-        path: ""
-      homepage_url: ""
-      scopes: []
     packages:
     - package:
         id: "Maven:ch.qos.logback:logback-classic:1.2.3"


### PR DESCRIPTION
The Sbt implementation uses the command `sbt makePom` to generate POM
files and then analyzes the POM files using ORT's Maven support. These
generated POM files are not siblings of their original POM files, but
are always placed within some directory named 'target'.

Thus, `Sbt.mapDefinitionFiles()` changes the directory of the POM file
which leads to the following problems:

1. If the root directory of the repository contains a `build.sbt` but
   no other definition file, then an Unmanaged project is added by the
   package manager, because there is no mapped definition file in the
   root directory.
2. The filtering of scan results done by `LocalScanner` via
   `ScanResultContainer.filterByProject()` removes all license and
   copyright findings from any generate POM project, because the
   generated POM file is the only file in the subtree of its parent
   directory.
3. The VCS path of scan results corresponding to a generated POM project
   can be inconsistent with the project directory.

Previously the POM files for a multi module project were generate like
e.g. [1]. Change it to [2] to fix all of the above problem while
maintaining the directories of the submodules. I've picked the approach
of just replacing '/' with '-' in the remainder of the path in order to
guarantee uniqueness. That is, to avoid conflicts when renaming or rather
moving the generate POM files to desired location.

[1] ./submodule/target/scala-2.11/submodule_2.11-1.0.0.pom
    ./target/scala-2.11/rootproject_2.11-1.0.0.pom
[2] ./submodule/target-scala-2.11-submodule_2.11-1.0.0.pom
    ./target-scala-2.11-rootproject_2.11-1.0.0.pom
