### PR TITLE
spdx-reporter: Fix creation date to be 'YYYY-MM-DDThh:mm:ssZ'

### DIFF
--- a/reporter/src/main/kotlin/utils/SpdxDocumentModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/SpdxDocumentModelMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.reporter.utils
 
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
@@ -161,7 +162,7 @@ object SpdxDocumentModelMapper {
             comment = params.documentComment,
             creationInfo = SpdxCreationInfo(
                 comment = params.creationInfoComment,
-                created = Instant.now(),
+                created = Instant.now().truncatedTo(ChronoUnit.SECONDS),
                 creators = listOf("${SpdxConstants.TOOL}$ORT_FULL_NAME - ${Environment().ortVersion}"),
                 licenseListVersion = SpdxLicense.LICENSE_LIST_VERSION.substringBefore("-")
             ),

--- a/spdx-utils/src/main/kotlin/model/SpdxCreationInfo.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxCreationInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ data class SpdxCreationInfo(
 
     /**
      * The date and time the [SpdxDocument] was created.
+     * Format: YYYY-MM-DDThh:mm:ssZ
      */
     val created: Instant,
 


### PR DESCRIPTION
SPDX reporter uses Instant as type for the creation data in CreatedInfo.
However Instant.toString() returns ISO-8601 string with macro seconds
whilst SPDX specification [1] only requires a precision in whole seconds.

[1]: https://github.com/spdx/spdx-spec/blob/development/v2.2.1/chapters/document-creation-information.md#691-description

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>
