### PR TITLE
Gradle: Use HTTPS to link to the Apache-2.0 license

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -373,7 +373,7 @@ subprojects {
                     licenses {
                         license {
                             name.set("Apache-2.0")
-                            url.set("http://www.apache.org/licenses/LICENSE-2.0")
+                            url.set("https://www.apache.org/licenses/LICENSE-2.0")
                         }
                     }
 


### PR DESCRIPTION
This fixes an IDEA inspection hint.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>