### PR TITLE
Downloader: Configure preferred source code origin

### DIFF
--- a/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
+++ b/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
@@ -41,6 +41,7 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
@@ -85,7 +86,7 @@ abstract class AbstractIntegrationSpec : StringSpec() {
         // Do not use the usual simple class name as the suffix here to shorten the path which otherwise gets too long
         // on Windows for SimpleFormIntegrationTest.
         outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
-        provenance = Downloader.download(pkg, outputDir)
+        provenance = Downloader(DownloaderConfiguration()).download(pkg, outputDir)
     }
 
     override fun afterSpec(spec: Spec) {

--- a/cli/src/main/kotlin/commands/RequirementsCommand.kt
+++ b/cli/src/main/kotlin/commands/RequirementsCommand.kt
@@ -28,6 +28,7 @@ import java.lang.reflect.Modifier
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.Scanner
@@ -76,8 +77,11 @@ class RequirementsCommand : CliktCommand(help = "Check for the command line tool
                     Scanner::class.java.isAssignableFrom(it) -> {
                         category = "Scanner"
                         log.debug { "$it is a $category." }
-                        it.getDeclaredConstructor(String::class.java, ScannerConfiguration::class.java)
-                            .newInstance("", ScannerConfiguration())
+                        it.getDeclaredConstructor(
+                            String::class.java,
+                            ScannerConfiguration::class.java,
+                            DownloaderConfiguration::class.java
+                        ).newInstance("", ScannerConfiguration(), DownloaderConfiguration())
                     }
 
                     VersionControlSystem::class.java.isAssignableFrom(it) -> {

--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -41,6 +41,7 @@ import kotlin.time.measureTime
 
 import org.ossreviewtoolkit.GlobalOptions
 import org.ossreviewtoolkit.model.FileFormat
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.mapper
 import org.ossreviewtoolkit.model.utils.mergeLabels
@@ -120,10 +121,13 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
 
     private val globalOptionsForSubcommands by requireObject<GlobalOptions>()
 
-    private fun configureScanner(scannerConfig: ScannerConfiguration): Scanner {
+    private fun configureScanner(
+        scannerConfig: ScannerConfiguration,
+        downloaderConfig: DownloaderConfiguration
+    ): Scanner {
         ScanResultsStorage.configure(scannerConfig)
 
-        val scanner = scannerFactory.create(scannerConfig)
+        val scanner = scannerFactory.create(scannerConfig, downloaderConfig)
 
         println("Using scanner '${scanner.scannerName}' with storage '${ScanResultsStorage.storage.name}'.")
 
@@ -166,7 +170,7 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
         }
 
         val config = globalOptionsForSubcommands.config
-        val scanner = configureScanner(config.scanner)
+        val scanner = configureScanner(config.scanner, config.downloader)
 
         val ortResult = if (input.isFile) {
             scanner.scanOrtResult(

--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -120,10 +120,10 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
 
     private val globalOptionsForSubcommands by requireObject<GlobalOptions>()
 
-    private fun configureScanner(config: ScannerConfiguration): Scanner {
-        ScanResultsStorage.configure(config)
+    private fun configureScanner(scannerConfig: ScannerConfiguration): Scanner {
+        ScanResultsStorage.configure(scannerConfig)
 
-        val scanner = scannerFactory.create(config)
+        val scanner = scannerFactory.create(scannerConfig)
 
         println("Using scanner '${scanner.scannerName}' with storage '${ScanResultsStorage.storage.name}'.")
 

--- a/downloader/src/funTest/kotlin/BabelFunTest.kt
+++ b/downloader/src/funTest/kotlin/BabelFunTest.kt
@@ -36,6 +36,7 @@ import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
@@ -81,7 +82,7 @@ class BabelFunTest : StringSpec() {
                 vcsProcessed = vcsMerged
             )
 
-            val provenance = Downloader.download(pkg, outputDir)
+            val provenance = Downloader(DownloaderConfiguration()).download(pkg, outputDir)
             val workingTree = VersionControlSystem.forDirectory(outputDir)
             val babelCliDir = outputDir.resolve("packages/babel-cli")
 

--- a/downloader/src/funTest/kotlin/BeanUtilsFunTest.kt
+++ b/downloader/src/funTest/kotlin/BeanUtilsFunTest.kt
@@ -35,6 +35,7 @@ import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
 
@@ -72,7 +73,7 @@ class BeanUtilsFunTest : StringSpec() {
                 vcs = vcsFromCuration
             )
 
-            val provenance = Downloader.download(pkg, outputDir)
+            val provenance = Downloader(DownloaderConfiguration()).download(pkg, outputDir)
 
             outputDir.walk().onEnter { it.name != ".svn" }.count() shouldBe 302
 

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -53,6 +53,7 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.Curations
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.IssueResolution
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
@@ -202,7 +203,7 @@ internal fun OrtResult.fetchScannedSources(id: Identifier): File {
         }
     }
 
-    Downloader.download(pkg, tempDir)
+    Downloader(DownloaderConfiguration()).download(pkg, tempDir)
 
     return tempDir
 }

--- a/model/src/main/kotlin/SourceCodeOrigin.kt
+++ b/model/src/main/kotlin/SourceCodeOrigin.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+/**
+ * An enumeration of supported source code origins.
+ */
+enum class SourceCodeOrigin {
+    /**
+     * Source code from the version control system.
+     */
+    VCS,
+
+    /**
+     * Source code from the distributed source code artifact.
+     */
+    ARTIFACT
+}

--- a/model/src/main/kotlin/config/DownloaderConfiguration.kt
+++ b/model/src/main/kotlin/config/DownloaderConfiguration.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.config
+
+import org.ossreviewtoolkit.model.SourceCodeOrigin
+import org.ossreviewtoolkit.spdx.getDuplicates
+
+data class DownloaderConfiguration(
+    /**
+     * Configuration of the considered source code origins and their priority order.
+     */
+    val sourceCodeOrigins: List<SourceCodeOrigin> = listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT)
+) {
+    init {
+        require(sourceCodeOrigins.isNotEmpty()) {
+            "'sourceCodeOrigins' must not be empty."
+        }
+
+        val duplicates = sourceCodeOrigins.getDuplicates()
+        require(duplicates.isEmpty()) {
+            "'sourceCodeOrigins' must not contain duplicates. Duplicates: $duplicates"
+        }
+    }
+}

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -43,6 +43,11 @@ data class OrtConfiguration(
     val analyzer: AnalyzerConfiguration = AnalyzerConfiguration(),
 
     /**
+     * The configuration of the downloader.
+     */
+    val downloader: DownloaderConfiguration = DownloaderConfiguration(),
+
+    /**
      * The configuration of the scanner.
      */
     val scanner: ScannerConfiguration = ScannerConfiguration(),

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -31,6 +31,12 @@ ort {
     rootLicenseFilenames = ["readme*"]
   }
 
+  downloader {
+    sourceCodeOrigins: [
+      "VCS", "ARTIFACT"
+    ]
+  }
+
   scanner {
     archive {
       fileStorage {

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -35,6 +35,7 @@ import java.lang.IllegalArgumentException
 
 import kotlin.io.path.createTempFile
 
+import org.ossreviewtoolkit.model.SourceCodeOrigin
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.test.containExactly as containExactlyEntries
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
@@ -58,6 +59,10 @@ class OrtConfigurationTest : WordSpec({
                     clientPassword shouldBe "clientPassword"
                     token shouldBe "token"
                 }
+            }
+
+            ortConfig.downloader shouldNotBeNull {
+                sourceCodeOrigins shouldBe listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT)
             }
 
             with(ortConfig.scanner) {

--- a/scanner/src/funTest/kotlin/scanners/AbstractScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/AbstractScannerFunTest.kt
@@ -32,6 +32,7 @@ import java.io.File
 
 import kotlin.io.path.createTempDirectory
 
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.LocalScanner
 import org.ossreviewtoolkit.spdx.SpdxExpression
@@ -40,6 +41,7 @@ import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 abstract class AbstractScannerFunTest(testTags: Set<Tag> = emptySet()) : StringSpec() {
+    protected val downloaderConfig = DownloaderConfiguration()
     protected val scannerConfig = ScannerConfiguration()
 
     // This is loosely based on the patterns from

--- a/scanner/src/funTest/kotlin/scanners/AbstractScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/AbstractScannerFunTest.kt
@@ -40,7 +40,7 @@ import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 abstract class AbstractScannerFunTest(testTags: Set<Tag> = emptySet()) : StringSpec() {
-    protected val config = ScannerConfiguration()
+    protected val scannerConfig = ScannerConfiguration()
 
     // This is loosely based on the patterns from
     // https://github.com/licensee/licensee/blob/6c0f803/lib/licensee/project_files/license_file.rb#L6-L43.

--- a/scanner/src/funTest/kotlin/scanners/AskalonoScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/AskalonoScannerFunTest.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.scanner.scanners
 import org.ossreviewtoolkit.spdx.toSpdx
 
 class AskalonoScannerFunTest : AbstractScannerFunTest() {
-    override val scanner = Askalono("Askalono", scannerConfig)
+    override val scanner = Askalono("Askalono", scannerConfig, downloaderConfig)
     override val expectedFileLicenses = setOf("Apache-2.0".toSpdx())
     override val expectedDirectoryLicenses = setOf("Apache-2.0".toSpdx())
 }

--- a/scanner/src/funTest/kotlin/scanners/AskalonoScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/AskalonoScannerFunTest.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.scanner.scanners
 import org.ossreviewtoolkit.spdx.toSpdx
 
 class AskalonoScannerFunTest : AbstractScannerFunTest() {
-    override val scanner = Askalono("Askalono", config)
+    override val scanner = Askalono("Askalono", scannerConfig)
     override val expectedFileLicenses = setOf("Apache-2.0".toSpdx())
     override val expectedDirectoryLicenses = setOf("Apache-2.0".toSpdx())
 }

--- a/scanner/src/funTest/kotlin/scanners/BoyterLcScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/BoyterLcScannerFunTest.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.scanner.scanners
 import org.ossreviewtoolkit.spdx.toSpdx
 
 class BoyterLcScannerFunTest : AbstractScannerFunTest() {
-    override val scanner = BoyterLc("BoyterLc", config)
+    override val scanner = BoyterLc("BoyterLc", scannerConfig)
     override val expectedFileLicenses = setOf("Apache-2.0".toSpdx(), "ECL-2.0".toSpdx())
     override val expectedDirectoryLicenses = setOf("Apache-2.0".toSpdx(), "ECL-2.0".toSpdx())
 }

--- a/scanner/src/funTest/kotlin/scanners/BoyterLcScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/BoyterLcScannerFunTest.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.scanner.scanners
 import org.ossreviewtoolkit.spdx.toSpdx
 
 class BoyterLcScannerFunTest : AbstractScannerFunTest() {
-    override val scanner = BoyterLc("BoyterLc", scannerConfig)
+    override val scanner = BoyterLc("BoyterLc", scannerConfig, downloaderConfig)
     override val expectedFileLicenses = setOf("Apache-2.0".toSpdx(), "ECL-2.0".toSpdx())
     override val expectedDirectoryLicenses = setOf("Apache-2.0".toSpdx(), "ECL-2.0".toSpdx())
 }

--- a/scanner/src/funTest/kotlin/scanners/FileCounterScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/FileCounterScannerFunTest.kt
@@ -26,6 +26,7 @@ import java.io.File
 
 import kotlin.io.path.createTempDirectory
 
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
@@ -48,7 +49,7 @@ class FileCounterScannerFunTest : StringSpec() {
                 assetsDir.resolve("file-counter-expected-output-for-analyzer-result.yml")
             )
 
-            val scanner = FileCounter("FileCounter", ScannerConfiguration())
+            val scanner = FileCounter("FileCounter", ScannerConfiguration(), DownloaderConfiguration())
             val ortResult = scanner.scanOrtResult(analyzerResultFile, outputDir, outputDir.resolve("downloads"))
             val result = yamlMapper.writeValueAsString(ortResult)
 

--- a/scanner/src/funTest/kotlin/scanners/LicenseeScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/LicenseeScannerFunTest.kt
@@ -23,7 +23,7 @@ import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 
 class LicenseeScannerFunTest : AbstractScannerFunTest(setOf(ExpensiveTag)) {
-    override val scanner = Licensee("Licensee", scannerConfig)
+    override val scanner = Licensee("Licensee", scannerConfig, downloaderConfig)
     override val expectedFileLicenses = setOf("Apache-2.0".toSpdx())
     override val expectedDirectoryLicenses = setOf("Apache-2.0".toSpdx())
 }

--- a/scanner/src/funTest/kotlin/scanners/LicenseeScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/LicenseeScannerFunTest.kt
@@ -23,7 +23,7 @@ import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 
 class LicenseeScannerFunTest : AbstractScannerFunTest(setOf(ExpensiveTag)) {
-    override val scanner = Licensee("Licensee", config)
+    override val scanner = Licensee("Licensee", scannerConfig)
     override val expectedFileLicenses = setOf("Apache-2.0".toSpdx())
     override val expectedDirectoryLicenses = setOf("Apache-2.0".toSpdx())
 }

--- a/scanner/src/funTest/kotlin/scanners/scancode/ScanCodeScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/scancode/ScanCodeScannerFunTest.kt
@@ -25,7 +25,7 @@ import org.ossreviewtoolkit.utils.test.ExpensiveTag
 import org.ossreviewtoolkit.utils.test.ScanCodeTag
 
 class ScanCodeScannerFunTest : AbstractScannerFunTest(setOf(ExpensiveTag, ScanCodeTag)) {
-    override val scanner = ScanCode("ScanCode", config)
+    override val scanner = ScanCode("ScanCode", scannerConfig)
     override val expectedFileLicenses = setOf("Apache-2.0".toSpdx())
     override val expectedDirectoryLicenses = setOf("Apache-2.0".toSpdx())
 }

--- a/scanner/src/funTest/kotlin/scanners/scancode/ScanCodeScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/scancode/ScanCodeScannerFunTest.kt
@@ -25,7 +25,7 @@ import org.ossreviewtoolkit.utils.test.ExpensiveTag
 import org.ossreviewtoolkit.utils.test.ScanCodeTag
 
 class ScanCodeScannerFunTest : AbstractScannerFunTest(setOf(ExpensiveTag, ScanCodeTag)) {
-    override val scanner = ScanCode("ScanCode", scannerConfig)
+    override val scanner = ScanCode("ScanCode", scannerConfig, downloaderConfig)
     override val expectedFileLicenses = setOf("Apache-2.0".toSpdx())
     override val expectedDirectoryLicenses = setOf("Apache-2.0".toSpdx())
 }

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -73,8 +73,9 @@ import org.ossreviewtoolkit.utils.showStackTrace
  */
 abstract class LocalScanner(
     name: String,
-    scannerConfig: ScannerConfiguration
-) : Scanner(name, scannerConfig), CommandLineTool {
+    scannerConfig: ScannerConfiguration,
+    downloaderConfig: DownloaderConfiguration
+) : Scanner(name, scannerConfig, downloaderConfig), CommandLineTool {
     companion object {
         /**
          * The number of threads to use for the storage dispatcher.
@@ -300,7 +301,7 @@ abstract class LocalScanner(
 
             if (missingArchives.isNotEmpty()) {
                 val pkgDownloadDirectory = downloadDirectory.resolve(pkg.id.toPath())
-                Downloader(DownloaderConfiguration()).download(pkg, pkgDownloadDirectory)
+                Downloader(downloaderConfig).download(pkg, pkgDownloadDirectory)
 
                 missingArchives.forEach { provenance ->
                     if (provenance is KnownProvenance) {
@@ -338,7 +339,7 @@ abstract class LocalScanner(
         val pkgDownloadDirectory = downloadDirectory.resolve(pkg.id.toPath())
 
         val provenance = try {
-            Downloader(DownloaderConfiguration()).download(pkg, pkgDownloadDirectory)
+            Downloader(downloaderConfig).download(pkg, pkgDownloadDirectory)
         } catch (e: DownloadException) {
             e.showStackTrace()
 

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -52,6 +52,7 @@ import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.Success
 import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.createAndLogIssue
@@ -299,7 +300,7 @@ abstract class LocalScanner(
 
             if (missingArchives.isNotEmpty()) {
                 val pkgDownloadDirectory = downloadDirectory.resolve(pkg.id.toPath())
-                Downloader.download(pkg, pkgDownloadDirectory)
+                Downloader(DownloaderConfiguration()).download(pkg, pkgDownloadDirectory)
 
                 missingArchives.forEach { provenance ->
                     if (provenance is KnownProvenance) {
@@ -337,7 +338,7 @@ abstract class LocalScanner(
         val pkgDownloadDirectory = downloadDirectory.resolve(pkg.id.toPath())
 
         val provenance = try {
-            Downloader.download(pkg, pkgDownloadDirectory)
+            Downloader(DownloaderConfiguration()).download(pkg, pkgDownloadDirectory)
         } catch (e: DownloadException) {
             e.showStackTrace()
 

--- a/scanner/src/main/kotlin/RemoteScanner.kt
+++ b/scanner/src/main/kotlin/RemoteScanner.kt
@@ -20,12 +20,17 @@
 package org.ossreviewtoolkit.scanner
 
 import org.ossreviewtoolkit.model.ScannerDetails
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 
 /**
  * Abstraction for a [Scanner] that runs on a remote host.
  */
-abstract class RemoteScanner(name: String, scannerConfig: ScannerConfiguration) : Scanner(name, scannerConfig) {
+abstract class RemoteScanner(
+    name: String,
+    scannerConfig: ScannerConfiguration,
+    downloaderConfig: DownloaderConfiguration
+) : Scanner(name, scannerConfig, downloaderConfig) {
     /**
      * The version of the scanner, or an empty string if not applicable.
      */

--- a/scanner/src/main/kotlin/RemoteScanner.kt
+++ b/scanner/src/main/kotlin/RemoteScanner.kt
@@ -25,7 +25,7 @@ import org.ossreviewtoolkit.model.config.ScannerConfiguration
 /**
  * Abstraction for a [Scanner] that runs on a remote host.
  */
-abstract class RemoteScanner(name: String, config: ScannerConfiguration) : Scanner(name, config) {
+abstract class RemoteScanner(name: String, scannerConfig: ScannerConfiguration) : Scanner(name, scannerConfig) {
     /**
      * The version of the scanner, or an empty string if not applicable.
      */

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -50,7 +50,7 @@ const val TOOL_NAME = "scanner"
  * The class to run license / copyright scanners. The signatures of public functions in this class define the library
  * API.
  */
-abstract class Scanner(val scannerName: String, protected val config: ScannerConfiguration) {
+abstract class Scanner(val scannerName: String, protected val scannerConfig: ScannerConfiguration) {
     companion object {
         private val LOADER = ServiceLoader.load(ScannerFactory::class.java)!!
 
@@ -142,14 +142,14 @@ abstract class Scanner(val scannerName: String, protected val config: ScannerCon
 
         val endTime = Instant.now()
 
-        val filteredScannerOptions = config.options?.let { options ->
+        val filteredScannerOptions = scannerConfig.options?.let { options ->
             options[scannerName]?.let { scannerOptions ->
                 val filteredScannerOptions = filterOptionsForResult(scannerOptions)
                 options.toMutableMap().apply { put(scannerName, filteredScannerOptions) }
             }
-        } ?: config.options
+        } ?: scannerConfig.options
 
-        val configWithFilteredOptions = config.copy(options = filteredScannerOptions)
+        val configWithFilteredOptions = scannerConfig.copy(options = filteredScannerOptions)
         val scannerRun = ScannerRun(startTime, endTime, Environment(), configWithFilteredOptions, scanRecord)
 
         // Note: This overwrites any existing ScannerRun from the input file.

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -35,6 +35,7 @@ import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.ScanRecord
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScannerRun
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.utils.filterByProject
@@ -50,7 +51,11 @@ const val TOOL_NAME = "scanner"
  * The class to run license / copyright scanners. The signatures of public functions in this class define the library
  * API.
  */
-abstract class Scanner(val scannerName: String, protected val scannerConfig: ScannerConfiguration) {
+abstract class Scanner(
+    val scannerName: String,
+    protected val scannerConfig: ScannerConfiguration,
+    protected val downloaderConfig: DownloaderConfiguration
+) {
     companion object {
         private val LOADER = ServiceLoader.load(ScannerFactory::class.java)!!
 

--- a/scanner/src/main/kotlin/ScannerFactory.kt
+++ b/scanner/src/main/kotlin/ScannerFactory.kt
@@ -33,9 +33,9 @@ interface ScannerFactory {
     val scannerName: String
 
     /**
-     * Create a [Scanner] using the specified [config].
+     * Create a [Scanner] using the specified [scannerConfig].
      */
-    fun create(config: ScannerConfiguration): Scanner
+    fun create(scannerConfig: ScannerConfiguration): Scanner
 }
 
 /**
@@ -44,7 +44,7 @@ interface ScannerFactory {
 abstract class AbstractScannerFactory<out T : Scanner>(
     override val scannerName: String
 ) : ScannerFactory {
-    abstract override fun create(config: ScannerConfiguration): T
+    abstract override fun create(scannerConfig: ScannerConfiguration): T
 
     /**
      * Return the scanner's name here to allow Clikt to display something meaningful when listing the scanners

--- a/scanner/src/main/kotlin/ScannerFactory.kt
+++ b/scanner/src/main/kotlin/ScannerFactory.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.scanner
 
 import java.util.ServiceLoader
 
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 
 /**
@@ -33,9 +34,9 @@ interface ScannerFactory {
     val scannerName: String
 
     /**
-     * Create a [Scanner] using the specified [scannerConfig].
+     * Create a [Scanner] using the specified [scannerConfig] and [downloaderConfig].
      */
-    fun create(scannerConfig: ScannerConfiguration): Scanner
+    fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration): Scanner
 }
 
 /**
@@ -44,7 +45,7 @@ interface ScannerFactory {
 abstract class AbstractScannerFactory<out T : Scanner>(
     override val scannerName: String
 ) : ScannerFactory {
-    abstract override fun create(scannerConfig: ScannerConfiguration): T
+    abstract override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration): T
 
     /**
      * Return the scanner's name here to allow Clikt to display something meaningful when listing the scanners

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -34,6 +34,7 @@ import org.ossreviewtoolkit.model.EMPTY_JSON_NODE
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.scanner.AbstractScannerFactory
@@ -47,9 +48,14 @@ import org.ossreviewtoolkit.utils.ProcessCapture
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.unpackZip
 
-class Askalono(name: String, scannerConfig: ScannerConfiguration) : LocalScanner(name, scannerConfig) {
+class Askalono(
+    name: String,
+    scannerConfig: ScannerConfiguration,
+    downloaderConfig: DownloaderConfiguration
+) : LocalScanner(name, scannerConfig, downloaderConfig) {
     class Factory : AbstractScannerFactory<Askalono>("Askalono") {
-        override fun create(scannerConfig: ScannerConfiguration) = Askalono(scannerName, scannerConfig)
+        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
+            Askalono(scannerName, scannerConfig, downloaderConfig)
     }
 
     override val expectedVersion = "0.4.3"

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -47,9 +47,9 @@ import org.ossreviewtoolkit.utils.ProcessCapture
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.unpackZip
 
-class Askalono(name: String, config: ScannerConfiguration) : LocalScanner(name, config) {
+class Askalono(name: String, scannerConfig: ScannerConfiguration) : LocalScanner(name, scannerConfig) {
     class Factory : AbstractScannerFactory<Askalono>("Askalono") {
-        override fun create(config: ScannerConfiguration) = Askalono(scannerName, config)
+        override fun create(scannerConfig: ScannerConfiguration) = Askalono(scannerName, scannerConfig)
     }
 
     override val expectedVersion = "0.4.3"

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -34,6 +34,7 @@ import org.ossreviewtoolkit.model.EMPTY_JSON_NODE
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.scanner.AbstractScannerFactory
@@ -47,9 +48,14 @@ import org.ossreviewtoolkit.utils.ProcessCapture
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.unpackZip
 
-class BoyterLc(name: String, scannerConfig: ScannerConfiguration) : LocalScanner(name, scannerConfig) {
+class BoyterLc(
+    name: String,
+    scannerConfig: ScannerConfiguration,
+    downloaderConfig: DownloaderConfiguration
+) : LocalScanner(name, scannerConfig, downloaderConfig) {
     class Factory : AbstractScannerFactory<BoyterLc>("BoyterLc") {
-        override fun create(scannerConfig: ScannerConfiguration) = BoyterLc(scannerName, scannerConfig)
+        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
+            BoyterLc(scannerName, scannerConfig, downloaderConfig)
     }
 
     companion object {

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -47,9 +47,9 @@ import org.ossreviewtoolkit.utils.ProcessCapture
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.unpackZip
 
-class BoyterLc(name: String, config: ScannerConfiguration) : LocalScanner(name, config) {
+class BoyterLc(name: String, scannerConfig: ScannerConfiguration) : LocalScanner(name, scannerConfig) {
     class Factory : AbstractScannerFactory<BoyterLc>("BoyterLc") {
-        override fun create(config: ScannerConfiguration) = BoyterLc(scannerName, config)
+        override fun create(scannerConfig: ScannerConfiguration) = BoyterLc(scannerName, scannerConfig)
     }
 
     companion object {

--- a/scanner/src/main/kotlin/scanners/FileCounter.kt
+++ b/scanner/src/main/kotlin/scanners/FileCounter.kt
@@ -26,6 +26,7 @@ import java.time.Instant
 
 import org.ossreviewtoolkit.model.EMPTY_JSON_NODE
 import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.scanner.AbstractScannerFactory
@@ -37,9 +38,14 @@ import org.ossreviewtoolkit.spdx.calculatePackageVerificationCode
  * scanners it is useful for testing the scanner tool, for example during development or when integrating it with other
  * tools.
  */
-class FileCounter(name: String, scannerConfig: ScannerConfiguration) : LocalScanner(name, scannerConfig) {
+class FileCounter(
+    name: String,
+    scannerConfig: ScannerConfiguration,
+    downloaderConfig: DownloaderConfiguration
+) : LocalScanner(name, scannerConfig, downloaderConfig) {
     class Factory : AbstractScannerFactory<FileCounter>("FileCounter") {
-        override fun create(scannerConfig: ScannerConfiguration) = FileCounter(scannerName, scannerConfig)
+        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
+            FileCounter(scannerName, scannerConfig, downloaderConfig)
     }
 
     data class FileCountResult(val fileCount: Int)

--- a/scanner/src/main/kotlin/scanners/FileCounter.kt
+++ b/scanner/src/main/kotlin/scanners/FileCounter.kt
@@ -37,9 +37,9 @@ import org.ossreviewtoolkit.spdx.calculatePackageVerificationCode
  * scanners it is useful for testing the scanner tool, for example during development or when integrating it with other
  * tools.
  */
-class FileCounter(name: String, config: ScannerConfiguration) : LocalScanner(name, config) {
+class FileCounter(name: String, scannerConfig: ScannerConfiguration) : LocalScanner(name, scannerConfig) {
     class Factory : AbstractScannerFactory<FileCounter>("FileCounter") {
-        override fun create(config: ScannerConfiguration) = FileCounter(scannerName, config)
+        override fun create(scannerConfig: ScannerConfiguration) = FileCounter(scannerName, scannerConfig)
     }
 
     data class FileCountResult(val fileCount: Int)

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -28,6 +28,7 @@ import org.ossreviewtoolkit.model.EMPTY_JSON_NODE
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.scanner.AbstractScannerFactory
@@ -38,9 +39,14 @@ import org.ossreviewtoolkit.utils.Os
 import org.ossreviewtoolkit.utils.ProcessCapture
 import org.ossreviewtoolkit.utils.log
 
-class Licensee(name: String, scannerConfig: ScannerConfiguration) : LocalScanner(name, scannerConfig) {
+class Licensee(
+    name: String,
+    scannerConfig: ScannerConfiguration,
+    downloaderConfig: DownloaderConfiguration
+) : LocalScanner(name, scannerConfig, downloaderConfig) {
     class Factory : AbstractScannerFactory<Licensee>("Licensee") {
-        override fun create(scannerConfig: ScannerConfiguration) = Licensee(scannerName, scannerConfig)
+        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
+            Licensee(scannerName, scannerConfig, downloaderConfig)
     }
 
     companion object {

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -38,9 +38,9 @@ import org.ossreviewtoolkit.utils.Os
 import org.ossreviewtoolkit.utils.ProcessCapture
 import org.ossreviewtoolkit.utils.log
 
-class Licensee(name: String, config: ScannerConfiguration) : LocalScanner(name, config) {
+class Licensee(name: String, scannerConfig: ScannerConfiguration) : LocalScanner(name, scannerConfig) {
     class Factory : AbstractScannerFactory<Licensee>("Licensee") {
-        override fun create(config: ScannerConfiguration) = Licensee(scannerName, config)
+        override fun create(scannerConfig: ScannerConfiguration) = Licensee(scannerName, scannerConfig)
     }
 
     companion object {

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -50,6 +50,7 @@ import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.AbstractScannerFactory
 import org.ossreviewtoolkit.scanner.RemoteScanner
@@ -69,9 +70,14 @@ import retrofit2.converter.jackson.JacksonConverterFactory
  * * **"user":** The user to connect to the FossID server.
  * * **"apiKey":** The API key of the user which connects to the FossID server.
  */
-class FossId(name: String, scannerConfig: ScannerConfiguration) : RemoteScanner(name, scannerConfig) {
+class FossId(
+    name: String,
+    scannerConfig: ScannerConfiguration,
+    downloaderConfig: DownloaderConfiguration
+) : RemoteScanner(name, scannerConfig, downloaderConfig) {
     class Factory : AbstractScannerFactory<FossId>("FossId") {
-        override fun create(scannerConfig: ScannerConfiguration) = FossId(scannerName, scannerConfig)
+        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
+            FossId(scannerName, scannerConfig, downloaderConfig)
     }
 
     companion object {

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -69,9 +69,9 @@ import retrofit2.converter.jackson.JacksonConverterFactory
  * * **"user":** The user to connect to the FossID server.
  * * **"apiKey":** The API key of the user which connects to the FossID server.
  */
-class FossId(name: String, config: ScannerConfiguration) : RemoteScanner(name, config) {
+class FossId(name: String, scannerConfig: ScannerConfiguration) : RemoteScanner(name, scannerConfig) {
     class Factory : AbstractScannerFactory<FossId>("FossId") {
-        override fun create(config: ScannerConfiguration) = FossId(scannerName, config)
+        override fun create(scannerConfig: ScannerConfiguration) = FossId(scannerName, scannerConfig)
     }
 
     companion object {
@@ -118,7 +118,7 @@ class FossId(name: String, config: ScannerConfiguration) : RemoteScanner(name, c
     override val configuration = ""
 
     init {
-        val fossIdScannerOptions = config.options?.get("FossId")
+        val fossIdScannerOptions = scannerConfig.options?.get("FossId")
 
         requireNotNull(fossIdScannerOptions) { "No FossId Scanner configuration found." }
 

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -61,10 +61,10 @@ import org.ossreviewtoolkit.utils.unpack
  */
 class ScanCode(
     name: String,
-    config: ScannerConfiguration
-) : LocalScanner(name, config) {
+    scannerConfig: ScannerConfiguration
+) : LocalScanner(name, scannerConfig) {
     class Factory : AbstractScannerFactory<ScanCode>(SCANNER_NAME) {
-        override fun create(config: ScannerConfiguration) = ScanCode(scannerName, config)
+        override fun create(scannerConfig: ScannerConfiguration) = ScanCode(scannerName, scannerConfig)
     }
 
     companion object {
@@ -110,7 +110,7 @@ class ScanCode(
 
     override val resultFileExt = "json"
 
-    private val scanCodeConfiguration = config.options?.get("ScanCode").orEmpty()
+    private val scanCodeConfiguration = scannerConfig.options?.get("ScanCode").orEmpty()
 
     private val configurationOptions = scanCodeConfiguration["commandLine"]?.split(' ')
         ?: DEFAULT_CONFIGURATION_OPTIONS

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -35,6 +35,7 @@ import okio.sink
 
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.AbstractScannerFactory
 import org.ossreviewtoolkit.scanner.LocalScanner
@@ -61,10 +62,12 @@ import org.ossreviewtoolkit.utils.unpack
  */
 class ScanCode(
     name: String,
-    scannerConfig: ScannerConfiguration
-) : LocalScanner(name, scannerConfig) {
+    scannerConfig: ScannerConfiguration,
+    downloaderConfig: DownloaderConfiguration
+) : LocalScanner(name, scannerConfig, downloaderConfig) {
     class Factory : AbstractScannerFactory<ScanCode>(SCANNER_NAME) {
-        override fun create(scannerConfig: ScannerConfiguration) = ScanCode(scannerName, scannerConfig)
+        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
+            ScanCode(scannerName, scannerConfig, downloaderConfig)
     }
 
     companion object {

--- a/scanner/src/test/kotlin/LocalScannerTest.kt
+++ b/scanner/src/test/kotlin/LocalScannerTest.kt
@@ -93,8 +93,8 @@ private fun createConfig(properties: Map<String, String>): ScannerConfiguration 
 /**
  * Create a test instance of [LocalScanner].
  */
-private fun createScanner(config: ScannerConfiguration): LocalScanner =
-    object : LocalScanner(SCANNER_NAME, config) {
+private fun createScanner(scannerConfig: ScannerConfiguration): LocalScanner =
+    object : LocalScanner(SCANNER_NAME, scannerConfig) {
         override val configuration = "someConfig"
 
         override val resultFileExt: String

--- a/scanner/src/test/kotlin/LocalScannerTest.kt
+++ b/scanner/src/test/kotlin/LocalScannerTest.kt
@@ -26,12 +26,13 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 
 class LocalScannerTest : WordSpec({
     "getScannerCriteria()" should {
         "obtain default values from the scanner" {
-            val scanner = createScanner(createConfig(emptyMap()))
+            val scanner = createScanner(createScannerConfig(emptyMap()), DownloaderConfiguration())
 
             val criteria = scanner.getScannerCriteria()
 
@@ -46,7 +47,7 @@ class LocalScannerTest : WordSpec({
                 LocalScanner.PROP_CRITERIA_MIN_VERSION to "1.2.3",
                 LocalScanner.PROP_CRITERIA_MAX_VERSION to "4.5.6"
             )
-            val scanner = createScanner(createConfig(config))
+            val scanner = createScanner(createScannerConfig(config), DownloaderConfiguration())
 
             val criteria = scanner.getScannerCriteria()
 
@@ -60,7 +61,7 @@ class LocalScannerTest : WordSpec({
                 LocalScanner.PROP_CRITERIA_MIN_VERSION to "1",
                 LocalScanner.PROP_CRITERIA_MAX_VERSION to "3.7"
             )
-            val scanner = createScanner(createConfig(config))
+            val scanner = createScanner(createScannerConfig(config), DownloaderConfiguration())
 
             val criteria = scanner.getScannerCriteria()
 
@@ -69,7 +70,7 @@ class LocalScannerTest : WordSpec({
         }
 
         "use an exact configuration matcher" {
-            val scanner = createScanner(createConfig(emptyMap()))
+            val scanner = createScanner(createScannerConfig(emptyMap()), DownloaderConfiguration())
 
             val criteria = scanner.getScannerCriteria()
 
@@ -85,7 +86,7 @@ private const val SCANNER_VERSION = "3.2.1.final"
 /**
  * Creates a [ScannerConfiguration] with the given properties for the test scanner.
  */
-private fun createConfig(properties: Map<String, String>): ScannerConfiguration {
+private fun createScannerConfig(properties: Map<String, String>): ScannerConfiguration {
     val options = mapOf(SCANNER_NAME to properties)
     return ScannerConfiguration(options = options)
 }
@@ -93,8 +94,11 @@ private fun createConfig(properties: Map<String, String>): ScannerConfiguration 
 /**
  * Create a test instance of [LocalScanner].
  */
-private fun createScanner(scannerConfig: ScannerConfiguration): LocalScanner =
-    object : LocalScanner(SCANNER_NAME, scannerConfig) {
+private fun createScanner(
+    scannerConfig: ScannerConfiguration,
+    downloaderConfig: DownloaderConfiguration
+): LocalScanner =
+    object : LocalScanner(SCANNER_NAME, scannerConfig, downloaderConfig) {
         override val configuration = "someConfig"
 
         override val resultFileExt: String

--- a/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
@@ -23,10 +23,11 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldMatch
 
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 
 class ScanCodeTest : WordSpec({
-    val scanner = ScanCode("ScanCode", ScannerConfiguration())
+    val scanner = ScanCode("ScanCode", ScannerConfiguration(), DownloaderConfiguration())
 
     "configuration()" should {
         "return the default values if the scanner configuration is empty" {
@@ -42,7 +43,8 @@ class ScanCodeTest : WordSpec({
                             "commandLineNonConfig" to "--commandLineNonConfig"
                         )
                     )
-                )
+                ),
+                DownloaderConfiguration()
             )
 
             scannerWithConfig.configuration shouldBe "--command --line --json-pp"
@@ -64,7 +66,8 @@ class ScanCodeTest : WordSpec({
                             "commandLineNonConfig" to "--commandLineNonConfig"
                         )
                     )
-                )
+                ),
+                DownloaderConfiguration()
             )
 
             scannerWithConfig.commandLineOptions.joinToString(" ") shouldBe


### PR DESCRIPTION
Add new downloader parameter `--source-code-origin` to set the preferred download location:
Either `vcs` or `artifact`.

Defaults to the current standard `vcs`.

See: https://github.com/oss-review-toolkit/ort/issues/2848
