### PR TITLE
Cargo: Add support for declared authors

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/cargo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/cargo-expected-output.yml
@@ -2,6 +2,9 @@
 project:
   id: "Cargo::lib:0.1.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
+  authors:
+  - "Another Author"
+  - "anon"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -125,6 +128,8 @@ project:
 packages:
 - id: "Crate::autocfg:0.1.6"
   purl: "pkg:cargo/autocfg@0.1.6"
+  authors:
+  - "Josh Stone"
   declared_licenses:
   - "Apache-2.0 OR MIT"
   declared_licenses_processed:
@@ -153,6 +158,8 @@ packages:
     path: ""
 - id: "Crate::bitflags:1.1.0"
   purl: "pkg:cargo/bitflags@1.1.0"
+  authors:
+  - "The Rust Project Developers"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -181,6 +188,8 @@ packages:
     path: ""
 - id: "Crate::cfg-if:0.1.9"
   purl: "pkg:cargo/cfg-if@0.1.9"
+  authors:
+  - "Alex Crichton"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -211,6 +220,8 @@ packages:
     path: ""
 - id: "Crate::cloudabi:0.0.3"
   purl: "pkg:cargo/cloudabi@0.0.3"
+  authors:
+  - "Nuxi (https://nuxi.nl/) and contributors"
   declared_licenses:
   - "BSD-2-Clause"
   declared_licenses_processed:
@@ -240,6 +251,8 @@ packages:
     path: ""
 - id: "Crate::fuchsia-cprng:0.1.1"
   purl: "pkg:cargo/fuchsia-cprng@0.1.1"
+  authors:
+  - "Erick Tryzelaar"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "Rust crate for the Fuchsia cryptographically secure pseudorandom number\
@@ -267,6 +280,8 @@ packages:
     path: ""
 - id: "Crate::libc:0.2.62"
   purl: "pkg:cargo/libc@0.2.62"
+  authors:
+  - "The Rust Project Developers"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -295,6 +310,9 @@ packages:
     path: ""
 - id: "Crate::rand:0.6.5"
   purl: "pkg:cargo/rand@0.6.5"
+  authors:
+  - "The Rand Project Developers"
+  - "The Rust Project Developers"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -323,6 +341,9 @@ packages:
     path: ""
 - id: "Crate::rand_chacha:0.1.1"
   purl: "pkg:cargo/rand_chacha@0.1.1"
+  authors:
+  - "The Rand Project Developers"
+  - "The Rust Project Developers"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -351,6 +372,9 @@ packages:
     path: ""
 - id: "Crate::rand_core:0.3.1"
   purl: "pkg:cargo/rand_core@0.3.1"
+  authors:
+  - "The Rand Project Developers"
+  - "The Rust Project Developers"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -379,6 +403,9 @@ packages:
     path: ""
 - id: "Crate::rand_core:0.4.2"
   purl: "pkg:cargo/rand_core@0.4.2"
+  authors:
+  - "The Rand Project Developers"
+  - "The Rust Project Developers"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -407,6 +434,8 @@ packages:
     path: ""
 - id: "Crate::rand_hc:0.1.0"
   purl: "pkg:cargo/rand_hc@0.1.0"
+  authors:
+  - "The Rand Project Developers"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -435,6 +464,9 @@ packages:
     path: ""
 - id: "Crate::rand_isaac:0.1.1"
   purl: "pkg:cargo/rand_isaac@0.1.1"
+  authors:
+  - "The Rand Project Developers"
+  - "The Rust Project Developers"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -463,6 +495,8 @@ packages:
     path: ""
 - id: "Crate::rand_jitter:0.1.4"
   purl: "pkg:cargo/rand_jitter@0.1.4"
+  authors:
+  - "The Rand Project Developers"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -491,6 +525,8 @@ packages:
     path: ""
 - id: "Crate::rand_os:0.1.3"
   purl: "pkg:cargo/rand_os@0.1.3"
+  authors:
+  - "The Rand Project Developers"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -519,6 +555,8 @@ packages:
     path: ""
 - id: "Crate::rand_pcg:0.1.2"
   purl: "pkg:cargo/rand_pcg@0.1.2"
+  authors:
+  - "The Rand Project Developers"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -547,6 +585,9 @@ packages:
     path: ""
 - id: "Crate::rand_xorshift:0.1.1"
   purl: "pkg:cargo/rand_xorshift@0.1.1"
