### PR TITLE
Composer: Add support for authors

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/composer-expected-output-no-deps.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/composer-expected-output-no-deps.yml
@@ -2,6 +2,9 @@
 project:
   id: "Composer:ort:composer-test-project:0.1.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
+  authors:
+  - "The Author"
+  - "The Other Author"
   declared_licenses:
   - "Apache-2.0"
   - "MIT"

--- a/analyzer/src/funTest/assets/projects/synthetic/composer-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/composer-expected-output.yml
@@ -90,6 +90,8 @@ project:
 packages:
 - id: "Composer:doctrine:instantiator:1.4.0"
   purl: "pkg:composer/doctrine/instantiator@1.4.0"
+  authors:
+  - "Marco Pivetta"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -119,6 +121,8 @@ packages:
     path: ""
 - id: "Composer:monolog:monolog:2.2.0"
   purl: "pkg:composer/monolog/monolog@2.2.0"
+  authors:
+  - "Jordi Boggiano"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -176,6 +180,10 @@ packages:
     path: ""
 - id: "Composer:phar-io:manifest:2.0.1"
   purl: "pkg:composer/phar-io/manifest@2.0.1"
+  authors:
+  - "Arne Blankerts"
+  - "Sebastian Bergmann"
+  - "Sebastian Heuer"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -205,6 +213,10 @@ packages:
     path: ""
 - id: "Composer:phar-io:version:3.0.4"
   purl: "pkg:composer/phar-io/version@3.0.4"
+  authors:
+  - "Arne Blankerts"
+  - "Sebastian Bergmann"
+  - "Sebastian Heuer"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -233,6 +245,8 @@ packages:
     path: ""
 - id: "Composer:phpdocumentor:reflection-common:2.2.0"
   purl: "pkg:composer/phpdocumentor/reflection-common@2.2.0"
+  authors:
+  - "Jaap van Otterdijk"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -262,6 +276,9 @@ packages:
     path: ""
 - id: "Composer:phpdocumentor:reflection-docblock:5.2.2"
   purl: "pkg:composer/phpdocumentor/reflection-docblock@5.2.2"
+  authors:
+  - "Jaap van Otterdijk"
+  - "Mike van Riel"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -291,6 +308,8 @@ packages:
     path: ""
 - id: "Composer:phpdocumentor:type-resolver:1.4.0"
   purl: "pkg:composer/phpdocumentor/type-resolver@1.4.0"
+  authors:
+  - "Mike van Riel"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -320,6 +339,9 @@ packages:
     path: ""
 - id: "Composer:phpspec:prophecy:1.12.2"
   purl: "pkg:composer/phpspec/prophecy@1.12.2"
+  authors:
+  - "Konstantin Kudryashov"
+  - "Marcello Duarte"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -348,6 +370,8 @@ packages:
     path: ""
 - id: "Composer:phpunit:php-code-coverage:7.0.14"
   purl: "pkg:composer/phpunit/php-code-coverage@7.0.14"
+  authors:
+  - "Sebastian Bergmann"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -377,6 +401,8 @@ packages:
     path: ""
 - id: "Composer:phpunit:php-file-iterator:2.0.3"
   purl: "pkg:composer/phpunit/php-file-iterator@2.0.3"
+  authors:
+  - "Sebastian Bergmann"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -406,6 +432,8 @@ packages:
     path: ""
 - id: "Composer:phpunit:php-text-template:1.2.1"
   purl: "pkg:composer/phpunit/php-text-template@1.2.1"
+  authors:
+  - "Sebastian Bergmann"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -434,6 +462,8 @@ packages:
     path: ""
 - id: "Composer:phpunit:php-timer:2.1.3"
   purl: "pkg:composer/phpunit/php-timer@2.1.3"
+  authors:
+  - "Sebastian Bergmann"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -462,6 +492,8 @@ packages:
     path: ""
 - id: "Composer:phpunit:php-token-stream:3.1.2"
   purl: "pkg:composer/phpunit/php-token-stream@3.1.2"
