### PR TITLE
declared-license-mapping: Map "The Go license" to BSD-3-Clause

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -395,6 +395,7 @@
 "The GNU General Public License, v2 with FOSS exception": GPL-2.0-only WITH Universal-FOSS-exception-1.0
 "The GNU Lesser General Public License, Version 2.1": LGPL-2.1-only
 "The GNU Lesser General Public License, Version 3.0": LGPL-3.0-only
+"The Go license": BSD-3-Clause
 "The JSON License": JSON
 "The MIT License (MIT)": MIT
 "The MIT License": MIT


### PR DESCRIPTION
As seen in [1]. Also see [2].

[1] https://repo1.maven.org/maven2/com/google/re2j/re2j/1.1/re2j-1.1.pom
[2] https://golang.org/LICENSE

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>