### PR TITLE
SpdxExpression: Remove duplicated licenses from validChoices

### DIFF
--- a/spdx-utils/src/main/kotlin/SpdxExpression.kt
+++ b/spdx-utils/src/main/kotlin/SpdxExpression.kt
@@ -233,7 +233,7 @@ class SpdxCompoundExpression(
 
     override fun validChoicesForDnf(): Set<SpdxExpression> =
         when (operator) {
-            SpdxOperator.AND -> setOf(this)
+            SpdxOperator.AND -> setOf(decompose().reduce(SpdxExpression::and))
 
             SpdxOperator.OR -> {
                 val validChoicesLeft = when (left) {

--- a/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
@@ -321,6 +321,24 @@ class SpdxExpressionTest : WordSpec() {
                     "b AND c AND e".toSpdx()
                 )
             }
+
+            "not contain a duplicate valid choice for a simple expression" {
+                "a AND a".toSpdx().validChoices() should containExactlyInAnyOrder("a".toSpdx())
+            }
+
+            "not contain duplicate valid choice for a complex expression" {
+                "(a OR b) AND (a OR b)".toSpdx().validChoices() should containExactlyInAnyOrder(
+                    "a".toSpdx(),
+                    "b".toSpdx(),
+                    "a AND b".toSpdx()
+                )
+            }
+
+            "not contain duplicate valid choice different left and right expressions" {
+                "a AND a AND b".toSpdx().validChoices() should containExactlyInAnyOrder(
+                    "a AND b".toSpdx()
+                )
+            }
         }
 
         "offersChoice()" should {


### PR DESCRIPTION
Valid choices for `a AND a` are only `a` and not `a AND a`.