### PR TITLE
Apply license choices specified for a package defined in the repository configuration file

### DIFF
--- a/evaluator/src/main/kotlin/PackageRule.kt
+++ b/evaluator/src/main/kotlin/PackageRule.kt
@@ -135,7 +135,8 @@ open class PackageRule(
      * A DSL function to configure a [LicenseRule] and add it to this rule.
      */
     fun licenseRule(name: String, licenseView: LicenseView, block: LicenseRule.() -> Unit) {
-        resolvedLicenseInfo.filter(licenseView, filterSources = true).forEach { resolvedLicense ->
+        resolvedLicenseInfo.filter(licenseView, filterSources = true)
+            .applyChoices(ruleSet.ortResult.getLicenseChoices(pkg.id)).forEach { resolvedLicense ->
             resolvedLicense.sources.forEach { licenseSource ->
                 licenseRules += LicenseRule(name, resolvedLicense, licenseSource).apply(block)
             }

--- a/evaluator/src/test/kotlin/RuleSetTest.kt
+++ b/evaluator/src/test/kotlin/RuleSetTest.kt
@@ -24,6 +24,7 @@ import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.should
 
 import org.ossreviewtoolkit.model.licenses.LicenseView
+import org.ossreviewtoolkit.spdx.toSpdx
 
 class RuleSetTest : WordSpec() {
     private val errorMessage = "error message"
@@ -119,6 +120,26 @@ class RuleSetTest : WordSpec() {
                 }
 
                 ruleSet.violations should haveSize(4)
+            }
+
+            "add no license errors if license is removed by license choice" {
+                val ruleSet = ruleSet(ortResult) {
+                    dependencyRule("test") {
+                        licenseRule("test", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+                            require {
+                                object : RuleMatcher {
+                                    override val description = "containsLicense(license)"
+
+                                    override fun matches() = license == "LicenseRef-b".toSpdx()
+                                }
+                            }
+
+                            error(errorMessage, howToFix)
+                        }
+                    }
+                }
+
+                ruleSet.violations should haveSize(5)
             }
         }
     }

--- a/evaluator/src/test/kotlin/TestData.kt
+++ b/evaluator/src/test/kotlin/TestData.kt
@@ -43,15 +43,18 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.Excludes
+import org.ossreviewtoolkit.model.config.LicenseChoices
+import org.ossreviewtoolkit.model.config.PackageLicenseChoice
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.config.PathExcludeReason
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.spdx.model.LicenseChoice
 import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.Environment
 
-val concludedLicense = "LicenseRef-a AND LicenseRef-b".toSpdx()
+val concludedLicense = "LicenseRef-a OR LicenseRef-b".toSpdx()
 val declaredLicenses = sortedSetOf("Apache-2.0", "MIT")
 val declaredLicensesProcessed = DeclaredLicenseProcessor.process(declaredLicenses)
 
@@ -160,6 +163,16 @@ val ortResult = OrtResult(
                         pattern = "excluded/**",
                         reason = PathExcludeReason.TEST_OF,
                         comment = "excluded"
+                    )
+                )
+            ),
+            licenseChoices = LicenseChoices(
+                packageLicenseChoices = listOf(
+                    PackageLicenseChoice(
+                        packageId = Identifier("Maven:org.ossreviewtoolkit:package-with-only-concluded-license:1.0"),
+                        licenseChoices = listOf(
+                            LicenseChoice("LicenseRef-a OR LicenseRef-b".toSpdx(), "LicenseRef-a".toSpdx())
+                        )
                     )
                 )
             )

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -24,6 +24,7 @@ val hopliteVersion: String by project
 val jacksonVersion: String by project
 val postgresEmbeddedVersion: String by project
 val postgresVersion: String by project
+val mockkVersion: String by project
 val semverVersion: String by project
 
 plugins {
@@ -54,4 +55,5 @@ dependencies {
     implementation("org.postgresql:postgresql:$postgresVersion")
 
     testImplementation("com.opentable.components:otj-pg-embedded:$postgresEmbeddedVersion")
+    testImplementation("io.mockk:mockk:$mockkVersion")
 }

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -32,6 +32,7 @@ import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.Resolutions
 import org.ossreviewtoolkit.model.config.orEmpty
+import org.ossreviewtoolkit.spdx.model.LicenseChoice
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.perf
 import org.ossreviewtoolkit.utils.zipWithDefault
@@ -384,6 +385,12 @@ data class OrtResult(
         advisorResultsById.filter { (id, _) ->
             !omitExcluded || !isExcluded(id)
         }
+
+    /**
+     * Return all [LicenseChoice]s for the [Package] with [id].
+     */
+    fun getLicenseChoices(id: Identifier): List<LicenseChoice> =
+        repository.config.licenseChoices.packageLicenseChoices.find { it.packageId == id }?.licenseChoices.orEmpty()
 
     /**
      * Return the list of [AdvisorResult]s for the given [id].

--- a/model/src/main/kotlin/config/LicenseChoices.kt
+++ b/model/src/main/kotlin/config/LicenseChoices.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.config
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonInclude
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.spdx.model.LicenseChoice
+
+/**
+ * The license choices configured for a repository.
+ */
+data class LicenseChoices(
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val packageLicenseChoices: List<PackageLicenseChoice> = emptyList()
+) {
+    @JsonIgnore
+    fun isEmpty() = packageLicenseChoices.isEmpty()
+}
+
+/**
+ * [LicenseChoice]s defined for an artifact.
+ */
+data class PackageLicenseChoice(
+    val packageId: Identifier,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val licenseChoices: List<LicenseChoice> = emptyList()
+)

--- a/model/src/main/kotlin/config/RepositoryConfiguration.kt
+++ b/model/src/main/kotlin/config/RepositoryConfiguration.kt
@@ -45,7 +45,13 @@ data class RepositoryConfiguration(
      * Defines curations for artifacts contained in this repository.
      */
     @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = CurationsFilter::class)
-    val curations: Curations = Curations()
+    val curations: Curations = Curations(),
+
+    /**
+     * Defines license choices within this repository.
+     */
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = LicenseChoiceFilter::class)
+    val licenseChoices: LicenseChoices = LicenseChoices()
 )
 
 @Suppress("EqualsOrHashCode", "EqualsWithHashCodeExist") // The class is not supposed to be used with hashing.
