### PR TITLE
Pub: Add support for authors

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/dart-http-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/dart-http-expected-output.yml
@@ -2,6 +2,8 @@
 project:
   id: "Pub:dart-http:dart-http:0.12.0+2"
   definition_file_path: "pubspec.yaml"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   vcs:
@@ -88,6 +90,8 @@ project:
 packages:
 - id: "Pub:analyzer:analyzer:0.37.0"
   purl: "pkg:pub/analyzer/analyzer@0.37.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Static analyzer for Dart."
@@ -114,6 +118,8 @@ packages:
     path: "pkg/analyzer"
 - id: "Pub:args:args:1.5.2"
   purl: "pkg:pub/args/args@1.5.2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Library for defining parsers for parsing raw command-line arguments\
@@ -141,6 +147,8 @@ packages:
     path: ""
 - id: "Pub:async:async:2.3.0"
   purl: "pkg:pub/async/async@2.3.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Utility functions and classes related to the 'dart:async' library."
@@ -167,6 +175,8 @@ packages:
     path: ""
 - id: "Pub:boolean_selector:boolean_selector:1.0.5"
   purl: "pkg:pub/boolean_selector/boolean_selector@1.0.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A flexible syntax for boolean expressions, based on a simplified version\
@@ -194,6 +204,8 @@ packages:
     path: ""
 - id: "Pub:charcode:charcode:1.1.2"
   purl: "pkg:pub/charcode/charcode@1.1.2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Constants for ASCII and common non-ASCII character codes. When working\
@@ -223,6 +235,8 @@ packages:
     path: ""
 - id: "Pub:collection:collection:1.14.11"
   purl: "pkg:pub/collection/collection@1.14.11"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Collections and utilities functions and classes related to collections."
@@ -249,6 +263,8 @@ packages:
     path: ""
 - id: "Pub:convert:convert:2.1.1"
   purl: "pkg:pub/convert/convert@2.1.1"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Utilities for converting between data representations."
@@ -275,6 +291,8 @@ packages:
     path: ""
 - id: "Pub:crypto:crypto:2.1.1+1"
   purl: "pkg:pub/crypto/crypto@2.1.1%2B1"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Library of cryptographic functions."
@@ -301,6 +319,8 @@ packages:
     path: ""
 - id: "Pub:csslib:csslib:0.16.1"
   purl: "pkg:pub/csslib/csslib@0.16.1"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A library for parsing CSS."
@@ -327,6 +347,8 @@ packages:
     path: ""
 - id: "Pub:front_end:front_end:0.1.20"
   purl: "pkg:pub/front_end/front_end@0.1.20"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Front end for compilation of Dart code."
@@ -353,6 +375,8 @@ packages:
     path: "pkg/front_end"
 - id: "Pub:glob:glob:1.1.7"
   purl: "pkg:pub/glob/glob@1.1.7"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Bash-style filename globbing."
@@ -379,6 +403,8 @@ packages:
     path: ""
 - id: "Pub:html:html:0.14.0+2"
   purl: "pkg:pub/html/html@0.14.0%2B2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "APIs for parsing and manipulating HTML content outside the browser."
@@ -405,6 +431,8 @@ packages:
     path: ""
 - id: "Pub:http_multi_server:http_multi_server:2.1.0"
   purl: "pkg:pub/http_multi_server/http_multi_server@2.1.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A dart:io HttpServer wrapper that handles requests from multiple servers."
@@ -431,6 +459,8 @@ packages:
     path: ""
 - id: "Pub:http_parser:http_parser:3.1.3"
   purl: "pkg:pub/http_parser/http_parser@3.1.3"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A platform-independent package for parsing and serializing HTTP formats.\n"
@@ -457,6 +487,8 @@ packages:
     path: ""
 - id: "Pub:io:io:0.3.3"
   purl: "pkg:pub/io/io@0.3.3"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Utilities for the Dart VM Runtime.\n"
@@ -483,6 +515,8 @@ packages:
     path: ""
 - id: "Pub:js:js:0.6.1+1"
   purl: "pkg:pub/js/js@0.6.1%2B1"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Access JavaScript from Dart."
@@ -509,6 +543,8 @@ packages:
     path: "pkg/js"
 - id: "Pub:kernel:kernel:0.3.20"
   purl: "pkg:pub/kernel/kernel@0.3.20"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Dart IR (Intermediate Representation)"
@@ -535,6 +571,8 @@ packages:
     path: "pkg/kernel"
 - id: "Pub:matcher:matcher:0.12.5"
   purl: "pkg:pub/matcher/matcher@0.12.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Support for specifying test expectations via an extensible Matcher\
@@ -563,6 +601,8 @@ packages:
     path: ""
 - id: "Pub:meta:meta:1.1.7"
   purl: "pkg:pub/meta/meta@1.1.7"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "This library contains the definitions of annotations that provide\
@@ -591,6 +631,8 @@ packages:
     path: "pkg/meta"
 - id: "Pub:mime:mime:0.9.6+3"
   purl: "pkg:pub/mime/mime@0.9.6%2B3"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Utilities for handling media (MIME) types, including determining a\
