### PR TITLE
Gradle: Remove JCenter from build scripts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,20 +117,12 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
 allprojects {
     buildscript {
         repositories {
-            // Explicitly add Maven Central as some plugins continue to have problems with JCenter, see
-            // https://github.com/detekt/detekt/issues/3062.
             mavenCentral()
-
-            jcenter()
         }
     }
 
     repositories {
-        // Work-around for JCenter not correctly proxying "maven-metadata.xml", see
-        // https://github.com/ben-manes/gradle-versions-plugin/issues/424#issuecomment-691628498.
         mavenCentral()
-
-        jcenter()
     }
 
     apply(plugin = "io.gitlab.arturbosch.detekt")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -33,8 +33,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
-
     exclusiveContent {
         forRepository {
             maven("https://plugins.gradle.org/m2/")


### PR DESCRIPTION
As JCenter will shut down, see https://blog.gradle.org/jcenter-shutdown.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>