### PR TITLE
Disclosure document: Do not drop license files in the appendix

### DIFF
--- a/reporter/src/main/resources/templates/asciidoc/disclosure_document.ftl
+++ b/reporter/src/main/resources/templates/asciidoc/disclosure_document.ftl
@@ -182,10 +182,9 @@ ${exceptionText}
 [#list copyrights as copyright]
 ${copyright}
 [/#list]
+[/#if]
 
 ${licenseFile.readFile()}
-
-[/#if]
 ++++
 <<<
 [/#list]


### PR DESCRIPTION
Due to wrong nesting of template tags, the content of license files
is only displayed if copyright statements are defined as well. Fix
the tag order, so that license files are always displayed (unless
they are explicitly excluded).