### PR TITLE
PackageConfiguration: Increase the strictness of the VCS matcher

### DIFF
--- a/model/src/main/kotlin/config/PackageConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageConfiguration.kt
@@ -32,7 +32,7 @@ import org.ossreviewtoolkit.utils.stripCredentialsFromUrl
 
 /**
  * A configuration for a specific package and provenance. It allows to setup [PathExclude]s and
- * [LicenseFindingCuration]s, similar to how its done via the [RepositoryConfiguration] for projects.
+ * [LicenseFindingCuration]s, similar to how it is done via the [RepositoryConfiguration] for projects.
  */
 data class PackageConfiguration(
     /**

--- a/model/src/main/kotlin/config/PackageConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageConfiguration.kt
@@ -101,7 +101,8 @@ data class VcsMatcher(
     val revision: String,
 
     /**
-     * The [path] to match for equality against [VcsInfo.path].
+     * The [path] to match for equality against [VcsInfo.path]. Must only be specified in case [type] equals
+     * [VcsType.GIT_REPO].
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val path: String? = null
@@ -112,6 +113,10 @@ data class VcsMatcher(
         if (type == VcsType.GIT_REPO) {
             require(!path.isNullOrBlank()) {
                 "Matching against Git-Repo VCS info requires a non-blank path."
+            }
+        } else {
+            require(path == null) {
+                "A path must only be specified for matching Git-Repo VCS info."
             }
         }
     }

--- a/model/src/main/kotlin/config/PackageConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageConfiguration.kt
@@ -85,9 +85,24 @@ data class PackageConfiguration(
  * A matcher which matches its properties against [VcsInfo]s.
  */
 data class VcsMatcher(
+    /**
+     * The [type] to match for equality against [VcsInfo.type].
+     */
     val type: VcsType,
+
+    /**
+     * The [url] to match for equality against [VcsInfo.url].
+     */
     val url: String,
+
+    /**
+     * The [url] to match for equality against [VcsInfo.resolvedRevision].
+     */
     val revision: String,
+
+    /**
+     * The [path] to match for equality against [VcsInfo.path].
+     */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val path: String? = null
 ) {


### PR DESCRIPTION
Don't allow specifying a path for matching non-Git-Repo projects.
This eliminates an edge case which does not make sense to have in the first place.