### PR TITLE
ExcelReporterFunTest: Disregard the font index as it is not stable

### DIFF
--- a/reporter/src/funTest/kotlin/reporters/ExcelReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/ExcelReporterFunTest.kt
@@ -87,7 +87,6 @@ class ExcelReporterFunTest : WordSpec({
 
                     actualCell.cellType shouldBe expectedCell.cellType
                     actualCell.stringCellValue shouldBe expectedCell.stringCellValue
-                    actualCell.cellStyle.fontIndex shouldBe expectedCell.cellStyle.fontIndex
                     actualCell.cellStyle.fillBackgroundColor shouldBe expectedCell.cellStyle.fillBackgroundColor
                 }
             }


### PR DESCRIPTION
Do not take the font index into account in test assertions as it might
change when just resaving the file without making real changes.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>