### PR TITLE
FileArchiver: Encapsulate the file storage path

### DIFF
--- a/model/src/main/kotlin/config/FileArchiverConfiguration.kt
+++ b/model/src/main/kotlin/config/FileArchiverConfiguration.kt
@@ -21,7 +21,7 @@ package org.ossreviewtoolkit.model.config
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
-import org.ossreviewtoolkit.utils.storage.FileArchiver
+import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.utils.storage.FileStorage
 import org.ossreviewtoolkit.utils.storage.LocalFileStorage
 

--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.model.config
 import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
-import org.ossreviewtoolkit.utils.storage.FileArchiver
+import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.utils.storage.FileStorage
 
 /**

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -32,7 +32,6 @@ import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.utils.FileArchiver
-import org.ossreviewtoolkit.model.utils.FileArchiver.Companion.getStoragePath
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.FindingsMatcher
 import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
@@ -207,9 +206,8 @@ class LicenseInfoResolver(
             resolvedLicense.locations.map { it.provenance }
         }.forEach { provenance ->
             val archiveDir = createTempDirectory("$ORT_NAME-archive").toFile().apply { deleteOnExit() }
-            val storagePath = getStoragePath(id, provenance)
 
-            if (!archiver.unarchive(archiveDir, storagePath)) return@forEach
+            if (!archiver.unarchive(archiveDir, id, provenance)) return@forEach
 
             val directory = provenance.vcsInfo?.path.orEmpty()
             val rootLicenseFiles = rootLicenseMatcher.getApplicableLicenseFilesForDirectories(

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -31,13 +31,13 @@ import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.model.config.PathExclude
+import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.FindingsMatcher
 import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
 import org.ossreviewtoolkit.model.utils.prependPath
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.utils.ORT_NAME
-import org.ossreviewtoolkit.utils.storage.FileArchiver
 
 class LicenseInfoResolver(
     val provider: LicenseInfoProvider,

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -206,9 +206,9 @@ class LicenseInfoResolver(
             resolvedLicense.locations.map { it.provenance }
         }.forEach { provenance ->
             val archiveDir = createTempDirectory("$ORT_NAME-archive").toFile().apply { deleteOnExit() }
-            val path = "${id.toPath()}/${provenance.hash()}"
+            val storagePath = "${id.toPath()}/${provenance.hash()}"
 
-            if (!archiver.unarchive(archiveDir, path)) return@forEach
+            if (!archiver.unarchive(archiveDir, storagePath)) return@forEach
 
             val directory = provenance.vcsInfo?.path.orEmpty()
             val rootLicenseFiles = rootLicenseMatcher.getApplicableLicenseFilesForDirectories(

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -32,6 +32,7 @@ import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.utils.FileArchiver
+import org.ossreviewtoolkit.model.utils.FileArchiver.Companion.getStoragePath
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.FindingsMatcher
 import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
@@ -206,7 +207,7 @@ class LicenseInfoResolver(
             resolvedLicense.locations.map { it.provenance }
         }.forEach { provenance ->
             val archiveDir = createTempDirectory("$ORT_NAME-archive").toFile().apply { deleteOnExit() }
-            val storagePath = "${id.toPath()}/${provenance.hash()}"
+            val storagePath = getStoragePath(id, provenance)
 
             if (!archiver.unarchive(archiveDir, storagePath)) return@forEach
 

--- a/model/src/main/kotlin/utils/FileArchiver.kt
+++ b/model/src/main/kotlin/utils/FileArchiver.kt
@@ -52,7 +52,7 @@ class FileArchiver(
     /**
      * The [FileStorage] to use for archiving files.
      */
