### PR TITLE
Gradle: Omit superfluous configureEach calls

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -219,7 +219,7 @@ subprojects {
         }
     }
 
-    tasks.withType<KotlinCompile>().configureEach {
+    tasks.withType<KotlinCompile> {
         val customCompilerArgs = listOf(
             "-Xallow-result-return-type",
             "-Xopt-in=kotlin.io.path.ExperimentalPathApi",
@@ -282,7 +282,7 @@ subprojects {
     gradle.taskGraph.whenReady {
         val enabled = allTasks.any { it is JacocoReport }
 
-        tasks.withType<Test>().configureEach {
+        tasks.withType<Test> {
             extensions.configure(JacocoTaskExtension::class) {
                 isEnabled = enabled
             }

--- a/spdx-utils/build.gradle.kts
+++ b/spdx-utils/build.gradle.kts
@@ -44,7 +44,7 @@ val generateGrammarSource by tasks.existing(AntlrTask::class) {
     arguments = arguments + listOf("-visitor")
 }
 
-tasks.withType<KotlinCompile>().configureEach {
+tasks.withType<KotlinCompile> {
     dependsOn(generateGrammarSource)
 }
 

--- a/utils/build.gradle.kts
+++ b/utils/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     testImplementation("io.mockk:mockk:$mockkVersion")
 }
 
-tasks.withType<Jar>().configureEach {
+tasks.withType<Jar> {
     manifest {
         val versionCandidates = listOf(project.version, rootProject.version)
         attributes["Implementation-Version"] = versionCandidates.find {


### PR DESCRIPTION
Configuring a task is the default action.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>