### PR TITLE
SpdxModelMapper: Fix forFile() to be case-insensitive

### DIFF
--- a/spdx-utils/src/main/kotlin/SpdxModelMapper.kt
+++ b/spdx-utils/src/main/kotlin/SpdxModelMapper.kt
@@ -47,14 +47,21 @@ object SpdxModelMapper {
 
         companion object {
             /**
+             * Return the [FileFormat] for the given [extension], or `null` if there is none.
+             */
+            fun forExtension(extension: String): FileFormat =
+                extension.toLowerCase().let { lowerCaseExtension ->
+                    enumValues<FileFormat>().find {
+                        lowerCaseExtension in it.fileExtensions
+                    } ?: throw IllegalArgumentException(
+                        "Unknown file format for file extension '$extension'."
+                    )
+                }
+
+            /**
              * Return the [FileFormat] for the given [file], or `null` if there is none.
              */
-            fun forFile(file: File): FileFormat =
-                enumValues<FileFormat>().find {
-                    file.extension in it.fileExtensions
-                } ?: throw IllegalArgumentException(
-                    "Unsupported file format '${file.extension}' of file '${file.absolutePath}'."
-                )
+            fun forFile(file: File): FileFormat = forExtension(file.extension)
         }
 
         /**


### PR DESCRIPTION
This picks the change in b3db2cf for FileFormat.kt to this independent
module.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>