+  authors:
+  - "The Rand Project Developers"
+  - "The Rust Project Developers"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -575,6 +616,8 @@ packages:
     path: ""
 - id: "Crate::rdrand:0.4.0"
   purl: "pkg:cargo/rdrand@0.4.0"
+  authors:
+  - "Simonas Kazlauskas"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -604,6 +647,9 @@ packages:
     path: ""
 - id: "Crate::spin:0.5.0"
   purl: "pkg:cargo/spin@0.5.0"
+  authors:
+  - "John Ericson"
+  - "Mathijs van de Nes"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -633,6 +679,8 @@ packages:
     path: ""
 - id: "Crate::winapi-i686-pc-windows-gnu:0.4.0"
   purl: "pkg:cargo/winapi-i686-pc-windows-gnu@0.4.0"
+  authors:
+  - "Peter Atashian"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -662,6 +710,8 @@ packages:
     path: ""
 - id: "Crate::winapi-x86_64-pc-windows-gnu:0.4.0"
   purl: "pkg:cargo/winapi-x86_64-pc-windows-gnu@0.4.0"
+  authors:
+  - "Peter Atashian"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -691,6 +741,8 @@ packages:
     path: ""
 - id: "Crate::winapi:0.3.8"
   purl: "pkg:cargo/winapi@0.3.8"
+  authors:
+  - "Peter Atashian"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate-client-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate-client-expected-output.yml
@@ -2,6 +2,8 @@
 project:
   id: "Cargo::client:0.1.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
+  authors:
+  - "anon"
   declared_licenses: []
   declared_licenses_processed: {}
   vcs:
@@ -26,6 +28,8 @@ project:
 packages:
 - id: "Crate::cfg-if:0.1.9"
   purl: "pkg:cargo/cfg-if@0.1.9"
+  authors:
+  - "Alex Crichton"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate-integration-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate-integration-expected-output.yml
@@ -2,6 +2,8 @@
 project:
   id: "Cargo::integration:0.1.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
+  authors:
+  - "anon"
   declared_licenses: []
   declared_licenses_processed: {}
   vcs:
@@ -23,6 +25,9 @@ project:
 packages:
 - id: "Crate::spin:0.4.10"
   purl: "pkg:cargo/spin@0.4.10"
+  authors:
+  - "John Ericson"
+  - "Mathijs van de Nes"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate-lib-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate-lib-expected-output.yml
@@ -34,6 +34,8 @@ project:
 packages:
 - id: "Crate::cfg-if:0.1.9"
   purl: "pkg:cargo/cfg-if@0.1.9"
+  authors:
+  - "Alex Crichton"
   declared_licenses:
   - "MIT OR Apache-2.0"
   declared_licenses_processed:
@@ -64,6 +66,9 @@ packages:
     path: ""
 - id: "Crate::spin:0.4.10"
   purl: "pkg:cargo/spin@0.4.10"
+  authors:
+  - "John Ericson"
+  - "Mathijs van de Nes"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -93,6 +98,9 @@ packages:
     path: ""
 - id: "Crate::spin:0.5.0"
   purl: "pkg:cargo/spin@0.5.0"
+  authors:
+  - "John Ericson"
+  - "Mathijs van de Nes"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate/Cargo.toml
+++ b/analyzer/src/funTest/assets/projects/synthetic/cargo-subcrate/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "lib"
 version = "0.1.0"
-authors = ["anon <anon@example.org>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://example.org"

--- a/analyzer/src/funTest/assets/projects/synthetic/cargo/Cargo.toml
+++ b/analyzer/src/funTest/assets/projects/synthetic/cargo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lib"
 version = "0.1.0"
-authors = ["anon <anon@example.org>"]
+authors = ["anon <anon@example.org>", "Another Author", "<mail.only@example.org>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
 homepage = "https://example.org"

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -282,3 +282,13 @@ abstract class PackageManager(
         }
     }
 }
+
+/**
+ * Parse a string with metadata about an [author] to extract the author name. Many package managers support
+ * such author information in string form that contain additional properties like an email address or a
+ * homepage. These additional properties are typically separated from the author name by specific [delimiters],
+ * e.g. the email address is often surrounded by angle brackets. This function assumes that the author name is the
+ * first portion in the given [author] string before one of the given [delimiters] is found.
+ */
+fun parseAuthorString(author: String?, vararg delimiters: Char = charArrayOf('<')): String? =
+    author?.split(*delimiters, limit = 2)?.firstOrNull()?.trim()?.ifEmpty { null }

