### PR TITLE
SpdxDocumentModelMapper: Remove a superfluous toLowerCase() call

### DIFF
--- a/reporter/src/main/kotlin/utils/SpdxDocumentModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/SpdxDocumentModelMapper.kt
@@ -212,7 +212,7 @@ private fun String?.nullOrBlankToSpdxNone(): String = if (isNullOrBlank()) SpdxC
 private fun ScanResult.toSpdxPackageVerificationCode(): SpdxPackageVerificationCode =
     SpdxPackageVerificationCode(
         packageVerificationCodeExcludedFiles = emptyList(),
-        packageVerificationCodeValue = summary.packageVerificationCode.toLowerCase()
+        packageVerificationCodeValue = summary.packageVerificationCode
     )
 
 private fun SpdxDocument.addExtractedLicenseInfo(licenseTextProvider: LicenseTextProvider): SpdxDocument {


### PR DESCRIPTION
The SPDX package verification code already is lower case, see e.g. the
assertions in ScanCodeResultParserTest.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>