### PR TITLE
SpdxDocumentFile: Put only packages contained in the project's scopes in the result file

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
@@ -50,6 +50,21 @@ packages:
   name: "openssl"
   versionInfo: "1.1.1g"
   originator: "Organization: OpenSSL Development Team"
+- SPDXID: "SPDXRef-Package-Saxon"
+  checksums:
+    - algorithm: "SHA1"
+      checksumValue: "85ed0817af83a24ad8da68c2b5094de69833983c"
+  copyrightText: "Copyright Saxonica Ltd"
+  description: "The Saxon package is a collection of tools for processing XML documents."
+  downloadLocation: "https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download"
+  filesAnalyzed: false
+  homepage: "http://saxon.sourceforge.net/"
+  licenseComments: "Other versions available for a commercial license"
+  licenseConcluded: "MPL-1.0"
+  licenseDeclared: "MPL-1.0"
+  name: "Saxon"
+  packageFileName: "saxonB-8.8.zip"
+  versionInfo: "8.8"
 relationships:
 - spdxElementId: "SPDXRef-Package-curl"
   relatedSpdxElement: "SPDXRef-Package-xyz"

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -164,6 +164,9 @@ class SpdxDocumentFile(
         ) = SpdxDocumentFile(managerName, analysisRoot, analyzerConfig, repoConfig)
     }
 
+    /**
+     * Create an [Identifier] out of this [SpdxPackage].
+     */
     private fun SpdxPackage.toIdentifier() =
         Identifier(
             type = managerName,


### PR DESCRIPTION
Currently all packages in the project.spdx.ymls packages list
that are not the project package itself are added to the
ProjectAnalyzerResult packages list. They should only be listed
if there is also a relationship to the package project or one of
it's dependencies. These packages were previously identified and
put into their respective scope.

In the modified test SPDXRef-Saxon should not be in the result file even
though it is in the spdx.project.yml, since it has no relationship to any
other element in the file.
