### PR TITLE
NuGetSupport: Add support for declared authors

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output-with-nuspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output-with-nuspec.yml
@@ -1,9 +1,15 @@
 ---
 project:
-  id: "DotNet::src/funTest/assets/projects/synthetic/dotnet/subProjectTest/test.csproj:"
-  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/dotnet/subProjectTest/test.csproj"
-  declared_licenses: []
-  declared_licenses_processed: {}
+  id: "DotNet::src/funTest/assets/projects/synthetic/dotnet/subProjectTestWithNuspec/test.csproj:"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/dotnet/subProjectTestWithNuspec/test.csproj"
+  authors:
+  - "Author1"
+  - "Author2"
+  - "Author3"
+  declared_licenses:
+  - "BSD-2-Clause OR MIT"
+  declared_licenses_processed:
+    spdx_expression: "BSD-2-Clause OR MIT"
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
@@ -26,6 +26,8 @@ project:
 packages:
 - id: "NuGet::Antlr:3.4.1.9004"
   purl: "pkg:nuget/Antlr@3.4.1.9004"
+  authors:
+  - "Terence Parr"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "ANother Tool for Language Recognition, is a language tool that provides\
@@ -54,6 +56,8 @@ packages:
     path: ""
 - id: "NuGet::Newtonsoft.Json:5.0.4"
   purl: "pkg:nuget/Newtonsoft.Json@5.0.4"
+  authors:
+  - "James Newton-King"
   declared_licenses:
   - "http://json.codeplex.com/license"
   declared_licenses_processed:
@@ -84,6 +88,8 @@ packages:
     path: ""
 - id: "NuGet::WebGrease:1.5.2"
   purl: "pkg:nuget/WebGrease@1.5.2"
+  authors:
+  - "webgrease@microsoft.com"
   declared_licenses:
   - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
   declared_licenses_processed:
@@ -114,6 +120,8 @@ packages:
     path: ""
 - id: "NuGet::jQuery:3.3.1"
   purl: "pkg:nuget/jQuery@3.3.1"
+  authors:
+  - "jQuery Foundation, Inc."
   declared_licenses:
   - "http://jquery.org/license"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet/subProjectTestWithNuspec/.nuspec
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet/subProjectTestWithNuspec/.nuspec
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>MyPackage</id>
+        <version>0.8.15</version>
+        <description>This is a test package.</description>
+        <authors>Author1, Author2; Author3</authors>
+        <licenseUrl>https://test.license.example.org/index.html</licenseUrl>
+        <license type="expression">BSD-2-Clause OR MIT</license>
+    </metadata>
+</package>

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet/subProjectTestWithNuspec/test.csproj
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet/subProjectTestWithNuspec/test.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="jQuery" Version="3.3.1"/>
+    <PackageReference Include="WebGrease" Version="1.5.2"/>
+    <PackageReference Include="foobar" Version="1.2.3"/>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>test</TargetFramework>
+    <RootNamespace>is</RootNamespace>
+    <AspNetCoreHostingModel>ignored</AspNetCoreHostingModel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Remove="compilerconfig.json" />
+    <Content Remove="wwwroot\css\x.css" />
+    <Content Remove="wwwroot\css\x.min.css" />
+  </ItemGroup>
+</Project>

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
@@ -121,7 +121,8 @@ packages:
 - id: "NuGet::jQuery:3.3.1"
   purl: "pkg:nuget/jQuery@3.3.1"
   authors:
-  - "jQuery Foundation, Inc."
+  - "Inc."
+  - "jQuery Foundation"
   declared_licenses:
   - "http://jquery.org/license"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
@@ -26,6 +26,8 @@ project:
 packages:
 - id: "NuGet::Antlr:3.4.1.9004"
   purl: "pkg:nuget/Antlr@3.4.1.9004"
+  authors:
+  - "Terence Parr"
   declared_licenses: []
   declared_licenses_processed: {}
   description: "ANother Tool for Language Recognition, is a language tool that provides\
@@ -54,6 +56,8 @@ packages:
     path: ""
 - id: "NuGet::Newtonsoft.Json:5.0.4"
   purl: "pkg:nuget/Newtonsoft.Json@5.0.4"
+  authors:
+  - "James Newton-King"
   declared_licenses:
   - "http://json.codeplex.com/license"
   declared_licenses_processed:
@@ -84,6 +88,8 @@ packages:
     path: ""
 - id: "NuGet::WebGrease:1.5.2"
   purl: "pkg:nuget/WebGrease@1.5.2"
+  authors:
+  - "webgrease@microsoft.com"
   declared_licenses:
   - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
   declared_licenses_processed:
@@ -114,6 +120,8 @@ packages:
     path: ""
 - id: "NuGet::jQuery:3.3.1"
   purl: "pkg:nuget/jQuery@3.3.1"
+  authors:
+  - "jQuery Foundation, Inc."
   declared_licenses:
   - "http://jquery.org/license"
   declared_licenses_processed:

--- a/analyzer/src/funTest/kotlin/managers/DotNetFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/DotNetFunTest.kt
@@ -70,6 +70,23 @@ class DotNetFunTest : StringSpec() {
 
             patchActualResult(result.toYaml()) shouldBe expectedResult
         }
+
+        "Project metadata is correctly extracted from a .nuspec file" {
+            val vcsPath = vcsDir.getPathToRoot(projectDir)
+            val expectedResult = patchExpectedResult(
+                File(
+                    projectDir.parentFile,
+                    "dotnet-expected-output-with-nuspec.yml"
+                ),
+                url = normalizeVcsUrl(vcsUrl),
+                revision = vcsRevision,
+                path = "$vcsPath/subProjectTestWithNuspec"
+            )
+            val result = createDotNet()
+                .resolveSingleProject(projectDir.resolve("subProjectTestWithNuspec/test.csproj"))
+
+            patchActualResult(result.toYaml()) shouldBe expectedResult
+        }
     }
 
     private fun createDotNet() =

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -272,7 +272,17 @@ private fun parseLicenses(spec: PackageSpec?): SortedSet<String> {
 /**
  * Parse information about the authors of a package from the given [spec].
  */
-private fun parseAuthors(spec: PackageSpec) = sortedSetOf(spec.metadata.authors)
+private fun parseAuthors(spec: PackageSpec?): SortedSet<String> =
+    spec?.metadata?.authors?.split(',', ';').orEmpty()
+        .map(String::trim)
+        .filterNot(String::isEmpty)
+        .toSortedSet()
+
+/**
+ * Try to find a .nuspec file for the given [definitionFile]. The file is looked up in the same directory.
+ */
+private fun resolveLocalSpec(definitionFile: File): File? =
+    definitionFile.parentFile?.resolve(".nuspec")?.takeIf { it.isFile }
 
 private fun getIdentifier(name: String, version: String) =
     Identifier(type = "NuGet", namespace = "", name = name, version = version)
@@ -297,7 +307,19 @@ fun PackageManager.resolveNuGetDependencies(
     val references = reader.getPackageReferences(definitionFile)
     support.buildDependencyTree(references, dependencies, packages, issues)
 
-    val project = Project(
+    val project = getProject(definitionFile, workingDir, scope)
+
+    return ProjectAnalyzerResult(project, packages, issues)
+}
+
+private fun PackageManager.getProject(
+    definitionFile: File,
+    workingDir: File,
+    scope: Scope
+): Project {
+    val spec = resolveLocalSpec(definitionFile)?.let { NuGetSupport.XML_MAPPER.readValue<PackageSpec>(it) }
+
+    return Project(
         id = Identifier(
             type = managerName,
             namespace = "",
@@ -305,16 +327,13 @@ fun PackageManager.resolveNuGetDependencies(
             version = ""
         ),
         definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
-        // TODO: Find a way to track authors.
-        authors = sortedSetOf(),
-        declaredLicenses = sortedSetOf(),
+        authors = parseAuthors(spec),
+        declaredLicenses = parseLicenses(spec),
         vcs = VcsInfo.EMPTY,
         vcsProcessed = PackageManager.processProjectVcs(workingDir),
         homepageUrl = "",
         scopeDependencies = sortedSetOf(scope)
     )
-
-    return ProjectAnalyzerResult(project, packages, issues)
 }
 
 /**

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -190,8 +190,7 @@ class NuGetSupport(serviceIndexUrls: List<String> = listOf(DEFAULT_SERVICE_INDEX
         return with(all.details) {
             Package(
                 id = getIdentifier(id, version),
-                // TODO: Find a way to track authors.
-                authors = sortedSetOf(),
+                authors = parseAuthors(all.spec),
                 declaredLicenses = setOfNotNull(license).toSortedSet(),
                 description = description.orEmpty(),
                 homepageUrl = projectUrl.orEmpty(),
@@ -261,6 +260,11 @@ class NuGetSupport(serviceIndexUrls: List<String> = listOf(DEFAULT_SERVICE_INDEX
         }
     }
 }
+
+/**
+ * Parse information about the authors of a package from the given [spec].
+ */
+private fun parseAuthors(spec: PackageSpec) = sortedSetOf(spec.metadata.authors)
 
 private fun getIdentifier(name: String, version: String) =
     Identifier(type = "NuGet", namespace = "", name = name, version = version)


### PR DESCRIPTION
Extract information about the authors of a package from the .nuspec
manifest.

