### PR TITLE
FileArchiverConfiguration: Fix JSON deserialization of old results

### DIFF
--- a/model/src/main/kotlin/config/FileArchiverConfiguration.kt
+++ b/model/src/main/kotlin/config/FileArchiverConfiguration.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.model.config
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 import com.sksamuel.hoplite.ConfigAlias
@@ -40,6 +41,7 @@ data class FileArchiverConfiguration(
      * Configuration of the [FileStorage] used for archiving the files.
      */
     @ConfigAlias("storage")
+    @JsonAlias("storage")
     val fileStorage: FileStorageConfiguration? = null,
 
     /**


### PR DESCRIPTION
The `storage` property was renamed to `fileStorage` in 8e1350f. The
renaming was made backward compatible for parsing with hoplite. Make it
also backward compatible for parsing with Jackson, so that old ORT
result files can still be read.