### PR TITLE
OrtConfiguration: Rename load()'s "configFile" to just "file"

### DIFF
--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -61,28 +61,28 @@ data class OrtConfiguration(
          * Load the [OrtConfiguration]. The different sources are used with this priority:
          *
          * 1. [Command line arguments][args]
-         * 2. [Configuration file][configFile]
+         * 2. [Configuration file][file]
          * 3. default.conf from resources
          *
          * The configuration file is optional and does not have to exist. However, if it exists, but does not
          * contain a valid configuration, an [IllegalArgumentException] is thrown.
          */
-        fun load(args: Map<String, String> = emptyMap(), configFile: File): OrtConfiguration {
-            if (configFile.isFile) {
-                log.info { "Using ORT configuration file at '$configFile'." }
+        fun load(args: Map<String, String> = emptyMap(), file: File): OrtConfiguration {
+            if (file.isFile) {
+                log.info { "Using ORT configuration file at '$file'." }
             }
 
             val result = ConfigLoader.Builder()
                 .addSource(argumentsSource(args))
-                .addSource(PropertySource.file(configFile, optional = true))
+                .addSource(PropertySource.file(file, optional = true))
                 .addSource(PropertySource.resource("/default.conf"))
                 .build()
                 .loadConfig<OrtConfigurationWrapper>()
 
             return result.map { it.ort }.getOrElse { failure ->
-                if (configFile.isFile) {
+                if (file.isFile) {
                     throw IllegalArgumentException(
-                        "Failed to load configuration from ${configFile.absolutePath}: ${failure.description()}"
+                        "Failed to load configuration from ${file.absolutePath}: ${failure.description()}"
                     )
                 }
 

--- a/model/src/test/kotlin/config/NexusIqConfigurationTest.kt
+++ b/model/src/test/kotlin/config/NexusIqConfigurationTest.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.model.readValue
 class NexusIqConfigurationTest : WordSpec({
     "NexusIqConfiguration" should {
         "support a serialization round-trip via an ObjectMapper" {
-            val referenceOrtConfig = OrtConfiguration.load(configFile = File("src/test/assets/reference.conf"))
+            val referenceOrtConfig = OrtConfiguration.load(file = File("src/test/assets/reference.conf"))
             val rereadOrtConfig = createTempFile(suffix = ".yml").toFile().apply {
                 mapper().writeValue(this, referenceOrtConfig)
                 deleteOnExit()

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -43,7 +43,7 @@ class OrtConfigurationTest : WordSpec({
     "OrtConfiguration" should {
         "be deserializable from HOCON" {
             val refConfig = File("src/test/assets/reference.conf")
-            val ortConfig = OrtConfiguration.load(configFile = refConfig)
+            val ortConfig = OrtConfiguration.load(file = refConfig)
 
             ortConfig.analyzer shouldNotBeNull {
                 ignoreToolVersions shouldBe true
@@ -152,7 +152,7 @@ class OrtConfigurationTest : WordSpec({
                         "ort.scanner.storages.postgresStorage.password" to "argsPassword",
                         "other.property" to "someValue"
                     ),
-                    configFile = configFile
+                    file = configFile
                 )
 
                 config.scanner?.storages shouldNotBeNull {
@@ -179,7 +179,7 @@ class OrtConfigurationTest : WordSpec({
             )
 
             shouldThrow<IllegalArgumentException> {
-                OrtConfiguration.load(configFile = configFile)
+                OrtConfiguration.load(file = configFile)
             }
         }
 
@@ -188,7 +188,7 @@ class OrtConfigurationTest : WordSpec({
             val args = mapOf("ort.scanner.storages.new" to "test")
 
             shouldThrow<IllegalArgumentException> {
-                OrtConfiguration.load(configFile = file, args = args)
+                OrtConfiguration.load(file = file, args = args)
             }
         }
 
@@ -196,7 +196,7 @@ class OrtConfigurationTest : WordSpec({
             val args = mapOf("foo" to "bar")
             val file = File("nonExistingConfig.conf")
 
-            val config = OrtConfiguration.load(configFile = file, args = args)
+            val config = OrtConfiguration.load(file = file, args = args)
 
             config.scanner should beNull()
         }
@@ -223,7 +223,7 @@ class OrtConfigurationTest : WordSpec({
             val env = mapOf("POSTGRES_USERNAME" to user, "POSTGRES_PASSWORD" to password)
 
             withEnvironment(env) {
-                val config = OrtConfiguration.load(configFile = configFile)
+                val config = OrtConfiguration.load(file = configFile)
 
                 config.scanner?.storages shouldNotBeNull {
                     val postgresStorage = this["postgresStorage"]
@@ -247,7 +247,7 @@ class OrtConfigurationTest : WordSpec({
             )
 
             withEnvironment(env) {
-                val config = OrtConfiguration.load(configFile = File("dummyPath"))
+                val config = OrtConfiguration.load(file = File("dummyPath"))
 
                 config.scanner?.storages shouldNotBeNull {
                     val postgresStorage = this["postgresStorage"]

--- a/model/src/test/kotlin/config/ScannerConfigurationTest.kt
+++ b/model/src/test/kotlin/config/ScannerConfigurationTest.kt
@@ -36,7 +36,7 @@ class ScannerConfigurationTest : WordSpec({
     "ScannerConfiguration" should {
         "support a serialization round-trip via an ObjectMapper" {
             val refConfig = File("src/test/assets/reference.conf")
-            val ortConfig = OrtConfiguration.load(configFile = refConfig)
+            val ortConfig = OrtConfiguration.load(file = refConfig)
             val file = createTempFile(suffix = ".yml").toFile().apply { deleteOnExit() }
 
             file.mapper().writeValue(file, ortConfig.scanner)


### PR DESCRIPTION
The "config" context is clear here, and "args" also does not have that
prefix.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>