### PR TITLE
filterVersionName: Ignore case of tag and package names

### DIFF
--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -123,7 +123,7 @@ fun filterVersionNames(version: String, names: List<String>, project: String? = 
 
     return filteredNames.filter {
         // startsWith("") returns "true" for any string, so we get an unfiltered list if "project" is "null".
-        it.startsWith(project.orEmpty())
+        it.startsWith(project.orEmpty(), ignoreCase = true)
     }.let {
         // Fall back to the original list if filtering by project results in an empty list.
         if (it.isEmpty()) filteredNames else it

--- a/utils/src/test/kotlin/UtilsTest.kt
+++ b/utils/src/test/kotlin/UtilsTest.kt
@@ -180,6 +180,8 @@ class UtilsTest : WordSpec({
 
             filterVersionNames("6.9.0", names, "babel-plugin-transform-simplify-comparison-operators")
                 .joinToString("\n") shouldBe "babel-plugin-transform-simplify-comparison-operators@6.9.0"
+            filterVersionNames("6.9.0", names, "Babel-plugin-transform-simplify-comparison-operators")
+                .joinToString("\n") shouldBe "babel-plugin-transform-simplify-comparison-operators@6.9.0"
         }
 
         "find names when others with trailing digits are present" {


### PR DESCRIPTION
Ignore the case when matching tag names with package names to increase
the likelihood of finding matching tags.