### PR TITLE
Proposal: Add a command to apply a JSLT transformation to an ORT result

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -43,6 +43,7 @@ hopliteVersion = 1.4.0
 jacksonVersion = 2.12.2
 jgitVersion = 5.11.0.202103091610-r
 jSchAgentProxyVersion = 0.0.7
+jsltVersion = 0.1.11
 kotestVersion = 4.4.3
 kotlinxCoroutinesVersion = 1.4.3
 kotlinxHtmlVersion = 0.7.2

--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -19,6 +19,7 @@
  */
 
 val cliktVersion: String by project
+val jsltVersion: String by project
 val log4jCoreVersion: String by project
 
 plugins {
@@ -71,6 +72,7 @@ dependencies {
     implementation(project(":utils"))
 
     implementation("com.github.ajalt.clikt:clikt:$cliktVersion")
+    implementation("com.schibsted.spt.data:jslt:$jsltVersion")
     implementation("org.apache.logging.log4j:log4j-core:$log4jCoreVersion")
     implementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jCoreVersion")
 }

--- a/helper-cli/src/main/kotlin/HelperMain.kt
+++ b/helper-cli/src/main/kotlin/HelperMain.kt
@@ -53,6 +53,7 @@ import org.ossreviewtoolkit.helper.commands.MergeRepositoryConfigurationsCommand
 import org.ossreviewtoolkit.helper.commands.RemoveConfigurationEntriesCommand
 import org.ossreviewtoolkit.helper.commands.SortRepositoryConfigurationCommand
 import org.ossreviewtoolkit.helper.commands.SubtractScanResultsCommand
+import org.ossreviewtoolkit.helper.commands.TransformResultCommand
 import org.ossreviewtoolkit.helper.commands.VerifySourceArtifactCurationsCommand
 import org.ossreviewtoolkit.helper.commands.packageconfig.PackageConfigurationCommand
 import org.ossreviewtoolkit.helper.common.ORTH_NAME
@@ -103,6 +104,7 @@ internal class HelperMain : CliktCommand(name = ORTH_NAME, epilog = "* denotes r
             RemoveConfigurationEntriesCommand(),
             SortRepositoryConfigurationCommand(),
             SubtractScanResultsCommand(),
+            TransformResultCommand(),
             VerifySourceArtifactCurationsCommand()
         )
     }