@@ -618,6 +660,8 @@ packages:
     path: ""
 - id: "Pub:multi_server_socket:multi_server_socket:1.0.2"
   purl: "pkg:pub/multi_server_socket/multi_server_socket@1.0.2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A dart:io ServerSocket wrapper that listens on multiple ports."
@@ -644,6 +688,8 @@ packages:
     path: ""
 - id: "Pub:node_preamble:node_preamble:1.4.6"
   purl: "pkg:pub/node_preamble/node_preamble@1.4.6"
+  authors:
+  - "Michael Bullington"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Better node.js preamble for dart2js, use it in your build system."
@@ -670,6 +716,8 @@ packages:
     path: ""
 - id: "Pub:package_config:package_config:1.0.5"
   purl: "pkg:pub/package_config/package_config@1.0.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Support for working with Package Resolution config files."
@@ -696,6 +744,8 @@ packages:
     path: ""
 - id: "Pub:package_resolver:package_resolver:1.0.10"
   purl: "pkg:pub/package_resolver/package_resolver@1.0.10"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "First-class package resolution strategy classes."
@@ -722,6 +772,8 @@ packages:
     path: ""
 - id: "Pub:path:path:1.6.4"
   purl: "pkg:pub/path/path@1.6.4"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A string-based path manipulation library. All of the path operations\
@@ -750,6 +802,8 @@ packages:
     path: ""
 - id: "Pub:pedantic:pedantic:1.8.0+1"
   purl: "pkg:pub/pedantic/pedantic@1.8.0%2B1"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "How to get the most value from Dart static analysis."
@@ -776,6 +830,8 @@ packages:
     path: ""
 - id: "Pub:pool:pool:1.4.0"
   purl: "pkg:pub/pool/pool@1.4.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Manage a finite pool of resources. Useful for controlling concurrent\
@@ -803,6 +859,8 @@ packages:
     path: ""
 - id: "Pub:pub_semver:pub_semver:1.4.2"
   purl: "pkg:pub/pub_semver/pub_semver@1.4.2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Versions and version constraints implementing pub's versioning policy.\
@@ -830,6 +888,8 @@ packages:
     path: ""
 - id: "Pub:shelf:shelf:0.7.5"
   purl: "pkg:pub/shelf/shelf@0.7.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A model for web server middleware that encourages composition and\
@@ -857,6 +917,8 @@ packages:
     path: ""
 - id: "Pub:shelf_packages_handler:shelf_packages_handler:1.0.4"
   purl: "pkg:pub/shelf_packages_handler/shelf_packages_handler@1.0.4"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A shelf handler for serving a `packages/` directory."
@@ -883,6 +945,8 @@ packages:
     path: ""
 - id: "Pub:shelf_static:shelf_static:0.2.8"
   purl: "pkg:pub/shelf_static/shelf_static@0.2.8"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Static file server support for Shelf"
@@ -909,6 +973,8 @@ packages:
     path: ""
 - id: "Pub:shelf_web_socket:shelf_web_socket:0.2.3"
   purl: "pkg:pub/shelf_web_socket/shelf_web_socket@0.2.3"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A shelf handler that wires up a listener for every connection."
@@ -935,6 +1001,8 @@ packages:
     path: ""
 - id: "Pub:source_map_stack_trace:source_map_stack_trace:1.1.5"
   purl: "pkg:pub/source_map_stack_trace/source_map_stack_trace@1.1.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A package for applying source maps to stack traces."
@@ -961,6 +1029,8 @@ packages:
     path: ""
 - id: "Pub:source_maps:source_maps:0.10.8"
   purl: "pkg:pub/source_maps/source_maps@0.10.8"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Library to programmatically manipulate source map files."
@@ -987,6 +1057,8 @@ packages:
     path: ""
 - id: "Pub:source_span:source_span:1.5.5"
   purl: "pkg:pub/source_span/source_span@1.5.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A library for identifying source spans and locations."
@@ -1013,6 +1085,8 @@ packages:
     path: ""
 - id: "Pub:stack_trace:stack_trace:1.9.3"
   purl: "pkg:pub/stack_trace/stack_trace@1.9.3"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A package for manipulating stack traces and printing them readably."
@@ -1039,6 +1113,8 @@ packages:
     path: ""
 - id: "Pub:stream_channel:stream_channel:2.0.0"
   purl: "pkg:pub/stream_channel/stream_channel@2.0.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "An abstraction for two-way communication channels."
@@ -1065,6 +1141,8 @@ packages:
     path: ""
 - id: "Pub:stream_transform:stream_transform:0.0.19"
   purl: "pkg:pub/stream_transform/stream_transform@0.0.19"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A collection of utilities to transform and manipulate streams."
@@ -1091,6 +1169,8 @@ packages:
     path: ""
 - id: "Pub:string_scanner:string_scanner:1.0.5"
   purl: "pkg:pub/string_scanner/string_scanner@1.0.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A class for parsing strings using a sequence of patterns."
@@ -1117,6 +1197,8 @@ packages:
     path: ""
 - id: "Pub:term_glyph:term_glyph:1.1.0"
   purl: "pkg:pub/term_glyph/term_glyph@1.1.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Useful Unicode glyphs and ASCII substitutes."
