### PR TITLE
Disable the extremely chatty FileSnapshot logger from JGit

### DIFF
--- a/cli/src/main/resources/log4j2.xml
+++ b/cli/src/main/resources/log4j2.xml
@@ -9,5 +9,8 @@
     <Root level="warn">
       <AppenderRef ref="Console"/>
     </Root>
+    <Logger name="org.eclipse.jgit.internal.storage.file.FileSnapshot" level="off">
+      <AppenderRef ref="Console"/>
+    </Logger>
   </Loggers>
 </Configuration>

--- a/test-utils/src/main/resources/log4j2.xml
+++ b/test-utils/src/main/resources/log4j2.xml
@@ -9,5 +9,8 @@
     <Root level="debug">
       <AppenderRef ref="Console"/>
     </Root>
+    <Logger name="org.eclipse.jgit.internal.storage.file.FileSnapshot" level="off">
+      <AppenderRef ref="Console"/>
+    </Logger>
   </Loggers>
 </Configuration>


### PR DESCRIPTION
The debug logs from this logger completely swamp ORT debug logs which
makes it hard to see through.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>