### PR TITLE
SpdxDocumentFile: Enhance project package function

### DIFF
--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -85,8 +85,9 @@ private fun SpdxDocument.isProject(): Boolean = projectPackage() != null
  * Return the [SpdxPackage] in the [SpdxDocument] that denotes a project, or null if no project but only packages are
  * defined.
  */
-private fun SpdxDocument.projectPackage(): SpdxPackage? =
-    packages.takeIf { it.size > 1 }?.find { it.packageFilename.isEmpty() || it.packageFilename == "." }
+internal fun SpdxDocument.projectPackage(): SpdxPackage? =
+    packages.takeIf { it.size > 1 || (it.size == 1 && externalDocumentRefs.isNotEmpty()) }
+        ?.find { it.packageFilename.isEmpty() || it.packageFilename == "." }
 
 /**
  * Return the organization from an "originator", "supplier", or "annotator" string, or null if no organization is

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -331,8 +331,7 @@ class SpdxDocumentFile(
         packages: MutableSet<Package>
     ): SortedSet<PackageReference> =
         getDependencies(pkg, doc, workingDir, packages, SpdxRelationship.Type.DEPENDENCY_OF) { target ->
-            val dependency = doc.packages.find { it.spdxId == target }
-                ?: throw IllegalArgumentException("No single package with target ID '$target' found.")
+            val dependency = getSpdxPackageForId(doc, target, workingDir)
 
             packages += dependency.toPackage(workingDir)
 


### PR DESCRIPTION
Since introducing external document references added the possibility
of just having one package (= the project package) and having the
other packages information be extracted to external document references,
the check for a project package needs to be enhanced.

