### PR TITLE
Npm: Add support for declared authors

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -216,6 +216,8 @@ analyzer:
           - id: "Maven:org.hamcrest:hamcrest-core:1.3"
     - id: "NPM::isarray:2.0.5"
       definition_file_path: "package.json"
+      authors:
+      - "Julian Gruber"
       declared_licenses:
       - "MIT"
       declared_licenses_processed:
@@ -2599,6 +2601,8 @@ analyzer:
     - package:
         id: "NPM::boolbase:1.0.0"
         purl: "pkg:npm/boolbase@1.0.0"
+        authors:
+        - "Felix Boehm"
         declared_licenses:
         - "ISC"
         declared_licenses_processed:
@@ -2629,6 +2633,8 @@ analyzer:
     - package:
         id: "NPM::cheerio:1.0.0-rc.1"
         purl: "pkg:npm/cheerio@1.0.0-rc.1"
+        authors:
+        - "Matt Mueller"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -2660,6 +2666,8 @@ analyzer:
     - package:
         id: "NPM::coffee-script:1.12.7"
         purl: "pkg:npm/coffee-script@1.12.7"
+        authors:
+        - "Jeremy Ashkenas"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -2690,6 +2698,8 @@ analyzer:
     - package:
         id: "NPM::cson-parser:1.3.5"
         purl: "pkg:npm/cson-parser@1.3.5"
+        authors:
+        - "Groupon"
         declared_licenses:
         - "BSD-3-Clause"
         declared_licenses_processed:
@@ -2720,6 +2730,8 @@ analyzer:
     - package:
         id: "NPM::cson:4.1.0"
         purl: "pkg:npm/cson@4.1.0"
+        authors:
+        - "2012+ Bevry Pty Ltd"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -2751,6 +2763,8 @@ analyzer:
     - package:
         id: "NPM::css-select:1.2.0"
         purl: "pkg:npm/css-select@1.2.0"
+        authors:
+        - "Felix Boehm"
         declared_licenses:
         - "BSD-like"
         declared_licenses_processed:
@@ -2783,6 +2797,8 @@ analyzer:
     - package:
         id: "NPM::css-what:2.1.3"
         purl: "pkg:npm/css-what@2.1.3"
+        authors:
+        - "Felix Böhm"
         declared_licenses:
         - "BSD-2-Clause"
         declared_licenses_processed:
@@ -2813,6 +2829,8 @@ analyzer:
     - package:
         id: "NPM::deep-equal:0.2.2"
         purl: "pkg:npm/deep-equal@0.2.2"
+        authors:
+        - "James Halliday"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -2843,6 +2861,8 @@ analyzer:
     - package:
         id: "NPM::defined:0.0.0"
         purl: "pkg:npm/defined@0.0.0"
+        authors:
+        - "James Halliday"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -2873,6 +2893,8 @@ analyzer:
     - package:
         id: "NPM::dom-serializer:0.1.1"
         purl: "pkg:npm/dom-serializer@0.1.1"
+        authors:
+        - "Felix Boehm"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -2903,6 +2925,8 @@ analyzer:
     - package:
         id: "NPM::domelementtype:1.3.1"
         purl: "pkg:npm/domelementtype@1.3.1"
+        authors:
+        - "Felix Boehm"
         declared_licenses:
         - "BSD-2-Clause"
         declared_licenses_processed:
@@ -2933,6 +2957,8 @@ analyzer:
     - package:
         id: "NPM::domhandler:2.4.2"
         purl: "pkg:npm/domhandler@2.4.2"
+        authors:
+        - "Felix Boehm"
         declared_licenses:
         - "BSD-2-Clause"
         declared_licenses_processed:
@@ -2963,6 +2989,8 @@ analyzer:
     - package:
         id: "NPM::domutils:1.5.1"
         purl: "pkg:npm/domutils@1.5.1"
+        authors:
+        - "Felix Boehm"
         declared_licenses: []
         declared_licenses_processed: {}
         description: "utilities for working with htmlparser2's dom"
@@ -2991,6 +3019,8 @@ analyzer:
     - package:
         id: "NPM::eachr:3.2.0"
         purl: "pkg:npm/eachr@3.2.0"
+        authors:
+        - "2011+ Bevry Pty Ltd"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3023,6 +3053,8 @@ analyzer:
     - package:
         id: "NPM::editions:1.3.4"
         purl: "pkg:npm/editions@1.3.4"
+        authors:
+        - "2016+ Bevry Pty Ltd"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3054,6 +3086,8 @@ analyzer:
     - package:
         id: "NPM::editions:2.1.3"
         purl: "pkg:npm/editions@2.1.3"
+        authors:
+        - "2016+ Bevry Pty Ltd"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3085,6 +3119,8 @@ analyzer:
     - package:
         id: "NPM::entities:1.1.2"
         purl: "pkg:npm/entities@1.1.2"
+        authors:
+        - "Felix Boehm"
         declared_licenses:
         - "BSD-2-Clause"
         declared_licenses_processed:
@@ -3115,6 +3151,8 @@ analyzer:
     - package:
         id: "NPM::errlop:1.1.1"
         purl: "pkg:npm/errlop@1.1.1"
+        authors:
+        - "2018+ Benjamin Lupton"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3146,6 +3184,8 @@ analyzer:
     - package:
         id: "NPM::extract-opts:3.3.1"
         purl: "pkg:npm/extract-opts@3.3.1"
+        authors:
+        - "2013+ Bevry Pty Ltd"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3177,6 +3217,8 @@ analyzer:
     - package:
         id: "NPM::glob:3.2.11"
         purl: "pkg:npm/glob@3.2.11"
+        authors:
+        - "Isaac Z. Schlueter"
         declared_licenses:
         - "BSD"
         declared_licenses_processed:
@@ -3239,6 +3281,8 @@ analyzer:
     - package:
         id: "NPM::htmlparser2:3.10.1"
         purl: "pkg:npm/htmlparser2@3.10.1"
+        authors:
+        - "Felix Boehm"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3300,6 +3344,8 @@ analyzer:
     - package:
         id: "NPM::lodash:4.17.11"
         purl: "pkg:npm/lodash@4.17.11"
+        authors:
+        - "John-David Dalton"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3330,6 +3376,8 @@ analyzer:
     - package:
         id: "NPM::lru-cache:2.7.3"
         purl: "pkg:npm/lru-cache@2.7.3"
+        authors:
+        - "Isaac Z. Schlueter"
         declared_licenses:
         - "ISC"
         declared_licenses_processed:
@@ -3360,6 +3408,8 @@ analyzer:
     - package:
         id: "NPM::minimatch:0.3.0"
         purl: "pkg:npm/minimatch@0.3.0"
+        authors:
+        - "Isaac Z. Schlueter"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3390,6 +3440,8 @@ analyzer:
     - package:
         id: "NPM::nth-check:1.0.2"
         purl: "pkg:npm/nth-check@1.0.2"
+        authors:
+        - "Felix Boehm"
         declared_licenses:
         - "BSD-2-Clause"
         declared_licenses_processed:
@@ -3420,6 +3472,8 @@ analyzer:
     - package:
         id: "NPM::object-inspect:0.4.0"
         purl: "pkg:npm/object-inspect@0.4.0"
+        authors:
+        - "James Halliday"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3450,6 +3504,8 @@ analyzer:
     - package:
         id: "NPM::parse5:3.0.3"
         purl: "pkg:npm/parse5@3.0.3"
+        authors:
+        - "Ivan Nikulin"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3511,6 +3567,8 @@ analyzer:
     - package:
         id: "NPM::requirefresh:2.2.0"
         purl: "pkg:npm/requirefresh@2.2.0"
+        authors:
+        - "2013+ Bevry Pty Ltd"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3541,6 +3599,8 @@ analyzer:
     - package:
         id: "NPM::resumer:0.0.0"
         purl: "pkg:npm/resumer@0.0.0"
+        authors:
+        - "James Halliday"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3572,6 +3632,8 @@ analyzer:
     - package:
         id: "NPM::safe-buffer:5.1.2"
         purl: "pkg:npm/safe-buffer@5.1.2"
+        authors:
+        - "Feross Aboukhadijeh"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3602,6 +3664,8 @@ analyzer:
     - package:
         id: "NPM::safefs:4.1.0"
         purl: "pkg:npm/safefs@4.1.0"
+        authors:
+        - "2013+ Bevry Pty Ltd"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3663,6 +3727,8 @@ analyzer:
     - package:
         id: "NPM::sigmund:1.0.1"
         purl: "pkg:npm/sigmund@1.0.1"
+        authors:
+        - "Isaac Z. Schlueter"
         declared_licenses:
         - "ISC"
         declared_licenses_processed:
@@ -3723,6 +3789,8 @@ analyzer:
     - package:
         id: "NPM::tape:2.13.4"
         purl: "pkg:npm/tape@2.13.4"
+        authors:
+        - "James Halliday"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3753,6 +3821,8 @@ analyzer:
     - package:
         id: "NPM::through:2.3.8"
         purl: "pkg:npm/through@2.3.8"
+        authors:
+        - "Dominic Tarr"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3783,6 +3853,8 @@ analyzer:
     - package:
         id: "NPM::typechecker:4.7.0"
         purl: "pkg:npm/typechecker@4.7.0"
+        authors:
+        - "2013+ Bevry Pty Ltd"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:
@@ -3814,6 +3886,8 @@ analyzer:
     - package:
         id: "NPM::util-deprecate:1.0.2"
         purl: "pkg:npm/util-deprecate@1.0.2"
+        authors:
+        - "Nathan Rajlich"
         declared_licenses:
         - "MIT"
         declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -2307,6 +2307,8 @@ project:
 packages:
 - id: "NPM::abbrev:1.1.1"
   purl: "pkg:npm/abbrev@1.1.1"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -2335,6 +2337,8 @@ packages:
     path: ""
 - id: "NPM::ansi-regex:2.1.1"
   purl: "pkg:npm/ansi-regex@2.1.1"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2363,6 +2367,8 @@ packages:
     path: ""
 - id: "NPM::ansi-styles:2.2.1"
   purl: "pkg:npm/ansi-styles@2.2.1"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2391,6 +2397,8 @@ packages:
     path: ""
 - id: "NPM::anymatch:1.3.2"
   purl: "pkg:npm/anymatch@1.3.2"
+  authors:
+  - "Elan Shanker"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -2420,6 +2428,8 @@ packages:
     path: ""
 - id: "NPM::aproba:1.2.0"
   purl: "pkg:npm/aproba@1.2.0"
+  authors:
+  - "Rebecca Turner"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -2448,6 +2458,8 @@ packages:
     path: ""
 - id: "NPM::are-we-there-yet:1.1.5"
   purl: "pkg:npm/are-we-there-yet@1.1.5"
+  authors:
+  - "Rebecca Turner"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -2476,6 +2488,8 @@ packages:
     path: ""
 - id: "NPM::arr-diff:2.0.0"
   purl: "pkg:npm/arr-diff@2.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2505,6 +2519,8 @@ packages:
     path: ""
 - id: "NPM::arr-diff:4.0.0"
   purl: "pkg:npm/arr-diff@4.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2534,6 +2550,8 @@ packages:
     path: ""
 - id: "NPM::arr-flatten:1.1.0"
   purl: "pkg:npm/arr-flatten@1.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2562,6 +2580,8 @@ packages:
     path: ""
 - id: "NPM::arr-union:3.1.0"
   purl: "pkg:npm/arr-union@3.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2591,6 +2611,8 @@ packages:
     path: ""
 - id: "NPM::array-unique:0.2.1"
   purl: "pkg:npm/array-unique@0.2.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2619,6 +2641,8 @@ packages:
     path: ""
 - id: "NPM::array-unique:0.3.2"
   purl: "pkg:npm/array-unique@0.3.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2647,6 +2671,8 @@ packages:
     path: ""
 - id: "NPM::assign-symbols:1.0.0"
   purl: "pkg:npm/assign-symbols@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2678,6 +2704,8 @@ packages:
     path: ""
 - id: "NPM::async-each:1.0.3"
   purl: "pkg:npm/async-each@1.0.3"
