### PR TITLE
PostgresStorage: Limit the number of chunks when reading results

### DIFF
--- a/scanner/src/main/kotlin/storages/PostgresStorage.kt
+++ b/scanner/src/main/kotlin/storages/PostgresStorage.kt
@@ -49,6 +49,7 @@ import org.ossreviewtoolkit.model.utils.DatabaseUtils.tableExists
 import org.ossreviewtoolkit.model.utils.arrayParam
 import org.ossreviewtoolkit.model.utils.rawParam
 import org.ossreviewtoolkit.model.utils.tilde
+import org.ossreviewtoolkit.scanner.LocalScanner
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.scanner.storages.utils.ScanResultDao
@@ -191,7 +192,7 @@ class PostgresStorage(
         @Suppress("TooGenericExceptionCaught")
         return try {
             val scanResults = runBlocking(Dispatchers.IO) {
-                packages.chunked(max(packages.size / 50, 1)).map { chunk ->
+                packages.chunked(max(packages.size / LocalScanner.NUM_STORAGE_THREADS, 1)).map { chunk ->
                     suspendedTransactionAsync {
                         @Suppress("MaxLineLength")
                         ScanResultDao.find {


### PR DESCRIPTION
The `PostgresStorage` splits the packages into chunks and requests the
scan results for each chunk of packages in parallel. If there are more
chunks than connections in the connection pool, it can happen that the
requests wait longer than the default timeout of 30 seconds for a free
connection.

As a quick fix, because this code is currently being rewritten anyway,
limit the number of chunks to be slighty smaller than the size of the
connection pool.

Fixes #3807.