### PR TITLE
Extend vulnerability model to support multiple sources

### DIFF
--- a/advisor/src/main/kotlin/advisors/VulnerableCode.kt
+++ b/advisor/src/main/kotlin/advisors/VulnerableCode.kt
@@ -35,6 +35,7 @@ import org.ossreviewtoolkit.model.AdvisorResult
 import org.ossreviewtoolkit.model.AdvisorSummary
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Vulnerability
+import org.ossreviewtoolkit.model.VulnerabilityReference
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
 import org.ossreviewtoolkit.model.config.VulnerableCodeConfiguration
 import org.ossreviewtoolkit.model.utils.toPurl
@@ -144,7 +145,12 @@ class VulnerableCode(
             vulnerabilityUrls.map { extractVulnerabilityId(it) }
                 .map { async { service.getVulnerability(it) } }
                 .awaitAll()
-                .map { Vulnerability(it.cveId.orEmpty(), it.cvss ?: SEVERITY_UNDEFINED, URI(it.url)) }
-                .associateBy { "${it.url}" }
+                .map {
+                    Vulnerability(
+                        it.cveId.orEmpty(),
+                        listOf(VulnerabilityReference(URI(it.url), null, (it.cvss ?: SEVERITY_UNDEFINED).toString()))
+                    )
+                }
+                .associateBy { it.references.first().url.toString() }
         }
 }

--- a/advisor/src/test/kotlin/advisors/VulnerableCodeTest.kt
+++ b/advisor/src/test/kotlin/advisors/VulnerableCodeTest.kt
@@ -49,6 +49,7 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.Vulnerability
+import org.ossreviewtoolkit.model.VulnerabilityReference
 import org.ossreviewtoolkit.model.config.VulnerableCodeConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.utils.toPurl
