### PR TITLE
GitHub: Upgrade the setup-java action to v2

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -17,8 +17,9 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v2
     - name: Setup Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: 'adopt'
         java-version: 11
     - name: Check for Detekt Issues
       uses: burrunan/gradle-cache-action@v1


### PR DESCRIPTION
See https://github.com/actions/setup-java/blob/v2/docs/switching-to-v2.md.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>