+  authors:
+  - "Paul Miller"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2707,6 +2735,8 @@ packages:
     path: ""
 - id: "NPM::atob:2.1.2"
   purl: "pkg:npm/atob@2.1.2"
+  authors:
+  - "AJ ONeal"
   declared_licenses:
   - "(MIT OR Apache-2.0)"
   declared_licenses_processed:
@@ -2735,6 +2765,8 @@ packages:
     path: ""
 - id: "NPM::babel-cli:6.26.0"
   purl: "pkg:npm/babel-cli@6.26.0"
+  authors:
+  - "Sebastian McKenzie"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2763,6 +2795,8 @@ packages:
     path: "packages/babel-cli"
 - id: "NPM::babel-code-frame:6.26.0"
   purl: "pkg:npm/babel-code-frame@6.26.0"
+  authors:
+  - "Sebastian McKenzie"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2791,6 +2825,8 @@ packages:
     path: "packages/babel-code-frame"
 - id: "NPM::babel-core:6.26.3"
   purl: "pkg:npm/babel-core@6.26.3"
+  authors:
+  - "Sebastian McKenzie"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2819,6 +2855,8 @@ packages:
     path: "packages/babel-core"
 - id: "NPM::babel-generator:6.26.1"
   purl: "pkg:npm/babel-generator@6.26.1"
+  authors:
+  - "Sebastian McKenzie"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2847,6 +2885,8 @@ packages:
     path: "packages/babel-generator"
 - id: "NPM::babel-helpers:6.24.1"
   purl: "pkg:npm/babel-helpers@6.24.1"
+  authors:
+  - "Sebastian McKenzie"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2875,6 +2915,8 @@ packages:
     path: "packages/babel-helpers"
 - id: "NPM::babel-messages:6.23.0"
   purl: "pkg:npm/babel-messages@6.23.0"
+  authors:
+  - "Sebastian McKenzie"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2903,6 +2945,8 @@ packages:
     path: "packages/babel-messages"
 - id: "NPM::babel-polyfill:6.26.0"
   purl: "pkg:npm/babel-polyfill@6.26.0"
+  authors:
+  - "Sebastian McKenzie"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2931,6 +2975,8 @@ packages:
     path: "packages/babel-polyfill"
 - id: "NPM::babel-register:6.26.0"
   purl: "pkg:npm/babel-register@6.26.0"
+  authors:
+  - "Sebastian McKenzie"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2959,6 +3005,8 @@ packages:
     path: "packages/babel-register"
 - id: "NPM::babel-runtime:6.26.0"
   purl: "pkg:npm/babel-runtime@6.26.0"
+  authors:
+  - "Sebastian McKenzie"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2987,6 +3035,8 @@ packages:
     path: "packages/babel-runtime"
 - id: "NPM::babel-template:6.26.0"
   purl: "pkg:npm/babel-template@6.26.0"
+  authors:
+  - "Sebastian McKenzie"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3015,6 +3065,8 @@ packages:
     path: "packages/babel-template"
 - id: "NPM::babel-traverse:6.26.0"
   purl: "pkg:npm/babel-traverse@6.26.0"
+  authors:
+  - "Sebastian McKenzie"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3044,6 +3096,8 @@ packages:
     path: "packages/babel-traverse"
 - id: "NPM::babel-types:6.26.0"
   purl: "pkg:npm/babel-types@6.26.0"
+  authors:
+  - "Sebastian McKenzie"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3072,6 +3126,8 @@ packages:
     path: "packages/babel-types"
 - id: "NPM::babylon:6.18.0"
   purl: "pkg:npm/babylon@6.18.0"
+  authors:
+  - "Sebastian McKenzie"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3100,6 +3156,8 @@ packages:
     path: ""
 - id: "NPM::balanced-match:1.0.0"
   purl: "pkg:npm/balanced-match@1.0.0"
+  authors:
+  - "Julian Gruber"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3128,6 +3186,8 @@ packages:
     path: ""
 - id: "NPM::base:0.11.2"
   purl: "pkg:npm/base@0.11.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3158,6 +3218,8 @@ packages:
     path: ""
 - id: "NPM::binary-extensions:1.13.1"
   purl: "pkg:npm/binary-extensions@1.13.1"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3186,6 +3248,8 @@ packages:
     path: ""
 - id: "NPM::brace-expansion:1.1.11"
   purl: "pkg:npm/brace-expansion@1.1.11"
+  authors:
+  - "Julian Gruber"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3214,6 +3278,8 @@ packages:
     path: ""
 - id: "NPM::braces:1.8.5"
   purl: "pkg:npm/braces@1.8.5"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3243,6 +3309,8 @@ packages:
     path: ""
 - id: "NPM::braces:2.3.2"
   purl: "pkg:npm/braces@2.3.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3273,6 +3341,8 @@ packages:
     path: ""
 - id: "NPM::cache-base:1.0.1"
   purl: "pkg:npm/cache-base@1.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3330,6 +3400,8 @@ packages:
     path: ""
 - id: "NPM::chokidar:1.7.0"
   purl: "pkg:npm/chokidar@1.7.0"
+  authors:
+  - "Paul Miller"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3358,6 +3430,8 @@ packages:
     path: ""
 - id: "NPM::chownr:1.1.1"
   purl: "pkg:npm/chownr@1.1.1"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -3386,6 +3460,8 @@ packages:
     path: ""
 - id: "NPM::class-utils:0.3.6"
   purl: "pkg:npm/class-utils@0.3.6"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3414,6 +3490,8 @@ packages:
     path: ""
 - id: "NPM::code-point-at:1.1.0"
   purl: "pkg:npm/code-point-at@1.1.0"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3442,6 +3520,8 @@ packages:
     path: ""
 - id: "NPM::collection-visit:1.0.0"
   purl: "pkg:npm/collection-visit@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3471,6 +3551,8 @@ packages:
     path: ""
 - id: "NPM::commander:2.20.0"
   purl: "pkg:npm/commander@2.20.0"
+  authors:
+  - "TJ Holowaychuk"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3527,6 +3609,8 @@ packages:
     path: ""
 - id: "NPM::concat-map:0.0.1"
   purl: "pkg:npm/concat-map@0.0.1"
+  authors:
+  - "James Halliday"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3555,6 +3639,8 @@ packages:
     path: ""
 - id: "NPM::console-control-strings:1.1.0"
   purl: "pkg:npm/console-control-strings@1.1.0"
+  authors:
+  - "Rebecca Turner"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -3586,6 +3672,8 @@ packages:
     path: ""
 - id: "NPM::convert-source-map:1.6.0"
   purl: "pkg:npm/convert-source-map@1.6.0"
+  authors:
+  - "Thorsten Lorenz"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3615,6 +3703,8 @@ packages:
     path: ""
 - id: "NPM::copy-descriptor:0.1.1"
   purl: "pkg:npm/copy-descriptor@0.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3671,6 +3761,8 @@ packages:
     path: ""
 - id: "NPM::core-util-is:1.0.2"
   purl: "pkg:npm/core-util-is@1.0.2"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3699,6 +3791,8 @@ packages:
     path: ""
 - id: "NPM::debug:2.6.9"
   purl: "pkg:npm/debug@2.6.9"
+  authors:
+  - "TJ Holowaychuk"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3727,6 +3821,8 @@ packages:
     path: ""
 - id: "NPM::debug:4.1.1"
   purl: "pkg:npm/debug@4.1.1"
+  authors:
+  - "TJ Holowaychuk"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3755,6 +3851,8 @@ packages:
     path: ""
 - id: "NPM::decode-uri-component:0.2.0"
   purl: "pkg:npm/decode-uri-component@0.2.0"
+  authors:
+  - "Sam Verschueren"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3783,6 +3881,8 @@ packages:
     path: ""
 - id: "NPM::deep-extend:0.6.0"
   purl: "pkg:npm/deep-extend@0.6.0"
+  authors:
+  - "Viacheslav Lotsmanov"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3811,6 +3911,8 @@ packages:
     path: ""
 - id: "NPM::define-property:0.2.5"
   purl: "pkg:npm/define-property@0.2.5"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3839,6 +3941,8 @@ packages:
     path: ""
 - id: "NPM::define-property:1.0.0"
   purl: "pkg:npm/define-property@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3867,6 +3971,8 @@ packages:
     path: ""
 - id: "NPM::define-property:2.0.2"
   purl: "pkg:npm/define-property@2.0.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3924,6 +4030,8 @@ packages:
     path: ""
 - id: "NPM::detect-indent:4.0.0"
   purl: "pkg:npm/detect-indent@4.0.0"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3952,6 +4060,8 @@ packages:
     path: ""
 - id: "NPM::detect-libc:1.0.3"
   purl: "pkg:npm/detect-libc@1.0.3"
+  authors:
+  - "Lovell Fuller"
   declared_licenses:
   - "Apache-2.0"
   declared_licenses_processed:
@@ -3981,6 +4091,8 @@ packages:
     path: ""
 - id: "NPM::escape-string-regexp:1.0.5"
   purl: "pkg:npm/escape-string-regexp@1.0.5"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4039,6 +4151,8 @@ packages:
     path: ""
 - id: "NPM::expand-brackets:0.1.5"
   purl: "pkg:npm/expand-brackets@0.1.5"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4067,6 +4181,8 @@ packages:
     path: ""
 - id: "NPM::expand-brackets:2.1.4"
   purl: "pkg:npm/expand-brackets@2.1.4"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4095,6 +4211,8 @@ packages:
     path: ""
 - id: "NPM::expand-range:1.8.2"
   purl: "pkg:npm/expand-range@1.8.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4124,6 +4242,8 @@ packages:
     path: ""
 - id: "NPM::extend-shallow:2.0.1"
   purl: "pkg:npm/extend-shallow@2.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4153,6 +4273,8 @@ packages:
     path: ""
 - id: "NPM::extend-shallow:3.0.2"
   purl: "pkg:npm/extend-shallow@3.0.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4182,6 +4304,8 @@ packages:
     path: ""
 - id: "NPM::extglob:0.3.2"
   purl: "pkg:npm/extglob@0.3.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4211,6 +4335,8 @@ packages:
     path: ""
 - id: "NPM::extglob:2.0.4"
   purl: "pkg:npm/extglob@2.0.4"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4240,6 +4366,8 @@ packages:
     path: ""
 - id: "NPM::filename-regex:2.0.1"
   purl: "pkg:npm/filename-regex@2.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4268,6 +4396,8 @@ packages:
     path: ""
 - id: "NPM::fill-range:2.2.4"
   purl: "pkg:npm/fill-range@2.2.4"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4297,6 +4427,8 @@ packages:
     path: ""
 - id: "NPM::fill-range:4.0.0"
   purl: "pkg:npm/fill-range@4.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4326,6 +4458,8 @@ packages:
     path: ""
 - id: "NPM::for-in:1.0.2"
   purl: "pkg:npm/for-in@1.0.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4356,6 +4490,8 @@ packages:
     path: ""
 - id: "NPM::for-own:0.1.5"
   purl: "pkg:npm/for-own@0.1.5"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4386,6 +4522,8 @@ packages:
     path: ""
 - id: "NPM::fragment-cache:0.2.1"
   purl: "pkg:npm/fragment-cache@0.2.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4414,6 +4552,8 @@ packages:
     path: ""
 - id: "NPM::fs-minipass:1.2.5"
   purl: "pkg:npm/fs-minipass@1.2.5"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -4442,6 +4582,8 @@ packages:
     path: ""
 - id: "NPM::fs-readdir-recursive:1.1.0"
   purl: "pkg:npm/fs-readdir-recursive@1.1.0"
