### PR TITLE
Disclosure document: Drop empty sections for NOASSERTION licenses in the appendix

### DIFF
--- a/reporter/build.gradle.kts
+++ b/reporter/build.gradle.kts
@@ -30,6 +30,7 @@ val hamcrestCoreVersion: String by project
 val jacksonVersion: String by project
 val kotlinxCoroutinesVersion: String by project
 val kotlinxHtmlVersion: String by project
+val mockkVersion: String by project
 val retrofitVersion: String by project
 val simpleExcelVersion: String by project
 val xalanVersion: String by project
@@ -92,4 +93,6 @@ dependencies {
     // This is required to not depend on the version of Apache Xalan bundled with the JDK. Otherwise the formatting of
     // the HTML generated in StaticHtmlReporter is slightly different with different Java versions.
     implementation("xalan:xalan:$xalanVersion")
+
+    testImplementation("io.mockk:mockk:$mockkVersion")
 }

--- a/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
@@ -253,7 +253,6 @@ class FreemarkerTemplateProcessor(
          * excluded packages, licenses, and copyrights by default. The returned list is sorted by license identifier.
          */
         @JvmOverloads
-        @Suppress("UNUSED") // This function is used in the templates.
         fun mergeLicenses(
             models: Collection<PackageModel>,
             licenseView: LicenseView = LicenseView.ALL,
@@ -270,7 +269,7 @@ class FreemarkerTemplateProcessor(
          * Return a list of [ResolvedLicense]s where all duplicate entries for a single license in [licenses] are
          * merged. The returned list is sorted by license identifier.
          */
-        fun mergeResolvedLicenses(licenses: List<ResolvedLicense>): List<ResolvedLicense> =
+        private fun mergeResolvedLicenses(licenses: List<ResolvedLicense>): List<ResolvedLicense> =
             licenses.groupBy { it.license }
                 .map { (_, licenses) -> licenses.merge() }
                 .sortedBy { it.license.toString() }

--- a/reporter/src/main/resources/templates/asciidoc/disclosure_document.ftl
+++ b/reporter/src/main/resources/templates/asciidoc/disclosure_document.ftl
@@ -123,7 +123,12 @@ The following licenses and copyrights were found in the source code of this pack
 
 [#list resolvedLicenses as resolvedLicense]
 
+[#-- In case of a NOASSERTION license, there is no license text; so do not add a link. --]
+[#if helper.isLicensePresent(resolvedLicense)]
 * License: <<${resolvedLicense.license}, ${resolvedLicense.license}>>
+[#else]
+* License: ${resolvedLicense.license}
+[/#if]
 
 [#assign copyrights = resolvedLicense.getCopyrights(true)]
 [#list copyrights as copyright]
@@ -142,7 +147,7 @@ Append the text of all licenses that have been listed in the above lists for lic
 [appendix]
 == License Texts
 
-[#assign mergedLicenses = helper.mergeLicenses(projects + packages, helper.licenseView("CONCLUDED_OR_DECLARED_AND_DETECTED"))]
+[#assign mergedLicenses = helper.mergeLicenses(projects + packages, helper.licenseView("CONCLUDED_OR_DECLARED_AND_DETECTED"), true)]
 [#list mergedLicenses as resolvedLicense]
 === ${resolvedLicense.license}
 

--- a/reporter/src/test/kotlin/utils/FreeMarkerTemplateProcessorTest.kt
+++ b/reporter/src/test/kotlin/utils/FreeMarkerTemplateProcessorTest.kt
@@ -296,5 +296,36 @@ class FreeMarkerTemplateProcessorTest : WordSpec({
             result should haveSize(1)
             result.first().license.toString() shouldBe "MIT"
         }
+
+        "filter NO_ASSERTION licenses" {
+            val projects = testProjects()
+            val resolver = mockk<LicenseInfoResolver>()
+
+            expectResolveLicenseInfo(
+                resolver,
+                projects[0].id,
+                "MIT",
+                mapOf(LicenseSource.DECLARED to setOf("MIT".toSpdx()))
+            )
+            expectResolveLicenseInfo(
+                resolver,
+                projects[1].id,
+                SpdxConstants.NOASSERTION,
+                mapOf(LicenseSource.DECLARED to setOf(SpdxConstants.NOASSERTION.toSpdx()))
+            )
+
+            val input = ReporterInput(ORT_RESULT, licenseInfoResolver = resolver)
+            val pkg1 = FreemarkerTemplateProcessor.PackageModel(projects[0].id, input)
+            val pkg2 = FreemarkerTemplateProcessor.PackageModel(projects[1].id, input)
+
+            val result = FreemarkerTemplateProcessor.TemplateHelper(
+                OrtResult.EMPTY,
+                LicenseClassifications(),
+                DefaultResolutionProvider()
+            ).mergeLicenses(listOf(pkg1, pkg2), omitNotPresent = true)
+
+            result should haveSize(1)
+            result.first().license.toString() shouldBe "MIT"
+        }
     }
 })


### PR DESCRIPTION
Refer to the single commit messages for further details.
