### PR TITLE
model: Generate copyright statements from authors

### DIFF
--- a/model/src/main/kotlin/licenses/DefaultLicenseInfoProvider.kt
+++ b/model/src/main/kotlin/licenses/DefaultLicenseInfoProvider.kt
@@ -60,17 +60,20 @@ class DefaultLicenseInfoProvider(
     private fun createDeclaredLicenseInfo(id: Identifier): DeclaredLicenseInfo =
         ortResult.getProject(id)?.let { project ->
             DeclaredLicenseInfo(
+                authors = project.authors,
                 licenses = project.declaredLicenses,
                 processed = project.declaredLicensesProcessed,
                 appliedCurations = emptyList()
             )
         } ?: ortResult.getPackage(id)?.let { (pkg, curations) ->
             DeclaredLicenseInfo(
+                authors = pkg.authors,
                 licenses = pkg.declaredLicenses,
                 processed = pkg.declaredLicensesProcessed,
                 appliedCurations = curations.filter { it.curation.declaredLicenses != null }
             )
         } ?: DeclaredLicenseInfo(
+            authors = sortedSetOf(),
             licenses = emptySet(),
             processed = ProcessedDeclaredLicense(null),
             appliedCurations = emptyList()

--- a/model/src/main/kotlin/licenses/LicenseInfo.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfo.kt
@@ -19,6 +19,8 @@
 
 package org.ossreviewtoolkit.model.licenses
 
+import java.util.SortedSet
+
 import org.ossreviewtoolkit.model.CopyrightFinding
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseFinding
@@ -75,6 +77,11 @@ data class ConcludedLicenseInfo(
  * Information about the declared license of a package or project.
  */
 data class DeclaredLicenseInfo(
+    /**
+     * The set of authors.
+     */
+    val authors: SortedSet<String>,
+
     /**
      * The unmodified set of declared licenses.
      */

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -28,6 +28,7 @@ import org.ossreviewtoolkit.model.CopyrightFinding
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.model.config.PathExclude
@@ -94,6 +95,22 @@ class LicenseInfoResolver(
                 originalDeclaredLicenses.addAll(
                     licenseInfo.declaredLicenseInfo.processed.mapped.filterValues { it == license }.keys
                 )
+
+                licenseInfo.declaredLicenseInfo.authors.takeIf { it.isNotEmpty() }?.let {
+                    locations.add(ResolvedLicenseLocation(
+                        provenance = Provenance(),
+                        location = UNDEFINED_TEXT_LOCATION,
+                        appliedCuration = null,
+                        matchingPathExcludes = emptyList(),
+                        copyrights = licenseInfo.declaredLicenseInfo.authors.mapTo(mutableSetOf()) {
+                            ResolvedCopyrightFinding(
+                                statement = "$COPYRIGHT_PREFIX $it",
+                                location = UNDEFINED_TEXT_LOCATION,
+                                matchingPathExcludes = emptyList()
+                            )
+                        }
+                    ))
+                }
             }
         }
 
@@ -248,3 +265,6 @@ private class ResolvedLicenseBuilder(val license: SpdxSingleLicenseExpression) {
 
     fun build() = ResolvedLicense(license, originalDeclaredLicenses, originalExpressions, locations)
 }
+
+private val UNDEFINED_TEXT_LOCATION = TextLocation(".", TextLocation.UNKNOWN_LINE, TextLocation.UNKNOWN_LINE)
+private const val COPYRIGHT_PREFIX = "Copyright (C)"

--- a/model/src/test/kotlin/licenses/DefaultLicenseInfoProviderTest.kt
+++ b/model/src/test/kotlin/licenses/DefaultLicenseInfoProviderTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.licenses
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
+
+class DefaultLicenseInfoProviderTest : WordSpec({
+    val defaultLicenseInfoProvider = DefaultLicenseInfoProvider(ortResult, SimplePackageConfigurationProvider.EMPTY)
+
+    "declaredLicenseInfo" should {
+        "contain author information for package" {
+            defaultLicenseInfoProvider.get(packageWithAuthors.id).declaredLicenseInfo.authors shouldBe authors
+        }
+
+        "contain author information for project" {
+            defaultLicenseInfoProvider.get(project.id).declaredLicenseInfo.authors shouldBe projectAuthors
+        }
+    }
+})

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -587,6 +587,7 @@ class LicenseInfoResolverTest : WordSpec() {
         LicenseInfo(
             id = id,
             declaredLicenseInfo = DeclaredLicenseInfo(
+                authors = sortedSetOf(),
                 licenses = declaredLicenses,
                 processed = DeclaredLicenseProcessor.process(declaredLicenses),
                 appliedCurations = emptyList()

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -32,6 +32,7 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 import java.lang.IllegalArgumentException
+import java.util.SortedSet
 
 import org.ossreviewtoolkit.model.CopyrightFinding
 import org.ossreviewtoolkit.model.Hash
@@ -506,6 +507,27 @@ class LicenseInfoResolverTest : WordSpec() {
                 result should containNumberOfLocationsForLicense(gplLicense, 2)
                 result should containNumberOfLocationsForLicense(bsdLicense, 4)
             }
+
+            "resolve copyrights from authors" {
+                val licenseInfos = listOf(
+                    createLicenseInfo(
+                        id = pkgId,
+                        authors = authors,
+                        declaredLicenses = declaredLicenses
+                    )
+                )
+                val resolver = createResolver(licenseInfos)
+
+                val result = resolver.resolveLicenseInfo(pkgId)
+                result should containCopyrightStatementsForLicenseExactly(
+                    "LicenseRef-a",
+                    "Copyright (C) The Author", "Copyright (C) The Other Author"
+                )
+                result should containCopyrightStatementsForLicenseExactly(
+                    "LicenseRef-b",
+                    "Copyright (C) The Author", "Copyright (C) The Other Author"
+                )
+            }
         }
 
         "resolveLicenseFiles()" should {
@@ -580,6 +602,7 @@ class LicenseInfoResolverTest : WordSpec() {
 
     private fun createLicenseInfo(
         id: Identifier,
+        authors: SortedSet<String> = sortedSetOf(),
         declaredLicenses: Set<String> = emptySet(),
         detectedLicenses: List<Findings> = emptyList(),
         concludedLicense: SpdxExpression? = null
@@ -587,7 +610,7 @@ class LicenseInfoResolverTest : WordSpec() {
         LicenseInfo(
             id = id,
             declaredLicenseInfo = DeclaredLicenseInfo(
-                authors = sortedSetOf(),
+                authors = authors,
                 licenses = declaredLicenses,
                 processed = DeclaredLicenseProcessor.process(declaredLicenses),
                 appliedCurations = emptyList()

--- a/model/src/test/kotlin/licenses/TestData.kt
+++ b/model/src/test/kotlin/licenses/TestData.kt
@@ -51,6 +51,9 @@ import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.Environment
 
+val authors = sortedSetOf("The Author", "The Other Author")
+val projectAuthors = sortedSetOf("The Project Author")
+
 val concludedLicense = "LicenseRef-a AND LicenseRef-b".toSpdx()
 val declaredLicenses = sortedSetOf("LicenseRef-a", "LicenseRef-b")
 val declaredLicensesProcessed = DeclaredLicenseProcessor.process(declaredLicenses)
@@ -58,6 +61,11 @@ val declaredLicensesProcessed = DeclaredLicenseProcessor.process(declaredLicense
 val licenseFindings = sortedSetOf(
     LicenseFinding("LicenseRef-a", TextLocation("LICENSE", 1)),
     LicenseFinding("LicenseRef-b", TextLocation("LICENSE", 2))
+)
+
+val packageWithAuthors = Package.EMPTY.copy(
+    id = Identifier("Maven:org.ossreviewtoolkit:package-with-authors:1.0"),
+    authors = authors
 )
 
 val packageWithoutLicense = Package.EMPTY.copy(
@@ -105,6 +113,7 @@ val packageWithConcludedAndDeclaredAndDetectedLicense = Package.EMPTY.copy(
 )
 
 val allPackages = listOf(
+    packageWithAuthors,
     packageWithoutLicense,
     packageWithConcludedLicense,
     packageWithDeclaredLicense,
@@ -128,6 +137,7 @@ val scope = Scope(
 val project = Project.EMPTY.copy(
     id = Identifier("Maven:org.ossreviewtoolkit:project-included:1.0"),
     definitionFilePath = "included/pom.xml",
+    authors = projectAuthors,
     scopeDependencies = sortedSetOf(scope)
 )
 


### PR DESCRIPTION
Extend LicenseInfoResolver to generate copyright statements for declared
licenses based on author information.