### PR TITLE
Initialize the proxy selector only once for all tests via the ProjectConfig

### DIFF
--- a/analyzer/src/test/kotlin/curation/ClearlyDefinedPackageCurationProviderTest.kt
+++ b/analyzer/src/test/kotlin/curation/ClearlyDefinedPackageCurationProviderTest.kt
@@ -27,11 +27,8 @@ import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.utils.OrtProxySelector
 
 class ClearlyDefinedPackageCurationProviderTest : WordSpec({
-    OrtProxySelector.install()
-
     "The production server" should {
         "return an existing curation for the javax.servlet-api Maven package" {
             val provider = ClearlyDefinedPackageCurationProvider()

--- a/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
+++ b/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
@@ -38,13 +38,10 @@ import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Curatio
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Licensed
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Patch
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
-import org.ossreviewtoolkit.utils.OrtProxySelector
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class ClearlyDefinedServiceFunTest : WordSpec({
-    OrtProxySelector.install()
-
     "A contribution patch" should {
         "be correctly deserialized even when using invalid facet arrays" {
             // See https://github.com/clearlydefined/curated-data/blob/0b2db78/curations/maven/mavencentral/com.google.code.gson/gson.yaml#L10-L11.

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
 
 dependencies {
     api(project(":model"))
+    api(project(":utils"))
 
     api("io.kotest:kotest-assertions-core:$kotestVersion")
     api("io.kotest:kotest-framework-api:$kotestVersion")

--- a/test-utils/src/main/kotlin/ProjectConfig.kt
+++ b/test-utils/src/main/kotlin/ProjectConfig.kt
@@ -23,8 +23,14 @@ import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.spec.SpecExecutionOrder
 import io.kotest.extensions.junitxml.JunitXmlReporter
 
+import org.ossreviewtoolkit.utils.OrtProxySelector
+
 class ProjectConfig : AbstractProjectConfig() {
     override val specExecutionOrder = SpecExecutionOrder.Annotated
+
+    init {
+        OrtProxySelector.install()
+    }
 
     override fun listeners() =
         listOf(


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>