### PR TITLE
declared-license-mapping: Remove conflicting BSD license mappings

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -35,8 +35,8 @@ packages:
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "Composable command line interface toolkit"
   homepage_url: "https://palletsprojects.com/p/click/"
   binary_artifact:
@@ -70,7 +70,8 @@ packages:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "A microframework based on Werkzeug, Jinja2 and good intentions"
   homepage_url: "http://github.com/pallets/flask/"
   binary_artifact:
@@ -137,7 +138,8 @@ packages:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "Various helpers to pass data to untrusted environments and back."
   homepage_url: "https://palletsprojects.com/p/itsdangerous/"
   binary_artifact:
@@ -171,7 +173,8 @@ packages:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "A small but fast and easy to use stand-alone template engine written\
     \ in pure python."
   homepage_url: "http://jinja.pocoo.org/"
@@ -204,8 +207,8 @@ packages:
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "Safely add untrusted strings to HTML/XML markup."
   homepage_url: "https://palletsprojects.com/p/markupsafe/"
   binary_artifact:
@@ -237,8 +240,8 @@ packages:
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "The comprehensive WSGI web application library."
   homepage_url: "https://palletsprojects.com/p/werkzeug/"
   binary_artifact:

--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -407,9 +407,8 @@ analyzer:
         declared_licenses:
         - "BSD License"
         declared_licenses_processed:
-          spdx_expression: "BSD-3-Clause"
-          mapped:
-            BSD License: "BSD-3-Clause"
+          unmapped:
+          - "BSD License"
         description: "A framework for constructing recognizers, compilers,\n    and\
           \ translators from grammatical descriptions containing\n    Java, C#, C++,\
           \ or Python actions."
@@ -697,9 +696,8 @@ analyzer:
         declared_licenses:
         - "BSD License"
         declared_licenses_processed:
-          spdx_expression: "BSD-3-Clause"
-          mapped:
-            BSD License: "BSD-3-Clause"
+          unmapped:
+          - "BSD License"
         description: "Implementation of various mathematical curves that define themselves\
           \ over a set of control points. The API is written in Java. The curves supported\
           \ are: Bezier, B-Spline, Cardinal Spline, Catmull-Rom Spline, Lagrange,\

--- a/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/jgnash-core-expected-output.yml
@@ -71,9 +71,8 @@ packages:
   declared_licenses:
   - "BSD License"
   declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "A framework for constructing recognizers, compilers,\n    and translators\
     \ from grammatical descriptions containing\n    Java, C#, C++, or Python actions."
   homepage_url: "http://www.antlr.org/"
@@ -140,9 +139,8 @@ packages:
   declared_licenses:
   - "BSD License"
   declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "Implementation of various mathematical curves that define themselves\
     \ over a set of control points. The API is written in Java. The curves supported\
     \ are: Bezier, B-Spline, Cardinal Spline, Catmull-Rom Spline, Lagrange, Natural\

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -46,7 +46,8 @@ packages:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "An ISO 8601 date/time/duration parser and formatter"
   homepage_url: "https://github.com/gweis/isodate/"
   binary_artifact:
@@ -142,8 +143,8 @@ packages:
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "RDFLib is a Python library for working with RDF, a simple yet powerful\
     \ language for representing information."
   homepage_url: "https://github.com/RDFLib/rdflib"

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -38,9 +38,8 @@ packages:
   declared_licenses:
   - "BSD License"
   declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "A simple wrapper around optparse for powerful command line utilities."
   homepage_url: "http://github.com/mitsuhiko/click"
   binary_artifact:
@@ -74,7 +73,8 @@ packages:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "A simple framework for building complex web applications."
   homepage_url: "https://www.palletsprojects.com/p/flask/"
   binary_artifact:
@@ -104,9 +104,8 @@ packages:
   declared_licenses:
   - "BSD License"
   declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "Various helpers to pass trusted data to untrusted environments and\
     \ back."
   homepage_url: "http://github.com/mitsuhiko/itsdangerous"
