### PR TITLE
Pip: Normalize package name

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -18,18 +18,49 @@ project:
   scopes:
   - name: "install"
     dependencies:
-    - id: "PyPI::Flask:0.12"
+    - id: "PyPI::flask:0.12"
       dependencies:
-      - id: "PyPI::Jinja2:2.8.1"
-        dependencies:
-        - id: "PyPI::MarkupSafe:1.1.1"
-      - id: "PyPI::Werkzeug:1.0.1"
       - id: "PyPI::click:7.1.2"
       - id: "PyPI::itsdangerous:1.1.0"
+      - id: "PyPI::jinja2:2.8.1"
+        dependencies:
+        - id: "PyPI::markupsafe:1.1.1"
+      - id: "PyPI::werkzeug:1.0.1"
     - id: "PyPI::gunicorn:19.6.0"
 packages:
-- id: "PyPI::Flask:0.12"
-  purl: "pkg:pypi/Flask@0.12"
+- id: "PyPI::click:7.1.2"
+  purl: "pkg:pypi/click@7.1.2"
+  declared_licenses:
+  - "BSD License"
+  - "BSD-3-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD License: "BSD-3-Clause"
+  description: "Composable command line interface toolkit"
+  homepage_url: "https://palletsprojects.com/p/click/"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/d2/3d/fa76db83bf75c4f8d338c2fd15c8d33fdd7ad23a9b5e57eb6c5de26b430e/click-7.1.2-py2.py3-none-any.whl"
+    hash:
+      value: "b4233221cacc473acd422a1d54ff4c41"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/27/6f/be940c8b1f1d69daceeb0032fee6c34d7bd70e3e649ccac0951500b4720e/click-7.1.2.tar.gz"
+    hash:
+      value: "53692f62cb99a1a10c59248f1776d9c0"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "PyPI::flask:0.12"
+  purl: "pkg:pypi/flask@0.12"
   authors:
   - "Armin Ronacher"
   declared_licenses:
@@ -60,138 +91,6 @@ packages:
   vcs_processed:
     type: "Git"
     url: "https://github.com/pallets/flask.git"
-    revision: ""
-    path: ""
-- id: "PyPI::Jinja2:2.8.1"
-  purl: "pkg:pypi/Jinja2@2.8.1"
-  authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD"
-  - "BSD License"
-  declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "A small but fast and easy to use stand-alone template engine written\
-    \ in pure python."
-  homepage_url: "http://jinja.pocoo.org/"
-  binary_artifact:
-    url: "https://files.pythonhosted.org/packages/67/ea/92b1d9d8f2dc43302df7f5271b9500bbfc237386782343561a5f62beb306/Jinja2-2.8.1-py2.py3-none-any.whl"
-    hash:
-      value: "7472b9df828747c2d44eb539558bbf7a"
-      algorithm: "MD5"
-  source_artifact:
-    url: "https://files.pythonhosted.org/packages/5f/bd/5815d4d925a2b8cbbb4b4960f018441b0c65f24ba29f3bdcfb3c8218a307/Jinja2-2.8.1.tar.gz"
-    hash:
-      value: "150a8f1c180272753cf46dd3cdd6decf"
-      algorithm: "MD5"
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-- id: "PyPI::MarkupSafe:1.1.1"
-  purl: "pkg:pypi/MarkupSafe@1.1.1"
-  authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD License"
-  - "BSD-3-Clause"
-  declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "Safely add untrusted strings to HTML/XML markup."
-  homepage_url: "https://palletsprojects.com/p/markupsafe/"
-  binary_artifact:
-    url: "https://files.pythonhosted.org/packages/6d/d2/0ccd2c0e2cd93b35e765d9b3205cd6602e6b202b522fc7997531353715b3/MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl"
-    hash:
-      value: "c937b3654640ee5864f2917bf24a7ad2"
-      algorithm: "MD5"
-  source_artifact:
-    url: "https://files.pythonhosted.org/packages/b9/2e/64db92e53b86efccfaea71321f597fa2e1b2bd3853d8ce658568f7a13094/MarkupSafe-1.1.1.tar.gz"
-    hash:
-      value: "43fd756864fe42063068e092e220c57b"
-      algorithm: "MD5"
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-- id: "PyPI::Werkzeug:1.0.1"
-  purl: "pkg:pypi/Werkzeug@1.0.1"
-  authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD License"
-  - "BSD-3-Clause"
-  declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "The comprehensive WSGI web application library."
-  homepage_url: "https://palletsprojects.com/p/werkzeug/"
-  binary_artifact:
-    url: "https://files.pythonhosted.org/packages/cc/94/5f7079a0e00bd6863ef8f1da638721e9da21e5bacee597595b318f71d62e/Werkzeug-1.0.1-py2.py3-none-any.whl"
-    hash:
-      value: "ceaf2433ef66e2d7a3fbe43a4e44e4ca"
-      algorithm: "MD5"
-  source_artifact:
-    url: "https://files.pythonhosted.org/packages/10/27/a33329150147594eff0ea4c33c2036c0eadd933141055be0ff911f7f8d04/Werkzeug-1.0.1.tar.gz"
-    hash:
-      value: "5d499cfdd30de5d9c946994783772efd"
-      algorithm: "MD5"
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-- id: "PyPI::click:7.1.2"
-  purl: "pkg:pypi/click@7.1.2"
-  declared_licenses:
-  - "BSD License"
-  - "BSD-3-Clause"
-  declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "Composable command line interface toolkit"
-  homepage_url: "https://palletsprojects.com/p/click/"
-  binary_artifact:
-    url: "https://files.pythonhosted.org/packages/d2/3d/fa76db83bf75c4f8d338c2fd15c8d33fdd7ad23a9b5e57eb6c5de26b430e/click-7.1.2-py2.py3-none-any.whl"
-    hash:
-      value: "b4233221cacc473acd422a1d54ff4c41"
-      algorithm: "MD5"
-  source_artifact:
-    url: "https://files.pythonhosted.org/packages/27/6f/be940c8b1f1d69daceeb0032fee6c34d7bd70e3e649ccac0951500b4720e/click-7.1.2.tar.gz"
-    hash:
-      value: "53692f62cb99a1a10c59248f1776d9c0"
-      algorithm: "MD5"
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: ""
-    url: ""
     revision: ""
     path: ""
 - id: "PyPI::gunicorn:19.6.0"