@@ -1143,6 +1225,8 @@ packages:
     path: ""
 - id: "Pub:test:test:1.6.5"
   purl: "pkg:pub/test/test@1.6.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A full featured library for writing and running Dart tests."
@@ -1169,6 +1253,8 @@ packages:
     path: "pkgs/test"
 - id: "Pub:test_api:test_api:0.2.6"
   purl: "pkg:pub/test_api/test_api@0.2.6"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A library for writing Dart tests."
@@ -1195,6 +1281,8 @@ packages:
     path: "pkgs/test_api"
 - id: "Pub:test_core:test_core:0.2.7"
   purl: "pkg:pub/test_core/test_core@0.2.7"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A basic library for writing tests and running them on the VM."
@@ -1221,6 +1309,8 @@ packages:
     path: "pkgs/test_core"
 - id: "Pub:typed_data:typed_data:1.1.6"
   purl: "pkg:pub/typed_data/typed_data@1.1.6"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Utility functions and classes related to the 'dart:typed_data' library."
@@ -1247,6 +1337,8 @@ packages:
     path: ""
 - id: "Pub:vm_service_lib:vm_service_lib:3.22.2+1"
   purl: "pkg:pub/vm_service_lib/vm_service_lib@3.22.2%2B1"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A library to access the VM Service API."
@@ -1273,6 +1365,8 @@ packages:
     path: ""
 - id: "Pub:watcher:watcher:0.9.7+12"
   purl: "pkg:pub/watcher/watcher@0.9.7%2B12"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A file system watcher. It monitors changes to contents of directories\
@@ -1300,6 +1394,8 @@ packages:
     path: ""
 - id: "Pub:web_socket_channel:web_socket_channel:1.0.14"
   purl: "pkg:pub/web_socket_channel/web_socket_channel@1.0.14"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "StreamChannel wrappers for WebSockets. Provides a cross-platform WebSocketChannel\
@@ -1328,6 +1424,8 @@ packages:
     path: ""
 - id: "Pub:yaml:yaml:2.1.16"
   purl: "pkg:pub/yaml/yaml@2.1.16"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A parser for YAML, a human-friendly data serialization standard"

--- a/analyzer/src/funTest/assets/projects/synthetic/pub-expected-output-any-version.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pub-expected-output-any-version.yml
@@ -2,6 +2,9 @@
 project:
   id: "Pub:any-version:any-version:0.1.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/pub/any-version/pubspec.yaml"
+  authors:
+  - "Another Author"
+  - "Marlon Hille"
   declared_licenses: []
   declared_licenses_processed: {}
   vcs:
@@ -96,6 +99,8 @@ project:
 packages:
 - id: "Pub:analyzer:analyzer:0.36.4"
   purl: "pkg:pub/analyzer/analyzer@0.36.4"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Static analyzer for Dart."
@@ -122,6 +127,8 @@ packages:
     path: "pkg/analyzer"
 - id: "Pub:args:args:1.5.2"
   purl: "pkg:pub/args/args@1.5.2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Library for defining parsers for parsing raw command-line arguments\
@@ -149,6 +156,8 @@ packages:
     path: ""
 - id: "Pub:async:async:2.2.0"
   purl: "pkg:pub/async/async@2.2.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Utility functions and classes related to the 'dart:async' library."
@@ -175,6 +184,8 @@ packages:
     path: ""
 - id: "Pub:boolean_selector:boolean_selector:1.0.5"
   purl: "pkg:pub/boolean_selector/boolean_selector@1.0.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A flexible syntax for boolean expressions, based on a simplified version\
@@ -202,6 +213,8 @@ packages:
     path: ""
 - id: "Pub:charcode:charcode:1.1.2"
   purl: "pkg:pub/charcode/charcode@1.1.2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Constants for ASCII and common non-ASCII character codes. When working\
@@ -231,6 +244,8 @@ packages:
     path: ""
 - id: "Pub:collection:collection:1.14.11"
   purl: "pkg:pub/collection/collection@1.14.11"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Collections and utilities functions and classes related to collections."
@@ -257,6 +272,8 @@ packages:
     path: ""
 - id: "Pub:convert:convert:2.1.1"
   purl: "pkg:pub/convert/convert@2.1.1"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Utilities for converting between data representations."
@@ -283,6 +300,8 @@ packages:
     path: ""
 - id: "Pub:crypto:crypto:2.0.6"
   purl: "pkg:pub/crypto/crypto@2.0.6"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Library of cryptographic functions."
@@ -309,6 +328,8 @@ packages:
     path: ""
 - id: "Pub:csslib:csslib:0.16.0"
   purl: "pkg:pub/csslib/csslib@0.16.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A library for parsing CSS."
@@ -335,6 +356,8 @@ packages:
     path: ""
 - id: "Pub:fixnum:fixnum:0.10.9"
   purl: "pkg:pub/fixnum/fixnum@0.10.9"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Library for 32- and 64-bit signed fixed-width integers."
@@ -361,6 +384,8 @@ packages:
     path: ""
 - id: "Pub:front_end:front_end:0.1.19"
   purl: "pkg:pub/front_end/front_end@0.1.19"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Front end for compilation of Dart code."
