### PR TITLE
helper-cli: Add a command to export path excludes from package configs

### DIFF
--- a/helper-cli/src/main/kotlin/commands/packageconfig/ExportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/ExportPathExcludesCommand.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands.packageconfig
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.file
+
+import org.ossreviewtoolkit.helper.commands.writeAsYaml
+import org.ossreviewtoolkit.helper.common.RepositoryPathExcludes
+import org.ossreviewtoolkit.helper.common.findRepositories
+import org.ossreviewtoolkit.helper.common.getPathExcludesByRepository
+import org.ossreviewtoolkit.helper.common.mergePathExcludes
+import org.ossreviewtoolkit.model.config.PackageConfiguration
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.utils.expandTilde
+
+class ExportPathExcludesCommand : CliktCommand(
+    help = "Export the path excludes to a path excludes file which maps repository URLs to the path excludes for the " +
+            "respective repository"
+) {
+    private val pathExcludesFile by option(
+        "--path-excludes-file",
+        help = "The output path excludes file."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val packageConfigurationFile by option(
+        "--package-configuration-file",
+        help = "The package configuration."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val sourceCodeDir by option(
+        "--source-code-dir",
+        help = "A directory containing the sources corresponding to the provided package configuration."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = false, canBeDir = true, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val updateOnlyExisting by option(
+        "--update-only-existing",
+        help = "If enabled, only entries are exported for which an entry with the same pattern already exists."
+    ).flag()
+
+    override fun run() {
+        val globalPathExcludes = if (pathExcludesFile.isFile) {
+            pathExcludesFile.readValue<RepositoryPathExcludes>()
+        } else {
+            mapOf()
+        }
+
+        val localPathExcludes = getPathExcludesByRepository(
+            pathExcludes = packageConfigurationFile.readValue<PackageConfiguration>().pathExcludes,
+            nestedRepositories = findRepositories(sourceCodeDir)
+        )
+
+        globalPathExcludes
+            .mergePathExcludes(localPathExcludes, updateOnlyExisting = updateOnlyExisting)
+            .writeAsYaml(pathExcludesFile)
+    }
+}

--- a/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
@@ -29,6 +29,7 @@ internal class PackageConfigurationCommand : CliktCommand(
         subcommands(
             FindCommand(),
             FormatCommand(),
+            ExportPathExcludesCommand(),
             ImportLicenseFindingCurationsCommand(),
             ImportPathExcludesCommand(),
             SortCommand(),

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -429,10 +429,21 @@ internal fun OrtResult.getRepositoryPathExcludes(): RepositoryPathExcludes {
         }
     }
 
-    val result = mutableMapOf<String, MutableList<PathExclude>>()
     val pathExcludes = repository.config.excludes.paths.filterNot { isDefinitionsFile(it) }
 
-    repository.nestedRepositories.forEach { (path, vcs) ->
+    return getPathExcludesByRepository(pathExcludes, repository.nestedRepositories)
+}
+
+/**
+ * Return all path excludes from [pathExcludes] represented as [RepositoryPathExcludes].
+ */
+internal fun getPathExcludesByRepository(
+    pathExcludes: Collection<PathExclude>,
+    nestedRepositories: Map<String, VcsInfo>
+): RepositoryPathExcludes {
+    val result = mutableMapOf<String, MutableList<PathExclude>>()
+
+    nestedRepositories.forEach { (path, vcs) ->
         val pathExcludesForRepository = result.getOrPut(vcs.url) { mutableListOf() }
         pathExcludes.forEach { pathExclude ->
             pathExclude.pattern.withoutPrefix("$path/")?.let {

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -430,11 +430,11 @@ internal fun OrtResult.getRepositoryPathExcludes(): RepositoryPathExcludes {
     }
 
     val result = mutableMapOf<String, MutableList<PathExclude>>()
-    val pathExcludes = repository.config.excludes.paths
+    val pathExcludes = repository.config.excludes.paths.filterNot { isDefinitionsFile(it) }
 
     repository.nestedRepositories.forEach { (path, vcs) ->
         val pathExcludesForRepository = result.getOrPut(vcs.url) { mutableListOf() }
-        pathExcludes.filterNot { isDefinitionsFile(it) }.forEach { pathExclude ->
+        pathExcludes.forEach { pathExclude ->
             pathExclude.pattern.withoutPrefix("$path/")?.let {
                 pathExcludesForRepository += pathExclude.copy(pattern = it)
             }

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -137,19 +137,26 @@ internal fun findFilesRecursive(directory: File): List<String> {
 internal fun findRepositoryPaths(directory: File): Map<String, Set<String>> {
     require(directory.isDirectory)
 
-    val analyzer = Analyzer(AnalyzerConfiguration(ignoreToolVersions = true, allowDynamicVersions = true))
-    val ortResult = analyzer.analyze(
-        absoluteProjectPath = directory,
-        packageManagers = emptyList()
-    )
-
     val result = mutableMapOf<String, MutableSet<String>>()
 
-    ortResult.repository.nestedRepositories.forEach { (path, vcs) ->
+    findRepositories(directory).forEach { (path, vcs) ->
         result.getOrPut(vcs.url.stripCredentialsFromUrl()) { mutableSetOf() } += path
     }
 
     return result
+}
+
+/**
+ * Search the given [directory] for repositories and return a mapping from paths where each respective repository was
+ * found to the corresponding [VcsInfo].
+ */
+internal fun findRepositories(directory: File): Map<String, VcsInfo> {
+    require(directory.isDirectory)
+
+    val analyzer = Analyzer(AnalyzerConfiguration(ignoreToolVersions = true, allowDynamicVersions = true))
+    val ortResult = analyzer.analyze(absoluteProjectPath = directory, packageManagers = emptyList())
+
+    return ortResult.repository.nestedRepositories
 }
 
 /**


### PR DESCRIPTION
This enables a workflow similar to what we already have for repository configurations.