### PR TITLE
Bower: Add support for authors

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/bower-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bower-expected-output.yml
@@ -2,6 +2,9 @@
 project:
   id: "Bower::a-test-project:"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
+  authors:
+  - "author-abc"
+  - "author-xyz"
   declared_licenses:
   - "Apache-2.0"
   declared_licenses_processed:
@@ -58,6 +61,8 @@ packages:
     path: ""
 - id: "Bower::polymer:2.4.0"
   purl: "pkg:bower/polymer@2.4.0"
+  authors:
+  - "The Polymer Authors"
   declared_licenses:
   - "http://polymer.github.io/LICENSE.txt"
   declared_licenses_processed:
@@ -114,6 +119,8 @@ packages:
     path: ""
 - id: "Bower::webcomponentsjs:1.3.3"
   purl: "pkg:bower/webcomponentsjs@1.3.3"
+  authors:
+  - "The Polymer Authors"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/bower/bower.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/bower/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "a-test-project",
   "authors": [
+    "author-abc",
     "author-xyz"
   ],
   "description": "This string describes the test project.",

--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -29,6 +29,7 @@ import java.util.Stack
 
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
+import org.ossreviewtoolkit.analyzer.parseAuthorString
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
@@ -52,6 +53,7 @@ import org.ossreviewtoolkit.utils.textValueOrEmpty
 /**
  * The [Bower](https://bower.io/) package manager for JavaScript.
  */
+@Suppress("TooManyFunctions")
 class Bower(
     name: String,
     analysisRoot: File,
@@ -96,11 +98,26 @@ class Bower(
                 }
             }
 
+        /**
+         * Parse information about the author. According to https://github.com/bower/spec/blob/master/json.md#authors,
+         * there are two formats to specify the authors of a package (similar to NPM). The difference is that the
+         * strings or objects are inside an array.
+         */
+        private fun parseAuthors(node: JsonNode): SortedSet<String> =
+            sortedSetOf<String>().apply {
+                node["pkgMeta"]["authors"]?.mapNotNull { authorNode ->
+                    when {
+                        authorNode.isObject -> authorNode["name"]?.textValue()
+                        authorNode.isTextual -> parseAuthorString(authorNode.textValue(), '<', '(')
+                        else -> null
+                    }
+                }?.let { addAll(it) }
+            }
+
         private fun extractPackage(node: JsonNode) =
             Package(
                 id = extractPackageId(node),
-                // TODO: Find a way to track authors.
-                authors = sortedSetOf(),
+                authors = parseAuthors(node),
                 declaredLicenses = extractDeclaredLicenses(node),
                 description = node["pkgMeta"]["description"].textValueOrEmpty(),
                 homepageUrl = node["pkgMeta"]["homepage"].textValueOrEmpty(),
@@ -235,8 +252,7 @@ class Bower(
             val project = Project(
                 id = projectPackage.id,
                 definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
-                // TODO: Find a way to track authors.
-                authors = sortedSetOf(),
+                authors = projectPackage.authors,
                 declaredLicenses = projectPackage.declaredLicenses,
                 vcs = projectPackage.vcs,
                 vcsProcessed = processProjectVcs(workingDir, projectPackage.vcs, projectPackage.homepageUrl),


### PR DESCRIPTION
Extract information about the authors of a package from the bower.json
definition file and make it available in the metadata of packages and
project.

Signed-off-by: Onur Demirci <onur.demirci@bosch.io>