@@ -67,4 +73,10 @@ private class ResolutionsFilter {
 private class CurationsFilter {
     override fun equals(other: Any?): Boolean =
         if (other is Curations) other.licenseFindings.isEmpty() else false
+}
+
+@Suppress("EqualsOrHashCode", "EqualsWithHashCodeExist") // The class is not supposed to be used with hashing.
+private class LicenseChoiceFilter {
+    override fun equals(other: Any?): Boolean =
+        other is LicenseChoices && other.isEmpty()
 }

--- a/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicenseInfo.kt
@@ -115,6 +115,15 @@ data class ResolvedLicenseInfo(
         }
 
     /**
+     * Apply [licenseChoices] on the effective license of [LicenseView.ALL].
+     */
+    fun applyChoices(licenseChoices: List<LicenseChoice>): ResolvedLicenseInfo {
+        val licenses = effectiveLicense(LicenseView.ALL, licenseChoices)?.decompose().orEmpty()
+
+        return this.copy(licenses = this.licenses.filter { it.license in licenses })
+    }
+
+    /**
      * Filter all excluded licenses and copyrights. Licenses are removed if they are only
      * [detected][LicenseSource.DETECTED] and all [locations][ResolvedLicense.locations] have
      * [matching path excludes][ResolvedLicenseLocation.matchingPathExcludes]. Copyrights are removed if all

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -51,6 +51,7 @@ import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.LicenseFindingCurationReason
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.config.PathExcludeReason
+import org.ossreviewtoolkit.model.licenses.TestUtils.containLicensesExactly
 import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.spdx.SpdxExpression
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
@@ -760,19 +761,6 @@ fun containLicenseExpressionsExactlyBySource(
                     "contain exactly ${expectedExpressions.show().value}, but has ${actualExpressions.show().value}",
             "ResolvedLicenseInfo for original ${source.show().value} license expressions " +
                     "should not contain exactly ${expectedExpressions.show().value}"
-        )
-    }
-
-fun containLicensesExactly(vararg licenses: String): Matcher<Iterable<ResolvedLicense>?> =
-    neverNullMatcher { value ->
-        val expected = licenses.map { SpdxExpression.parse(it) as SpdxSingleLicenseExpression }.toSet()
-        val actual = value.map { it.license }.toSet()
-
-        MatcherResult(
-            expected == actual,
-            "ResolvedLicenseInfo should contain exactly licenses ${expected.show().value}, but has " +
-                    actual.show().value,
-            "ResolvedLicenseInfo should not contain exactly ${expected.show().value}"
         )
     }
 

--- a/model/src/test/kotlin/licenses/ResolvedLicenseInfoTest.kt
+++ b/model/src/test/kotlin/licenses/ResolvedLicenseInfoTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.licenses
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import io.mockk.mockk
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.LicenseSource
+import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
+import org.ossreviewtoolkit.spdx.model.LicenseChoice
+import org.ossreviewtoolkit.spdx.toSpdx
+
+class ResolvedLicenseInfoTest : WordSpec() {
+    private val mit = "MIT"
+    private val apache = "Apache-2.0 WITH LLVM-exception"
+    private val gpl = "GPL-2.0-only"
+    private val bsd = "0BSD"
+
+    init {
+        "effectiveLicense()" should {
+            "apply choices for LicenseView.ALL on all resolved licenses" {
+                // All: (Apache-2.0 WITH LLVM-exception OR MIT) AND (MIT OR GPL-2.0-only) AND (0BSD OR GPL-2.0-only)
+                val choices = listOf(
+                    LicenseChoice("$apache OR $mit".toSpdx(), mit.toSpdx()),
+                    LicenseChoice("$mit OR $gpl".toSpdx(), mit.toSpdx()),
+                    LicenseChoice("$bsd OR $gpl".toSpdx(), bsd.toSpdx())
+                )
+
+                val effectiveLicense = createResolvedLicenseInfo().effectiveLicense(LicenseView.ALL, choices)
+
+                effectiveLicense shouldBe "$mit AND $bsd".toSpdx()
+            }
+
+            "apply a choice for a sub-expression only" {
+                // Declared: Apache-2.0 WITH LLVM-exception OR MIT OR GPL-2.0-only
+                val resolvedLicenseInfo = ResolvedLicenseInfo(
+                    id = Identifier.EMPTY,
+                    licenseInfo = mockk(),
+                    licenses = listOf(
+                        ResolvedLicense(
+                            license = apache.toSpdx() as SpdxSingleLicenseExpression,
+                            originalDeclaredLicenses = setOf("$apache OR $mit"),
+                            originalExpressions = mapOf(
+                                LicenseSource.DECLARED to setOf("$apache OR $mit OR $gpl".toSpdx())
+                            ),
+                            locations = emptySet()
+                        )
+                    ),
+                    copyrightGarbage = emptyMap(),
+                    unmatchedCopyrights = emptyMap()
+                )
+
+                val choices = listOf(
+                    LicenseChoice("$apache OR $mit".toSpdx(), mit.toSpdx())
+                )
+
+                val effectiveLicense = resolvedLicenseInfo.effectiveLicense(LicenseView.ONLY_DECLARED, choices)
+
+                effectiveLicense shouldBe "$mit OR $gpl".toSpdx()
+            }
+
+            "apply choices for LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED" {
+                // Concluded: 0BSD OR GPL-2.0-only
+                val choices = listOf(
+                    LicenseChoice("$bsd OR $gpl".toSpdx(), bsd.toSpdx())
+                )
+
+                val effectiveLicense = createResolvedLicenseInfo().effectiveLicense(
+                    LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED,
+                    choices
+                )
+
+                effectiveLicense shouldBe bsd.toSpdx()
+            }
+
+            "apply choices for LicenseView.ONLY_DECLARED" {
+                // Declared: Apache-2.0 WITH LLVM-exception OR MIT
+                val choices = listOf(
+                    LicenseChoice("$apache OR $mit".toSpdx(), mit.toSpdx())
+                )
+
+                val effectiveLicense = createResolvedLicenseInfo().effectiveLicense(
+                    LicenseView.ONLY_DECLARED,
+                    choices
+                )
+
+                effectiveLicense shouldBe mit.toSpdx()
+            }
+        }
+    }
+
+    private fun createResolvedLicenseInfo(): ResolvedLicenseInfo {
+        val resolvedLicenses = listOf(
+            ResolvedLicense(
+                license = apache.toSpdx() as SpdxSingleLicenseExpression,
+                originalDeclaredLicenses = setOf("$apache OR $mit"),
+                originalExpressions = mapOf(
+                    LicenseSource.DECLARED to setOf("$apache OR $mit".toSpdx())
+                ),
+                locations = emptySet()
+            ),
+            ResolvedLicense(
+                license = mit.toSpdx() as SpdxSingleLicenseExpression,
+                originalDeclaredLicenses = setOf("$apache OR $mit"),
+                originalExpressions = mapOf(
+                    LicenseSource.DECLARED to setOf("$apache OR $mit".toSpdx()),
+                    LicenseSource.DETECTED to setOf("$mit OR $gpl".toSpdx())
+                ),
+                locations = emptySet()
+            ),
+            ResolvedLicense(
+                license = gpl.toSpdx() as SpdxSingleLicenseExpression,
+                originalDeclaredLicenses = emptySet(),
+                originalExpressions = mapOf(
+                    LicenseSource.DETECTED to setOf("$mit OR $gpl".toSpdx()),
+                    LicenseSource.CONCLUDED to setOf("$bsd OR $gpl".toSpdx())
+                ),
+                locations = emptySet()
+            ),
+            ResolvedLicense(
+                license = bsd.toSpdx() as SpdxSingleLicenseExpression,
+                originalDeclaredLicenses = emptySet(),
+                originalExpressions = mapOf(
+                    LicenseSource.CONCLUDED to setOf("$bsd OR $gpl".toSpdx())
+                ),
+                locations = emptySet()
+            )
+        )
+
+        return ResolvedLicenseInfo(
+            id = Identifier.EMPTY,
+            licenseInfo = mockk(),
+            licenses = resolvedLicenses,
+            copyrightGarbage = emptyMap(),
+            unmatchedCopyrights = emptyMap()
+        )
+    }
+}

--- a/model/src/test/kotlin/licenses/ResolvedLicenseInfoTest.kt
+++ b/model/src/test/kotlin/licenses/ResolvedLicenseInfoTest.kt
@@ -20,12 +20,14 @@
 package org.ossreviewtoolkit.model.licenses
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import io.mockk.mockk
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseSource
+import org.ossreviewtoolkit.model.licenses.TestUtils.containLicensesExactly
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.spdx.model.LicenseChoice
 import org.ossreviewtoolkit.spdx.toSpdx
@@ -105,6 +107,22 @@ class ResolvedLicenseInfoTest : WordSpec() {
                 )
 
                 effectiveLicense shouldBe mit.toSpdx()
+            }
+        }
+
+        "applyChoices(licenseChoices)" should {
+            "apply license choices on all licenses" {
+                val resolvedLicenseInfo = createResolvedLicenseInfo()
+
+                val choices = listOf(
+                    LicenseChoice("$apache OR $mit".toSpdx(), mit.toSpdx()),
+                    LicenseChoice("$mit OR $gpl".toSpdx(), mit.toSpdx()),
+                    LicenseChoice("$bsd OR $gpl".toSpdx(), bsd.toSpdx())
+                )
+
+                val filteredResolvedLicenseInfo = resolvedLicenseInfo.applyChoices(choices)
+
+                filteredResolvedLicenseInfo.licenses should containLicensesExactly(mit, bsd)
             }
         }
     }

--- a/model/src/test/kotlin/licenses/TestUtils.kt
+++ b/model/src/test/kotlin/licenses/TestUtils.kt
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2021 Bosch.IO GmbH.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *  License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.licenses
+
+import io.kotest.assertions.show.show
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.neverNullMatcher
+
+import org.ossreviewtoolkit.spdx.SpdxExpression
+import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
+
+object TestUtils {
+    fun containLicensesExactly(vararg licenses: String): Matcher<Iterable<ResolvedLicense>?> =
+        neverNullMatcher { value ->
+            val expected = licenses.map { SpdxExpression.parse(it) as SpdxSingleLicenseExpression }.toSet()
+            val actual = value.map { it.license }.toSet()
+
+            MatcherResult(
+                expected == actual,
+                "ResolvedLicenseInfo should contain exactly licenses ${expected.show().value}, but has " +
+                        actual.show().value,
+                "ResolvedLicenseInfo should not contain exactly ${expected.show().value}"
+            )
+        }
+}

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -55,9 +55,15 @@
     "id" : "EPL-1.0"
   }, {
     "_id" : 11,
-    "id" : "Apache License, Version 2.0"
+    "id" : "MPL 2.0 or EPL 1.0"
   }, {
     "_id" : 12,
+    "id" : "MPL-2.0"
+  }, {
+    "_id" : 13,
+    "id" : "Apache License, Version 2.0"
+  }, {
+    "_id" : 14,
     "id" : "New BSD License"
   } ],
   "scopes" : [ {
@@ -149,6 +155,27 @@
     "provenance" : {
       "download_time" : "1970-01-01T00:00:00Z",
       "source_artifact" : {
+        "url" : "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar",
+        "hash" : {
+          "value" : "3b5883b7a5a05b932c699760f0854ca565785a84",
+          "algorithm" : "SHA-1"
+        }
+      }
+    },
+    "scanner" : {
+      "name" : "FileCounter",
+      "version" : "1.0",
+      "configuration" : ""
+    },
+    "start_time" : "1970-01-01T00:00:00Z",
+    "end_time" : "1970-01-01T00:00:00Z",
+    "file_count" : 42,
+    "package_verification_code" : "0000000000000000000000000000000000000000"
+  }, {
+    "_id" : 4,
+    "provenance" : {
+      "download_time" : "1970-01-01T00:00:00Z",
+      "source_artifact" : {
         "url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar",
         "hash" : {
           "value" : "f7d878153e86a1cdddf6b37850e00a9f8bff726f",
@@ -166,7 +193,7 @@
     "file_count" : 168,
     "package_verification_code" : "0000000000000000000000000000000000000000"
   }, {
-    "_id" : 4,
+    "_id" : 5,
     "provenance" : {
       "download_time" : "1970-01-01T00:00:00Z",
       "source_artifact" : {
@@ -187,7 +214,7 @@
     "file_count" : 80,
     "package_verification_code" : "0000000000000000000000000000000000000000"
   }, {
-    "_id" : 5,
+    "_id" : 6,
     "provenance" : {
       "download_time" : "1970-01-01T00:00:00Z",
       "source_artifact" : {
@@ -440,11 +467,64 @@
     "scope_excludes" : [ 0 ]
   }, {
     "_id" : 3,
+    "id" : "Maven:com.h2database:h2:1.4.200",
+    "is_project" : false,
+    "definition_file_path" : "",
+    "purl" : "pkg:maven/com.h2database/h2@1.4.200",
+    "declared_licenses" : [ 11 ],
+    "declared_licenses_processed" : {
+      "spdx_expression" : "MPL-2.0 OR EPL-1.0",
+      "mapped_licenses" : [ 12, 10 ]
+    },
+    "concluded_license" : "MPL-2.0 OR EPL-1.0",
+    "description" : "H2 Database Engine",
+    "homepage_url" : "https://h2database.com",
+    "binary_artifact" : {
+      "url" : "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200.jar",
+      "hash" : {
+        "value" : "f7533fe7cb8e99c87a43d325a77b4b678ad9031a",
+        "algorithm" : "SHA-1"
+      }
+    },
+    "source_artifact" : {
+      "url" : "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar",
+      "hash" : {
+        "value" : "3b5883b7a5a05b932c699760f0854ca565785a84",
+        "algorithm" : "SHA-1"
+      }
+    },
+    "vcs" : {
+      "type" : "Git",
+      "url" : "https://github.com/h2database/h2database",
+      "revision" : "",
+      "path" : ""
+    },
+    "vcs_processed" : {
+      "type" : "Git",
+      "url" : "https://github.com/h2database/h2database.git",
+      "revision" : "",
+      "path" : ""
+    },
+    "curations" : [ {
+      "base" : { },
+      "curation" : {
+        "concluded_license" : "MPL-2.0 OR EPL-1.0",
+        "comment" : "H2 database offers a license choice"
+      }
+    } ],
+    "paths" : [ 1 ],
+    "levels" : [ 1 ],
+    "scopes" : [ 1 ],
+    "scan_results" : [ 3 ],
+    "is_excluded" : true,
+    "scope_excludes" : [ 0 ]
+  }, {
+    "_id" : 4,
     "id" : "Maven:org.apache.commons:commons-lang3:3.5",
     "is_project" : false,
     "definition_file_path" : "",
     "purl" : "pkg:maven/org.apache.commons/commons-lang3@3.5",
-    "declared_licenses" : [ 11 ],
+    "declared_licenses" : [ 13 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "Apache-2.0",
       "mapped_licenses" : [ 8 ]
@@ -477,18 +557,18 @@
       "revision" : "",
       "path" : ""
     },
-    "paths" : [ 1, 2 ],
+    "paths" : [ 2, 3 ],
     "levels" : [ 1 ],
     "scopes" : [ 0, 1 ],
-    "scan_results" : [ 3 ],
+    "scan_results" : [ 4 ],
     "is_excluded" : false
   }, {
-    "_id" : 4,
+    "_id" : 5,
     "id" : "Maven:org.apache.commons:commons-text:1.1",
     "is_project" : false,
     "definition_file_path" : "",
     "purl" : "pkg:maven/org.apache.commons/commons-text@1.1",
-    "declared_licenses" : [ 11 ],
+    "declared_licenses" : [ 13 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "Apache-2.0",
       "mapped_licenses" : [ 8 ]
@@ -521,18 +601,18 @@
       "revision" : "",
       "path" : ""
     },
-    "paths" : [ 3, 4 ],
+    "paths" : [ 4, 5 ],
     "levels" : [ 0 ],
     "scopes" : [ 0, 1 ],
-    "scan_results" : [ 4 ],
+    "scan_results" : [ 5 ],
     "is_excluded" : false
   }, {
-    "_id" : 5,
+    "_id" : 6,
     "id" : "Maven:org.hamcrest:hamcrest-core:1.3",
     "is_project" : false,
     "definition_file_path" : "",
     "purl" : "pkg:maven/org.hamcrest/hamcrest-core@1.3",
-    "declared_licenses" : [ 12 ],
+    "declared_licenses" : [ 14 ],
     "declared_licenses_processed" : {
       "spdx_expression" : "BSD-3-Clause",
       "mapped_licenses" : [ 1 ]
@@ -565,10 +645,10 @@
       "revision" : "",
       "path" : ""
     },
-    "paths" : [ 5 ],
+    "paths" : [ 6 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
-    "scan_results" : [ 5 ],
+    "scan_results" : [ 6 ],
     "is_excluded" : true,
     "scope_excludes" : [ 0 ]
   } ],
@@ -582,29 +662,35 @@
     "_id" : 1,
     "pkg" : 3,
     "project" : 0,
-    "scope" : 0,
-    "path" : [ 4 ]
+    "scope" : 1,
+    "path" : [ 2 ]
   }, {
     "_id" : 2,
-    "pkg" : 3,
+    "pkg" : 4,
     "project" : 0,
-    "scope" : 1,
-    "path" : [ 4 ]
+    "scope" : 0,
+    "path" : [ 5 ]
   }, {
     "_id" : 3,
     "pkg" : 4,
     "project" : 0,
-    "scope" : 0,
-    "path" : [ ]
+    "scope" : 1,
+    "path" : [ 5 ]
   }, {
     "_id" : 4,
-    "pkg" : 4,
+    "pkg" : 5,
     "project" : 0,
-    "scope" : 1,
+    "scope" : 0,
     "path" : [ ]
   }, {
     "_id" : 5,
     "pkg" : 5,
+    "project" : 0,
+    "scope" : 1,
+    "path" : [ ]
+  }, {
+    "_id" : 6,
+    "pkg" : 6,
     "project" : 0,
     "scope" : 1,
     "path" : [ 2 ]
@@ -618,11 +704,11 @@
       "children" : [ {
         "key" : 2,
         "linkage" : "DYNAMIC",
-        "pkg" : 4,
+        "pkg" : 5,
         "children" : [ {
           "key" : 3,
           "linkage" : "DYNAMIC",
-          "pkg" : 3
+          "pkg" : 4
         } ]
       } ]
     }, {
@@ -636,21 +722,25 @@
         "children" : [ {
           "key" : 6,
           "linkage" : "DYNAMIC",
-          "pkg" : 5
+          "pkg" : 3
+        }, {
+          "key" : 7,
+          "linkage" : "DYNAMIC",
+          "pkg" : 6
         } ]
       }, {
-        "key" : 7,
+        "key" : 8,
         "linkage" : "DYNAMIC",
-        "pkg" : 4,
+        "pkg" : 5,
         "children" : [ {
-          "key" : 8,
+          "key" : 9,
           "linkage" : "DYNAMIC",
-          "pkg" : 3
+          "pkg" : 4
         } ]
       } ]
     } ]
   }, {
-    "key" : 9,
+    "key" : 10,
     "pkg" : 1,
     "path_excludes" : [ 0 ]
   } ],
@@ -672,7 +762,7 @@
   }, {
     "_id" : 1,
     "rule" : "rule 2",
-    "pkg" : 4,
+    "pkg" : 5,
     "license" : 8,
     "license_source" : "DECLARED",
     "severity" : "HINT",
@@ -682,7 +772,7 @@
   }, {
     "_id" : 2,
     "rule" : "rule 3",
-    "pkg" : 5,
+    "pkg" : 6,
     "license" : 1,
     "license_source" : "CONCLUDED",
     "severity" : "WARNING",
@@ -704,7 +794,7 @@
       "included_projects" : 1,
       "excluded_projects" : 1,
       "included_packages" : 2,
-      "excludes_packages" : 2,
+      "excludes_packages" : 3,
       "total_tree_depth" : 2,
       "included_tree_depth" : 2,
       "included_scopes" : [ "compile" ],
@@ -715,8 +805,9 @@
         "Apache-2.0" : 2,
         "BSD-3-Clause" : 1,
         "CC-BY-NC-3.0" : 1,
-        "EPL-1.0" : 1,
-        "GPL-3.0-only WITH GCC-exception-3.1" : 1
+        "EPL-1.0" : 2,
+        "GPL-3.0-only WITH GCC-exception-3.1" : 1,
+        "MPL-2.0" : 1
       },
       "detected" : {
         "Apache-2.0" : 1,
@@ -756,10 +847,19 @@
       },
       "resolutions" : {
         "rule_violations" : [ 0 ]
+      },
+      "license_choices" : {
+        "package_license_choices" : [ {
+          "package_id" : "Maven:com.h2database:h2:1.4.200",
+          "license_choices" : [ {
+            "given" : "MPL-2.0 OR EPL-1.0",
+            "choice" : "MPL-2.0"
+          } ]
+        } ]
       }
     }
   },
-  "repository_configuration" : "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/project/build.gradle\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"The project is an example.\"\n  - pattern: \"**.java\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"These are example files.\"\n  scopes:\n  - pattern: \"testCompile\"\n    reason: \"TEST_DEPENDENCY_OF\"\n    comment: \"The scope only contains test dependencies.\"\nresolutions:\n  rule_violations:\n  - message: \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2 is not an issue.\"\n",
+  "repository_configuration" : "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/project/build.gradle\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"The project is an example.\"\n  - pattern: \"**.java\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"These are example files.\"\n  scopes:\n  - pattern: \"testCompile\"\n    reason: \"TEST_DEPENDENCY_OF\"\n    comment: \"The scope only contains test dependencies.\"\nresolutions:\n  rule_violations:\n  - message: \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2 is not an issue.\"\nlicense_choices:\n  package_license_choices:\n  - package_id: \"Maven:com.h2database:h2:1.4.200\"\n    license_choices:\n    - given: \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\n",
   "labels" : {
     "job_parameters.JOB_PARAM_1" : "label job param 1",
     "job_parameters.JOB_PARAM_2" : "label job param 2",

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -40,8 +40,12 @@ licenses:
 - _id: 10
   id: "EPL-1.0"
 - _id: 11
-  id: "Apache License, Version 2.0"
+  id: "MPL 2.0 or EPL 1.0"
 - _id: 12
+  id: "MPL-2.0"
+- _id: 13
+  id: "Apache License, Version 2.0"
+- _id: 14
   id: "New BSD License"
 scopes:
 - _id: 0
@@ -120,6 +124,22 @@ scan_results:
   provenance:
     download_time: "1970-01-01T00:00:00Z"
     source_artifact:
+      url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+      hash:
+        value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+        algorithm: "SHA-1"
+  scanner:
+    name: "FileCounter"
+    version: "1.0"
+    configuration: ""
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  file_count: 42
+  package_verification_code: "0000000000000000000000000000000000000000"
+- _id: 4
+  provenance:
+    download_time: "1970-01-01T00:00:00Z"
+    source_artifact:
       url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
       hash:
         value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
@@ -132,7 +152,7 @@ scan_results:
   end_time: "1970-01-01T00:00:00Z"
   file_count: 168
   package_verification_code: "0000000000000000000000000000000000000000"
-- _id: 4
+- _id: 5
   provenance:
     download_time: "1970-01-01T00:00:00Z"
     source_artifact:
@@ -148,7 +168,7 @@ scan_results:
   end_time: "1970-01-01T00:00:00Z"
   file_count: 80
   package_verification_code: "0000000000000000000000000000000000000000"
-- _id: 5
+- _id: 6
   provenance:
     download_time: "1970-01-01T00:00:00Z"
     source_artifact:
@@ -388,12 +408,63 @@ packages:
   scope_excludes:
   - 0
 - _id: 3
+  id: "Maven:com.h2database:h2:1.4.200"
+  is_project: false
+  definition_file_path: ""
+  purl: "pkg:maven/com.h2database/h2@1.4.200"
+  declared_licenses:
+  - 11
+  declared_licenses_processed:
+    spdx_expression: "MPL-2.0 OR EPL-1.0"
+    mapped_licenses:
+    - 12
+    - 10
+  concluded_license: "MPL-2.0 OR EPL-1.0"
+  description: "H2 Database Engine"
+  homepage_url: "https://h2database.com"
+  binary_artifact:
+    url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200.jar"
+    hash:
+      value: "f7533fe7cb8e99c87a43d325a77b4b678ad9031a"
+      algorithm: "SHA-1"
+  source_artifact:
+    url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+    hash:
+      value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/h2database/h2database"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/h2database/h2database.git"
+    revision: ""
+    path: ""
+  curations:
+  - base: {}
+    curation:
+      concluded_license: "MPL-2.0 OR EPL-1.0"
+      comment: "H2 database offers a license choice"
+  paths:
+  - 1
+  levels:
+  - 1
+  scopes:
+  - 1
+  scan_results:
+  - 3
+  is_excluded: true
+  scope_excludes:
+  - 0
+- _id: 4
   id: "Maven:org.apache.commons:commons-lang3:3.5"
   is_project: false
   definition_file_path: ""
   purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
   declared_licenses:
-  - 11
+  - 13
   declared_licenses_processed:
     spdx_expression: "Apache-2.0"
     mapped_licenses:
@@ -423,23 +494,23 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 1
   - 2
+  - 3
   levels:
   - 1
   scopes:
   - 0
   - 1
   scan_results:
-  - 3
+  - 4
   is_excluded: false
-- _id: 4
+- _id: 5
   id: "Maven:org.apache.commons:commons-text:1.1"
   is_project: false
   definition_file_path: ""
   purl: "pkg:maven/org.apache.commons/commons-text@1.1"
   declared_licenses:
-  - 11
+  - 13
   declared_licenses_processed:
     spdx_expression: "Apache-2.0"
     mapped_licenses:
@@ -468,23 +539,23 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 3
   - 4
+  - 5
   levels:
   - 0
   scopes:
   - 0
   - 1
   scan_results:
-  - 4
+  - 5
   is_excluded: false
-- _id: 5
+- _id: 6
   id: "Maven:org.hamcrest:hamcrest-core:1.3"
   is_project: false
   definition_file_path: ""
   purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
   declared_licenses:
-  - 12
+  - 14
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped_licenses:
@@ -514,13 +585,13 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 5
+  - 6
   levels:
   - 1
   scopes:
   - 1
   scan_results:
-  - 5
+  - 6
   is_excluded: true
   scope_excludes:
   - 0
@@ -533,27 +604,33 @@ paths:
 - _id: 1
   pkg: 3
   project: 0
-  scope: 0
-  path:
-  - 4
-- _id: 2
-  pkg: 3
-  project: 0
   scope: 1
   path:
-  - 4
+  - 2
+- _id: 2
+  pkg: 4
+  project: 0
+  scope: 0
+  path:
+  - 5
 - _id: 3
   pkg: 4
   project: 0
-  scope: 0
-  path: []
-- _id: 4
-  pkg: 4
-  project: 0
   scope: 1
+  path:
+  - 5
+- _id: 4
+  pkg: 5
+  project: 0
+  scope: 0
   path: []
 - _id: 5
   pkg: 5
+  project: 0
+  scope: 1
+  path: []
+- _id: 6
+  pkg: 6
   project: 0
   scope: 1
   path:
@@ -567,11 +644,11 @@ dependency_trees:
     children:
     - key: 2
       linkage: "DYNAMIC"
-      pkg: 4
+      pkg: 5
       children:
       - key: 3
         linkage: "DYNAMIC"
-        pkg: 3
+        pkg: 4
   - key: 4
     scope: 1
     scope_excludes:
@@ -583,15 +660,18 @@ dependency_trees:
       children:
       - key: 6
         linkage: "DYNAMIC"
-        pkg: 5
-    - key: 7
-      linkage: "DYNAMIC"
-      pkg: 4
-      children:
-      - key: 8
-        linkage: "DYNAMIC"
         pkg: 3
-- key: 9
+      - key: 7
+        linkage: "DYNAMIC"
+        pkg: 6
+    - key: 8
+      linkage: "DYNAMIC"
+      pkg: 5
+      children:
+      - key: 9
+        linkage: "DYNAMIC"
+        pkg: 4
+- key: 10
   pkg: 1
   path_excludes:
   - 0
@@ -612,7 +692,7 @@ rule_violations:
     \ that overflow:scroll is working as expected.\n```"
 - _id: 1
   rule: "rule 2"
-  pkg: 4
+  pkg: 5
   license: 8
   license_source: "DECLARED"
   severity: "HINT"
@@ -623,7 +703,7 @@ rule_violations:
   - 0
 - _id: 2
   rule: "rule 3"
-  pkg: 5
+  pkg: 6
   license: 1
   license_source: "CONCLUDED"
   severity: "WARNING"
@@ -643,7 +723,7 @@ statistics:
     included_projects: 1
     excluded_projects: 1
     included_packages: 2
-    excludes_packages: 2
+    excludes_packages: 3
     total_tree_depth: 2
     included_tree_depth: 2
     included_scopes:
@@ -655,8 +735,9 @@ statistics:
       Apache-2.0: 2
       BSD-3-Clause: 1
       CC-BY-NC-3.0: 1
-      EPL-1.0: 1
+      EPL-1.0: 2
       GPL-3.0-only WITH GCC-exception-3.1: 1
+      MPL-2.0: 1
     detected:
       Apache-2.0: 1
       BSD-3-Clause: 1
@@ -691,13 +772,21 @@ repository:
     resolutions:
       rule_violations:
       - 0
+    license_choices:
+      package_license_choices:
+      - package_id: "Maven:com.h2database:h2:1.4.200"
+        license_choices:
+        - given: "MPL-2.0 OR EPL-1.0"
+          choice: "MPL-2.0"
 repository_configuration: "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/project/build.gradle\"\
   \n    reason: \"EXAMPLE_OF\"\n    comment: \"The project is an example.\"\n  - pattern:\
   \ \"**.java\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"These are example files.\"\
   \n  scopes:\n  - pattern: \"testCompile\"\n    reason: \"TEST_DEPENDENCY_OF\"\n\
   \    comment: \"The scope only contains test dependencies.\"\nresolutions:\n  rule_violations:\n\
   \  - message: \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment:\
-  \ \"Apache-2 is not an issue.\"\n"
+  \ \"Apache-2 is not an issue.\"\nlicense_choices:\n  package_license_choices:\n\
+  \  - package_id: \"Maven:com.h2database:h2:1.4.200\"\n    license_choices:\n   \
+  \ - given: \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\n"
 labels:
   job_parameters.JOB_PARAM_1: "label job param 1"
   job_parameters.JOB_PARAM_2: "label job param 2"

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -620,6 +620,10 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
                   <div>MIT (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
                 </dd>
               </dl>
+              <em>Effective License:</em>
+              <dl>
+                <dd>GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause AND LicenseRef-test-Apache-2.0-multi-line AND LicenseRef-test-Apache-2.0-single-line OR MIT AND LicenseRef-test-Apache-2.0-multi-line AND LicenseRef-test-Apache-2.0-single-line</dd>
+              </dl>
             </td><td>
               <ul></ul>
             </td><td>
@@ -642,24 +646,36 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
                   <div>EPL-1.0</div>
                 </dd>
               </dl>
+              <em>Effective License:</em>
+              <dl>
+                <dd>EPL-1.0</dd>
+              </dl>
             </td><td>
               <ul></ul>
             </td><td>
               <ul></ul>
             </td>
           </tr>
-          <tr class="ort-success " id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-3">
-            <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-3">3</a></td><td>Maven:org.apache.commons:commons-lang3:3.5</td><td>
+          <tr class="ort-success ort-excluded" id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-3">
+            <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-3">3</a></td><td>Maven:com.h2database:h2:1.4.200</td><td>
               <ul>
-                <li class="">compile</li>
                 <li class="ort-excluded">testCompile <div class="ort-reason">Excluded: TEST_DEPENDENCY_OF - The scope only contains test dependencies.</div>
                 </li>
               </ul>
-            </td><td><em>Declared Licenses:</em>
+            </td><td><em>Concluded License:</em>
+              <dl>
+                <dd>MPL-2.0 OR EPL-1.0</dd>
+              </dl>
+              <em>Declared Licenses:</em>
               <dl>
                 <dd>
-                  <div>Apache-2.0</div>
+                  <div>EPL-1.0</div>
+                  <div>MPL-2.0</div>
                 </dd>
+              </dl>
+              <em>Effective License:</em>
+              <dl>
+                <dd>MPL-2.0</dd>
               </dl>
             </td><td>
               <ul></ul>
@@ -668,7 +684,7 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
             </td>
           </tr>
           <tr class="ort-success " id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-4">
-            <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-4">4</a></td><td>Maven:org.apache.commons:commons-text:1.1</td><td>
+            <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-4">4</a></td><td>Maven:org.apache.commons:commons-lang3:3.5</td><td>
               <ul>
                 <li class="">compile</li>
                 <li class="ort-excluded">testCompile <div class="ort-reason">Excluded: TEST_DEPENDENCY_OF - The scope only contains test dependencies.</div>
@@ -680,14 +696,41 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
                   <div>Apache-2.0</div>
                 </dd>
               </dl>
+              <em>Effective License:</em>
+              <dl>
+                <dd>Apache-2.0</dd>
+              </dl>
             </td><td>
               <ul></ul>
             </td><td>
               <ul></ul>
             </td>
           </tr>
-          <tr class="ort-success ort-excluded" id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-5">
-            <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-5">5</a></td><td>Maven:org.hamcrest:hamcrest-core:1.3</td><td>
+          <tr class="ort-success " id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-5">
+            <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-5">5</a></td><td>Maven:org.apache.commons:commons-text:1.1</td><td>
+              <ul>
+                <li class="">compile</li>
+                <li class="ort-excluded">testCompile <div class="ort-reason">Excluded: TEST_DEPENDENCY_OF - The scope only contains test dependencies.</div>
+                </li>
+              </ul>
+            </td><td><em>Declared Licenses:</em>
+              <dl>
+                <dd>
+                  <div>Apache-2.0</div>
+                </dd>
+              </dl>
+              <em>Effective License:</em>
+              <dl>
+                <dd>Apache-2.0</dd>
+              </dl>
+            </td><td>
+              <ul></ul>
+            </td><td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr class="ort-success ort-excluded" id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-6">
+            <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-6">6</a></td><td>Maven:org.hamcrest:hamcrest-core:1.3</td><td>
               <ul>
                 <li class="ort-excluded">testCompile <div class="ort-reason">Excluded: TEST_DEPENDENCY_OF - The scope only contains test dependencies.</div>
                 </li>
@@ -697,6 +740,10 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
                 <dd>
                   <div>BSD-3-Clause</div>
                 </dd>
+              </dl>
+              <em>Effective License:</em>
+              <dl>
+                <dd>BSD-3-Clause</dd>
               </dl>
             </td><td>
               <ul></ul>
@@ -752,6 +799,10 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
                   <div class="ort-excluded">MIT (Excluded: EXAMPLE_OF - These are example files.)</div>
                 </dd>
               </dl>
+              <em>Effective License:</em>
+              <dl>
+                <dd>GPL-3.0-only WITH GCC-exception-3.1 AND CC-BY-NC-3.0 AND Apache-2.0 AND MIT</dd>
+              </dl>
             </td><td>
               <ul></ul>
             </td><td>
@@ -781,6 +832,12 @@ resolutions:
   - message: "Apache-2.0 hint"
     reason: "CANT_FIX_EXCEPTION"
     comment: "Apache-2 is not an issue."
+license_choices:
+  package_license_choices:
+  - package_id: "Maven:com.h2database:h2:1.4.200"
+    license_choices:
+    - given: "MPL-2.0 OR EPL-1.0"
+      choice: "MPL-2.0"
 </code>
       </pre>
     </div>

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -34,6 +34,12 @@ repository:
       - message: "Apache-2.0 hint"
         reason: "CANT_FIX_EXCEPTION"
         comment: "Apache-2 is not an issue."
+    license_choices:
+      package_license_choices:
+        - package_id: "Maven:com.h2database:h2:1.4.200"
+          license_choices:
+            - given: "MPL-2.0 OR EPL-1.0"
+              choice: "MPL-2.0"
 analyzer:
   start_time: "1970-01-01T00:00:00Z"
   end_time: "1970-01-01T00:00:00Z"
@@ -74,6 +80,7 @@ analyzer:
         - id: "Ant:junit:junit:4.12"
           dependencies:
           - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+          - id: "Maven:com.h2database:h2:1.4.200"
         - id: "Maven:org.apache.commons:commons-text:1.1"
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
@@ -228,6 +235,45 @@ analyzer:
           revision: ""
           path: ""
       curations: []
+    - package:
+        id: "Maven:com.h2database:h2:1.4.200"
+        purl: "pkg:maven/com.h2database/h2@1.4.200"
+        authors:
+          - "Thomas Mueller"
+        declared_licenses:
+          - "MPL 2.0 or EPL 1.0"
+        declared_licenses_processed:
+          spdx_expression: "MPL-2.0 OR EPL-1.0"
+          mapped:
+            MPL 2.0 or EPL 1.0: "MPL-2.0 OR EPL-1.0"
+        concluded_license: "MPL-2.0 OR EPL-1.0"
+        description: "H2 Database Engine"
+        homepage_url: "https://h2database.com"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200.jar"
+          hash:
+            value: "f7533fe7cb8e99c87a43d325a77b4b678ad9031a"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+          hash:
+            value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "https://github.com/h2database/h2database"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/h2database/h2database.git"
+          revision: ""
+          path: ""
+      curations:
+        - base: { }
+          curation:
+            concluded_license: "MPL-2.0 OR EPL-1.0"
+            comment: "H2 database offers a license choice"
     has_issues: false
 scanner:
   start_time: "1970-01-01T00:00:00Z"
@@ -435,6 +481,26 @@ scanner:
           package_verification_code: "0000000000000000000000000000000000000000"
           licenses: []
           copyrights: []
+    - id: "Maven:com.h2database:h2:1.4.200"
+      results:
+      - provenance:
+          download_time: "1970-01-01T00:00:00Z"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+            hash:
+              value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+              algorithm: "SHA-1"
+        scanner:
+          name: "FileCounter"
+          version: "1.0"
+          configuration: ""
+        summary:
+          start_time: "1970-01-01T00:00:00Z"
+          end_time: "1970-01-01T00:00:00Z"
+          file_count: 42
+          package_verification_code: "0000000000000000000000000000000000000000"
+          licenses: [ ]
+          copyrights: [ ]
     storage_stats:
       num_reads: 5
       num_hits: 0

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -573,6 +573,11 @@ class StaticHtmlReporter : Reporter {
                         }
                     }
                 }
+
+                if (row.effectiveLicense != null) {
+                    em { +"Effective License:" }
+                    dl { dd { +"${row.effectiveLicense}" } }
+                }
             }
 
             td { issueList(row.analyzerIssues) }

--- a/reporter/src/main/kotlin/utils/ReportTableModel.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModel.kt
@@ -135,6 +135,12 @@ data class ReportTableModel(
         val detectedLicenses: List<ResolvedLicense>,
 
         /**
+         * The effective license of the package derived from the licenses of the license sources chosen by a
+         * LicenseView, with optional choices applied.
+         */
+        val effectiveLicense: SpdxExpression?,
+
+        /**
          * All analyzer issues related to this package.
          */
         val analyzerIssues: List<ResolvableIssue>,

--- a/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
@@ -30,6 +30,7 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
+import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.model.utils.ResolutionProvider
 import org.ossreviewtoolkit.reporter.HowToFixTextProvider
 import org.ossreviewtoolkit.reporter.utils.ReportTableModel.DependencyRow
@@ -159,6 +160,10 @@ class ReportTableModelMapper(
                     concludedLicense = concludedLicense,
                     declaredLicenses = declaredLicenses,
                     detectedLicenses = detectedLicenses,
+                    effectiveLicense = resolvedLicenseInfo.effectiveLicense(
+                        LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED,
+                        ortResult.getLicenseChoices(id)
+                    ),
                     analyzerIssues = analyzerIssues.map { it.toResolvableIssue() },
                     scanIssues = scanIssues.map { it.toResolvableIssue() }
                 ).also { row ->

--- a/spdx-utils/src/main/kotlin/model/LicenseChoice.kt
+++ b/spdx-utils/src/main/kotlin/model/LicenseChoice.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.spdx.model
 
+import org.ossreviewtoolkit.spdx.InvalidLicenseChoiceException
 import org.ossreviewtoolkit.spdx.SpdxExpression
 
 /**
@@ -53,4 +54,12 @@ import org.ossreviewtoolkit.spdx.SpdxExpression
 data class LicenseChoice(
     val given: SpdxExpression?,
     val choice: SpdxExpression,
-)
+) {
+    init {
+        if (given?.isValidChoice(choice) == false) {
+            throw InvalidLicenseChoiceException(
+                "$choice is not a valid choice for $given. Valid choices are: ${given.validChoices()}."
+            )
+        }
+    }
+}

--- a/spdx-utils/src/main/kotlin/model/LicenseChoice.kt
+++ b/spdx-utils/src/main/kotlin/model/LicenseChoice.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.spdx.model
+
+import org.ossreviewtoolkit.spdx.SpdxExpression
+
+/**
+ * An individual license choice.
+ *
+ * [given] is the complete license expression, or a sub-expression of the license, where [choice] is going to be applied
+ * on. If no [given] is supplied, the [choice] will be applied to the complete expression of the package.
+ *
+ * e.g.: with [given] as complete expression
+ * ```
+ *  -> Complete license expression: (A OR B) AND C
+ *  given: (A OR B) AND C
+ *  choice: A AND C
+ *  -> result: A AND C
+ * ```
+ *
+ * e.g.: with [given] as sub-expression
+ * ```
+ *  -> Complete license expression: (A OR B) AND C
+ *  given: (A OR B)
+ *  choice: A
+ *  -> result: A AND C
+ * ```
+ *
+ * e.g.: without [given]
+ * ```
+ *  -> Complete license expression: (A OR B) AND (C OR D)
+ *  choice: A AND C
+ *  -> result: A AND C
+ * ```
+ */
+data class LicenseChoice(
+    val given: SpdxExpression?,
+    val choice: SpdxExpression,
+)


### PR DESCRIPTION
Apply license choices specified for a package defined in the repository configuration file.

The choices are used in the `licenseRule` and the `StaticHtmlReporter` and applied in the `effectiveLicense` function of `ResolveLicenseInfo`.

Related to #3396.

CC: @neubs-bsi