@@ -387,6 +412,8 @@ packages:
     path: "pkg/front_end"
 - id: "Pub:glob:glob:1.1.7"
   purl: "pkg:pub/glob/glob@1.1.7"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Bash-style filename globbing."
@@ -413,6 +440,8 @@ packages:
     path: ""
 - id: "Pub:html:html:0.14.0+2"
   purl: "pkg:pub/html/html@0.14.0%2B2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "APIs for parsing and manipulating HTML content outside the browser."
@@ -439,6 +468,8 @@ packages:
     path: ""
 - id: "Pub:http:http:0.12.0+2"
   purl: "pkg:pub/http/http@0.12.0%2B2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A composable, cross-platform, Future-based API for making HTTP requests."
@@ -465,6 +496,8 @@ packages:
     path: ""
 - id: "Pub:http_multi_server:http_multi_server:2.1.0"
   purl: "pkg:pub/http_multi_server/http_multi_server@2.1.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A dart:io HttpServer wrapper that handles requests from multiple servers."
@@ -491,6 +524,8 @@ packages:
     path: ""
 - id: "Pub:http_parser:http_parser:3.1.3"
   purl: "pkg:pub/http_parser/http_parser@3.1.3"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A platform-independent package for parsing and serializing HTTP formats.\n"
@@ -517,6 +552,8 @@ packages:
     path: ""
 - id: "Pub:io:io:0.3.3"
   purl: "pkg:pub/io/io@0.3.3"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Utilities for the Dart VM Runtime.\n"
@@ -543,6 +580,8 @@ packages:
     path: ""
 - id: "Pub:js:js:0.6.1+1"
   purl: "pkg:pub/js/js@0.6.1%2B1"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Access JavaScript from Dart."
@@ -569,6 +608,8 @@ packages:
     path: "pkg/js"
 - id: "Pub:json_rpc_2:json_rpc_2:2.1.0"
   purl: "pkg:pub/json_rpc_2/json_rpc_2@2.1.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Utilities to write a client or server using the JSON-RPC 2.0 spec."
@@ -595,6 +636,8 @@ packages:
     path: ""
 - id: "Pub:kernel:kernel:0.3.19"
   purl: "pkg:pub/kernel/kernel@0.3.19"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Dart IR (Intermediate Representation)"
@@ -621,6 +664,8 @@ packages:
     path: "pkg/kernel"
 - id: "Pub:matcher:matcher:0.12.5"
   purl: "pkg:pub/matcher/matcher@0.12.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Support for specifying test expectations via an extensible Matcher\
@@ -649,6 +694,8 @@ packages:
     path: ""
 - id: "Pub:meta:meta:1.1.7"
   purl: "pkg:pub/meta/meta@1.1.7"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "This library contains the definitions of annotations that provide\
@@ -677,6 +724,8 @@ packages:
     path: "pkg/meta"
 - id: "Pub:mime:mime:0.9.6+3"
   purl: "pkg:pub/mime/mime@0.9.6%2B3"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Utilities for handling media (MIME) types, including determining a\
@@ -704,6 +753,8 @@ packages:
     path: ""
 - id: "Pub:multi_server_socket:multi_server_socket:1.0.2"
   purl: "pkg:pub/multi_server_socket/multi_server_socket@1.0.2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A dart:io ServerSocket wrapper that listens on multiple ports."
@@ -730,6 +781,8 @@ packages:
     path: ""
 - id: "Pub:node_preamble:node_preamble:1.4.4"
   purl: "pkg:pub/node_preamble/node_preamble@1.4.4"
+  authors:
+  - "Michael Bullington"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Better node.js preamble for dart2js, use it in your build system."
@@ -756,6 +809,8 @@ packages:
     path: ""
 - id: "Pub:package_config:package_config:1.0.5"
   purl: "pkg:pub/package_config/package_config@1.0.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Support for working with Package Resolution config files."
@@ -782,6 +837,8 @@ packages:
     path: ""
 - id: "Pub:package_resolver:package_resolver:1.0.10"
   purl: "pkg:pub/package_resolver/package_resolver@1.0.10"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "First-class package resolution strategy classes."
@@ -808,6 +865,8 @@ packages:
     path: ""
 - id: "Pub:path:path:1.6.2"
   purl: "pkg:pub/path/path@1.6.2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A string-based path manipulation library. All of the path operations\
@@ -836,6 +895,8 @@ packages:
     path: ""
 - id: "Pub:pedantic:pedantic:1.7.0"
   purl: "pkg:pub/pedantic/pedantic@1.7.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "How to get the most value from Dart static analysis."
@@ -862,6 +923,8 @@ packages:
     path: ""
 - id: "Pub:pool:pool:1.4.0"
   purl: "pkg:pub/pool/pool@1.4.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Manage a finite pool of resources. Useful for controlling concurrent\
@@ -889,6 +952,8 @@ packages:
     path: ""
 - id: "Pub:protobuf:protobuf:0.13.12"
   purl: "pkg:pub/protobuf/protobuf@0.13.12"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Runtime library for protocol buffers support. Use https://pub.dartlang.org/packages/protoc_plugin\
