### PR TITLE
Conan: Add support for declared authors

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-py.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-py.yml
@@ -2,6 +2,8 @@
 project:
   id: "Conan::Poco:1.9.3"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/conan-py/conanfile.py"
+  authors:
+  - "The Author"
   declared_licenses:
   - "The Boost Software License 1.0"
   declared_licenses_processed:
@@ -30,6 +32,8 @@ project:
 packages:
 - id: "Conan::OpenSSL:1.0.2o"
   purl: "pkg:conan/OpenSSL@1.0.2o"
+  authors:
+  - "Conan Community"
   declared_licenses:
   - "OpenSSL"
   declared_licenses_processed:
@@ -59,6 +63,8 @@ packages:
     path: ""
 - id: "Conan::zlib:1.2.11"
   purl: "pkg:conan/zlib@1.2.11"
+  authors:
+  - "Conan Community"
   declared_licenses:
   - "Zlib"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-txt.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-txt.yml
@@ -26,6 +26,8 @@ project:
 packages:
 - id: "Conan::protobuf:3.6.1"
   purl: "pkg:conan/protobuf@3.6.1"
+  authors:
+  - "Bincrafters"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -54,6 +56,8 @@ packages:
     path: ""
 - id: "Conan::protoc_installer:3.6.1"
   purl: "pkg:conan/protoc_installer@3.6.1"
+  authors:
+  - "Bincrafters"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/conan-py/conanfile.py
+++ b/analyzer/src/funTest/assets/projects/synthetic/conan-py/conanfile.py
@@ -12,6 +12,7 @@ class PocoConan(ConanFile):
     exports_sources = "CMakeLists.txt", "PocoMacros.cmake"  # REMOVE POCOMACROS IN NEXT VERSION!
     generators = "cmake", "txt"
     settings = "os", "arch", "compiler", "build_type"
+    author = "The Author <author@example.org>"
     license = "The Boost Software License 1.0"
     description = "Modern, powerful open source C++ class libraries for building network- and internet-based " \
                   "applications that run on desktop, server, mobile and embedded systems."


### PR DESCRIPTION
Extract information about the author of a package from the metadata
returned by an invocation of the "conan info" command.