+  authors:
+  - "Jonathan Ong"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4470,6 +4612,8 @@ packages:
     path: ""
 - id: "NPM::fs.realpath:1.0.0"
   purl: "pkg:npm/fs.realpath@1.0.0"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -4499,6 +4643,8 @@ packages:
     path: ""
 - id: "NPM::fsevents:1.2.9"
   purl: "pkg:npm/fsevents@1.2.9"
+  authors:
+  - "Philipp Dunkel"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4527,6 +4673,8 @@ packages:
     path: ""
 - id: "NPM::gauge:2.7.4"
   purl: "pkg:npm/gauge@2.7.4"
+  authors:
+  - "Rebecca Turner"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -4555,6 +4703,8 @@ packages:
     path: ""
 - id: "NPM::get-value:2.0.6"
   purl: "pkg:npm/get-value@2.0.6"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4583,6 +4733,8 @@ packages:
     path: ""
 - id: "NPM::glob-base:0.3.0"
   purl: "pkg:npm/glob-base@0.3.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4611,6 +4763,8 @@ packages:
     path: ""
 - id: "NPM::glob-parent:2.0.0"
   purl: "pkg:npm/glob-parent@2.0.0"
+  authors:
+  - "Elan Shanker"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -4639,6 +4793,8 @@ packages:
     path: ""
 - id: "NPM::glob:7.1.3"
   purl: "pkg:npm/glob@7.1.3"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -4667,6 +4823,8 @@ packages:
     path: ""
 - id: "NPM::glob:7.1.4"
   purl: "pkg:npm/glob@7.1.4"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -4695,6 +4853,8 @@ packages:
     path: ""
 - id: "NPM::globals:9.18.0"
   purl: "pkg:npm/globals@9.18.0"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4751,6 +4911,8 @@ packages:
     path: ""
 - id: "NPM::has-ansi:2.0.0"
   purl: "pkg:npm/has-ansi@2.0.0"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4779,6 +4941,8 @@ packages:
     path: ""
 - id: "NPM::has-unicode:2.0.1"
   purl: "pkg:npm/has-unicode@2.0.1"
+  authors:
+  - "Rebecca Turner"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -4807,6 +4971,8 @@ packages:
     path: ""
 - id: "NPM::has-value:0.3.1"
   purl: "pkg:npm/has-value@0.3.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4836,6 +5002,8 @@ packages:
     path: ""
 - id: "NPM::has-value:1.0.0"
   purl: "pkg:npm/has-value@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4865,6 +5033,8 @@ packages:
     path: ""
 - id: "NPM::has-values:0.1.4"
   purl: "pkg:npm/has-values@0.1.4"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4894,6 +5064,8 @@ packages:
     path: ""
 - id: "NPM::has-values:1.0.0"
   purl: "pkg:npm/has-values@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4923,6 +5095,8 @@ packages:
     path: ""
 - id: "NPM::home-or-tmp:2.0.0"
   purl: "pkg:npm/home-or-tmp@2.0.0"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4951,6 +5125,8 @@ packages:
     path: ""
 - id: "NPM::iconv-lite:0.4.24"
   purl: "pkg:npm/iconv-lite@0.4.24"
+  authors:
+  - "Alexander Shtuchkin"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4979,6 +5155,8 @@ packages:
     path: ""
 - id: "NPM::ignore-walk:3.0.1"
   purl: "pkg:npm/ignore-walk@3.0.1"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -5007,6 +5185,8 @@ packages:
     path: ""
 - id: "NPM::inflight:1.0.6"
   purl: "pkg:npm/inflight@1.0.6"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -5093,6 +5273,8 @@ packages:
     path: ""
 - id: "NPM::ini:1.3.5"
   purl: "pkg:npm/ini@1.3.5"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -5121,6 +5303,8 @@ packages:
     path: ""
 - id: "NPM::invariant:2.2.4"
   purl: "pkg:npm/invariant@2.2.4"
+  authors:
+  - "Andres Suarez"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5149,6 +5333,8 @@ packages:
     path: ""
 - id: "NPM::is-accessor-descriptor:0.1.6"
   purl: "pkg:npm/is-accessor-descriptor@0.1.6"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5178,6 +5364,8 @@ packages:
     path: ""
 - id: "NPM::is-accessor-descriptor:1.0.0"
   purl: "pkg:npm/is-accessor-descriptor@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5207,6 +5395,8 @@ packages:
     path: ""
 - id: "NPM::is-binary-path:1.0.1"
   purl: "pkg:npm/is-binary-path@1.0.1"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5235,6 +5425,8 @@ packages:
     path: ""
 - id: "NPM::is-buffer:1.1.6"
   purl: "pkg:npm/is-buffer@1.1.6"
+  authors:
+  - "Feross Aboukhadijeh"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5263,6 +5455,8 @@ packages:
     path: ""
 - id: "NPM::is-data-descriptor:0.1.4"
   purl: "pkg:npm/is-data-descriptor@0.1.4"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5292,6 +5486,8 @@ packages:
     path: ""
 - id: "NPM::is-data-descriptor:1.0.0"
   purl: "pkg:npm/is-data-descriptor@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5321,6 +5517,8 @@ packages:
     path: ""
 - id: "NPM::is-descriptor:0.1.6"
   purl: "pkg:npm/is-descriptor@0.1.6"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5350,6 +5548,8 @@ packages:
     path: ""
 - id: "NPM::is-descriptor:1.0.2"
   purl: "pkg:npm/is-descriptor@1.0.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5379,6 +5579,8 @@ packages:
     path: ""
 - id: "NPM::is-dotfile:1.0.3"
   purl: "pkg:npm/is-dotfile@1.0.3"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5408,6 +5610,8 @@ packages:
     path: ""
 - id: "NPM::is-equal-shallow:0.1.3"
   purl: "pkg:npm/is-equal-shallow@0.1.3"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5437,6 +5641,8 @@ packages:
     path: ""
 - id: "NPM::is-extendable:0.1.1"
   purl: "pkg:npm/is-extendable@0.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5467,6 +5673,8 @@ packages:
     path: ""
 - id: "NPM::is-extendable:1.0.1"
   purl: "pkg:npm/is-extendable@1.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5495,6 +5703,8 @@ packages:
     path: ""
 - id: "NPM::is-extglob:1.0.0"
   purl: "pkg:npm/is-extglob@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5523,6 +5733,8 @@ packages:
     path: ""
 - id: "NPM::is-finite:1.0.2"
   purl: "pkg:npm/is-finite@1.0.2"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5551,6 +5763,8 @@ packages:
     path: ""
 - id: "NPM::is-fullwidth-code-point:1.0.0"
   purl: "pkg:npm/is-fullwidth-code-point@1.0.0"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5580,6 +5794,8 @@ packages:
     path: ""
 - id: "NPM::is-glob:2.0.1"
   purl: "pkg:npm/is-glob@2.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5611,6 +5827,8 @@ packages:
     path: ""
 - id: "NPM::is-number:2.1.0"
   purl: "pkg:npm/is-number@2.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5639,6 +5857,8 @@ packages:
     path: ""
 - id: "NPM::is-number:3.0.0"
   purl: "pkg:npm/is-number@3.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5667,6 +5887,8 @@ packages:
     path: ""
 - id: "NPM::is-number:4.0.0"
   purl: "pkg:npm/is-number@4.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5695,6 +5917,8 @@ packages:
     path: ""
 - id: "NPM::is-plain-object:2.0.4"
   purl: "pkg:npm/is-plain-object@2.0.4"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5723,6 +5947,8 @@ packages:
     path: ""
 - id: "NPM::is-posix-bracket:0.1.1"
   purl: "pkg:npm/is-posix-bracket@0.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5752,6 +5978,8 @@ packages:
     path: ""
 - id: "NPM::is-primitive:2.0.0"
   purl: "pkg:npm/is-primitive@2.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5780,6 +6008,8 @@ packages:
     path: ""
 - id: "NPM::is-windows:1.0.2"
   purl: "pkg:npm/is-windows@1.0.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5809,6 +6039,8 @@ packages:
     path: ""
 - id: "NPM::isarray:1.0.0"
   purl: "pkg:npm/isarray@1.0.0"
+  authors:
+  - "Julian Gruber"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5837,6 +6069,8 @@ packages:
     path: ""
 - id: "NPM::isobject:2.1.0"
   purl: "pkg:npm/isobject@2.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5865,6 +6099,8 @@ packages:
     path: ""
 - id: "NPM::isobject:3.0.1"
   purl: "pkg:npm/isobject@3.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5893,6 +6129,8 @@ packages:
     path: ""
 - id: "NPM::js-tokens:3.0.2"
   purl: "pkg:npm/js-tokens@3.0.2"
+  authors:
+  - "Simon Lydell"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5921,6 +6159,8 @@ packages:
     path: ""
 - id: "NPM::jsesc:1.3.0"
   purl: "pkg:npm/jsesc@1.3.0"
+  authors:
+  - "Mathias Bynens"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5950,6 +6190,8 @@ packages:
     path: ""
 - id: "NPM::json5:0.5.1"
   purl: "pkg:npm/json5@0.5.1"
+  authors:
+  - "Aseem Kishore"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -5978,6 +6220,8 @@ packages:
     path: ""
 - id: "NPM::kind-of:3.2.2"
   purl: "pkg:npm/kind-of@3.2.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6006,6 +6250,8 @@ packages:
     path: ""
 - id: "NPM::kind-of:4.0.0"
   purl: "pkg:npm/kind-of@4.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6034,6 +6280,8 @@ packages:
     path: ""
 - id: "NPM::kind-of:5.1.0"
   purl: "pkg:npm/kind-of@5.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6062,6 +6310,8 @@ packages:
     path: ""
 - id: "NPM::kind-of:6.0.2"
   purl: "pkg:npm/kind-of@6.0.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6090,6 +6340,8 @@ packages:
     path: ""
 - id: "NPM::lodash:4.17.15"
   purl: "pkg:npm/lodash@4.17.15"
+  authors:
+  - "John-David Dalton"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6118,6 +6370,8 @@ packages:
     path: ""
 - id: "NPM::loose-envify:1.4.0"
   purl: "pkg:npm/loose-envify@1.4.0"
+  authors:
+  - "Andres Suarez"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6147,6 +6401,8 @@ packages:
     path: ""
 - id: "NPM::map-cache:0.2.2"
   purl: "pkg:npm/map-cache@0.2.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6175,6 +6431,8 @@ packages:
     path: ""
 - id: "NPM::map-visit:1.0.0"
   purl: "pkg:npm/map-visit@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6203,6 +6461,8 @@ packages:
     path: ""
 - id: "NPM::math-random:1.0.4"
   purl: "pkg:npm/math-random@1.0.4"
