### PR TITLE
Verify that license mappings to *-only have a digit

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -111,8 +111,8 @@
 "CDDL or GPLv2 with exceptions": CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 "CDDL v1.0 / GPL v2 dual license": CDDL-1.0 OR GPL-2.0-only
 "CDDL v1.1 / GPL v2 dual license": CDDL-1.0 OR GPL-2.0-only
-"CDDL+GPL License": CDDL-1.0 AND GPL-2.0-only
-"CDDL+GPL": CDDL-1.0 AND GPL-2.0-only
+"CDDL+GPL License": CDDL-1.0 AND GPL-2.0-or-later
+"CDDL+GPL": CDDL-1.0 AND GPL-2.0-or-later
 "CDDL+GPLv2": CDDL-1.0 AND GPL-2.0-only
 "CDDL/GPLv2 dual license": CDDL-1.0 OR GPL-2.0-only
 "CDDL/GPLv2+CE": CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
@@ -209,16 +209,16 @@
 "GNU Affero General Public License v3": AGPL-3.0-only
 "GNU Affero General Public License, Version 3 with the Commons Clause": AGPL-3.0-only AND LicenseRef-scancode-public-domain-disclaimer
 "GNU Affero General Public License, Version 3": AGPL-3.0-only
-"GNU Free Documentation License (FDL)": GFDL-1.3-only
+"GNU Free Documentation License (FDL)": GFDL-1.3-or-later
 "GNU Free Documentation License (GFDL-1.3)": GFDL-1.3-only
 "GNU GENERAL PUBLIC LICENSE Version 2, June 1991": GPL-2.0-only
 "GNU GPL v2": GPL-2.0-only
 "GNU General Lesser Public License (LGPL) version 2.1": LGPL-2.1-only
 "GNU General Lesser Public License (LGPL) version 3.0": LGPL-3.0-only
-"GNU General Public Library": GPL-3.0-only
+"GNU General Public Library": GPL-3.0-or-later
 "GNU General Public License (GPL) v. 2": GPL-2.0-only
 "GNU General Public License (GPL) v. 3": GPL-3.0-only
-"GNU General Public License (GPL)": GPL-3.0-only
+"GNU General Public License (GPL)": GPL-3.0-or-later
 "GNU General Public License (GPL), version 2, with the Classpath exception": GPL-2.0-only WITH Classpath-exception-2.0
 "GNU General Public License 3": GPL-3.0-only
 "GNU General Public License Version 2": GPL-2.0-only
@@ -261,8 +261,8 @@
 "GNU Lesser Public License": LGPL-2.1-or-later
 "GNU Library or Lesser General Public License (LGPL)": LGPL-2.1-or-later
 "GNU Library or Lesser General Public License version 2.0 (LGPLv2)": LGPL-2.0-only
-"GNU Public": GPL-2.0-only
-"GPL (with dual licensing option)": GPL-2.0-only
+"GNU Public": GPL-2.0-or-later
+"GPL (with dual licensing option)": GPL-2.0-or-later
 "GPL 2": GPL-2.0-only
 "GPL 3": GPL-3.0-only
 "GPL v2 with ClassPath Exception": GPL-2.0-only WITH Classpath-exception-2.0
@@ -273,7 +273,7 @@
 "GPL2 w/ CPE": GPL-2.0-only WITH Classpath-exception-2.0
 "GPLv2+CE": GPL-2.0-only WITH Classpath-exception-2.0
 "GWT Terms": Apache-2.0 AND BSD-3-Clause AND CC0-1.0 AND EPL-1.0 AND LGPL-2.1-only AND MPL-1.1
-"General Public License (GPL)": GPL-2.0-only
+"General Public License (GPL)": GPL-2.0-or-later
 "General Public License 2.0 (GPL)": GPL-2.0-only
 "Google Maps Platform Terms of Service": LicenseRef-ort-google-maps-tos
 "HERE Proprietary License": LicenseRef-scancode-here-proprietary
@@ -295,13 +295,13 @@
 "LGPL 3.0": LGPL-3.0-only
 "LGPL v3": LGPL-3.0-only
 "LGPL v3+": LGPL-3.0-or-later
-"LGPL with exceptions or ZPL": LGPL-3.0-only OR ZPL-2.1
+"LGPL with exceptions or ZPL": LGPL-3.0-or-later OR ZPL-2.1
 "LGPL+BSD": LGPL-2.1-or-later AND BSD-2-Clause
 "LGPL, version 2.1": LGPL-2.1-only
 "LGPL, version 3.0": LGPL-3.0-only
-"LGPL/MIT": LGPL-3.0-only OR MIT
+"LGPL/MIT": LGPL-3.0-or-later OR MIT
 "LGPLv3 or later": LGPL-3.0-or-later
