### PR TITLE
Flutter: Bootstrap Flutter/Pub/Dart

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -19,7 +19,6 @@ variables:
   BUNDLER_VERSION: 2.1.4
   COMPOSER_VERSION: 5.1.0 # The version refers to the installer, not to Composer.
   CONAN_VERSION: 1.18.0
-  FLUTTER_VERSION: v1.12.13+hotfix.9-stable
   GO_DEP_VERSION: 0.5.4
   PYTHON_PIPENV_VERSION: 2018.11.26
   RUST_VERSION: 1.35.0

--- a/.azure-pipelines/LinuxAnalyzerTest.yml
+++ b/.azure-pipelines/LinuxAnalyzerTest.yml
@@ -2,8 +2,6 @@ jobs:
 - job: LinuxAnalyzerTest
   pool:
     vmImage: ubuntu-18.04
-  variables:
-    FLUTTER_HOME: /opt/flutter
   steps:
   - task: UsePythonVersion@0
     displayName: Enable Python 3.6
@@ -36,14 +34,6 @@ jobs:
 
       # Downgrade Rust, because the CargoSubcrateTest fails with the pre-installed version.
       rustup default $RUST_VERSION
-
-      # Install Flutter.
-      curl -Os https://storage.googleapis.com/flutter_infra/releases/stable/linux/flutter_linux_$FLUTTER_VERSION.tar.xz
-      tar xf flutter_linux_$FLUTTER_VERSION.tar.xz -C $(dirname $FLUTTER_HOME)
-      rm flutter_linux_$FLUTTER_VERSION.tar.xz
-      export PATH="$PATH:$FLUTTER_HOME/bin:$FLUTTER_HOME/bin/cache/dart-sdk/bin"
-      flutter config --no-analytics
-      flutter doctor
 
       # Install git-repo.
       curl https://storage.googleapis.com/git-repo-downloads/repo > ~/.local/bin/repo

--- a/.azure-pipelines/WindowsAnalyzerTest.yml
+++ b/.azure-pipelines/WindowsAnalyzerTest.yml
@@ -2,8 +2,6 @@ jobs:
 - job: WindowsAnalyzerTest
   pool:
     vmImage: windows-2019
-  variables:
-    FLUTTER_HOME: C:\flutter
   steps:
   - task: UsePythonVersion@0
     displayName: Enable Python 3.6
@@ -33,14 +31,6 @@ jobs:
 
       # Install Ruby packages.
       gem install bundler -v $env:BUNDLER_VERSION
-
-      # Install Flutter.
-      Invoke-WebRequest -Uri "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_$env:FLUTTER_VERSION.zip" -OutFile "C:\flutter_windows_$env:FLUTTER_VERSION.zip"
-      7z x C:\flutter_windows_$env:FLUTTER_VERSION.zip -oC:\
-      Remove-Item "C:\flutter_windows_$env:FLUTTER_VERSION.zip"
-      $env:PATH += ";$env:FLUTTER_HOME\bin;$env:FLUTTER_HOME\bin\cache\dart-sdk\bin"
-      flutter config --no-analytics
-      flutter doctor
 
       # Stop adb because it otherwise locks the working directory which fails the checkout step.
       Stop-Process -Name "adb"

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,6 @@ ENV \
     CARGO_VERSION=0.47.0-1~exp1ubuntu1~18.04.1 \
     COMPOSER_VERSION=1.6.3-1 \
     CONAN_VERSION=1.18.0 \
-    FLUTTER_VERSION=v1.12.13+hotfix.9-stable \
     GO_DEP_VERSION=0.5.4 \
     GO_VERSION=1.13.4 \
     HASKELL_STACK_VERSION=2.1.3 \
@@ -65,11 +64,10 @@ ENV \
     SCANCODE_VERSION=3.2.1rc2 \
     # Installation directories.
     ANDROID_HOME=/opt/android-sdk \
