### PR TITLE
Enable adding custom certificates to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,8 +117,15 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
 
 COPY --from=build /usr/local/src/ort/scripts/*.sh /opt/ort/bin/
 
+# This can be set to a directory containing CRT-files for custom certificates that ORT and all build tools should know about.
+ARG CRT_FILES=""
+COPY "$CRT_FILES" /tmp/certificates/
+
 # Custom install commands.
 RUN /opt/ort/bin/import_proxy_certs.sh && \
+    if [ -n "$CRT_FILES" ]; then \
+      /opt/ort/bin/import_certificates.sh /tmp/certificates/; \
+    fi && \
     # Install VCS tools (no specific versions required here).
     curl -ksS https://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo && \
     chmod a+x /usr/local/bin/repo && \

--- a/docs/hints-for-use-with-docker.md
+++ b/docs/hints-for-use-with-docker.md
@@ -14,6 +14,13 @@ docker run \
 
 **Note:** The single forward slash `/` between the environment variable `$PWD` and the `:` is required for PowerShell compatibility, as PowerShell otherwise interprets `:` as part of the environment variable. 
 
+### Setting custom certificates to Docker image keystore
+
+It is possible to install custom certificates when building the image so that they are installed into various keystores.
+To do this, specify `--build-arg CRT_FILES=<path>` when running `docker build`. 
+Note that this requires the directory or certificate file to be inside the Docker build context (usually the directory where the build is run, i.e. probably the directory the Dockerfile resides in). 
+Otherwise, the directories cannot be copied into the Docker image.
+
 ## Common Issues
 
 ### Docker build fails with an "SSL Handshake" error

--- a/scripts/import_certificates.sh
+++ b/scripts/import_certificates.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# Copyright (C) 2020-2021 Bosch.IO GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+FILE_PREFIX=$1
+
+if [ -z "$FILE_PREFIX" ]; then
+  echo "No certificates specified. Skipping installation."
+  exit 0
+fi
+
+echo "Import certificates $FILE_PREFIX:"
+
+KEYTOOL=$(realpath $(command -v keytool))
+
+for KEYSTORE_CANDIDATE in "$(realpath -m $(dirname $KEYTOOL)/../lib/security/cacerts)" "$(realpath -m $(dirname $KEYTOOL)/../jre/lib/security/cacerts)"; do
+    if [ -f "$KEYSTORE_CANDIDATE" ]; then
+        KEYSTORE=$KEYSTORE_CANDIDATE
+        break
+    fi
+done
+
+if [ -n "$KEYSTORE" ]; then
+    for CRT_FILE in $FILE_PREFIX*; do
+        echo "Adding the following certificate from '$CRT_FILE' to the JRE's certificate store at '$KEYSTORE':"
+        cat $CRT_FILE
+
+        ALIAS=$(basename $CRT_FILE .crt)
+        $KEYTOOL -importcert -noprompt -trustcacerts -alias $ALIAS -file $CRT_FILE -keystore $KEYSTORE -storepass changeit
+    done
+else
+    echo "No JVM keystore found, skipping the import."
+fi
+
+# Also add the certificates to the system certificates, e.g. for curl to work.
+echo "Adding certificates to the system certificates..."
+cp -r "$FILE_PREFIX" /usr/local/share/ca-certificates/
+update-ca-certificates


### PR DESCRIPTION
Enable adding custom certificates via `--build-arg` to a Docker build. The certificates will be added to the Java keystore as well as the system keystore like the proxy-certificates. This is necessary for certain company repositories which provide their own certificate authority and trip up the analyzer. 

Tested internally with repository having certificate problems.