### PR TITLE
Revert "ScanCodeResultParser: Fix-up the construction of the SPDX exp…

### DIFF
--- a/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
@@ -173,7 +173,7 @@ private fun getLicenseFindings(result: JsonNode, parseExpressions: Boolean): Lis
             }
         ).map { (licenseExpression, replacements) ->
             val spdxLicenseExpression = replacements.fold(licenseExpression.expression) { expression, replacement ->
-                expression.replace("\\b${replacement.scanCodeLicenseKey}\\b".toRegex(), replacement.spdxExpression)
+                expression.replace(replacement.scanCodeLicenseKey, replacement.spdxExpression)
             }
 
             LicenseFinding(


### PR DESCRIPTION
…ressions"

The commit made the bug even worse, because it uses the word boundary in
the regular expression which matches also '-'.

This reverts commit e3d6511a4808df1093084d16efc5ab970435267b.