+  authors:
+  - "Michael Rhodes"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6233,6 +6493,8 @@ packages:
     path: ""
 - id: "NPM::micromatch:2.3.11"
   purl: "pkg:npm/micromatch@2.3.11"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6262,6 +6524,8 @@ packages:
     path: ""
 - id: "NPM::micromatch:3.1.10"
   purl: "pkg:npm/micromatch@3.1.10"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6291,6 +6555,8 @@ packages:
     path: ""
 - id: "NPM::minimatch:3.0.4"
   purl: "pkg:npm/minimatch@3.0.4"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -6319,6 +6585,8 @@ packages:
     path: ""
 - id: "NPM::minimist:0.0.8"
   purl: "pkg:npm/minimist@0.0.8"
+  authors:
+  - "James Halliday"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6347,6 +6615,8 @@ packages:
     path: ""
 - id: "NPM::minimist:1.2.0"
   purl: "pkg:npm/minimist@1.2.0"
+  authors:
+  - "James Halliday"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6375,6 +6645,8 @@ packages:
     path: ""
 - id: "NPM::minipass:2.3.5"
   purl: "pkg:npm/minipass@2.3.5"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -6403,6 +6675,8 @@ packages:
     path: ""
 - id: "NPM::minizlib:1.2.1"
   purl: "pkg:npm/minizlib@1.2.1"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6432,6 +6706,8 @@ packages:
     path: ""
 - id: "NPM::mixin-deep:1.3.2"
   purl: "pkg:npm/mixin-deep@1.3.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6461,6 +6737,8 @@ packages:
     path: ""
 - id: "NPM::mkdirp:0.5.1"
   purl: "pkg:npm/mkdirp@0.5.1"
+  authors:
+  - "James Halliday"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6573,6 +6851,8 @@ packages:
     path: ""
 - id: "NPM::nanomatch:1.2.13"
   purl: "pkg:npm/nanomatch@1.2.13"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6603,6 +6883,8 @@ packages:
     path: ""
 - id: "NPM::needle:2.3.0"
   purl: "pkg:npm/needle@2.3.0"
+  authors:
+  - "Tomás Pollak"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6631,6 +6913,8 @@ packages:
     path: ""
 - id: "NPM::node-pre-gyp:0.12.0"
   purl: "pkg:npm/node-pre-gyp@0.12.0"
+  authors:
+  - "Dane Springmeyer"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -6659,6 +6943,8 @@ packages:
     path: ""
 - id: "NPM::nopt:4.0.1"
   purl: "pkg:npm/nopt@4.0.1"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -6688,6 +6974,8 @@ packages:
     path: ""
 - id: "NPM::normalize-path:2.1.1"
   purl: "pkg:npm/normalize-path@2.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6718,6 +7006,8 @@ packages:
     path: ""
 - id: "NPM::npm-bundled:1.0.6"
   purl: "pkg:npm/npm-bundled@1.0.6"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -6747,6 +7037,8 @@ packages:
     path: ""
 - id: "NPM::npm-packlist:1.4.1"
   purl: "pkg:npm/npm-packlist@1.4.1"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -6775,6 +7067,8 @@ packages:
     path: ""
 - id: "NPM::npmlog:4.1.2"
   purl: "pkg:npm/npmlog@4.1.2"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -6803,6 +7097,8 @@ packages:
     path: ""
 - id: "NPM::number-is-nan:1.0.1"
   purl: "pkg:npm/number-is-nan@1.0.1"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6831,6 +7127,8 @@ packages:
     path: ""
 - id: "NPM::object-assign:4.1.1"
   purl: "pkg:npm/object-assign@4.1.1"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6859,6 +7157,8 @@ packages:
     path: ""
 - id: "NPM::object-copy:0.1.0"
   purl: "pkg:npm/object-copy@0.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6888,6 +7188,8 @@ packages:
     path: ""
 - id: "NPM::object-visit:1.0.1"
   purl: "pkg:npm/object-visit@1.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6916,6 +7218,8 @@ packages:
     path: ""
 - id: "NPM::object.omit:2.0.1"
   purl: "pkg:npm/object.omit@2.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6945,6 +7249,8 @@ packages:
     path: ""
 - id: "NPM::object.pick:1.3.0"
   purl: "pkg:npm/object.pick@1.3.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -6974,6 +7280,8 @@ packages:
     path: ""
 - id: "NPM::once:1.4.0"
   purl: "pkg:npm/once@1.4.0"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -7002,6 +7310,8 @@ packages:
     path: ""
 - id: "NPM::os-homedir:1.0.2"
   purl: "pkg:npm/os-homedir@1.0.2"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7030,6 +7340,8 @@ packages:
     path: ""
 - id: "NPM::os-tmpdir:1.0.2"
   purl: "pkg:npm/os-tmpdir@1.0.2"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7058,6 +7370,8 @@ packages:
     path: ""
 - id: "NPM::osenv:0.1.5"
   purl: "pkg:npm/osenv@0.1.5"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -7086,6 +7400,8 @@ packages:
     path: ""
 - id: "NPM::output-file-sync:1.1.2"
   purl: "pkg:npm/output-file-sync@1.1.2"
+  authors:
+  - "Shinnosuke Watanabe"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7115,6 +7431,8 @@ packages:
     path: ""
 - id: "NPM::parse-glob:3.0.4"
   purl: "pkg:npm/parse-glob@3.0.4"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7143,6 +7461,8 @@ packages:
     path: ""
 - id: "NPM::pascalcase:0.1.1"
   purl: "pkg:npm/pascalcase@0.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7171,6 +7491,8 @@ packages:
     path: ""
 - id: "NPM::path-is-absolute:1.0.1"
   purl: "pkg:npm/path-is-absolute@1.0.1"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7199,6 +7521,8 @@ packages:
     path: ""
 - id: "NPM::posix-character-classes:0.1.1"
   purl: "pkg:npm/posix-character-classes@0.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7227,6 +7551,8 @@ packages:
     path: ""
 - id: "NPM::preserve:0.2.0"
   purl: "pkg:npm/preserve@0.2.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7256,6 +7582,8 @@ packages:
     path: ""
 - id: "NPM::private:0.1.8"
   purl: "pkg:npm/private@0.1.8"
+  authors:
+  - "Ben Newman"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7340,6 +7668,8 @@ packages:
     path: ""
 - id: "NPM::randomatic:3.1.1"
   purl: "pkg:npm/randomatic@3.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7369,6 +7699,8 @@ packages:
     path: ""
 - id: "NPM::rc:1.2.8"
   purl: "pkg:npm/rc@1.2.8"
+  authors:
+  - "Dominic Tarr"
   declared_licenses:
   - "(BSD-2-Clause OR MIT OR Apache-2.0)"
   declared_licenses_processed:
@@ -7425,6 +7757,8 @@ packages:
     path: ""
 - id: "NPM::readdirp:2.2.1"
   purl: "pkg:npm/readdirp@2.2.1"
+  authors:
+  - "Thorsten Lorenz"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7453,6 +7787,8 @@ packages:
     path: ""
 - id: "NPM::regenerator-runtime:0.10.5"
   purl: "pkg:npm/regenerator-runtime@0.10.5"
+  authors:
+  - "Ben Newman"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7481,6 +7817,8 @@ packages:
     path: "packages/regenerator-runtime"
 - id: "NPM::regenerator-runtime:0.11.1"
   purl: "pkg:npm/regenerator-runtime@0.11.1"
+  authors:
+  - "Ben Newman"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7509,6 +7847,8 @@ packages:
     path: "packages/regenerator-runtime"
 - id: "NPM::regex-cache:0.4.4"
   purl: "pkg:npm/regex-cache@0.4.4"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7539,6 +7879,8 @@ packages:
     path: ""
 - id: "NPM::regex-not:1.0.2"
   purl: "pkg:npm/regex-not@1.0.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7568,6 +7910,8 @@ packages:
     path: ""
 - id: "NPM::remove-trailing-separator:1.1.0"
   purl: "pkg:npm/remove-trailing-separator@1.1.0"
+  authors:
+  - "darsain"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -7596,6 +7940,8 @@ packages:
     path: ""
 - id: "NPM::repeat-element:1.1.3"
   purl: "pkg:npm/repeat-element@1.1.3"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7624,6 +7970,8 @@ packages:
     path: ""
 - id: "NPM::repeat-string:1.6.1"
   purl: "pkg:npm/repeat-string@1.6.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7653,6 +8001,8 @@ packages:
     path: ""
 - id: "NPM::repeating:2.0.1"
   purl: "pkg:npm/repeating@2.0.1"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7681,6 +8031,8 @@ packages:
     path: ""
 - id: "NPM::resolve-url:0.2.1"
   purl: "pkg:npm/resolve-url@0.2.1"
+  authors:
+  - "Simon Lydell"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7709,6 +8061,8 @@ packages:
     path: ""
 - id: "NPM::ret:0.1.15"
   purl: "pkg:npm/ret@0.1.15"
+  authors:
+  - "Roly Fentanes"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7737,6 +8091,8 @@ packages:
     path: ""
 - id: "NPM::rimraf:2.6.3"
   purl: "pkg:npm/rimraf@2.6.3"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -7765,6 +8121,8 @@ packages:
     path: ""
 - id: "NPM::safe-buffer:5.1.2"
   purl: "pkg:npm/safe-buffer@5.1.2"
+  authors:
+  - "Feross Aboukhadijeh"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7793,6 +8151,8 @@ packages:
     path: ""
 - id: "NPM::safe-regex:1.1.0"
   purl: "pkg:npm/safe-regex@1.1.0"
+  authors:
+  - "James Halliday"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7821,6 +8181,8 @@ packages:
     path: ""
 - id: "NPM::safer-buffer:2.1.2"
   purl: "pkg:npm/safer-buffer@2.1.2"
+  authors:
+  - "Nikita Skovoroda"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7849,6 +8211,8 @@ packages:
     path: ""
 - id: "NPM::sax:1.2.4"
   purl: "pkg:npm/sax@1.2.4"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -7905,6 +8269,8 @@ packages:
     path: ""
 - id: "NPM::set-blocking:2.0.0"
   purl: "pkg:npm/set-blocking@2.0.0"
+  authors:
+  - "Ben Coe"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -7934,6 +8300,8 @@ packages:
     path: ""
 - id: "NPM::set-value:2.0.1"
   purl: "pkg:npm/set-value@2.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7963,6 +8331,8 @@ packages:
     path: ""
 - id: "NPM::signal-exit:3.0.2"
   purl: "pkg:npm/signal-exit@3.0.2"
+  authors:
+  - "Ben Coe"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -7991,6 +8361,8 @@ packages:
     path: ""
 - id: "NPM::slash:1.0.0"
   purl: "pkg:npm/slash@1.0.0"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8019,6 +8391,8 @@ packages:
     path: ""
 - id: "NPM::snapdragon-node:2.1.1"
   purl: "pkg:npm/snapdragon-node@2.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8048,6 +8422,8 @@ packages:
     path: ""
 - id: "NPM::snapdragon-util:3.0.1"
   purl: "pkg:npm/snapdragon-util@3.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8076,6 +8452,8 @@ packages:
     path: ""
 - id: "NPM::snapdragon:0.8.2"
   purl: "pkg:npm/snapdragon@0.8.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8104,6 +8482,8 @@ packages:
     path: ""
 - id: "NPM::source-map-resolve:0.5.2"
   purl: "pkg:npm/source-map-resolve@0.5.2"
+  authors:
+  - "Simon Lydell"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8160,6 +8540,8 @@ packages:
     path: ""
 - id: "NPM::source-map-url:0.4.0"
   purl: "pkg:npm/source-map-url@0.4.0"
