### PR TITLE
spdx-utils: Move license choice exceptions to SpdxException

### DIFF
--- a/spdx-utils/src/main/kotlin/SpdxException.kt
+++ b/spdx-utils/src/main/kotlin/SpdxException.kt
@@ -24,3 +24,7 @@ open class SpdxException : RuntimeException {
     constructor(message: String?) : super(message)
     constructor(cause: Throwable?) : super(cause)
 }
+
+class InvalidLicenseChoiceException(message: String) : SpdxException(message)
+
+class InvalidSubExpressionException(message: String) : SpdxException(message)

--- a/spdx-utils/src/main/kotlin/SpdxExpression.kt
+++ b/spdx-utils/src/main/kotlin/SpdxExpression.kt
@@ -619,7 +619,3 @@ enum class SpdxOperator(
      */
     OR(0)
 }
-
-class InvalidLicenseChoiceException(message: String) : SpdxException(message)
-
-class InvalidSubExpressionException(message: String) : SpdxException(message)


### PR DESCRIPTION
These plain "retypes" are better kept together with SpdxException.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>