@@ -250,6 +149,107 @@ packages:
     url: "https://files.pythonhosted.org/packages/68/1a/f27de07a8a304ad5fa817bbe383d1238ac4396da447fa11ed937039fa04b/itsdangerous-1.1.0.tar.gz"
     hash:
       value: "9b7f5afa7f1e3acfb7786eeca3d99307"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "PyPI::jinja2:2.8.1"
+  purl: "pkg:pypi/jinja2@2.8.1"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD"
+  - "BSD License"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD: "BSD-3-Clause"
+      BSD License: "BSD-3-Clause"
+  description: "A small but fast and easy to use stand-alone template engine written\
+    \ in pure python."
+  homepage_url: "http://jinja.pocoo.org/"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/67/ea/92b1d9d8f2dc43302df7f5271b9500bbfc237386782343561a5f62beb306/Jinja2-2.8.1-py2.py3-none-any.whl"
+    hash:
+      value: "7472b9df828747c2d44eb539558bbf7a"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/5f/bd/5815d4d925a2b8cbbb4b4960f018441b0c65f24ba29f3bdcfb3c8218a307/Jinja2-2.8.1.tar.gz"
+    hash:
+      value: "150a8f1c180272753cf46dd3cdd6decf"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "PyPI::markupsafe:1.1.1"
+  purl: "pkg:pypi/markupsafe@1.1.1"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD License"
+  - "BSD-3-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD License: "BSD-3-Clause"
+  description: "Safely add untrusted strings to HTML/XML markup."
+  homepage_url: "https://palletsprojects.com/p/markupsafe/"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/6d/d2/0ccd2c0e2cd93b35e765d9b3205cd6602e6b202b522fc7997531353715b3/MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl"
+    hash:
+      value: "c937b3654640ee5864f2917bf24a7ad2"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/b9/2e/64db92e53b86efccfaea71321f597fa2e1b2bd3853d8ce658568f7a13094/MarkupSafe-1.1.1.tar.gz"
+    hash:
+      value: "43fd756864fe42063068e092e220c57b"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "PyPI::werkzeug:1.0.1"
+  purl: "pkg:pypi/werkzeug@1.0.1"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD License"
+  - "BSD-3-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD License: "BSD-3-Clause"
+  description: "The comprehensive WSGI web application library."
+  homepage_url: "https://palletsprojects.com/p/werkzeug/"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/cc/94/5f7079a0e00bd6863ef8f1da638721e9da21e5bacee597595b318f71d62e/Werkzeug-1.0.1-py2.py3-none-any.whl"
+    hash:
+      value: "ceaf2433ef66e2d7a3fbe43a4e44e4ca"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/10/27/a33329150147594eff0ea4c33c2036c0eadd933141055be0ff911f7f8d04/Werkzeug-1.0.1.tar.gz"
+    hash:
+      value: "5d499cfdd30de5d9c946994783772efd"
       algorithm: "MD5"
   vcs:
     type: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -22,151 +22,15 @@ project:
   scopes:
   - name: "install"
     dependencies:
-    - id: "PyPI::Flask:1.0"
+    - id: "PyPI::flask:1.0"
       dependencies:
-      - id: "PyPI::Jinja2:2.10.1"
-        dependencies:
-        - id: "PyPI::MarkupSafe:1.0"
-      - id: "PyPI::Werkzeug:0.15.3"
       - id: "PyPI::click:6.7"
       - id: "PyPI::itsdangerous:0.24"
+      - id: "PyPI::jinja2:2.10.1"
+        dependencies:
+        - id: "PyPI::markupsafe:1.0"
+      - id: "PyPI::werkzeug:0.15.3"
 packages:
-- id: "PyPI::Flask:1.0"
-  purl: "pkg:pypi/Flask@1.0"
-  authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD"
-  - "BSD License"
-  declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "A simple framework for building complex web applications."
-  homepage_url: "https://www.palletsprojects.com/p/flask/"
-  binary_artifact:
-    url: "https://files.pythonhosted.org/packages/55/b1/4365193655df97227ace49311365cc296e74b60c7f5c63d23cd30175e2f6/Flask-1.0-py2.py3-none-any.whl"
-    hash:
-      value: "4c0757a5a489d4db8260c6d722c5e6b0"
-      algorithm: "MD5"
-  source_artifact:
-    url: "https://files.pythonhosted.org/packages/99/ab/eedb921f26adf7057ade1291f9c1bfa35a506d64894f58546457ef658772/Flask-1.0.tar.gz"
-    hash:
-      value: "7140df3116386c7af0f389800a91817b"
-      algorithm: "MD5"
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-- id: "PyPI::Jinja2:2.10.1"
-  purl: "pkg:pypi/Jinja2@2.10.1"
-  authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD"
-  - "BSD License"
-  declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "A small but fast and easy to use stand-alone template engine written\
-    \ in pure python."
-  homepage_url: "http://jinja.pocoo.org/"
-  binary_artifact:
-    url: "https://files.pythonhosted.org/packages/1d/e7/fd8b501e7a6dfe492a433deb7b9d833d39ca74916fa8bc63dd1a4947a671/Jinja2-2.10.1-py2.py3-none-any.whl"
-    hash:
-      value: "93ca8152bf9ca03214158a49d542402f"
-      algorithm: "MD5"
-  source_artifact:
-    url: "https://files.pythonhosted.org/packages/93/ea/d884a06f8c7f9b7afbc8138b762e80479fb17aedbbe2b06515a12de9378d/Jinja2-2.10.1.tar.gz"
-    hash:
-      value: "0ae535be40fd215a8114a090c8b68e5a"
-      algorithm: "MD5"
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-- id: "PyPI::MarkupSafe:1.0"
-  purl: "pkg:pypi/MarkupSafe@1.0"
-  authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD"
-  - "BSD License"
-  declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "Implements a XML/HTML/XHTML Markup safe string for Python"
-  homepage_url: "http://github.com/pallets/markupsafe"
-  binary_artifact:
-    url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
-    hash:
-      value: "2fcedc9284d50e577b5192e8e3578355"
-      algorithm: "MD5"
-  source_artifact:
-    url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
-    hash:
-      value: "2fcedc9284d50e577b5192e8e3578355"
-      algorithm: "MD5"
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/pallets/markupsafe.git"
-    revision: ""
-    path: ""
-- id: "PyPI::Werkzeug:0.15.3"
-  purl: "pkg:pypi/Werkzeug@0.15.3"
-  authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD License"
-  - "BSD-3-Clause"
-  declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "The comprehensive WSGI web application library."
-  homepage_url: "https://palletsprojects.com/p/werkzeug/"
-  binary_artifact:
-    url: "https://files.pythonhosted.org/packages/3d/bf/79101bd1d6a2b3fe0888e8d6e039800b173f26b7388308fc4bcc45de8d0a/Werkzeug-0.15.3-py2.py3-none-any.whl"
-    hash:
-      value: "5e1e9fb526428fbafe0eccadc2015a5c"
-      algorithm: "MD5"
-  source_artifact:
-    url: "https://files.pythonhosted.org/packages/9c/6d/854f2aa124dcfeb901815492b7fa7f026d114a18784c1c679fbdea36c809/Werkzeug-0.15.3.tar.gz"
-    hash:
-      value: "2da857b57e7e4c5b6403369a9d1c15a9"
-      algorithm: "MD5"
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
 - id: "PyPI::click:6.7"
   purl: "pkg:pypi/click@6.7"
   authors:
@@ -197,6 +61,40 @@ packages:
   vcs_processed:
     type: "Git"
     url: "https://github.com/mitsuhiko/click.git"
+    revision: ""
+    path: ""
+- id: "PyPI::flask:1.0"
+  purl: "pkg:pypi/flask@1.0"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD"
+  - "BSD License"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD: "BSD-3-Clause"
+      BSD License: "BSD-3-Clause"
+  description: "A simple framework for building complex web applications."
+  homepage_url: "https://www.palletsprojects.com/p/flask/"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/55/b1/4365193655df97227ace49311365cc296e74b60c7f5c63d23cd30175e2f6/Flask-1.0-py2.py3-none-any.whl"
+    hash:
+      value: "4c0757a5a489d4db8260c6d722c5e6b0"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/99/ab/eedb921f26adf7057ade1291f9c1bfa35a506d64894f58546457ef658772/Flask-1.0.tar.gz"
+    hash:
+      value: "7140df3116386c7af0f389800a91817b"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
     revision: ""
     path: ""
 - id: "PyPI::itsdangerous:0.24"
@@ -230,5 +128,107 @@ packages:
   vcs_processed:
     type: "Git"
     url: "https://github.com/mitsuhiko/itsdangerous.git"
+    revision: ""
+    path: ""
+- id: "PyPI::jinja2:2.10.1"
+  purl: "pkg:pypi/jinja2@2.10.1"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD"
+  - "BSD License"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD: "BSD-3-Clause"
+      BSD License: "BSD-3-Clause"
+  description: "A small but fast and easy to use stand-alone template engine written\
+    \ in pure python."
+  homepage_url: "http://jinja.pocoo.org/"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/1d/e7/fd8b501e7a6dfe492a433deb7b9d833d39ca74916fa8bc63dd1a4947a671/Jinja2-2.10.1-py2.py3-none-any.whl"
+    hash:
+      value: "93ca8152bf9ca03214158a49d542402f"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/93/ea/d884a06f8c7f9b7afbc8138b762e80479fb17aedbbe2b06515a12de9378d/Jinja2-2.10.1.tar.gz"
+    hash:
+      value: "0ae535be40fd215a8114a090c8b68e5a"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "PyPI::markupsafe:1.0"
+  purl: "pkg:pypi/markupsafe@1.0"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD"
+  - "BSD License"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD: "BSD-3-Clause"
+      BSD License: "BSD-3-Clause"
+  description: "Implements a XML/HTML/XHTML Markup safe string for Python"
+  homepage_url: "http://github.com/pallets/markupsafe"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
+    hash:
+      value: "2fcedc9284d50e577b5192e8e3578355"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
+    hash:
+      value: "2fcedc9284d50e577b5192e8e3578355"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/pallets/markupsafe.git"
+    revision: ""
+    path: ""
+- id: "PyPI::werkzeug:0.15.3"
+  purl: "pkg:pypi/werkzeug@0.15.3"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD License"
+  - "BSD-3-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD License: "BSD-3-Clause"
+  description: "The comprehensive WSGI web application library."
+  homepage_url: "https://palletsprojects.com/p/werkzeug/"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/3d/bf/79101bd1d6a2b3fe0888e8d6e039800b173f26b7388308fc4bcc45de8d0a/Werkzeug-0.15.3-py2.py3-none-any.whl"
+    hash:
+      value: "5e1e9fb526428fbafe0eccadc2015a5c"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/9c/6d/854f2aa124dcfeb901815492b7fa7f026d114a18784c1c679fbdea36c809/Werkzeug-0.15.3.tar.gz"
+    hash:
+      value: "2da857b57e7e4c5b6403369a9d1c15a9"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
     revision: ""
     path: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-python3-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-python3-expected-output.yml