@@ -916,6 +981,8 @@ packages:
     path: ""
 - id: "Pub:pub_semver:pub_semver:1.4.2"
   purl: "pkg:pub/pub_semver/pub_semver@1.4.2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Versions and version constraints implementing pub's versioning policy.\
@@ -943,6 +1010,8 @@ packages:
     path: ""
 - id: "Pub:shelf:shelf:0.7.5"
   purl: "pkg:pub/shelf/shelf@0.7.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A model for web server middleware that encourages composition and\
@@ -970,6 +1039,8 @@ packages:
     path: ""
 - id: "Pub:shelf_packages_handler:shelf_packages_handler:1.0.4"
   purl: "pkg:pub/shelf_packages_handler/shelf_packages_handler@1.0.4"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A shelf handler for serving a `packages/` directory."
@@ -996,6 +1067,8 @@ packages:
     path: ""
 - id: "Pub:shelf_static:shelf_static:0.2.8"
   purl: "pkg:pub/shelf_static/shelf_static@0.2.8"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Static file server support for Shelf"
@@ -1022,6 +1095,8 @@ packages:
     path: ""
 - id: "Pub:shelf_web_socket:shelf_web_socket:0.2.3"
   purl: "pkg:pub/shelf_web_socket/shelf_web_socket@0.2.3"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A shelf handler that wires up a listener for every connection."
@@ -1048,6 +1123,8 @@ packages:
     path: ""
 - id: "Pub:source_map_stack_trace:source_map_stack_trace:1.1.5"
   purl: "pkg:pub/source_map_stack_trace/source_map_stack_trace@1.1.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A package for applying source maps to stack traces."
@@ -1074,6 +1151,8 @@ packages:
     path: ""
 - id: "Pub:source_maps:source_maps:0.10.8"
   purl: "pkg:pub/source_maps/source_maps@0.10.8"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Library to programmatically manipulate source map files."
@@ -1100,6 +1179,8 @@ packages:
     path: ""
 - id: "Pub:source_span:source_span:1.5.5"
   purl: "pkg:pub/source_span/source_span@1.5.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A library for identifying source spans and locations."
@@ -1126,6 +1207,8 @@ packages:
     path: ""
 - id: "Pub:stack_trace:stack_trace:1.9.3"
   purl: "pkg:pub/stack_trace/stack_trace@1.9.3"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A package for manipulating stack traces and printing them readably."
@@ -1152,6 +1235,8 @@ packages:
     path: ""
 - id: "Pub:stream_channel:stream_channel:2.0.0"
   purl: "pkg:pub/stream_channel/stream_channel@2.0.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "An abstraction for two-way communication channels."
@@ -1178,6 +1263,8 @@ packages:
     path: ""
 - id: "Pub:string_scanner:string_scanner:1.0.4"
   purl: "pkg:pub/string_scanner/string_scanner@1.0.4"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A class for parsing strings using a sequence of patterns."
@@ -1204,6 +1291,8 @@ packages:
     path: ""
 - id: "Pub:term_glyph:term_glyph:1.1.0"
   purl: "pkg:pub/term_glyph/term_glyph@1.1.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Useful Unicode glyphs and ASCII substitutes."
@@ -1230,6 +1319,8 @@ packages:
     path: ""
 - id: "Pub:test:test:1.6.4"
   purl: "pkg:pub/test/test@1.6.4"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A full featured library for writing and running Dart tests."
@@ -1256,6 +1347,8 @@ packages:
     path: "pkgs/test"
 - id: "Pub:test_api:test_api:0.2.6"
   purl: "pkg:pub/test_api/test_api@0.2.6"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A library for writing Dart tests."
@@ -1282,6 +1375,8 @@ packages:
     path: "pkgs/test_api"
 - id: "Pub:test_core:test_core:0.2.6"
   purl: "pkg:pub/test_core/test_core@0.2.6"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A basic library for writing tests and running them on the VM."
@@ -1308,6 +1403,8 @@ packages:
     path: "pkgs/test_core"
 - id: "Pub:typed_data:typed_data:1.1.6"
   purl: "pkg:pub/typed_data/typed_data@1.1.6"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Utility functions and classes related to the 'dart:typed_data' library."
@@ -1334,6 +1431,8 @@ packages:
     path: ""
 - id: "Pub:vm_service_client:vm_service_client:0.2.6+2"
   purl: "pkg:pub/vm_service_client/vm_service_client@0.2.6%2B2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A client for the Dart VM service."
@@ -1360,6 +1459,8 @@ packages:
     path: ""
 - id: "Pub:watcher:watcher:0.9.7+10"
   purl: "pkg:pub/watcher/watcher@0.9.7%2B10"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A file system watcher. It monitors changes to contents of directories\
@@ -1387,6 +1488,8 @@ packages:
     path: ""
 - id: "Pub:web_socket_channel:web_socket_channel:1.0.13"
   purl: "pkg:pub/web_socket_channel/web_socket_channel@1.0.13"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "StreamChannel wrappers for WebSockets. Provides a cross-platform WebSocketChannel\
@@ -1415,6 +1518,8 @@ packages:
     path: ""
 - id: "Pub:yaml:yaml:2.1.16"
   purl: "pkg:pub/yaml/yaml@2.1.16"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A parser for YAML, a human-friendly data serialization standard"

