### PR TITLE
spdx-utils: Fix referenceCategory enum values

### DIFF
--- a/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
+++ b/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
@@ -33,7 +33,7 @@
     "copyrightText" : "Copyright 2020 Some copyright holder in VCS\nCopyright 2020 Some copyright holder in source artifact\nCopyright 2020 Some other copyright holder in source artifact",
     "downloadLocation" : "https://some-host/first-package.jar",
     "externalRefs" : [ {
-      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceCategory" : "PACKAGE_MANAGER",
       "referenceLocator" : "pkg:maven/first-package-group/first-package@0.0.1",
       "referenceType" : "purl"
     } ],
@@ -49,7 +49,7 @@
     "copyrightText" : "Copyright 2020 Some copyright holder in VCS\nCopyright 2020 Some copyright holder in source artifact\nCopyright 2020 Some other copyright holder in source artifact",
     "downloadLocation" : "git+ssh://github.com/path/first-package-repo.git@deadbeef#project-path",
     "externalRefs" : [ {
-      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceCategory" : "PACKAGE_MANAGER",
       "referenceLocator" : "pkg:maven/first-package-group/first-package@0.0.1",
       "referenceType" : "purl"
     } ],
@@ -68,7 +68,7 @@
     "copyrightText" : "Copyright 2020 Some copyright holder in VCS\nCopyright 2020 Some copyright holder in source artifact\nCopyright 2020 Some other copyright holder in source artifact",
     "downloadLocation" : "https://some-host/first-package-sources.jar",
     "externalRefs" : [ {
-      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceCategory" : "PACKAGE_MANAGER",
       "referenceLocator" : "pkg:maven/first-package-group/first-package@0.0.1",
       "referenceType" : "purl"
     } ],
@@ -87,7 +87,7 @@
     "copyrightText" : "NONE",
     "downloadLocation" : "NONE",
     "externalRefs" : [ {
-      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceCategory" : "PACKAGE_MANAGER",
       "referenceLocator" : "pkg:maven/fourth-package-group/fourth-package@0.0.1",
       "referenceType" : "purl"
     } ],
@@ -103,7 +103,7 @@
     "copyrightText" : "NONE",
     "downloadLocation" : "NONE",
     "externalRefs" : [ {
-      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceCategory" : "PACKAGE_MANAGER",
       "referenceLocator" : "pkg:maven/second-package-group/second-package@0.0.1",
       "referenceType" : "purl"
     } ],
@@ -119,7 +119,7 @@
     "copyrightText" : "NONE",
     "downloadLocation" : "NONE",
     "externalRefs" : [ {
-      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceCategory" : "PACKAGE_MANAGER",
       "referenceLocator" : "pkg:maven/sixth-package-group/sixth-package@0.0.1",
       "referenceType" : "purl"
     } ],
@@ -135,7 +135,7 @@
     "copyrightText" : "NONE",
     "downloadLocation" : "NONE",
     "externalRefs" : [ {
-      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceCategory" : "PACKAGE_MANAGER",
       "referenceLocator" : "pkg:maven/third-package-group/third-package@0.0.1",
       "referenceType" : "purl"
     } ],

--- a/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
+++ b/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
@@ -44,7 +44,7 @@ packages:
     \ in source artifact"
   downloadLocation: "https://some-host/first-package.jar"
   externalRefs:
-  - referenceCategory: "PACKAGE-MANAGER"
+  - referenceCategory: "PACKAGE_MANAGER"
     referenceLocator: "pkg:maven/first-package-group/first-package@0.0.1"
     referenceType: "purl"
   filesAnalyzed: false
@@ -62,7 +62,7 @@ packages:
     \ in source artifact"
   downloadLocation: "git+ssh://github.com/path/first-package-repo.git@deadbeef#project-path"
   externalRefs:
-  - referenceCategory: "PACKAGE-MANAGER"
+  - referenceCategory: "PACKAGE_MANAGER"
     referenceLocator: "pkg:maven/first-package-group/first-package@0.0.1"
     referenceType: "purl"
   filesAnalyzed: true
@@ -82,7 +82,7 @@ packages:
     \ in source artifact"
   downloadLocation: "https://some-host/first-package-sources.jar"
   externalRefs:
-  - referenceCategory: "PACKAGE-MANAGER"
+  - referenceCategory: "PACKAGE_MANAGER"
     referenceLocator: "pkg:maven/first-package-group/first-package@0.0.1"
     referenceType: "purl"
   filesAnalyzed: true
@@ -100,7 +100,7 @@ packages:
   copyrightText: "NONE"
   downloadLocation: "NONE"
   externalRefs:
-  - referenceCategory: "PACKAGE-MANAGER"
+  - referenceCategory: "PACKAGE_MANAGER"
     referenceLocator: "pkg:maven/fourth-package-group/fourth-package@0.0.1"
     referenceType: "purl"
   filesAnalyzed: false
@@ -114,7 +114,7 @@ packages:
   copyrightText: "NONE"
   downloadLocation: "NONE"
   externalRefs:
-  - referenceCategory: "PACKAGE-MANAGER"
+  - referenceCategory: "PACKAGE_MANAGER"
     referenceLocator: "pkg:maven/second-package-group/second-package@0.0.1"
     referenceType: "purl"
   filesAnalyzed: false
@@ -128,7 +128,7 @@ packages:
   copyrightText: "NONE"
   downloadLocation: "NONE"
   externalRefs:
-  - referenceCategory: "PACKAGE-MANAGER"
+  - referenceCategory: "PACKAGE_MANAGER"
     referenceLocator: "pkg:maven/sixth-package-group/sixth-package@0.0.1"
     referenceType: "purl"
   filesAnalyzed: false
@@ -142,7 +142,7 @@ packages:
   copyrightText: "NONE"
   downloadLocation: "NONE"
   externalRefs:
-  - referenceCategory: "PACKAGE-MANAGER"
+  - referenceCategory: "PACKAGE_MANAGER"
     referenceLocator: "pkg:maven/third-package-group/third-package@0.0.1"
     referenceType: "purl"
   filesAnalyzed: false

--- a/spdx-utils/src/main/kotlin/model/SpdxExternalReference.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxExternalReference.kt
@@ -55,8 +55,8 @@ data class SpdxExternalReference(
         val serializedName: String
     ) {
         SECURITY("SECURITY"),
-        PACKAGE_MANAGER("PACKAGE-MANAGER"),
-        PERSISTENT_ID("PERSISTENT-ID"),
+        PACKAGE_MANAGER("PACKAGE_MANAGER"),
+        PERSISTENT_ID("PERSISTENT_ID"),
         OTHER("OTHER");
     }
 


### PR DESCRIPTION
Seperator is a underscore not a hyphen see [1].

[1]: https://github.com/spdx/spdx-spec/blob/3dddfc34d7e770d4c17fc19f61be8554e3934c3d/schemas/spdx-schema.json#L273

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>
