### PR TITLE
OkHttpClientHelper: Only set a User-Agent if none was set before

### DIFF
--- a/downloader/src/funTest/kotlin/vcs/SubversionWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/SubversionWorkingTreeFunTest.kt
@@ -117,6 +117,7 @@ class SubversionWorkingTreeFunTest : StringSpec() {
                 "docutils-0.14rc2",
                 "docutils-0.15",
                 "docutils-0.16",
+                "docutils-0.17",
                 "docutils-0.3.7",
                 "docutils-0.3.9",
                 "docutils-0.4",

--- a/utils/src/main/kotlin/OkHttpClientHelper.kt
+++ b/utils/src/main/kotlin/OkHttpClientHelper.kt
@@ -71,10 +71,13 @@ object OkHttpClientHelper {
         // proxy authenticator.
         return OkHttpClient.Builder()
             .addNetworkInterceptor { chain ->
+                val request = chain.request()
                 chain.proceed(
-                    chain.request().newBuilder()
-                        .header("User-Agent", Environment.ORT_USER_AGENT)
-                        .build()
+                    if (request.header("User-Agent") == null) {
+                        request.newBuilder().header("User-Agent", Environment.ORT_USER_AGENT).build()
+                    } else {
+                        request
+                    }
                 )
             }
             .cache(cache)


### PR DESCRIPTION
This allows to keep a User-Agent that was explicitly set in a request.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>