### PR TITLE
FileArchiver: Allow configuring the PostgreSQL based storage

### DIFF
--- a/model/src/main/kotlin/config/FileArchiverConfiguration.kt
+++ b/model/src/main/kotlin/config/FileArchiverConfiguration.kt
@@ -21,6 +21,8 @@ package org.ossreviewtoolkit.model.config
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
+import com.sksamuel.hoplite.ConfigAlias
+
 import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.utils.storage.FileStorage
 import org.ossreviewtoolkit.utils.storage.LocalFileStorage
@@ -33,14 +35,15 @@ data class FileArchiverConfiguration(
     /**
      * Configuration of the [FileStorage] used for archiving the files.
      */
-    val storage: FileStorageConfiguration
+    @ConfigAlias("storage")
+    val fileStorage: FileStorageConfiguration
 )
 
 /**
  * Create a [FileArchiver] based on this configuration.
  */
 fun FileArchiverConfiguration?.createFileArchiver(): FileArchiver {
-    val storage = this?.storage?.createFileStorage() ?: LocalFileStorage(FileArchiver.DEFAULT_ARCHIVE_DIR)
+    val storage = this?.fileStorage?.createFileStorage() ?: LocalFileStorage(FileArchiver.DEFAULT_ARCHIVE_DIR)
     val patterns = LicenseFilenamePatterns.getInstance().allLicenseFilenames
 
     return FileArchiver(patterns, storage)

--- a/model/src/main/kotlin/config/FileArchiverConfiguration.kt
+++ b/model/src/main/kotlin/config/FileArchiverConfiguration.kt
@@ -23,7 +23,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 import com.sksamuel.hoplite.ConfigAlias
 
+import org.ossreviewtoolkit.model.utils.DatabaseUtils
 import org.ossreviewtoolkit.model.utils.FileArchiver
+import org.ossreviewtoolkit.model.utils.FileArchiverFileStorage
+import org.ossreviewtoolkit.model.utils.PostgresFileArchiverStorage
+import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.storage.FileStorage
 import org.ossreviewtoolkit.utils.storage.LocalFileStorage
 
@@ -36,14 +40,42 @@ data class FileArchiverConfiguration(
      * Configuration of the [FileStorage] used for archiving the files.
      */
     @ConfigAlias("storage")
-    val fileStorage: FileStorageConfiguration
-)
+    val fileStorage: FileStorageConfiguration? = null,
+
+    /**
+     * Configuration of the [PostgresFileArchiverStorage] used for archiving the files.
+     */
+    val postgresStorage: PostgresStorageConfiguration? = null
+) {
+    init {
+        if (fileStorage != null && postgresStorage != null) {
+            log.warn {
+                "'fileStorage' and 'postgresStorage' are both configured but only one storage can be used. Using " +
+                        "'fileStorage'."
+            }
+        }
+    }
+}
 
 /**
  * Create a [FileArchiver] based on this configuration.
  */
 fun FileArchiverConfiguration?.createFileArchiver(): FileArchiver {
-    val storage = this?.fileStorage?.createFileStorage() ?: LocalFileStorage(FileArchiver.DEFAULT_ARCHIVE_DIR)
+    val storage = when {
+        this?.fileStorage != null -> FileArchiverFileStorage(fileStorage.createFileStorage())
+
+        this?.postgresStorage != null -> {
+            val dataSource = DatabaseUtils.createHikariDataSource(
+                config = postgresStorage,
+                applicationNameSuffix = "file-archiver"
+            )
+
+            PostgresFileArchiverStorage(dataSource)
+        }
+
+        else -> FileArchiverFileStorage(LocalFileStorage(FileArchiver.DEFAULT_ARCHIVE_DIR))
+    }
+
     val patterns = LicenseFilenamePatterns.getInstance().allLicenseFilenames
 
     return FileArchiver(patterns, storage)

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -39,6 +39,13 @@ ort {
           compression = false
         }
       }
+
+      postgresStorage {
+        url = "url"
+        schema = "schema"
+        username = "user"
+        password = "password"
+      }
     }
 
     createMissingArchives = false

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -33,7 +33,7 @@ ort {
 
   scanner {
     archive {
-      storage {
+      fileStorage {
         localFileStorage {
           directory = ~/.ort/scanner/archive
           compression = false

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -62,9 +62,18 @@ class OrtConfigurationTest : WordSpec({
 
             with(ortConfig.scanner) {
                 archive shouldNotBeNull {
-                    fileStorage.httpFileStorage should beNull()
-                    fileStorage.localFileStorage shouldNotBeNull {
-                        directory shouldBe File("~/.ort/scanner/archive")
+                    fileStorage shouldNotBeNull {
+                        httpFileStorage should beNull()
+                        localFileStorage shouldNotBeNull {
+                            directory shouldBe File("~/.ort/scanner/archive")
+                        }
+                    }
+
+                    postgresStorage shouldNotBeNull {
+                        url shouldBe "url"
+                        schema shouldBe "schema"
+                        username shouldBe "user"
+                        password shouldBe "password"
                     }
                 }
 

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -62,8 +62,8 @@ class OrtConfigurationTest : WordSpec({
 
             with(ortConfig.scanner) {
                 archive shouldNotBeNull {
-                    storage.httpFileStorage should beNull()
-                    storage.localFileStorage shouldNotBeNull {
+                    fileStorage.httpFileStorage should beNull()
+                    fileStorage.localFileStorage shouldNotBeNull {
                         directory shouldBe File("~/.ort/scanner/archive")
                     }
                 }

--- a/model/src/test/kotlin/config/ScannerConfigurationTest.kt
+++ b/model/src/test/kotlin/config/ScannerConfigurationTest.kt
@@ -46,7 +46,7 @@ class ScannerConfigurationTest : WordSpec({
             // Relative paths have been normalized, passwords do not get serialized, etc.
             loadedConfig.storageReaders shouldBe ortConfig.scanner.storageReaders
             loadedConfig.storageWriters shouldBe ortConfig.scanner.storageWriters
-            loadedConfig.archive?.storage?.httpFileStorage should beNull()
+            loadedConfig.archive?.fileStorage?.httpFileStorage should beNull()
 
             val loadedStorages = loadedConfig.storages.orEmpty()
             val orgStorages = ortConfig.scanner.storages.orEmpty()

--- a/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/NoticeTemplateReporterFunTest.kt
@@ -59,7 +59,7 @@ class NoticeTemplateReporterFunTest : WordSpec({
             val config = OrtConfiguration(
                 scanner = ScannerConfiguration(
                     archive = FileArchiverConfiguration(
-                        storage = FileStorageConfiguration(
+                        fileStorage = FileStorageConfiguration(
                             localFileStorage = LocalFileStorageConfiguration(
                                 directory = archiveDir,
                                 compression = false


### PR DESCRIPTION
The adjust the `FileArchiverConfiguration` so that either a file based storage or a PostgreSQL based storage can be configured for the file archiver.

Note: You may utilized the code on branch 'migrate-file-archive-to-postgres' for migrating your file archives from a file storage to postgres, see [1] [2].

[1] https://github.com/oss-review-toolkit/ort/blob/migrate-file-archive-to-postgres/scanner/src/main/kotlin/MigrateFileArchives.kt#L109 
[2] https://github.com/oss-review-toolkit/ort/blob/migrate-file-archive-to-postgres/scanner/src/main/kotlin/MigrateFileArchives.kt#L46-L55.