### PR TITLE
Pip: Add support for declared authors

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -30,6 +30,8 @@ project:
 packages:
 - id: "PyPI::Flask:0.12"
   purl: "pkg:pypi/Flask@0.12"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD"
   - "BSD License"
@@ -62,6 +64,8 @@ packages:
     path: ""
 - id: "PyPI::Jinja2:2.8.1"
   purl: "pkg:pypi/Jinja2@2.8.1"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD"
   - "BSD License"
@@ -95,6 +99,8 @@ packages:
     path: ""
 - id: "PyPI::MarkupSafe:1.1.1"
   purl: "pkg:pypi/MarkupSafe@1.1.1"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD License"
   - "BSD-3-Clause"
@@ -126,6 +132,8 @@ packages:
     path: ""
 - id: "PyPI::Werkzeug:1.0.1"
   purl: "pkg:pypi/Werkzeug@1.0.1"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD License"
   - "BSD-3-Clause"
@@ -188,6 +196,8 @@ packages:
     path: ""
 - id: "PyPI::gunicorn:19.6.0"
   purl: "pkg:pypi/gunicorn@19.6.0"
+  authors:
+  - "Benoit Chesneau"
   declared_licenses:
   - "MIT"
   - "MIT License"
@@ -219,6 +229,8 @@ packages:
     path: ""
 - id: "PyPI::itsdangerous:1.1.0"
   purl: "pkg:pypi/itsdangerous@1.1.0"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD"
   - "BSD License"

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -2,6 +2,8 @@
 project:
   id: "PIP::spdx-tools:0.5.4"
   definition_file_path: "setup.py"
+  authors:
+  - "Ahmed H. Ismail"
   declared_licenses:
   - "Apache Software License"
   - "Apache-2.0"
@@ -35,6 +37,8 @@ project:
 packages:
 - id: "PyPI::isodate:0.6.0"
   purl: "pkg:pypi/isodate@0.6.0"
+  authors:
+  - "Gerhard Weis"
   declared_licenses:
   - "BSD"
   - "BSD License"
@@ -67,6 +71,8 @@ packages:
     path: ""
 - id: "PyPI::ply:3.11"
   purl: "pkg:pypi/ply@3.11"
+  authors:
+  - "David Beazley"
   declared_licenses:
   - "BSD"
   declared_licenses_processed:
@@ -97,6 +103,8 @@ packages:
     path: ""
 - id: "PyPI::pyparsing:2.4.7"
   purl: "pkg:pypi/pyparsing@2.4.7"
+  authors:
+  - "Paul McGuire"
   declared_licenses:
   - "MIT License"
   declared_licenses_processed:
@@ -127,6 +135,8 @@ packages:
     path: ""
 - id: "PyPI::rdflib:5.0.0"
   purl: "pkg:pypi/rdflib@5.0.0"
+  authors:
+  - "Daniel 'eikeon' Krech"
   declared_licenses:
   - "BSD License"
   - "BSD-3-Clause"
@@ -159,6 +169,8 @@ packages:
     path: ""
 - id: "PyPI::six:1.15.0"
   purl: "pkg:pypi/six@1.15.0"
+  authors:
+  - "Benjamin Peterson"
   declared_licenses:
   - "MIT"
   - "MIT License"

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -33,6 +33,8 @@ project:
 packages:
 - id: "PyPI::Flask:1.0"
   purl: "pkg:pypi/Flask@1.0"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD"
   - "BSD License"
@@ -65,6 +67,8 @@ packages:
     path: ""
 - id: "PyPI::Jinja2:2.10.1"
   purl: "pkg:pypi/Jinja2@2.10.1"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD"
   - "BSD License"
@@ -98,6 +102,8 @@ packages:
     path: ""
 - id: "PyPI::MarkupSafe:1.0"
   purl: "pkg:pypi/MarkupSafe@1.0"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD"
   - "BSD License"
@@ -130,6 +136,8 @@ packages:
     path: ""
 - id: "PyPI::Werkzeug:0.15.3"
   purl: "pkg:pypi/Werkzeug@0.15.3"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD License"
   - "BSD-3-Clause"