--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -28,6 +28,7 @@ import java.util.SortedSet
 
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
+import org.ossreviewtoolkit.analyzer.parseAuthorString
 import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Hash
@@ -117,8 +118,7 @@ class Cargo(
     private fun extractPackage(node: JsonNode, hashes: Map<String, String>) =
         Package(
             id = extractPackageId(node),
-            // TODO: Find a way to track authors.
-            authors = sortedSetOf(),
+            authors = parseAuthors(node["authors"]),
             declaredLicenses = extractDeclaredLicenses(node),
             description = node["description"].textValueOrEmpty(),
             binaryArtifact = RemoteArtifact.EMPTY,
@@ -231,6 +231,12 @@ class Cargo(
         return null
     }
 
+    /**
+     * Extract information about authors from the given [node] with package metadata.
+     */
+    private fun parseAuthors(node: JsonNode?): SortedSet<String> =
+        node?.mapNotNullTo(sortedSetOf()) { parseAuthorString(it.textValue()) } ?: sortedSetOf()
+
     override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         // Get the project name and version. If one of them is missing return null, because this is a workspace
         // definition file that does not contain a project.
@@ -283,11 +289,13 @@ class Cargo(
         }.let { it.copy(id = it.id.copy(type = managerName)) }
 
         val homepageUrl = pkgDefinition.getString("package.homepage").orEmpty()
+        val authors = pkgDefinition.getList("package.authors", emptyList<String>())
+            .mapNotNullTo(sortedSetOf(), ::parseAuthorString)
+
         val project = Project(
             id = projectPkg.id,
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
-            // TODO: Find a way to track authors.
-            authors = sortedSetOf(),
+            authors = authors,
             declaredLicenses = projectPkg.declaredLicenses,
             vcs = projectPkg.vcs,
             vcsProcessed = processProjectVcs(workingDir, projectPkg.vcs, homepageUrl),

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -40,6 +40,7 @@ import org.ossreviewtoolkit.analyzer.managers.utils.hasNpmLockFile
 import org.ossreviewtoolkit.analyzer.managers.utils.mapDefinitionFilesForNpm
 import org.ossreviewtoolkit.analyzer.managers.utils.readProxySettingsFromNpmRc
 import org.ossreviewtoolkit.analyzer.managers.utils.readRegistryFromNpmRc
+import org.ossreviewtoolkit.analyzer.parseAuthorString
 import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Hash
@@ -204,19 +205,10 @@ open class Npm(
             json["author"]?.let { authorNode ->
                 when {
                     authorNode.isObject -> authorNode["name"]?.textValue()
-                    authorNode.isTextual -> parseAuthorString(authorNode.textValue())
+                    authorNode.isTextual -> parseAuthorString(authorNode.textValue(), '<', '(')
                     else -> null
                 }
             }?.let { add(it) }
-        }
-
-    /**
-     * Parse the author if it is defined as a single string in the format "Name <mail> (url)". Try to extract the name
-     * part from the string or return the full string if no mail or url components are found.
-     */
-    private fun parseAuthorString(authorStr: String?): String? =
-        authorStr?.let { str ->
-            str.substringBefore('<').substringBefore('(').trim().ifEmpty { null }
         }
 
     private fun parseInstalledModules(rootDirectory: File): Map<String, Package> {

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -30,6 +30,7 @@ import java.util.SortedSet
 
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
+import org.ossreviewtoolkit.analyzer.parseAuthorString
 import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Identifier
@@ -527,11 +528,5 @@ class Pub(
  */
 private fun parseAuthors(pubspec: JsonNode): SortedSet<String> =
     (listOfNotNull(pubspec["author"]) + pubspec["authors"]?.toList().orEmpty()).mapNotNullTo(sortedSetOf()) {
-        extractAuthorName(it.textValue())
+        parseAuthorString(it.textValue())
     }
-
-/**
- * Extract the author name from an author string of the form "name <email>".
- */
-private fun extractAuthorName(authorStr: String?): String? =
-    authorStr?.substringBefore('<')?.trim()?.ifEmpty { null }


### PR DESCRIPTION
Extract information about the authors of a package from the Cargo.toml
definition file or from the metadata returned by cargo.