### PR TITLE
Gradle: Deal with missing support for authors field

### DIFF
--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -240,7 +240,6 @@ class Gradle(
                         version = dependencyTreeModel.version
                     ),
                     definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
-                    // TODO: Find a way to track authors.
                     authors = sortedSetOf(),
                     declaredLicenses = sortedSetOf(),
                     vcs = VcsInfo.EMPTY,


### PR DESCRIPTION
As is true for declared licenses, there is no support for authors in
gradle projects. Therefore, remove the TODO comment and just pass an
empty set for the authors field.

Signed-off-by: Onur Demirci <onur.demirci@bosch.io>