### PR TITLE
Gradle: Remove the work-around to look for JGit directly on Eclipse servers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,19 +49,6 @@ plugins {
 }
 
 buildscript {
-    // TODO: Remove this again once this JGit release is properly mirrored to Maven Central.
-    repositories {
-        exclusiveContent {
-            forRepository {
-                maven("https://repo.eclipse.org/content/repositories/jgit-releases/")
-            }
-
-            filter {
-                includeGroup("org.eclipse.jgit")
-            }
-        }
-    }
-
     dependencies {
         // For some reason "jgitVersion" needs to be declared here instead of globally.
         val jgitVersion: String by project

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -89,17 +89,6 @@ repositories {
         }
     }
 
-    // TODO: Remove this again once this JGit release is properly mirrored to Maven Central.
-    exclusiveContent {
-        forRepository {
-            maven("https://repo.eclipse.org/content/repositories/jgit-releases/")
-        }
-
-        filter {
-            includeGroup("org.eclipse.jgit")
-        }
-    }
-
     exclusiveContent {
         forRepository {
             maven("https://repo.eclipse.org/content/repositories/sw360-releases/")

--- a/downloader/build.gradle.kts
+++ b/downloader/build.gradle.kts
@@ -27,19 +27,6 @@ plugins {
     `java-library`
 }
 
-// TODO: Remove this again once this JGit release is properly mirrored to Maven Central.
-repositories {
-    exclusiveContent {
-        forRepository {
-            maven("https://repo.eclipse.org/content/repositories/jgit-releases/")
-        }
-
-        filter {
-            includeGroup("org.eclipse.jgit")
-        }
-    }
-}
-
 dependencies {
     api(project(":model"))
 

--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -53,17 +53,6 @@ repositories {
         }
     }
 
-    // TODO: Remove this again once this JGit release is properly mirrored to Maven Central.
-    exclusiveContent {
-        forRepository {
-            maven("https://repo.eclipse.org/content/repositories/jgit-releases/")
-        }
-
-        filter {
-            includeGroup("org.eclipse.jgit")
-        }
-    }
-
     exclusiveContent {
         forRepository {
             maven("https://repo.eclipse.org/content/repositories/sw360-releases/")


### PR DESCRIPTION
The 5.11 release of JGit is available on Maven Central now.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>