### PR TITLE
ImportLicenseFindingCurationsCommand: Require the package config file to exist

### DIFF
--- a/helper-cli/src/main/kotlin/commands/packageconfig/ImportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/ImportLicenseFindingCurationsCommand.kt
@@ -61,7 +61,7 @@ class ImportLicenseFindingCurationsCommand : CliktCommand(
         "--package-configuration-file",
         help = "The package configuration file where the imported curations are to be merged into."
     ).convert { it.expandTilde() }
-        .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
         .convert { it.absoluteFile.normalize() }
         .required()
 


### PR DESCRIPTION
The code is implemented in such a way that it actually expects the file
to be present, so let clikt also enforce the existence.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>