+  authors:
+  - "Simon Lydell"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8188,6 +8570,8 @@ packages:
     path: ""
 - id: "NPM::source-map:0.5.7"
   purl: "pkg:npm/source-map@0.5.7"
+  authors:
+  - "Nick Fitzgerald"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -8216,6 +8600,8 @@ packages:
     path: ""
 - id: "NPM::split-string:3.1.0"
   purl: "pkg:npm/split-string@3.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8244,6 +8630,8 @@ packages:
     path: ""
 - id: "NPM::static-extend:0.1.2"
   purl: "pkg:npm/static-extend@0.1.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8274,6 +8662,8 @@ packages:
     path: ""
 - id: "NPM::string-width:1.0.2"
   purl: "pkg:npm/string-width@1.0.2"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8331,6 +8721,8 @@ packages:
     path: ""
 - id: "NPM::strip-ansi:3.0.1"
   purl: "pkg:npm/strip-ansi@3.0.1"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8359,6 +8751,8 @@ packages:
     path: ""
 - id: "NPM::strip-json-comments:2.0.1"
   purl: "pkg:npm/strip-json-comments@2.0.1"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8387,6 +8781,8 @@ packages:
     path: ""
 - id: "NPM::supports-color:2.0.0"
   purl: "pkg:npm/supports-color@2.0.0"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8415,6 +8811,8 @@ packages:
     path: ""
 - id: "NPM::tar:4.4.8"
   purl: "pkg:npm/tar@4.4.8"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -8443,6 +8841,8 @@ packages:
     path: ""
 - id: "NPM::to-fast-properties:1.0.3"
   purl: "pkg:npm/to-fast-properties@1.0.3"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8471,6 +8871,8 @@ packages:
     path: ""
 - id: "NPM::to-object-path:0.3.0"
   purl: "pkg:npm/to-object-path@0.3.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8499,6 +8901,8 @@ packages:
     path: ""
 - id: "NPM::to-regex-range:2.1.1"
   purl: "pkg:npm/to-regex-range@2.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8528,6 +8932,8 @@ packages:
     path: ""
 - id: "NPM::to-regex:3.0.2"
   purl: "pkg:npm/to-regex@3.0.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8556,6 +8962,8 @@ packages:
     path: ""
 - id: "NPM::trim-right:1.0.1"
   purl: "pkg:npm/trim-right@1.0.1"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8584,6 +8992,8 @@ packages:
     path: ""
 - id: "NPM::union-value:1.0.1"
   purl: "pkg:npm/union-value@1.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8613,6 +9023,8 @@ packages:
     path: ""
 - id: "NPM::unset-value:1.0.0"
   purl: "pkg:npm/unset-value@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8641,6 +9053,8 @@ packages:
     path: ""
 - id: "NPM::urix:0.1.0"
   purl: "pkg:npm/urix@0.1.0"
+  authors:
+  - "Simon Lydell"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8669,6 +9083,8 @@ packages:
     path: ""
 - id: "NPM::use:3.1.1"
   purl: "pkg:npm/use@3.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8697,6 +9113,8 @@ packages:
     path: ""
 - id: "NPM::user-home:1.1.1"
   purl: "pkg:npm/user-home@1.1.1"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8725,6 +9143,8 @@ packages:
     path: ""
 - id: "NPM::util-deprecate:1.0.2"
   purl: "pkg:npm/util-deprecate@1.0.2"
+  authors:
+  - "Nathan Rajlich"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8753,6 +9173,8 @@ packages:
     path: ""
 - id: "NPM::v8flags:2.1.1"
   purl: "pkg:npm/v8flags@2.1.1"
+  authors:
+  - "Tyler Kellen"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -8781,6 +9203,8 @@ packages:
     path: ""
 - id: "NPM::wide-align:1.1.3"
   purl: "pkg:npm/wide-align@1.1.3"
+  authors:
+  - "Rebecca Turner"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -8810,6 +9234,8 @@ packages:
     path: ""
 - id: "NPM::wrappy:1.0.2"
   purl: "pkg:npm/wrappy@1.0.2"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -8838,6 +9264,8 @@ packages:
     path: ""
 - id: "NPM::yallist:3.0.3"
   purl: "pkg:npm/yallist@3.0.3"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
@@ -2,6 +2,8 @@
 project:
   id: "NPM::npm-project:1.0.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
+  authors:
+  - "The Author"
   declared_licenses:
   - "Apache-2.0"
   declared_licenses_processed:
@@ -138,6 +140,8 @@ packages:
     path: ""
 - id: "NPM::boolbase:1.0.0"
   purl: "pkg:npm/boolbase@1.0.0"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -166,6 +170,8 @@ packages:
     path: ""
 - id: "NPM::cheerio:1.0.0-rc.1"
   purl: "pkg:npm/cheerio@1.0.0-rc.1"
+  authors:
+  - "Matt Mueller"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -195,6 +201,8 @@ packages:
     path: ""
 - id: "NPM::coffee-script:1.12.7"
   purl: "pkg:npm/coffee-script@1.12.7"
+  authors:
+  - "Jeremy Ashkenas"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -223,6 +231,8 @@ packages:
     path: ""
 - id: "NPM::cson-parser:1.3.5"
   purl: "pkg:npm/cson-parser@1.3.5"
+  authors:
+  - "Groupon"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -251,6 +261,8 @@ packages:
     path: ""
 - id: "NPM::cson:4.1.0"
   purl: "pkg:npm/cson@4.1.0"
+  authors:
+  - "2012+ Bevry Pty Ltd"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -280,6 +292,8 @@ packages:
     path: ""
 - id: "NPM::css-select:1.2.0"
   purl: "pkg:npm/css-select@1.2.0"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "BSD-like"
   declared_licenses_processed:
@@ -310,6 +324,8 @@ packages:
     path: ""
 - id: "NPM::css-what:2.1.3"
   purl: "pkg:npm/css-what@2.1.3"
+  authors:
+  - "Felix Böhm"
   declared_licenses:
   - "BSD-2-Clause"
   declared_licenses_processed:
@@ -338,6 +354,8 @@ packages:
     path: ""
 - id: "NPM::dom-serializer:0.1.1"
   purl: "pkg:npm/dom-serializer@0.1.1"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -366,6 +384,8 @@ packages:
     path: ""
 - id: "NPM::domelementtype:1.3.1"
   purl: "pkg:npm/domelementtype@1.3.1"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "BSD-2-Clause"
   declared_licenses_processed:
@@ -394,6 +414,8 @@ packages:
     path: ""
 - id: "NPM::domhandler:2.4.2"
   purl: "pkg:npm/domhandler@2.4.2"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "BSD-2-Clause"
   declared_licenses_processed:
@@ -422,6 +444,8 @@ packages:
     path: ""
 - id: "NPM::domutils:1.5.1"
   purl: "pkg:npm/domutils@1.5.1"
+  authors:
+  - "Felix Boehm"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "utilities for working with htmlparser2's dom"
@@ -448,6 +472,8 @@ packages:
     path: ""
 - id: "NPM::eachr:3.2.0"
   purl: "pkg:npm/eachr@3.2.0"
+  authors:
+  - "2011+ Bevry Pty Ltd"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -478,6 +504,8 @@ packages:
     path: ""
 - id: "NPM::editions:1.3.4"
   purl: "pkg:npm/editions@1.3.4"
+  authors:
+  - "2016+ Bevry Pty Ltd"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -507,6 +535,8 @@ packages:
     path: ""
 - id: "NPM::editions:2.1.3"
   purl: "pkg:npm/editions@2.1.3"
+  authors:
+  - "2016+ Bevry Pty Ltd"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -536,6 +566,8 @@ packages:
     path: ""
 - id: "NPM::entities:1.1.2"
   purl: "pkg:npm/entities@1.1.2"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "BSD-2-Clause"
   declared_licenses_processed:
@@ -564,6 +596,8 @@ packages:
     path: ""
 - id: "NPM::errlop:1.1.1"
   purl: "pkg:npm/errlop@1.1.1"
+  authors:
+  - "2018+ Benjamin Lupton"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -593,6 +627,8 @@ packages:
     path: ""
 - id: "NPM::extract-opts:3.3.1"
   purl: "pkg:npm/extract-opts@3.3.1"
+  authors:
+  - "2013+ Bevry Pty Ltd"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -649,6 +685,8 @@ packages:
     path: ""
 - id: "NPM::htmlparser2:3.10.1"
   purl: "pkg:npm/htmlparser2@3.10.1"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -706,6 +744,8 @@ packages:
     path: ""
 - id: "NPM::lodash:4.17.15"
   purl: "pkg:npm/lodash@4.17.15"
+  authors:
+  - "John-David Dalton"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -734,6 +774,8 @@ packages:
     path: ""
 - id: "NPM::long:3.2.0"
   purl: "pkg:npm/long@3.2.0"
+  authors:
+  - "Daniel Wirtz"
   declared_licenses:
   - "Apache-2.0"
   declared_licenses_processed:
@@ -762,6 +804,8 @@ packages:
     path: ""
 - id: "NPM::nth-check:1.0.2"
   purl: "pkg:npm/nth-check@1.0.2"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "BSD-2-Clause"
   declared_licenses_processed:
@@ -790,6 +834,8 @@ packages:
     path: ""
 - id: "NPM::parse5:3.0.3"
   purl: "pkg:npm/parse5@3.0.3"
+  authors:
+  - "Ivan Nikulin"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -819,6 +865,8 @@ packages:
     path: ""
 - id: "NPM::promise:7.3.1"
   purl: "pkg:npm/promise@7.3.1"
+  authors:
+  - "ForbesLindesay"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -875,6 +923,8 @@ packages:
     path: ""
 - id: "NPM::requirefresh:2.2.0"
   purl: "pkg:npm/requirefresh@2.2.0"
+  authors:
+  - "2013+ Bevry Pty Ltd"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -903,6 +953,8 @@ packages:
     path: ""
 - id: "NPM::safe-buffer:5.1.2"
   purl: "pkg:npm/safe-buffer@5.1.2"
+  authors:
+  - "Feross Aboukhadijeh"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -931,6 +983,8 @@ packages:
     path: ""
 - id: "NPM::safefs:4.1.0"
   purl: "pkg:npm/safefs@4.1.0"
+  authors:
+  - "2013+ Bevry Pty Ltd"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1016,6 +1070,8 @@ packages:
     path: ""
 - id: "NPM::typechecker:4.7.0"
   purl: "pkg:npm/typechecker@4.7.0"
+  authors:
+  - "2013+ Bevry Pty Ltd"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1045,6 +1101,8 @@ packages:
     path: ""
 - id: "NPM::util-deprecate:1.0.2"
   purl: "pkg:npm/util-deprecate@1.0.2"
+  authors:
+  - "Nathan Rajlich"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
@@ -638,6 +638,8 @@ project:
 packages:
 - id: "NPM::ansi-green:0.1.1"
   purl: "pkg:npm/ansi-green@0.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -666,6 +668,8 @@ packages:
     path: ""
 - id: "NPM::ansi-wrap:0.1.0"
   purl: "pkg:npm/ansi-wrap@0.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -723,6 +727,8 @@ packages:
     path: ""
 - id: "NPM::arr-union:3.1.0"
   purl: "pkg:npm/arr-union@3.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -752,6 +758,8 @@ packages:
     path: ""
 - id: "NPM::array-each:1.0.1"
   purl: "pkg:npm/array-each@1.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -781,6 +789,8 @@ packages:
     path: ""
 - id: "NPM::array-slice:0.2.3"
   purl: "pkg:npm/array-slice@0.2.3"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -810,6 +820,8 @@ packages:
     path: ""
 - id: "NPM::assign-symbols:1.0.0"
   purl: "pkg:npm/assign-symbols@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -841,6 +853,8 @@ packages:
     path: ""
 - id: "NPM::atob:2.1.2"
   purl: "pkg:npm/atob@2.1.2"
