### PR TITLE
Add disclaimer in AsciidocTemplate disclosure document, if there are unresolved issues.

### DIFF
--- a/examples/asciidoctor-pdf-theme.yml
+++ b/examples/asciidoctor-pdf-theme.yml
@@ -28,3 +28,6 @@ footer:
 code:
   background-color: transparent
   border-color: transparent
+role:
+  alert:
+    font-color: #ff0000

--- a/reporter/src/main/resources/templates/asciidoc/disclosure_document.ftl
+++ b/reporter/src/main/resources/templates/asciidoc/disclosure_document.ftl
@@ -31,7 +31,14 @@ Excluded projects and packages are ignored.
 :sectnums:
 :toc: preamble
 
-= Disclosure Document
+[#assign errorTitle = "DISCLAIMER! THERE ARE UNRESOLVED ISSUES.
+    THIS DOCUMENT SHOULD NOT BE DISTRIBUTED UNTIL THESE ISSUES ARE RESOLVED."?replace("\n", " ")]
+
+[#--
+The alert role needs to be defined in the pdf-theme file, where the color can be customized.
+If not present, the text is displayed normally.
+--]
+= [#if helper.hasUnresolvedIssues()][.alert]#${errorTitle}#[#else] Disclosure Document[/#if]
 :author-name: OSS Review Toolkit
 [#assign now = .now]
 :revdate: ${now?date?iso_local}

--- a/reporter/src/test/kotlin/utils/FreeMarkerTemplateProcessorTest.kt
+++ b/reporter/src/test/kotlin/utils/FreeMarkerTemplateProcessorTest.kt
@@ -50,6 +50,7 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.licenses.LicenseClassifications
 import org.ossreviewtoolkit.model.licenses.ResolvedLicense
+import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.Environment
@@ -207,8 +208,11 @@ class FreeMarkerTemplateProcessorTest : WordSpec({
                 )
             )
 
-            val result = FreemarkerTemplateProcessor.TemplateHelper(OrtResult.EMPTY, LicenseClassifications())
-                .mergeResolvedLicenses(resolvedLicenses)
+            val result = FreemarkerTemplateProcessor.TemplateHelper(
+                OrtResult.EMPTY,
+                LicenseClassifications(),
+                DefaultResolutionProvider()
+            ).mergeResolvedLicenses(resolvedLicenses)
 
             with(result[0]) {
                 originalExpressions[LicenseSource.DECLARED] shouldBe setOf(


### PR DESCRIPTION
In practice you probably do not want to use a disclosure document if there are unresolved issues in the reporter input.
To emphasize this, a check for unresolved issues is added that, if it is successful, adds a disclaimer to the disclosure document.
