### PR TITLE
(Lack of) author support for go package managers

### DIFF
--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -131,7 +131,6 @@ class GoDep(
 
             val pkg = Package(
                 id = Identifier(managerName, "", name, version),
-                // TODO: Find a way to track authors.
                 authors = sortedSetOf(),
                 declaredLicenses = sortedSetOf(),
                 description = "",
@@ -174,7 +173,6 @@ class GoDep(
                         version = projectVcs.revision
                     ),
                     definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
-                    // TODO: Find a way to track authors.
                     authors = sortedSetOf(),
                     declaredLicenses = sortedSetOf(),
                     vcs = VcsInfo.EMPTY,

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -132,8 +132,7 @@ class GoMod(
                             version = projectVcs.revision
                         ),
                         definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
-                        // TODO: Find a way to track authors.
-                        authors = sortedSetOf(),
+                        authors = sortedSetOf(), // Go mod doesn't support author information.
                         declaredLicenses = sortedSetOf(), // Go mod doesn't support declared licenses.
                         vcs = projectVcs,
                         vcsProcessed = projectVcs,
@@ -198,8 +197,7 @@ class GoMod(
 
         return Package(
             id = Identifier(managerName, "", id.name, id.version),
-            // TODO: Find a way to track authors.
-            authors = sortedSetOf(),
+            authors = sortedSetOf(), // Go mod doesn't support author information.
             declaredLicenses = sortedSetOf(), // Go mod doesn't support declared licenses.
             description = "",
             homepageUrl = "",


### PR DESCRIPTION
After studying the reference documentation about go modules and go dep, it turned out that both formats do not support standardized metadata for package authors. So, just remove the corresponding TODO comments.