### PR TITLE
Show disclaimer in disclosure document if there are unresolved rule violations

### DIFF
--- a/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
@@ -32,6 +32,7 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
@@ -282,6 +283,15 @@ class FreemarkerTemplateProcessor(
             ortResult.collectIssues().values.flatten().any { issue ->
                 resolutionProvider.getIssueResolutionsFor(issue).isEmpty()
             }
+
+        /**
+         * Return `true` if there are any unresolved [RuleViolation]s, or `false` otherwise.
+         */
+        @Suppress("UNUSED") // This function is used in the templates.
+        fun hasUnresolvedRuleViolations() =
+            ortResult.evaluator?.violations?.any { violation ->
+                resolutionProvider.getRuleViolationResolutionsFor(violation).isEmpty()
+            } ?: false
     }
 }
 

--- a/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
@@ -30,6 +30,7 @@ import kotlin.reflect.full.memberProperties
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseSource
+import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.TextLocation
@@ -274,7 +275,7 @@ class FreemarkerTemplateProcessor(
                 .sortedBy { it.license.toString() }
 
         /**
-         * Return `true` if there are any unresolved issues, or `false` otherwise.
+         * Return `true` if there are any unresolved [OrtIssue]s, or `false` otherwise.
          */
         @Suppress("UNUSED") // This function is used in the templates.
         fun hasUnresolvedIssues() =

--- a/reporter/src/main/resources/templates/asciidoc/disclosure_document.ftl
+++ b/reporter/src/main/resources/templates/asciidoc/disclosure_document.ftl
@@ -31,14 +31,14 @@ Excluded projects and packages are ignored.
 :sectnums:
 :toc: preamble
 
-[#assign errorTitle = "DISCLAIMER! THERE ARE UNRESOLVED ISSUES.
-    THIS DOCUMENT SHOULD NOT BE DISTRIBUTED UNTIL THESE ISSUES ARE RESOLVED."?replace("\n", " ")]
+[#assign errorTitle = "DISCLAIMER! THERE ARE UNRESOLVED ISSUES OR UNRESOLVED RULE VIOLATIONS.
+    THIS DOCUMENT SHOULD NOT BE DISTRIBUTED UNTIL THESE PROBLEMS ARE RESOLVED."?replace("\n", " ")]
 
 [#--
 The alert role needs to be defined in the pdf-theme file, where the color can be customized.
 If not present, the text is displayed normally.
 --]
-= [#if helper.hasUnresolvedIssues()][.alert]#${errorTitle}#[#else] Disclosure Document[/#if]
+= [#if helper.hasUnresolvedIssues() || helper.hasUnresolvedRuleViolations()][.alert]#${errorTitle}#[#else] Disclosure Document[/#if]
 :author-name: OSS Review Toolkit
 [#assign now = .now]
 :revdate: ${now?date?iso_local}


### PR DESCRIPTION
This is a follow-up to #3677.
The disclaimer should be shown for unresolved violations as well.