-    FLUTTER_HOME=/opt/flutter \
     GOPATH=$HOME/go
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    PATH="$PATH:$HOME/.local/bin:$FLUTTER_HOME/bin:$FLUTTER_HOME/bin/cache/dart-sdk/bin:$GOPATH/bin:/opt/go/bin"
+    PATH="$PATH:$HOME/.local/bin:$GOPATH/bin:/opt/go/bin"
 
 # Apt install commands.
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
@@ -134,12 +132,6 @@ RUN /opt/ort/bin/import_proxy_certs.sh && \
     npm install --global npm@$NPM_VERSION bower@$BOWER_VERSION yarn@$YARN_VERSION && \
     pip install wheel && \
     pip install conan==$CONAN_VERSION pipenv==$PYTHON_PIPENV_VERSION virtualenv==$PYTHON_VIRTUALENV_VERSION && \
-    curl -ksSO https://storage.googleapis.com/flutter_infra/releases/stable/linux/flutter_linux_$FLUTTER_VERSION.tar.xz && \
-    tar xf flutter_linux_$FLUTTER_VERSION.tar.xz -C $(dirname $FLUTTER_HOME) && \
-    rm flutter_linux_$FLUTTER_VERSION.tar.xz && \
-    chmod -R a+rw $FLUTTER_HOME && \
-    flutter config --no-analytics && \
-    flutter doctor && \
     # Install golang in order to have `go mod` as package manager.
     curl -ksSO https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz && \
     tar -C /opt -xzf go$GO_VERSION.linux-amd64.tar.gz && \

--- a/cli/src/main/kotlin/commands/RequirementsCommand.kt
+++ b/cli/src/main/kotlin/commands/RequirementsCommand.kt
@@ -114,7 +114,7 @@ class RequirementsCommand : CliktCommand(help = "Check for the command line tool
             tools.forEach { tool ->
                 // TODO: State whether a tool can be bootstrapped, but that requires refactoring of CommandLineTool.
                 val message = buildString {
-                    val (prefix, suffix) = if (tool.isInPath()) {
+                    val (prefix, suffix) = if (tool.isInPath() || File(tool.command()).isFile) {
                         runCatching {
                             val actualVersion = tool.getVersion()
                             runCatching {
@@ -137,8 +137,8 @@ class RequirementsCommand : CliktCommand(help = "Check for the command line tool
                             Pair("\t+ ", "Could not determine the version.")
                         }
                     } else {
-                        // Tolerate scanners to be missing as they can be bootstrapped.
-                        if (category != "Scanner") {
+                        // Tolerate scanners and Pub to be missing as they can be bootstrapped.
+                        if (category != "Scanner" && tool.javaClass.simpleName != "Pub") {
                             statusCode = statusCode or 4
                         }
 

--- a/utils/src/main/kotlin/Constants.kt
+++ b/utils/src/main/kotlin/Constants.kt
@@ -36,6 +36,11 @@ const val ORT_FULL_NAME = "OSS Review Toolkit"
 const val ORT_CONFIG_DIR_ENV_NAME = "ORT_CONFIG_DIR"
 
 /**
+ * The name of the environment variable to customize the ORT tools directory.
+ */
+const val ORT_TOOLS_DIR_ENV_NAME = "ORT_TOOLS_DIR"
+
+/**
  * The name of the environment variable to customize the ORT data directory.
  */
 const val ORT_DATA_DIR_ENV_NAME = "ORT_DATA_DIR"

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -38,6 +38,17 @@ val ortConfigDirectory by lazy {
 }
 
 /**
+ * The directory to store ORT (read-write) tools in.
+ */
+val ortToolsDirectory by lazy {
+    Os.env[ORT_TOOLS_DIR_ENV_NAME]?.takeUnless {
+        it.isEmpty()
+    }?.let {
+        File(it)
+    } ?: ortDataDirectory.resolve("tools")
+}
+
+/**
  * The directory to store ORT (read-write) data in, like caches and archives.
  */
 val ortDataDirectory by lazy {


### PR DESCRIPTION
Due to the big size (around 1.7Gb) and rare use it is more optimal to
bootstrap Flutter on demand instead of installing it in the Docker
container.

This commit implements the bootstrapping logic for Flutter (which
includes Pub) and removes Flutter from the Docker image and the CI
configurations.

With this change it is now possible to choose the Flutter version by
setting the `FLUTTER_VERSION` environment variable.

Co-authored-by: Martin Nonnenmacher <martin.nonnenmacher@here.com>
Signed-off-by: zhernovs <ext-andriy.zhernovskyi@here.com>