### PR TITLE
github: Also trigger static analysis on pushes

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,6 +1,12 @@
 name: Static Analysis
 
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
 
 jobs:
   detekt:


### PR DESCRIPTION
This is required to get a baseline e.g. for detekt issues to show up in
the GitHub web UI.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>