### PR TITLE
Prepare advisor module for supporting multiple advisors in one run

### DIFF
--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -45,7 +45,7 @@ import org.ossreviewtoolkit.utils.showStackTrace
  */
 abstract class Advisor(val advisorName: String, protected val config: AdvisorConfiguration) {
     companion object {
-        private val LOADER = ServiceLoader.load(AdvisorFactory::class.java)!!
+        private val LOADER = ServiceLoader.load(VulnerabilityProviderFactory::class.java)!!
 
         /**
          * The list of all available advisors in the classpath.

--- a/advisor/src/main/kotlin/VulnerabilityProvider.kt
+++ b/advisor/src/main/kotlin/VulnerabilityProvider.kt
@@ -40,7 +40,7 @@ abstract class VulnerabilityProvider(val providerName: String) {
      * that associates each package with a list of [AdvisorResult]s. Needs to be implemented
      * by child classes.
      */
-    protected abstract suspend fun retrievePackageVulnerabilities(
+    abstract suspend fun retrievePackageVulnerabilities(
         packages: List<Package>
     ): Map<Package, List<AdvisorResult>>
 

--- a/advisor/src/main/kotlin/VulnerabilityProvider.kt
+++ b/advisor/src/main/kotlin/VulnerabilityProvider.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020-2021 Bosch.IO GmbH
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.advisor
+
+import java.time.Instant
+
+import org.ossreviewtoolkit.model.AdvisorDetails
+import org.ossreviewtoolkit.model.AdvisorResult
+import org.ossreviewtoolkit.model.AdvisorSummary
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.createAndLogIssue
+import org.ossreviewtoolkit.utils.collectMessagesAsString
+import org.ossreviewtoolkit.utils.showStackTrace
+
+/**
+ * An abstract class that represents a service that can retrieve vulnerability information
+ * for a list of given [Package]s.
+ */
+abstract class VulnerabilityProvider(val providerName: String) {
+    /**
+     * For a given list of [Package]s, retrieve vulnerability information and return a map
+     * that associates each package with a list of [AdvisorResult]s. Needs to be implemented
+     * by child classes.
+     */
+    protected abstract suspend fun retrievePackageVulnerabilities(
+        packages: List<Package>
+    ): Map<Package, List<AdvisorResult>>
+
+    /**
+     * A generic method that creates a failed [AdvisorResult] for [Package]s if there was an issue
+     * during the retrieval of vulnerability information.
+     */
+    protected fun createFailedResults(
+        startTime: Instant,
+        packages: List<Package>,
+        t: Throwable
+    ): Map<Package, List<AdvisorResult>> {
+        val endTime = Instant.now()
+
+        t.showStackTrace()
+
+        val failedResults = listOf(
+            AdvisorResult(
+                vulnerabilities = emptyList(),
+                advisor = AdvisorDetails(providerName),
+                summary = AdvisorSummary(
+                    startTime = startTime,
+                    endTime = endTime,
+                    issues = listOf(
+                        createAndLogIssue(
+                            source = providerName,
+                            message = "Failed to retrieve security vulnerabilities from $providerName: " +
+                                    t.collectMessagesAsString()
+                        )
+                    )
+                )
+            )
+        )
+
+        return packages.associateWith { failedResults }
+    }
+}

--- a/advisor/src/main/kotlin/VulnerabilityProviderFactory.kt
+++ b/advisor/src/main/kotlin/VulnerabilityProviderFactory.kt
@@ -31,32 +31,32 @@ import org.ossreviewtoolkit.utils.ortConfigDirectory
  */
 interface VulnerabilityProviderFactory {
     /**
-     * The name to use to refer to the advisor.
+     * The name to use to refer to the provider.
      */
-    val advisorName: String
+    val providerName: String
 
     /**
-     * Create an [Advisor] using the specified [config].
+     * Create a [VulnerabilityProvider] using the specified [config].
      */
-    fun create(config: AdvisorConfiguration): Advisor
+    fun create(config: AdvisorConfiguration): VulnerabilityProvider
 }
 
 /**
- * A generic factory class for an [Advisor].
+ * A generic factory class for a [VulnerabilityProvider].
  */
-abstract class AbstractVulnerabilityProviderFactory<out T : Advisor>(
-    override val advisorName: String
+abstract class AbstractVulnerabilityProviderFactory<out T : VulnerabilityProvider>(
+    override val providerName: String
 ) : VulnerabilityProviderFactory {
     abstract override fun create(config: AdvisorConfiguration): T
 
     protected fun <T> getProviderConfiguration(config: AdvisorConfiguration, select: (AdvisorConfiguration) -> T?): T =
         select(config) ?: throw IllegalArgumentException(
-            "No $advisorName advisor configuration found in ${ortConfigDirectory.resolve(ORT_CONFIG_FILENAME)}"
+            "No configuration for $providerName found in ${ortConfigDirectory.resolve(ORT_CONFIG_FILENAME)}"
         )
 
     /**
-     * Return the advisor's name here to allow Clikt to display something meaningful when listing the scanners
+     * Return the provider's name here to allow Clikt to display something meaningful when listing the scanners
      * which are enabled by default via their factories.
      */
-    override fun toString() = advisorName
+    override fun toString() = providerName
 }

--- a/advisor/src/main/kotlin/VulnerabilityProviderFactory.kt
+++ b/advisor/src/main/kotlin/VulnerabilityProviderFactory.kt
@@ -22,11 +22,14 @@ package org.ossreviewtoolkit.advisor
 import java.util.ServiceLoader
 
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
+import org.ossreviewtoolkit.utils.ORT_CONFIG_FILENAME
+import org.ossreviewtoolkit.utils.ortConfigDirectory
 
 /**
- * A common interface for use with [ServiceLoader] that all [AbstractAdvisorFactory] classes need to implement.
+ * A common interface for use with [ServiceLoader] that all [AbstractVulnerabilityProviderFactory]
+ * classes need to implement.
  */
-interface AdvisorFactory {
+interface VulnerabilityProviderFactory {
     /**
      * The name to use to refer to the advisor.
      */
@@ -41,10 +44,15 @@ interface AdvisorFactory {
 /**
  * A generic factory class for an [Advisor].
  */
-abstract class AbstractAdvisorFactory<out T : Advisor>(
+abstract class AbstractVulnerabilityProviderFactory<out T : Advisor>(
     override val advisorName: String
-) : AdvisorFactory {
+) : VulnerabilityProviderFactory {
     abstract override fun create(config: AdvisorConfiguration): T
+
+    protected fun <T> getProviderConfiguration(config: AdvisorConfiguration, select: (AdvisorConfiguration) -> T?): T =
+        select(config) ?: throw IllegalArgumentException(
+            "No $advisorName advisor configuration found in ${ortConfigDirectory.resolve(ORT_CONFIG_FILENAME)}"
+        )
 
     /**
      * Return the advisor's name here to allow Clikt to display something meaningful when listing the scanners

--- a/advisor/src/main/kotlin/advisors/NexusIq.kt
+++ b/advisor/src/main/kotlin/advisors/NexusIq.kt
@@ -23,7 +23,7 @@ import java.io.IOException
 import java.net.URI
 import java.time.Instant
 
-import org.ossreviewtoolkit.advisor.AbstractAdvisorFactory
+import org.ossreviewtoolkit.advisor.AbstractVulnerabilityProviderFactory
 import org.ossreviewtoolkit.advisor.Advisor
 import org.ossreviewtoolkit.clients.nexusiq.NexusIqService
 import org.ossreviewtoolkit.model.AdvisorDetails
@@ -54,7 +54,7 @@ class NexusIq(
     name: String,
     config: AdvisorConfiguration
 ) : Advisor(name, config) {
-    class Factory : AbstractAdvisorFactory<NexusIq>("NexusIQ") {
+    class Factory : AbstractVulnerabilityProviderFactory<NexusIq>("NexusIQ") {
         override fun create(config: AdvisorConfiguration) = NexusIq(advisorName, config)
     }
 

--- a/advisor/src/main/kotlin/advisors/VulnerableCode.kt
+++ b/advisor/src/main/kotlin/advisors/VulnerableCode.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 
-import org.ossreviewtoolkit.advisor.AbstractAdvisorFactory
+import org.ossreviewtoolkit.advisor.AbstractVulnerabilityProviderFactory
 import org.ossreviewtoolkit.advisor.Advisor
 import org.ossreviewtoolkit.clients.vulnerablecode.VulnerableCodeService
 import org.ossreviewtoolkit.model.AdvisorDetails
@@ -46,7 +46,7 @@ import org.ossreviewtoolkit.utils.ortConfigDirectory
  * [VulnerableCode][https://github.com/nexB/vulnerablecode] instance.
  */
 class VulnerableCode(name: String, config: AdvisorConfiguration) : Advisor(name, config) {
-    class Factory : AbstractAdvisorFactory<VulnerableCode>("VulnerableCode") {
+    class Factory : AbstractVulnerabilityProviderFactory<VulnerableCode>("VulnerableCode") {
         override fun create(config: AdvisorConfiguration) = VulnerableCode(advisorName, config)
     }
 

--- a/advisor/src/main/kotlin/advisors/VulnerableCode.kt
+++ b/advisor/src/main/kotlin/advisors/VulnerableCode.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 
 import org.ossreviewtoolkit.advisor.AbstractVulnerabilityProviderFactory
-import org.ossreviewtoolkit.advisor.Advisor
+import org.ossreviewtoolkit.advisor.VulnerabilityProvider
 import org.ossreviewtoolkit.clients.vulnerablecode.VulnerableCodeService
 import org.ossreviewtoolkit.model.AdvisorDetails
 import org.ossreviewtoolkit.model.AdvisorResult
@@ -36,18 +36,21 @@ import org.ossreviewtoolkit.model.AdvisorSummary
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Vulnerability
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
+import org.ossreviewtoolkit.model.config.VulnerableCodeConfiguration
 import org.ossreviewtoolkit.model.utils.toPurl
-import org.ossreviewtoolkit.utils.ORT_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.OkHttpClientHelper
-import org.ossreviewtoolkit.utils.ortConfigDirectory
 
 /**
- * An [Advisor] implementation that obtains security vulnerability information from a
+ * A [VulnerabilityProvider] implementation that obtains security vulnerability information from a
  * [VulnerableCode][https://github.com/nexB/vulnerablecode] instance.
  */
-class VulnerableCode(name: String, config: AdvisorConfiguration) : Advisor(name, config) {
+class VulnerableCode(
+    name: String,
+    private val vulnerableCodeConfiguration: VulnerableCodeConfiguration
+) : VulnerabilityProvider(name) {
     class Factory : AbstractVulnerabilityProviderFactory<VulnerableCode>("VulnerableCode") {
-        override fun create(config: AdvisorConfiguration) = VulnerableCode(advisorName, config)
+        override fun create(config: AdvisorConfiguration) =
+            VulnerableCode(providerName, getProviderConfiguration(config) { it.vulnerableCode })
     }
 
     companion object {
@@ -73,10 +76,6 @@ class VulnerableCode(name: String, config: AdvisorConfiguration) : Advisor(name,
     }
 
     private val service by lazy {
-        val vulnerableCodeConfiguration = config.vulnerableCode
-            ?: throw IllegalArgumentException(
-                "No $advisorName advisor configuration found in ${ortConfigDirectory.resolve(ORT_CONFIG_FILENAME)}"
-            )
         VulnerableCodeService.create(vulnerableCodeConfiguration.serverUrl, OkHttpClientHelper.buildClient())
     }
 
@@ -103,7 +102,7 @@ class VulnerableCode(name: String, config: AdvisorConfiguration) : Advisor(name,
                     pkg to listOf(
                         AdvisorResult(
                             vulnerabilities,
-                            AdvisorDetails(advisorName),
+                            AdvisorDetails(providerName),
                             AdvisorSummary(startTime, endTime)
                         )
                     )

--- a/cli/src/main/kotlin/commands/AdvisorCommand.kt
+++ b/cli/src/main/kotlin/commands/AdvisorCommand.kt
@@ -43,6 +43,9 @@ import org.ossreviewtoolkit.utils.expandTilde
 import org.ossreviewtoolkit.utils.safeMkdirs
 
 class AdvisorCommand : CliktCommand(name = "advise", help = "Check dependencies for security vulnerabilities.") {
+    private val allAdvisorsByName = Advisor.ALL.associateBy { it.advisorName }
+        .toSortedMap(String.CASE_INSENSITIVE_ORDER)
+
     private val input by option(
         "--ort-file", "-i",
         help = "An ORT result file with an analyzer result to use."
@@ -76,10 +79,10 @@ class AdvisorCommand : CliktCommand(name = "advise", help = "Check dependencies 
 
     private val advisorFactory by option(
         "--advisor", "-a",
-        help = "The advisor to use, one of ${Advisor.ALL}"
+        help = "The advisor to use, one of ${allAdvisorsByName.keys}"
     ).convert { advisorName ->
-        Advisor.ALL.find { it.advisorName.equals(advisorName, ignoreCase = true) }
-            ?: throw BadParameterValue("Advisor '$advisorName' is not one of ${Advisor.ALL}")
+        allAdvisorsByName[advisorName]
+            ?: throw BadParameterValue("Advisor '$advisorName' is not one of ${allAdvisorsByName.keys}")
     }.required()
 
     private val skipExcluded by option(


### PR DESCRIPTION
I think it is a good idea to split #3638 into multiple PRs.

This PR is a preparation of allowing multiple advisors during a single run.
I am following the idea of the analyzer: The `Analyzer` class has a single instance and is 
to call all the demanded `PackageManager`s. 

For the advisor, the `Advisor` class should also be a single instance that calls several providers of vulnerabilities.
Thus, a new class is created called `VulnerabilityProvider`, from which `NexusIq` and `VulnerablerCode` inherit.

The PR implements the basics of such a structure, but does not change the logic of calling only one `VulnerabilityProvider` so this should not be a breaking change. In a following PR, this should then be extended to multiple providers.