@@ -161,6 +169,8 @@ packages:
     path: ""
 - id: "PyPI::click:6.7"
   purl: "pkg:pypi/click@6.7"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD License"
   declared_licenses_processed:
@@ -191,6 +201,8 @@ packages:
     path: ""
 - id: "PyPI::itsdangerous:0.24"
   purl: "pkg:pypi/itsdangerous@0.24"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD License"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-python3-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-python3-expected-output.yml
@@ -25,6 +25,8 @@ project:
 packages:
 - id: "PyPI::Django:2.2.13"
   purl: "pkg:pypi/Django@2.2.13"
+  authors:
+  - "Django Software Foundation"
   declared_licenses:
   - "BSD"
   - "BSD License"
@@ -58,6 +60,8 @@ packages:
     path: ""
 - id: "PyPI::pytz:2021.1"
   purl: "pkg:pypi/pytz@2021.1"
+  authors:
+  - "Stuart Bishop"
   declared_licenses:
   - "MIT"
   - "MIT License"
@@ -89,6 +93,8 @@ packages:
     path: ""
 - id: "PyPI::sqlparse:0.4.1"
   purl: "pkg:pypi/sqlparse@0.4.1"
+  authors:
+  - "Andi Albrecht"
   declared_licenses:
   - "BSD License"
   - "BSD-3-Clause"

--- a/analyzer/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
@@ -29,6 +29,8 @@ project:
 packages:
 - id: "PyPI::Flask:1.0"
   purl: "pkg:pypi/Flask@1.0"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD"
   - "BSD License"
@@ -61,6 +63,8 @@ packages:
     path: ""
 - id: "PyPI::Jinja2:2.10.1"
   purl: "pkg:pypi/Jinja2@2.10.1"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD"
   - "BSD License"
@@ -94,6 +98,8 @@ packages:
     path: ""
 - id: "PyPI::MarkupSafe:1.0"
   purl: "pkg:pypi/MarkupSafe@1.0"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD"
   - "BSD License"
@@ -126,6 +132,8 @@ packages:
     path: ""
 - id: "PyPI::Werkzeug:0.15.3"
   purl: "pkg:pypi/Werkzeug@0.15.3"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD License"
   - "BSD-3-Clause"
@@ -157,6 +165,8 @@ packages:
     path: ""
 - id: "PyPI::click:6.7"
   purl: "pkg:pypi/click@6.7"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD License"
   declared_licenses_processed:
@@ -187,6 +197,8 @@ packages:
     path: ""
 - id: "PyPI::itsdangerous:0.24"
   purl: "pkg:pypi/itsdangerous@0.24"
+  authors:
+  - "Armin Ronacher"
   declared_licenses:
   - "BSD License"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/pipenv-python3-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pipenv-python3-expected-output.yml
@@ -24,6 +24,8 @@ project:
 packages:
 - id: "PyPI::Django:2.1.11"
   purl: "pkg:pypi/Django@2.1.11"
+  authors:
+  - "Django Software Foundation"
   declared_licenses:
   - "BSD"
   - "BSD License"
@@ -57,6 +59,8 @@ packages:
     path: ""
 - id: "PyPI::pytz:2019.3"
   purl: "pkg:pypi/pytz@2019.3"
+  authors:
+  - "Stuart Bishop"
   declared_licenses:
   - "MIT"
   - "MIT License"

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -260,7 +260,7 @@ class Pip(
         }
         pip.requireSuccess()
 
-        var declaredLicenses: SortedSet<String> = sortedSetOf<String>()
+        var declaredLicenses: SortedSet<String> = sortedSetOf()
 
         // First try to get meta-data from "setup.py" in any case, even for "requirements.txt" projects.
         val (setupName, setupVersion, setupHomepage) = if (workingDir.resolve("setup.py").isFile) {


### PR DESCRIPTION
Extract information about the author of a package from its setup.py
file or from the PyPi metadata, and make it available in the metadata
of packages and projects.