+  authors:
+  - "AJ ONeal"
   declared_licenses:
   - "(MIT OR Apache-2.0)"
   declared_licenses_processed:
@@ -869,6 +883,8 @@ packages:
     path: ""
 - id: "NPM::autolinker:0.28.1"
   purl: "pkg:npm/autolinker@0.28.1"
+  authors:
+  - "Gregory Jacobs"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -898,6 +914,8 @@ packages:
     path: ""
 - id: "NPM::balanced-match:1.0.0"
   purl: "pkg:npm/balanced-match@1.0.0"
+  authors:
+  - "Julian Gruber"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -926,6 +944,8 @@ packages:
     path: ""
 - id: "NPM::base:0.11.2"
   purl: "pkg:npm/base@0.11.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -956,6 +976,8 @@ packages:
     path: ""
 - id: "NPM::brace-expansion:1.1.11"
   purl: "pkg:npm/brace-expansion@1.1.11"
+  authors:
+  - "Julian Gruber"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -984,6 +1006,8 @@ packages:
     path: ""
 - id: "NPM::browser-stdout:1.3.1"
   purl: "pkg:npm/browser-stdout@1.3.1"
+  authors:
+  - "kumavis"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -1012,6 +1036,8 @@ packages:
     path: ""
 - id: "NPM::cache-base:1.0.1"
   purl: "pkg:npm/cache-base@1.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1041,6 +1067,8 @@ packages:
     path: ""
 - id: "NPM::class-utils:0.3.6"
   purl: "pkg:npm/class-utils@0.3.6"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1069,6 +1097,8 @@ packages:
     path: ""
 - id: "NPM::clone-buffer:1.0.0"
   purl: "pkg:npm/clone-buffer@1.0.0"
+  authors:
+  - "Gulp Team"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1097,6 +1127,8 @@ packages:
     path: ""
 - id: "NPM::clone-stats:1.0.0"
   purl: "pkg:npm/clone-stats@1.0.0"
+  authors:
+  - "Hugh Kennedy"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1126,6 +1158,8 @@ packages:
     path: ""
 - id: "NPM::clone:2.1.2"
   purl: "pkg:npm/clone@2.1.2"
+  authors:
+  - "Paul Vorbach"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1154,6 +1188,8 @@ packages:
     path: ""
 - id: "NPM::cloneable-readable:1.1.3"
   purl: "pkg:npm/cloneable-readable@1.1.3"
+  authors:
+  - "Matteo Collina"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1182,6 +1218,8 @@ packages:
     path: ""
 - id: "NPM::collection-visit:1.0.0"
   purl: "pkg:npm/collection-visit@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1211,6 +1249,8 @@ packages:
     path: ""
 - id: "NPM::commander:2.15.1"
   purl: "pkg:npm/commander@2.15.1"
+  authors:
+  - "TJ Holowaychuk"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1267,6 +1307,8 @@ packages:
     path: ""
 - id: "NPM::concat-map:0.0.1"
   purl: "pkg:npm/concat-map@0.0.1"
+  authors:
+  - "James Halliday"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1295,6 +1337,8 @@ packages:
     path: ""
 - id: "NPM::concat-with-sourcemaps:1.1.0"
   purl: "pkg:npm/concat-with-sourcemaps@1.1.0"
+  authors:
+  - "Florian Reiterer"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -1324,6 +1368,8 @@ packages:
     path: ""
 - id: "NPM::copy-descriptor:0.1.1"
   purl: "pkg:npm/copy-descriptor@0.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1352,6 +1398,8 @@ packages:
     path: ""
 - id: "NPM::core-util-is:1.0.2"
   purl: "pkg:npm/core-util-is@1.0.2"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1380,6 +1428,8 @@ packages:
     path: ""
 - id: "NPM::debug:2.6.9"
   purl: "pkg:npm/debug@2.6.9"
+  authors:
+  - "TJ Holowaychuk"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1408,6 +1458,8 @@ packages:
     path: ""
 - id: "NPM::debug:3.1.0"
   purl: "pkg:npm/debug@3.1.0"
+  authors:
+  - "TJ Holowaychuk"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1436,6 +1488,8 @@ packages:
     path: ""
 - id: "NPM::decode-uri-component:0.2.0"
   purl: "pkg:npm/decode-uri-component@0.2.0"
+  authors:
+  - "Sam Verschueren"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1464,6 +1518,8 @@ packages:
     path: ""
 - id: "NPM::define-property:0.2.5"
   purl: "pkg:npm/define-property@0.2.5"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1492,6 +1548,8 @@ packages:
     path: ""
 - id: "NPM::define-property:1.0.0"
   purl: "pkg:npm/define-property@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1520,6 +1578,8 @@ packages:
     path: ""
 - id: "NPM::define-property:2.0.2"
   purl: "pkg:npm/define-property@2.0.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1577,6 +1637,8 @@ packages:
     path: ""
 - id: "NPM::escape-string-regexp:1.0.5"
   purl: "pkg:npm/escape-string-regexp@1.0.5"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1605,6 +1667,8 @@ packages:
     path: ""
 - id: "NPM::expand-range:1.8.2"
   purl: "pkg:npm/expand-range@1.8.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1634,6 +1698,8 @@ packages:
     path: ""
 - id: "NPM::expand-reflinks:0.2.1"
   purl: "pkg:npm/expand-reflinks@0.2.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1662,6 +1728,8 @@ packages:
     path: ""
 - id: "NPM::extend-shallow:2.0.1"
   purl: "pkg:npm/extend-shallow@2.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1691,6 +1759,8 @@ packages:
     path: ""
 - id: "NPM::extend-shallow:3.0.2"
   purl: "pkg:npm/extend-shallow@3.0.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1720,6 +1790,8 @@ packages:
     path: ""
 - id: "NPM::fill-range:2.2.4"
   purl: "pkg:npm/fill-range@2.2.4"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1749,6 +1821,8 @@ packages:
     path: ""
 - id: "NPM::for-in:1.0.2"
   purl: "pkg:npm/for-in@1.0.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1779,6 +1853,8 @@ packages:
     path: ""
 - id: "NPM::fs-exists-sync:0.1.0"
   purl: "pkg:npm/fs-exists-sync@0.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1809,6 +1885,8 @@ packages:
     path: ""
 - id: "NPM::fs.realpath:1.0.0"
   purl: "pkg:npm/fs.realpath@1.0.0"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -1838,6 +1916,8 @@ packages:
     path: ""
 - id: "NPM::get-value:2.0.6"
   purl: "pkg:npm/get-value@2.0.6"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1866,6 +1946,8 @@ packages:
     path: ""
 - id: "NPM::gfm-code-block-regex:1.0.0"
   purl: "pkg:npm/gfm-code-block-regex@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1894,6 +1976,8 @@ packages:
     path: ""
 - id: "NPM::gfm-code-blocks:1.0.0"
   purl: "pkg:npm/gfm-code-blocks@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1922,6 +2006,8 @@ packages:
     path: ""
 - id: "NPM::glob:7.1.2"
   purl: "pkg:npm/glob@7.1.2"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -1950,6 +2036,8 @@ packages:
     path: ""
 - id: "NPM::growl:1.10.5"
   purl: "pkg:npm/growl@1.10.5"
+  authors:
+  - "TJ Holowaychuk"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1978,6 +2066,8 @@ packages:
     path: ""
 - id: "NPM::gulp-format-md:1.0.0"
   purl: "pkg:npm/gulp-format-md@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2006,6 +2096,8 @@ packages:
     path: ""
 - id: "NPM::gulp-header:1.8.12"
   purl: "pkg:npm/gulp-header@1.8.12"
+  authors:
+  - "Michael J. Ryan"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2034,6 +2126,8 @@ packages:
     path: ""
 - id: "NPM::has-flag:3.0.0"
   purl: "pkg:npm/has-flag@3.0.0"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2062,6 +2156,8 @@ packages:
     path: ""
 - id: "NPM::has-value:0.3.1"
   purl: "pkg:npm/has-value@0.3.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2091,6 +2187,8 @@ packages:
     path: ""
 - id: "NPM::has-value:1.0.0"
   purl: "pkg:npm/has-value@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2120,6 +2218,8 @@ packages:
     path: ""
 - id: "NPM::has-values:0.1.4"
   purl: "pkg:npm/has-values@0.1.4"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2149,6 +2249,8 @@ packages:
     path: ""
 - id: "NPM::has-values:1.0.0"
   purl: "pkg:npm/has-values@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2178,6 +2280,8 @@ packages:
     path: ""
 - id: "NPM::he:1.1.1"
   purl: "pkg:npm/he@1.1.1"
+  authors:
+  - "Mathias Bynens"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2206,6 +2310,8 @@ packages:
     path: ""
 - id: "NPM::inflight:1.0.6"
   purl: "pkg:npm/inflight@1.0.6"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -2263,6 +2369,8 @@ packages:
     path: ""
 - id: "NPM::is-accessor-descriptor:0.1.6"
   purl: "pkg:npm/is-accessor-descriptor@0.1.6"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2292,6 +2400,8 @@ packages:
     path: ""
 - id: "NPM::is-accessor-descriptor:1.0.0"
   purl: "pkg:npm/is-accessor-descriptor@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2321,6 +2431,8 @@ packages:
     path: ""
 - id: "NPM::is-buffer:1.1.6"
   purl: "pkg:npm/is-buffer@1.1.6"
+  authors:
+  - "Feross Aboukhadijeh"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2349,6 +2461,8 @@ packages:
     path: ""
 - id: "NPM::is-data-descriptor:0.1.4"
   purl: "pkg:npm/is-data-descriptor@0.1.4"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2378,6 +2492,8 @@ packages:
     path: ""
 - id: "NPM::is-data-descriptor:1.0.0"
   purl: "pkg:npm/is-data-descriptor@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2407,6 +2523,8 @@ packages:
     path: ""
 - id: "NPM::is-descriptor:0.1.6"
   purl: "pkg:npm/is-descriptor@0.1.6"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2436,6 +2554,8 @@ packages:
     path: ""
 - id: "NPM::is-descriptor:1.0.2"
   purl: "pkg:npm/is-descriptor@1.0.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2465,6 +2585,8 @@ packages:
     path: ""
 - id: "NPM::is-extendable:0.1.1"
   purl: "pkg:npm/is-extendable@0.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2495,6 +2617,8 @@ packages:
     path: ""
 - id: "NPM::is-extendable:1.0.1"
   purl: "pkg:npm/is-extendable@1.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2523,6 +2647,8 @@ packages:
     path: ""
 - id: "NPM::is-number:2.1.0"
   purl: "pkg:npm/is-number@2.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2551,6 +2677,8 @@ packages:
     path: ""
 - id: "NPM::is-number:3.0.0"
   purl: "pkg:npm/is-number@3.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2579,6 +2707,8 @@ packages:
     path: ""
 - id: "NPM::is-number:4.0.0"
   purl: "pkg:npm/is-number@4.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2607,6 +2737,8 @@ packages:
     path: ""
 - id: "NPM::is-plain-object:2.0.4"
   purl: "pkg:npm/is-plain-object@2.0.4"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2635,6 +2767,8 @@ packages:
     path: ""
 - id: "NPM::is-win:1.0.8"
   purl: "pkg:npm/is-win@1.0.8"