+  authors:
+  - "Sebastian Bergmann"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -490,6 +522,8 @@ packages:
     path: ""
 - id: "Composer:phpunit:phpunit:8.5.14"
   purl: "pkg:composer/phpunit/phpunit@8.5.14"
+  authors:
+  - "Sebastian Bergmann"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -518,6 +552,8 @@ packages:
     path: ""
 - id: "Composer:psr:log:1.1.3"
   purl: "pkg:composer/psr/log@1.1.3"
+  authors:
+  - "PHP-FIG"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -546,6 +582,8 @@ packages:
     path: ""
 - id: "Composer:sebastian:code-unit-reverse-lookup:1.0.2"
   purl: "pkg:composer/sebastian/code-unit-reverse-lookup@1.0.2"
+  authors:
+  - "Sebastian Bergmann"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -574,6 +612,11 @@ packages:
     path: ""
 - id: "Composer:sebastian:comparator:3.0.3"
   purl: "pkg:composer/sebastian/comparator@3.0.3"
+  authors:
+  - "Bernhard Schussek"
+  - "Jeff Welch"
+  - "Sebastian Bergmann"
+  - "Volker Dusch"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -602,6 +645,9 @@ packages:
     path: ""
 - id: "Composer:sebastian:diff:3.0.3"
   purl: "pkg:composer/sebastian/diff@3.0.3"
+  authors:
+  - "Kore Nordmann"
+  - "Sebastian Bergmann"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -630,6 +676,8 @@ packages:
     path: ""
 - id: "Composer:sebastian:environment:4.2.4"
   purl: "pkg:composer/sebastian/environment@4.2.4"
+  authors:
+  - "Sebastian Bergmann"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -658,6 +706,12 @@ packages:
     path: ""
 - id: "Composer:sebastian:exporter:3.1.3"
   purl: "pkg:composer/sebastian/exporter@3.1.3"
+  authors:
+  - "Adam Harvey"
+  - "Bernhard Schussek"
+  - "Jeff Welch"
+  - "Sebastian Bergmann"
+  - "Volker Dusch"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -686,6 +740,8 @@ packages:
     path: ""
 - id: "Composer:sebastian:global-state:3.0.1"
   purl: "pkg:composer/sebastian/global-state@3.0.1"
+  authors:
+  - "Sebastian Bergmann"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -714,6 +770,8 @@ packages:
     path: ""
 - id: "Composer:sebastian:object-enumerator:3.0.4"
   purl: "pkg:composer/sebastian/object-enumerator@3.0.4"
+  authors:
+  - "Sebastian Bergmann"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -743,6 +801,8 @@ packages:
     path: ""
 - id: "Composer:sebastian:object-reflector:1.1.2"
   purl: "pkg:composer/sebastian/object-reflector@1.1.2"
+  authors:
+  - "Sebastian Bergmann"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -772,6 +832,10 @@ packages:
     path: ""
 - id: "Composer:sebastian:recursion-context:3.0.1"
   purl: "pkg:composer/sebastian/recursion-context@3.0.1"
+  authors:
+  - "Adam Harvey"
+  - "Jeff Welch"
+  - "Sebastian Bergmann"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -800,6 +864,8 @@ packages:
     path: ""
 - id: "Composer:sebastian:resource-operations:2.0.2"
   purl: "pkg:composer/sebastian/resource-operations@2.0.2"
+  authors:
+  - "Sebastian Bergmann"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -828,6 +894,8 @@ packages:
     path: ""
 - id: "Composer:sebastian:type:1.1.4"
   purl: "pkg:composer/sebastian/type@1.1.4"
+  authors:
+  - "Sebastian Bergmann"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -857,6 +925,8 @@ packages:
     path: ""
 - id: "Composer:sebastian:version:2.0.1"
   purl: "pkg:composer/sebastian/version@2.0.1"
