### PR TITLE
Downloader: Fix the reading of content-disposition

### DIFF
--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -302,7 +302,8 @@ object Downloader {
                     // So first look for a dedicated header in the response, but then also try both redirected and
                     // original URLs to find a name which has a recognized archive type extension.
                     response.headers("Content-disposition").mapNotNullTo(candidateNames) { value ->
-                        value.withoutPrefix("attachment; filename=")
+                        val filenames = value.split(';').mapNotNull { it.trim().withoutPrefix("filename=") }
+                        filenames.firstOrNull()?.removeSurrounding("\"")
                     }
 
                     listOf(response.request.url, request.url).mapTo(candidateNames) {


### PR DESCRIPTION
I've got a exception :
```
 Exception in thread "main" java.nio.file.InvalidPathException: Illegal char <"> at index 22: ort5136863379338526039"logback-logger_2.12-1.0.14-sources.jar"; filename*=UTF-8''logback-logger_2.12-1.0.14-sources.jar
        at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
        at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
        at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
        at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)
        at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:229)
        at java.base/java.nio.file.TempFileHelper.generatePath(TempFileHelper.java:59)
        at java.base/java.nio.file.TempFileHelper.create(TempFileHelper.java:126)
        at java.base/java.nio.file.TempFileHelper.createTempFile(TempFileHelper.java:160)
        at java.base/java.nio.file.Files.createTempFile(Files.java:912)
        at org.ossreviewtoolkit.downloader.Downloader.downloadSourceArtifact(Downloader.kt:316)
```
when my artifactory return that kind of value for content-disposition header : `attachment; filename="logback-logger_2.12-1.0.14-sources.jar"; filename*=UTF-8''logback-logger_2.12-1.0.14-sources.jar`
the tempFileName is `"logback-logger_2.12-1.0.14-sources.jar"; filename*=UTF-8''logback-logger_2.12-1.0.14-sources.jar`
and that causes the error.

The content-disposition may have more than one "filename =" pattern. (see https://tools.ietf.org/html/rfc6266#section-4.1)

The parsing of this value can be a bit complex, example : https://github.com/spring-projects/spring-framework/blob/master/spring-web/src/main/java/org/springframework/http/ContentDisposition.java#L336

I propose a simplistic approach by taking only the first value with filename=xxx


