### PR TITLE
analyzer: Fix SPDX metadata to point to a source artifact

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
@@ -53,15 +53,15 @@ packages:
       value: ""
       algorithm: ""
   vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
+    type: "Git"
+    url: "<REPLACE_URL>"
+    revision: "<REPLACE_REVISION>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl"
   vcs_processed:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
+    type: "Git"
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl"
 - id: "SpdxDocumentFile::zlib:1.2.11"
   purl: "pkg:spdxdocumentfile/zlib@1.2.11"
   authors:

--- a/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
@@ -43,12 +43,12 @@ packages:
     \ of powerful features."
   homepage_url: "https://curl.haxx.se/"
   binary_artifact:
-    url: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
+    url: ""
     hash:
       value: ""
       algorithm: ""
   source_artifact:
-    url: ""
+    url: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
     hash:
       value: ""
       algorithm: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl/package.spdx.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl/package.spdx.yml
@@ -19,7 +19,7 @@ packages:
   copyrightText: "Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many
     contributors, see the THANKS file."
   downloadLocation: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
-  filesAnalyzed: false
+  filesAnalyzed: true
   homepage: "https://curl.haxx.se/"
   licenseConcluded: "NOASSERTION"
   licenseDeclared: "curl"

--- a/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
@@ -15,7 +15,7 @@ externalDocumentRefs:
 - externalDocumentId: "DocumentRef-curl-7.70.0"
   checksum:
     algorithm: "SHA1"
-    checksumValue: "d884ee4774abb0540a9eab31c422645ffcd43b19"
+    checksumValue: "231ea539171f0422016bb9271f8061c8297b069c"
   spdxDocument: "../package/libs/curl/package.spdx.yml"
 - externalDocumentId: "DocumentRef-zlib-1.2.11"
   checksum:

--- a/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
@@ -16,7 +16,7 @@ externalDocumentRefs:
   checksum:
     algorithm: "SHA1"
     checksumValue: "d884ee4774abb0540a9eab31c422645ffcd43b19"
-  spdxDocument: "https://raw.githubusercontent.com/oss-review-toolkit/ort/master/analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl/package.spdx.yml"
+  spdxDocument: "../package/libs/curl/package.spdx.yml"
 - externalDocumentId: "DocumentRef-zlib-1.2.11"
   checksum:
     algorithm: "SHA1"


### PR DESCRIPTION
The "curl-7.70.0.tar.gz" archive contains the source code, so it should
be treated as a source artifact instead of a binary artifact, which is
signalled by setting "filesAnalyzed" to "true".

Also see 15512d3.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>