### PR TITLE
CycloneDxReporter: In single.bom mode, use the default name even for a single project

### DIFF
--- a/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
+++ b/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
@@ -107,7 +107,7 @@ class CycloneDxReporter : Reporter {
         val projects = input.ortResult.getProjects(omitExcluded = true)
         val createSingleBom = !options[OPTION_SINGLE_BOM].isFalse()
 
-        if (createSingleBom && projects.size > 1) {
+        if (createSingleBom) {
             val reportFilename = "$REPORT_BASE_FILENAME.$REPORT_EXTENSION"
             val outputFile = outputDir.resolve(reportFilename)
 


### PR DESCRIPTION
In single.bom mode, we can expect to have the same behavior with 1 or more projects and therefore have the same filename in all cases.
This can be useful when using the CycloneDx result file in other processing/pipeline