+  authors:
+  - "Ionică Bizău"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2663,6 +2797,8 @@ packages:
     path: ""
 - id: "NPM::is-windows:1.0.2"
   purl: "pkg:npm/is-windows@1.0.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2692,6 +2828,8 @@ packages:
     path: ""
 - id: "NPM::isarray:1.0.0"
   purl: "pkg:npm/isarray@1.0.0"
+  authors:
+  - "Julian Gruber"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2720,6 +2858,8 @@ packages:
     path: ""
 - id: "NPM::isobject:2.1.0"
   purl: "pkg:npm/isobject@2.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2748,6 +2888,8 @@ packages:
     path: ""
 - id: "NPM::isobject:3.0.1"
   purl: "pkg:npm/isobject@3.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2776,6 +2918,8 @@ packages:
     path: ""
 - id: "NPM::kind-of:3.2.2"
   purl: "pkg:npm/kind-of@3.2.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2804,6 +2948,8 @@ packages:
     path: ""
 - id: "NPM::kind-of:4.0.0"
   purl: "pkg:npm/kind-of@4.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2832,6 +2978,8 @@ packages:
     path: ""
 - id: "NPM::kind-of:5.1.0"
   purl: "pkg:npm/kind-of@5.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2860,6 +3008,8 @@ packages:
     path: ""
 - id: "NPM::kind-of:6.0.3"
   purl: "pkg:npm/kind-of@6.0.3"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2888,6 +3038,8 @@ packages:
     path: ""
 - id: "NPM::lazy-cache:2.0.2"
   purl: "pkg:npm/lazy-cache@2.0.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2916,6 +3068,8 @@ packages:
     path: ""
 - id: "NPM::list-item:1.1.1"
   purl: "pkg:npm/list-item@1.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2945,6 +3099,8 @@ packages:
     path: ""
 - id: "NPM::lodash._reinterpolate:3.0.0"
   purl: "pkg:npm/lodash._reinterpolate@3.0.0"
+  authors:
+  - "John-David Dalton"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -2973,6 +3129,8 @@ packages:
     path: ""
 - id: "NPM::lodash.template:4.5.0"
   purl: "pkg:npm/lodash.template@4.5.0"
+  authors:
+  - "John-David Dalton"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3001,6 +3159,8 @@ packages:
     path: ""
 - id: "NPM::lodash.templatesettings:4.2.0"
   purl: "pkg:npm/lodash.templatesettings@4.2.0"
+  authors:
+  - "John-David Dalton"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3029,6 +3189,8 @@ packages:
     path: ""
 - id: "NPM::log-ok:0.1.1"
   purl: "pkg:npm/log-ok@0.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3057,6 +3219,8 @@ packages:
     path: ""
 - id: "NPM::map-cache:0.2.2"
   purl: "pkg:npm/map-cache@0.2.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3085,6 +3249,8 @@ packages:
     path: ""
 - id: "NPM::map-visit:1.0.0"
   purl: "pkg:npm/map-visit@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3113,6 +3279,8 @@ packages:
     path: ""
 - id: "NPM::markdown-utils:0.7.3"
   purl: "pkg:npm/markdown-utils@0.7.3"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3141,6 +3309,8 @@ packages:
     path: ""
 - id: "NPM::math-random:1.0.4"
   purl: "pkg:npm/math-random@1.0.4"
+  authors:
+  - "Michael Rhodes"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3171,6 +3341,8 @@ packages:
     path: ""
 - id: "NPM::minimatch:3.0.4"
   purl: "pkg:npm/minimatch@3.0.4"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -3199,6 +3371,8 @@ packages:
     path: ""
 - id: "NPM::minimist:0.0.8"
   purl: "pkg:npm/minimist@0.0.8"
+  authors:
+  - "James Halliday"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3227,6 +3401,8 @@ packages:
     path: ""
 - id: "NPM::minimist:1.2.5"
   purl: "pkg:npm/minimist@1.2.5"
+  authors:
+  - "James Halliday"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3255,6 +3431,8 @@ packages:
     path: ""
 - id: "NPM::mixin-deep:1.3.2"
   purl: "pkg:npm/mixin-deep@1.3.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3284,6 +3462,8 @@ packages:
     path: ""
 - id: "NPM::mkdirp:0.5.1"
   purl: "pkg:npm/mkdirp@0.5.1"
+  authors:
+  - "James Halliday"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3312,6 +3492,8 @@ packages:
     path: ""
 - id: "NPM::mocha:5.2.0"
   purl: "pkg:npm/mocha@5.2.0"
+  authors:
+  - "TJ Holowaychuk"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3368,6 +3550,8 @@ packages:
     path: ""
 - id: "NPM::object-copy:0.1.0"
   purl: "pkg:npm/object-copy@0.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3397,6 +3581,8 @@ packages:
     path: ""
 - id: "NPM::object-visit:1.0.1"
   purl: "pkg:npm/object-visit@1.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3425,6 +3611,8 @@ packages:
     path: ""
 - id: "NPM::once:1.4.0"
   purl: "pkg:npm/once@1.4.0"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -3453,6 +3641,8 @@ packages:
     path: ""
 - id: "NPM::pascalcase:0.1.1"
   purl: "pkg:npm/pascalcase@0.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3481,6 +3671,8 @@ packages:
     path: ""
 - id: "NPM::path-is-absolute:1.0.1"
   purl: "pkg:npm/path-is-absolute@1.0.1"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3509,6 +3701,8 @@ packages:
     path: ""
 - id: "NPM::pretty-remarkable:0.4.1"
   purl: "pkg:npm/pretty-remarkable@0.4.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3566,6 +3760,8 @@ packages:
     path: ""
 - id: "NPM::randomatic:3.1.1"
   purl: "pkg:npm/randomatic@3.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3623,6 +3819,8 @@ packages:
     path: ""
 - id: "NPM::regex-not:1.0.2"
   purl: "pkg:npm/regex-not@1.0.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3681,6 +3879,8 @@ packages:
     path: ""
 - id: "NPM::remove-trailing-separator:1.1.0"
   purl: "pkg:npm/remove-trailing-separator@1.1.0"
+  authors:
+  - "darsain"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -3709,6 +3909,8 @@ packages:
     path: ""
 - id: "NPM::repeat-element:1.1.3"
   purl: "pkg:npm/repeat-element@1.1.3"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3737,6 +3939,8 @@ packages:
     path: ""
 - id: "NPM::repeat-string:1.6.1"
   purl: "pkg:npm/repeat-string@1.6.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3766,6 +3970,8 @@ packages:
     path: ""
 - id: "NPM::replace-ext:1.0.0"
   purl: "pkg:npm/replace-ext@1.0.0"
+  authors:
+  - "Gulp Team"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3794,6 +4000,8 @@ packages:
     path: ""
 - id: "NPM::resolve-url:0.2.1"
   purl: "pkg:npm/resolve-url@0.2.1"
+  authors:
+  - "Simon Lydell"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3822,6 +4030,8 @@ packages:
     path: ""
 - id: "NPM::ret:0.1.15"
   purl: "pkg:npm/ret@0.1.15"
+  authors:
+  - "Roly Fentanes"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3850,6 +4060,8 @@ packages:
     path: ""
 - id: "NPM::safe-buffer:5.1.2"
   purl: "pkg:npm/safe-buffer@5.1.2"
+  authors:
+  - "Feross Aboukhadijeh"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3878,6 +4090,8 @@ packages:
     path: ""
 - id: "NPM::safe-regex:1.1.0"
   purl: "pkg:npm/safe-regex@1.1.0"
+  authors:
+  - "James Halliday"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3906,6 +4120,8 @@ packages:
     path: ""
 - id: "NPM::sections:1.0.0"
   purl: "pkg:npm/sections@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3935,6 +4151,8 @@ packages:
     path: ""
 - id: "NPM::set-getter:0.1.0"
   purl: "pkg:npm/set-getter@0.1.0"
+  authors:
+  - "Brian Woodward"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3964,6 +4182,8 @@ packages:
     path: ""
 - id: "NPM::set-value:2.0.1"
   purl: "pkg:npm/set-value@2.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3993,6 +4213,8 @@ packages:
     path: ""
 - id: "NPM::snapdragon-node:1.0.6"
   purl: "pkg:npm/snapdragon-node@1.0.6"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4022,6 +4244,8 @@ packages:
     path: ""
 - id: "NPM::snapdragon-util:1.0.6"
   purl: "pkg:npm/snapdragon-util@1.0.6"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4050,6 +4274,8 @@ packages:
     path: ""
 - id: "NPM::snapdragon-util:2.1.1"
   purl: "pkg:npm/snapdragon-util@2.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4078,6 +4304,8 @@ packages:
     path: ""
 - id: "NPM::snapdragon:0.11.5"
   purl: "pkg:npm/snapdragon@0.11.5"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4107,6 +4335,8 @@ packages:
     path: ""
 - id: "NPM::snapdragon:0.8.2"
   purl: "pkg:npm/snapdragon@0.8.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4135,6 +4365,8 @@ packages:
     path: ""
 - id: "NPM::sort-by-value:0.1.0"
   purl: "pkg:npm/sort-by-value@0.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4164,6 +4396,8 @@ packages:
     path: ""
 - id: "NPM::source-map-resolve:0.5.3"
   purl: "pkg:npm/source-map-resolve@0.5.3"
+  authors:
+  - "Simon Lydell"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4192,6 +4426,8 @@ packages:
     path: ""
 - id: "NPM::source-map-url:0.4.0"
   purl: "pkg:npm/source-map-url@0.4.0"
+  authors:
+  - "Simon Lydell"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4220,6 +4456,8 @@ packages:
     path: ""
 - id: "NPM::source-map:0.5.7"
   purl: "pkg:npm/source-map@0.5.7"
+  authors:
+  - "Nick Fitzgerald"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -4248,6 +4486,8 @@ packages:
     path: ""
 - id: "NPM::source-map:0.6.1"
   purl: "pkg:npm/source-map@0.6.1"
+  authors:
+  - "Nick Fitzgerald"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -4276,6 +4516,8 @@ packages:
     path: ""
 - id: "NPM::split-string:3.1.0"
   purl: "pkg:npm/split-string@3.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4304,6 +4546,8 @@ packages:
     path: ""
 - id: "NPM::sprintf-js:1.0.3"
   purl: "pkg:npm/sprintf-js@1.0.3"
+  authors:
+  - "Alexandru Marasteanu"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -4332,6 +4576,8 @@ packages:
     path: ""
 - id: "NPM::static-extend:0.1.2"
   purl: "pkg:npm/static-extend@0.1.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4390,6 +4636,8 @@ packages:
     path: ""
 - id: "NPM::success-symbol:0.1.0"
   purl: "pkg:npm/success-symbol@0.1.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4418,6 +4666,8 @@ packages:
     path: ""
 - id: "NPM::supports-color:5.4.0"
   purl: "pkg:npm/supports-color@5.4.0"
+  authors:
+  - "Sindre Sorhus"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4446,6 +4696,8 @@ packages:
     path: ""
 - id: "NPM::through2:2.0.5"
   purl: "pkg:npm/through2@2.0.5"
