### PR TITLE
model: Align tool configs to not serialize null values

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -196,7 +196,6 @@ class Pub(
 
     override fun getVersionRequirement(): Requirement = Requirement.buildIvy("[2.2,)")
 
-    // Bootstrap flutter if it's not yet installed
     override fun beforeResolution(definitionFiles: List<File>) {
         if (flutterAbsolutePath.resolve(flutterCommand).isFile) {
             log.info { "Skipping to bootstrap flutter as it was found in $flutterAbsolutePath." }

--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -191,7 +191,7 @@ class Downloader(private val config: DownloaderConfiguration) {
     }
 
     /**
-     * Download the source code of the [package][pkg] to the [outputDirectory] using it's VCS information. The
+     * Download the source code of the [package][pkg] to the [outputDirectory] using its VCS information. The
      * [allowMovingRevisions] parameter indicates whether the download accepts symbolic names, like branches, instead of
      * only fixed revisions. A [Provenance] is returned on success or a [DownloadException] is thrown in case of
      * failure.
@@ -294,7 +294,7 @@ class Downloader(private val config: DownloaderConfiguration) {
     }
 
     /**
-     * Download the source code of the [package][pkg] to the [outputDirectory] using it's source artifact. A
+     * Download the source code of the [package][pkg] to the [outputDirectory] using its source artifact. A
      * [Provenance] is returned on success or a [DownloadException] is thrown in case of failure.
      */
     fun downloadSourceArtifact(pkg: Package, outputDirectory: File): Provenance {

--- a/model/src/main/kotlin/config/AdvisorConfiguration.kt
+++ b/model/src/main/kotlin/config/AdvisorConfiguration.kt
@@ -43,6 +43,7 @@ data class NexusIqConfiguration(
     /**
      * A URL to use as a base for browsing vulnerability details. Defaults to the server URL.
      */
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     val browseUrl: String = serverUrl,
 
     /**

--- a/model/src/main/kotlin/config/AdvisorConfiguration.kt
+++ b/model/src/main/kotlin/config/AdvisorConfiguration.kt
@@ -19,11 +19,13 @@
 
 package org.ossreviewtoolkit.model.config
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
 /**
  * The base configuration model of the advisor.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class AdvisorConfiguration(
     val nexusIq: NexusIqConfiguration? = null,
     val vulnerableCode: VulnerableCodeConfiguration? = null

--- a/model/src/main/kotlin/config/AnalyzerConfiguration.kt
+++ b/model/src/main/kotlin/config/AnalyzerConfiguration.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.model.config
 
 import com.fasterxml.jackson.annotation.JsonInclude
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class AnalyzerConfiguration(
     /**
      * If set to true, ignore the versions of used command line tools. Note that this might lead to erroneous
@@ -42,6 +43,5 @@ data class AnalyzerConfiguration(
     /**
      * Configuration of the SW360 package curation provider.
      */
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     val sw360Configuration: Sw360StorageConfiguration? = null
 )

--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.model.config
 
 import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
 
 import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.utils.storage.FileStorage
@@ -29,6 +30,7 @@ import org.ossreviewtoolkit.utils.storage.FileStorage
  * The configuration model of the scanner.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class ScannerConfiguration(
     /**
      * A flag to indicate whether packages that have a concluded license and authors set (to derive copyrights from)

--- a/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/file-counter-expected-output-for-analyzer-result.yml
@@ -205,12 +205,7 @@ scanner:
     tool_versions: {}
   config:
     skip_concluded: false
-    archive: null
     create_missing_archives: false
-    options: null
-    storages: null
-    storage_readers: null
-    storage_writers: null
     ignore_patterns:
     - "**/*.ort.yml"
     - "**/META-INF/DEPENDENCIES"


### PR DESCRIPTION
This avoids null configs to be seralized to ORT result files.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>