### PR TITLE
StaticHtmlReporter: Add Software Heritage links to licenses

### DIFF
--- a/model/src/main/kotlin/HashAlgorithm.kt
+++ b/model/src/main/kotlin/HashAlgorithm.kt
@@ -128,9 +128,9 @@ enum class HashAlgorithm(private vararg val aliases: String, val verifiable: Boo
     /**
      * Return the hexadecimal digest of this hash for the given [resourceName].
      */
-    fun calculate(resourceName: String): String {
+    fun calculate(resourceName: String): String? {
         val resource = javaClass.getResource(resourceName)
-        val size = resource.openConnection().contentLengthLong
+        val size = resource?.openConnection()?.contentLengthLong ?: return null
         return resource.openStream().use { calculate(it, size) }
     }
 

--- a/model/src/test/kotlin/HashAlgorithmTest.kt
+++ b/model/src/test/kotlin/HashAlgorithmTest.kt
@@ -44,4 +44,8 @@ class HashAlgorithmTest : StringSpec({
         HashAlgorithm.SHA1_GIT.calculate("/licenses/Apache-2.0") shouldBe
                 "261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64"
     }
+
+    "Calculating the SHA1-GIT on non-existent field should return null" {
+        HashAlgorithm.SHA1_GIT.calculate("/license/DOESNOTEXIST") shouldBe null
+    }
 })

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -725,7 +725,11 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
               </dl>
               <em>Effective License:</em>
               <dl>
-                <dd>EPL-1.0</dd>
+                <dd>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:2aa9b989e0fec475baf21544f8613cb53d03c3f7">EPL-1.0</a>
+                  </div>
+                </dd>
               </dl>
             </td><td>
               <ul></ul>
@@ -741,7 +745,11 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
               </ul>
             </td><td><em>Concluded License:</em>
               <dl>
-                <dd>GPL-2.0-only OR MIT</dd>
+                <dd>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:d159169d1050894d3ea3b98e1c965c4058208fe1">GPL-2.0-only</a> OR <a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a>
+                  </div>
+                </dd>
               </dl>
               <em>Declared Licenses:</em>
               <dl>
@@ -756,7 +764,11 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
               </dl>
               <em>Effective License:</em>
               <dl>
-                <dd>MIT</dd>
+                <dd>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a>
+                  </div>
+                </dd>
               </dl>
             </td><td>
               <ul></ul>
@@ -772,7 +784,11 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
               </ul>
             </td><td><em>Concluded License:</em>
               <dl>
-                <dd>MPL-2.0 OR EPL-1.0</dd>
+                <dd>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:a612ad9813b006ce81d1ee438dd784da99a54007">MPL-2.0</a> OR <a href="https://archive.softwareheritage.org/browse/content/sha1_git:2aa9b989e0fec475baf21544f8613cb53d03c3f7">EPL-1.0</a>
+                  </div>
+                </dd>
               </dl>
               <em>Declared Licenses:</em>
               <dl>
@@ -787,7 +803,11 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
               </dl>
               <em>Effective License:</em>
               <dl>
-                <dd>MPL-2.0</dd>
+                <dd>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:a612ad9813b006ce81d1ee438dd784da99a54007">MPL-2.0</a>
+                  </div>
+                </dd>
               </dl>
             </td><td>
               <ul></ul>
@@ -812,7 +832,11 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
               </dl>
               <em>Effective License:</em>
               <dl>
-                <dd>Apache-2.0</dd>
+                <dd>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a>
+                  </div>
+                </dd>
               </dl>
             </td><td>
               <ul></ul>
@@ -837,7 +861,11 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
               </dl>
               <em>Effective License:</em>
               <dl>
-                <dd>Apache-2.0</dd>
+                <dd>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a>
+                  </div>
+                </dd>
               </dl>
             </td><td>
               <ul></ul>
@@ -861,7 +889,11 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
               </dl>
               <em>Effective License:</em>
               <dl>
-                <dd>BSD-3-Clause</dd>
+                <dd>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:c329ef6d12d2a701a57fedeab0437884fe0d8de2">BSD-3-Clause</a>
+                  </div>
+                </dd>
               </dl>
             </td><td>
               <ul></ul>

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -618,20 +618,30 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
             <td><a href="#Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0-pkg-1">1</a></td><td>Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0</td><td></td><td><em>Declared Licenses:</em>
               <dl>
                 <dd>
-                  <div>CC-BY-NC-3.0</div>
-                  <div>GPL-3.0-only WITH GCC-exception-3.1</div>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:197ec4de65a2e5414b290fb46dee75f55e1b69e8">CC-BY-NC-3.0</a>
+                  </div>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:f288702d2fa16d3cdf0035b15a9fcbc552cd88e7">GPL-3.0-only</a> WITH <a href="https://archive.softwareheritage.org/browse/content/sha1_git:e86f7fb58a4656330ebdfab5e75d72f86f5e9af9">GCC-exception-3.1</a>
+                  </div>
                 </dd>
               </dl>
               <em>Detected Licenses (from <a href="https://example.com/git">VCS</a>):</em>
               <dl>
                 <dd>
-                  <div>Apache-2.0</div>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a>
+                  </div>
                   <div class="ort-excluded">MIT (Excluded: EXAMPLE_OF - These are example files.)</div>
                 </dd>
               </dl>
               <em>Effective License:</em>
               <dl>
-                <dd>Apache-2.0 AND CC-BY-NC-3.0 AND GPL-3.0-only WITH GCC-exception-3.1 AND MIT</dd>
+                <dd>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a> AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:197ec4de65a2e5414b290fb46dee75f55e1b69e8">CC-BY-NC-3.0</a> AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:f288702d2fa16d3cdf0035b15a9fcbc552cd88e7">GPL-3.0-only</a> WITH <a href="https://archive.softwareheritage.org/browse/content/sha1_git:e86f7fb58a4656330ebdfab5e75d72f86f5e9af9">GCC-exception-3.1</a> AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a>
+                  </div>
+                </dd>
               </dl>
             </td><td>
               <ul></ul>
@@ -671,16 +681,23 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
             <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-1">1</a></td><td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td><td></td><td><em>Detected Licenses (from <a href="https://github.com/oss-review-toolkit/ort.git">VCS</a>):</em>
               <dl>
                 <dd>
-                  <div>BSD-3-Clause (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
-                  <div>GPL-2.0-only WITH Classpath-exception-2.0 (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:c329ef6d12d2a701a57fedeab0437884fe0d8de2">BSD-3-Clause</a> (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:d159169d1050894d3ea3b98e1c965c4058208fe1">GPL-2.0-only</a> WITH <a href="https://archive.softwareheritage.org/browse/content/sha1_git:63ae6d171e2da985784f3e0ac865491fa093521d">Classpath-exception-2.0</a> (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
                   <div>LicenseRef-test-Apache-2.0-multi-line (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle#L19-L20">link</a> to the location)</div>
                   <div>LicenseRef-test-Apache-2.0-single-line (exemplary <a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle#L19">link</a> to the first of 2 locations)</div>
-                  <div>MIT (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a> (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
                 </dd>
               </dl>
               <em>Effective License:</em>
               <dl>
-                <dd>BSD-3-Clause AND GPL-2.0-only WITH Classpath-exception-2.0 AND LicenseRef-test-Apache-2.0-multi-line AND LicenseRef-test-Apache-2.0-single-line OR LicenseRef-test-Apache-2.0-multi-line AND LicenseRef-test-Apache-2.0-single-line AND MIT</dd>
+                <dd>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:c329ef6d12d2a701a57fedeab0437884fe0d8de2">BSD-3-Clause</a> AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:d159169d1050894d3ea3b98e1c965c4058208fe1">GPL-2.0-only</a> WITH <a href="https://archive.softwareheritage.org/browse/content/sha1_git:63ae6d171e2da985784f3e0ac865491fa093521d">Classpath-exception-2.0</a> AND LicenseRef-test-Apache-2.0-multi-line AND LicenseRef-test-Apache-2.0-single-line OR LicenseRef-test-Apache-2.0-multi-line AND LicenseRef-test-Apache-2.0-single-line AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a>
+                  </div>
+                </dd>
               </dl>
             </td><td>
               <ul></ul>
@@ -701,7 +718,9 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
             </td><td><em>Declared Licenses:</em>
               <dl>
                 <dd>
-                  <div>EPL-1.0</div>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:2aa9b989e0fec475baf21544f8613cb53d03c3f7">EPL-1.0</a>
+                  </div>
                 </dd>
               </dl>
               <em>Effective License:</em>
@@ -727,8 +746,12 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
               <em>Declared Licenses:</em>
               <dl>
                 <dd>
-                  <div>GPL-2.0-only</div>
-                  <div>MIT</div>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:d159169d1050894d3ea3b98e1c965c4058208fe1">GPL-2.0-only</a>
+                  </div>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a>
+                  </div>
                 </dd>
               </dl>
               <em>Effective License:</em>
@@ -754,8 +777,12 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
               <em>Declared Licenses:</em>
               <dl>
                 <dd>
-                  <div>EPL-1.0</div>
-                  <div>MPL-2.0</div>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:2aa9b989e0fec475baf21544f8613cb53d03c3f7">EPL-1.0</a>
+                  </div>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:a612ad9813b006ce81d1ee438dd784da99a54007">MPL-2.0</a>
+                  </div>
                 </dd>
               </dl>
               <em>Effective License:</em>
@@ -778,7 +805,9 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
             </td><td><em>Declared Licenses:</em>
               <dl>
                 <dd>
-                  <div>Apache-2.0</div>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a>
+                  </div>
                 </dd>
               </dl>
               <em>Effective License:</em>
@@ -801,7 +830,9 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
             </td><td><em>Declared Licenses:</em>
               <dl>
                 <dd>
-                  <div>Apache-2.0</div>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a>
+                  </div>
                 </dd>
               </dl>
               <em>Effective License:</em>
@@ -823,7 +854,9 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
             </td><td><em>Declared Licenses:</em>
               <dl>
                 <dd>
-                  <div>BSD-3-Clause</div>
+                  <div>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:c329ef6d12d2a701a57fedeab0437884fe0d8de2">BSD-3-Clause</a>
+                  </div>
                 </dd>
               </dl>
               <em>Effective License:</em>


### PR DESCRIPTION
Add links to licenses in the table of the `StaticHtmlReporter`. 
Once for Strings of licenses and once for SpdxExpressions. 

In order to have a consistent link, the software heritage links to licenses was used. 
Using the files from ORT might be less consistent across forks and blobs. 