### PR TITLE
Fix URLs of downloadLocation in SPDX example files

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl/package.spdx.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl/package.spdx.yml
@@ -18,7 +18,7 @@ packages:
      IMAP, SMTP, POP3, RTSP and RTMP. libcurl offers a myriad of powerful features."
   copyrightText: "Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many
     contributors, see the THANKS file."
-  downloadLocation: "git+github.com:curl/curl.git@53cdc2c963e33bc0cc1a51ad2df79396202e07f8"
+  downloadLocation: "git+https://github.com/curl/curl.git@53cdc2c963e33bc0cc1a51ad2df79396202e07f8"
   filesAnalyzed: false
   homepage: "https://curl.haxx.se/"
   licenseConcluded: "NOASSERTION"

--- a/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
@@ -39,7 +39,7 @@ packages:
 - SPDXID: "SPDXRef-Package-openssl"
   description: "OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit for the Transport Layer Security (TLS) protocol formerly known as the Secure Sockets Layer (SSL) protocol. The protocol implementation is based on a full-strength general purpose cryptographic library, which can also be used stand-alone."
   copyrightText: "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
-  downloadLocation: "git+ssh://github.com:openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
+  downloadLocation: "git+ssh://github.com/openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
   filesAnalyzed: false
   homepage: "https://www.openssl.org/"
   licenseConcluded: "NOASSERTION"


### PR DESCRIPTION
Using the spdx-java-tool verify functionality [1]
these URIs were validated.

[1] https://github.com/spdx/tools-java.git

This commit is originally from https://github.com/oss-review-toolkit/ort/pull/3521, but was separated into a smaller PR.