### PR TITLE
Bundler: Parse authors correctly from JSON

### DIFF
--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -348,11 +348,20 @@ data class GemSpec(
                 RemoteArtifact.EMPTY
             }
 
+            val authors = json["authors"]
+                .textValueOrEmpty()
+                .split(',')
+                .mapNotNullTo(sortedSetOf()) { author ->
+                    author.trim().takeIf {
+                        it.isNotEmpty()
+                    }
+                }
+
             return GemSpec(
                 json["name"].textValue(),
                 json["version"].textValue(),
                 json["homepage_uri"].textValueOrEmpty(),
-                json["authors"]?.asIterable()?.mapTo(sortedSetOf()) { it.textValue() } ?: sortedSetOf(),
+                authors,
                 json["licenses"]?.asIterable()?.mapTo(sortedSetOf()) { it.textValue() } ?: sortedSetOf(),
                 json["description"].textValueOrEmpty(),
                 runtimeDependencies.orEmpty(),

--- a/analyzer/src/test/assets/bundler/rspec-3.7.0.json
+++ b/analyzer/src/test/assets/bundler/rspec-3.7.0.json
@@ -1,0 +1,53 @@
+{
+  "name": "rspec",
+  "downloads": 528354083,
+  "version": "3.7.0",
+  "version_created_at": "2017-10-17T15:12:32.872Z",
+  "version_downloads": 132398752,
+  "platform": "ruby",
+  "authors": "Steven Baker, David Chelimsky, Myron Marston",
+  "info": "BDD for Ruby",
+  "licenses": [
+    "MIT"
+  ],
+  "metadata": {},
+  "yanked": false,
+  "sha": "0174cfbed780e42aa181227af623e2ae37511f20a2fdfec48b54f6cf4d7a6404",
+  "project_uri": "https://rubygems.org/gems/rspec",
+  "gem_uri": "https://rubygems.org/gems/rspec-3.7.0.gem",
+  "homepage_uri": "http://github.com/rspec",
+  "wiki_uri": "",
+  "documentation_uri": "http://relishapp.com/rspec",
+  "mailing_list_uri": "http://rubyforge.org/mailman/listinfo/rspec-users",
+  "source_code_uri": "http://github.com/rspec/rspec",
+  "bug_tracker_uri": "",
+  "changelog_uri": null,
+  "funding_uri": null,
+  "dependencies": {
+    "development": [],
+    "runtime": [
+      {
+        "name": "rspec-core",
+        "requirements": "~\u003e 3.7.0"
+      },
+      {
+        "name": "rspec-expectations",
+        "requirements": "~\u003e 3.7.0"
+      },
+      {
+        "name": "rspec-mocks",
+        "requirements": "~\u003e 3.7.0"
+      }
+    ]
+  },
+  "built_at": "2017-10-17T00:00:00.000Z",
+  "created_at": "2017-10-17T15:12:32.872Z",
+  "description": "BDD for Ruby",
+  "downloads_count": 132398752,
+  "number": "3.7.0",
+  "summary": "rspec-3.7.0",
+  "rubygems_version": "\u003e= 0",
+  "ruby_version": "\u003e= 0",
+  "prerelease": false,
+  "requirements": []
+}

--- a/analyzer/src/test/kotlin/managers/BundlerTest.kt
+++ b/analyzer/src/test/kotlin/managers/BundlerTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+import java.io.File
+
+import org.ossreviewtoolkit.model.Hash
+import org.ossreviewtoolkit.model.HashAlgorithm
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
+
+class BundlerTest : StringSpec({
+    "createFromJson() parses JSON metadata for a Gem correctly" {
+        val rspecGemJson = File("src/test/assets/bundler/rspec-3.7.0.json")
+
+        val gemspec = GemSpec.Factory.createFromJson(rspecGemJson.readText())
+
+        gemspec shouldBe GemSpec(
+            name = "rspec",
+            version = "3.7.0",
+            homepageUrl = "http://github.com/rspec",
+            authors = sortedSetOf("Steven Baker", "David Chelimsky", "Myron Marston"),
+            declaredLicenses = sortedSetOf("MIT"),
+            description = "BDD for Ruby",
+            runtimeDependencies = setOf("rspec-core", "rspec-expectations", "rspec-mocks"),
+            vcs = VcsInfo(VcsType.GIT, "http://github.com/rspec/rspec.git", ""),
+            artifact = RemoteArtifact(
+                "https://rubygems.org/gems/rspec-3.7.0.gem",
+                Hash("0174cfbed780e42aa181227af623e2ae37511f20a2fdfec48b54f6cf4d7a6404", HashAlgorithm.SHA256)
+            )
+        )
+    }
+})


### PR DESCRIPTION
After obtaining a metadata from gemspec via Bundler, additional metadata
is queried from 'https://rubygems.org' as a json. The authors in this
json are provided as a single String with comma separated authors. Thus,
split this String to correctly obtain each author.

See, for instance, the [rspec  gem](https://rubygems.org/api/v2/rubygems/rspec/versions/3.7.0.json).