@@ -139,8 +138,8 @@ packages:
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "A very fast and expressive template engine."
   homepage_url: "https://palletsprojects.com/p/jinja/"
   binary_artifact:
@@ -174,7 +173,8 @@ packages:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "Implements a XML/HTML/XHTML Markup safe string for Python"
   homepage_url: "http://github.com/pallets/markupsafe"
   binary_artifact:
@@ -206,8 +206,8 @@ packages:
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "The comprehensive WSGI web application library."
   homepage_url: "https://palletsprojects.com/p/werkzeug/"
   binary_artifact:

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-python3-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-python3-expected-output.yml
@@ -34,7 +34,8 @@ packages:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "A high-level Python Web framework that encourages rapid development\
     \ and clean, pragmatic design."
   homepage_url: "https://www.djangoproject.com/"
@@ -100,8 +101,8 @@ packages:
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "A non-validating SQL parser."
   homepage_url: "https://github.com/andialbrecht/sqlparse"
   binary_artifact:

--- a/analyzer/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
@@ -34,9 +34,8 @@ packages:
   declared_licenses:
   - "BSD License"
   declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "A simple wrapper around optparse for powerful command line utilities."
   homepage_url: "http://github.com/mitsuhiko/click"
   binary_artifact:
@@ -70,7 +69,8 @@ packages:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "A simple framework for building complex web applications."
   homepage_url: "https://www.palletsprojects.com/p/flask/"
   binary_artifact:
@@ -100,9 +100,8 @@ packages:
   declared_licenses:
   - "BSD License"
   declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "Various helpers to pass trusted data to untrusted environments and\
     \ back."
   homepage_url: "http://github.com/mitsuhiko/itsdangerous"
@@ -137,7 +136,8 @@ packages:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "A small but fast and easy to use stand-alone template engine written\
     \ in pure python."
   homepage_url: "http://jinja.pocoo.org/"
@@ -172,7 +172,8 @@ packages:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "Implements a XML/HTML/XHTML Markup safe string for Python"
   homepage_url: "http://github.com/pallets/markupsafe"
   binary_artifact:
@@ -204,8 +205,8 @@ packages:
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "The comprehensive WSGI web application library."
   homepage_url: "https://palletsprojects.com/p/werkzeug/"
   binary_artifact:

--- a/analyzer/src/funTest/assets/projects/synthetic/pipenv-python3-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pipenv-python3-expected-output.yml
@@ -33,7 +33,8 @@ packages:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
+    unmapped:
+    - "BSD License"
   description: "A high-level Python Web framework that encourages rapid development\
     \ and clean, pragmatic design."
   homepage_url: "https://www.djangoproject.com/"

--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -79,7 +79,6 @@
 "BSD Licence 3": BSD-3-Clause
 "BSD License 3": BSD-3-Clause
 "BSD License for HSQL": BSD-3-Clause
-"BSD License": BSD-3-Clause
 "BSD New license": BSD-3-Clause
 "BSD New": BSD-3-Clause
 "BSD Three Clause License": BSD-3-Clause
@@ -389,7 +388,6 @@
 "The Apache Software License, Version 2.0": Apache-2.0
 "The BSD 2-Clause License": BSD-2-Clause
 "The BSD 3-Clause License": BSD-3-Clause
-"The BSD License": BSD-2-Clause
 "The BSD Software License": BSD-2-Clause
 "The Eclipse Public License Version 1.0": EPL-1.0
 "The Eclipse Public License Version 2.0": EPL-2.0


### PR DESCRIPTION
It does not make sense to map "BSD License" and "The BSD License"
differently. In fact, the version cannot be told in either case. So simply
remove both mappings.

As an example why the version cannot be assumed, take [1] where "The BSD
License" is supposed to mean BSD-3-Clause instead of BSD-2-Clause.

[1] https://repo1.maven.org/maven2/org/antlr/antlr4-master/4.7.1/antlr4-master-4.7.1.pom

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>