### PR TITLE
Support guessing revision some Lerna specific Git tag format

### DIFF
--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -242,14 +242,18 @@ abstract class VersionControlSystem {
             workingTree.guessRevisionName(pkg.id.name, pkg.id.version).also {
                 if (revisionCandidates.add(it)) {
                     log.info {
-                        "Adding $type revision '$it' (guessed from version '${pkg.id.version}') as a candidate."
+                        "Adding $type revision '$it' (guessed from package '${pkg.id.name}' and version " +
+                                "'${pkg.id.version}') as a candidate."
                     }
                 }
             }
         } catch (e: IOException) {
             e.showStackTrace()
 
-            log.info { "No $type revision for version '${pkg.id.version}' found: ${e.collectMessagesAsString()}" }
+            log.info {
+                "No $type revision for package '${pkg.id.name}' and version '${pkg.id.version}' found: " +
+                    e.collectMessagesAsString()
+            }
         }
 
         if (revisionCandidates.isEmpty()) {

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -261,7 +261,11 @@ abstract class VersionControlSystem {
                 false
             }
 
-        addGuessedRevision(pkg.id.name, pkg.id.version)
+        if (!addGuessedRevision(pkg.id.name, pkg.id.version) && pkg.id.type == "NPM" && pkg.id.namespace.isNotEmpty()) {
+            // Fallback for Lerna workspaces when scoped packages combined with independent versioning are used, e.g.
+            // support Git tag of the format "@organisation/my-component@x.x.x".
+            addGuessedRevision("${pkg.id.namespace}/${pkg.id.name}", pkg.id.version)
+        }
 
         if (revisionCandidates.isEmpty()) {
             throw DownloadException("Unable to determine a revision to checkout.")

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -238,23 +238,30 @@ abstract class VersionControlSystem {
             }
         }
 
-        try {
-            workingTree.guessRevisionName(pkg.id.name, pkg.id.version).also {
-                if (revisionCandidates.add(it)) {
-                    log.info {
-                        "Adding $type revision '$it' (guessed from package '${pkg.id.name}' and version " +
-                                "'${pkg.id.version}') as a candidate."
+        fun addGuessedRevision(project: String, version: String): Boolean =
+            try {
+                workingTree.guessRevisionName(project, version).also {
+                    if (revisionCandidates.add(it)) {
+                        log.info {
+                            "Adding $type revision '$it' (guessed from package '$project' and version " +
+                                    "'$version') as a candidate."
+                        }
                     }
                 }
-            }
-        } catch (e: IOException) {
-            e.showStackTrace()
 
-            log.info {
-                "No $type revision for package '${pkg.id.name}' and version '${pkg.id.version}' found: " +
-                    e.collectMessagesAsString()
+                true
+            } catch (e: IOException) {
+                e.showStackTrace()
+
+                log.info {
+                    "No $type revision for package '$project' and version '$version' found: " +
+                            e.collectMessagesAsString()
+                }
+
+                false
             }
-        }
+
+        addGuessedRevision(pkg.id.name, pkg.id.version)
 
         if (revisionCandidates.isEmpty()) {
             throw DownloadException("Unable to determine a revision to checkout.")


### PR DESCRIPTION
Support guessing revisions for Git tags of the form "@organization/component@1.2.3".
