### PR TITLE
SpdxDocumentFile: Properly parse the downloadLocation

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
@@ -37,7 +37,7 @@ packages:
     \ of powerful features."
   homepage_url: "https://curl.haxx.se/"
   binary_artifact:
-    url: ""
+    url: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
     hash:
       value: ""
       algorithm: ""
@@ -79,11 +79,11 @@ packages:
       algorithm: ""
   vcs:
     type: "Git"
-    url: "<REPLACE_URL>"
-    revision: "<REPLACE_REVISION>"
-    path: "analyzer/src/funTest/assets/projects/synthetic/spdx/project/libs/openssl"
+    url: "ssh://github.com/openssl/openssl.git"
+    revision: "e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
+    path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL_PROCESSED>"
-    revision: "<REPLACE_REVISION>"
-    path: "analyzer/src/funTest/assets/projects/synthetic/spdx/project/libs/openssl"
+    url: "ssh://git@github.com/openssl/openssl.git"
+    revision: "e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
+    path: ""

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -35,6 +35,7 @@ import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
@@ -56,6 +57,13 @@ private val SPDX_SCOPE_RELATIONSHIPS = listOf(
     SpdxRelationship.Type.PROVIDED_DEPENDENCY_OF,
     SpdxRelationship.Type.RUNTIME_DEPENDENCY_OF,
     SpdxRelationship.Type.TEST_DEPENDENCY_OF
+)
+
+private val SPDX_VCS_PREFIXES = mapOf(
+    "git+" to VcsType.GIT,
+    "hg+" to VcsType.MERCURIAL,
+    "bzr+" to VcsType.UNKNOWN,
+    "svn+" to VcsType.SUBVERSION
 )
 
 /**
@@ -80,17 +88,61 @@ private fun getConcludedLicense(pkg: SpdxPackage): SpdxExpression? =
     pkg.licenseConcluded.takeIf { SpdxConstants.isPresent(it) }?.toSpdx()
 
 /**
- * Return a [RemoteArtifact] created from the downloadLocation of the given package [SpdxPackage] if it is a local
- * file, or return an [RemoteArtifact.EMPTY].
- *
- * TODO: Consider also taking "sourceInfo" or "externalRefs" into account.
+ * Return a [RemoteArtifact] for the binary artifact that the [pkg]'s [downloadLocation][SpdxPackage.downloadLocation]
+ * points to. If the download location is a "not present" value, or if it points to a source artifact or a VCS location
+ * instead, return null.
  */