@@ -18,13 +18,13 @@ project:
   scopes:
   - name: "install"
     dependencies:
-    - id: "PyPI::Django:2.2.13"
+    - id: "PyPI::django:2.2.13"
       dependencies:
       - id: "PyPI::pytz:2021.1"
       - id: "PyPI::sqlparse:0.4.1"
 packages:
-- id: "PyPI::Django:2.2.13"
-  purl: "pkg:pypi/Django@2.2.13"
+- id: "PyPI::django:2.2.13"
+  purl: "pkg:pypi/django@2.2.13"
   authors:
   - "Django Software Foundation"
   declared_licenses:

--- a/analyzer/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
@@ -18,151 +18,15 @@ project:
   scopes:
   - name: "install"
     dependencies:
-    - id: "PyPI::Flask:1.0"
+    - id: "PyPI::flask:1.0"
       dependencies:
-      - id: "PyPI::Jinja2:2.10.1"
-        dependencies:
-        - id: "PyPI::MarkupSafe:1.0"
-      - id: "PyPI::Werkzeug:0.15.3"
       - id: "PyPI::click:6.7"
       - id: "PyPI::itsdangerous:0.24"
+      - id: "PyPI::jinja2:2.10.1"
+        dependencies:
+        - id: "PyPI::markupsafe:1.0"
+      - id: "PyPI::werkzeug:0.15.3"
 packages:
-- id: "PyPI::Flask:1.0"
-  purl: "pkg:pypi/Flask@1.0"
-  authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD"
-  - "BSD License"
-  declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "A simple framework for building complex web applications."
-  homepage_url: "https://www.palletsprojects.com/p/flask/"
-  binary_artifact:
-    url: "https://files.pythonhosted.org/packages/55/b1/4365193655df97227ace49311365cc296e74b60c7f5c63d23cd30175e2f6/Flask-1.0-py2.py3-none-any.whl"
-    hash:
-      value: "4c0757a5a489d4db8260c6d722c5e6b0"
-      algorithm: "MD5"
-  source_artifact:
-    url: "https://files.pythonhosted.org/packages/99/ab/eedb921f26adf7057ade1291f9c1bfa35a506d64894f58546457ef658772/Flask-1.0.tar.gz"
-    hash:
-      value: "7140df3116386c7af0f389800a91817b"
-      algorithm: "MD5"
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-- id: "PyPI::Jinja2:2.10.1"
-  purl: "pkg:pypi/Jinja2@2.10.1"
-  authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD"
-  - "BSD License"
-  declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "A small but fast and easy to use stand-alone template engine written\
-    \ in pure python."
-  homepage_url: "http://jinja.pocoo.org/"
-  binary_artifact:
-    url: "https://files.pythonhosted.org/packages/1d/e7/fd8b501e7a6dfe492a433deb7b9d833d39ca74916fa8bc63dd1a4947a671/Jinja2-2.10.1-py2.py3-none-any.whl"
-    hash:
-      value: "93ca8152bf9ca03214158a49d542402f"
-      algorithm: "MD5"
-  source_artifact:
-    url: "https://files.pythonhosted.org/packages/93/ea/d884a06f8c7f9b7afbc8138b762e80479fb17aedbbe2b06515a12de9378d/Jinja2-2.10.1.tar.gz"
-    hash:
-      value: "0ae535be40fd215a8114a090c8b68e5a"
-      algorithm: "MD5"
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-- id: "PyPI::MarkupSafe:1.0"
-  purl: "pkg:pypi/MarkupSafe@1.0"
-  authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD"
-  - "BSD License"
-  declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "Implements a XML/HTML/XHTML Markup safe string for Python"
-  homepage_url: "http://github.com/pallets/markupsafe"
-  binary_artifact:
-    url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
-    hash:
-      value: "2fcedc9284d50e577b5192e8e3578355"
-      algorithm: "MD5"
-  source_artifact:
-    url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
-    hash:
-      value: "2fcedc9284d50e577b5192e8e3578355"
-      algorithm: "MD5"
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/pallets/markupsafe.git"
-    revision: ""
-    path: ""
-- id: "PyPI::Werkzeug:0.15.3"
-  purl: "pkg:pypi/Werkzeug@0.15.3"
-  authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD License"
-  - "BSD-3-Clause"
-  declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "The comprehensive WSGI web application library."
-  homepage_url: "https://palletsprojects.com/p/werkzeug/"
-  binary_artifact:
-    url: "https://files.pythonhosted.org/packages/3d/bf/79101bd1d6a2b3fe0888e8d6e039800b173f26b7388308fc4bcc45de8d0a/Werkzeug-0.15.3-py2.py3-none-any.whl"
-    hash:
-      value: "5e1e9fb526428fbafe0eccadc2015a5c"
-      algorithm: "MD5"
-  source_artifact:
-    url: "https://files.pythonhosted.org/packages/9c/6d/854f2aa124dcfeb901815492b7fa7f026d114a18784c1c679fbdea36c809/Werkzeug-0.15.3.tar.gz"
-    hash:
-      value: "2da857b57e7e4c5b6403369a9d1c15a9"
-      algorithm: "MD5"
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
 - id: "PyPI::click:6.7"
   purl: "pkg:pypi/click@6.7"
   authors:
@@ -193,6 +57,40 @@ packages:
   vcs_processed:
     type: "Git"
     url: "https://github.com/mitsuhiko/click.git"
+    revision: ""
+    path: ""
+- id: "PyPI::flask:1.0"
+  purl: "pkg:pypi/flask@1.0"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD"
+  - "BSD License"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD: "BSD-3-Clause"
+      BSD License: "BSD-3-Clause"
+  description: "A simple framework for building complex web applications."
+  homepage_url: "https://www.palletsprojects.com/p/flask/"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/55/b1/4365193655df97227ace49311365cc296e74b60c7f5c63d23cd30175e2f6/Flask-1.0-py2.py3-none-any.whl"
+    hash:
+      value: "4c0757a5a489d4db8260c6d722c5e6b0"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/99/ab/eedb921f26adf7057ade1291f9c1bfa35a506d64894f58546457ef658772/Flask-1.0.tar.gz"
+    hash:
+      value: "7140df3116386c7af0f389800a91817b"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
     revision: ""
     path: ""
 - id: "PyPI::itsdangerous:0.24"
@@ -226,5 +124,107 @@ packages:
   vcs_processed:
     type: "Git"
     url: "https://github.com/mitsuhiko/itsdangerous.git"
+    revision: ""
+    path: ""
+- id: "PyPI::jinja2:2.10.1"
+  purl: "pkg:pypi/jinja2@2.10.1"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD"
+  - "BSD License"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD: "BSD-3-Clause"
+      BSD License: "BSD-3-Clause"
+  description: "A small but fast and easy to use stand-alone template engine written\
+    \ in pure python."
+  homepage_url: "http://jinja.pocoo.org/"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/1d/e7/fd8b501e7a6dfe492a433deb7b9d833d39ca74916fa8bc63dd1a4947a671/Jinja2-2.10.1-py2.py3-none-any.whl"
+    hash:
+      value: "93ca8152bf9ca03214158a49d542402f"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/93/ea/d884a06f8c7f9b7afbc8138b762e80479fb17aedbbe2b06515a12de9378d/Jinja2-2.10.1.tar.gz"
+    hash:
+      value: "0ae535be40fd215a8114a090c8b68e5a"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "PyPI::markupsafe:1.0"
+  purl: "pkg:pypi/markupsafe@1.0"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD"
+  - "BSD License"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD: "BSD-3-Clause"
+      BSD License: "BSD-3-Clause"
+  description: "Implements a XML/HTML/XHTML Markup safe string for Python"
+  homepage_url: "http://github.com/pallets/markupsafe"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
+    hash:
+      value: "2fcedc9284d50e577b5192e8e3578355"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
+    hash:
+      value: "2fcedc9284d50e577b5192e8e3578355"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/pallets/markupsafe.git"
+    revision: ""
+    path: ""
+- id: "PyPI::werkzeug:0.15.3"
+  purl: "pkg:pypi/werkzeug@0.15.3"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD License"
+  - "BSD-3-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD License: "BSD-3-Clause"
+  description: "The comprehensive WSGI web application library."
+  homepage_url: "https://palletsprojects.com/p/werkzeug/"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/3d/bf/79101bd1d6a2b3fe0888e8d6e039800b173f26b7388308fc4bcc45de8d0a/Werkzeug-0.15.3-py2.py3-none-any.whl"
+    hash:
+      value: "5e1e9fb526428fbafe0eccadc2015a5c"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/9c/6d/854f2aa124dcfeb901815492b7fa7f026d114a18784c1c679fbdea36c809/Werkzeug-0.15.3.tar.gz"
+    hash:
+      value: "2da857b57e7e4c5b6403369a9d1c15a9"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
     revision: ""
     path: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/pipenv-python3-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pipenv-python3-expected-output.yml
