### PR TITLE
SpdxDocumentFile: Add originator to example files

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
@@ -21,7 +21,7 @@ project:
   - name: "default"
     dependencies:
     - id: "SpdxDocumentFile::curl:7.70.0"
-    - id: "SpdxDocumentFile::openssl:1.1.1g"
+    - id: "SpdxDocumentFile:OpenSSL Development Team:openssl:1.1.1g"
 packages:
 - id: "SpdxDocumentFile::curl:7.70.0"
   purl: "pkg:spdxdocumentfile/curl@7.70.0"
@@ -54,8 +54,8 @@ packages:
     url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/spdx/project/libs/curl"
-- id: "SpdxDocumentFile::openssl:1.1.1g"
-  purl: "pkg:spdxdocumentfile/openssl@1.1.1g"
+- id: "SpdxDocumentFile:OpenSSL Development Team:openssl:1.1.1g"
+  purl: "pkg:spdxdocumentfile/OpenSSL%20Development%20Team/openssl@1.1.1g"
   declared_licenses:
   - "Apache-2.0"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
@@ -22,6 +22,7 @@ packages:
   licenseDeclared: "Apache-2.0 AND curl AND LicenseRef-Proprietary-ExampleInc"
   name: "xyz"
   versionInfo: "0.1.0"
+  originator: "Person: Thomas Steenbergen"
 - SPDXID: "SPDXRef-Package-curl"
   description: "A command line tool and library for transferring data with URL syntax, supporting \
      HTTP, HTTPS, FTP, FTPS, GOPHER, TFTP, SCP, SFTP, SMB, TELNET, DICT, LDAP, LDAPS, MQTT, FILE, \
@@ -36,6 +37,7 @@ packages:
   name: "curl"
   packageFileName: "./libs/curl"
   versionInfo: "7.70.0"
+  originator: "Person: Daniel Stenberg (daniel@haxx.se)"
 - SPDXID: "SPDXRef-Package-openssl"
   description: "OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit for the Transport Layer Security (TLS) protocol formerly known as the Secure Sockets Layer (SSL) protocol. The protocol implementation is based on a full-strength general purpose cryptographic library, which can also be used stand-alone."
   copyrightText: "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
@@ -47,6 +49,7 @@ packages:
   packageFileName: "./libs/openssl"
   name: "openssl"
   versionInfo: "1.1.1g"
+  originator: "Organization: OpenSSL Development Team"
 relationships:
 - spdxElementId: "SPDXRef-Package-xyz"
   relatedSpdxElement: "SPDXRef-Package-curl"


### PR DESCRIPTION
This helps to have a higher coverage of tested code and ensures
that changes in the future aren't accidentally breaking anything.
