### PR TITLE
declared-license-mapping: Add "The Eclipse Public License Version 2.0"

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -390,6 +390,7 @@
 "The BSD License": BSD-2-Clause
 "The BSD Software License": BSD-2-Clause
 "The Eclipse Public License Version 1.0": EPL-1.0
+"The Eclipse Public License Version 2.0": EPL-2.0
 "The GNU General Public License (GPL), Version 2, With Classpath Exception": GPL-2.0-only WITH Classpath-exception-2.0
 "The GNU General Public License, Version 2": GPL-2.0-only
 "The GNU General Public License, v2 with FOSS exception": GPL-2.0-only WITH Universal-FOSS-exception-1.0


### PR DESCRIPTION
As seen in [1].

[1] https://repo1.maven.org/maven2/org/eclipse/emf/org.eclipse.emf.common/2.18.0/org.eclipse.emf.common-2.18.0.pom

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>