### PR TITLE
Gradle: Upgrade dokka to version 1.4.30

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 # License-Filename: LICENSE
 
 detektPluginVersion = 1.16.0
-dokkaPluginVersion = 1.4.20
+dokkaPluginVersion = 1.4.30
 kotlinPluginVersion = 1.4.31
 svntoolsPluginVersion = 3.1
 taskinfoPluginVersion = 1.0.5


### PR DESCRIPTION
This partly fixes a nasty memory leak issue, see

https://github.com/Kotlin/dokka/issues/1405#issuecomment-799666125

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>