--- a/analyzer/src/funTest/assets/projects/synthetic/pub-expected-output-project-with-flutter.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pub-expected-output-project-with-flutter.yml
@@ -2,6 +2,8 @@
 project:
   id: "Pub:project-with-flutter:project-with-flutter:0.1.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/pub/project-with-flutter/pubspec.yaml"
+  authors:
+  - "Marlon Hille"
   declared_licenses: []
   declared_licenses_processed: {}
   vcs:
@@ -298,6 +300,8 @@ packages:
     path: ""
 - id: "Pub:analyzer:analyzer:0.36.4"
   purl: "pkg:pub/analyzer/analyzer@0.36.4"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Static analyzer for Dart."
@@ -351,6 +355,8 @@ packages:
     path: ""
 - id: "Pub:args:args:1.5.2"
   purl: "pkg:pub/args/args@1.5.2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Library for defining parsers for parsing raw command-line arguments\
@@ -378,6 +384,8 @@ packages:
     path: ""
 - id: "Pub:async:async:2.4.0"
   purl: "pkg:pub/async/async@2.4.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Utility functions and classes related to the 'dart:async' library."
@@ -404,6 +412,8 @@ packages:
     path: ""
 - id: "Pub:boolean_selector:boolean_selector:1.0.5"
   purl: "pkg:pub/boolean_selector/boolean_selector@1.0.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A flexible syntax for boolean expressions, based on a simplified version\
@@ -431,6 +441,8 @@ packages:
     path: ""
 - id: "Pub:charcode:charcode:1.1.2"
   purl: "pkg:pub/charcode/charcode@1.1.2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Constants for ASCII and common non-ASCII character codes. When working\
@@ -460,6 +472,8 @@ packages:
     path: ""
 - id: "Pub:collection:collection:1.14.11"
   purl: "pkg:pub/collection/collection@1.14.11"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Collections and utilities functions and classes related to collections."
@@ -486,6 +500,8 @@ packages:
     path: ""
 - id: "Pub:convert:convert:2.1.1"
   purl: "pkg:pub/convert/convert@2.1.1"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Utilities for converting between data representations."
@@ -538,6 +554,8 @@ packages:
     path: ""
 - id: "Pub:crypto:crypto:2.1.3"
   purl: "pkg:pub/crypto/crypto@2.1.3"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Library of cryptographic functions."
@@ -564,6 +582,8 @@ packages:
     path: ""
 - id: "Pub:csslib:csslib:0.16.0"
   purl: "pkg:pub/csslib/csslib@0.16.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A library for parsing CSS."
@@ -642,6 +662,9 @@ packages:
     path: ""
 - id: "Pub:flutter_crashlytics:flutter_crashlytics:1.0.0"
   purl: "pkg:pub/flutter_crashlytics/flutter_crashlytics@1.0.0"
+  authors:
+  - "jaumard"
+  - "long1eu"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Flutter plugin to enable Crashlytics reporting on Android and iOS,\
@@ -669,6 +692,8 @@ packages:
     path: ""
 - id: "Pub:front_end:front_end:0.1.19"
   purl: "pkg:pub/front_end/front_end@0.1.19"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Front end for compilation of Dart code."
@@ -695,6 +720,8 @@ packages:
     path: "pkg/front_end"
 - id: "Pub:glob:glob:1.1.7"
   purl: "pkg:pub/glob/glob@1.1.7"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Bash-style filename globbing."
@@ -721,6 +748,8 @@ packages:
     path: ""
 - id: "Pub:html:html:0.14.0+2"
   purl: "pkg:pub/html/html@0.14.0%2B2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "APIs for parsing and manipulating HTML content outside the browser."
@@ -747,6 +776,8 @@ packages:
     path: ""
 - id: "Pub:http:http:0.12.0+2"
   purl: "pkg:pub/http/http@0.12.0%2B2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A composable, cross-platform, Future-based API for making HTTP requests."
@@ -773,6 +804,8 @@ packages:
     path: ""
 - id: "Pub:http_multi_server:http_multi_server:2.1.0"
   purl: "pkg:pub/http_multi_server/http_multi_server@2.1.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A dart:io HttpServer wrapper that handles requests from multiple servers."
@@ -799,6 +832,8 @@ packages:
     path: ""
 - id: "Pub:http_parser:http_parser:3.1.3"
   purl: "pkg:pub/http_parser/http_parser@3.1.3"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A platform-independent package for parsing and serializing HTTP formats.\n"
@@ -825,6 +860,8 @@ packages:
     path: ""
 - id: "Pub:image:image:2.1.4"
   purl: "pkg:pub/image/image@2.1.4"
+  authors:
+  - "Brendan Duncan"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Provides server and web apps the ability to load, manipulate, and\
@@ -853,6 +890,8 @@ packages:
     path: ""
 - id: "Pub:io:io:0.3.3"
   purl: "pkg:pub/io/io@0.3.3"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Utilities for the Dart VM Runtime.\n"
@@ -879,6 +918,8 @@ packages:
     path: ""
 - id: "Pub:js:js:0.6.1+1"
   purl: "pkg:pub/js/js@0.6.1%2B1"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Access JavaScript from Dart."
