### PR TITLE
LocalScanner: Fix-up the creation of missing file archives

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -271,9 +271,8 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
 
                 if (config.createMissingArchives) {
                     val packagePath = pkg.id.toPath()
-                    val missingArchives = HashSet<Provenance>()
 
-                    storedResults.mapNotNullTo(mutableSetOf()) { result ->
+                    val missingArchives = storedResults.mapNotNullTo(mutableSetOf()) { result ->
                         result.provenance.takeUnless { archiver.hasArchive("$packagePath/${it.hash()}") }
                     }
 

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -278,6 +278,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
 
                     if (missingArchives.isNotEmpty()) {
                         val downloadResult = Downloader.download(pkg, downloadDirectory.resolve(packagePath))
+
                         missingArchives.forEach {
                             archiveFiles(downloadResult.downloadDirectory, pkg.id, it)
                         }


### PR DESCRIPTION
Previously, mapNotNullTo() added the mapped elements to the wrong set,
and thus `missingArchives` was guaranteed to always remain empty.

Trivially fix this by assigning the variable properly. This is a fix-up
of 90de765.