@@ -18,12 +18,12 @@ project:
   scopes:
   - name: "install"
     dependencies:
-    - id: "PyPI::Django:2.1.11"
+    - id: "PyPI::django:2.1.11"
       dependencies:
       - id: "PyPI::pytz:2019.3"
 packages:
-- id: "PyPI::Django:2.1.11"
-  purl: "pkg:pypi/Django@2.1.11"
+- id: "PyPI::django:2.1.11"
+  purl: "pkg:pypi/django@2.1.11"
   authors:
   - "Django Software Foundation"
   declared_licenses:

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -567,7 +567,7 @@ class Pip(
                 id = Identifier(
                     type = "PyPI",
                     namespace = "",
-                    name = dependency["package_name"].textValue(),
+                    name = dependency["package_name"].textValue().normalizePackageName(),
                     version = dependency["installed_version"].textValue()
                 ),
                 authors = sortedSetOf(),
@@ -721,7 +721,7 @@ class Pip(
             id = Identifier(
                 type = "PyPI",
                 namespace = "",
-                name = map.getValue("Name").single(),
+                name = map.getValue("Name").single().normalizePackageName(),
                 version = map.getValue("Version").single()
             ),
             description = map["Summary"]?.single().orEmpty(),
@@ -751,3 +751,18 @@ private fun Package.enrichWith(other: Package?): Package =
     } else {
         this
     }
+
+/**
+ * Normalize all PyPI package names to be lowercase and hyphenated as per PEP 426 and 503:
+ *
+ * PEP 426 (https://www.python.org/dev/peps/pep-0426/#name):
+ * "All comparisons of distribution names MUST be case insensitive,
+ * and MUST consider hyphens and underscores to be equivalent".
+ *
+ * PEP 503 (https://www.python.org/dev/peps/pep-0503/#normalized-names):
+ * "This PEP references the concept of a "normalized" project name.
+ * As per PEP 426 the only valid characters in a name are the ASCII alphabet,
+ * ASCII numbers, ., -, and _. The name should be lowercased with all runs
+ * of the characters ., -, or _ replaced with a single - character."
+ */
+private fun String.normalizePackageName(): String = replace(Regex("[-_.]+"), "-").toLowerCase()

--- a/examples/curations.yml
+++ b/examples/curations.yml
@@ -55,7 +55,7 @@
     comment: "The package is a Maven BOM file and thus is metadata only."
     is_meta_data_only: true
 
-- id: "PyPI::pyramid_workflow:1.0.0"
+- id: "PyPI::pyramid-workflow:1.0.0"
   curations:
     comment: "The package has an unmappable declared license entry."
     declared_license_mapping:


### PR DESCRIPTION
In Python package names are case-insensitive, and uses of hyphens and underscores are considered to be equivalent.
This may lead to cases where the same dependency appears twice in ORT scan results with different cased ids.

For example, this happens if say in transitive dependency on https://pypi.org/project/Flask has been declared as either
[Flask][1] or [flask][2].

[1]: https://github.com/corydolphin/flask-cors/blob/3.0.10/requirements.txt
[2]: https://github.com/rycus86/prometheus_flask_exporter/blob/0.18.1/requirements.txt

**This PR is a breaking change for all ORT users analyzing Python projects**

After this PR is merged Python packages may get a different package id assigned by ORT in the scan results. If you have Python packages defined in your [curations.yml](https://github.com/oss-review-toolkit/ort/blob/master/docs/config-file-curations-yml.md) or [package configuration](https://github.com/oss-review-toolkit/ort/blob/master/docs/config-file-package-configuration-yml.md) then you will need to update all Python package ids to be lowercase and replace any `.` or `_` with a `-`.