### PR TITLE
SpdxDocumentFile: Add authors

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
@@ -2,6 +2,9 @@
 project:
   id: "SpdxDocumentFile::xyz:0.1.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml"
+  authors:
+  - "Copyright (C) 2020 Example Inc."
+  - "Copyright (C) 2021 Second Example Inc."
   declared_licenses:
   - "Apache-2.0 AND curl AND LicenseRef-Proprietary-ExampleInc"
   declared_licenses_processed:
@@ -25,6 +28,9 @@ project:
 packages:
 - id: "SpdxDocumentFile::curl:7.70.0"
   purl: "pkg:spdxdocumentfile/curl@7.70.0"
+  authors:
+  - "Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many contributors,\
+    \ see the THANKS file."
   declared_licenses:
   - "curl"
   declared_licenses_processed:
@@ -56,6 +62,8 @@ packages:
     path: "analyzer/src/funTest/assets/projects/synthetic/spdx/project/libs/curl"
 - id: "SpdxDocumentFile:OpenSSL Development Team:openssl:1.1.1g"
   purl: "pkg:spdxdocumentfile/OpenSSL%20Development%20Team/openssl@1.1.1g"
+  authors:
+  - "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
   declared_licenses:
   - "Apache-2.0"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
@@ -14,7 +14,8 @@ documentDescribes:
 packages:
 - SPDXID: "SPDXRef-Package-xyz"
   description: "Awesome product created by Example Inc."
-  copyrightText: "Copyright (C) 2020 Example Inc."
+  copyrightText: "Copyright (C) 2020 Example Inc. \
+      Copyright (C) 2021 Second Example Inc."
   downloadLocation: "git+ssh://gitlab.example.com:3389/products/xyz.git@b2c358080011af6a366d2512a25a379fbe7b1f78"
   filesAnalyzed: false
   homepage: "https://example.com/products/xyz"

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -50,6 +50,19 @@ import org.ossreviewtoolkit.utils.withoutPrefix
 private const val DEFAULT_SCOPE_NAME = "default"
 
 /**
+ *
+ */
+private val COPYRIGHT_REGEX = Regex("(?=copyright)", RegexOption.IGNORE_CASE)
+
+/**
+ * Gets a set of copyright statements from the [SpdxPackage.copyrightText] field.
+ * The statements
+ */
+fun SpdxPackage.getAuthorsFromCopyrightText(): SortedSet<String> =
+    COPYRIGHT_REGEX.split(copyrightText).filter { it.isNotEmpty() }
+        .map { it.trimEnd() }.toSortedSet()
+
+/**
  * A "fake" package manager implementation that uses SPDX documents as definition files to declare projects and describe
  * packages. See https://github.com/spdx/spdx-spec/issues/439 for details.
  */
@@ -192,8 +205,7 @@ class SpdxDocumentFile(
             Project(
                 id = projectPackage.toIdentifier(),
                 definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
-                // TODO: Find a way to track authors.
-                authors = sortedSetOf(),
+                authors = projectPackage.getAuthorsFromCopyrightText(),
                 declaredLicenses = sortedSetOf(projectPackage.licenseDeclared),
                 vcs = VcsInfo.EMPTY,
                 vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY, projectPackage.homepage),
@@ -218,8 +230,7 @@ class SpdxDocumentFile(
 
             Package(
                 id = pkg.toIdentifier(),
-                // TODO: Find a way to track authors.
-                authors = sortedSetOf(),
+                authors = pkg.getAuthorsFromCopyrightText(),
                 declaredLicenses = sortedSetOf(pkg.licenseDeclared),
                 concludedLicense = getConcludedLicense(pkg),
                 description = packageDescription,


### PR DESCRIPTION
Using the field "copyrightText" authors where added to the package
and project information. Since the SPDX guideline don't specifically
state how to separate individual copyrights (e.g. through newline)
splitting by the regex look-ahead with "Copyright (C)" was chosen.
