### PR TITLE
ClearlyDefinedService: Support deserializing invalid curations

### DIFF
--- a/analyzer/src/test/kotlin/curation/ClearlyDefinedPackageCurationProviderTest.kt
+++ b/analyzer/src/test/kotlin/curation/ClearlyDefinedPackageCurationProviderTest.kt
@@ -27,8 +27,11 @@ import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.utils.OrtProxySelector
 
 class ClearlyDefinedPackageCurationProviderTest : WordSpec({
+    OrtProxySelector.install()
+
     "The production server" should {
         "return an existing curation for the javax.servlet-api Maven package" {
             val provider = ClearlyDefinedPackageCurationProvider()

--- a/clients/clearly-defined/src/funTest/assets/gson.json
+++ b/clients/clearly-defined/src/funTest/assets/gson.json
@@ -1,0 +1,16 @@
+{
+  "described": {
+    "facets": {
+      "dev": [],
+      "tests": []
+    },
+    "sourceLocation": {
+      "name": "gson",
+      "namespace": "google",
+      "provider": "github",
+      "revision": "29c93895bbcaed02178abc9e3d47b73878aaca73",
+      "type": "git",
+      "url": "https://github.com/google/gson/commit/29c93895bbcaed02178abc9e3d47b73878aaca73"
+    }
+  }
+}

--- a/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
+++ b/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
@@ -19,11 +19,17 @@
 
 package org.ossreviewtoolkit.clients.clearlydefined
 
+import com.fasterxml.jackson.module.kotlin.readValue
+
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.shouldStartWith
+
+import java.io.File
 
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionInfo
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionPatch
@@ -38,6 +44,20 @@ import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class ClearlyDefinedServiceFunTest : WordSpec({
     OrtProxySelector.install()
+
+    "A contribution patch" should {
+        "be correctly deserialized even when using invalid facet arrays" {
+            // See https://github.com/clearlydefined/curated-data/blob/0b2db78/curations/maven/mavencentral/com.google.code.gson/gson.yaml#L10-L11.
+            val curationWithInvalidFacetArrays = File("src/funTest/assets/gson.json")
+
+            val curation = ClearlyDefinedService.JSON_MAPPER.readValue<Curation>(curationWithInvalidFacetArrays)
+
+            curation.described?.facets.shouldNotBeNull {
+                dev should beNull()
+                tests should beNull()
+            }
+        }
+    }
 
     "Downloading a contribution patch" should {
         "return curation data".config(tags = setOf(ExpensiveTag)) {

--- a/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
+++ b/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
@@ -32,10 +32,13 @@ import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Curatio
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Licensed
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Patch
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
+import org.ossreviewtoolkit.utils.OrtProxySelector
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class ClearlyDefinedServiceFunTest : WordSpec({
+    OrtProxySelector.install()
+
     "Downloading a contribution patch" should {
         "return curation data".config(tags = setOf(ExpensiveTag)) {
             val service = ClearlyDefinedService.create(Server.PRODUCTION)

--- a/clients/clearly-defined/src/main/kotlin/ClearlyDefinedService.kt
+++ b/clients/clearly-defined/src/main/kotlin/ClearlyDefinedService.kt
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 
@@ -53,7 +54,8 @@ interface ClearlyDefinedService {
         /**
          * The mapper for JSON serialization used by this service.
          */
-        val JSON_MAPPER = JsonMapper().registerKotlinModule()
+        val JSON_MAPPER = JsonMapper().enable(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT)
+            .registerKotlinModule()
 
         /**
          * Create a ClearlyDefined service instance for communicating with the given [server], optionally using a


### PR DESCRIPTION
ClearlyDefined now returns HTTP 404 errors for non-existing curations,
see [1]. Lower the log level from "warn" to "debug" as not having a
curation is just fine with us if none is available.

Resolves #3559.

[1] https://github.com/clearlydefined/service/issues/795

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>