### PR TITLE
AdvisorRecord: Change the type of advisorResults to a map

### DIFF
--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Bosch.IO GmbH
+ * Copyright (C) 2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +29,6 @@ import kotlinx.coroutines.runBlocking
 import org.ossreviewtoolkit.model.AdvisorDetails
 import org.ossreviewtoolkit.model.AdvisorRecord
 import org.ossreviewtoolkit.model.AdvisorResult
-import org.ossreviewtoolkit.model.AdvisorResultContainer
 import org.ossreviewtoolkit.model.AdvisorRun
 import org.ossreviewtoolkit.model.AdvisorSummary
 import org.ossreviewtoolkit.model.OrtResult
@@ -71,12 +71,9 @@ abstract class Advisor(val advisorName: String, protected val config: AdvisorCon
 
         val packages = ortResult.getPackages(skipExcluded).map { it.pkg }
         val results = runBlocking { retrievePackageVulnerabilities(packages) }
+            .mapKeysTo(sortedMapOf()) { (pkg, _) -> pkg.id }
 
-        val resultContainers = results.map { (pkg, results) ->
-            AdvisorResultContainer(pkg.id, results)
-        }.toSortedSet()
-
-        val advisorRecord = AdvisorRecord(resultContainers)
+        val advisorRecord = AdvisorRecord(results)
 
         val endTime = Instant.now()
 

--- a/model/src/main/kotlin/AdvisorRecord.kt
+++ b/model/src/main/kotlin/AdvisorRecord.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Bosch.IO GmbH
+ * Copyright (C) 2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +21,14 @@
 package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 
-import java.util.SortedSet
+import java.util.SortedMap
 
 /**
  * A record of a single run of the advisor tool, containing the input and the [Vulnerability] for every checked package.
@@ -31,14 +38,15 @@ data class AdvisorRecord(
     /**
      * The [AdvisorResult]s for all [Package]s.
      */
-    val advisorResults: SortedSet<AdvisorResultContainer>
+    @JsonDeserialize(using = AdvisorResultsDeserializer::class)
+    val advisorResults: SortedMap<Identifier, List<AdvisorResult>>
 ) {
     fun collectIssues(): Map<Identifier, Set<OrtIssue>> {
         val collectedIssues = mutableMapOf<Identifier, MutableSet<OrtIssue>>()
 
-        advisorResults.forEach { container ->
-            container.results.forEach { result ->
-                collectedIssues.getOrPut(container.id) { mutableSetOf() } += result.summary.issues
+        advisorResults.forEach { (id, results) ->
+            results.forEach { result ->
+                collectedIssues.getOrPut(id) { mutableSetOf() } += result.summary.issues
             }
         }
 
@@ -49,8 +57,20 @@ data class AdvisorRecord(
      * True if any of the [advisorResults] contain [OrtIssue]s.
      */
     val hasIssues by lazy {
-        advisorResults.any { advisorResultContainer ->
-            advisorResultContainer.results.any { it.summary.issues.isNotEmpty() }
+        advisorResults.any { (_, results) ->
+            results.any { it.summary.issues.isNotEmpty() }
         }
     }
+}
+
+private class AdvisorResultsDeserializer : StdDeserializer<SortedMap<Identifier, List<AdvisorResult>>>(
+    SortedMap::class.java
+) {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): SortedMap<Identifier, List<AdvisorResult>> =
+        if (p.currentToken == JsonToken.START_ARRAY) {
+            val containers = jsonMapper.readValue(p, jacksonTypeRef<List<AdvisorResultContainer>>())
+            containers.associateTo(sortedMapOf()) { it.id to it.results }
+        } else {
+            jsonMapper.readValue(p, jacksonTypeRef<SortedMap<Identifier, List<AdvisorResult>>>())
+        }
 }

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -169,7 +169,7 @@ data class OrtResult(
     }
 
     private val advisorResultsById: Map<Identifier, List<AdvisorResult>> by lazy {
-        advisor?.results?.advisorResults?.associateBy({ it.id }, { it.results }).orEmpty()
+        advisor?.results?.advisorResults.orEmpty()
     }
 
     /**
@@ -378,13 +378,13 @@ data class OrtResult(
         }
 
     /**
-     * Return all [AdvisorResultContainer]s contained in this [OrtResult] or only the non-excluded ones if
-     * [omitExcluded] is true.
+     * Return all [AdvisorResult]s contained in this [OrtResult] or only the non-excluded ones if [omitExcluded] is
+     * true.
      */
     @JsonIgnore
-    fun getAdvisorResultContainers(omitExcluded: Boolean = false): Set<AdvisorResultContainer> =
-        advisor?.results?.advisorResults.orEmpty().filterTo(mutableSetOf()) { result ->
-            !omitExcluded || !isExcluded(result.id)
+    fun getAdvisorResults(omitExcluded: Boolean = false): Map<Identifier, List<AdvisorResult>> =
+        advisorResultsById.filter { (id, _) ->
+            !omitExcluded || !isExcluded(id)
         }
 
     /**

--- a/model/src/test/kotlin/AdvisorRecordTest.kt
+++ b/model/src/test/kotlin/AdvisorRecordTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import com.fasterxml.jackson.module.kotlin.readValue
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.maps.haveSize
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+class AdvisorRecordTest : StringSpec({
+    "AdvisorRecord with advisor results can be deserialized" {
+        val yaml = """
+            ---
+            advisor_results:
+              type:namespace:name:version:
+              - vulnerabilities: []
+                advisor:
+                  name: "advisor"
+                summary:
+                  start_time: "1970-01-01T00:00:00Z"
+                  end_time: "1970-01-01T00:00:00Z"
+            has_issues: false
+        """.trimIndent()
+
+        val record = shouldNotThrowAny { yamlMapper.readValue<AdvisorRecord>(yaml) }
+        record.advisorResults should haveSize(1)
+        record.advisorResults.entries.single().let { (id, results) ->
+            id shouldBe Identifier("type:namespace:name:version")
+            results shouldHaveSize 1
+        }
+    }
+
+    "Legacy AdvisorRecord with AdvisorResultContainers can be deserialized" {
+        val yaml = """
+            ---
+            advisor_results:
+            - id: "type:namespace:name:version"
+              results:
+              - vulnerabilities: []
+                advisor:
+                  name: "advisor"
+                summary:
+                  start_time: "1970-01-01T00:00:00Z"
+                  end_time: "1970-01-01T00:00:00Z"
+            has_issues: false
+        """.trimIndent()
+
+        val record = shouldNotThrowAny { yamlMapper.readValue<AdvisorRecord>(yaml) }
+        record.advisorResults should haveSize(1)
+        record.advisorResults.entries.single().let { (id, results) ->
+            id shouldBe Identifier("type:namespace:name:version")
+            results shouldHaveSize 1
+        }
+    }
+})

--- a/reporter/src/main/kotlin/reporters/AsciiDocTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AsciiDocTemplateReporter.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Bosch.IO GmbH
+ * Copyright (C) 2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,7 +119,7 @@ class AsciiDocTemplateReporter : Reporter {
             templateOptions.putIfAbsent(FreemarkerTemplateProcessor.OPTION_TEMPLATE_ID, buildString {
                 append(DISCLOSURE_TEMPLATE_ID)
 
-                if (input.ortResult.getAdvisorResultContainers().isNotEmpty()) {
+                if (input.ortResult.getAdvisorResults().isNotEmpty()) {
                     append(",$VULNERABILITY_TEMPLATE_ID")
                 }
             })

--- a/reporter/src/main/resources/templates/asciidoc/vulnerability_report.ftl
+++ b/reporter/src/main/resources/templates/asciidoc/vulnerability_report.ftl
@@ -9,11 +9,11 @@
 :revnumber: 1.0.0
 
 == Packages:
-[#assign advisorResults = ortResult.getAdvisorResultContainers(false)]
-[#list advisorResults as advisorResult]
-Package: *${advisorResult.id.toCoordinates()}*
+[#assign advisorResults = ortResult.getAdvisorResults(false)]
+[#list advisorResults as id, results]
+Package: *${id.toCoordinates()}*
 
-[#list advisorResult.results as result]
+[#list results as result]
 
 * Advisor: ${result.advisor.name}
 


### PR DESCRIPTION
Use a map of instead of a list of `AdvisorResultContainer`s, because
this provides faster lookup by id and allows to simplify the code
working with the property.

The change adds a custom deserializer for the `advisorResults` property
to make sure that old ORT result files can still be read. When this
backward compatibility is not required anymore, the
`AdvisorResultContainer` class can be removed.

See also the related change for `ScanRecord`: #3720 