+  authors:
+  - "Rod Vagg"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4475,6 +4727,8 @@ packages:
     path: ""
 - id: "NPM::to-gfm-code-block:0.1.1"
   purl: "pkg:npm/to-gfm-code-block@0.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4503,6 +4757,8 @@ packages:
     path: ""
 - id: "NPM::to-object-path:0.3.0"
   purl: "pkg:npm/to-object-path@0.3.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4531,6 +4787,8 @@ packages:
     path: ""
 - id: "NPM::to-regex:3.0.2"
   purl: "pkg:npm/to-regex@3.0.2"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4559,6 +4817,8 @@ packages:
     path: ""
 - id: "NPM::tokenize-comment:1.0.3"
   purl: "pkg:npm/tokenize-comment@1.0.3"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4589,6 +4849,8 @@ packages:
     path: ""
 - id: "NPM::union-value:1.0.1"
   purl: "pkg:npm/union-value@1.0.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4618,6 +4880,8 @@ packages:
     path: ""
 - id: "NPM::unset-value:1.0.0"
   purl: "pkg:npm/unset-value@1.0.0"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4646,6 +4910,8 @@ packages:
     path: ""
 - id: "NPM::urix:0.1.0"
   purl: "pkg:npm/urix@0.1.0"
+  authors:
+  - "Simon Lydell"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4674,6 +4940,8 @@ packages:
     path: ""
 - id: "NPM::use:3.1.1"
   purl: "pkg:npm/use@3.1.1"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4702,6 +4970,8 @@ packages:
     path: ""
 - id: "NPM::util-deprecate:1.0.2"
   purl: "pkg:npm/util-deprecate@1.0.2"
+  authors:
+  - "Nathan Rajlich"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4730,6 +5000,8 @@ packages:
     path: ""
 - id: "NPM::vinyl:2.2.0"
   purl: "pkg:npm/vinyl@2.2.0"
+  authors:
+  - "Gulp Team"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4758,6 +5030,8 @@ packages:
     path: ""
 - id: "NPM::wrappy:1.0.2"
   purl: "pkg:npm/wrappy@1.0.2"
+  authors:
+  - "Isaac Z. Schlueter"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -4786,6 +5060,8 @@ packages:
     path: ""
 - id: "NPM::write:0.3.3"
   purl: "pkg:npm/write@0.3.3"
+  authors:
+  - "Jon Schlinkert"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -4815,6 +5091,8 @@ packages:
     path: ""
 - id: "NPM::xtend:4.0.2"
   purl: "pkg:npm/xtend@4.0.2"
+  authors:
+  - "Raynos"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/npm/README.md
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm/README.md
@@ -1,6 +1,6 @@
 # npm
 
-This repository contains multiple NPM projects for testing. Each directory contains the same package.json plus the
+This repository contains multiple NPM projects for testing. Each directory contains an equivalent package.json plus the
 additional files described below.
 
 ## no-lockfile

--- a/analyzer/src/funTest/assets/projects/synthetic/npm/node-modules/package.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm/node-modules/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/oss-review-toolkit/ort.git"
   },
   "license": "Apache-2.0",
+  "author": "The Author",
   "private": true,
   "dependencies": {
     "long": "^3.2.0",

--- a/analyzer/src/funTest/assets/projects/synthetic/npm/package-lock/package.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm/package-lock/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/oss-review-toolkit/ort.git"
   },
   "license": "Apache-2.0",
+  "author": "The Author <the.author@mail.example> (https://www.the.author.example/index.html)",
   "private": true,
   "dependencies": {
     "long": "^3.2.0",

--- a/analyzer/src/funTest/assets/projects/synthetic/npm/shrinkwrap/package.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm/shrinkwrap/package.json
@@ -7,6 +7,11 @@
     "url": "https://github.com/oss-review-toolkit/ort.git"
   },
   "license": "Apache-2.0",
+  "author": {
+    "name": "The Author",
+    "email": "the.author@mail.example",
+    "url": "https://www.the.author.example/index.html"
+  },
   "private": true,
   "dependencies": {
     "long": "^3.2.0",

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
@@ -138,6 +138,8 @@ packages:
     path: ""
 - id: "NPM::boolbase:1.0.0"
   purl: "pkg:npm/boolbase@1.0.0"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -166,6 +168,8 @@ packages:
     path: ""
 - id: "NPM::cheerio:1.0.0-rc.1"
   purl: "pkg:npm/cheerio@1.0.0-rc.1"
+  authors:
+  - "Matt Mueller"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -195,6 +199,8 @@ packages:
     path: ""
 - id: "NPM::coffee-script:1.12.7"
   purl: "pkg:npm/coffee-script@1.12.7"
+  authors:
+  - "Jeremy Ashkenas"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -223,6 +229,8 @@ packages:
     path: ""
 - id: "NPM::cson-parser:1.3.5"
   purl: "pkg:npm/cson-parser@1.3.5"
+  authors:
+  - "Groupon"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -251,6 +259,8 @@ packages:
     path: ""
 - id: "NPM::cson:4.1.0"
   purl: "pkg:npm/cson@4.1.0"
+  authors:
+  - "2012+ Bevry Pty Ltd"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -280,6 +290,8 @@ packages:
     path: ""
 - id: "NPM::css-select:1.2.0"
   purl: "pkg:npm/css-select@1.2.0"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "BSD-like"
   declared_licenses_processed:
@@ -310,6 +322,8 @@ packages:
     path: ""
 - id: "NPM::css-what:2.1.3"
   purl: "pkg:npm/css-what@2.1.3"
+  authors:
+  - "Felix Böhm"
   declared_licenses:
   - "BSD-2-Clause"
   declared_licenses_processed:
@@ -338,6 +352,8 @@ packages:
     path: ""
 - id: "NPM::dom-serializer:0.1.1"
   purl: "pkg:npm/dom-serializer@0.1.1"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -366,6 +382,8 @@ packages:
     path: ""
 - id: "NPM::domelementtype:1.3.1"
   purl: "pkg:npm/domelementtype@1.3.1"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "BSD-2-Clause"
   declared_licenses_processed:
@@ -394,6 +412,8 @@ packages:
     path: ""
 - id: "NPM::domhandler:2.4.2"
   purl: "pkg:npm/domhandler@2.4.2"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "BSD-2-Clause"
   declared_licenses_processed:
@@ -422,6 +442,8 @@ packages:
     path: ""
 - id: "NPM::domutils:1.5.1"
   purl: "pkg:npm/domutils@1.5.1"
+  authors:
+  - "Felix Boehm"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "utilities for working with htmlparser2's dom"
@@ -448,6 +470,8 @@ packages:
     path: ""
 - id: "NPM::domutils:1.7.0"
   purl: "pkg:npm/domutils@1.7.0"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "BSD-2-Clause"
   declared_licenses_processed:
@@ -476,6 +500,8 @@ packages:
     path: ""
 - id: "NPM::eachr:3.2.0"
   purl: "pkg:npm/eachr@3.2.0"
+  authors:
+  - "2011+ Bevry Pty Ltd"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -506,6 +532,8 @@ packages:
     path: ""
 - id: "NPM::editions:1.3.4"
   purl: "pkg:npm/editions@1.3.4"
+  authors:
+  - "2016+ Bevry Pty Ltd"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -535,6 +563,8 @@ packages:
     path: ""
 - id: "NPM::editions:2.1.3"
   purl: "pkg:npm/editions@2.1.3"
+  authors:
+  - "2016+ Bevry Pty Ltd"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -564,6 +594,8 @@ packages:
     path: ""
 - id: "NPM::entities:1.1.2"
   purl: "pkg:npm/entities@1.1.2"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "BSD-2-Clause"
   declared_licenses_processed:
@@ -592,6 +624,8 @@ packages:
     path: ""
 - id: "NPM::errlop:1.1.1"
   purl: "pkg:npm/errlop@1.1.1"
+  authors:
+  - "2018+ Benjamin Lupton"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -621,6 +655,8 @@ packages:
     path: ""
 - id: "NPM::extract-opts:3.3.1"
   purl: "pkg:npm/extract-opts@3.3.1"
+  authors:
+  - "2013+ Bevry Pty Ltd"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -677,6 +713,8 @@ packages:
     path: ""
 - id: "NPM::htmlparser2:3.10.1"
   purl: "pkg:npm/htmlparser2@3.10.1"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -734,6 +772,8 @@ packages:
     path: ""
 - id: "NPM::lodash:4.17.15"
   purl: "pkg:npm/lodash@4.17.15"
+  authors:
+  - "John-David Dalton"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -762,6 +802,8 @@ packages:
     path: ""
 - id: "NPM::long:3.2.0"
   purl: "pkg:npm/long@3.2.0"
+  authors:
+  - "Daniel Wirtz"
   declared_licenses:
   - "Apache-2.0"
   declared_licenses_processed:
@@ -790,6 +832,8 @@ packages:
     path: ""
 - id: "NPM::nth-check:1.0.2"
   purl: "pkg:npm/nth-check@1.0.2"
+  authors:
+  - "Felix Boehm"
   declared_licenses:
   - "BSD-2-Clause"
   declared_licenses_processed:
@@ -818,6 +862,8 @@ packages:
     path: ""
 - id: "NPM::parse5:3.0.3"
   purl: "pkg:npm/parse5@3.0.3"
+  authors:
+  - "Ivan Nikulin"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -847,6 +893,8 @@ packages:
     path: ""
 - id: "NPM::promise:7.3.1"
   purl: "pkg:npm/promise@7.3.1"
+  authors:
+  - "ForbesLindesay"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -903,6 +951,8 @@ packages:
     path: ""
 - id: "NPM::requirefresh:2.2.0"
   purl: "pkg:npm/requirefresh@2.2.0"
+  authors:
+  - "2013+ Bevry Pty Ltd"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -931,6 +981,8 @@ packages:
     path: ""
 - id: "NPM::safe-buffer:5.1.2"
   purl: "pkg:npm/safe-buffer@5.1.2"
+  authors:
+  - "Feross Aboukhadijeh"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -959,6 +1011,8 @@ packages:
     path: ""
 - id: "NPM::safefs:4.1.0"
   purl: "pkg:npm/safefs@4.1.0"
+  authors:
+  - "2013+ Bevry Pty Ltd"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1044,6 +1098,8 @@ packages:
     path: ""
 - id: "NPM::typechecker:4.7.0"
   purl: "pkg:npm/typechecker@4.7.0"
+  authors:
+  - "2013+ Bevry Pty Ltd"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -1073,6 +1129,8 @@ packages:
     path: ""
 - id: "NPM::util-deprecate:1.0.2"
   purl: "pkg:npm/util-deprecate@1.0.2"
+  authors:
+  - "Nathan Rajlich"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces-expected-output.yml
@@ -31,6 +31,8 @@ project:
 packages:
 - id: "NPM::node-fetch:2.6.0"
   purl: "pkg:npm/node-fetch@2.6.0"
+  authors:
+  - "David Frank"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -87,6 +89,8 @@ packages:
     path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg2"
 - id: "NPM:@here:harp-fetch:0.11.0"
   purl: "pkg:npm/%40here/harp-fetch@0.11.0"
+  authors:
+  - "HERE Europe B.V."
   declared_licenses:
   - "Apache-2.0"
   declared_licenses_processed:
@@ -115,6 +119,8 @@ packages:
     path: "@here/harp-fetch"
 - id: "NPM:@here:harp-fetch:0.3.6"
   purl: "pkg:npm/%40here/harp-fetch@0.3.6"
+  authors:
+  - "HERE Europe B.V."
   declared_licenses:
   - "Apache-2.0"
   declared_licenses_processed:


### PR DESCRIPTION
Extract information about the author of a package from package.json
and make it available in the metadata of packages and projects.

Note: The major part of the changes is related to adapting the expected output of tests.