### PR TITLE
azure-pipelines: Do not quote variables as part of cache keys

### DIFF
--- a/.azure-pipelines/LinuxAnalyzerTest.yml
+++ b/.azure-pipelines/LinuxAnalyzerTest.yml
@@ -67,17 +67,17 @@ jobs:
   # Gradle build cache, see: https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | analyzer-test | gradle-caches | v2 | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
+      key: '$(Agent.OS) | analyzer-test | gradle-caches | v2 | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
       restoreKeys: |
-        "$(Agent.OS)" | analyzer-test | gradle-caches | v2
+        $(Agent.OS) | analyzer-test | gradle-caches | v2
       path: $(GRADLE_USER_HOME)/caches
     displayName: Cache Gradle Caches
 
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | gradle-wrapper | gradle/wrapper/gradle-wrapper.properties'
+      key: '$(Agent.OS) | gradle-wrapper | gradle/wrapper/gradle-wrapper.properties'
       restoreKeys: |
-        "$(Agent.OS)" | gradle-wrapper
+        $(Agent.OS) | gradle-wrapper
       path: $(GRADLE_USER_HOME)/wrapper/dists
     displayName: Cache Gradle Wrapper
 
@@ -94,9 +94,9 @@ jobs:
   # instead to make sure the cache is updated once a day.
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | analyzer-test | ort-data | "$(DAY_OF_YEAR)"'
+      key: '$(Agent.OS) | analyzer-test | ort-data | $(DAY_OF_YEAR)'
       restoreKeys: |
-        "$(Agent.OS)" | analyzer-test | ort-data
+        $(Agent.OS) | analyzer-test | ort-data
       path: $(ORT_DATA_DIR)
     displayName: Cache ORT Data Dir
 

--- a/.azure-pipelines/LinuxTest.yml
+++ b/.azure-pipelines/LinuxTest.yml
@@ -36,17 +36,17 @@ jobs:
   # Gradle build cache, see: https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | test | gradle-caches | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
+      key: '$(Agent.OS) | test | gradle-caches | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
       restoreKeys: |
-        "$(Agent.OS)" | test | gradle-caches
+        $(Agent.OS) | test | gradle-caches
       path: $(GRADLE_USER_HOME)/caches
     displayName: Cache Gradle Caches
 
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | gradle-wrapper | gradle/wrapper/gradle-wrapper.properties'
+      key: '$(Agent.OS) | gradle-wrapper | gradle/wrapper/gradle-wrapper.properties'
       restoreKeys: |
-        "$(Agent.OS)" | gradle-wrapper
+        $(Agent.OS) | gradle-wrapper
       path: $(GRADLE_USER_HOME)/wrapper/dists
     displayName: Cache Gradle Wrapper
 
@@ -63,9 +63,9 @@ jobs:
   # instead to make sure the cache is updated once a day.
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | test | ort-data | "$(DAY_OF_YEAR)"'
+      key: '$(Agent.OS) | test | ort-data | $(DAY_OF_YEAR)'
       restoreKeys: |
-        "$(Agent.OS)" | test | ort-data
+        $(Agent.OS) | test | ort-data
       path: $(ORT_DATA_DIR)
     displayName: Cache ORT Data Dir
 

--- a/.azure-pipelines/StaticAnalysis.yml
+++ b/.azure-pipelines/StaticAnalysis.yml
@@ -9,17 +9,17 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | detekt | gradle-caches | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
+      key: '$(Agent.OS) | detekt | gradle-caches | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
       restoreKeys: |
-        "$(Agent.OS)" | detekt | gradle-caches
+        $(Agent.OS) | detekt | gradle-caches
       path: $(GRADLE_USER_HOME)/caches
     displayName: Cache Gradle Caches
 
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | gradle-wrapper | gradle/wrapper/gradle-wrapper.properties'
+      key: '$(Agent.OS) | gradle-wrapper | gradle/wrapper/gradle-wrapper.properties'
       restoreKeys: |
-        "$(Agent.OS)" | gradle-wrapper
+        $(Agent.OS) | gradle-wrapper
       path: $(GRADLE_USER_HOME)/wrapper/dists
     displayName: Cache Gradle Wrapper
 

--- a/.azure-pipelines/WindowsAnalyzerTest.yml
+++ b/.azure-pipelines/WindowsAnalyzerTest.yml
@@ -63,17 +63,17 @@ jobs:
   # Gradle build cache, see: https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | analyzer-test | gradle-caches | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
+      key: '$(Agent.OS) | analyzer-test | gradle-caches | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
       restoreKeys: |
-        "$(Agent.OS)" | analyzer-test | gradle-caches
+        $(Agent.OS) | analyzer-test | gradle-caches
       path: $(GRADLE_USER_HOME)/caches
     displayName: Cache Gradle Caches
 
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | gradle-wrapper | gradle/wrapper/gradle-wrapper.properties'
+      key: '$(Agent.OS) | gradle-wrapper | gradle/wrapper/gradle-wrapper.properties'
       restoreKeys: |
-        "$(Agent.OS)" | gradle-wrapper
+        $(Agent.OS) | gradle-wrapper
       path: $(GRADLE_USER_HOME)/wrapper/dists
     displayName: Cache Gradle Wrapper
 
@@ -90,9 +90,9 @@ jobs:
   # instead to make sure the cache is updated once a day.
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | analyzer-test | ort-data | "$(DAY_OF_YEAR)"'
+      key: '$(Agent.OS) | analyzer-test | ort-data | $(DAY_OF_YEAR)'
       restoreKeys: |
-        "$(Agent.OS)" | analyzer-test | ort-data
+        $(Agent.OS) | analyzer-test | ort-data
       path: $(ORT_DATA_DIR)
     displayName: Cache ORT Data Dir
 

--- a/.azure-pipelines/WindowsTest.yml
+++ b/.azure-pipelines/WindowsTest.yml
@@ -26,17 +26,17 @@ jobs:
   # Gradle build cache, see: https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | test | gradle-caches | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
+      key: '$(Agent.OS) | test | gradle-caches | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
       restoreKeys: |
-        "$(Agent.OS)" | test | gradle-caches
+        $(Agent.OS) | test | gradle-caches
       path: $(GRADLE_USER_HOME)/caches
     displayName: Cache Gradle Caches
 
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | gradle-wrapper | gradle/wrapper/gradle-wrapper.properties'
+      key: '$(Agent.OS) | gradle-wrapper | gradle/wrapper/gradle-wrapper.properties'
       restoreKeys: |
-        "$(Agent.OS)" | gradle-wrapper
+        $(Agent.OS) | gradle-wrapper
       path: $(GRADLE_USER_HOME)/wrapper/dists
     displayName: Cache Gradle Wrapper
 
@@ -53,9 +53,9 @@ jobs:
   # instead to make sure the cache is updated once a day.
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | test | ort-data | "$(DAY_OF_YEAR)"'
+      key: '$(Agent.OS) | test | ort-data | $(DAY_OF_YEAR)'
       restoreKeys: |
-        "$(Agent.OS)" | test | ort-data
+        $(Agent.OS) | test | ort-data
       path: $(ORT_DATA_DIR)
     displayName: Cache ORT Data Dir
 


### PR DESCRIPTION
The double-quotes literally become part of the key, see e.g. [1]. While
it does no harm, it is unnecessary and does not look so nice, so just
remove the quotes.

[1] https://dev.azure.com/oss-review-toolkit/ort/_build/results?buildId=3196&view=logs&j=013fdcb2-895b-5fd8-9f51-43834fcdfa43&t=d02a6001-8912-5fa6-3820-05daa7b31d3e&l=42

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>