@@ -905,6 +946,8 @@ packages:
     path: "pkg/js"
 - id: "Pub:kernel:kernel:0.3.19"
   purl: "pkg:pub/kernel/kernel@0.3.19"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Dart IR (Intermediate Representation)"
@@ -959,6 +1002,8 @@ packages:
     path: ""
 - id: "Pub:matcher:matcher:0.12.6"
   purl: "pkg:pub/matcher/matcher@0.12.6"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Support for specifying test expectations via an extensible Matcher\
@@ -987,6 +1032,8 @@ packages:
     path: ""
 - id: "Pub:meta:meta:1.1.8"
   purl: "pkg:pub/meta/meta@1.1.8"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "This library contains the definitions of annotations that provide\
@@ -1015,6 +1062,8 @@ packages:
     path: "pkg/meta"
 - id: "Pub:mime:mime:0.9.6+3"
   purl: "pkg:pub/mime/mime@0.9.6%2B3"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Utilities for handling media (MIME) types, including determining a\
@@ -1042,6 +1091,8 @@ packages:
     path: ""
 - id: "Pub:multi_server_socket:multi_server_socket:1.0.2"
   purl: "pkg:pub/multi_server_socket/multi_server_socket@1.0.2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A dart:io ServerSocket wrapper that listens on multiple ports."
@@ -1068,6 +1119,8 @@ packages:
     path: ""
 - id: "Pub:node_preamble:node_preamble:1.4.4"
   purl: "pkg:pub/node_preamble/node_preamble@1.4.4"
+  authors:
+  - "Michael Bullington"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Better node.js preamble for dart2js, use it in your build system."
@@ -1094,6 +1147,8 @@ packages:
     path: ""
 - id: "Pub:package_config:package_config:1.0.5"
   purl: "pkg:pub/package_config/package_config@1.0.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Support for working with Package Resolution config files."
@@ -1120,6 +1175,8 @@ packages:
     path: ""
 - id: "Pub:package_resolver:package_resolver:1.0.10"
   purl: "pkg:pub/package_resolver/package_resolver@1.0.10"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "First-class package resolution strategy classes."
@@ -1146,6 +1203,8 @@ packages:
     path: ""
 - id: "Pub:path:path:1.6.4"
   purl: "pkg:pub/path/path@1.6.4"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A string-based path manipulation library. All of the path operations\
@@ -1174,6 +1233,8 @@ packages:
     path: ""
 - id: "Pub:pedantic:pedantic:1.8.0+1"
   purl: "pkg:pub/pedantic/pedantic@1.8.0%2B1"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "How to get the most value from Dart static analysis."
@@ -1200,6 +1261,8 @@ packages:
     path: ""
 - id: "Pub:petitparser:petitparser:2.4.0"
   purl: "pkg:pub/petitparser/petitparser@2.4.0"
+  authors:
+  - "Lukas Renggli"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A dynamic parser framework to build efficient grammars and parsers\
@@ -1227,6 +1290,8 @@ packages:
     path: ""
 - id: "Pub:pool:pool:1.4.0"
   purl: "pkg:pub/pool/pool@1.4.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Manage a finite pool of resources. Useful for controlling concurrent\
@@ -1254,6 +1319,8 @@ packages:
     path: ""
 - id: "Pub:pub_semver:pub_semver:1.4.2"
   purl: "pkg:pub/pub_semver/pub_semver@1.4.2"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Versions and version constraints implementing pub's versioning policy.\
@@ -1281,6 +1348,23 @@ packages:
     path: ""
 - id: "Pub:quiver:quiver:2.0.5"
   purl: "pkg:pub/quiver/quiver@2.0.5"
+  authors:
+  - "Adam Lofts"
+  - "Alec Henninger"
+  - "Alexandre Ardhuin"
+  - "Chris Bracken"
+  - "David Morgan"
+  - "Günter Zöchbauer"
+  - "John McDole"
+  - "Justin Fagnani"
+  - "Lucy Gettinger"
+  - "Mark Fielbig"
+  - "Matan Lurey"
+  - "Michel Feinstein"
+  - "Sean Eagan"
+  - "Victor Berchet"
+  - "Wil Pirino"
+  - "Yegor Jbanov"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A set of utility libraries for Dart"
@@ -1307,6 +1391,8 @@ packages:
     path: ""
 - id: "Pub:shelf:shelf:0.7.5"
   purl: "pkg:pub/shelf/shelf@0.7.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A model for web server middleware that encourages composition and\
@@ -1334,6 +1420,8 @@ packages:
     path: ""
 - id: "Pub:shelf_packages_handler:shelf_packages_handler:1.0.4"
   purl: "pkg:pub/shelf_packages_handler/shelf_packages_handler@1.0.4"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A shelf handler for serving a `packages/` directory."
@@ -1360,6 +1448,8 @@ packages:
     path: ""
 - id: "Pub:shelf_static:shelf_static:0.2.8"
   purl: "pkg:pub/shelf_static/shelf_static@0.2.8"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Static file server support for Shelf"
@@ -1386,6 +1476,8 @@ packages:
     path: ""
 - id: "Pub:shelf_web_socket:shelf_web_socket:0.2.3"
   purl: "pkg:pub/shelf_web_socket/shelf_web_socket@0.2.3"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A shelf handler that wires up a listener for every connection."