-    val storage: FileStorage
+    private val storage: FileStorage
 ) {
     companion object {
         val DEFAULT_ARCHIVE_DIR by lazy { ortDataDirectory.resolve("scanner/archive") }

--- a/model/src/main/kotlin/utils/FileArchiver.kt
+++ b/model/src/main/kotlin/utils/FileArchiver.kt
@@ -55,7 +55,6 @@ class FileArchiver(
     val storage: FileStorage
 ) {
     companion object {
-        private const val ARCHIVE_FILE_NAME = "archive.zip"
         val DEFAULT_ARCHIVE_DIR by lazy { ortDataDirectory.resolve("scanner/archive") }
     }
 
@@ -136,5 +135,5 @@ class FileArchiver(
     }
 
     private fun getArchivePath(id: Identifier, provenance: Provenance): String =
-        "${id.toPath()}/${provenance.hash()}/$ARCHIVE_FILE_NAME"
+        "${id.toPath()}/${provenance.hash()}/archive.zip"
 }

--- a/model/src/main/kotlin/utils/FileArchiver.kt
+++ b/model/src/main/kotlin/utils/FileArchiver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.utils.storage
+package org.ossreviewtoolkit.model.utils
 
 import java.io.File
 import java.io.IOException
@@ -34,6 +34,7 @@ import org.ossreviewtoolkit.utils.ortDataDirectory
 import org.ossreviewtoolkit.utils.packZip
 import org.ossreviewtoolkit.utils.perf
 import org.ossreviewtoolkit.utils.showStackTrace
+import org.ossreviewtoolkit.utils.storage.FileStorage
 import org.ossreviewtoolkit.utils.unpackZip
 
 /**

--- a/model/src/main/kotlin/utils/FileArchiver.kt
+++ b/model/src/main/kotlin/utils/FileArchiver.kt
@@ -26,6 +26,8 @@ import kotlin.io.path.createTempFile
 import kotlin.time.measureTime
 import kotlin.time.measureTimedValue
 
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.utils.FileMatcher
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.collectMessagesAsString
@@ -55,6 +57,12 @@ class FileArchiver(
     companion object {
         private const val ARCHIVE_FILE_NAME = "archive.zip"
         val DEFAULT_ARCHIVE_DIR by lazy { ortDataDirectory.resolve("scanner/archive") }
+
+        /**
+         * Return the storage path for the given [id] and [provenance].
+         */
+        fun getStoragePath(id: Identifier, provenance: Provenance): String =
+            "${id.toPath()}/${provenance.hash()}"
     }
 
     private val matcher = FileMatcher(

--- a/model/src/main/kotlin/utils/FileArchiver.kt
+++ b/model/src/main/kotlin/utils/FileArchiver.kt
@@ -133,7 +133,7 @@ class FileArchiver(
             false
         }
     }
-
-    private fun getArchivePath(id: Identifier, provenance: Provenance): String =
-        "${id.toPath()}/${provenance.hash()}/archive.zip"
 }
+
+private fun getArchivePath(id: Identifier, provenance: Provenance): String =
+    "${id.toPath()}/${provenance.hash()}/archive.zip"

--- a/model/src/main/kotlin/utils/OrtResultExtensions.kt
+++ b/model/src/main/kotlin/utils/OrtResultExtensions.kt
@@ -25,7 +25,6 @@ import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.model.licenses.DefaultLicenseInfoProvider
 import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
-import org.ossreviewtoolkit.utils.storage.FileArchiver
 
 /**
  * Return a map of concluded licenses for each package [Identifier] that has a concluded license. Note that this

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -50,12 +50,12 @@ import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.LicenseFindingCurationReason
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.config.PathExcludeReason
+import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.spdx.SpdxExpression
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.spdx.getLicenseText
 import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
-import org.ossreviewtoolkit.utils.storage.FileArchiver
 import org.ossreviewtoolkit.utils.storage.LocalFileStorage
 import org.ossreviewtoolkit.utils.test.createDefault
 

--- a/model/src/test/kotlin/licenses/LicenseViewTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseViewTest.kt
@@ -31,11 +31,11 @@ import io.kotest.matchers.should
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
+import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
 import org.ossreviewtoolkit.spdx.SpdxExpression
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.spdx.toSpdx
-import org.ossreviewtoolkit.utils.storage.FileArchiver
 import org.ossreviewtoolkit.utils.test.createDefault
 
 class LicenseViewTest : WordSpec() {

--- a/model/src/test/kotlin/utils/FileArchiverTest.kt
+++ b/model/src/test/kotlin/utils/FileArchiverTest.kt
@@ -28,12 +28,17 @@ import java.io.File
 
 import kotlin.io.path.createTempDirectory
 
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.safeMkdirs
 import org.ossreviewtoolkit.utils.storage.LocalFileStorage
 import org.ossreviewtoolkit.utils.test.createDefault
-import org.ossreviewtoolkit.utils.unpack
+
+private val ID = Identifier("a:b:c:1.0.0")
+private val PROVENANCE = Provenance(vcsInfo = VcsInfo.EMPTY)
 
 class FileArchiverTest : StringSpec() {
     private lateinit var workingDir: File
@@ -75,13 +80,8 @@ class FileArchiverTest : StringSpec() {
 
             val archiver = FileArchiver(listOf("a", "**/a"), storage)
 
