### PR TITLE
ScanCodeResultParser: Fix-up the construction of the SPDX expressions

### DIFF
--- a/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
@@ -173,7 +173,7 @@ private fun getLicenseFindings(result: JsonNode, parseExpressions: Boolean): Lis
             }
         ).map { (licenseExpression, replacements) ->
             val spdxLicenseExpression = replacements.fold(licenseExpression.expression) { expression, replacement ->
-                expression.replace(replacement.scanCodeLicenseKey, replacement.spdxExpression)
+                expression.replace("\\b${replacement.scanCodeLicenseKey}\\b".toRegex(), replacement.spdxExpression)
             }
 
             LicenseFinding(


### PR DESCRIPTION
The recently introduced replacement mechanism [1] does not adhere to
word boundaries. For example, if the expression variable holds the value
"LicenseRef-scancode-public-doman" prior to a replacement of
"public-domain" with "LicenseRef-scancode-public-doman", then in the
next iteration the expression variable has the value
"LicenseRef-scancode-LicenseRef-scancode-public-doman". Note that
multiple iterations may produce results like e.g. [2].

Adhere to word boundaries to fix that issue.

This is a fix-up for [1].

[1] c369766f018a88ae4c2ca9cfe46a52e71d387422
[2] LicenseRef-scancode-LicenseRef-scancode-LicenseRef-scancode-public-domain

Signed-off-by: Frank Viernau <frank.viernau@here.com>

Please ensure that your pull request adheres to our [contribution guidelines](../CONTRIBUTING.md). Thank you!