@@ -1412,6 +1504,8 @@ packages:
     path: ""
 - id: "Pub:source_map_stack_trace:source_map_stack_trace:1.1.5"
   purl: "pkg:pub/source_map_stack_trace/source_map_stack_trace@1.1.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A package for applying source maps to stack traces."
@@ -1438,6 +1532,8 @@ packages:
     path: ""
 - id: "Pub:source_maps:source_maps:0.10.8"
   purl: "pkg:pub/source_maps/source_maps@0.10.8"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Library to programmatically manipulate source map files."
@@ -1464,6 +1560,8 @@ packages:
     path: ""
 - id: "Pub:source_span:source_span:1.5.5"
   purl: "pkg:pub/source_span/source_span@1.5.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A library for identifying source spans and locations."
@@ -1490,6 +1588,8 @@ packages:
     path: ""
 - id: "Pub:stack_trace:stack_trace:1.9.3"
   purl: "pkg:pub/stack_trace/stack_trace@1.9.3"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A package for manipulating stack traces and printing them readably."
@@ -1516,6 +1616,8 @@ packages:
     path: ""
 - id: "Pub:stream_channel:stream_channel:2.0.0"
   purl: "pkg:pub/stream_channel/stream_channel@2.0.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "An abstraction for two-way communication channels."
@@ -1542,6 +1644,8 @@ packages:
     path: ""
 - id: "Pub:string_scanner:string_scanner:1.0.5"
   purl: "pkg:pub/string_scanner/string_scanner@1.0.5"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A class for parsing strings using a sequence of patterns."
@@ -1568,6 +1672,8 @@ packages:
     path: ""
 - id: "Pub:term_glyph:term_glyph:1.1.0"
   purl: "pkg:pub/term_glyph/term_glyph@1.1.0"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Useful Unicode glyphs and ASCII substitutes."
@@ -1594,6 +1700,8 @@ packages:
     path: ""
 - id: "Pub:test:test:1.9.4"
   purl: "pkg:pub/test/test@1.9.4"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A full featured library for writing and running Dart tests."
@@ -1620,6 +1728,8 @@ packages:
     path: "pkgs/test"
 - id: "Pub:test_api:test_api:0.2.11"
   purl: "pkg:pub/test_api/test_api@0.2.11"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A library for writing Dart tests."
@@ -1646,6 +1756,8 @@ packages:
     path: "pkgs/test_api"
 - id: "Pub:test_core:test_core:0.2.15"
   purl: "pkg:pub/test_core/test_core@0.2.15"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A basic library for writing tests and running them on the VM."
@@ -1672,6 +1784,8 @@ packages:
     path: "pkgs/test_core"
 - id: "Pub:typed_data:typed_data:1.1.6"
   purl: "pkg:pub/typed_data/typed_data@1.1.6"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Utility functions and classes related to the 'dart:typed_data' library."
@@ -1698,6 +1812,8 @@ packages:
     path: ""
 - id: "Pub:vector_math:vector_math:2.0.8"
   purl: "pkg:pub/vector_math/vector_math@2.0.8"
+  authors:
+  - "John McCutchan"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A Vector Math library for 2D and 3D applications."
@@ -1751,6 +1867,8 @@ packages:
     path: "pkg/vm_service"
 - id: "Pub:watcher:watcher:0.9.7+10"
   purl: "pkg:pub/watcher/watcher@0.9.7%2B10"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A file system watcher. It monitors changes to contents of directories\
@@ -1778,6 +1896,8 @@ packages:
     path: ""
 - id: "Pub:web_socket_channel:web_socket_channel:1.0.13"
   purl: "pkg:pub/web_socket_channel/web_socket_channel@1.0.13"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "StreamChannel wrappers for WebSockets. Provides a cross-platform WebSocketChannel\
@@ -1806,6 +1926,8 @@ packages:
     path: ""
 - id: "Pub:xml:xml:3.5.0"
   purl: "pkg:pub/xml/xml@3.5.0"
+  authors:
+  - "Lukas Renggli"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A lightweight library for parsing, traversing, querying, transforming\
@@ -1833,6 +1955,8 @@ packages:
     path: ""
 - id: "Pub:yaml:yaml:2.1.16"
   purl: "pkg:pub/yaml/yaml@2.1.16"
+  authors:
+  - "Dart Team"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "A parser for YAML, a human-friendly data serialization standard"

--- a/analyzer/src/funTest/assets/projects/synthetic/pub/any-version/pubspec.yaml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pub/any-version/pubspec.yaml
@@ -1,7 +1,10 @@
 name: version_any
 description: A Sample project that is using dependencies without fixed versions
 version: 0.1.0
-author: Marlon Hille <marlon.hille@here.com>
+authors:
+- "Marlon Hille <marlon.hille@here.com>"
+- "Another Author"
+- "<mail.only@test.example>"
 homepage: http://oss-review-toolkit.org/
 repository: https://github.com/oss-review-toolkit/ort.git
 


### PR DESCRIPTION
Extract information about the authors of a package from the
pubspec.yaml definition file and make it available in the metadata of
packages and projects.
