### PR TITLE
Scanner: Do not try so scan projects and packages with the same id

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -119,12 +119,14 @@ abstract class Scanner(
 
         // Add the projects as packages to scan.
         val consolidatedProjects = consolidateProjectPackagesByVcs(ortResult.getProjects(skipExcluded))
-        val consolidatedReferencePackages = consolidatedProjects.keys.map { it.toCuratedPackage() }
+        val consolidatedReferencePackages = consolidatedProjects.keys.toList()
 
-        val referencePackageIdentifiers = consolidatedReferencePackages.map { it.pkg.id }
-        val packages = ortResult.getPackages(skipExcluded).filter { it.pkg.id !in referencePackageIdentifiers }
+        val referencePackageIdentifiers = consolidatedReferencePackages.map { it.id }
+        val packages = ortResult.getPackages(skipExcluded)
+            .filter { it.pkg.id !in referencePackageIdentifiers }
+            .map { it.pkg }
 
-        val packagesToScan = (consolidatedReferencePackages + packages).map { it.pkg }
+        val packagesToScan = consolidatedReferencePackages + packages
         val scanResults = runBlocking {
             scanPackages(packagesToScan, outputDirectory, downloadDirectory).mapKeys { it.key.id }
         }.toSortedMap()

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -121,7 +121,10 @@ abstract class Scanner(
         val consolidatedProjects = consolidateProjectPackagesByVcs(ortResult.getProjects(skipExcluded))
         val consolidatedReferencePackages = consolidatedProjects.keys.map { it.toCuratedPackage() }
 
-        val packagesToScan = (consolidatedReferencePackages + ortResult.getPackages(skipExcluded)).map { it.pkg }
+        val referencePackageIdentifiers = consolidatedReferencePackages.map { it.pkg.id }
+        val packages = ortResult.getPackages(skipExcluded).filter { it.pkg.id !in referencePackageIdentifiers }
+
+        val packagesToScan = (consolidatedReferencePackages + packages).map { it.pkg }
         val scanResults = runBlocking {
             scanPackages(packagesToScan, outputDirectory, downloadDirectory).mapKeys { it.key.id }
         }.toSortedMap()


### PR DESCRIPTION
It can happen that the same identifier appears for a project and for a
package. Possible reasons for this are that the package manager
implementation does not detect that a dependency is also a project and
creates a package instance for it, or that the same identifier appears
for different package managers, for example NPM and Yarn.

If those duplicates are passed to the `PostgresStorage` it fails because
it expects identifiers to be unique.

To fix this make sure to not pass duplicate identifiers to the scanner.
If duplicates are found prefer the project over the package, because it
has likely more accurate metadata.

Other means to further improve this in future are:
- Change the `Scanner` and `ScanResultsStorage` API to take a set of
  packages instead of a list.
- Add post-processing to the analyzer to detect those duplicates.