@@ -103,8 +104,7 @@ class VulnerableCodeTest : WordSpec({
             langResults[0].advisor.name shouldBe ADVISOR_NAME
             val expLangVulnerability = Vulnerability(
                 id = "CVE-2014-8242",
-                severity = 42.0f,
-                url = URI("http://localhost:8000/api/vulnerabilities/v1/")
+                createReferences(URI("http://localhost:8000/api/vulnerabilities/v1/"), severity = 42.0f)
             )
             langResults.flatMap { it.vulnerabilities } should containExactly(expLangVulnerability)
 
@@ -113,13 +113,11 @@ class VulnerableCodeTest : WordSpec({
             val expStrutsVulnerabilities = listOf(
                 Vulnerability(
                     id = "CVE-2009-1382",
-                    url = URI("http://localhost:8000/api/vulnerabilities/v2/"),
-                    severity = 11.0f
+                    createReferences(URI("http://localhost:8000/api/vulnerabilities/v2/"), severity = 11.0f)
                 ),
                 Vulnerability(
                     id = "CVE-2019-CoV19",
-                    severity = 77.0f,
-                    url = URI("http://localhost:8000/api/vulnerabilities/v3/")
+                    createReferences(URI("http://localhost:8000/api/vulnerabilities/v3/"), severity = 77.0f)
                 )
             )
             strutsResults.flatMap { it.vulnerabilities } should containExactlyInAnyOrder(expStrutsVulnerabilities)
@@ -154,13 +152,11 @@ class VulnerableCodeTest : WordSpec({
                 val expStrutsVulnerabilities = listOf(
                     Vulnerability(
                         id = "CVE-2009-1382",
-                        url = URI("http://localhost:8000/api/vulnerabilities/v2/"),
-                        severity = 11.0f
+                        createReferences(URI("http://localhost:8000/api/vulnerabilities/v2/"), severity = 11.0f)
                     ),
                     Vulnerability(
                         id = "",
-                        severity = -1f,
-                        url = URI("http://localhost:8000/api/vulnerabilities/v3/")
+                        createReferences(URI("http://localhost:8000/api/vulnerabilities/v3/"), severity = -1f)
                     )
                 )
                 strutsResults.flatMap { it.vulnerabilities } should containExactlyInAnyOrder(expStrutsVulnerabilities)
@@ -307,3 +303,10 @@ private fun stubVulnerability(id: String, cveId: String, score: Float, statusCod
             )
     )
 }
+
+/**
+ * Create the references for a single vulnerability source with the given [url] that assigns the given [severity].
+ * So far, some properties are still dummy data; this will be extended when the bulk query API is available.
+ */
+private fun createReferences(url: URI, severity: Float): List<VulnerabilityReference> =
+    listOf(VulnerabilityReference(url, scoringSystem = null, severity = severity.toString()))

--- a/clients/nexus-iq/src/main/kotlin/NexusIqService.kt
+++ b/clients/nexus-iq/src/main/kotlin/NexusIqService.kt
@@ -42,6 +42,18 @@ import retrofit2.http.Path
  */
 interface NexusIqService {
     companion object {
+        /** Identifier of the scoring system _Common Vulnerability Scoring System_ version 2. */
+        const val CVSS2_SCORE = "CVSS2"
+
+        /** Identifier of the scoring system _Common Vulnerability Scoring System_ version 3. */
+        const val CVSS3_SCORE = "CVSS3"
+
+        /**
+         * A Sonatype-specific prefix for references of security issues. The prefix determines how some of the
+         * properties need to be interpreted, e.g. the severity value.
+         */
+        const val SONATYPE_PREFIX = "sonatype-"
+
         /**
          * The mapper for JSON (de-)serialization used by this service.
          */
@@ -102,7 +114,14 @@ interface NexusIqService {
         val reference: String,
         val severity: Float,
         val url: URI?
-    )
+    ) {
+        /**
+         * Return an identifier for the scoring system used for this issue. According to the documentation, the
+         * prefix of the reference determines the scoring system. See
+         * https://guides.sonatype.com/iqserver/technical-guides/sonatype-vuln-data/#how-is-a-vulnerability-score-severity-calculated
+         */
+        fun scoringSystem(): String = if (reference.startsWith(SONATYPE_PREFIX)) CVSS3_SCORE else CVSS2_SCORE
+    }
 
     data class ComponentsWrapper(
         val components: List<Component>

--- a/clients/nexus-iq/src/test/kotlin/NexusIqServiceTest.kt
+++ b/clients/nexus-iq/src/test/kotlin/NexusIqServiceTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.clients.nexusiq
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import java.net.URI
+
+class NexusIqServiceTest : WordSpec({
+    "SecurityIssue" should {
+        "return the correct scoring system for sonatype references" {
+            val issue = NexusIqService.SecurityIssue(
+                "${NexusIqService.SONATYPE_PREFIX}foo",
+                1.7f,
+                URI("https://security.example.org/an-issue")
+            )
+
+            issue.scoringSystem() shouldBe NexusIqService.CVSS3_SCORE
+        }
+
+        "return the correct scoring system for other references" {
+            val issue = NexusIqService.SecurityIssue(
+                "CVE-0815",
+                2.7f,
+                URI("https://security.example.org/another-issue")
+            )
+
+            issue.scoringSystem() shouldBe NexusIqService.CVSS2_SCORE
+        }
+    }
+})

--- a/model/src/main/kotlin/Vulnerability.kt
+++ b/model/src/main/kotlin/Vulnerability.kt
@@ -19,12 +19,22 @@
 
 package org.ossreviewtoolkit.model
 
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
+
+import java.net.URI
+
 /**
  * Base model for all vulnerability providers supported by the advisor.
  *
  * This class stores the information about a single vulnerability, which may have been retrieved from multiple
  * vulnerability providers. For each source of information a [VulnerabilityReference] is contained.
  */
+@JsonDeserialize(using = VulnerabilityDeserializer::class)
 data class Vulnerability(
     /**
      * The ID of a vulnerability. Most likely a CVE identifier.
@@ -91,6 +101,29 @@ data class Vulnerability(
                     score <= CRITICAL.upperBound -> CRITICAL
                     else -> null
                 }
+        }
+    }
+}
+
+/**
+ * A custom deserializer to support the deserialization of [Vulnerability] instances using an older format, in which
+ * detailed information was embedded into the class rather than externalized in [VulnerabilityReference] objects.
+ */
+private class VulnerabilityDeserializer : StdDeserializer<Vulnerability>(Vulnerability::class.java) {
+    override fun deserialize(p: JsonParser, ctx: DeserializationContext): Vulnerability {
+        val vulnerabilityNode = p.codec.readTree<JsonNode>(p)
+        val id = vulnerabilityNode["id"].textValue()
+
+        return if (vulnerabilityNode["references"] != null) {
+            val references = jsonMapper.convertValue(
+                vulnerabilityNode["references"], jacksonTypeRef<List<VulnerabilityReference>>()
+            )
+            Vulnerability(id, references)
+        } else {
+            val severity = vulnerabilityNode["severity"].floatValue()
+            val uri = vulnerabilityNode["url"].textValue()
+            val reference = VulnerabilityReference(URI(uri), null, severity.toString())
+            Vulnerability(id, listOf(reference))
         }
     }
 }

--- a/model/src/main/kotlin/Vulnerability.kt
+++ b/model/src/main/kotlin/Vulnerability.kt
@@ -19,12 +19,11 @@
 
 package org.ossreviewtoolkit.model
 
-import com.fasterxml.jackson.annotation.JsonInclude
-
-import java.net.URI
-
 /**
  * Base model for all vulnerability providers supported by the advisor.
+ *
+ * This class stores the information about a single vulnerability, which may have been retrieved from multiple
+ * vulnerability providers. For each source of information a [VulnerabilityReference] is contained.
  */
 data class Vulnerability(
     /**
@@ -33,17 +32,16 @@ data class Vulnerability(
     val id: String,
 
     /**
-     * Severity of the vulnerability. Most likely expressed using the CVSS version 2 or 3 in range 0.0 to 10.0, see
-     * https://www.first.org/cvss/
+     * A list with detailed information for this vulnerability obtained from different sources.
      */
-    val severity: Float,
-
-    /**
-     * URL pointing to a website with information regarding the vulnerability.
-     */
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    val url: URI? = null
+    val references: List<VulnerabilityReference>
 ) {
+    init {
+        require(references.isNotEmpty()) {
+            "A Vulnerability must have at least one reference."
+        }
+    }
+
     /**
      * The rating attaches human-readable semantics to the score number according to CVSS version 2, see
      * https://www.balbix.com/insights/cvss-v2-vs-cvss-v3/#CVSSv3-Scoring-Scale-vs-CVSSv2-6.

--- a/model/src/main/kotlin/VulnerabilityReference.kt
+++ b/model/src/main/kotlin/VulnerabilityReference.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import java.net.URI
+
+/**
+ * A data class representing detailed information about a vulnerability obtained from a specific source.
+ *
+ * A single vulnerability can be listed by multiple sources using different scoring systems to denote its severity.
+ * So when ORT queries different providers for vulnerability information it may well find multiple records for a single
+ * vulnerability, which could even contain contradicting information. To model this, a [Vulnerability] is associated
+ * with a list of references; each reference points to the source of the information and has some detailed information
+ * provided by this source.
+ */
+data class VulnerabilityReference(
+    /**
+     * The URI pointing to details of this vulnerability. This can also be used to derive the source of this
+     * information.
+     */
+    val url: URI,
+
+    /**
+     * The name of the scoring system to express the severity of this vulnerability if available.
+     */
+    val scoringSystem: String?,
+
+    /**
+     * The severity assigned to the vulnerability by this reference. Note that this is a plain string, whose meaning
+     * depends on the concrete scoring system. It could be a number, but also a constant like _LOW_ or _HIGH_. A
+     * *null* value is possible as well, meaning that this reference does not contain any information about the
+     * severity.
+     */
+    val severity: String?
+)

--- a/model/src/test/assets/advisor-result-initial.yml
+++ b/model/src/test/assets/advisor-result-initial.yml
@@ -1,0 +1,6275 @@
+---
+repository:
+  vcs:
+    type: "Git"
+    url: "https://github.com/vdurmont/semver4j.git"
+    revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/vdurmont/semver4j.git"
+    revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+    path: ""
+  config: {}
+analyzer:
+  start_time: "2021-03-30T01:07:44.010004Z"
+  end_time: "2021-03-30T01:07:54.268037Z"
+  environment:
+    ort_version: "de3668b"
+    java_version: "11.0.8"
+    os: "Linux"
+    processors: 4
+    max_memory: 12884901888
+    variables:
+      JAVA_HOME: "/opt/java/openjdk"
+      ANDROID_HOME: "/opt/android-sdk"
+      GOPATH: "/go"
+    tool_versions: {}
+  config:
+    ignore_tool_versions: false
+    allow_dynamic_versions: false
+  result:
+    projects:
+    - id: "Maven:com.vdurmont:semver4j:3.1.0"
+      definition_file_path: "pom.xml"
+      authors:
+      - "Vincent DURMONT"
+      declared_licenses:
+      - "The MIT License"
+      declared_licenses_processed:
+        spdx_expression: "MIT"
+        mapped:
+          The MIT License: "MIT"
+      vcs:
+        type: "Git"
+        url: "git@github.com:vdurmont/semver4j.git"
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/vdurmont/semver4j.git"
+        revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+        path: ""
+      homepage_url: "https://github.com/vdurmont/semver4j"
+      scopes:
+      - name: "test"
+        dependencies:
+        - id: "Maven:junit:junit:4.12"
+          dependencies:
+          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+        - id: "Maven:org.mockito:mockito-all:1.10.19"
+    packages:
+    - package:
+        id: "Maven:junit:junit:4.12"
+        purl: "pkg:maven/junit/junit@4.12"
+        authors:
+        - "David Saff"
+        - "JUnit"
+        - "Kevin Cooney"
+        - "Marc Philipp"
+        - "Stefan Birkner"
+        declared_licenses:
+        - "Eclipse Public License 1.0"
+        declared_licenses_processed:
+          spdx_expression: "EPL-1.0"
+          mapped:
+            Eclipse Public License 1.0: "EPL-1.0"
+        concluded_license: "EPL-1.0"
+        description: "JUnit is a unit testing framework for Java, created by Erich\
+          \ Gamma and Kent Beck."
+        homepage_url: "http://junit.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
+          hash:
+            value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+          hash:
+            value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "https://github.com/junit-team/junit4.git"
+          revision: "r4.12"
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/junit-team/junit4.git"
+          revision: "r4.12"
+          path: ""
+      curations:
+      - base:
+          vcs:
+            type: "Git"
+            url: "git://github.com/junit-team/junit.git"
+            revision: "r4.12"
+            path: ""
+        curation:
+          concluded_license: "EPL-1.0"
+          vcs:
+            type: "Git"
+            url: "https://github.com/junit-team/junit4.git"
+            revision: "r4.12"
+          comment: "ScanCode claims to find some NOASSERTION and Apache-2.0 in the\
+            \ FAQ and the pom.xml, both are false-positives."
+    - package:
+        id: "Maven:org.hamcrest:hamcrest-core:1.3"
+        purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
+        authors:
+        - "Joe Walnes"
+        - "Nat Pryce"
+        - "Neil Dunn"
+        - "Steve Freeman"
+        - "Tom Denley"
+        declared_licenses:
+        - "BSD-3-Clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+        description: "This is the core API of hamcrest matcher framework to be used\
+          \ by third-party framework providers. This includes the a foundation set\
+          \ of matcher implementations for common operations."
+        homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
+          hash:
+            value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+          hash:
+            value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:hamcrest/JavaHamcrest.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
+          revision: ""
+          path: ""
+      curations:
+      - base:
+          declared_licenses:
+          - "New BSD License"
+        curation:
+          declared_licenses:
+          - "BSD-3-Clause"
+          comment: "Provided by ClearlyDefined."
+    - package:
+        id: "Maven:org.mockito:mockito-all:1.10.19"
+        purl: "pkg:maven/org.mockito/mockito-all@1.10.19"
+        authors:
+        - "Szczepan Faber"
+        declared_licenses:
+        - "MIT"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+        description: "Mock objects library for java"
+        homepage_url: "http://www.mockito.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/mockito/mockito-all/1.10.19/mockito-all-1.10.19.jar"
+          hash:
+            value: "539df70269cc254a58cccc5d8e43286b4a73bf30"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/mockito/mockito-all/1.10.19/mockito-all-1.10.19-sources.jar"
+          hash:
+            value: "8269667b73d9616600359a9b0ba1b1c7d0cf7a97"
+            algorithm: "SHA-1"
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+      curations:
+      - base:
+          declared_licenses:
+          - "The MIT License"
+        curation:
+          declared_licenses:
+          - "MIT"
+          comment: "Provided by ClearlyDefined."
+    has_issues: false
+scanner:
+  start_time: "2021-03-30T01:25:55.052430Z"
+  end_time: "2021-03-30T01:25:57.605188Z"
+  environment:
+    ort_version: "de3668b"
+    java_version: "11.0.8"
+    os: "Linux"
+    processors: 4
+    max_memory: 12884901888
+    variables:
+      JAVA_HOME: "/opt/java/openjdk"
+      ANDROID_HOME: "/opt/android-sdk"
+      GOPATH: "/go"
+    tool_versions: {}
+  config:
+    archive:
+      file_storage:
+        http_file_storage:
+          url: "https://osmiocaasprodarchive.blob.core.windows.net/archive"
+          query: "***"
+          headers:
+            x-ms-blob-type: "***"
+        local_file_storage: null
+      postgres_storage: null
+    create_missing_archives: true
+    options:
+      ScanCode:
+        parseLicenseExpressions: "true"
+      FossId:
+        user: "osi9be"
+    storages:
+      postgresStorage: !<.PostgresStorageConfiguration>
+        url: "jdbc:postgresql://osmi-ocaas-prod-pipeline-psqlserver.postgres.database.azure.com:5432/ort?gssEncMode=disable"
+        schema: "scan_storage"
+        username: "c186cd7f9cd62563f64b7c4fda307d34@osmi-ocaas-prod-pipeline-psqlserver.postgres.database.azure.com"
+        sslmode: "require"
+        sslcert: null
+        sslkey: null
+        sslrootcert: null
+    storage_readers:
+    - "postgresStorage"
+    storage_writers:
+    - "postgresStorage"
+    ignore_patterns:
+    - "**/*.ort.yml"
+    - "**/META-INF/DEPENDENCIES"
+  results:
+    scan_results:
+      Maven:com.vdurmont:semver4j:3.1.0:
+      - provenance:
+          download_time: "2020-09-30T09:27:08.894485Z"
+          vcs_info:
+            type: "Git"
+            url: "https://github.com/vdurmont/semver4j.git"
+            revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+            resolved_revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+            path: ""
+          original_vcs_info:
+            type: "Git"
+            url: "https://github.com/vdurmont/semver4j.git"
+            revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+            path: ""
+        scanner:
+          name: "ScanCode"
+          version: "3.2.1-rc2"
+          configuration: "--copyright --license --info --strip-root --timeout 300\
+            \ --json-pp"
+        summary:
+          start_time: "2020-09-30T09:27:12.023451Z"
+          end_time: "2020-09-30T09:28:20.525647Z"
+          file_count: 16
+          package_verification_code: "48ba11487d53ce933b5d4db1d069b70a803ff19b"
+          licenses:
+          - license: "BSD-3-Clause"
+            location:
+              path: "pom.xml"
+              start_line: 28
+              end_line: 34
+          - license: "MIT"
+            location:
+              path: "LICENSE.md"
+              start_line: 1
+              end_line: 1
+          - license: "MIT"
+            location:
+              path: "LICENSE.md"
+              start_line: 5
+              end_line: 21
+          - license: "MIT"
+            location:
+              path: "pom.xml"
+              start_line: 30
+              end_line: 31
+          copyrights:
+          - statement: "Copyright (c) 2015-present Vincent DURMONT <vdurmont@gmail.com>"
+            location:
+              path: "LICENSE.md"
+              start_line: 3
+              end_line: 3
+      Maven:junit:junit:4.12:
+      - provenance:
+          download_time: "2021-03-22T16:38:03.486241Z"
+          vcs_info:
+            type: "Git"
+            url: "https://github.com/junit-team/junit4.git"
+            revision: "r4.12"
+            resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
+            path: ""
+          original_vcs_info:
+            type: "Git"
+            url: "https://github.com/junit-team/junit4.git"
+            revision: "r4.12"
+            path: ""
+        scanner:
+          name: "ScanCode"
+          version: "3.2.1-rc2"
+          configuration: "--copyright --license --info --strip-root --timeout 300\
+            \ --json-pp"
+        summary:
+          start_time: "2021-03-22T16:38:10.201134Z"
+          end_time: "2021-03-22T16:39:16.747151Z"
+          file_count: 478
+          package_verification_code: "2acb4f0b06b706fa94e9159c2f9abc1397c46ba0"
+          licenses:
+          - license: "Apache-2.0"
+            location:
+              path: "src/site/resources/css/hopscotch-0.1.2.min.css"
+              start_line: 5
+              end_line: 15
+          - license: "Apache-2.0"
+            location:
+              path: "src/site/resources/scripts/hopscotch-0.1.2.min.js"
+              start_line: 5
+              end_line: 15
+          - license: "Apache-2.0 OR EPL-2.0"
+            location:
+              path: "pom.xml"
+              start_line: 19
+              end_line: 23
+          - license: "EPL-1.0"
+            location:
+              path: "LICENSE-junit.txt"
+              start_line: 3
+              end_line: 213
+          - license: "EPL-1.0"
+            location:
+              path: "epl-v10.html"
+              start_line: 7
+              end_line: 257
+          - license: "EPL-1.0"
+            location:
+              path: "pom.xml"
+              start_line: 18
+              end_line: 20
+          - license: "EPL-1.0"
+            location:
+              path: "src/site/fml/faq.fml"
+              start_line: 157
+              end_line: 157
+          - license: "NOASSERTION"
+            location:
+              path: "src/site/fml/faq.fml"
+              start_line: 156
+              end_line: 156
+          copyrights:
+          - statement: "Copyright 2013 LinkedIn Corp."
+            location:
+              path: "src/site/resources/css/hopscotch-0.1.2.min.css"
+              start_line: 3
+              end_line: 3
+          - statement: "Copyright 2013 LinkedIn Corp."
+            location:
+              path: "src/site/resources/scripts/hopscotch-0.1.2.min.js"
+              start_line: 3
+              end_line: 3
+      Maven:org.hamcrest:hamcrest-core:1.3:
+      - provenance:
+          download_time: "2021-03-23T07:34:08.704983Z"
+          vcs_info:
+            type: "Git"
+            url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
+            revision: "36d525e1e425006939a77aec5183aecd7c775b05"
+            resolved_revision: "36d525e1e425006939a77aec5183aecd7c775b05"
+            path: ""
+          original_vcs_info:
+            type: "Git"
+            url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
+            revision: ""
+            path: ""
+        scanner:
+          name: "ScanCode"
+          version: "3.2.1-rc2"
+          configuration: "--copyright --license --info --strip-root --timeout 300\
+            \ --json-pp"
+        summary:
+          start_time: "2021-03-23T07:34:13.547701Z"
+          end_time: "2021-03-23T07:34:44.000299Z"
+          file_count: 213
+          package_verification_code: "251423eeb35c4e26853c23c4ffadd9381a5d07eb"
+          licenses:
+          - license: "Apache-2.0"
+            location:
+              path: "googlecode_upload.py"
+              start_line: 39
+              end_line: 40
+          - license: "Apache-2.0"
+            location:
+              path: "lib/integration/testng-license.txt"
+              start_line: 1
+              end_line: 201
+          - license: "BSD-3-Clause"
+            location:
+              path: "LICENSE.txt"
+              start_line: 1
+              end_line: 27
+          - license: "BSD-3-Clause"
+            location:
+              path: "lib/integration/jmock-license.txt"
+              start_line: 4
+              end_line: 25
+          - license: "BSD-3-Clause"
+            location:
+              path: "pom/hamcrest-parent.pom"
+              start_line: 15
+              end_line: 21
+          - license: "CPL-1.0"
+            location:
+              path: "lib/integration/junit-license.html"
+              start_line: 4
+              end_line: 119
+          - license: "MIT"
+            location:
+              path: "lib/integration/easymock-license.html"
+              start_line: 14
+              end_line: 14
+          - license: "MIT"
+            location:
+              path: "lib/integration/easymock-license.html"
+              start_line: 20
+              end_line: 26
+          copyrights:
+          - statement: "Copyright (c) 2000-20010 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/beans/HasPropertyWithValueTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-20010 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/IsNullTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2003, jMock.org"
+            location:
+              path: "lib/integration/jmock-license.txt"
+              start_line: 1
+              end_line: 2
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/BaseMatcher.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/Matcher.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/MatcherAssert.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/DescribedAs.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/IsAnything.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/IsEqual.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/IsInstanceOf.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/IsSame.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/StringContains.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/StringEndsWith.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/StringStartsWith.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-library/src/main/java/org/hamcrest/beans/HasProperty.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-library/src/main/java/org/hamcrest/beans/HasPropertyWithValue.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-library/src/main/java/org/hamcrest/beans/PropertyUtil.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-library/src/main/java/org/hamcrest/number/IsCloseTo.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-library/src/main/java/org/hamcrest/object/IsEventFrom.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-library/src/main/java/org/hamcrest/text/IsEqualIgnoringCase.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-library/src/main/java/org/hamcrest/text/IsEqualIgnoringWhiteSpace.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/AbstractMatcherTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/beans/HasPropertyTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/DescribedAsTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/IsEqualTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/IsSameTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/number/IsCloseToTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/object/IsEventFromTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/text/IsEqualIgnoringCaseTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/text/IsEqualIgnoringWhiteSpaceTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/text/StringContainsTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/text/StringEndsWithTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/text/StringStartsWithTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006, www.hamcrest.org"
+            location:
+              path: "LICENSE.txt"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2008 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/beans/SamePropertyValuesAsTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2009 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/IsNot.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2009 hamcrest.org"
+            location:
+              path: "hamcrest-library/src/main/java/org/hamcrest/number/OrderingComparison.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2009 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/IsNotTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2009 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/number/OrderingComparisonTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2010 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/IsNull.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2010 hamcrest.org"
+            location:
+              path: "hamcrest-examples/src/main/java/org/hamcrest/examples/junit4/ExampleWithAssertThat.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2010 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/AllOfTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2010 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/AnyOfTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2010 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/IsAnythingTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2010 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/IsInstanceOfTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2001-2006 http://www.offis.de' OFFIS, http://www.tammofreese.de'\
+              \ Tammo Freese"
+            location:
+              path: "lib/integration/easymock-license.html"
+              start_line: 17
+              end_line: 17
+          - statement: "Copyright 2006, 2007 Google Inc."
+            location:
+              path: "googlecode_upload.py"
+              start_line: 3
+              end_line: 3
+      - provenance:
+          download_time: "2020-09-30T09:29:05.259873Z"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+            hash:
+              value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+              algorithm: "SHA-1"
+        scanner:
+          name: "ScanCode"
+          version: "3.2.1-rc2"
+          configuration: "--copyright --license --info --strip-root --timeout 300\
+            \ --json-pp"
+        summary:
+          start_time: "2020-09-30T09:29:05.608077Z"
+          end_time: "2020-09-30T09:29:11.356106Z"
+          file_count: 41
+          package_verification_code: "a42897bec728695ae0e3ecdcc891ced065dae355"
+          licenses: []
+          copyrights:
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/BaseMatcher.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/Matcher.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/MatcherAssert.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/DescribedAs.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/IsAnything.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/IsEqual.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/IsInstanceOf.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/IsSame.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/StringContains.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/StringEndsWith.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/StringStartsWith.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2009 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/IsNot.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2010 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/IsNull.java"
+              start_line: 1
+              end_line: 1
+      Maven:org.mockito:mockito-all:1.10.19:
+      - provenance:
+          download_time: "2020-09-30T09:29:12.938665Z"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/mockito/mockito-all/1.10.19/mockito-all-1.10.19-sources.jar"
+            hash:
+              value: "8269667b73d9616600359a9b0ba1b1c7d0cf7a97"
+              algorithm: "SHA-1"
+        scanner:
+          name: "ScanCode"
+          version: "3.2.1-rc2"
+          configuration: "--copyright --license --info --strip-root --timeout 300\
+            \ --json-pp"
+        summary:
+          start_time: "2020-09-30T09:29:13.204350Z"
+          end_time: "2020-09-30T09:30:08.409869Z"
+          file_count: 576
+          package_verification_code: "956e73550e4be365fdc0d20d75614c5c983da68d"
+          licenses:
+          - license: "Apache-2.0"
+            location:
+              path: "NOTICE"
+              start_line: 5
+              end_line: 5
+          - license: "Apache-2.0"
+            location:
+              path: "cglib-license.txt"
+              start_line: 1
+              end_line: 201
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/BeanCopier.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/BeanGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/BeanMap.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/BeanMapEmitter.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/BulkBean.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/BulkBeanEmitter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/BulkBeanException.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/FixedKeySet.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/ImmutableBean.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/AbstractClassGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/Block.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ClassEmitter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ClassGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ClassInfo.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ClassNameReader.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ClassesKey.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/CodeEmitter.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/CodeGenerationException.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/CollectionUtils.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/Constants.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/Converter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/Customizer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/DebuggingClassWriter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/DefaultGeneratorStrategy.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/DefaultNamingPolicy.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/DuplicatesPredicate.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/EmitUtils.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/GeneratorStrategy.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/KeyFactory.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/Local.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/MethodInfo.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/MethodInfoTransformer.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/MethodWrapper.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/NamingPolicy.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ObjectSwitchCallback.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/Predicate.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ProcessArrayCallback.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ProcessSwitchCallback.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ReflectUtils.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/RejectModifierPredicate.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/Signature.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/TinyBitSet.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/Transformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/TypeUtils.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/VisibilityPredicate.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/Callback.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/CallbackFilter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/CallbackGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/CallbackHelper.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/CallbackInfo.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/Dispatcher.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/DispatcherGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/Enhancer.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/Factory.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/FixedValue.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/FixedValueGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/InterfaceMaker.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/InvocationHandler.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/InvocationHandlerGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/LazyLoader.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/LazyLoaderGenerator.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/MethodInterceptor.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/MethodInterceptorGenerator.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/MethodProxy.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/Mixin.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/MixinBeanEmitter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/MixinEmitter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/MixinEverythingEmitter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/NoOp.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/NoOpGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/Proxy.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/ProxyRefDispatcher.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/UndeclaredThrowableException.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/reflect/ConstructorDelegate.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/reflect/FastClass.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/reflect/FastClassEmitter.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/reflect/FastConstructor.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/reflect/FastMember.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/reflect/FastMethod.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/reflect/MethodDelegate.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/reflect/MulticastDelegate.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/AbstractClassFilterTransformer.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/AbstractClassLoader.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/AbstractClassTransformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/AbstractProcessTask.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/AbstractTransformTask.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/AnnotationVisitorTee.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassEmitterTransformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassFilter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassFilterTransformer.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassReaderGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassTransformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassTransformerChain.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassTransformerFactory.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassTransformerTee.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassVisitorTee.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/FieldVisitorTee.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/MethodFilter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/MethodFilterTransformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/MethodVisitorTee.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/TransformingClassGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/TransformingClassLoader.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/AbstractInterceptFieldCallback.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/AccessFieldTransformer.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/AddDelegateTransformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/AddInitTransformer.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/AddPropertyTransformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/AddStaticInitTransformer.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/FieldProvider.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/FieldProviderTransformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/InterceptFieldCallback.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/InterceptFieldEnabled.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/InterceptFieldFilter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/InterceptFieldTransformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/UndeclaredThrowableStrategy.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/UndeclaredThrowableTransformer.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/util/ParallelSorter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/util/ParallelSorterEmitter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/util/SorterTemplate.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/util/StringSwitcher.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/internal/matchers/apachecommons/commons-lang-license.txt"
+              start_line: 1
+              end_line: 201
+          - license: "BSD-3-Clause"
+            location:
+              path: "NOTICE"
+              start_line: 6
+              end_line: 6
+          - license: "BSD-3-Clause"
+            location:
+              path: "NOTICE"
+              start_line: 11
+              end_line: 11
+          - license: "BSD-3-Clause"
+            location:
+              path: "asm-license.txt"
+              start_line: 4
+              end_line: 29
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/AnnotationVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/AnnotationWriter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/Attribute.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/ByteVector.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/ClassAdapter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/ClassReader.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/ClassVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/ClassWriter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/Edge.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/FieldVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/FieldWriter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/Frame.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/Handler.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/Item.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/Label.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/MethodAdapter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/MethodVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/MethodWriter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/Opcodes.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/Type.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/package.html"
+              start_line: 7
+              end_line: 29
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/signature/SignatureReader.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/signature/SignatureVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/signature/SignatureWriter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/signature/package.html"
+              start_line: 7
+              end_line: 29
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/AbstractInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/AnnotationNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/ClassNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/FieldInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/FieldNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/FrameNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/IincInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/InnerClassNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/InsnList.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/InsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/IntInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/JumpInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/LabelNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/LdcInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/LineNumberNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/LocalVariableNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/LookupSwitchInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/MemberNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/MethodInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/MethodNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/MultiANewArrayInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/TableSwitchInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/TryCatchBlockNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/TypeInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/VarInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/Analyzer.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/AnalyzerException.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/BasicInterpreter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/BasicValue.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/BasicVerifier.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/Frame.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/Interpreter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/SimpleVerifier.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/SmallSet.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/SourceInterpreter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/SourceValue.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/Subroutine.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/Value.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/package.html"
+              start_line: 7
+              end_line: 29
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/package.html"
+              start_line: 7
+              end_line: 29
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/ASMifiable.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/ASMifierAbstractVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/ASMifierAnnotationVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/ASMifierClassVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/ASMifierFieldVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/ASMifierMethodVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/AbstractVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/CheckAnnotationAdapter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/CheckClassAdapter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/CheckFieldAdapter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/CheckMethodAdapter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/CheckSignatureAdapter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/TraceAbstractVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/TraceAnnotationVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/TraceClassVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/TraceFieldVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/TraceMethodVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/TraceSignatureVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/Traceable.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/package.html"
+              start_line: 7
+              end_line: 29
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/cglib/core/LocalVariablesSorter.java"
+              start_line: 6
+              end_line: 28
+          - license: "MIT"
+            location:
+              path: "LICENSE"
+              start_line: 1
+              end_line: 1
+          - license: "MIT"
+            location:
+              path: "LICENSE"
+              start_line: 5
+              end_line: 21
+          - license: "MIT"
+            location:
+              path: "NOTICE"
+              start_line: 1
+              end_line: 1
+          - license: "MIT"
+            location:
+              path: "NOTICE"
+              start_line: 10
+              end_line: 10
+          - license: "MIT"
+            location:
+              path: "org/mockito/AdditionalAnswers.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/AdditionalMatchers.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/Answers.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/ArgumentCaptor.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/ArgumentMatcher.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/BDDMockito.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/Captor.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/InOrder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/Incubating.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/InjectMocks.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/Matchers.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/Mock.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/MockSettings.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/MockingDetails.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/Mockito.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/MockitoAnnotations.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/MockitoDebugger.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/ReturnValues.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/Spy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/configuration/AnnotationEngine.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/configuration/DefaultMockitoConfiguration.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/configuration/IMockitoConfiguration.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/configuration/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/Discrepancy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/Pluralizer.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/PrintableInvocation.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/Reporter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/base/MockitoAssertionError.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/base/MockitoException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/base/MockitoSerializationIssue.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/base/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/CannotVerifyStubOnlyMock.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/FriendlyReminderException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/InvalidUseOfMatchersException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/MissingMethodInvocationException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/MockitoConfigurationException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/NotAMockException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/NullInsteadOfMockException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/UnfinishedStubbingException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/UnfinishedVerificationException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/WrongTypeOfReturnValue.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/stacktrace/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/ArgumentsAreDifferent.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/NeverWantedButInvoked.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/NoInteractionsWanted.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/SmartNullPointerException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/TooLittleActualInvocations.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/TooManyActualInvocations.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/VerificationInOrderFailure.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/WantedButNotInvoked.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/junit/ArgumentsAreDifferent.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/junit/JUnitTool.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/junit/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/InOrderImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/InternalMockHandler.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/MockitoCore.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/CaptorAnnotationProcessor.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/ClassPathLoader.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/DefaultAnnotationEngine.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/DefaultInjectionEngine.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/FieldAnnotationProcessor.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/GlobalConfiguration.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/InjectingAnnotationEngine.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/MockAnnotationProcessor.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/MockitoAnnotationsMockAnnotationProcessor.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/SpyAnnotationEngine.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/ConstructorInjection.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/MockInjection.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/MockInjectionStrategy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/SpyOnInjectedFieldsHandler.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/FinalMockCandidateFilter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/MockCandidateFilter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/NameBasedCandidateFilter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/OngoingInjecter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/scanner/MockScanner.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/DelegatingMethod.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/MockSettingsImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/AcrossJVMSerializationFeature.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/CGLIBHacker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/CglibMockMaker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/ClassImposterizer.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/DelegatingMockitoMethodProxy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/MethodInterceptorFilter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/MockitoNamingPolicy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/SerializableMockitoMethodProxy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/SerializableNoOp.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/settings/CreationSettings.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/util/MockitoMethodProxy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/util/SearchingClassLoader.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/util/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/FindingsListener.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/Localized.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/LocationImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/LoggingListener.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/MockitoDebuggerImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/VerboseMockInvocationLogger.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/WarningsCollector.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/WarningsFinder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/WarningsPrinterImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/exceptions/ExceptionIncludingMockitoWarnings.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/exceptions/VerificationAwareInvocation.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/exceptions/stacktrace/ConditionalStackTraceFilter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/exceptions/stacktrace/StackTraceFilter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/exceptions/stacktrace/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/exceptions/util/ScenarioPrinter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/handler/InvocationNotifierHandler.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/handler/MockHandlerFactory.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/handler/MockHandlerImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/handler/NullResultGuardian.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/AbstractAwareMethod.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/ArgumentsComparator.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/ArgumentsProcessor.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/CapturesArgumensFromInvocation.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/InvocationImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/InvocationMarker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/InvocationMatcher.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/InvocationsFinder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/MatchersBinder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/MockitoMethod.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/SerializableMethod.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/StubInfoImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/UnusedStubsFinder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/finder/AllInvocationsFinder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/finder/VerifiableInvocationsFinder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/realmethod/CleanTraceRealMethod.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/realmethod/DefaultRealMethod.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/realmethod/RealMethod.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/realmethod/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/junit/JUnitTool.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/listeners/CollectCreatedMocks.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/listeners/MockingProgressListener.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/listeners/MockingStartedListener.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/listeners/NotifiedMethodInvocationReport.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/And.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Any.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/AnyVararg.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/ArrayEquals.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/CapturesArguments.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/CapturingMatcher.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/CompareEqual.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/CompareTo.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Contains.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/ContainsExtraTypeInformation.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/EndsWith.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Equality.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Equals.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/EqualsWithDelta.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Find.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/GreaterOrEqual.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/GreaterThan.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/InstanceOf.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/LessOrEqual.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/LessThan.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/LocalizedMatcher.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/MatcherDecorator.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/MatchersPrinter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Matches.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Not.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/NotNull.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Null.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Or.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Same.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/StartsWith.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/VarargMatcher.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/apachecommons/EqualsBuilder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/apachecommons/ReflectionEquals.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/apachecommons/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/ArgumentMatcherStorage.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/ArgumentMatcherStorageImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/HandyReturnValues.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/IOngoingStubbing.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/MockingProgress.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/MockingProgressImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/SequenceNumber.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/ThreadSafeMockingProgress.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/reporting/Discrepancy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/reporting/Pluralizer.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/reporting/PrintSettings.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/reporting/SmartPrinter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/reporting/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/JUnit44RunnerImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/JUnit45AndHigherRunnerImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/RunnerFactory.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/RunnerImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/util/FrameworkUsageValidator.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/util/RunnerProvider.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/util/TestMethodsFinder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/util/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/BaseStubbing.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/ConsecutiveStubbing.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/InvocationContainer.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/InvocationContainerImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/OngoingStubbingImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/StubbedInvocationMatcher.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/StubberImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/VoidMethodStubbableImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/AnswerReturnValuesAdapter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/AnswersValidator.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/CallsRealMethods.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ClonesArguments.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/DoesNothing.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/MethodInfo.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/Returns.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ReturnsElementsOf.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ThrowsException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/Answers.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/GloballyConfiguredAnswer.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsMocks.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsMoreEmptyValues.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/Checks.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/ConsoleMockitoLogger.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/Decamelizer.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/DefaultMockingDetails.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/MockCreationValidator.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/MockNameImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/MockUtil.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/MockitoLogger.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/ObjectMethodsGuru.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/Primitives.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/RemoveFirstLine.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/SimpleMockitoLogger.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/StringJoiner.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/collections/ArrayUtils.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/collections/HashCodeAndEqualsMockWrapper.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/collections/HashCodeAndEqualsSafeSet.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/collections/IdentitySet.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/collections/ListUtil.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/collections/Sets.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/junit/JUnitFailureHacker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/AccessibilityChanger.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/BeanPropertySetter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldCopier.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldInitializationReport.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldInitializer.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldReader.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldSetter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/Fields.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/GenericMaster.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/GenericMetadataSupport.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/InstanceField.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/LenientCopyTool.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/Whitebox.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/AtLeast.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/AtMost.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/Calls.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/DefaultRegisteredInvocations.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/InOrderContextImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/InOrderWrapper.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/MockAwareVerificationMode.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/NoMoreInteractions.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/Only.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/RegisteredInvocations.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/SingleRegisteredInvocation.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/Times.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/VerificationDataImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/VerificationModeFactory.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/VerificationOverTimeImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/api/InOrderContext.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/api/VerificationData.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/api/VerificationDataInOrder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/api/VerificationDataInOrderImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/api/VerificationInOrderMode.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/api/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/argumentmatching/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/AtLeastDiscrepancy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsChecker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsInOrderChecker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/MissingInvocationChecker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/MissingInvocationInOrderChecker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/NonGreedyNumberOfInvocationsInOrderChecker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/NumberOfInvocationsChecker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/NumberOfInvocationsInOrderChecker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/invocation/DescribedInvocation.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/invocation/Invocation.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/invocation/InvocationOnMock.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/invocation/Location.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/invocation/MockHandler.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/invocation/StubInfo.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/invocation/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/listeners/InvocationListener.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/listeners/MethodInvocationReport.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/listeners/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/mock/MockCreationSettings.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/mock/MockName.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/plugins/MockMaker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/plugins/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/runners/ConsoleSpammingMockitoJUnitRunner.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/runners/MockitoJUnit44Runner.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/runners/MockitoJUnitRunner.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/runners/VerboseMockitoJUnitRunner.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/runners/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/stubbing/Answer.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/stubbing/DeprecatedOngoingStubbing.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/stubbing/OngoingStubbing.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/stubbing/Stubber.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/stubbing/VoidMethodStubbable.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/stubbing/answers/ReturnsElementsOf.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/stubbing/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/verification/Timeout.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/verification/VerificationAfterDelay.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/verification/VerificationMode.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/verification/VerificationWithTimeout.java"
+              start_line: 3
+              end_line: 3
+          copyrights:
+          - statement: "Copyright (c) 2000-2005 INRIA, France Telecom"
+            location:
+              path: "asm-license.txt"
+              start_line: 1
+              end_line: 2
+          - statement: "Copyright (c) 2000-2005 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/package.html"
+              start_line: 4
+              end_line: 5
+          - statement: "Copyright (c) 2000-2005 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/signature/package.html"
+              start_line: 4
+              end_line: 5
+          - statement: "Copyright (c) 2000-2005 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/package.html"
+              start_line: 4
+              end_line: 5
+          - statement: "Copyright (c) 2000-2005 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/package.html"
+              start_line: 4
+              end_line: 5
+          - statement: "Copyright (c) 2000-2005 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/package.html"
+              start_line: 4
+              end_line: 5
+          - statement: "Copyright (c) 2000-2005 INRIA, France Telecom"
+            location:
+              path: "org/mockito/cglib/core/LocalVariablesSorter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/AnnotationVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/AnnotationWriter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/Attribute.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/ByteVector.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/ClassAdapter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/ClassReader.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/ClassVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/ClassWriter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/Edge.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/FieldVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/FieldWriter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/Frame.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/Handler.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/Item.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/Label.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/MethodAdapter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/MethodVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/MethodWriter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/Opcodes.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/Type.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/signature/SignatureReader.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/signature/SignatureVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/signature/SignatureWriter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/AbstractInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/AnnotationNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/ClassNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/FieldInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/FieldNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/FrameNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/IincInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/InnerClassNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/InsnList.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/InsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/IntInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/JumpInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/LabelNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/LdcInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/LineNumberNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/LocalVariableNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/LookupSwitchInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/MemberNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/MethodInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/MethodNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/MultiANewArrayInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/TableSwitchInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/TryCatchBlockNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/TypeInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/VarInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/Analyzer.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/AnalyzerException.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/BasicInterpreter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/BasicValue.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/BasicVerifier.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/Frame.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/Interpreter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/SimpleVerifier.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/SmallSet.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/SourceInterpreter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/SourceValue.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/Subroutine.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/Value.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/ASMifiable.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/ASMifierAbstractVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/ASMifierAnnotationVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/ASMifierClassVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/ASMifierFieldVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/ASMifierMethodVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/AbstractVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/CheckAnnotationAdapter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/CheckClassAdapter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/CheckFieldAdapter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/CheckMethodAdapter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/CheckSignatureAdapter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/TraceAbstractVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/TraceAnnotationVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/TraceClassVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/TraceFieldVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/TraceMethodVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/TraceSignatureVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/Traceable.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "LICENSE"
+              start_line: 3
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/AdditionalAnswers.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/AdditionalMatchers.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/Answers.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/ArgumentCaptor.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/ArgumentMatcher.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/BDDMockito.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/Captor.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/InOrder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/Incubating.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/InjectMocks.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/Matchers.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/Mock.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/MockSettings.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/MockingDetails.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/Mockito.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/MockitoAnnotations.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/MockitoDebugger.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/ReturnValues.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/Spy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/configuration/AnnotationEngine.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/configuration/DefaultMockitoConfiguration.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/configuration/IMockitoConfiguration.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/configuration/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/Discrepancy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/Pluralizer.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/PrintableInvocation.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/Reporter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/base/MockitoAssertionError.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/base/MockitoException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/base/MockitoSerializationIssue.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/base/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/CannotVerifyStubOnlyMock.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/FriendlyReminderException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/InvalidUseOfMatchersException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/MissingMethodInvocationException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/MockitoConfigurationException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/NotAMockException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/NullInsteadOfMockException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/UnfinishedStubbingException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/UnfinishedVerificationException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/WrongTypeOfReturnValue.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/stacktrace/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/ArgumentsAreDifferent.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/NeverWantedButInvoked.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/NoInteractionsWanted.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/SmartNullPointerException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/TooLittleActualInvocations.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/TooManyActualInvocations.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/VerificationInOrderFailure.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/WantedButNotInvoked.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/junit/ArgumentsAreDifferent.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/junit/JUnitTool.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/junit/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/InOrderImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/InternalMockHandler.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/MockitoCore.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/CaptorAnnotationProcessor.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/ClassPathLoader.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/DefaultAnnotationEngine.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/DefaultInjectionEngine.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/FieldAnnotationProcessor.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/GlobalConfiguration.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/InjectingAnnotationEngine.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/MockAnnotationProcessor.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/MockitoAnnotationsMockAnnotationProcessor.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/SpyAnnotationEngine.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/ConstructorInjection.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/MockInjection.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/MockInjectionStrategy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/SpyOnInjectedFieldsHandler.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/FinalMockCandidateFilter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/MockCandidateFilter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/NameBasedCandidateFilter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/OngoingInjecter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/scanner/MockScanner.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/DelegatingMethod.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/MockSettingsImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/AcrossJVMSerializationFeature.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/CGLIBHacker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/CglibMockMaker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/ClassImposterizer.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/DelegatingMockitoMethodProxy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/MethodInterceptorFilter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/MockitoNamingPolicy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/SerializableMockitoMethodProxy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/SerializableNoOp.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/settings/CreationSettings.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/util/MockitoMethodProxy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/util/SearchingClassLoader.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/util/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/FindingsListener.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/Localized.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/LocationImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/LoggingListener.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/MockitoDebuggerImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/VerboseMockInvocationLogger.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/WarningsCollector.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/WarningsFinder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/WarningsPrinterImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/exceptions/ExceptionIncludingMockitoWarnings.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/exceptions/VerificationAwareInvocation.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/exceptions/stacktrace/ConditionalStackTraceFilter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/exceptions/stacktrace/StackTraceFilter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/exceptions/stacktrace/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/exceptions/util/ScenarioPrinter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/handler/InvocationNotifierHandler.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/handler/MockHandlerFactory.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/handler/MockHandlerImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/handler/NullResultGuardian.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/AbstractAwareMethod.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/ArgumentsComparator.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/ArgumentsProcessor.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/CapturesArgumensFromInvocation.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/InvocationImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/InvocationMarker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/InvocationMatcher.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/InvocationsFinder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/MatchersBinder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/MockitoMethod.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/SerializableMethod.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/StubInfoImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/UnusedStubsFinder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/finder/AllInvocationsFinder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/finder/VerifiableInvocationsFinder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/realmethod/CleanTraceRealMethod.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/realmethod/DefaultRealMethod.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/realmethod/RealMethod.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/realmethod/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/junit/JUnitTool.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/listeners/CollectCreatedMocks.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/listeners/MockingProgressListener.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/listeners/MockingStartedListener.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/listeners/NotifiedMethodInvocationReport.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/And.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Any.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/AnyVararg.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/ArrayEquals.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/CapturesArguments.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/CapturingMatcher.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/CompareEqual.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/CompareTo.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Contains.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/ContainsExtraTypeInformation.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/EndsWith.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Equality.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Equals.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/EqualsWithDelta.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Find.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/GreaterOrEqual.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/GreaterThan.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/InstanceOf.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/LessOrEqual.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/LessThan.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/LocalizedMatcher.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/MatcherDecorator.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/MatchersPrinter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Matches.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Not.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/NotNull.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Null.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Or.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Same.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/StartsWith.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/VarargMatcher.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/apachecommons/EqualsBuilder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/apachecommons/ReflectionEquals.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/apachecommons/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/ArgumentMatcherStorage.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/ArgumentMatcherStorageImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/HandyReturnValues.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/IOngoingStubbing.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/MockingProgress.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/MockingProgressImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/SequenceNumber.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/ThreadSafeMockingProgress.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/reporting/Discrepancy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/reporting/Pluralizer.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/reporting/PrintSettings.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/reporting/SmartPrinter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/reporting/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/JUnit44RunnerImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/JUnit45AndHigherRunnerImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/RunnerFactory.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/RunnerImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/util/FrameworkUsageValidator.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/util/RunnerProvider.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/util/TestMethodsFinder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/util/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/BaseStubbing.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/ConsecutiveStubbing.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/InvocationContainer.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/InvocationContainerImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/OngoingStubbingImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/StubbedInvocationMatcher.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/StubberImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/VoidMethodStubbableImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/AnswerReturnValuesAdapter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/AnswersValidator.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/CallsRealMethods.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ClonesArguments.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/DoesNothing.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/MethodInfo.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/Returns.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ReturnsElementsOf.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ThrowsException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/Answers.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/GloballyConfiguredAnswer.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsMocks.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsMoreEmptyValues.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/Checks.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/ConsoleMockitoLogger.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/Decamelizer.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/DefaultMockingDetails.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/MockCreationValidator.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/MockNameImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/MockUtil.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/MockitoLogger.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/ObjectMethodsGuru.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/Primitives.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/RemoveFirstLine.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/SimpleMockitoLogger.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/StringJoiner.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/collections/ArrayUtils.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/collections/HashCodeAndEqualsMockWrapper.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/collections/HashCodeAndEqualsSafeSet.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/collections/IdentitySet.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/collections/ListUtil.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/collections/Sets.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/junit/JUnitFailureHacker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/AccessibilityChanger.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/BeanPropertySetter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldCopier.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldInitializationReport.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldInitializer.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldReader.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldSetter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/Fields.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/GenericMaster.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/GenericMetadataSupport.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/InstanceField.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/LenientCopyTool.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/Whitebox.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/AtLeast.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/AtMost.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/Calls.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/DefaultRegisteredInvocations.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/InOrderContextImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/InOrderWrapper.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/MockAwareVerificationMode.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/NoMoreInteractions.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/Only.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/RegisteredInvocations.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/SingleRegisteredInvocation.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/Times.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/VerificationDataImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/VerificationModeFactory.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/VerificationOverTimeImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/api/InOrderContext.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/api/VerificationData.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/api/VerificationDataInOrder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/api/VerificationDataInOrderImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/api/VerificationInOrderMode.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/api/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/argumentmatching/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/AtLeastDiscrepancy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsChecker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsInOrderChecker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/MissingInvocationChecker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/MissingInvocationInOrderChecker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/NonGreedyNumberOfInvocationsInOrderChecker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/NumberOfInvocationsChecker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/NumberOfInvocationsInOrderChecker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/invocation/DescribedInvocation.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/invocation/Invocation.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/invocation/InvocationOnMock.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/invocation/Location.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/invocation/MockHandler.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/invocation/StubInfo.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/invocation/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/listeners/InvocationListener.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/listeners/MethodInvocationReport.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/listeners/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/mock/MockCreationSettings.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/mock/MockName.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/plugins/MockMaker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/plugins/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/runners/ConsoleSpammingMockitoJUnitRunner.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/runners/MockitoJUnit44Runner.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/runners/MockitoJUnitRunner.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/runners/VerboseMockitoJUnitRunner.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/runners/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/stubbing/Answer.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/stubbing/DeprecatedOngoingStubbing.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/stubbing/OngoingStubbing.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/stubbing/Stubber.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/stubbing/VoidMethodStubbable.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/stubbing/answers/ReturnsElementsOf.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/stubbing/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/verification/Timeout.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/verification/VerificationAfterDelay.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/verification/VerificationMode.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/verification/VerificationWithTimeout.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright 2002,2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/Factory.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2002,2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/MethodInterceptor.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2002,2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/UndeclaredThrowableException.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2002,2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/Enhancer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/BeanGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/BulkBean.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/BulkBeanException.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/FixedKeySet.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/Block.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ClassEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ClassGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ClassNameReader.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ClassesKey.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/CodeGenerationException.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/Constants.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/Converter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/Customizer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/DefaultGeneratorStrategy.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/DuplicatesPredicate.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/GeneratorStrategy.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/Local.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/NamingPolicy.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ObjectSwitchCallback.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/Predicate.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ProcessArrayCallback.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ProcessSwitchCallback.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/Signature.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/TinyBitSet.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/Transformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/Callback.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/Dispatcher.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/FixedValue.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/InvocationHandler.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/LazyLoader.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/MixinBeanEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/NoOp.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/ProxyRefDispatcher.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/reflect/ConstructorDelegate.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/reflect/FastConstructor.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/reflect/FastMember.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/AbstractClassTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/AbstractProcessTask.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/AnnotationVisitorTee.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassEmitterTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassFilter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassReaderGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassTransformerFactory.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassTransformerTee.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassVisitorTee.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/FieldVisitorTee.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/MethodFilter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/MethodFilterTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/MethodVisitorTee.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/TransformingClassGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/TransformingClassLoader.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/AccessFieldTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/AddDelegateTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/AddPropertyTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/FieldProvider.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/FieldProviderTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/InterceptFieldCallback.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/InterceptFieldEnabled.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/InterceptFieldFilter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/InterceptFieldTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/UndeclaredThrowableStrategy.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/UndeclaredThrowableTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/util/ParallelSorter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/util/ParallelSorterEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/util/SorterTemplate.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/util/StringSwitcher.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/BeanCopier.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/BeanMap.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/BeanMapEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/BulkBeanEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/ImmutableBean.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/AbstractClassGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/CodeEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/CollectionUtils.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/DebuggingClassWriter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/DefaultNamingPolicy.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/EmitUtils.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/KeyFactory.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/MethodWrapper.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ReflectUtils.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/TypeUtils.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/VisibilityPredicate.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/CallbackFilter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/CallbackGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/DispatcherGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/FixedValueGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/InvocationHandlerGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/LazyLoaderGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/MethodInterceptorGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/MethodProxy.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/Mixin.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/MixinEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/NoOpGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/Proxy.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/reflect/FastClass.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/reflect/FastClassEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/reflect/FastMethod.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/reflect/MethodDelegate.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/reflect/MulticastDelegate.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/AbstractClassLoader.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/AbstractTransformTask.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassFilterTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassTransformerChain.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/AddStaticInitTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ClassInfo.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/MethodInfo.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/MethodInfoTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/RejectModifierPredicate.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/CallbackHelper.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/CallbackInfo.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/InterfaceMaker.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/MixinEverythingEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/AbstractClassFilterTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/AbstractInterceptFieldCallback.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/AddInitTransformer.java"
+              start_line: 2
+              end_line: 2
+    storage_stats:
+      num_reads: 4
+      num_hits: 4
+    has_issues: false
+advisor:
+  start_time: "2021-03-30T01:21:54.671027Z"
+  end_time: "2021-03-30T01:21:56.567225Z"
+  environment:
+    ort_version: "de3668b"
+    java_version: "11.0.8"
+    os: "Linux"
+    processors: 4
+    max_memory: 12884901888
+    variables:
+      JAVA_HOME: "/opt/java/openjdk"
+      ANDROID_HOME: "/opt/android-sdk"
+      GOPATH: "/go"
+    tool_versions: {}
+  config:
+    nexus_iq:
+      server_url: "https://nexusiq-production-basic-auth.osm-si.com"
+      browse_url: "https://nexusiq-production.osm-si.com"
+      username: "osi9be"
+    vulnerable_code: null
+  results:
+    advisor_results:
+      Maven:junit:junit:4.12:
+      - vulnerabilities:
+        - id: "CVE-2020-15250"
+          severity: 5.5
+          url: "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250"
+        advisor:
+          name: "NexusIQ"
+        summary:
+          start_time: "2021-03-30T01:21:55.532835Z"
+          end_time: "2021-03-30T01:21:56.560374Z"
+    has_issues: false
+evaluator:
+  start_time: "2021-03-30T01:36:23.566808Z"
+  end_time: "2021-03-30T01:36:30.715613Z"
+  violations:
+  - rule: "Rules not finalized yet"
+    pkg: ":::"
+    license: null
+    license_source: null
+    severity: "HINT"
+    message: "This is only a preliminary report, as not all policy rules are implemented\
+      \ yet.\nNot all possible policy violations are shown in this report.\nHandle\
+      \ with care."
+    how_to_fix: "Please contact [osmi-support@bosch.io](mailto:osmi-support@bosch.io)\
+      \ in case of any questions."
+labels:
+  applicationCategory: "BT05 Client application"
+  projectName: "Test ORT"

--- a/model/src/test/assets/advisor-result-vulnerability-refs.yml
+++ b/model/src/test/assets/advisor-result-vulnerability-refs.yml
@@ -1,0 +1,6276 @@
+---
+advisor:
+  results:
+    advisor_results:
+      Maven:junit:junit:4.12:
+      - vulnerabilities:
+        - id: "CVE-2020-15250"
+          references:
+          - url: "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250"
+            severity: "5.5"
+        advisor:
+          name: "NexusIQ"
+        summary:
+          start_time: "2021-03-30T01:21:55.532835Z"
+          end_time: "2021-03-30T01:21:56.560374Z"
+    has_issues: false
+  start_time: "2021-03-30T01:21:54.671027Z"
+  end_time: "2021-03-30T01:21:56.567225Z"
+  environment:
+    ort_version: "de3668b"
+    java_version: "11.0.8"
+    os: "Linux"
+    processors: 4
+    max_memory: 12884901888
+    variables:
+      JAVA_HOME: "/opt/java/openjdk"
+      ANDROID_HOME: "/opt/android-sdk"
+      GOPATH: "/go"
+    tool_versions: {}
+  config:
+    nexus_iq:
+      server_url: "https://nexusiq-production-basic-auth.osm-si.com"
+      browse_url: "https://nexusiq-production.osm-si.com"
+      username: "osi9be"
+    vulnerable_code: null
+repository:
+  vcs:
+    type: "Git"
+    url: "https://github.com/vdurmont/semver4j.git"
+    revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/vdurmont/semver4j.git"
+    revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+    path: ""
+  config: {}
+analyzer:
+  start_time: "2021-03-30T01:07:44.010004Z"
+  end_time: "2021-03-30T01:07:54.268037Z"
+  environment:
+    ort_version: "de3668b"
+    java_version: "11.0.8"
+    os: "Linux"
+    processors: 4
+    max_memory: 12884901888
+    variables:
+      JAVA_HOME: "/opt/java/openjdk"
+      ANDROID_HOME: "/opt/android-sdk"
+      GOPATH: "/go"
+    tool_versions: {}
+  config:
+    ignore_tool_versions: false
+    allow_dynamic_versions: false
+  result:
+    projects:
+    - id: "Maven:com.vdurmont:semver4j:3.1.0"
+      definition_file_path: "pom.xml"
+      authors:
+      - "Vincent DURMONT"
+      declared_licenses:
+      - "The MIT License"
+      declared_licenses_processed:
+        spdx_expression: "MIT"
+        mapped:
+          The MIT License: "MIT"
+      vcs:
+        type: "Git"
+        url: "git@github.com:vdurmont/semver4j.git"
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/vdurmont/semver4j.git"
+        revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+        path: ""
+      homepage_url: "https://github.com/vdurmont/semver4j"
+      scopes:
+      - name: "test"
+        dependencies:
+        - id: "Maven:junit:junit:4.12"
+          dependencies:
+          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+        - id: "Maven:org.mockito:mockito-all:1.10.19"
+    packages:
+    - package:
+        id: "Maven:junit:junit:4.12"
+        purl: "pkg:maven/junit/junit@4.12"
+        authors:
+        - "David Saff"
+        - "JUnit"
+        - "Kevin Cooney"
+        - "Marc Philipp"
+        - "Stefan Birkner"
+        declared_licenses:
+        - "Eclipse Public License 1.0"
+        declared_licenses_processed:
+          spdx_expression: "EPL-1.0"
+          mapped:
+            Eclipse Public License 1.0: "EPL-1.0"
+        concluded_license: "EPL-1.0"
+        description: "JUnit is a unit testing framework for Java, created by Erich\
+          \ Gamma and Kent Beck."
+        homepage_url: "http://junit.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
+          hash:
+            value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+          hash:
+            value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "https://github.com/junit-team/junit4.git"
+          revision: "r4.12"
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/junit-team/junit4.git"
+          revision: "r4.12"
+          path: ""
+      curations:
+      - base:
+          vcs:
+            type: "Git"
+            url: "git://github.com/junit-team/junit.git"
+            revision: "r4.12"
+            path: ""
+        curation:
+          concluded_license: "EPL-1.0"
+          vcs:
+            type: "Git"
+            url: "https://github.com/junit-team/junit4.git"
+            revision: "r4.12"
+          comment: "ScanCode claims to find some NOASSERTION and Apache-2.0 in the\
+            \ FAQ and the pom.xml, both are false-positives."
+    - package:
+        id: "Maven:org.hamcrest:hamcrest-core:1.3"
+        purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
+        authors:
+        - "Joe Walnes"
+        - "Nat Pryce"
+        - "Neil Dunn"
+        - "Steve Freeman"
+        - "Tom Denley"
+        declared_licenses:
+        - "BSD-3-Clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+        description: "This is the core API of hamcrest matcher framework to be used\
+          \ by third-party framework providers. This includes the a foundation set\
+          \ of matcher implementations for common operations."
+        homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
+          hash:
+            value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+          hash:
+            value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:hamcrest/JavaHamcrest.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
+          revision: ""
+          path: ""
+      curations:
+      - base:
+          declared_licenses:
+          - "New BSD License"
+        curation:
+          declared_licenses:
+          - "BSD-3-Clause"
+          comment: "Provided by ClearlyDefined."
+    - package:
+        id: "Maven:org.mockito:mockito-all:1.10.19"
+        purl: "pkg:maven/org.mockito/mockito-all@1.10.19"
+        authors:
+        - "Szczepan Faber"
+        declared_licenses:
+        - "MIT"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+        description: "Mock objects library for java"
+        homepage_url: "http://www.mockito.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/mockito/mockito-all/1.10.19/mockito-all-1.10.19.jar"
+          hash:
+            value: "539df70269cc254a58cccc5d8e43286b4a73bf30"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/mockito/mockito-all/1.10.19/mockito-all-1.10.19-sources.jar"
+          hash:
+            value: "8269667b73d9616600359a9b0ba1b1c7d0cf7a97"
+            algorithm: "SHA-1"
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+      curations:
+      - base:
+          declared_licenses:
+          - "The MIT License"
+        curation:
+          declared_licenses:
+          - "MIT"
+          comment: "Provided by ClearlyDefined."
+    has_issues: false
+scanner:
+  start_time: "2021-03-30T01:25:55.052430Z"
+  end_time: "2021-03-30T01:25:57.605188Z"
+  environment:
+    ort_version: "de3668b"
+    java_version: "11.0.8"
+    os: "Linux"
+    processors: 4
+    max_memory: 12884901888
+    variables:
+      JAVA_HOME: "/opt/java/openjdk"
+      ANDROID_HOME: "/opt/android-sdk"
+      GOPATH: "/go"
+    tool_versions: {}
+  config:
+    archive:
+      file_storage:
+        http_file_storage:
+          url: "https://osmiocaasprodarchive.blob.core.windows.net/archive"
+          query: "***"
+          headers:
+            x-ms-blob-type: "***"
+        local_file_storage: null
+      postgres_storage: null
+    create_missing_archives: true
+    options:
+      ScanCode:
+        parseLicenseExpressions: "true"
+      FossId:
+        user: "osi9be"
+    storages:
+      postgresStorage: !<.PostgresStorageConfiguration>
+        url: "jdbc:postgresql://osmi-ocaas-prod-pipeline-psqlserver.postgres.database.azure.com:5432/ort?gssEncMode=disable"
+        schema: "scan_storage"
+        username: "c186cd7f9cd62563f64b7c4fda307d34@osmi-ocaas-prod-pipeline-psqlserver.postgres.database.azure.com"
+        sslmode: "require"
+        sslcert: null
+        sslkey: null
+        sslrootcert: null
+    storage_readers:
+    - "postgresStorage"
+    storage_writers:
+    - "postgresStorage"
+    ignore_patterns:
+    - "**/*.ort.yml"
+    - "**/META-INF/DEPENDENCIES"
+  results:
+    scan_results:
+      Maven:com.vdurmont:semver4j:3.1.0:
+      - provenance:
+          download_time: "2020-09-30T09:27:08.894485Z"
+          vcs_info:
+            type: "Git"
+            url: "https://github.com/vdurmont/semver4j.git"
+            revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+            resolved_revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+            path: ""
+          original_vcs_info:
+            type: "Git"
+            url: "https://github.com/vdurmont/semver4j.git"
+            revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+            path: ""
+        scanner:
+          name: "ScanCode"
+          version: "3.2.1-rc2"
+          configuration: "--copyright --license --info --strip-root --timeout 300\
+            \ --json-pp"
+        summary:
+          start_time: "2020-09-30T09:27:12.023451Z"
+          end_time: "2020-09-30T09:28:20.525647Z"
+          file_count: 16
+          package_verification_code: "48ba11487d53ce933b5d4db1d069b70a803ff19b"
+          licenses:
+          - license: "BSD-3-Clause"
+            location:
+              path: "pom.xml"
+              start_line: 28
+              end_line: 34
+          - license: "MIT"
+            location:
+              path: "LICENSE.md"
+              start_line: 1
+              end_line: 1
+          - license: "MIT"
+            location:
+              path: "LICENSE.md"
+              start_line: 5
+              end_line: 21
+          - license: "MIT"
+            location:
+              path: "pom.xml"
+              start_line: 30
+              end_line: 31
+          copyrights:
+          - statement: "Copyright (c) 2015-present Vincent DURMONT <vdurmont@gmail.com>"
+            location:
+              path: "LICENSE.md"
+              start_line: 3
+              end_line: 3
+      Maven:junit:junit:4.12:
+      - provenance:
+          download_time: "2021-03-22T16:38:03.486241Z"
+          vcs_info:
+            type: "Git"
+            url: "https://github.com/junit-team/junit4.git"
+            revision: "r4.12"
+            resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
+            path: ""
+          original_vcs_info:
+            type: "Git"
+            url: "https://github.com/junit-team/junit4.git"
+            revision: "r4.12"
+            path: ""
+        scanner:
+          name: "ScanCode"
+          version: "3.2.1-rc2"
+          configuration: "--copyright --license --info --strip-root --timeout 300\
+            \ --json-pp"
+        summary:
+          start_time: "2021-03-22T16:38:10.201134Z"
+          end_time: "2021-03-22T16:39:16.747151Z"
+          file_count: 478
+          package_verification_code: "2acb4f0b06b706fa94e9159c2f9abc1397c46ba0"
+          licenses:
+          - license: "Apache-2.0"
+            location:
+              path: "src/site/resources/css/hopscotch-0.1.2.min.css"
+              start_line: 5
+              end_line: 15
+          - license: "Apache-2.0"
+            location:
+              path: "src/site/resources/scripts/hopscotch-0.1.2.min.js"
+              start_line: 5
+              end_line: 15
+          - license: "Apache-2.0 OR EPL-2.0"
+            location:
+              path: "pom.xml"
+              start_line: 19
+              end_line: 23
+          - license: "EPL-1.0"
+            location:
+              path: "LICENSE-junit.txt"
+              start_line: 3
+              end_line: 213
+          - license: "EPL-1.0"
+            location:
+              path: "epl-v10.html"
+              start_line: 7
+              end_line: 257
+          - license: "EPL-1.0"
+            location:
+              path: "pom.xml"
+              start_line: 18
+              end_line: 20
+          - license: "EPL-1.0"
+            location:
+              path: "src/site/fml/faq.fml"
+              start_line: 157
+              end_line: 157
+          - license: "NOASSERTION"
+            location:
+              path: "src/site/fml/faq.fml"
+              start_line: 156
+              end_line: 156
+          copyrights:
+          - statement: "Copyright 2013 LinkedIn Corp."
+            location:
+              path: "src/site/resources/css/hopscotch-0.1.2.min.css"
+              start_line: 3
+              end_line: 3
+          - statement: "Copyright 2013 LinkedIn Corp."
+            location:
+              path: "src/site/resources/scripts/hopscotch-0.1.2.min.js"
+              start_line: 3
+              end_line: 3
+      Maven:org.hamcrest:hamcrest-core:1.3:
+      - provenance:
+          download_time: "2021-03-23T07:34:08.704983Z"
+          vcs_info:
+            type: "Git"
+            url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
+            revision: "36d525e1e425006939a77aec5183aecd7c775b05"
+            resolved_revision: "36d525e1e425006939a77aec5183aecd7c775b05"
+            path: ""
+          original_vcs_info:
+            type: "Git"
+            url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
+            revision: ""
+            path: ""
+        scanner:
+          name: "ScanCode"
+          version: "3.2.1-rc2"
+          configuration: "--copyright --license --info --strip-root --timeout 300\
+            \ --json-pp"
+        summary:
+          start_time: "2021-03-23T07:34:13.547701Z"
+          end_time: "2021-03-23T07:34:44.000299Z"
+          file_count: 213
+          package_verification_code: "251423eeb35c4e26853c23c4ffadd9381a5d07eb"
+          licenses:
+          - license: "Apache-2.0"
+            location:
+              path: "googlecode_upload.py"
+              start_line: 39
+              end_line: 40
+          - license: "Apache-2.0"
+            location:
+              path: "lib/integration/testng-license.txt"
+              start_line: 1
+              end_line: 201
+          - license: "BSD-3-Clause"
+            location:
+              path: "LICENSE.txt"
+              start_line: 1
+              end_line: 27
+          - license: "BSD-3-Clause"
+            location:
+              path: "lib/integration/jmock-license.txt"
+              start_line: 4
+              end_line: 25
+          - license: "BSD-3-Clause"
+            location:
+              path: "pom/hamcrest-parent.pom"
+              start_line: 15
+              end_line: 21
+          - license: "CPL-1.0"
+            location:
+              path: "lib/integration/junit-license.html"
+              start_line: 4
+              end_line: 119
+          - license: "MIT"
+            location:
+              path: "lib/integration/easymock-license.html"
+              start_line: 14
+              end_line: 14
+          - license: "MIT"
+            location:
+              path: "lib/integration/easymock-license.html"
+              start_line: 20
+              end_line: 26
+          copyrights:
+          - statement: "Copyright (c) 2000-20010 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/beans/HasPropertyWithValueTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-20010 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/IsNullTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2003, jMock.org"
+            location:
+              path: "lib/integration/jmock-license.txt"
+              start_line: 1
+              end_line: 2
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/BaseMatcher.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/Matcher.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/MatcherAssert.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/DescribedAs.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/IsAnything.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/IsEqual.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/IsInstanceOf.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/IsSame.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/StringContains.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/StringEndsWith.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/StringStartsWith.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-library/src/main/java/org/hamcrest/beans/HasProperty.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-library/src/main/java/org/hamcrest/beans/HasPropertyWithValue.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-library/src/main/java/org/hamcrest/beans/PropertyUtil.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-library/src/main/java/org/hamcrest/number/IsCloseTo.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-library/src/main/java/org/hamcrest/object/IsEventFrom.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-library/src/main/java/org/hamcrest/text/IsEqualIgnoringCase.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-library/src/main/java/org/hamcrest/text/IsEqualIgnoringWhiteSpace.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/AbstractMatcherTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/beans/HasPropertyTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/DescribedAsTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/IsEqualTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/IsSameTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/number/IsCloseToTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/object/IsEventFromTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/text/IsEqualIgnoringCaseTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/text/IsEqualIgnoringWhiteSpaceTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/text/StringContainsTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/text/StringEndsWithTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/text/StringStartsWithTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006, www.hamcrest.org"
+            location:
+              path: "LICENSE.txt"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2008 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/beans/SamePropertyValuesAsTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2009 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/IsNot.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2009 hamcrest.org"
+            location:
+              path: "hamcrest-library/src/main/java/org/hamcrest/number/OrderingComparison.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2009 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/IsNotTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2009 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/number/OrderingComparisonTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2010 hamcrest.org"
+            location:
+              path: "hamcrest-core/src/main/java/org/hamcrest/core/IsNull.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2010 hamcrest.org"
+            location:
+              path: "hamcrest-examples/src/main/java/org/hamcrest/examples/junit4/ExampleWithAssertThat.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2010 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/AllOfTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2010 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/AnyOfTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2010 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/IsAnythingTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2010 hamcrest.org"
+            location:
+              path: "hamcrest-unit-test/src/main/java/org/hamcrest/core/IsInstanceOfTest.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2001-2006 http://www.offis.de' OFFIS, http://www.tammofreese.de'\
+              \ Tammo Freese"
+            location:
+              path: "lib/integration/easymock-license.html"
+              start_line: 17
+              end_line: 17
+          - statement: "Copyright 2006, 2007 Google Inc."
+            location:
+              path: "googlecode_upload.py"
+              start_line: 3
+              end_line: 3
+      - provenance:
+          download_time: "2020-09-30T09:29:05.259873Z"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+            hash:
+              value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+              algorithm: "SHA-1"
+        scanner:
+          name: "ScanCode"
+          version: "3.2.1-rc2"
+          configuration: "--copyright --license --info --strip-root --timeout 300\
+            \ --json-pp"
+        summary:
+          start_time: "2020-09-30T09:29:05.608077Z"
+          end_time: "2020-09-30T09:29:11.356106Z"
+          file_count: 41
+          package_verification_code: "a42897bec728695ae0e3ecdcc891ced065dae355"
+          licenses: []
+          copyrights:
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/BaseMatcher.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/Matcher.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/MatcherAssert.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/DescribedAs.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/IsAnything.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/IsEqual.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/IsInstanceOf.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/IsSame.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/StringContains.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/StringEndsWith.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2006 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/StringStartsWith.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2009 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/IsNot.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) 2000-2010 hamcrest.org"
+            location:
+              path: "org/hamcrest/core/IsNull.java"
+              start_line: 1
+              end_line: 1
+      Maven:org.mockito:mockito-all:1.10.19:
+      - provenance:
+          download_time: "2020-09-30T09:29:12.938665Z"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/mockito/mockito-all/1.10.19/mockito-all-1.10.19-sources.jar"
+            hash:
+              value: "8269667b73d9616600359a9b0ba1b1c7d0cf7a97"
+              algorithm: "SHA-1"
+        scanner:
+          name: "ScanCode"
+          version: "3.2.1-rc2"
+          configuration: "--copyright --license --info --strip-root --timeout 300\
+            \ --json-pp"
+        summary:
+          start_time: "2020-09-30T09:29:13.204350Z"
+          end_time: "2020-09-30T09:30:08.409869Z"
+          file_count: 576
+          package_verification_code: "956e73550e4be365fdc0d20d75614c5c983da68d"
+          licenses:
+          - license: "Apache-2.0"
+            location:
+              path: "NOTICE"
+              start_line: 5
+              end_line: 5
+          - license: "Apache-2.0"
+            location:
+              path: "cglib-license.txt"
+              start_line: 1
+              end_line: 201
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/BeanCopier.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/BeanGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/BeanMap.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/BeanMapEmitter.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/BulkBean.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/BulkBeanEmitter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/BulkBeanException.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/FixedKeySet.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/beans/ImmutableBean.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/AbstractClassGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/Block.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ClassEmitter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ClassGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ClassInfo.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ClassNameReader.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ClassesKey.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/CodeEmitter.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/CodeGenerationException.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/CollectionUtils.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/Constants.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/Converter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/Customizer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/DebuggingClassWriter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/DefaultGeneratorStrategy.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/DefaultNamingPolicy.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/DuplicatesPredicate.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/EmitUtils.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/GeneratorStrategy.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/KeyFactory.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/Local.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/MethodInfo.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/MethodInfoTransformer.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/MethodWrapper.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/NamingPolicy.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ObjectSwitchCallback.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/Predicate.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ProcessArrayCallback.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ProcessSwitchCallback.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/ReflectUtils.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/RejectModifierPredicate.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/Signature.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/TinyBitSet.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/Transformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/TypeUtils.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/core/VisibilityPredicate.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/Callback.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/CallbackFilter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/CallbackGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/CallbackHelper.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/CallbackInfo.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/Dispatcher.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/DispatcherGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/Enhancer.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/Factory.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/FixedValue.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/FixedValueGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/InterfaceMaker.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/InvocationHandler.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/InvocationHandlerGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/LazyLoader.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/LazyLoaderGenerator.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/MethodInterceptor.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/MethodInterceptorGenerator.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/MethodProxy.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/Mixin.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/MixinBeanEmitter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/MixinEmitter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/MixinEverythingEmitter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/NoOp.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/NoOpGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/Proxy.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/ProxyRefDispatcher.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/proxy/UndeclaredThrowableException.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/reflect/ConstructorDelegate.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/reflect/FastClass.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/reflect/FastClassEmitter.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/reflect/FastConstructor.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/reflect/FastMember.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/reflect/FastMethod.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/reflect/MethodDelegate.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/reflect/MulticastDelegate.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/AbstractClassFilterTransformer.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/AbstractClassLoader.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/AbstractClassTransformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/AbstractProcessTask.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/AbstractTransformTask.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/AnnotationVisitorTee.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassEmitterTransformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassFilter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassFilterTransformer.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassReaderGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassTransformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassTransformerChain.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassTransformerFactory.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassTransformerTee.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/ClassVisitorTee.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/FieldVisitorTee.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/MethodFilter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/MethodFilterTransformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/MethodVisitorTee.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/TransformingClassGenerator.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/TransformingClassLoader.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/AbstractInterceptFieldCallback.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/AccessFieldTransformer.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/AddDelegateTransformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/AddInitTransformer.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/AddPropertyTransformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/AddStaticInitTransformer.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/FieldProvider.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/FieldProviderTransformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/InterceptFieldCallback.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/InterceptFieldEnabled.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/InterceptFieldFilter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/InterceptFieldTransformer.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/UndeclaredThrowableStrategy.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/transform/impl/UndeclaredThrowableTransformer.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/util/ParallelSorter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/util/ParallelSorterEmitter.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/util/SorterTemplate.java"
+              start_line: 2
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/cglib/util/StringSwitcher.java"
+              start_line: 4
+              end_line: 14
+          - license: "Apache-2.0"
+            location:
+              path: "org/mockito/internal/matchers/apachecommons/commons-lang-license.txt"
+              start_line: 1
+              end_line: 201
+          - license: "BSD-3-Clause"
+            location:
+              path: "NOTICE"
+              start_line: 6
+              end_line: 6
+          - license: "BSD-3-Clause"
+            location:
+              path: "NOTICE"
+              start_line: 11
+              end_line: 11
+          - license: "BSD-3-Clause"
+            location:
+              path: "asm-license.txt"
+              start_line: 4
+              end_line: 29
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/AnnotationVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/AnnotationWriter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/Attribute.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/ByteVector.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/ClassAdapter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/ClassReader.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/ClassVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/ClassWriter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/Edge.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/FieldVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/FieldWriter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/Frame.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/Handler.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/Item.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/Label.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/MethodAdapter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/MethodVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/MethodWriter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/Opcodes.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/Type.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/package.html"
+              start_line: 7
+              end_line: 29
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/signature/SignatureReader.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/signature/SignatureVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/signature/SignatureWriter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/signature/package.html"
+              start_line: 7
+              end_line: 29
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/AbstractInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/AnnotationNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/ClassNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/FieldInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/FieldNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/FrameNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/IincInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/InnerClassNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/InsnList.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/InsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/IntInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/JumpInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/LabelNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/LdcInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/LineNumberNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/LocalVariableNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/LookupSwitchInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/MemberNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/MethodInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/MethodNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/MultiANewArrayInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/TableSwitchInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/TryCatchBlockNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/TypeInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/VarInsnNode.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/Analyzer.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/AnalyzerException.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/BasicInterpreter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/BasicValue.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/BasicVerifier.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/Frame.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/Interpreter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/SimpleVerifier.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/SmallSet.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/SourceInterpreter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/SourceValue.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/Subroutine.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/Value.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/analysis/package.html"
+              start_line: 7
+              end_line: 29
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/tree/package.html"
+              start_line: 7
+              end_line: 29
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/ASMifiable.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/ASMifierAbstractVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/ASMifierAnnotationVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/ASMifierClassVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/ASMifierFieldVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/ASMifierMethodVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/AbstractVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/CheckAnnotationAdapter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/CheckClassAdapter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/CheckFieldAdapter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/CheckMethodAdapter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/CheckSignatureAdapter.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/TraceAbstractVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/TraceAnnotationVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/TraceClassVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/TraceFieldVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/TraceMethodVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/TraceSignatureVisitor.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/Traceable.java"
+              start_line: 6
+              end_line: 28
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/asm/util/package.html"
+              start_line: 7
+              end_line: 29
+          - license: "BSD-3-Clause"
+            location:
+              path: "org/mockito/cglib/core/LocalVariablesSorter.java"
+              start_line: 6
+              end_line: 28
+          - license: "MIT"
+            location:
+              path: "LICENSE"
+              start_line: 1
+              end_line: 1
+          - license: "MIT"
+            location:
+              path: "LICENSE"
+              start_line: 5
+              end_line: 21
+          - license: "MIT"
+            location:
+              path: "NOTICE"
+              start_line: 1
+              end_line: 1
+          - license: "MIT"
+            location:
+              path: "NOTICE"
+              start_line: 10
+              end_line: 10
+          - license: "MIT"
+            location:
+              path: "org/mockito/AdditionalAnswers.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/AdditionalMatchers.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/Answers.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/ArgumentCaptor.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/ArgumentMatcher.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/BDDMockito.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/Captor.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/InOrder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/Incubating.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/InjectMocks.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/Matchers.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/Mock.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/MockSettings.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/MockingDetails.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/Mockito.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/MockitoAnnotations.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/MockitoDebugger.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/ReturnValues.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/Spy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/configuration/AnnotationEngine.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/configuration/DefaultMockitoConfiguration.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/configuration/IMockitoConfiguration.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/configuration/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/Discrepancy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/Pluralizer.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/PrintableInvocation.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/Reporter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/base/MockitoAssertionError.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/base/MockitoException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/base/MockitoSerializationIssue.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/base/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/CannotVerifyStubOnlyMock.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/FriendlyReminderException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/InvalidUseOfMatchersException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/MissingMethodInvocationException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/MockitoConfigurationException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/NotAMockException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/NullInsteadOfMockException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/UnfinishedStubbingException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/UnfinishedVerificationException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/WrongTypeOfReturnValue.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/misusing/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/stacktrace/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/ArgumentsAreDifferent.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/NeverWantedButInvoked.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/NoInteractionsWanted.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/SmartNullPointerException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/TooLittleActualInvocations.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/TooManyActualInvocations.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/VerificationInOrderFailure.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/WantedButNotInvoked.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/junit/ArgumentsAreDifferent.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/junit/JUnitTool.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/junit/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/exceptions/verification/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/InOrderImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/InternalMockHandler.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/MockitoCore.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/CaptorAnnotationProcessor.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/ClassPathLoader.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/DefaultAnnotationEngine.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/DefaultInjectionEngine.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/FieldAnnotationProcessor.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/GlobalConfiguration.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/InjectingAnnotationEngine.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/MockAnnotationProcessor.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/MockitoAnnotationsMockAnnotationProcessor.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/SpyAnnotationEngine.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/ConstructorInjection.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/MockInjection.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/MockInjectionStrategy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/SpyOnInjectedFieldsHandler.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/FinalMockCandidateFilter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/MockCandidateFilter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/NameBasedCandidateFilter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/OngoingInjecter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/injection/scanner/MockScanner.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/configuration/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/DelegatingMethod.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/MockSettingsImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/AcrossJVMSerializationFeature.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/CGLIBHacker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/CglibMockMaker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/ClassImposterizer.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/DelegatingMockitoMethodProxy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/MethodInterceptorFilter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/MockitoNamingPolicy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/SerializableMockitoMethodProxy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/SerializableNoOp.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/cglib/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/settings/CreationSettings.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/util/MockitoMethodProxy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/util/SearchingClassLoader.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/creation/util/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/FindingsListener.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/Localized.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/LocationImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/LoggingListener.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/MockitoDebuggerImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/VerboseMockInvocationLogger.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/WarningsCollector.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/WarningsFinder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/WarningsPrinterImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/debugging/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/exceptions/ExceptionIncludingMockitoWarnings.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/exceptions/VerificationAwareInvocation.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/exceptions/stacktrace/ConditionalStackTraceFilter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/exceptions/stacktrace/StackTraceFilter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/exceptions/stacktrace/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/exceptions/util/ScenarioPrinter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/handler/InvocationNotifierHandler.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/handler/MockHandlerFactory.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/handler/MockHandlerImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/handler/NullResultGuardian.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/AbstractAwareMethod.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/ArgumentsComparator.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/ArgumentsProcessor.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/CapturesArgumensFromInvocation.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/InvocationImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/InvocationMarker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/InvocationMatcher.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/InvocationsFinder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/MatchersBinder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/MockitoMethod.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/SerializableMethod.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/StubInfoImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/UnusedStubsFinder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/finder/AllInvocationsFinder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/finder/VerifiableInvocationsFinder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/realmethod/CleanTraceRealMethod.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/realmethod/DefaultRealMethod.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/realmethod/RealMethod.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/invocation/realmethod/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/junit/JUnitTool.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/listeners/CollectCreatedMocks.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/listeners/MockingProgressListener.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/listeners/MockingStartedListener.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/listeners/NotifiedMethodInvocationReport.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/And.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Any.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/AnyVararg.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/ArrayEquals.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/CapturesArguments.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/CapturingMatcher.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/CompareEqual.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/CompareTo.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Contains.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/ContainsExtraTypeInformation.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/EndsWith.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Equality.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Equals.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/EqualsWithDelta.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Find.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/GreaterOrEqual.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/GreaterThan.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/InstanceOf.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/LessOrEqual.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/LessThan.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/LocalizedMatcher.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/MatcherDecorator.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/MatchersPrinter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Matches.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Not.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/NotNull.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Null.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Or.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/Same.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/StartsWith.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/VarargMatcher.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/apachecommons/EqualsBuilder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/apachecommons/ReflectionEquals.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/apachecommons/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/matchers/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/ArgumentMatcherStorage.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/ArgumentMatcherStorageImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/HandyReturnValues.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/IOngoingStubbing.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/MockingProgress.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/MockingProgressImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/SequenceNumber.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/ThreadSafeMockingProgress.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/progress/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/reporting/Discrepancy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/reporting/Pluralizer.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/reporting/PrintSettings.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/reporting/SmartPrinter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/reporting/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/JUnit44RunnerImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/JUnit45AndHigherRunnerImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/RunnerFactory.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/RunnerImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/util/FrameworkUsageValidator.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/util/RunnerProvider.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/util/TestMethodsFinder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/runners/util/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/BaseStubbing.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/ConsecutiveStubbing.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/InvocationContainer.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/InvocationContainerImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/OngoingStubbingImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/StubbedInvocationMatcher.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/StubberImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/VoidMethodStubbableImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/AnswerReturnValuesAdapter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/AnswersValidator.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/CallsRealMethods.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ClonesArguments.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/DoesNothing.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/MethodInfo.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/Returns.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ReturnsElementsOf.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ThrowsException.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/answers/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/Answers.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/GloballyConfiguredAnswer.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsMocks.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsMoreEmptyValues.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/stubbing/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/Checks.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/ConsoleMockitoLogger.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/Decamelizer.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/DefaultMockingDetails.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/MockCreationValidator.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/MockNameImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/MockUtil.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/MockitoLogger.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/ObjectMethodsGuru.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/Primitives.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/RemoveFirstLine.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/SimpleMockitoLogger.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/StringJoiner.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/collections/ArrayUtils.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/collections/HashCodeAndEqualsMockWrapper.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/collections/HashCodeAndEqualsSafeSet.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/collections/IdentitySet.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/collections/ListUtil.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/collections/Sets.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/junit/JUnitFailureHacker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/AccessibilityChanger.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/BeanPropertySetter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldCopier.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldInitializationReport.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldInitializer.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldReader.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldSetter.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/Fields.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/GenericMaster.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/GenericMetadataSupport.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/InstanceField.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/LenientCopyTool.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/Whitebox.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/util/reflection/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/AtLeast.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/AtMost.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/Calls.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/DefaultRegisteredInvocations.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/InOrderContextImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/InOrderWrapper.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/MockAwareVerificationMode.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/NoMoreInteractions.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/Only.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/RegisteredInvocations.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/SingleRegisteredInvocation.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/Times.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/VerificationDataImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/VerificationModeFactory.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/VerificationOverTimeImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/api/InOrderContext.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/api/VerificationData.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/api/VerificationDataInOrder.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/api/VerificationDataInOrderImpl.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/api/VerificationInOrderMode.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/api/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/argumentmatching/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/AtLeastDiscrepancy.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsChecker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsInOrderChecker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/MissingInvocationChecker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/MissingInvocationInOrderChecker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/NonGreedyNumberOfInvocationsInOrderChecker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/NumberOfInvocationsChecker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/NumberOfInvocationsInOrderChecker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/checkers/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/internal/verification/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/invocation/DescribedInvocation.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/invocation/Invocation.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/invocation/InvocationOnMock.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/invocation/Location.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/invocation/MockHandler.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/invocation/StubInfo.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/invocation/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/listeners/InvocationListener.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/listeners/MethodInvocationReport.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/listeners/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/mock/MockCreationSettings.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/mock/MockName.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/plugins/MockMaker.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/plugins/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/runners/ConsoleSpammingMockitoJUnitRunner.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/runners/MockitoJUnit44Runner.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/runners/MockitoJUnitRunner.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/runners/VerboseMockitoJUnitRunner.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/runners/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/stubbing/Answer.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/stubbing/DeprecatedOngoingStubbing.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/stubbing/OngoingStubbing.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/stubbing/Stubber.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/stubbing/VoidMethodStubbable.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/stubbing/answers/ReturnsElementsOf.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/stubbing/package.html"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/verification/Timeout.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/verification/VerificationAfterDelay.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/verification/VerificationMode.java"
+              start_line: 3
+              end_line: 3
+          - license: "MIT"
+            location:
+              path: "org/mockito/verification/VerificationWithTimeout.java"
+              start_line: 3
+              end_line: 3
+          copyrights:
+          - statement: "Copyright (c) 2000-2005 INRIA, France Telecom"
+            location:
+              path: "asm-license.txt"
+              start_line: 1
+              end_line: 2
+          - statement: "Copyright (c) 2000-2005 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/package.html"
+              start_line: 4
+              end_line: 5
+          - statement: "Copyright (c) 2000-2005 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/signature/package.html"
+              start_line: 4
+              end_line: 5
+          - statement: "Copyright (c) 2000-2005 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/package.html"
+              start_line: 4
+              end_line: 5
+          - statement: "Copyright (c) 2000-2005 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/package.html"
+              start_line: 4
+              end_line: 5
+          - statement: "Copyright (c) 2000-2005 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/package.html"
+              start_line: 4
+              end_line: 5
+          - statement: "Copyright (c) 2000-2005 INRIA, France Telecom"
+            location:
+              path: "org/mockito/cglib/core/LocalVariablesSorter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/AnnotationVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/AnnotationWriter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/Attribute.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/ByteVector.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/ClassAdapter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/ClassReader.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/ClassVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/ClassWriter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/Edge.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/FieldVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/FieldWriter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/Frame.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/Handler.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/Item.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/Label.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/MethodAdapter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/MethodVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/MethodWriter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/Opcodes.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/Type.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/signature/SignatureReader.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/signature/SignatureVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/signature/SignatureWriter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/AbstractInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/AnnotationNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/ClassNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/FieldInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/FieldNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/FrameNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/IincInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/InnerClassNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/InsnList.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/InsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/IntInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/JumpInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/LabelNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/LdcInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/LineNumberNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/LocalVariableNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/LookupSwitchInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/MemberNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/MethodInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/MethodNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/MultiANewArrayInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/TableSwitchInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/TryCatchBlockNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/TypeInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/VarInsnNode.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/Analyzer.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/AnalyzerException.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/BasicInterpreter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/BasicValue.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/BasicVerifier.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/Frame.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/Interpreter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/SimpleVerifier.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/SmallSet.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/SourceInterpreter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/SourceValue.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/Subroutine.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/tree/analysis/Value.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/ASMifiable.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/ASMifierAbstractVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/ASMifierAnnotationVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/ASMifierClassVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/ASMifierFieldVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/ASMifierMethodVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/AbstractVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/CheckAnnotationAdapter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/CheckClassAdapter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/CheckFieldAdapter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/CheckMethodAdapter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/CheckSignatureAdapter.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/TraceAbstractVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/TraceAnnotationVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/TraceClassVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/TraceFieldVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/TraceMethodVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/TraceSignatureVisitor.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2000-2007 INRIA, France Telecom"
+            location:
+              path: "org/mockito/asm/util/Traceable.java"
+              start_line: 3
+              end_line: 4
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "LICENSE"
+              start_line: 3
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/AdditionalAnswers.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/AdditionalMatchers.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/Answers.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/ArgumentCaptor.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/ArgumentMatcher.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/BDDMockito.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/Captor.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/InOrder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/Incubating.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/InjectMocks.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/Matchers.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/Mock.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/MockSettings.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/MockingDetails.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/Mockito.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/MockitoAnnotations.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/MockitoDebugger.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/ReturnValues.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/Spy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/configuration/AnnotationEngine.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/configuration/DefaultMockitoConfiguration.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/configuration/IMockitoConfiguration.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/configuration/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/Discrepancy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/Pluralizer.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/PrintableInvocation.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/Reporter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/base/MockitoAssertionError.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/base/MockitoException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/base/MockitoSerializationIssue.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/base/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/CannotVerifyStubOnlyMock.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/FriendlyReminderException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/InvalidUseOfMatchersException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/MissingMethodInvocationException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/MockitoConfigurationException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/NotAMockException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/NullInsteadOfMockException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/UnfinishedStubbingException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/UnfinishedVerificationException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/WrongTypeOfReturnValue.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/misusing/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/stacktrace/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/ArgumentsAreDifferent.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/NeverWantedButInvoked.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/NoInteractionsWanted.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/SmartNullPointerException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/TooLittleActualInvocations.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/TooManyActualInvocations.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/VerificationInOrderFailure.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/WantedButNotInvoked.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/junit/ArgumentsAreDifferent.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/junit/JUnitTool.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/junit/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/exceptions/verification/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/InOrderImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/InternalMockHandler.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/MockitoCore.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/CaptorAnnotationProcessor.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/ClassPathLoader.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/DefaultAnnotationEngine.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/DefaultInjectionEngine.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/FieldAnnotationProcessor.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/GlobalConfiguration.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/InjectingAnnotationEngine.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/MockAnnotationProcessor.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/MockitoAnnotationsMockAnnotationProcessor.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/SpyAnnotationEngine.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/ConstructorInjection.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/MockInjection.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/MockInjectionStrategy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/PropertyAndSetterInjection.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/SpyOnInjectedFieldsHandler.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/FinalMockCandidateFilter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/MockCandidateFilter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/NameBasedCandidateFilter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/OngoingInjecter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/filter/TypeBasedCandidateFilter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/scanner/InjectMocksScanner.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/injection/scanner/MockScanner.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/configuration/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/DelegatingMethod.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/MockSettingsImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/AcrossJVMSerializationFeature.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/CGLIBHacker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/CglibMockMaker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/ClassImposterizer.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/DelegatingMockitoMethodProxy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/MethodInterceptorFilter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/MockitoNamingPolicy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/SerializableMockitoMethodProxy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/SerializableNoOp.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/cglib/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/settings/CreationSettings.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/util/MockitoMethodProxy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/util/SearchingClassLoader.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/creation/util/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/FindingsListener.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/Localized.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/LocationImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/LoggingListener.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/MockitoDebuggerImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/VerboseMockInvocationLogger.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/WarningsCollector.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/WarningsFinder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/WarningsPrinterImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/debugging/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/exceptions/ExceptionIncludingMockitoWarnings.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/exceptions/VerificationAwareInvocation.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/exceptions/stacktrace/ConditionalStackTraceFilter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/exceptions/stacktrace/StackTraceFilter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/exceptions/stacktrace/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/exceptions/util/ScenarioPrinter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/handler/InvocationNotifierHandler.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/handler/MockHandlerFactory.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/handler/MockHandlerImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/handler/NullResultGuardian.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/AbstractAwareMethod.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/ArgumentsComparator.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/ArgumentsProcessor.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/CapturesArgumensFromInvocation.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/InvocationImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/InvocationMarker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/InvocationMatcher.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/InvocationsFinder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/MatchersBinder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/MockitoMethod.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/SerializableMethod.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/StubInfoImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/UnusedStubsFinder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/finder/AllInvocationsFinder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/finder/VerifiableInvocationsFinder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/realmethod/CleanTraceRealMethod.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/realmethod/DefaultRealMethod.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/realmethod/RealMethod.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/invocation/realmethod/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/junit/JUnitTool.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/listeners/CollectCreatedMocks.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/listeners/MockingProgressListener.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/listeners/MockingStartedListener.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/listeners/NotifiedMethodInvocationReport.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/And.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Any.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/AnyVararg.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/ArrayEquals.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/CapturesArguments.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/CapturingMatcher.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/CompareEqual.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/CompareTo.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Contains.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/ContainsExtraTypeInformation.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/EndsWith.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Equality.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Equals.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/EqualsWithDelta.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Find.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/GreaterOrEqual.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/GreaterThan.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/InstanceOf.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/LessOrEqual.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/LessThan.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/LocalizedMatcher.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/MatcherDecorator.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/MatchersPrinter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Matches.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Not.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/NotNull.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Null.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Or.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/Same.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/StartsWith.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/VarargMatcher.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/apachecommons/EqualsBuilder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/apachecommons/ReflectionEquals.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/apachecommons/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/matchers/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/ArgumentMatcherStorage.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/ArgumentMatcherStorageImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/HandyReturnValues.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/IOngoingStubbing.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/MockingProgress.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/MockingProgressImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/SequenceNumber.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/ThreadSafeMockingProgress.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/progress/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/reporting/Discrepancy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/reporting/Pluralizer.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/reporting/PrintSettings.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/reporting/SmartPrinter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/reporting/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/JUnit44RunnerImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/JUnit45AndHigherRunnerImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/RunnerFactory.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/RunnerImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/util/FrameworkUsageValidator.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/util/RunnerProvider.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/util/TestMethodsFinder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/runners/util/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/BaseStubbing.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/ConsecutiveStubbing.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/InvocationContainer.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/InvocationContainerImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/OngoingStubbingImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/StubbedInvocationMatcher.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/StubberImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/VoidMethodStubbableImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/AnswerReturnValuesAdapter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/AnswersValidator.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/CallsRealMethods.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ClonesArguments.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/DoesNothing.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/MethodInfo.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/Returns.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ReturnsArgumentAt.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ReturnsElementsOf.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ThrowsException.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/answers/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/Answers.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ForwardsInvocations.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/GloballyConfiguredAnswer.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsDeepStubs.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsMocks.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsMoreEmptyValues.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/ReturnsSmartNulls.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/defaultanswers/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/stubbing/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/Checks.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/ConsoleMockitoLogger.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/Decamelizer.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/DefaultMockingDetails.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/MockCreationValidator.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/MockNameImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/MockUtil.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/MockitoLogger.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/ObjectMethodsGuru.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/Primitives.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/RemoveFirstLine.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/SimpleMockitoLogger.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/StringJoiner.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/collections/ArrayUtils.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/collections/HashCodeAndEqualsMockWrapper.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/collections/HashCodeAndEqualsSafeSet.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/collections/IdentitySet.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/collections/ListUtil.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/collections/Sets.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/junit/JUnitFailureHacker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/AccessibilityChanger.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/BeanPropertySetter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldCopier.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldInitializationReport.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldInitializer.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldReader.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/FieldSetter.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/Fields.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/GenericMaster.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/GenericMetadataSupport.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/InstanceField.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/LenientCopyTool.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/Whitebox.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/util/reflection/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/AtLeast.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/AtMost.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/Calls.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/DefaultRegisteredInvocations.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/InOrderContextImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/InOrderWrapper.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/MockAwareVerificationMode.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/NoMoreInteractions.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/Only.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/RegisteredInvocations.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/SingleRegisteredInvocation.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/Times.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/VerificationDataImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/VerificationModeFactory.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/VerificationOverTimeImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/api/InOrderContext.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/api/VerificationData.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/api/VerificationDataInOrder.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/api/VerificationDataInOrderImpl.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/api/VerificationInOrderMode.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/api/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/argumentmatching/ArgumentMatchingTool.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/argumentmatching/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/AtLeastDiscrepancy.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsChecker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/AtLeastXNumberOfInvocationsInOrderChecker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/MissingInvocationChecker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/MissingInvocationInOrderChecker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/NonGreedyNumberOfInvocationsInOrderChecker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/NumberOfInvocationsChecker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/NumberOfInvocationsInOrderChecker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/checkers/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/internal/verification/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/invocation/DescribedInvocation.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/invocation/Invocation.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/invocation/InvocationOnMock.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/invocation/Location.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/invocation/MockHandler.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/invocation/StubInfo.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/invocation/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/listeners/InvocationListener.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/listeners/MethodInvocationReport.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/listeners/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/mock/MockCreationSettings.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/mock/MockName.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/plugins/MockMaker.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/plugins/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/runners/ConsoleSpammingMockitoJUnitRunner.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/runners/MockitoJUnit44Runner.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/runners/MockitoJUnitRunner.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/runners/VerboseMockitoJUnitRunner.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/runners/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/stubbing/Answer.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/stubbing/DeprecatedOngoingStubbing.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/stubbing/OngoingStubbing.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/stubbing/Stubber.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/stubbing/VoidMethodStubbable.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/stubbing/answers/ReturnsElementsOf.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/stubbing/package.html"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/verification/Timeout.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/verification/VerificationAfterDelay.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/verification/VerificationMode.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright (c) 2007 Mockito"
+            location:
+              path: "org/mockito/verification/VerificationWithTimeout.java"
+              start_line: 2
+              end_line: 3
+          - statement: "Copyright 2002,2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/Factory.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2002,2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/MethodInterceptor.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2002,2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/UndeclaredThrowableException.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2002,2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/Enhancer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/BeanGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/BulkBean.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/BulkBeanException.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/FixedKeySet.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/Block.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ClassEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ClassGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ClassNameReader.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ClassesKey.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/CodeGenerationException.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/Constants.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/Converter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/Customizer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/DefaultGeneratorStrategy.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/DuplicatesPredicate.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/GeneratorStrategy.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/Local.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/NamingPolicy.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ObjectSwitchCallback.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/Predicate.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ProcessArrayCallback.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ProcessSwitchCallback.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/Signature.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/TinyBitSet.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/Transformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/Callback.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/Dispatcher.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/FixedValue.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/InvocationHandler.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/LazyLoader.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/MixinBeanEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/NoOp.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/ProxyRefDispatcher.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/reflect/ConstructorDelegate.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/reflect/FastConstructor.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/reflect/FastMember.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/AbstractClassTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/AbstractProcessTask.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/AnnotationVisitorTee.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassEmitterTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassFilter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassReaderGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassTransformerFactory.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassTransformerTee.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassVisitorTee.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/FieldVisitorTee.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/MethodFilter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/MethodFilterTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/MethodVisitorTee.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/TransformingClassGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/TransformingClassLoader.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/AccessFieldTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/AddDelegateTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/AddPropertyTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/FieldProvider.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/FieldProviderTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/InterceptFieldCallback.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/InterceptFieldEnabled.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/InterceptFieldFilter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/InterceptFieldTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/UndeclaredThrowableStrategy.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/UndeclaredThrowableTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/util/ParallelSorter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/util/ParallelSorterEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/util/SorterTemplate.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/util/StringSwitcher.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/BeanCopier.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/BeanMap.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/BeanMapEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/BulkBeanEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/beans/ImmutableBean.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/AbstractClassGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/CodeEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/CollectionUtils.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/DebuggingClassWriter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/DefaultNamingPolicy.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/EmitUtils.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/KeyFactory.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/MethodWrapper.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ReflectUtils.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/TypeUtils.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/VisibilityPredicate.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/CallbackFilter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/CallbackGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/DispatcherGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/FixedValueGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/InvocationHandlerGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/LazyLoaderGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/MethodInterceptorGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/MethodProxy.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/Mixin.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/MixinEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/NoOpGenerator.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/Proxy.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/reflect/FastClass.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/reflect/FastClassEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/reflect/FastMethod.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/reflect/MethodDelegate.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/reflect/MulticastDelegate.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/AbstractClassLoader.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/AbstractTransformTask.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassFilterTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/ClassTransformerChain.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2003,2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/AddStaticInitTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/ClassInfo.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/MethodInfo.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/MethodInfoTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/core/RejectModifierPredicate.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/CallbackHelper.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/CallbackInfo.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/InterfaceMaker.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/proxy/MixinEverythingEmitter.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/AbstractClassFilterTransformer.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/AbstractInterceptFieldCallback.java"
+              start_line: 2
+              end_line: 2
+          - statement: "Copyright 2004 The Apache Software Foundation"
+            location:
+              path: "org/mockito/cglib/transform/impl/AddInitTransformer.java"
+              start_line: 2
+              end_line: 2
+    storage_stats:
+      num_reads: 4
+      num_hits: 4
+    has_issues: false
+evaluator:
+  start_time: "2021-03-30T01:36:23.566808Z"
+  end_time: "2021-03-30T01:36:30.715613Z"
+  violations:
+  - rule: "Rules not finalized yet"
+    pkg: ":::"
+    license: null
+    license_source: null
+    severity: "HINT"
+    message: "This is only a preliminary report, as not all policy rules are implemented\
+      \ yet.\nNot all possible policy violations are shown in this report.\nHandle\
+      \ with care."
+    how_to_fix: "Please contact [osmi-support@bosch.io](mailto:osmi-support@bosch.io)\
+      \ in case of any questions."
+labels:
+  applicationCategory: "BT05 Client application"
+  projectName: "Test ORT"

--- a/model/src/test/kotlin/AdvisorResultContainerTest.kt
+++ b/model/src/test/kotlin/AdvisorResultContainerTest.kt
@@ -23,8 +23,11 @@ package org.ossreviewtoolkit.model
 import com.fasterxml.jackson.module.kotlin.readValue
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
 
+import java.io.File
 import java.net.URI
 import java.time.Duration
 import java.time.Instant
@@ -89,6 +92,22 @@ class AdvisorResultContainerTest : WordSpec() {
                 val deserializedAdvisorResults = jsonMapper.readValue<AdvisorResultContainer>(serializedAdvisorResults)
 
                 deserializedAdvisorResults shouldBe advisorResults
+            }
+
+            "be deserialized with vulnerabilities in the initial format" {
+                val resultsFile = File("src/test/assets/advisor-result-initial.yml")
+
+                val result = resultsFile.readValue<OrtResult>()
+
+                result.advisor shouldNot beNull()
+            }
+
+            "be deserialized with vulnerabilities in format with references" {
+                val resultsFile = File("src/test/assets/advisor-result-vulnerability-refs.yml")
+
+                val result = resultsFile.readValue<OrtResult>()
+
+                result.advisor shouldNot beNull()
             }
         }
     }

--- a/model/src/test/kotlin/AdvisorResultContainerTest.kt
+++ b/model/src/test/kotlin/AdvisorResultContainerTest.kt
@@ -32,10 +32,22 @@ import java.time.Instant
 class AdvisorResultContainerTest : WordSpec() {
     private val id = Identifier("type", "namespace", "name", "version")
 
-    private val vulnerability11 = Vulnerability("CVE-11", 1.1F, URI("https://1.1.com"))
-    private val vulnerability12 = Vulnerability("CVE-12", 1.2F, URI("https://1.2.com"))
-    private val vulnerability21 = Vulnerability("CVE-21", 2.1F)
-    private val vulnerability22 = Vulnerability("CVE-22", 2.2F)
+    private val vulnerability11 = Vulnerability(
+        "CVE-11",
+        listOf(VulnerabilityReference(URI("https://src1.example.org"), "score1", "5"))
+    )
+    private val vulnerability12 = Vulnerability(
+        "CVE-12",
+        listOf(VulnerabilityReference(URI("https://src2.example.org"), "score1", "7"))
+    )
+    private val vulnerability21 = Vulnerability(
+        "CVE-21",
+        listOf(VulnerabilityReference(URI("https://src3.example.org"), "score2", "medium"))
+    )
+    private val vulnerability22 = Vulnerability(
+        "CVE-22",
+        listOf(VulnerabilityReference(URI("https://src1.example.org"), "score2", "low"))
+    )
 
     private val vulnerabilities1 = listOf(vulnerability11, vulnerability12)
     private val vulnerabilities2 = listOf(vulnerability21, vulnerability22)
@@ -54,15 +66,15 @@ class AdvisorResultContainerTest : WordSpec() {
     private val issue22 = OrtIssue(source = "source-22", message = "issue-22")
 
     private val advisorSummary1 = AdvisorSummary(
-            advisorStartTime1,
-            advisorEndTime1,
-            mutableListOf(issue11, issue12)
+        advisorStartTime1,
+        advisorEndTime1,
+        mutableListOf(issue11, issue12)
     )
 
     private val advisorSummary2 = AdvisorSummary(
-            advisorStartTime2,
-            advisorEndTime2,
-            mutableListOf(issue21, issue22)
+        advisorStartTime2,
+        advisorEndTime2,
+        mutableListOf(issue21, issue22)
     )
 
     private val advisorResult1 = AdvisorResult(vulnerabilities1, advisorDetails1, advisorSummary1)

--- a/model/src/test/kotlin/VulnerabilityTest.kt
+++ b/model/src/test/kotlin/VulnerabilityTest.kt
@@ -19,10 +19,13 @@
 
 package org.ossreviewtoolkit.model
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+
+import java.lang.IllegalArgumentException
 
 import org.ossreviewtoolkit.model.Vulnerability.Cvss2Rating
 import org.ossreviewtoolkit.model.Vulnerability.Cvss3Rating
@@ -61,5 +64,11 @@ class VulnerabilityTest : StringSpec({
         Cvss3Rating.fromScore(10.0f) shouldBe Cvss3Rating.CRITICAL
 
         Cvss3Rating.fromScore(10.1f) should beNull()
+    }
+
+    "A vulnerability must have at least one reference" {
+        shouldThrow<IllegalArgumentException> {
+            Vulnerability("CVE-2021-1234", emptyList())
+        }
     }
 })


### PR DESCRIPTION
This PR prepares the full integration of VulnerableCode as an advisor.

VulnerableCode supports multiple sources of vulnerability information. Each vulnerability has a list of references to the sources from which information has been drawn. To represent this, the PR extends the data model accordingly.

Note that this is only a change of the data model, but the VulnerableCode advisor implementation is not yet updated to actually populate this data model.