-private fun getSourceArtifact(pkg: SpdxPackage): RemoteArtifact =
-    if (pkg.downloadLocation.startsWith("file:/")) {
-        RemoteArtifact(pkg.downloadLocation, Hash.NONE)
-    } else {
-        RemoteArtifact.EMPTY
+internal fun getBinaryArtifact(pkg: SpdxPackage): RemoteArtifact? =
+    getRemoteArtifact(pkg).takeUnless {
+        // Note: The "FilesAnalyzed" field "Indicates whether the file content of this package has been available for or
+        // subjected to analysis when creating the SPDX document". It does not indicate whether files were actually
+        // analyzed.
+        // If files were available, do *not* consider this do be a *binary* artifact.
+        pkg.filesAnalyzed
     }
+
+/**
+ * Return a [RemoteArtifact] for the source artifact that the [pkg]'s [downloadLocation][SpdxPackage.downloadLocation]
+ * points to. If the download location is a "not present" value, or if it points to a binary artifact or a VCS location
+ * instead, return null.
+ */
+internal fun getSourceArtifact(pkg: SpdxPackage): RemoteArtifact? =
+    getRemoteArtifact(pkg).takeIf {
+        // Note: The "FilesAnalyzed" field "Indicates whether the file content of this package has been available for or
+        // subjected to analysis when creating the SPDX document". It does not indicate whether files were actually
+        // analyzed.
+        // If files were available, *do* consider this do be a *source* artifact.
+        pkg.filesAnalyzed
+    }
+
+private fun getRemoteArtifact(pkg: SpdxPackage): RemoteArtifact? =
+    when {
+        SpdxConstants.isNotPresent(pkg.downloadLocation) -> null
+        SPDX_VCS_PREFIXES.any { (prefix, _) -> pkg.downloadLocation.startsWith(prefix) } -> null
+        else -> RemoteArtifact(pkg.downloadLocation, Hash.NONE)
+    }
+
+/**
+ * Return the [VcsInfo] contained in [pkg]'s [downloadLocation][SpdxPackage.downloadLocation], or null if the download
+ * location is a "not present" value / does not point to a VCS location.
+ */
+internal fun getVcsInfo(pkg: SpdxPackage): VcsInfo? {
+    if (SpdxConstants.isNotPresent(pkg.downloadLocation)) return null
+
+    return SPDX_VCS_PREFIXES.mapNotNull { (prefix, vcsType) ->
+        pkg.downloadLocation.withoutPrefix(prefix)?.let { url ->
+            var vcsUrl = url
+
+            val vcsPath = vcsUrl.substringAfterLast('#', "")
+            vcsUrl = vcsUrl.removeSuffix("#$vcsPath")
+
+            val vcsRevision = vcsUrl.substringAfterLast('@', "")
+            vcsUrl = vcsUrl.removeSuffix("@$vcsRevision")
+
+            VcsInfo(vcsType, vcsUrl, vcsRevision, path = vcsPath)
+        }
+    }.firstOrNull()
+}
 
 /**
  * A "fake" package manager implementation that uses SPDX documents as definition files to declare projects and describe
@@ -246,7 +298,13 @@ class SpdxDocumentFile(
 
         val packages = nonProjectPackages.mapTo(sortedSetOf()) { pkg ->
             val packageDescription = pkg.description.takeUnless { it.isEmpty() } ?: pkg.summary
-            val packageDir = workingDir.resolve(pkg.packageFilename)
+
+            // If the VCS information cannot be determined from the download location, fall back to try getting it from
+            // the VCS working tree itself.
+            val vcs = getVcsInfo(pkg) ?: run {
+                val packageDir = workingDir.resolve(pkg.packageFilename)
+                VersionControlSystem.forDirectory(packageDir)?.getInfo()
+            } ?: VcsInfo.EMPTY
 
             Package(
                 id = pkg.toIdentifier(),
@@ -256,9 +314,9 @@ class SpdxDocumentFile(
                 concludedLicense = getConcludedLicense(pkg),
                 description = packageDescription,
                 homepageUrl = pkg.homepage.mapNotPresentToEmpty(),
-                binaryArtifact = RemoteArtifact.EMPTY, // TODO: Use "downloadLocation" or "externalRefs"?
-                sourceArtifact = getSourceArtifact(pkg),
-                vcs = VersionControlSystem.forDirectory(packageDir)?.getInfo() ?: VcsInfo.EMPTY
+                binaryArtifact = getBinaryArtifact(pkg) ?: RemoteArtifact.EMPTY,
+                sourceArtifact = getSourceArtifact(pkg) ?: RemoteArtifact.EMPTY,
+                vcs = vcs
             )
         }
 

--- a/analyzer/src/test/kotlin/managers/SpdxDocumentFileTest.kt
+++ b/analyzer/src/test/kotlin/managers/SpdxDocumentFileTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.model.Hash
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.spdx.SpdxConstants
+import org.ossreviewtoolkit.spdx.model.SpdxPackage
+
+/*
+ * The below package data is based on example data taken from the SPDX specification.
+ */
+
+private val pkgForBinaryArtifact = SpdxPackage(
+    spdxId = "SPDXRef-Package-Dummy",
+    downloadLocation = "https://repo1.maven.org/maven2/junit/junit/4.11/junit-4.11.jar",
+    filesAnalyzed = false,
+    copyrightText = "Copyright 2008-2010 John Smith",
+    licenseConcluded = "NOASSERTION",
+    licenseDeclared = "NOASSERTION",
+    name = "Dummy"
+)
+
+private val pkgForSourceArtifact = SpdxPackage(
+    spdxId = "SPDXRef-Package-Dummy",
+    downloadLocation = "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz",
+    filesAnalyzed = true,
+    copyrightText = "Copyright 2008-2010 John Smith",
+    licenseConcluded = "NOASSERTION",
+    licenseDeclared = "NOASSERTION",
+    name = "Dummy"
+)
+
+private val pkgForVcs = SpdxPackage(
+    spdxId = "SPDXRef-Package-Dummy",
+    downloadLocation = "git+https://git.myproject.org/MyProject.git@master#/src/MyClass.cpp",
+    copyrightText = "Copyright 2008-2010 John Smith",
+    licenseConcluded = "NOASSERTION",
+    licenseDeclared = "NOASSERTION",
+    name = "Dummy"
+)
+
+class SpdxDocumentFileTest : WordSpec({
+    "getBinaryArtifact()" should {
+        "return a RemoteArtifact for a downloadLocation that points to a binary artifact" {
+            getBinaryArtifact(pkgForBinaryArtifact) shouldBe RemoteArtifact(
+                url = "https://repo1.maven.org/maven2/junit/junit/4.11/junit-4.11.jar",
+                hash = Hash.NONE
+            )
+        }
+
+        "return null for a downloadLocation that does not point to a binary artifact" {
+            getBinaryArtifact(pkgForBinaryArtifact.copy(downloadLocation = SpdxConstants.NONE)) should beNull()
+            getBinaryArtifact(pkgForBinaryArtifact.copy(downloadLocation = SpdxConstants.NOASSERTION)) should beNull()
+            getBinaryArtifact(pkgForSourceArtifact) should beNull()
+            getBinaryArtifact(pkgForVcs) should beNull()
+        }
+    }
+
+    "getSourceArtifact()" should {
+        "return a RemoteArtifact for a downloadLocation that points to a source artifact" {
+            getSourceArtifact(pkgForSourceArtifact) shouldBe RemoteArtifact(
+                url = "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz",
+                hash = Hash.NONE
+            )
+        }
+
+        "return null for a downloadLocation that does not point to a source artifact" {
+            getSourceArtifact(pkgForSourceArtifact.copy(downloadLocation = SpdxConstants.NONE)) should beNull()
+            getSourceArtifact(pkgForSourceArtifact.copy(downloadLocation = SpdxConstants.NOASSERTION)) should beNull()
+            getSourceArtifact(pkgForBinaryArtifact) should beNull()
+            getSourceArtifact(pkgForVcs) should beNull()
+        }
+    }
+
+    "getVcsInfo()" should {
+        "return the VcsInfo for a downloadLocation that points to a VCS" {
+            getVcsInfo(pkgForVcs) shouldBe VcsInfo(
+                type = VcsType.GIT,
+                url = "https://git.myproject.org/MyProject.git",
+                revision = "master",
+                path = "/src/MyClass.cpp"
+            )
+        }
+
+        "return null for a downloadLocation that does not point to a VCS" {
+            getVcsInfo(pkgForVcs.copy(downloadLocation = SpdxConstants.NONE)) should beNull()
+            getVcsInfo(pkgForVcs.copy(downloadLocation = SpdxConstants.NOASSERTION)) should beNull()
+            getVcsInfo(pkgForBinaryArtifact) should beNull()
+            getVcsInfo(pkgForSourceArtifact) should beNull()
+        }
+    }
+})


### PR DESCRIPTION
Previously, the downloadLocation was only considered if it was a file
URL, and it was not considered for determining the VCS location, which
is wrong. Address both issues by properly parsing the downloadLocation
and getting any artifact or VCS location from it.

Fixes #3700.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>