### PR TITLE
Bundler: Add support for authors

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
@@ -2,6 +2,8 @@
 project:
   id: "Bundler::test-project:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/bundler/gemspec/Gemfile"
+  authors:
+  - "Bob Example"
   declared_licenses: []
   declared_licenses_processed: {}
   vcs:
@@ -49,6 +51,8 @@ project:
 packages:
 - id: "Gem::addressable:2.7.0"
   purl: "pkg:gem/addressable@2.7.0"
+  authors:
+  - "Bob Aman"
   declared_licenses:
   - "Apache-2.0"
   declared_licenses_processed:
@@ -79,6 +83,8 @@ packages:
     path: ""
 - id: "Gem::diff-lcs:1.3"
   purl: "pkg:gem/diff-lcs@1.3"
+  authors:
+  - "Austin Ziegler"
   declared_licenses:
   - "Artistic-2.0"
   - "GPL-2.0+"
@@ -117,6 +123,10 @@ packages:
     path: ""
 - id: "Gem::faraday:0.17.3"
   purl: "pkg:gem/faraday@0.17.3"
+  authors:
+  - "@iMacTia"
+  - "@olleolleolle"
+  - "@technoweenie"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -145,6 +155,8 @@ packages:
     path: ""
 - id: "Gem::jwt:2.2.1"
   purl: "pkg:gem/jwt@2.2.1"
+  authors:
+  - "Tim Rudat"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -174,6 +186,11 @@ packages:
     path: ""
 - id: "Gem::multi_json:1.14.1"
   purl: "pkg:gem/multi_json@1.14.1"
+  authors:
+  - "Erik Michaels-Ober"
+  - "Josh Kalderimis"
+  - "Michael Bleigh"
+  - "Pavel Pravosud"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -204,6 +221,9 @@ packages:
     path: ""
 - id: "Gem::multipart-post:2.1.1"
   purl: "pkg:gem/multipart-post@2.1.1"
+  authors:
+  - "Nick Sieger"
+  - "Samuel Williams"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -234,6 +254,8 @@ packages:
     path: ""
 - id: "Gem::public_suffix:4.0.5"
   purl: "pkg:gem/public_suffix@4.0.5"
+  authors:
+  - "Simone Carletti"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -263,6 +285,8 @@ packages:
     path: ""
 - id: "Gem::rack:2.2.3"
   purl: "pkg:gem/rack@2.2.3"
+  authors:
+  - "Leah Neukirchen"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -294,6 +318,11 @@ packages:
     path: ""
 - id: "Gem::rspec-core:3.7.1"
   purl: "pkg:gem/rspec-core@3.7.1"
+  authors:
+  - "Chad Humphries"
+  - "David Chelimsky"
+  - "Myron Marston"
+  - "Steven Baker"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -322,6 +351,10 @@ packages:
     path: ""
 - id: "Gem::rspec-expectations:3.7.0"
   purl: "pkg:gem/rspec-expectations@3.7.0"
+  authors:
+  - "David Chelimsky"
+  - "Myron Marston"
+  - "Steven Baker"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -351,6 +384,10 @@ packages:
     path: ""
 - id: "Gem::rspec-mocks:3.7.0"
   purl: "pkg:gem/rspec-mocks@3.7.0"
+  authors:
+  - "David Chelimsky"
+  - "Myron Marston"
+  - "Steven Baker"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -379,6 +416,13 @@ packages:
     path: ""
 - id: "Gem::rspec-support:3.7.1"
   purl: "pkg:gem/rspec-support@3.7.1"
+  authors:
+  - "Bradley Schaefer"
+  - "David Chelimsky"
+  - "Jon Rowe"
+  - "Myron Marson"
+  - "Sam Phippen"
+  - "Xaviery Shay"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -407,6 +451,10 @@ packages:
     path: ""
 - id: "Gem::rspec:3.7.0"
   purl: "pkg:gem/rspec@3.7.0"
+  authors:
+  - "David Chelimsky"
+  - "Myron Marston"
+  - "Steven Baker"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -435,6 +483,9 @@ packages:
     path: ""
 - id: "Gem::signet:0.8.1"
   purl: "pkg:gem/signet@0.8.1"
+  authors:
+  - "Bob Aman"
+  - "Steven Bazyl"
   declared_licenses:
   - "Apache-2.0"
   declared_licenses_processed:
@@ -463,6 +514,8 @@ packages:
     path: ""
 - id: "Gem::test-project:1.0.0"
   purl: "pkg:gem/test-project@1.0.0"
+  authors:
+  - "Bob Example"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
@@ -40,6 +40,8 @@ project:
 packages:
 - id: "Gem::diff-lcs:1.3"
   purl: "pkg:gem/diff-lcs@1.3"
+  authors:
+  - "Austin Ziegler"
   declared_licenses:
   - "Artistic-2.0"
   - "GPL-2.0+"
@@ -78,6 +80,10 @@ packages:
     path: ""
 - id: "Gem::mini_portile2:2.4.0"
   purl: "pkg:gem/mini_portile2@2.4.0"
+  authors:
+  - "Lars Kanis"
+  - "Luis Lavena"
+  - "Mike Dalessio"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -108,6 +114,14 @@ packages:
     path: ""
 - id: "Gem::nokogiri:1.10.8"
   purl: "pkg:gem/nokogiri@1.10.8"
+  authors:
+  - "Aaron Patterson"
+  - "Akinori MUSHA"
+  - "John Shahid"
+  - "Lars Kanis"
+  - "Mike Dalessio"
+  - "Tim Elliott"
+  - "Yoko Harada"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -137,6 +151,8 @@ packages:
     path: ""
 - id: "Gem::rack:2.1.4"
   purl: "pkg:gem/rack@2.1.4"