--- a/helper-cli/src/main/kotlin/commands/ExportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ExportLicenseFindingCurationsCommand.kt
@@ -51,7 +51,7 @@ internal class ExportLicenseFindingCurationsCommand : CliktCommand(
         .required()
 
     private val ortResultFile by option(
-        "--ort-result-file",
+        "--ort-result-file", "-i",
         help = "The input ORT file from which the license finding curations are to be read."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)

--- a/helper-cli/src/main/kotlin/commands/ExportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ExportPathExcludesCommand.kt
@@ -51,7 +51,7 @@ internal class ExportPathExcludesCommand : CliktCommand(
         .required()
 
     private val ortResultFile by option(
-        "--ort-result-file",
+        "--ort-result-file", "-i",
         help = "The input ORT file from which the path excludes are to be read."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)

--- a/helper-cli/src/main/kotlin/commands/ExtractRepositoryConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ExtractRepositoryConfigurationCommand.kt
@@ -34,7 +34,7 @@ class ExtractRepositoryConfigurationCommand : CliktCommand(
     help = "Extract the repository configuration from the given ORT result file."
 ) {
     private val ortResultFile by option(
-        "--ort-result-file",
+        "--ort-result-file", "-i",
         help = "The input ORT file from which repository configuration shall be extracted."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)

--- a/helper-cli/src/main/kotlin/commands/GenerateProjectExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateProjectExcludesCommand.kt
@@ -40,7 +40,7 @@ internal class GenerateProjectExcludesCommand : CliktCommand(
             "the given repository configuration file."
 ) {
     private val ortResultFile by option(
-        "--ort-result-file",
+        "--ort-result-file", "-i",
         help = "The input ORT file from which the rule violations are read."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)

--- a/helper-cli/src/main/kotlin/commands/GenerateRuleViolationResolutionsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateRuleViolationResolutionsCommand.kt
@@ -44,7 +44,7 @@ internal class GenerateRuleViolationResolutionsCommand : CliktCommand(
             "configuration file."
 ) {
     private val ortResultFile by option(
-        "--ort-result-file",
+        "--ort-result-file", "-i",
         help = "The input ORT file from which the rule violations are read."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)

--- a/helper-cli/src/main/kotlin/commands/GenerateScopeExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateScopeExcludesCommand.kt
@@ -41,7 +41,7 @@ internal class GenerateScopeExcludesCommand : CliktCommand(
             "given repository configuration file."
 ) {
     private val ortResultFile by option(
-        "--ort-result-file",
+        "--ort-result-file", "-i",
         help = "The input ORT file from which the rule violations are read."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)

--- a/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
@@ -41,7 +41,7 @@ internal class GenerateTimeoutErrorResolutionsCommand : CliktCommand(
     help = "Generates resolutions for scanner timeout errors. The result is written to the standard output."
 ) {
     private val ortResultFile by option(
-        "--ort-result-file",
+        "--ort-result-file", "-i",
         help = "The input ORT file containing the scan timeout errors."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)

--- a/helper-cli/src/main/kotlin/commands/ImportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportLicenseFindingCurationsCommand.kt
@@ -52,7 +52,7 @@ internal class ImportLicenseFindingCurationsCommand : CliktCommand(
         .required()
 
     private val ortResultFile by option(
-        "--ort-result-file",
+        "--ort-result-file", "-i",
         help = "The ORT file containing the findings the imported curations need to match against."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)

--- a/helper-cli/src/main/kotlin/commands/ImportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportPathExcludesCommand.kt
@@ -40,7 +40,7 @@ internal class ImportPathExcludesCommand : CliktCommand(
     help = "Import path excludes by repository from a file into the given repository configuration."
 ) {
     private val pathExcludesFile by option(
-        "--path-excludes-file",
+        "--path-excludes-file", "-i",
         help = "The input path excludes file."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)

--- a/helper-cli/src/main/kotlin/commands/ImportScanResultsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportScanResultsCommand.kt
@@ -35,7 +35,7 @@ internal class ImportScanResultsCommand : CliktCommand(
     help = "Import all scan results from the given ORT result file to the file based scan results storage directory."
 ) {
     private val ortResultFile by option(
-        "--ort-result-file",
+        "--ort-result-file", "-i",
         help = "The input ORT file from which repository configuration shall be extracted."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)

--- a/helper-cli/src/main/kotlin/commands/ListCopyrightsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListCopyrightsCommand.kt
@@ -42,7 +42,7 @@ internal class ListCopyrightsCommand : CliktCommand(
     help = "Lists the copyright findings."
 ) {
     private val ortResultFile by option(
-        "--ort-result-file",
+        "--ort-result-file", "-i",
         help = "The ORT result file to read as input."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)

--- a/helper-cli/src/main/kotlin/commands/ListLicenseCategoriesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicenseCategoriesCommand.kt
@@ -35,7 +35,7 @@ class ListLicenseCategoriesCommand : CliktCommand(
     help = "Lists the license categories."
 ) {
     private val licenseClassificationsFile by option(
-        "--license-classifications-file",
+        "--license-classifications-file", "-i",
         help = "The license classifications file."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)

--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -59,7 +59,7 @@ internal class ListLicensesCommand : CliktCommand(
     help = "Lists the license findings for a given package as distinct text locations."
 ) {
     private val ortResultFile by option(
-        "--ort-result-file",
+        "--ort-result-file", "-i",
         help = "The ORT result file to read as input."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)

--- a/helper-cli/src/main/kotlin/commands/ListPackagesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListPackagesCommand.kt
@@ -38,7 +38,7 @@ class ListPackagesCommand : CliktCommand(
     help = "Lists the packages and projects contained in the given ORT result file."
 ) {
     private val ortResultFile by option(
-        "--ort-result-file",
+        "--ort-result-file", "-i",
         help = "The ORT result file to read as input."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)

--- a/helper-cli/src/main/kotlin/commands/RemoveConfigurationEntriesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/RemoveConfigurationEntriesCommand.kt
@@ -44,7 +44,7 @@ internal class RemoveConfigurationEntriesCommand : CliktCommand(
             "written to the given repository configuration file."
 ) {
     private val ortResultFile by option(
-        "--ort-result-file",
+        "--ort-result-file", "-i",
         help = "The ORT result file to read as input which should contain an evaluator result."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)

--- a/helper-cli/src/main/kotlin/commands/TransformResultCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/TransformResultCommand.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.file
+
+import com.schibsted.spt.data.jslt.Parser
+
+import org.ossreviewtoolkit.model.yamlMapper
+import org.ossreviewtoolkit.utils.expandTilde
+
+/**
+ * A command to transform an ORT result using a JSLT expression.
+ *
+ * See https://github.com/schibsted/jslt.
+ */
+class TransformResultCommand : CliktCommand(
+    name = "transform", help = "Implements a JSLT transformation on the given ORT result file."
+) {
+    private val ortResultFile by option(
+        "--ort-result-file", "-i",
+        help = "The ORT result file to read as input."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val transformationFile by option(
+        "--transformation-file",
+        help = "The file defining the JSLT transformation to apply."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val outputFile by option(
+        "--output-file", "-o",
+        help = "The file in which to write the result of the transformation."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    override fun run() {
+        val node = yamlMapper.readTree(ortResultFile)
+
+        val expression = Parser.compile(transformationFile)
+
+        val result = expression.apply(node)
+        yamlMapper.writeValue(outputFile, result)
+
+        println("Wrote result to $outputFile.")
+    }
+}


### PR DESCRIPTION
JSLT [1] supports powerful transformations on JSON data. Possible use cases would be the conversion of existing results to conform to breaking changes in ORT's data model or the manipulation of results to generate test data. I played around with JSLT when I changed the data format for vulnerabilities in the Advisor module. As I found it useful, I thought I could share it. If you think, this is out of scope, just close this PR.

There is one limitation, however: JSLT does not handle tags in YAML and simply drops them. This is a problem with ORT result files because Jackson uses such tags to deal with class hierarchies. Currently the configuration of scan result storages makes use of this mechanism; so a manual post-processing of result files is necessary.

As an example for a JSLT transformation that could be applied, here is one that converts the advisor result section from the old format of vulnerabilities to the new one (as introduced in #3823):
```

{
  "advisor": {
    "results": {
      "advisor_results": {for(.advisor.results.advisor_results)
        .key: [for(.value) {
          "vulnerabilities": [for(.vulnerabilities) {
            "id": .id,
            "references": [
              {
                "url": .url,
                "severity": string(.severity)
              }
            ]
          }],
          "advisor": .advisor,
          "summary": .summary
        }]
      },
      * : .
    },
    * : .
  },
  * : .
}

```

[1] https://github.com/schibsted/jslt
