### PR TITLE
Remove most usages of ScanResultContainer

### DIFF
--- a/evaluator/src/test/kotlin/TestData.kt
+++ b/evaluator/src/test/kotlin/TestData.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@ import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.Repository
 import org.ossreviewtoolkit.model.ScanRecord
 import org.ossreviewtoolkit.model.ScanResult
-import org.ossreviewtoolkit.model.ScanResultContainer
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.ScannerRun
@@ -181,24 +180,21 @@ val ortResult = OrtResult(
         environment = Environment(),
         config = ScannerConfiguration(),
         results = ScanRecord(
-            scanResults = sortedSetOf(
-                ScanResultContainer(
-                    id = Identifier("Maven:org.ossreviewtoolkit:package-with-only-detected-license:1.0"),
-                    results = listOf(
-                        ScanResult(
-                            provenance = Provenance(),
-                            scanner = ScannerDetails.EMPTY,
-                            summary = ScanSummary(
-                                startTime = Instant.EPOCH,
-                                endTime = Instant.EPOCH,
-                                fileCount = 1,
-                                packageVerificationCode = "",
-                                licenseFindings = sortedSetOf(
-                                    LicenseFinding("LicenseRef-a", TextLocation("LICENSE", 1)),
-                                    LicenseFinding("LicenseRef-b", TextLocation("LICENSE", 2))
-                                ),
-                                copyrightFindings = sortedSetOf()
-                            )
+            scanResults = sortedMapOf(
+                Identifier("Maven:org.ossreviewtoolkit:package-with-only-detected-license:1.0") to listOf(
+                    ScanResult(
+                        provenance = Provenance(),
+                        scanner = ScannerDetails.EMPTY,
+                        summary = ScanSummary(
+                            startTime = Instant.EPOCH,
+                            endTime = Instant.EPOCH,
+                            fileCount = 1,
+                            packageVerificationCode = "",
+                            licenseFindings = sortedSetOf(
+                                LicenseFinding("LicenseRef-a", TextLocation("LICENSE", 1)),
+                                LicenseFinding("LicenseRef-b", TextLocation("LICENSE", 2))
+                            ),
+                            copyrightFindings = sortedSetOf()
                         )
                     )
                 )

--- a/helper-cli/src/main/kotlin/commands/GeneratePackageConfigurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GeneratePackageConfigurationsCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ internal class GeneratePackageConfigurationsCommand : CliktCommand(
         outputDir.safeMkdirs()
 
         val scanResultsStorage = FileBasedStorage(LocalFileStorage(scanResultsStorageDir))
-        val scanResults = (scanResultsStorage.read(packageId) as? Success)?.result?.results ?: emptyList()
+        val scanResults = (scanResultsStorage.read(packageId) as? Success)?.result ?: emptyList()
 
         scanResults.find { it.provenance.vcsInfo != null }?.provenance
             ?.writePackageConfigurationFile("vcs.yml")

--- a/helper-cli/src/main/kotlin/commands/ImportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportLicenseFindingCurationsCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,9 +134,9 @@ private fun OrtResult.getLicenseFindingsForAllProjects(): Set<LicenseFinding> {
     val result = mutableSetOf<LicenseFinding>()
 
     val projectIds = getProjects().mapTo(mutableSetOf()) { it.id }
-    scanner?.results?.scanResults?.forEach { container ->
-        if (container.id in projectIds) {
-            container.results.forEach { scanResult ->
+    scanner?.results?.scanResults?.forEach { (id, results) ->
+        if (id in projectIds) {
+            results.forEach { scanResult ->
                 result += scanResult.summary.licenseFindings
             }
         }

--- a/helper-cli/src/main/kotlin/commands/ListStoredScanResultsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListStoredScanResultsCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,9 +77,9 @@ internal class ListStoredScanResultsCommand : CliktCommand(
             }
         }
 
-        println("Found ${scanResults.results.size} scan results:")
+        println("Found ${scanResults.size} scan results:")
 
-        scanResults.results.forEach { result ->
+        scanResults.forEach { result ->
             println("\n${yamlMapper.writeValueAsString(result.provenance)}")
         }
     }

--- a/helper-cli/src/main/kotlin/commands/SubtractScanResultsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/SubtractScanResultsCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,25 +65,24 @@ internal class SubtractScanResultsCommand : CliktCommand(
         val lhsOrtResult = lhsOrtResultFile.readValue<OrtResult>()
         val rhsOrtResult = rhsOrtResultFile.readValue<OrtResult>()
 
-        val rhsScanSummaries = rhsOrtResult.scanner!!.results.scanResults.flatMap { it.results }.associateBy(
+        val rhsScanSummaries = rhsOrtResult.scanner!!.results.scanResults.flatMap { it.value }.associateBy(
             keySelector = { it.provenance.key() },
             valueTransform = { it.summary }
         )
 
-        val scanResultContainers = lhsOrtResult.scanner!!.results.scanResults.mapTo(sortedSetOf()) { container ->
-            val results = container.results.map { lhsScanResult ->
+        val scanResults = lhsOrtResult.scanner!!.results.scanResults.mapValuesTo(sortedMapOf()) { (_, results) ->
+            results.map { lhsScanResult ->
                 val lhsSummary = lhsScanResult.summary
                 val rhsSummary = rhsScanSummaries[lhsScanResult.provenance.key()]
 
                 lhsScanResult.copy(summary = lhsSummary - rhsSummary)
             }
-            container.copy(results = results)
-       }
+        }
 
        val result = lhsOrtResult.copy(
            scanner = lhsOrtResult.scanner!!.copy(
                results = lhsOrtResult.scanner!!.results.copy(
-                    scanResults = scanResultContainers
+                    scanResults = scanResults
                )
            )
        )

--- a/model/src/main/kotlin/AdvisorRecord.kt
+++ b/model/src/main/kotlin/AdvisorRecord.kt
@@ -63,6 +63,10 @@ data class AdvisorRecord(
     }
 }
 
+/**
+ * A custom deserializer to support deserialization of old [AdvisorRecord]s where [AdvisorRecord.advisorResults] was a
+ * `List<AdvisorResultContainer>`.
+ */
 private class AdvisorResultsDeserializer : StdDeserializer<SortedMap<Identifier, List<AdvisorResult>>>(
     SortedMap::class.java
 ) {

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -164,9 +164,7 @@ data class OrtResult(
         result
     }
 
-    private val scanResultsById: Map<Identifier, List<ScanResult>> by lazy {
-        scanner?.results?.scanResults?.associateBy({ it.id }, { it.results }).orEmpty()
-    }
+    private val scanResultsById: Map<Identifier, List<ScanResult>> by lazy { scanner?.results?.scanResults.orEmpty() }
 
     private val advisorResultsById: Map<Identifier, List<AdvisorResult>> by lazy {
         advisor?.results?.advisorResults.orEmpty()

--- a/model/src/main/kotlin/ScanResultContainer.kt
+++ b/model/src/main/kotlin/ScanResultContainer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@
 
 package org.ossreviewtoolkit.model
 
-import java.io.File
-
 /**
  * A container for [ScanResult]s for the package identified by [id].
  */
@@ -39,22 +37,4 @@ data class ScanResultContainer(
      * A comparison function to sort scan result containers by their identifier.
      */
     override fun compareTo(other: ScanResultContainer) = id.compareTo(other.id)
-
-    /**
-     * Return a [ScanResultContainer] whose [results] contains only findings from the same directory as the [project]'s
-     * definition file.
-     */
-    fun filterByProject(project: Project): ScanResultContainer {
-        val parentPath = File(project.definitionFilePath).parent ?: return this
-
-        val filteredResults = results.map { result ->
-            if (result.provenance.vcsInfo == null) {
-                result
-            } else {
-                result.filterByPath(parentPath)
-            }
-        }
-
-        return ScanResultContainer(project.id, filteredResults)
-    }
 }

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,17 @@
 
 package org.ossreviewtoolkit.model.utils
 
+import java.io.File
+
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Coordinates
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.SourceLocation
 import org.ossreviewtoolkit.clients.clearlydefined.ComponentType
 import org.ossreviewtoolkit.clients.clearlydefined.Provider
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfoCurationData
 import org.ossreviewtoolkit.utils.percentEncode
@@ -183,3 +187,19 @@ fun Identifier.toPurl() = "".takeIf { this == Identifier.EMPTY }
         append('@')
         append(version.percentEncode())
     }
+
+/**
+ * Return a list of [ScanResult]s where all results contains only findings from the same directory as the [project]'s
+ * definition file.
+ */
+fun List<ScanResult>.filterByProject(project: Project): List<ScanResult> {
+    val parentPath = File(project.definitionFilePath).parent ?: return this
+
+    return map { result ->
+        if (result.provenance.vcsInfo == null) {
+            result
+        } else {
+            result.filterByPath(parentPath)
+        }
+    }
+}

--- a/model/src/test/kotlin/ScanRecordTest.kt
+++ b/model/src/test/kotlin/ScanRecordTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2017-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import com.fasterxml.jackson.module.kotlin.readValue
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.maps.haveSize
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+class ScanRecordTest : StringSpec({
+    "ScanRecord with scan results can be deserialized" {
+        val yaml = """
+            ---
+            scan_results:
+              type:namespace:name:version:
+              - provenance:
+                  download_time: "1970-01-01T00:00:00Z"
+                scanner:
+                  name: "scanner"
+                  version: "version"
+                  configuration: "configuration"
+                summary:
+                  start_time: "1970-01-01T00:00:00Z"
+                  end_time: "1970-01-01T00:00:00Z"
+                  file_count: 1
+                  package_verification_code: "0123456789abcdef0123456789abcdef01234567"
+                  licenses: []
+                  copyrights: []
+            storage_stats:
+              num_reads: 2
+              num_hits: 1
+            has_issues: false
+        """.trimIndent()
+
+        val record = shouldNotThrowAny { yamlMapper.readValue<ScanRecord>(yaml) }
+        record.scanResults should haveSize(1)
+        record.scanResults.entries.single().let { (id, results) ->
+            id shouldBe Identifier("type:namespace:name:version")
+            results shouldHaveSize 1
+        }
+    }
+
+    "Legacy ScanRecord with ScanResultContainers can be deserialized" {
+        val yaml = """
+            ---
+            scan_results:
+            - id: "type:namespace:name:version"
+              results:
+              - provenance:
+                  download_time: "1970-01-01T00:00:00Z"
+                scanner:
+                  name: "scanner"
+                  version: "version"
+                  configuration: "configuration"
+                summary:
+                  start_time: "1970-01-01T00:00:00Z"
+                  end_time: "1970-01-01T00:00:00Z"
+                  file_count: 1
+                  package_verification_code: "0123456789abcdef0123456789abcdef01234567"
+                  licenses: []
+                  copyrights: []
+            storage_stats:
+              num_reads: 2
+              num_hits: 1
+            has_issues: false
+        """.trimIndent()
+
+        val record = shouldNotThrowAny { yamlMapper.readValue<ScanRecord>(yaml) }
+        record.scanResults should haveSize(1)
+        record.scanResults.entries.single().let { (id, results) ->
+            id shouldBe Identifier("type:namespace:name:version")
+            results shouldHaveSize 1
+        }
+    }
+})

--- a/model/src/test/kotlin/ScannerRunTest.kt
+++ b/model/src/test/kotlin/ScannerRunTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ class ScannerRunTest : StringSpec({
             config:
               scanner: null
             results:
-              scan_results: []
+              scan_results: {}
               storage_stats:
                 num_reads: 0
                 num_hits: 0
@@ -60,7 +60,7 @@ class ScannerRunTest : StringSpec({
             config:
               scanner: null
             results:
-              scan_results: []
+              scan_results: {}
               storage_stats:
                 num_reads: 0
                 num_hits: 0

--- a/model/src/test/kotlin/licenses/TestData.kt
+++ b/model/src/test/kotlin/licenses/TestData.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2017-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@ import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Repository
 import org.ossreviewtoolkit.model.ScanRecord
 import org.ossreviewtoolkit.model.ScanResult
-import org.ossreviewtoolkit.model.ScanResultContainer
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.ScannerRun
@@ -139,21 +138,18 @@ val scanResults = listOf(
     packageWithConcludedAndDetectedLicense,
     packageWithDeclaredAndDetectedLicense,
     packageWithConcludedAndDeclaredAndDetectedLicense
-).mapTo(sortedSetOf()) {
-    ScanResultContainer(
-        id = it.id,
-        results = listOf(
-            ScanResult(
-                provenance = provenance,
-                scanner = ScannerDetails.EMPTY,
-                summary = ScanSummary(
-                    startTime = Instant.EPOCH,
-                    endTime = Instant.EPOCH,
-                    fileCount = 1,
-                    packageVerificationCode = "",
-                    licenseFindings = licenseFindings,
-                    copyrightFindings = sortedSetOf()
-                )
+).associateTo(sortedMapOf()) {
+    it.id to listOf(
+        ScanResult(
+            provenance = provenance,
+            scanner = ScannerDetails.EMPTY,
+            summary = ScanSummary(
+                startTime = Instant.EPOCH,
+                endTime = Instant.EPOCH,
+                fileCount = 1,
+                packageVerificationCode = "",
+                licenseFindings = licenseFindings,
+                copyrightFindings = sortedSetOf()
             )
         )
     )

--- a/reporter/src/funTest/kotlin/TestData.kt
+++ b/reporter/src/funTest/kotlin/TestData.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,6 @@ import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Repository
 import org.ossreviewtoolkit.model.ScanRecord
 import org.ossreviewtoolkit.model.ScanResult
-import org.ossreviewtoolkit.model.ScanResultContainer
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.ScannerRun
@@ -214,233 +213,212 @@ val ORT_RESULT = OrtResult(
         environment = Environment(),
         config = ScannerConfiguration(),
         results = ScanRecord(
-            scanResults = sortedSetOf(
-                ScanResultContainer(
-                    id = Identifier("NPM:@ort:project-with-findings:1.0"),
-                    results = listOf(
-                        ScanResult(
-                            provenance = Provenance(sourceArtifact = RemoteArtifact.EMPTY),
-                            scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
-                            summary = ScanSummary(
-                                startTime = Instant.EPOCH,
-                                endTime = Instant.EPOCH,
-                                fileCount = 0,
-                                packageVerificationCode = "",
-                                licenseFindings = sortedSetOf(
-                                    LicenseFinding(
-                                        license = "MIT",
-                                        location = TextLocation("project-with-findings/file", 1)
-                                    )
-                                ),
-                                copyrightFindings = sortedSetOf(
-                                    CopyrightFinding(
-                                        statement = "Copyright 1",
-                                        location = TextLocation("project-with-findings/file", 1)
-                                    )
-                                )
-                            )
-                        )
-                    )
-                ),
-                ScanResultContainer(
-                    id = Identifier("NPM:@ort:project-without-findings:1.0"),
-                    results = listOf(
-                        ScanResult(
-                            provenance = Provenance(sourceArtifact = RemoteArtifact.EMPTY),
-                            scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
-                            summary = ScanSummary(
-                                startTime = Instant.EPOCH,
-                                endTime = Instant.EPOCH,
-                                fileCount = 0,
-                                packageVerificationCode = "",
-                                licenseFindings = sortedSetOf(),
-                                copyrightFindings = sortedSetOf()
-                            )
-                        )
-                    )
-                ),
-                ScanResultContainer(
-                    id = Identifier("NPM:@ort:no-license-file:1.0"),
-                    results = listOf(
-                        ScanResult(
-                            provenance = Provenance(sourceArtifact = RemoteArtifact.EMPTY),
-                            scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
-                            summary = ScanSummary(
-                                startTime = Instant.EPOCH,
-                                endTime = Instant.EPOCH,
-                                fileCount = 0,
-                                packageVerificationCode = "",
-                                licenseFindings = sortedSetOf(
-                                    LicenseFinding(
-                                        license = "MIT",
-                                        location = TextLocation("file", 1)
-                                    )
-                                ),
-                                copyrightFindings = sortedSetOf(
-                                    CopyrightFinding(
-                                        statement = "Copyright 1",
-                                        location = TextLocation("file", 1)
-                                    )
-                                )
-                            )
-                        )
-                    )
-                ),
-                ScanResultContainer(
-                    id = Identifier("NPM:@ort:license-file:1.0"),
-                    results = listOf(
-                        ScanResult(
-                            provenance = Provenance(
-                                sourceArtifact = RemoteArtifact(
-                                    url = "https://example.com/license-file-1.0.tgz",
-                                    hash = Hash(value = "", algorithm = HashAlgorithm.SHA1)
+            scanResults = sortedMapOf(
+                Identifier("NPM:@ort:project-with-findings:1.0") to listOf(
+                    ScanResult(
+                        provenance = Provenance(sourceArtifact = RemoteArtifact.EMPTY),
+                        scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
+                        summary = ScanSummary(
+                            startTime = Instant.EPOCH,
+                            endTime = Instant.EPOCH,
+                            fileCount = 0,
+                            packageVerificationCode = "",
+                            licenseFindings = sortedSetOf(
+                                LicenseFinding(
+                                    license = "MIT",
+                                    location = TextLocation("project-with-findings/file", 1)
                                 )
                             ),
-                            scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
-                            summary = ScanSummary(
-                                startTime = Instant.EPOCH,
-                                endTime = Instant.EPOCH,
-                                fileCount = 0,
-                                packageVerificationCode = "",
-                                licenseFindings = sortedSetOf(
-                                    LicenseFinding(
-                                        license = "MIT",
-                                        location = TextLocation("LICENSE", 1)
-                                    ),
-                                    LicenseFinding(
-                                        license = "MIT",
-                                        location = TextLocation("file", 1)
-                                    )
-                                ),
-                                copyrightFindings = sortedSetOf(
-                                    CopyrightFinding(
-                                        statement = "Copyright 1",
-                                        location = TextLocation("LICENSE", 1)
-                                    ),
-                                    CopyrightFinding(
-                                        statement = "Copyright 2",
-                                        location = TextLocation("file", 1)
-                                    )
+                            copyrightFindings = sortedSetOf(
+                                CopyrightFinding(
+                                    statement = "Copyright 1",
+                                    location = TextLocation("project-with-findings/file", 1)
                                 )
                             )
                         )
                     )
                 ),
-                ScanResultContainer(
-                    id = Identifier("NPM:@ort:license-file-and-additional-licenses:1.0"),
-                    results = listOf(
-                        ScanResult(
-                            provenance = Provenance(
-                                sourceArtifact = RemoteArtifact(
-                                    url = "https://example.com/license-file-and-additional-licenses-1.0.tgz",
-                                    hash = Hash(value = "", algorithm = HashAlgorithm.SHA1)
+                Identifier("NPM:@ort:project-without-findings:1.0") to listOf(
+                    ScanResult(
+                        provenance = Provenance(sourceArtifact = RemoteArtifact.EMPTY),
+                        scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
+                        summary = ScanSummary(
+                            startTime = Instant.EPOCH,
+                            endTime = Instant.EPOCH,
+                            fileCount = 0,
+                            packageVerificationCode = "",
+                            licenseFindings = sortedSetOf(),
+                            copyrightFindings = sortedSetOf()
+                        )
+                    )
+                ),
+                Identifier("NPM:@ort:no-license-file:1.0") to listOf(
+                    ScanResult(
+                        provenance = Provenance(sourceArtifact = RemoteArtifact.EMPTY),
+                        scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
+                        summary = ScanSummary(
+                            startTime = Instant.EPOCH,
+                            endTime = Instant.EPOCH,
+                            fileCount = 0,
+                            packageVerificationCode = "",
+                            licenseFindings = sortedSetOf(
+                                LicenseFinding(
+                                    license = "MIT",
+                                    location = TextLocation("file", 1)
                                 )
                             ),
-                            scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
-                            summary = ScanSummary(
-                                startTime = Instant.EPOCH,
-                                endTime = Instant.EPOCH,
-                                fileCount = 0,
-                                packageVerificationCode = "",
-                                licenseFindings = sortedSetOf(
-                                    LicenseFinding(
-                                        license = "MIT",
-                                        location = TextLocation("LICENSE", 1)
-                                    ),
-                                    LicenseFinding(
-                                        license = "MIT",
-                                        location = TextLocation("file", 1)
-                                    ),
-                                    LicenseFinding(
-                                        license = "BSD-3-Clause",
-                                        location = TextLocation("file", 50)
-                                    )
-                                ),
-                                copyrightFindings = sortedSetOf(
-                                    CopyrightFinding(
-                                        statement = "Copyright 1",
-                                        location = TextLocation("LICENSE", 1)
-                                    ),
-                                    CopyrightFinding(
-                                        statement = "Copyright 2",
-                                        location = TextLocation("file", 1)
-                                    ),
-                                    CopyrightFinding(
-                                        statement = "Copyright 3",
-                                        location = TextLocation("file", 50)
-                                    )
+                            copyrightFindings = sortedSetOf(
+                                CopyrightFinding(
+                                    statement = "Copyright 1",
+                                    location = TextLocation("file", 1)
                                 )
                             )
                         )
                     )
                 ),
-                ScanResultContainer(
-                    id = Identifier("NPM:@ort:concluded-license:1.0"),
-                    results = listOf(
-                        ScanResult(
-                            provenance = Provenance(
-                                sourceArtifact = RemoteArtifact(
-                                    url = "https://example.com/concluded-license-1.0.tgz",
-                                    hash = Hash(value = "", algorithm = HashAlgorithm.SHA1)
+                Identifier("NPM:@ort:license-file:1.0") to listOf(
+                    ScanResult(
+                        provenance = Provenance(
+                            sourceArtifact = RemoteArtifact(
+                                url = "https://example.com/license-file-1.0.tgz",
+                                hash = Hash(value = "", algorithm = HashAlgorithm.SHA1)
+                            )
+                        ),
+                        scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
+                        summary = ScanSummary(
+                            startTime = Instant.EPOCH,
+                            endTime = Instant.EPOCH,
+                            fileCount = 0,
+                            packageVerificationCode = "",
+                            licenseFindings = sortedSetOf(
+                                LicenseFinding(
+                                    license = "MIT",
+                                    location = TextLocation("LICENSE", 1)
+                                ),
+                                LicenseFinding(
+                                    license = "MIT",
+                                    location = TextLocation("file", 1)
                                 )
                             ),
-                            scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
-                            summary = ScanSummary(
-                                startTime = Instant.EPOCH,
-                                endTime = Instant.EPOCH,
-                                fileCount = 0,
-                                packageVerificationCode = "",
-                                licenseFindings = sortedSetOf(
-                                    LicenseFinding(
-                                        license = "MIT",
-                                        location = TextLocation("file1", 1)
-                                    ),
-                                    LicenseFinding(
-                                        license = "BSD-2-Clause",
-                                        location = TextLocation("file2", 1)
-                                    )
+                            copyrightFindings = sortedSetOf(
+                                CopyrightFinding(
+                                    statement = "Copyright 1",
+                                    location = TextLocation("LICENSE", 1)
                                 ),
-                                copyrightFindings = sortedSetOf(
-                                    CopyrightFinding(
-                                        statement = "Copyright 1",
-                                        location = TextLocation("file1", 1)
-                                    ),
-                                    CopyrightFinding(
-                                        statement = "Copyright 2",
-                                        location = TextLocation("file2", 1)
-                                    )
+                                CopyrightFinding(
+                                    statement = "Copyright 2",
+                                    location = TextLocation("file", 1)
                                 )
                             )
                         )
                     )
                 ),
-                ScanResultContainer(
-                    id = Identifier("NPM:@ort:declared-license:1.0"),
-                    results = listOf(
-                        ScanResult(
-                            provenance = Provenance(
-                                sourceArtifact = RemoteArtifact(
-                                    url = "https://example.com/declared-license-1.0.tgz",
-                                    hash = Hash(value = "", algorithm = HashAlgorithm.SHA1)
+                Identifier("NPM:@ort:license-file-and-additional-licenses:1.0") to listOf(
+                    ScanResult(
+                        provenance = Provenance(
+                            sourceArtifact = RemoteArtifact(
+                                url = "https://example.com/license-file-and-additional-licenses-1.0.tgz",
+                                hash = Hash(value = "", algorithm = HashAlgorithm.SHA1)
+                            )
+                        ),
+                        scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
+                        summary = ScanSummary(
+                            startTime = Instant.EPOCH,
+                            endTime = Instant.EPOCH,
+                            fileCount = 0,
+                            packageVerificationCode = "",
+                            licenseFindings = sortedSetOf(
+                                LicenseFinding(
+                                    license = "MIT",
+                                    location = TextLocation("LICENSE", 1)
+                                ),
+                                LicenseFinding(
+                                    license = "MIT",
+                                    location = TextLocation("file", 1)
+                                ),
+                                LicenseFinding(
+                                    license = "BSD-3-Clause",
+                                    location = TextLocation("file", 50)
                                 )
                             ),
-                            scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
-                            summary = ScanSummary(
-                                startTime = Instant.EPOCH,
-                                endTime = Instant.EPOCH,
-                                fileCount = 0,
-                                packageVerificationCode = "",
-                                licenseFindings = sortedSetOf(
-                                    LicenseFinding(
-                                        license = "BSD-3-Clause",
-                                        location = TextLocation("LICENSE", 1)
-                                    )
+                            copyrightFindings = sortedSetOf(
+                                CopyrightFinding(
+                                    statement = "Copyright 1",
+                                    location = TextLocation("LICENSE", 1)
                                 ),
-                                copyrightFindings = sortedSetOf(
-                                    CopyrightFinding(
-                                        statement = "Copyright 1",
-                                        location = TextLocation("LICENSE", 1)
-                                    )
+                                CopyrightFinding(
+                                    statement = "Copyright 2",
+                                    location = TextLocation("file", 1)
+                                ),
+                                CopyrightFinding(
+                                    statement = "Copyright 3",
+                                    location = TextLocation("file", 50)
+                                )
+                            )
+                        )
+                    )
+                ),
+                Identifier("NPM:@ort:concluded-license:1.0") to listOf(
+                    ScanResult(
+                        provenance = Provenance(
+                            sourceArtifact = RemoteArtifact(
+                                url = "https://example.com/concluded-license-1.0.tgz",
+                                hash = Hash(value = "", algorithm = HashAlgorithm.SHA1)
+                            )
+                        ),
+                        scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
+                        summary = ScanSummary(
+                            startTime = Instant.EPOCH,
+                            endTime = Instant.EPOCH,
+                            fileCount = 0,
+                            packageVerificationCode = "",
+                            licenseFindings = sortedSetOf(
+                                LicenseFinding(
+                                    license = "MIT",
+                                    location = TextLocation("file1", 1)
+                                ),
+                                LicenseFinding(
+                                    license = "BSD-2-Clause",
+                                    location = TextLocation("file2", 1)
+                                )
+                            ),
+                            copyrightFindings = sortedSetOf(
+                                CopyrightFinding(
+                                    statement = "Copyright 1",
+                                    location = TextLocation("file1", 1)
+                                ),
+                                CopyrightFinding(
+                                    statement = "Copyright 2",
+                                    location = TextLocation("file2", 1)
+                                )
+                            )
+                        )
+                    )
+                ),
+                Identifier("NPM:@ort:declared-license:1.0") to listOf(
+                    ScanResult(
+                        provenance = Provenance(
+                            sourceArtifact = RemoteArtifact(
+                                url = "https://example.com/declared-license-1.0.tgz",
+                                hash = Hash(value = "", algorithm = HashAlgorithm.SHA1)
+                            )
+                        ),
+                        scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
+                        summary = ScanSummary(
+                            startTime = Instant.EPOCH,
+                            endTime = Instant.EPOCH,
+                            fileCount = 0,
+                            packageVerificationCode = "",
+                            licenseFindings = sortedSetOf(
+                                LicenseFinding(
+                                    license = "BSD-3-Clause",
+                                    location = TextLocation("LICENSE", 1)
+                                )
+                            ),
+                            copyrightFindings = sortedSetOf(
+                                CopyrightFinding(
+                                    statement = "Copyright 1",
+                                    location = TextLocation("LICENSE", 1)
                                 )
                             )
                         )

--- a/reporter/src/funTest/kotlin/reporters/SpdxDocumentReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/SpdxDocumentReporterFunTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,6 @@ import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Repository
 import org.ossreviewtoolkit.model.ScanRecord
 import org.ossreviewtoolkit.model.ScanResult
-import org.ossreviewtoolkit.model.ScanResultContainer
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.ScannerRun
@@ -284,68 +283,65 @@ private fun createOrtResult(): OrtResult {
             environment = Environment(),
             config = ScannerConfiguration(),
             results = ScanRecord(
-                scanResults = sortedSetOf(
-                    ScanResultContainer(
-                        id = Identifier("Maven:first-package-group:first-package:0.0.1"),
-                        results = listOf(
-                            ScanResult(
-                                provenance = Provenance(
-                                    sourceArtifact = RemoteArtifact(
-                                        url = "https://some-host/first-package-sources.jar",
-                                        hash = Hash.NONE
-                                    )
-                                ),
-                                scanner = ScannerDetails.EMPTY,
-                                summary = ScanSummary(
-                                    startTime = Instant.MIN,
-                                    endTime = Instant.MIN,
-                                    fileCount = 10,
-                                    packageVerificationCode = "1111222233334444555566667777888899990000",
-                                    licenseFindings = sortedSetOf(
-                                        LicenseFinding(
-                                            license = "Apache-2.0",
-                                            location = TextLocation("LICENSE", 1)
-                                        )
-                                    ),
-                                    copyrightFindings = sortedSetOf(
-                                        CopyrightFinding(
-                                            statement = "Copyright 2020 Some copyright holder in source artifact",
-                                            location = TextLocation("some/file", 1)
-                                        ),
-                                        CopyrightFinding(
-                                            statement = "Copyright 2020 Some other copyright holder in source artifact",
-                                            location = TextLocation("some/file", 7)
-                                        )
-                                    )
+                scanResults = sortedMapOf(
+                    Identifier("Maven:first-package-group:first-package:0.0.1") to listOf(
+                        ScanResult(
+                            provenance = Provenance(
+                                sourceArtifact = RemoteArtifact(
+                                    url = "https://some-host/first-package-sources.jar",
+                                    hash = Hash.NONE
                                 )
                             ),
-                            ScanResult(
-                                provenance = Provenance(
-                                    vcsInfo = VcsInfo(
-                                        type = VcsType.GIT,
-                                        revision = "master",
-                                        resolvedRevision = "deadbeef",
-                                        url = "ssh://git@github.com/path/first-package-repo.git",
-                                        path = "project-path"
+                            scanner = ScannerDetails.EMPTY,
+                            summary = ScanSummary(
+                                startTime = Instant.MIN,
+                                endTime = Instant.MIN,
+                                fileCount = 10,
+                                packageVerificationCode = "1111222233334444555566667777888899990000",
+                                licenseFindings = sortedSetOf(
+                                    LicenseFinding(
+                                        license = "Apache-2.0",
+                                        location = TextLocation("LICENSE", 1)
                                     )
                                 ),
-                                scanner = ScannerDetails.EMPTY,
-                                summary = ScanSummary(
-                                    startTime = Instant.MIN,
-                                    endTime = Instant.MIN,
-                                    fileCount = 10,
-                                    packageVerificationCode = "0000000000000000000011111111111111111111",
-                                    licenseFindings = sortedSetOf(
-                                        LicenseFinding(
-                                            license = "BSD-2-Clause",
-                                            location = TextLocation("LICENSE", 1)
-                                        )
+                                copyrightFindings = sortedSetOf(
+                                    CopyrightFinding(
+                                        statement = "Copyright 2020 Some copyright holder in source artifact",
+                                        location = TextLocation("some/file", 1)
                                     ),
-                                    copyrightFindings = sortedSetOf(
-                                        CopyrightFinding(
-                                            statement = "Copyright 2020 Some copyright holder in VCS",
-                                            location = TextLocation("some/file", 1)
-                                        )
+                                    CopyrightFinding(
+                                        statement = "Copyright 2020 Some other copyright holder in source artifact",
+                                        location = TextLocation("some/file", 7)
+                                    )
+                                )
+                            )
+                        ),
+                        ScanResult(
+                            provenance = Provenance(
+                                vcsInfo = VcsInfo(
+                                    type = VcsType.GIT,
+                                    revision = "master",
+                                    resolvedRevision = "deadbeef",
+                                    url = "ssh://git@github.com/path/first-package-repo.git",
+                                    path = "project-path"
+                                )
+                            ),
+                            scanner = ScannerDetails.EMPTY,
+                            summary = ScanSummary(
+                                startTime = Instant.MIN,
+                                endTime = Instant.MIN,
+                                fileCount = 10,
+                                packageVerificationCode = "0000000000000000000011111111111111111111",
+                                licenseFindings = sortedSetOf(
+                                    LicenseFinding(
+                                        license = "BSD-2-Clause",
+                                        location = TextLocation("LICENSE", 1)
+                                    )
+                                ),
+                                copyrightFindings = sortedSetOf(
+                                    CopyrightFinding(
+                                        statement = "Copyright 2020 Some copyright holder in VCS",
+                                        location = TextLocation("some/file", 1)
                                     )
                                 )
                             )

--- a/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,7 +132,7 @@ class ReportTableModelMapper(
 
             val projectIssues = project.collectIssues()
             val tableRows = allIds.map { id ->
-                val scanResult = scanRecord?.scanResults?.find { it.id == id }
+                val scanResult = scanRecord?.scanResults?.get(id)
 
                 val resolvedLicenseInfo = licenseInfoResolver.resolveLicenseInfo(id)
 
@@ -145,7 +145,7 @@ class ReportTableModelMapper(
                 val analyzerIssues = projectIssues[id].orEmpty() + analyzerResult.issues[id].orEmpty() +
                         analyzerIssuesForPackages[id].orEmpty()
 
-                val scanIssues = scanResult?.results?.flatMapTo(mutableSetOf()) {
+                val scanIssues = scanResult?.flatMapTo(mutableSetOf()) {
                     it.summary.issues
                 }.orEmpty()
 

--- a/reporter/src/test/kotlin/utils/FreeMarkerTemplateProcessorTest.kt
+++ b/reporter/src/test/kotlin/utils/FreeMarkerTemplateProcessorTest.kt
@@ -39,7 +39,6 @@ import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.Repository
 import org.ossreviewtoolkit.model.ScanRecord
 import org.ossreviewtoolkit.model.ScanResult
-import org.ossreviewtoolkit.model.ScanResultContainer
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.ScannerRun
@@ -56,28 +55,24 @@ import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.Environment
 import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
 
-private fun scanResultContainer(
-    id: String,
+private fun scanResults(
     vcsInfo: VcsInfo,
     findingsPaths: Collection<String>
-): ScanResultContainer {
+): List<ScanResult> {
     val licenseFindings = findingsPaths.mapTo(sortedSetOf()) { LicenseFinding("MIT", TextLocation(it, 1)) }
     val copyrightFindings = findingsPaths.mapTo(sortedSetOf()) { CopyrightFinding("(c)", TextLocation(it, 1)) }
 
-    return ScanResultContainer(
-        id = Identifier(id),
-        results = listOf(
-            ScanResult(
-                provenance = Provenance(vcsInfo = vcsInfo),
-                scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
-                summary = ScanSummary(
-                    startTime = Instant.EPOCH,
-                    endTime = Instant.EPOCH,
-                    fileCount = 0,
-                    packageVerificationCode = "",
-                    licenseFindings = licenseFindings,
-                    copyrightFindings = copyrightFindings,
-                )
+    return listOf(
+        ScanResult(
+            provenance = Provenance(vcsInfo = vcsInfo),
+            scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
+            summary = ScanSummary(
+                startTime = Instant.EPOCH,
+                endTime = Instant.EPOCH,
+                fileCount = 0,
+                packageVerificationCode = "",
+                licenseFindings = licenseFindings,
+                copyrightFindings = copyrightFindings,
             )
         )
     )
@@ -131,9 +126,8 @@ private val ORT_RESULT = OrtResult(
         environment = Environment(),
         config = ScannerConfiguration(),
         results = ScanRecord(
-            scanResults = sortedSetOf(
-                scanResultContainer(
-                    id = "NPM:@ort:project-in-root-dir:1.0",
+            scanResults = sortedMapOf(
+                Identifier("NPM:@ort:project-in-root-dir:1.0") to scanResults(
                     vcsInfo = PROJECT_VCS_INFO,
                     findingsPaths = listOf(
                         "src/main.js",
@@ -141,15 +135,13 @@ private val ORT_RESULT = OrtResult(
                         "nested-vcs-dir/src/main.cpp"
                     )
                 ),
-                scanResultContainer(
-                    id = "SpdxDocumentFile:@ort:project-in-sub-dir:1.0",
+                Identifier("SpdxDocumentFile:@ort:project-in-sub-dir:1.0") to scanResults(
                     vcsInfo = PROJECT_VCS_INFO,
                     findingsPaths = listOf(
                         "sub-dir/src/main.cpp"
                     )
                 ),
-                scanResultContainer(
-                    id = "SpdxDocumentFile:@ort:project-in-nested-vcs:1.0",
+                Identifier("SpdxDocumentFile:@ort:project-in-nested-vcs:1.0") to scanResults(
                     vcsInfo = NESTED_VCS_INFO,
                     findingsPaths = listOf(
                         "src/main.cpp"

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -215,8 +215,7 @@ scanner:
     - "**/META-INF/DEPENDENCIES"
   results:
     scan_results:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      results:
+      Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0:
       - provenance:
           download_time: "1970-01-01T00:00:00Z"
         scanner:
@@ -240,8 +239,7 @@ scanner:
               \ see: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom\n\
               Suppressed: DownloadException: No source artifact URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'."
             severity: "ERROR"
-    - id: "Maven:junit:junit:4.12"
-      results:
+      Maven:junit:junit:4.12:
       - provenance:
           download_time: "1970-01-01T00:00:00Z"
           source_artifact:
@@ -260,8 +258,7 @@ scanner:
           package_verification_code: "a86513854c8896d354a2d84f51beeaf9b378c233"
           licenses: []
           copyrights: []
-    - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      results:
+      Maven:org.apache.commons:commons-lang3:3.5:
       - provenance:
           download_time: "1970-01-01T00:00:00Z"
           source_artifact:
@@ -280,8 +277,7 @@ scanner:
           package_verification_code: "bff2d5982a9b1985295c372b3ae2f90a7a860747"
           licenses: []
           copyrights: []
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      results:
+      Maven:org.apache.commons:commons-text:1.1:
       - provenance:
           download_time: "1970-01-01T00:00:00Z"
           source_artifact:
@@ -300,8 +296,7 @@ scanner:
           package_verification_code: "78daf07d29c2b84b09766a98c1728b2daeeb59e6"
           licenses: []
           copyrights: []
-    - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-      results:
+      Maven:org.hamcrest:hamcrest-core:1.3:
       - provenance:
           download_time: "1970-01-01T00:00:00Z"
           source_artifact:

--- a/scanner/src/funTest/kotlin/scanners/AbstractScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/AbstractScannerFunTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ abstract class AbstractScannerFunTest(testTags: Set<Tag> = emptySet()) : StringS
     init {
         "Scanning a single file succeeds".config(tags = testTags) {
             val result = scanner.scanPath(inputDir.resolve("LICENSE"), outputDir)
-            val summary = result.scanner?.results?.scanResults?.singleOrNull()?.results?.singleOrNull()?.summary
+            val summary = result.scanner?.results?.scanResults?.singleOrNull()?.singleOrNull()?.summary
 
             summary shouldNotBeNull {
                 fileCount shouldBe 1
@@ -93,7 +93,7 @@ abstract class AbstractScannerFunTest(testTags: Set<Tag> = emptySet()) : StringS
 
         "Scanning a directory succeeds".config(tags = testTags) {
             val result = scanner.scanPath(inputDir, outputDir)
-            val summary = result.scanner?.results?.scanResults?.singleOrNull()?.results?.singleOrNull()?.summary
+            val summary = result.scanner?.results?.scanResults?.singleOrNull()?.singleOrNull()?.summary
 
             summary shouldNotBeNull {
                 fileCount shouldBe commonlyDetectedFiles.size
@@ -105,3 +105,5 @@ abstract class AbstractScannerFunTest(testTags: Set<Tag> = emptySet()) : StringS
         }
     }
 }
+
+private fun <K, V> Map<K, V>.singleOrNull() = entries.singleOrNull()?.value

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
@@ -171,10 +171,7 @@ abstract class AbstractStorageFunTest : WordSpec() {
 
                 addResult should beSuccess()
                 readResult should beSuccess()
-                (readResult as Success).result.let { result ->
-                    result.id shouldBe id1
-                    result.results should containExactly(scanResult)
-                }
+                (readResult as Success).result should containExactly(scanResult)
             }
 
             "fail if the fileCount is 0" {
@@ -188,10 +185,7 @@ abstract class AbstractStorageFunTest : WordSpec() {
                 (addResult as Failure).error shouldBe
                         "Not storing scan result for '${id1.toCoordinates()}' because no files were scanned."
                 readResult should beSuccess()
-                (readResult as Success).result.let { result ->
-                    result.id shouldBe id1
-                    result.results should beEmpty()
-                }
+                (readResult as Success).result should beEmpty()
             }
 
             "fail if provenance information is missing" {
@@ -205,10 +199,7 @@ abstract class AbstractStorageFunTest : WordSpec() {
                 (addResult as Failure).error shouldBe "Not storing scan result for '${id1.toCoordinates()}' because " +
                         "no provenance information is available."
                 readResult should beSuccess()
-                (readResult as Success).result.let { result ->
-                    result.id shouldBe id1
-                    result.results should beEmpty()
-                }
+                (readResult as Success).result should beEmpty()
             }
         }
 
@@ -223,10 +214,7 @@ abstract class AbstractStorageFunTest : WordSpec() {
                 val readResult = storage.read(id1)
 
                 readResult should beSuccess()
-                (readResult as Success).result.let { result ->
-                    result.id shouldBe id1
-                    result.results should containExactlyInAnyOrder(scanResult1, scanResult2)
-                }
+                (readResult as Success).result should containExactlyInAnyOrder(scanResult1, scanResult2)
             }
 
             "find all scan results for a specific scanner" {
@@ -241,10 +229,7 @@ abstract class AbstractStorageFunTest : WordSpec() {
                 val readResult = storage.read(pkg1, criteriaForDetails(scannerDetails1))
 
                 readResult should beSuccess()
-                (readResult as Success).result.let { result ->
-                    result.id shouldBe id1
-                    result.results should containExactlyInAnyOrder(scanResult1, scanResult2)
-                }
+                (readResult as Success).result should containExactlyInAnyOrder(scanResult1, scanResult2)
             }
 
             "find all scan results for scanners with names matching a pattern" {
@@ -264,10 +249,7 @@ abstract class AbstractStorageFunTest : WordSpec() {
                 val readResult = storage.read(pkg1, criteria)
 
                 readResult should beSuccess()
-                (readResult as Success).result.let { result ->
-                    result.id shouldBe id1
-                    result.results should containExactlyInAnyOrder(scanResult1, scanResult2)
-                }
+                (readResult as Success).result should containExactlyInAnyOrder(scanResult1, scanResult2)
             }
 
             "find all scan results for compatible scanners" {
@@ -287,14 +269,11 @@ abstract class AbstractStorageFunTest : WordSpec() {
                 val readResult = storage.read(pkg1, criteriaForDetails(scannerDetails1))
 
                 readResult should beSuccess()
-                (readResult as Success).result.let { result ->
-                    result.id shouldBe id1
-                    result.results should containExactlyInAnyOrder(
-                        scanResult,
-                        scanResultCompatible1,
-                        scanResultCompatible2
-                    )
-                }
+                (readResult as Success).result should containExactlyInAnyOrder(
+                    scanResult,
+                    scanResultCompatible1,
+                    scanResultCompatible2
+                )
             }
 
             "find all scan results for a scanner in a version range" {
@@ -315,15 +294,12 @@ abstract class AbstractStorageFunTest : WordSpec() {
                 val readResult = storage.read(pkg1, criteria)
 
                 readResult should beSuccess()
-                (readResult as Success).result.let { result ->
-                    result.id shouldBe id1
-                    result.results should containExactlyInAnyOrder(
-                        scanResult,
-                        scanResultCompatible1,
-                        scanResultCompatible2,
-                        scanResultIncompatible
-                    )
-                }
+                (readResult as Success).result should containExactlyInAnyOrder(
+                    scanResult,
+                    scanResultCompatible1,
+                    scanResultCompatible2,
+                    scanResultIncompatible
+                )
             }
 
             "find only packages with matching provenance" {
@@ -351,13 +327,10 @@ abstract class AbstractStorageFunTest : WordSpec() {
                 val readResult = storage.read(pkg1, criteriaForDetails(scannerDetails1))
 
                 readResult should beSuccess()
-                (readResult as Success).result.let { result ->
-                    result.id shouldBe id1
-                    result.results should containExactlyInAnyOrder(
-                        scanResultSourceArtifactMatching,
-                        scanResultVcsMatching
-                    )
-                }
+                (readResult as Success).result should containExactlyInAnyOrder(
+                    scanResultSourceArtifactMatching,
+                    scanResultVcsMatching
+                )
             }
 
             "find a scan result if the revision was detected from a version" {
@@ -368,10 +341,7 @@ abstract class AbstractStorageFunTest : WordSpec() {
                 val readResult = storage.read(pkgWithoutRevision, criteriaForDetails(scannerDetails1))
 
                 readResult should beSuccess()
-                (readResult as Success).result.let { result ->
-                    result.id shouldBe id1
-                    result.results should containExactly(scanResult)
-                }
+                (readResult as Success).result should containExactly(scanResult)
             }
         }
 

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -44,7 +44,6 @@ import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Repository
 import org.ossreviewtoolkit.model.ScanRecord
 import org.ossreviewtoolkit.model.ScanResult
-import org.ossreviewtoolkit.model.ScanResultContainer
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.ScannerRun
@@ -466,8 +465,7 @@ abstract class LocalScanner(name: String, config: ScannerConfiguration) : Scanne
         )
 
         val scanResult = ScanResult(Provenance(), details, summary)
-        val scanResultContainer = ScanResultContainer(id, listOf(scanResult))
-        val scanRecord = ScanRecord(sortedSetOf(scanResultContainer), ScanResultsStorage.storage.stats)
+        val scanRecord = ScanRecord(sortedMapOf(id to listOf(scanResult)), ScanResultsStorage.storage.stats)
 
         val endTime = Instant.now()
         val scannerRun = ScannerRun(startTime, endTime, Environment(), config, scanRecord)

--- a/scanner/src/main/kotlin/ScanResultsStorage.kt
+++ b/scanner/src/main/kotlin/ScanResultsStorage.kt
@@ -36,7 +36,6 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Result
 import org.ossreviewtoolkit.model.ScanResult
-import org.ossreviewtoolkit.model.ScanResultContainer
 import org.ossreviewtoolkit.model.Success
 import org.ossreviewtoolkit.model.config.ClearlyDefinedStorageConfiguration
 import org.ossreviewtoolkit.model.config.FileBasedStorageConfiguration
@@ -213,21 +212,21 @@ abstract class ScanResultsStorage {
     val stats = AccessStatistics()
 
     /**
-     * Read all [ScanResult]s for a package with [id] from the storage. Return a [ScanResultContainer] wrapped in a
+     * Read all [ScanResult]s for a package with [id] from the storage. Return a list of [ScanResult]s wrapped in a
      * [Result], which is a [Failure] if an unexpected error occurred and a [Success] otherwise.
      */
-    fun read(id: Identifier): Result<ScanResultContainer> {
+    fun read(id: Identifier): Result<List<ScanResult>> {
         val (result, duration) = measureTimedValue { readInternal(id) }
 
         stats.numReads.incrementAndGet()
 
         if (result is Success) {
-            if (result.result.results.isNotEmpty()) {
+            if (result.result.isNotEmpty()) {
                 stats.numHits.incrementAndGet()
             }
 
             log.perf {
-                "Read ${result.result.results.size} scan results for '${id.toCoordinates()}' from " +
+                "Read ${result.result.size} scan results for '${id.toCoordinates()}' from " +
                         "${javaClass.simpleName} in ${duration.inMilliseconds}ms."
             }
         }
@@ -241,21 +240,21 @@ abstract class ScanResultsStorage {
      * [Package.vcs], and [Package.vcsProcessed] are used to check if the scan result matches the expected source code
      * location. That check is important to find the correct results when different revisions of a package using the
      * same version name are used (e.g. multiple scans of a "1.0-SNAPSHOT" version during development). Return a
-     * [ScanResultContainer] wrapped in a [Result], which is a [Failure] if an unexpected error occurred and a [Success]
+     * list of [ScanResult]s wrapped in a [Result], which is a [Failure] if an unexpected error occurred and a [Success]
      * otherwise.
      */
-    fun read(pkg: Package, scannerCriteria: ScannerCriteria): Result<ScanResultContainer> {
+    fun read(pkg: Package, scannerCriteria: ScannerCriteria): Result<List<ScanResult>> {
         val (result, duration) = measureTimedValue { readInternal(pkg, scannerCriteria) }
 
         stats.numReads.incrementAndGet()
 
         if (result is Success) {
-            if (result.result.results.isNotEmpty()) {
+            if (result.result.isNotEmpty()) {
                 stats.numHits.incrementAndGet()
             }
 
             log.perf {
-                "Read ${result.result.results.size} scan results for '${pkg.id.toCoordinates()}' from " +
+                "Read ${result.result.size} scan results for '${pkg.id.toCoordinates()}' from " +
                         "${javaClass.simpleName} in ${duration.inMilliseconds}ms."
             }
         }
@@ -290,9 +289,9 @@ abstract class ScanResultsStorage {
     }
 
     /**
-     * Add the given [scanResult] to the [ScanResultContainer] for the scanned [Package] with the provided [id].
-     * Depending on the storage implementation this might first read any existing [ScanResultContainer] and write the
-     * new [ScanResultContainer] to the storage again, implicitly deleting the original storage entry by overwriting it.
+     * Add the given [scanResult] to the stored [ScanResult]s for the scanned [Package] with the provided [id].
+     * Depending on the storage implementation this might first read any existing [ScanResult]s and write the new
+     * [ScanResult]s to the storage again, implicitly deleting the original storage entry by overwriting it.
      * Return a [Result] describing whether the operation was successful.
      */
     fun add(id: Identifier, scanResult: ScanResult): Result<Unit> {
@@ -327,19 +326,19 @@ abstract class ScanResultsStorage {
     /**
      * Internal version of [read] that does not update the [access statistics][stats].
      */
-    protected abstract fun readInternal(id: Identifier): Result<ScanResultContainer>
+    protected abstract fun readInternal(id: Identifier): Result<List<ScanResult>>
 
     /**
      * Internal version of [read] that does not update the [access statistics][stats]. Implementations may want to
      * override this function if they can filter for the wanted [scannerCriteria] in a more efficient way.
      */
-    protected open fun readInternal(pkg: Package, scannerCriteria: ScannerCriteria): Result<ScanResultContainer> {
+    protected open fun readInternal(pkg: Package, scannerCriteria: ScannerCriteria): Result<List<ScanResult>> {
         val scanResults = when (val readResult = readInternal(pkg.id)) {
-            is Success -> readResult.result.results.toMutableList()
+            is Success -> readResult.result.toMutableList()
             is Failure -> return readResult
         }
 
-        if (scanResults.isEmpty()) return Success(ScanResultContainer(pkg.id, scanResults))
+        if (scanResults.isEmpty()) return Success(scanResults)
 
         // Only keep scan results whose provenance information matches the package information.
         scanResults.retainAll { it.provenance.matches(pkg) }
@@ -348,7 +347,7 @@ abstract class ScanResultsStorage {
                 "No stored scan results found for $pkg. The following entries with non-matching provenance have " +
                         "been ignored: ${scanResults.map { it.provenance }}"
             }
-            return Success(ScanResultContainer(pkg.id, scanResults))
+            return Success(scanResults)
         }
 
         // Only keep scan results from compatible scanners.
@@ -358,10 +357,10 @@ abstract class ScanResultsStorage {
                 "No stored scan results found for $scannerCriteria. The following entries with incompatible scanners " +
                         "have been ignored: ${scanResults.map { it.scanner }}"
             }
-            return Success(ScanResultContainer(pkg.id, scanResults))
+            return Success(scanResults)
         }
 
-        return Success(ScanResultContainer(pkg.id, scanResults))
+        return Success(scanResults)
     }
 
     /**
@@ -375,16 +374,13 @@ abstract class ScanResultsStorage {
         scannerCriteria: ScannerCriteria
     ): Result<Map<Identifier, List<ScanResult>>> {
         val results = runBlocking(Dispatchers.IO) {
-            packages.map { async { readInternal(it, scannerCriteria) } }.awaitAll()
-        }
+            packages.map { async { it.id to readInternal(it, scannerCriteria) } }.awaitAll()
+        }.associate { it }
 
-        return if (results.all { it is Failure }) {
+        return if (results.all { it.value is Failure }) {
             Failure("Could not read any scan results from ${javaClass.simpleName}.")
         } else {
-            Success(
-                results.filterIsInstance<Success<ScanResultContainer>>()
-                    .associate { Pair(it.result.id, it.result.results) }
-            )
+            Success(results.filter { it.value is Success }.mapValues { (it.value as Success).result })
         }
     }
 

--- a/scanner/src/main/kotlin/storages/NoStorage.kt
+++ b/scanner/src/main/kotlin/storages/NoStorage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2021 HERE Europe B.V.
  * Copyright (C) 2019 Bosch Software Innovations GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,6 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Result
 import org.ossreviewtoolkit.model.ScanResult
-import org.ossreviewtoolkit.model.ScanResultContainer
 import org.ossreviewtoolkit.model.Success
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.scanner.ScannerCriteria
@@ -35,10 +34,9 @@ import org.ossreviewtoolkit.scanner.ScannerCriteria
  * errors.
  */
 class NoStorage : ScanResultsStorage() {
-    override fun readInternal(id: Identifier) = Success(ScanResultContainer(id, emptyList()))
+    override fun readInternal(id: Identifier) = Success<List<ScanResult>>(emptyList())
 
-    override fun readInternal(pkg: Package, scannerCriteria: ScannerCriteria) =
-        Success(ScanResultContainer(pkg.id, emptyList()))
+    override fun readInternal(pkg: Package, scannerCriteria: ScannerCriteria) = Success<List<ScanResult>>(emptyList())
 
     override fun addInternal(id: Identifier, scanResult: ScanResult) = Success(Unit)
 }

--- a/scanner/src/main/kotlin/storages/PostgresStorage.kt
+++ b/scanner/src/main/kotlin/storages/PostgresStorage.kt
@@ -43,7 +43,6 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Result
 import org.ossreviewtoolkit.model.ScanResult
-import org.ossreviewtoolkit.model.ScanResultContainer
 import org.ossreviewtoolkit.model.Success
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.scanner.ScannerCriteria
@@ -138,14 +137,14 @@ class PostgresStorage(
             """.trimIndent()
         )
 
-    override fun readInternal(id: Identifier): Result<ScanResultContainer> {
+    override fun readInternal(id: Identifier): Result<List<ScanResult>> {
         @Suppress("TooGenericExceptionCaught")
         return try {
             transaction {
                 val scanResults =
                     ScanResultDao.find { ScanResults.identifier eq id.toCoordinates() }.map { it.scanResult }
 
-                Success(ScanResultContainer(id, scanResults))
+                Success(scanResults)
             }
         } catch (e: Exception) {
             when (e) {
@@ -163,7 +162,7 @@ class PostgresStorage(
         }
     }
 
-    override fun readInternal(pkg: Package, scannerCriteria: ScannerCriteria): Result<ScanResultContainer> {
+    override fun readInternal(pkg: Package, scannerCriteria: ScannerCriteria): Result<List<ScanResult>> {
         val minVersionArray = with(scannerCriteria.minVersion) { intArrayOf(major, minor, patch) }
         val maxVersionArray = with(scannerCriteria.maxVersion) { intArrayOf(major, minor, patch) }
 
@@ -183,7 +182,7 @@ class PostgresStorage(
                     // safe side.
                     .filter { scannerCriteria.matches(it.scanner) }
 
-                Success(ScanResultContainer(pkg.id, scanResults))
+                Success(scanResults)
             }
         } catch (e: Exception) {
             when (e) {

--- a/scanner/src/main/kotlin/storages/Sw360Storage.kt
+++ b/scanner/src/main/kotlin/storages/Sw360Storage.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020-2021 Bosch.IO GmbH
+ * Copyright (C) 2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +43,6 @@ import org.ossreviewtoolkit.model.Failure
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Result
 import org.ossreviewtoolkit.model.ScanResult
-import org.ossreviewtoolkit.model.ScanResultContainer
 import org.ossreviewtoolkit.model.Success
 import org.ossreviewtoolkit.model.config.Sw360StorageConfiguration
 import org.ossreviewtoolkit.model.jsonMapper
@@ -65,7 +65,7 @@ class Sw360Storage(
     )
     private val releaseClient = sw360ConnectionFactory.releaseAdapter
 
-    override fun readInternal(id: Identifier): Result<ScanResultContainer> {
+    override fun readInternal(id: Identifier): Result<List<ScanResult>> {
         val tempScanResultFile = createTempFileForUpload(id)
 
         return try {
@@ -76,7 +76,7 @@ class Sw360Storage(
                 .map { path ->
                     yamlMapper.readValue<ScanResult>(path.toFile())
                 }
-            Success(ScanResultContainer(id, scanResults))
+            Success(scanResults)
         } catch (e: SW360ClientException) {
             val message = "Could not read scan results for ${id.toCoordinates()} in SW360."
             log.info { message }

--- a/scanner/src/test/kotlin/storages/CompositeStorageTest.kt
+++ b/scanner/src/test/kotlin/storages/CompositeStorageTest.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Bosch.IO GmbH
+ * Copyright (C) 2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +40,6 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.ScanResult
-import org.ossreviewtoolkit.model.ScanResultContainer
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.Success
@@ -109,23 +109,19 @@ class CompositeStorageTest : WordSpec({
             val storage = CompositeStorage(emptyList(), listOf(mockk()))
 
             when (val result = storage.read(ID)) {
-                is Success -> {
-                    result.result.id shouldBe ID
-                    result.result.results.isEmpty() shouldBe true
-                }
-
+                is Success -> result.result.isEmpty() shouldBe true
                 is Failure -> fail("Unexpected failure result: ${result.error}")
             }
         }
 
         "return the first non-empty, success result from a reader when asked for an identifier" {
-            val result = Success(ScanResultContainer(ID, listOf(createScanResult(1))))
+            val result = Success(listOf(createScanResult(1)))
             val readerErr = storageMock("r1")
             val readerEmptyContainer = storageMock("r2")
             val readerResult = storageMock("r3")
             val readerUnused = storageMock("r4")
             every { readerErr.read(ID) } returns Failure("an error")
-            every { readerEmptyContainer.read(ID) } returns Success(ScanResultContainer(ID, emptyList()))
+            every { readerEmptyContainer.read(ID) } returns Success(emptyList())
             every { readerResult.read(ID) } returns result
 
             val storage = CompositeStorage(
@@ -138,7 +134,7 @@ class CompositeStorageTest : WordSpec({
         }
 
         "detect a non-empty scan result even if the container contains empty results" {
-            val result = Success(ScanResultContainer(ID, listOf(createScanResult(0), createScanResult(1))))
+            val result = Success(listOf(createScanResult(0), createScanResult(1)))
             val reader = storageMock("reader")
             every { reader.read(ID) } returns result
 
@@ -152,23 +148,19 @@ class CompositeStorageTest : WordSpec({
             val storage = CompositeStorage(emptyList(), listOf(mockk()))
 
             when (val result = storage.read(PACKAGE, CRITERIA)) {
-                is Success -> {
-                    result.result.id shouldBe ID
-                    result.result.results.isEmpty() shouldBe true
-                }
-
+                is Success -> result.result.isEmpty() shouldBe true
                 is Failure -> fail("Unexpected failure result: ${result.error}")
             }
         }
 
         "return the first non-empty, success result from a reader when asked for a package" {
-            val result = Success(ScanResultContainer(ID, listOf(createScanResult(1))))
+            val result = Success(listOf(createScanResult(1)))
             val readerErr = storageMock("r1")
             val readerEmptyContainer = storageMock("r2")
             val readerResult = storageMock("r3")
             val readerUnused = storageMock("r4")
             every { readerErr.read(PACKAGE, CRITERIA) } returns Failure("an error")
-            every { readerEmptyContainer.read(PACKAGE, CRITERIA) } returns Success(ScanResultContainer(ID, emptyList()))
+            every { readerEmptyContainer.read(PACKAGE, CRITERIA) } returns Success(emptyList())
             every { readerResult.read(PACKAGE, CRITERIA) } returns result
 
             val storage = CompositeStorage(


### PR DESCRIPTION
Remove most usages of the `ScanResultContainer`, mostly to simplify the code. See the commit messages for details.