+  authors:
+  - "Sebastian Bergmann"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -886,6 +956,9 @@ packages:
     path: ""
 - id: "Composer:symfony:polyfill-ctype:v1.22.0"
   purl: "pkg:composer/symfony/polyfill-ctype@v1.22.0"
+  authors:
+  - "Gert de Pagter"
+  - "Symfony Community"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -914,6 +987,8 @@ packages:
     path: ""
 - id: "Composer:theseer:tokenizer:1.2.0"
   purl: "pkg:composer/theseer/tokenizer@1.2.0"
+  authors:
+  - "Arne Blankerts"
   declared_licenses:
   - "BSD-3-Clause"
   declared_licenses_processed:
@@ -943,6 +1018,8 @@ packages:
     path: ""
 - id: "Composer:webmozart:assert:1.9.1"
   purl: "pkg:composer/webmozart/assert@1.9.1"
+  authors:
+  - "Bernhard Schussek"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/composer/empty-deps/composer.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/composer/empty-deps/composer.json
@@ -4,6 +4,14 @@
     "homepage": "https://github.com/oss-review-toolkit/ort",
     "version": "0.1.0",
     "license": ["Apache-2.0","MIT"],
+    "authors": [
+        {
+            "name": "The Author"
+        },
+        {
+            "name": "The Other Author"
+        }
+    ],
     "require": {},
     "require-dev": {}
 }

--- a/analyzer/src/funTest/assets/projects/synthetic/composer/no-deps/composer.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/composer/no-deps/composer.json
@@ -3,5 +3,13 @@
     "description": "A simple project for parsing composer projects in oss-review-toolkit",
     "homepage": "https://github.com/oss-review-toolkit/ort",
     "version": "0.1.0",
-    "license": ["Apache-2.0","MIT"]
+    "license": ["Apache-2.0","MIT"],
+    "authors": [
+        {
+            "name": "The Author"
+        },
+        {
+            "name": "The Other Author"
+        }
+    ]
 }

--- a/analyzer/src/main/kotlin/managers/Composer.kt
+++ b/analyzer/src/main/kotlin/managers/Composer.kt
@@ -66,6 +66,7 @@ private val EXCLUDED_PACKAGES = setOf(
 /**
  * The [Composer](https://getcomposer.org/) package manager for PHP.
  */
+@Suppress("TooManyFunctions")
 class Composer(
     name: String,
     analysisRoot: File,
@@ -232,8 +233,7 @@ class Composer(
                 version = json["version"].textValueOrEmpty()
             ),
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
-            // TODO: Find a way to track authors.
-            authors = sortedSetOf(),
+            authors = parseAuthors(json),
             declaredLicenses = parseDeclaredLicenses(json),
             vcs = vcs,
             vcsProcessed = processProjectVcs(definitionFile.parentFile, vcs, homepageUrl),
@@ -265,8 +265,7 @@ class Composer(
                         name = rawName.substringAfter('/'),
                         version = version
                     ),
-                    // TODO: Find a way to track authors.
-                    authors = sortedSetOf(),
+                    authors = parseAuthors(pkgInfo),
                     declaredLicenses = parseDeclaredLicenses(pkgInfo),
                     description = pkgInfo["description"].textValueOrEmpty(),
                     homepageUrl = homepageUrl,
@@ -311,6 +310,11 @@ class Composer(
         listOf("replace", "provide").flatMap {
             packageInfo[it]?.fieldNames()?.asSequence()?.toSet().orEmpty()
         }.toSet()
+
+    private fun parseAuthors(packageInfo: JsonNode) =
+        sortedSetOf<String>().also { authors ->
+            packageInfo["authors"]?.mapNotNullTo(authors) { it["name"]?.textValue() }
+        }
 
     private fun parseDeclaredLicenses(packageInfo: JsonNode) =
         sortedSetOf<String>().also { set ->


### PR DESCRIPTION
Extract information about the authors of a package from the
composer.json definition file and make it available in the metadata
of packages and projects.