### PR TITLE
analyzer: Add a work-around for wrongly named High Availability artifacts

### DIFF
--- a/analyzer/src/main/resources/META-INF/plexus/components.xml
+++ b/analyzer/src/main/resources/META-INF/plexus/components.xml
@@ -102,6 +102,24 @@
         </component>
 
         <!--
+         | GlassFish High Availability API (https://mvnrepository.com/artifact/org.glassfish.ha/ha-api/)
+         |-->
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>hk2-jar</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+
+        <!--
          | Jenkins Plugin (https://jenkins.io/doc/book/managing/plugins/)
          |-->
         <component>

--- a/analyzer/src/main/resources/META-INF/plexus/components.xml
+++ b/analyzer/src/main/resources/META-INF/plexus/components.xml
@@ -120,6 +120,24 @@
         </component>
 
         <!--
+         | Jenkins Module (https://mvnrepository.com/artifact/org.jenkins-ci.modules/instance-identity/)
+         |-->
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>jenkins-module</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+
+        <!--
          | Jenkins Plugin (https://jenkins.io/doc/book/managing/plugins/)
          |-->
         <component>


### PR DESCRIPTION
The packaging [1] says "hk2-jar", but the file extension is "jar".

[1] https://repo1.maven.org/maven2/org/glassfish/ha/ha-api/3.1.9/ha-api-3.1.9.pom

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>