-"LPGL, see LICENSE file.": LGPL-3.0-only
+"LPGL, see LICENSE file.": LGPL-3.0-or-later
 "Lesser General Public License (LGPL)": LGPL-2.1-or-later
 "Lesser General Public License, version 3 or greater": LGPL-3.0-or-later
 "License Agreement For Open Source Computer Vision Library (3-clause BSD License)": BSD-3-Clause
@@ -336,7 +336,7 @@
 "Mozilla Public License, Version 2.0": MPL-2.0
 "NCSA License": NCSA
 "NCSA Open Source License": NCSA
-"NetBeans CDDL/GPL": CDDL-1.0 OR GPL-2.0-only
+"NetBeans CDDL/GPL": CDDL-1.0 OR GPL-2.0-or-later
 "Netscape Public License (NPL)": NPL-1.0
 "Netscape Public License": NPL-1.0
 "New BSD License": BSD-3-Clause
@@ -457,7 +457,7 @@
 "european union public licence 1.1 (eupl 1.1)": EUPL-1.1
 "european union public licence 1.2 (eupl 1.2)": EUPL-1.2
 "gnu gpl v3": GPL-3.0-only
-"gnu gpl": GPL-2.0-only
+"gnu gpl": GPL-2.0-or-later
 "gpl (≥ 3)": GPL-3.0-or-later
 "http://ant-contrib.sourceforge.net/tasks/LICENSE.txt": Apache-1.1
 "http://asm.ow2.org/license.html": BSD-3-Clause

--- a/spdx-utils/src/main/resources/simple-license-mapping.yml
+++ b/spdx-utils/src/main/resources/simple-license-mapping.yml
@@ -26,7 +26,7 @@ EDL-1.0: BSD-3-Clause
 FreeBSD: BSD-2-Clause-Views
 GPL-2: GPL-2.0-only
 GPL2: GPL-2.0-only
-GPL: GPL-2.0-only
+GPL: GPL-2.0-or-later
 GPLv2+: GPL-2.0-or-later
 GPLv2: GPL-2.0-only
 GPLv3+: GPL-3.0-or-later
@@ -52,7 +52,7 @@ afl2.0: AFL-2.0
 afl2.1: AFL-2.1
 afl2: AFL-2.0
 afl: AFL-3.0
-agpl: AGPL-3.0-only
+agpl: AGPL-3.0-or-later
 apache-license: Apache-2.0
 bouncy-license: MIT
 bsd-license: BSD-3-Clause
@@ -71,9 +71,9 @@ eupl1.0: EUPL-1.0
 eupl1.1: EUPL-1.1
 eupl1.2: EUPL-1.2
 eupl: EUPL-1.0
-fdl: GFDL-1.3-only
-gfdl: GFDL-1.3-only
-gpl-license: GPL-2.0-only
+fdl: GFDL-1.3-or-later
+gfdl: GFDL-1.3-or-later
+gpl-license: GPL-2.0-or-later
 gpl3: GPL-3.0-only
 isc-license: ISC
 mit-license: MIT

--- a/spdx-utils/src/test/kotlin/SpdxSimpleLicenseMappingTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxSimpleLicenseMappingTest.kt
@@ -27,6 +27,7 @@ import io.kotest.matchers.collections.shouldHaveAtMostSize
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.containADigit
 
 class SpdxSimpleLicenseMappingTest : WordSpec({
     "The raw map" should {
@@ -43,6 +44,12 @@ class SpdxSimpleLicenseMappingTest : WordSpec({
         "not contain any deprecated values" {
             SpdxSimpleLicenseMapping.customLicenseIdsMap.values.forAll {
                 it.deprecated shouldBe false
+            }
+        }
+
+        "not associate licenses without a version to *-only" {
+            SpdxSimpleLicenseMapping.customLicenseIdsMap.asSequence().forAll { (key, license) ->
+                if (license.id.endsWith("-only")) key should containADigit()
             }
         }
     }


### PR DESCRIPTION
@tsteenbe @mnonnenmacher what do you think about adding a test like this? I currently fails with

```
The following elements failed:
GPL=GPL_2_0_ONLY => "GPL" should contain at least one digit
agpl=AGPL_3_0_ONLY => "agpl" should contain at least one digit
fdl=GFDL_1_3_ONLY => "fdl" should contain at least one digit
gfdl=GFDL_1_3_ONLY => "gfdl" should contain at least one digit
gpl-license=GPL_2_0_ONLY => "gpl-license" should contain at least one digit
```

which indeed IMO are entries that should be fixed to *-or-later, as no version is indicated.