### PR TITLE
Rename parameter `project` to `packageName`

### DIFF
--- a/downloader/src/main/kotlin/WorkingTree.kt
+++ b/downloader/src/main/kotlin/WorkingTree.kt
@@ -82,15 +82,15 @@ abstract class WorkingTree(val workingDir: File, val vcsType: VcsType) {
     abstract fun listRemoteTags(): List<String>
 
     /**
-     * Search (symbolic) names of VCS revisions for a match with the given [project] and [version].
+     * Search (symbolic) names of VCS revisions for a match with the given [packageName] and [version].
      *
      * @return The matching VCS revision, never blank.
      * @throws IOException If no or multiple matching revisions are found.
      */
-    fun guessRevisionName(project: String, version: String): String {
+    fun guessRevisionName(packageName: String, version: String): String {
         if (version.isBlank()) throw IOException("Cannot guess a revision name from a blank version.")
 
-        val versionNames = filterVersionNames(version, listRemoteTags(), project)
+        val versionNames = filterVersionNames(version, listRemoteTags(), packageName)
         return when {
             versionNames.isEmpty() ->
                 throw IOException(

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -62,9 +62,10 @@ inline fun <reified T : Any> T.hasNonNullProperty() =
     T::class.memberProperties.asSequence().map { it.get(this) }.any { it != null }
 
 /**
- * Filter a list of [names] to include only those that likely belong to the given [version] of an optional [project].
+ * Filter a list of [names] to include only those that likely belong to the given [version] of an optional
+ * [packageName].
  */
-fun filterVersionNames(version: String, names: List<String>, project: String? = null): List<String> {
+fun filterVersionNames(version: String, names: List<String>, packageName: String? = null): List<String> {
     if (version.isBlank() || names.isEmpty()) return emptyList()
 
     // If there are full matches, return them right away.
@@ -123,7 +124,7 @@ fun filterVersionNames(version: String, names: List<String>, project: String? = 
 
     return filteredNames.filter {
         // startsWith("") returns "true" for any string, so we get an unfiltered list if "project" is "null".
-        it.startsWith(project.orEmpty())
+        it.startsWith(packageName.orEmpty())
     }.let {
         // Fall back to the original list if filtering by project results in an empty list.
         if (it.isEmpty()) filteredNames else it


### PR DESCRIPTION
The name "project" is usually only used for projects found by the
Analyzer, and the code from which these functions are called also takes
the name from a package, not a project.

Use `packageName` instead of `pkg` to distinguish from `Package` objects
for which the name `pkg` is usually used.