### PR TITLE
pull-request-template: Replace relative link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,1 @@
-Please ensure that your pull request adheres to our [contribution guidelines](../CONTRIBUTING.md). Thank you!
+Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/ort/blob/master/CONTRIBUTING.md). Thank you!


### PR DESCRIPTION
The relative link [1] is resolved to 'Not Found' page
as GitHub requires branch to be specified.

[1] https://github.com/oss-review-toolkit/ort/CONTRIBUTING.md

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>

