### PR TITLE
Omit the default separator in calls to joinToString()

### DIFF
--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -146,7 +146,7 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
 
         val distinctPackageManagers = packageManagers.distinct()
         println("The following package managers are activated:")
-        println("\t" + distinctPackageManagers.joinToString(", "))
+        println("\t" + distinctPackageManagers.joinToString())
 
         println("Analyzing project path:\n\t$inputDir")
 

--- a/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
+++ b/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
@@ -159,7 +159,7 @@ class CycloneDxReporter : Reporter {
                 val licenseNames = input.licenseInfoResolver.resolveLicenseInfo(project.id).filterExcluded()
                     .getLicenseNames(LicenseSource.DECLARED, LicenseSource.DETECTED)
 
-                bom.addExternalReference(ExternalReference.Type.LICENSE, licenseNames.joinToString(", "))
+                bom.addExternalReference(ExternalReference.Type.LICENSE, licenseNames.joinToString())
 
                 bom.addExternalReference(ExternalReference.Type.BUILD_SYSTEM, project.id.type)
 


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>