### PR TITLE
FreemarkerTemplateProcesser: Make mergeResolvedLicenses() public again

### DIFF
--- a/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
@@ -273,7 +273,8 @@ class FreemarkerTemplateProcessor(
          * Return a list of [ResolvedLicense]s where all duplicate entries for a single license in [licenses] are
          * merged. The returned list is sorted by license identifier.
          */
-        private fun mergeResolvedLicenses(licenses: List<ResolvedLicense>): List<ResolvedLicense> =
+        // This function is used in the templates and needs to be public.
+        fun mergeResolvedLicenses(licenses: List<ResolvedLicense>): List<ResolvedLicense> =
             licenses.groupBy { it.license }
                 .map { (_, licenses) -> licenses.merge() }
                 .sortedBy { it.license.toString() }


### PR DESCRIPTION
The comment stating that the function is used by templates has been
removed by [1]. Afterwards the function has been made private by [2].

Make the function public again to re-enable calling it from within the
Freemarker template.

[1] 097410208d78243eff1bfe44efc44d626e1aa2f0
[2] 2a19381147aacc5297af7b25e303d18934514131

Signed-off-by: Frank Viernau <frank.viernau@here.com>