+  authors:
+  - "Leah Neukirchen"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -169,6 +185,11 @@ packages:
     path: ""
 - id: "Gem::rspec-core:3.7.1"
   purl: "pkg:gem/rspec-core@3.7.1"
+  authors:
+  - "Chad Humphries"
+  - "David Chelimsky"
+  - "Myron Marston"
+  - "Steven Baker"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -197,6 +218,10 @@ packages:
     path: ""
 - id: "Gem::rspec-expectations:3.7.0"
   purl: "pkg:gem/rspec-expectations@3.7.0"
+  authors:
+  - "David Chelimsky"
+  - "Myron Marston"
+  - "Steven Baker"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -226,6 +251,10 @@ packages:
     path: ""
 - id: "Gem::rspec-mocks:3.7.0"
   purl: "pkg:gem/rspec-mocks@3.7.0"
+  authors:
+  - "David Chelimsky"
+  - "Myron Marston"
+  - "Steven Baker"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -254,6 +283,13 @@ packages:
     path: ""
 - id: "Gem::rspec-support:3.7.1"
   purl: "pkg:gem/rspec-support@3.7.1"
+  authors:
+  - "Bradley Schaefer"
+  - "David Chelimsky"
+  - "Jon Rowe"
+  - "Myron Marson"
+  - "Sam Phippen"
+  - "Xaviery Shay"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -282,6 +318,10 @@ packages:
     path: ""
 - id: "Gem::rspec:3.7.0"
   purl: "pkg:gem/rspec@3.7.0"
+  authors:
+  - "David Chelimsky"
+  - "Myron Marston"
+  - "Steven Baker"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -101,7 +101,7 @@ class Bundler(
 
             installDependencies(workingDir)
 
-            val (projectName, version, homepageUrl, declaredLicenses) = parseProject(workingDir)
+            val (projectName, version, homepageUrl, authors, declaredLicenses) = parseProject(workingDir)
             val projectId = Identifier(managerName, "", projectName, version)
             val groupedDeps = getDependencyGroups(workingDir)
 
@@ -112,8 +112,7 @@ class Bundler(
             val project = Project(
                 id = projectId,
                 definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
-                // TODO: Find a way to track authors.
-                authors = sortedSetOf(),
+                authors = authors,
                 declaredLicenses = declaredLicenses.toSortedSet(),
                 vcs = VcsInfo.EMPTY,
                 vcsProcessed = processProjectVcs(workingDir, VcsInfo.EMPTY, homepageUrl),
@@ -164,8 +163,7 @@ class Bundler(
 
                 packages += Package(
                     id = gemId,
-                    // TODO: Find a way to track authors.
-                    authors = sortedSetOf(),
+                    authors = gemSpec.authors,
                     declaredLicenses = gemSpec.declaredLicenses,
                     description = gemSpec.description,
                     homepageUrl = gemSpec.homepageUrl,
@@ -215,7 +213,17 @@ class Bundler(
         getGemspecFile(workingDir)?.let { gemspecFile ->
             // Project is a Gem, i.e. a library.
             getGemspec(gemspecFile.nameWithoutExtension, workingDir)
-        } ?: GemSpec(workingDir.name, "", "", sortedSetOf(), "", emptySet(), VcsInfo.EMPTY, RemoteArtifact.EMPTY)
+        } ?: GemSpec(
+            workingDir.name,
+            "",
+            "",
+            sortedSetOf(),
+            sortedSetOf(),
+            "",
+            emptySet(),
+            VcsInfo.EMPTY,
+            RemoteArtifact.EMPTY
+        )
 
     private fun getGemspec(gemName: String, workingDir: File): GemSpec {
         val spec = run(
@@ -291,6 +299,7 @@ data class GemSpec(
     val name: String,
     val version: String,
     val homepageUrl: String,
+    val authors: SortedSet<String>,
     val declaredLicenses: SortedSet<String>,
     val description: String,
     val runtimeDependencies: Set<String>,
@@ -310,6 +319,7 @@ data class GemSpec(
                 yaml["name"].textValue(),
                 yaml["version"]["version"].textValue(),
                 homepage,
+                yaml["authors"]?.asIterable()?.mapTo(sortedSetOf()) { it.textValue() } ?: sortedSetOf(),
                 yaml["licenses"]?.asIterable()?.mapTo(sortedSetOf()) { it.textValue() } ?: sortedSetOf(),
                 yaml["description"].textValueOrEmpty(),
                 runtimeDependencies.orEmpty(),
@@ -342,6 +352,7 @@ data class GemSpec(
                 json["name"].textValue(),
                 json["version"].textValue(),
                 json["homepage_uri"].textValueOrEmpty(),
+                json["authors"]?.asIterable()?.mapTo(sortedSetOf()) { it.textValue() } ?: sortedSetOf(),
                 json["licenses"]?.asIterable()?.mapTo(sortedSetOf()) { it.textValue() } ?: sortedSetOf(),
                 json["description"].textValueOrEmpty(),
                 runtimeDependencies.orEmpty(),
@@ -358,6 +369,7 @@ data class GemSpec(
 
         return GemSpec(name, version,
             homepageUrl.takeUnless { it.isEmpty() } ?: other.homepageUrl,
+            authors.takeUnless { it.isEmpty() } ?: other.authors,
             declaredLicenses.takeUnless { it.isEmpty() } ?: other.declaredLicenses,
             description.takeUnless { it.isEmpty() } ?: other.description,
             runtimeDependencies.takeUnless { it.isEmpty() } ?: other.runtimeDependencies,


### PR DESCRIPTION
Extract information about the author of a package from its .gemspec
file and make it available in the metadata of packages and projects.

