### PR TITLE
config-file-ort-yml: Fix formatting with backticks

### DIFF
--- a/docs/config-file-ort-yml.md
+++ b/docs/config-file-ort-yml.md
@@ -19,8 +19,8 @@ building, documenting or testing the code.
 
 Exclusions apply to paths (files/directories) or scopes. Examples of currently supported exclusions:
 
-* all dependencies defined in ./test/pom.xml in Maven-based projects.
-* dependencies in scopes ‘test’ or ‘provided’.
+* all dependencies defined in `./test/pom.xml` in Maven-based projects.
+* dependencies in scopes `test` or `provided`.
 
 ### Excludes Basics
 


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>