-            archiver.archive(workingDir, "save")
-
-            val archiveFile = storageDir.resolve("save/archive.zip")
-
-            archiveFile.isFile shouldBe true
-
-            archiveFile.unpack(targetDir)
+            archiver.archive(workingDir, ID, PROVENANCE)
+            archiver.unarchive(targetDir, ID, PROVENANCE)
 
             targetDir.assertFileContent("a")
             targetDir.assertFileContent("d/a")
@@ -101,11 +101,10 @@ class FileArchiverTest : StringSpec() {
             createFile("c/a")
             createFile("c/b")
 
-            val storagePath = "save"
             val archiver = FileArchiver(listOf("**"), storage)
-            archiver.archive(workingDir, storagePath)
+            archiver.archive(workingDir, ID, PROVENANCE)
 
-            val result = archiver.unarchive(targetDir, storagePath)
+            val result = archiver.unarchive(targetDir, ID, PROVENANCE)
 
             result shouldBe true
             with(targetDir) {
@@ -121,8 +120,8 @@ class FileArchiverTest : StringSpec() {
             createFile("path/LICENSE")
 
             val archiver = FileArchiver.createDefault()
-            archiver.archive(workingDir, "save")
-            archiver.unarchive(targetDir, "save")
+            archiver.archive(workingDir, ID, PROVENANCE)
+            archiver.unarchive(targetDir, ID, PROVENANCE)
 
             with(targetDir) {
                 assertFileContent("LICENSE")
@@ -137,8 +136,8 @@ class FileArchiverTest : StringSpec() {
             createFile("d/LiCeNsE")
 
             val archiver = FileArchiver.createDefault()
-            archiver.archive(workingDir, "save")
-            archiver.unarchive(targetDir, "save")
+            archiver.archive(workingDir, ID, PROVENANCE)
+            archiver.unarchive(targetDir, ID, PROVENANCE)
 
             with(targetDir) {
                 assertFileContent("a/LICENSE")

--- a/model/src/test/kotlin/utils/FileArchiverTest.kt
+++ b/model/src/test/kotlin/utils/FileArchiverTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.utils.storage
+package org.ossreviewtoolkit.model.utils
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
@@ -31,6 +31,7 @@ import kotlin.io.path.createTempDirectory
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.safeMkdirs
+import org.ossreviewtoolkit.utils.storage.LocalFileStorage
 import org.ossreviewtoolkit.utils.test.createDefault
 import org.ossreviewtoolkit.utils.unpack
 

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -270,14 +270,13 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
                 }
 
                 if (config.createMissingArchives) {
-                    val packagePath = pkg.id.toPath()
-
                     val missingArchives = storedResults.mapNotNullTo(mutableSetOf()) { result ->
-                        result.provenance.takeUnless { archiver.hasArchive("$packagePath/${it.hash()}") }
+                        val storagePath = "${pkg.id.toPath()}/${result.provenance.hash()}"
+                        result.provenance.takeUnless { archiver.hasArchive(storagePath) }
                     }
 
                     if (missingArchives.isNotEmpty()) {
-                        val downloadResult = Downloader.download(pkg, downloadDirectory.resolve(packagePath))
+                        val downloadResult = Downloader.download(pkg, downloadDirectory.resolve(pkg.id.toPath()))
 
                         missingArchives.forEach {
                             archiveFiles(downloadResult.downloadDirectory, pkg.id, it)

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -439,9 +439,9 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
     private fun archiveFiles(directory: File, id: Identifier, provenance: Provenance) {
         log.info { "Archiving files for ${id.toCoordinates()}." }
 
-        val path = "${id.toPath()}/${provenance.hash()}"
+        val storagePath = "${id.toPath()}/${provenance.hash()}"
 
-        val duration = measureTime { archiver.archive(directory, path) }
+        val duration = measureTime { archiver.archive(directory, storagePath) }
 
         log.perf { "Archived files for '${id.toCoordinates()}' in ${duration.inMilliseconds}ms." }
     }

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -61,6 +61,7 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.createAndLogIssue
+import org.ossreviewtoolkit.model.utils.FileArchiver.Companion.getStoragePath
 import org.ossreviewtoolkit.scanner.storages.PostgresStorage
 import org.ossreviewtoolkit.utils.CommandLineTool
 import org.ossreviewtoolkit.utils.Environment
@@ -271,7 +272,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
 
                 if (config.createMissingArchives) {
                     val missingArchives = storedResults.mapNotNullTo(mutableSetOf()) { result ->
-                        val storagePath = "${pkg.id.toPath()}/${result.provenance.hash()}"
+                        val storagePath = getStoragePath(pkg.id, result.provenance)
                         result.provenance.takeUnless { archiver.hasArchive(storagePath) }
                     }
 
@@ -438,7 +439,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
     private fun archiveFiles(directory: File, id: Identifier, provenance: Provenance) {
         log.info { "Archiving files for ${id.toCoordinates()}." }
 
-        val storagePath = "${id.toPath()}/${provenance.hash()}"
+        val storagePath = getStoragePath(id, provenance)
 
         val duration = measureTime { archiver.archive(directory, storagePath) }
 

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -61,7 +61,6 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.createAndLogIssue
-import org.ossreviewtoolkit.model.utils.FileArchiver.Companion.getStoragePath
 import org.ossreviewtoolkit.scanner.storages.PostgresStorage
 import org.ossreviewtoolkit.utils.CommandLineTool
 import org.ossreviewtoolkit.utils.Environment
@@ -272,8 +271,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
 
                 if (config.createMissingArchives) {
                     val missingArchives = storedResults.mapNotNullTo(mutableSetOf()) { result ->
-                        val storagePath = getStoragePath(pkg.id, result.provenance)
-                        result.provenance.takeUnless { archiver.hasArchive(storagePath) }
+                        result.provenance.takeUnless { archiver.hasArchive(pkg.id, result.provenance) }
                     }
 
                     if (missingArchives.isNotEmpty()) {
@@ -439,9 +437,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
     private fun archiveFiles(directory: File, id: Identifier, provenance: Provenance) {
         log.info { "Archiving files for ${id.toCoordinates()}." }
 
-        val storagePath = getStoragePath(id, provenance)
-
-        val duration = measureTime { archiver.archive(directory, storagePath) }
+        val duration = measureTime { archiver.archive(directory, id, provenance) }
 
         log.perf { "Archived files for '${id.toCoordinates()}' in ${duration.inMilliseconds}ms." }
     }

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -277,8 +277,8 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
                     if (missingArchives.isNotEmpty()) {
                         val downloadResult = Downloader.download(pkg, downloadDirectory.resolve(pkg.id.toPath()))
 
-                        missingArchives.forEach {
-                            archiveFiles(downloadResult.downloadDirectory, pkg.id, it)
+                        missingArchives.forEach { provenance ->
+                            archiveFiles(downloadResult.downloadDirectory, pkg.id, provenance)
                         }
                     }
                 }

--- a/test-utils/src/main/kotlin/Extensions.kt
+++ b/test-utils/src/main/kotlin/Extensions.kt
@@ -25,7 +25,7 @@ import java.net.InetSocketAddress
 import java.net.Proxy
 
 import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
-import org.ossreviewtoolkit.utils.storage.FileArchiver
+import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.utils.storage.LocalFileStorage
 
 fun Proxy.toGenericString() =


### PR DESCRIPTION
The `FileArchiver` implementation is going to be extended to support a PostgreSQL storage in addition to / as alternative to the currently supported file storage in a following PR. Thus, the API of the file archiver must abstract from any storage specific details.
This is exactly what the changes are about. In particular, the `storagePath` API parameter is removed in favor of making the file archiver derive the archive file path internally from any given `id` and `provenance`.

 