### PR TITLE
Revert "VulnerableCodeService: Add slash character at bulk search URLs"

### DIFF
--- a/advisor/src/test/kotlin/advisors/VulnerableCodeTest.kt
+++ b/advisor/src/test/kotlin/advisors/VulnerableCodeTest.kt
@@ -76,7 +76,7 @@ class VulnerableCodeTest : WordSpec({
     "VulnerabilityCode" should {
         "return vulnerability information" {
             stubFor(
-                post(urlPathEqualTo("/api/packages/bulk_search/"))
+                post(urlPathEqualTo("/api/packages/bulk_search"))
                     .withRequestBody(equalToJson(packagesRequestJson, false, false))
                     .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                     .willReturn(
@@ -124,7 +124,7 @@ class VulnerableCodeTest : WordSpec({
 
         "handle missing details of a vulnerability" {
             stubFor(
-                post(urlPathEqualTo("/api/packages/bulk_search/"))
+                post(urlPathEqualTo("/api/packages/bulk_search"))
                     .withRequestBody(equalToJson(packagesRequestJson, false, false))
                     .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                     .willReturn(

--- a/clients/vulnerable-code/src/main/kotlin/VulnerableCodeService.kt
+++ b/clients/vulnerable-code/src/main/kotlin/VulnerableCodeService.kt
@@ -127,14 +127,14 @@ interface VulnerableCodeService {
      * Return a map whose keys are the URLs of packages; so for each package the referenced vulnerabilities can be
      * retrieved.
      */
-    @POST("/api/packages/bulk_search/")
+    @POST("/api/packages/bulk_search")
     suspend fun getPackageVulnerabilities(@Body packageUrls: PackagesWrapper): Map<String, Vulnerabilities>
 
     /**
      * Retrieve detail information about the specified [vulnerabilities][vulnerabilityIds]. The resulting map
      * associates the IDs of vulnerabilities with their details.
      */
-    @POST("/api/vulnerabilities/bulk_search/")
+    @POST("/api/vulnerabilities/bulk_search")
     suspend fun getVulnerabilityDetails(@Body vulnerabilityIds: VulnerabilitiesWrapper): Map<String, Vulnerability>
 
     /**


### PR DESCRIPTION
This reverts commit 04be50f. The work-around is not necessary anymore as
the issue has been fixed upstream in VulnerableCode, see

https://github.com/nexB/vulnerablecode/issues/284#issuecomment-778739208

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>