### PR TITLE
Use sane fallbacks when reading empty files

### DIFF
--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -66,6 +66,10 @@ class Advisor(
             "Read ORT result from '${ortFile.name}' (${ortFile.formatSizeInMib}) in ${duration.inMilliseconds}ms."
         }
 
+        requireNotNull(ortResult) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }
+
         if (ortResult.analyzer == null) {
             log.warn {
                 "Cannot run the advisor as the provided ORT result file '${ortFile.canonicalPath}' does not contain " +

--- a/advisor/src/test/kotlin/advisors/VulnerableCodeTest.kt
+++ b/advisor/src/test/kotlin/advisors/VulnerableCodeTest.kt
@@ -268,7 +268,7 @@ private fun resultFile(): File = File(TEST_FILES_ROOT).resolve(TEST_RESULT_NAME)
  * Return a list with [Package]s from the analyzer result file that serve as input for the [VulnerableCode] advisor.
  */
 private fun inputPackages(): List<Package> =
-    resultFile().readValue<OrtResult>().getPackages(false).map { it.pkg }
+    resultFile().readValue<OrtResult>()?.getPackages(false)?.map { it.pkg }.orEmpty()
 
 /**
  * Generate the JSON body of the request to query information about packages. It mainly consists of an array with the

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -60,7 +60,7 @@ class Analyzer(private val config: AnalyzerConfiguration) {
         val repositoryConfiguration = if (actualRepositoryConfigurationFile.isFile) {
             log.info { "Using configuration file '${actualRepositoryConfigurationFile.absolutePath}'." }
 
-            actualRepositoryConfigurationFile.readValue()
+            actualRepositoryConfigurationFile.readValue() ?: RepositoryConfiguration()
         } else {
             RepositoryConfiguration()
         }

--- a/analyzer/src/main/kotlin/curation/FilePackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/FilePackageCurationProvider.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.model.readValue
  */
 class FilePackageCurationProvider(curationFile: File) : PackageCurationProvider {
     internal val packageCurations: List<PackageCuration> by lazy {
-        curationFile.readValue<List<PackageCuration>>()
+        curationFile.readValue<List<PackageCuration>>().orEmpty()
     }
 
     override fun getCurationsFor(pkgId: Identifier) = packageCurations.filter { it.isApplicable(pkgId) }

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -223,7 +223,7 @@ open class Npm(
 
             log.debug { "Found a 'package.json' file in '$packageDir'." }
 
-            val json = file.readValue<ObjectNode>()
+            val json = file.readValue<ObjectNode>() ?: return@forEach
             val rawName = json["name"].textValue()
             val (namespace, name) = splitNamespaceAndName(rawName)
             val version = json["version"].textValue()

--- a/analyzer/src/main/kotlin/managers/utils/NodeSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NodeSupport.kt
@@ -23,13 +23,12 @@ package org.ossreviewtoolkit.analyzer.managers.utils
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.node.ArrayNode
-import com.fasterxml.jackson.databind.node.ObjectNode
 
 import java.io.File
 import java.nio.file.FileSystems
 import java.nio.file.PathMatcher
 
-import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.readJsonFile
 import org.ossreviewtoolkit.utils.AuthenticatedProxy
 import org.ossreviewtoolkit.utils.ProtocolProxyMap
 import org.ossreviewtoolkit.utils.collectMessagesAsString
@@ -176,7 +175,7 @@ private fun getPackageJsonInfo(definitionFiles: Set<File>): Collection<PackageJs
 
 private fun isYarnWorkspaceRoot(definitionFile: File) =
     try {
-        definitionFile.readValue<ObjectNode>()["workspaces"] != null
+        readJsonFile(definitionFile).has("workspaces")
     } catch (e: JsonProcessingException) {
         e.showStackTrace()
 
@@ -211,7 +210,7 @@ private fun getYarnWorkspaceSubmodules(definitionFiles: Set<File>): Set<File> {
 
 private fun getWorkspaceMatchers(definitionFile: File): List<PathMatcher> {
     var workspaces = try {
-        definitionFile.readValue<ObjectNode>()["workspaces"]
+        readJsonFile(definitionFile).get("workspaces")
     } catch (e: JsonProcessingException) {
         e.showStackTrace()
 

--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -187,6 +187,10 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
                             "${duration.inMilliseconds}ms."
                 }
 
+                requireNotNull(ortResult) {
+                    "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+                }
+
                 val analyzerResult = ortResult.analyzer?.result
 
                 if (analyzerResult == null) {

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -45,9 +45,11 @@ import org.ossreviewtoolkit.GroupTypes.StringType
 import org.ossreviewtoolkit.evaluator.Evaluator
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
+import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.config.orEmpty
 import org.ossreviewtoolkit.model.licenses.DefaultLicenseInfoProvider
@@ -239,12 +241,12 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate ORT re
             }
         }
 
-        repositoryConfigurationFile?.let {
-            ortResultInput = ortResultInput?.replaceConfig(it.readValue())
+        repositoryConfigurationFile?.readValue<RepositoryConfiguration>()?.let {
+            ortResultInput = ortResultInput?.replaceConfig(it)
         }
 
-        packageCurationsFile?.let {
-            ortResultInput = ortResultInput?.replacePackageCurations(it.readValue())
+        packageCurationsFile?.readValue<List<PackageCuration>>()?.let {
+            ortResultInput = ortResultInput?.replacePackageCurations(it)
         }
 
         val finalOrtResult = requireNotNull(ortResultInput) {

--- a/cli/src/main/kotlin/commands/UploadCurationsCommand.kt
+++ b/cli/src/main/kotlin/commands/UploadCurationsCommand.kt
@@ -95,7 +95,7 @@ class UploadCurationsCommand : CliktCommand(
         }
 
     override fun run() {
-        val curations = inputFile.readValue<List<PackageCuration>>()
+        val curations = inputFile.readValue<List<PackageCuration>>().orEmpty()
         val curationsToCoordinates = curations.mapNotNull { curation ->
             curation.id.toClearlyDefinedCoordinates()?.let { coordinates ->
                 curation to coordinates

--- a/cli/src/main/kotlin/commands/UploadResultToPostgresCommand.kt
+++ b/cli/src/main/kotlin/commands/UploadResultToPostgresCommand.kt
@@ -93,6 +93,10 @@ class UploadResultToPostgresCommand : CliktCommand(
             "Read ORT result from '${ortFile.name}' (${ortFile.formatSizeInMib}) in ${duration.inMilliseconds}ms."
         }
 
+        requireNotNull(ortResult) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }
+
         val postgresConfig = globalOptionsForSubcommands.config.scanner.storages?.values
             ?.filterIsInstance<PostgresStorageConfiguration>()?.singleOrNull()
 

--- a/cli/src/main/kotlin/commands/UploadResultToSw360Command.kt
+++ b/cli/src/main/kotlin/commands/UploadResultToSw360Command.kt
@@ -82,6 +82,10 @@ class UploadResultToSw360Command : CliktCommand(
             "Read ORT result from '${ortFile.name}' (${ortFile.formatSizeInMib}) in ${duration.inMilliseconds}ms."
         }
 
+        requireNotNull(ortResult) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }
+
         val sw360Config = globalOptionsForSubcommands.config.scanner.storages?.values
             ?.filterIsInstance<Sw360StorageConfiguration>()?.singleOrNull()
 

--- a/helper-cli/src/main/kotlin/commands/ExportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ExportPathExcludesCommand.kt
@@ -68,16 +68,15 @@ internal class ExportPathExcludesCommand : CliktCommand(
     ).flag()
 
     override fun run() {
-        val localPathExcludes = ortFile
-            .readValue<OrtResult>()
+        val ortResult = requireNotNull(ortFile.readValue<OrtResult>()) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }
+
+        val localPathExcludes = ortResult
             .replaceConfig(repositoryConfigurationFile)
             .getRepositoryPathExcludes()
 
-        val globalPathExcludes = if (pathExcludesFile.isFile) {
-            pathExcludesFile.readValue<RepositoryPathExcludes>()
-        } else {
-            mapOf()
-        }
+        val globalPathExcludes = pathExcludesFile.takeIf { it.isFile }?.readValue<RepositoryPathExcludes>().orEmpty()
 
         globalPathExcludes
             .mergePathExcludes(localPathExcludes, updateOnlyExisting = updateOnlyExisting)

--- a/helper-cli/src/main/kotlin/commands/ExtractRepositoryConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ExtractRepositoryConfigurationCommand.kt
@@ -50,9 +50,10 @@ class ExtractRepositoryConfigurationCommand : CliktCommand(
         .required()
 
     override fun run() {
-        ortFile
-            .readValue<OrtResult>()
-            .repository
-            .config.write(repositoryConfigurationFile)
+        val ortResult = requireNotNull(ortFile.readValue<OrtResult>()) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }
+
+        ortResult.repository.config.write(repositoryConfigurationFile)
     }
 }

--- a/helper-cli/src/main/kotlin/commands/FormatRepositoryConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/FormatRepositoryConfigurationCommand.kt
@@ -41,8 +41,10 @@ internal class FormatRepositoryConfigurationCommand : CliktCommand(
         .convert { it.absoluteFile.normalize() }
 
     override fun run() {
-        repositoryConfigurationFile
-            .readValue<RepositoryConfiguration>()
-            .write(repositoryConfigurationFile)
+        val repoConfig = requireNotNull(repositoryConfigurationFile.readValue<RepositoryConfiguration>()) {
+            "The provided ORT result file '${repositoryConfigurationFile.canonicalPath}' has no content."
+        }
+
+        repoConfig.write(repositoryConfigurationFile)
     }
 }

--- a/helper-cli/src/main/kotlin/commands/GenerateProjectExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateProjectExcludesCommand.kt
@@ -57,14 +57,12 @@ internal class GenerateProjectExcludesCommand : CliktCommand(
         .required()
 
     override fun run() {
-        val repositoryConfiguration = if (repositoryConfigurationFile.isFile) {
-            repositoryConfigurationFile.readValue()
-        } else {
-            RepositoryConfiguration()
-        }
+        val repositoryConfiguration = repositoryConfigurationFile.takeIf { it.isFile }?.readValue()
+            ?: RepositoryConfiguration()
 
-        val ortResult = ortFile.readValue<OrtResult>()
-            .replaceConfig(repositoryConfiguration)
+        val ortResult = requireNotNull(ortFile.readValue<OrtResult>()) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }.replaceConfig(repositoryConfiguration)
 
         val generatedPathExcludes = ortResult
             .getProjects()

--- a/helper-cli/src/main/kotlin/commands/GenerateRuleViolationResolutionsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateRuleViolationResolutionsCommand.kt
@@ -66,8 +66,11 @@ internal class GenerateRuleViolationResolutionsCommand : CliktCommand(
     ).enum<Severity>().split(",").default(enumValues<Severity>().asList())
 
     override fun run() {
-        val repositoryConfiguration = repositoryConfigurationFile.readValue<RepositoryConfiguration>()
-        val ortResult = ortFile.readValue<OrtResult>().replaceConfig(repositoryConfiguration)
+        val repositoryConfiguration = repositoryConfigurationFile.readValue() ?: RepositoryConfiguration()
+
+        val ortResult = requireNotNull(ortFile.readValue<OrtResult>()) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }.replaceConfig(repositoryConfiguration)
 
         val generatedResolutions = ortResult
             .getUnresolvedRuleViolations()

--- a/helper-cli/src/main/kotlin/commands/GenerateScopeExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateScopeExcludesCommand.kt
@@ -57,14 +57,17 @@ internal class GenerateScopeExcludesCommand : CliktCommand(
         .required()
 
     override fun run() {
-        val ortResult = ortFile.readValue<OrtResult>()
+        val ortResult = requireNotNull(ortFile.readValue<OrtResult>()) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }
+
         val scopeExcludes = ortResult.generateScopeExcludes()
 
-        repositoryConfigurationFile
-            .readValue<RepositoryConfiguration>()
-            .replaceScopeExcludes(scopeExcludes)
-            .sortScopeExcludes()
-            .write(repositoryConfigurationFile)
+        val repoConfig = requireNotNull(repositoryConfigurationFile.readValue<RepositoryConfiguration>()) {
+            "The provided ORT result file '${repositoryConfigurationFile.canonicalPath}' has no content."
+        }
+
+        repoConfig.replaceScopeExcludes(scopeExcludes).sortScopeExcludes().write(repositoryConfigurationFile)
     }
 }
 

--- a/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
@@ -68,13 +68,15 @@ internal class GenerateTimeoutErrorResolutionsCommand : CliktCommand(
     ).flag()
 
     override fun run() {
-        val ortResult = ortFile.readValue<OrtResult>().replaceConfig(repositoryConfigurationFile)
+        val ortResult = requireNotNull(ortFile.readValue<OrtResult>()) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }.replaceConfig(repositoryConfigurationFile)
 
         val resolutionProvider = DefaultResolutionProvider().apply {
             var resolutions = Resolutions()
 
-            resolutionsFile?.let {
-                resolutions = resolutions.merge(it.readValue())
+            resolutionsFile?.readValue<Resolutions>()?.let {
+                resolutions = resolutions.merge(it)
             }
 
             resolutions = resolutions.merge(ortResult.getResolutions())

--- a/helper-cli/src/main/kotlin/commands/ImportCopyrightGarbageCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportCopyrightGarbageCommand.kt
@@ -59,11 +59,8 @@ internal class ImportCopyrightGarbageCommand : CliktCommand(
     override fun run() {
         val entriesToImport = inputCopyrightGarbageFile.readLines().filterNot { it.isBlank() }
 
-        val existingCopyrightGarbage = if (outputCopyrightGarbageFile.isFile) {
-            outputCopyrightGarbageFile.readValue<CopyrightGarbage>().items
-        } else {
-            emptySet<String>()
-        }
+        val existingCopyrightGarbage = outputCopyrightGarbageFile.takeIf { it.isFile }
+                ?.readValue<CopyrightGarbage>()?.items.orEmpty()
 
         val collator = Collator.getInstance(Locale("en", "US.utf-8", "POSIX"))
         CopyrightGarbage((entriesToImport + existingCopyrightGarbage).toSortedSet(collator)).let {

--- a/helper-cli/src/main/kotlin/commands/ImportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportPathExcludesCommand.kt
@@ -72,11 +72,8 @@ internal class ImportPathExcludesCommand : CliktCommand(
     override fun run() {
         val allFiles = findFilesRecursive(sourceCodeDir)
 
-        val repositoryConfiguration = if (repositoryConfigurationFile.isFile) {
-            repositoryConfigurationFile.readValue()
-        } else {
-            RepositoryConfiguration()
-        }
+        val repositoryConfiguration = repositoryConfigurationFile.takeIf { it.isFile }?.readValue()
+            ?: RepositoryConfiguration()
 
         val existingPathExcludes = repositoryConfiguration.excludes.paths
         val importedPathExcludes = importPathExcludes(sourceCodeDir, pathExcludesFile).filter { pathExclude ->

--- a/helper-cli/src/main/kotlin/commands/ImportScanResultsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportScanResultsCommand.kt
@@ -51,7 +51,10 @@ internal class ImportScanResultsCommand : CliktCommand(
         .required()
 
     override fun run() {
-        val ortResult = ortFile.readValue<OrtResult>()
+        val ortResult = requireNotNull(ortFile.readValue<OrtResult>()) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }
+
         val scanResultsStorage = FileBasedStorage(LocalFileStorage(scanResultsStorageDir))
         val ids = ortResult.getProjects().map { it.id } + ortResult.getPackages().map { it.pkg.id }
 

--- a/helper-cli/src/main/kotlin/commands/ListCopyrightsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListCopyrightsCommand.kt
@@ -88,7 +88,10 @@ internal class ListCopyrightsCommand : CliktCommand(
     ).single()
 
     override fun run() {
-        val ortResult = ortFile.readValue<OrtResult>()
+        val ortResult = requireNotNull(ortFile.readValue<OrtResult>()) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }
+
         val copyrightGarbage = copyrightGarbageFile?.readValue<CopyrightGarbage>().orEmpty()
         val packageConfigurationProvider = packageConfigurationOption.createProvider()
 

--- a/helper-cli/src/main/kotlin/commands/ListLicenseCategoriesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicenseCategoriesCommand.kt
@@ -48,7 +48,7 @@ class ListLicenseCategoriesCommand : CliktCommand(
     ).flag()
 
     override fun run() {
-        val licenseClassifications = licenseClassificationsFile.readValue<LicenseClassifications>()
+        val licenseClassifications = licenseClassificationsFile.readValue() ?: LicenseClassifications()
 
         println(licenseClassifications.summary())
 

--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -155,7 +155,9 @@ internal class ListLicensesCommand : CliktCommand(
     }.default(emptyList())
 
     override fun run() {
-        val ortResult = ortFile.readValue<OrtResult>().replaceConfig(repositoryConfigurationFile)
+        val ortResult = requireNotNull(ortFile.readValue<OrtResult>()) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }.replaceConfig(repositoryConfigurationFile)
 
         if (ortResult.getPackageOrProject(packageId) == null) {
             throw UsageError("Could not find the package for the given id '${packageId.toCoordinates()}'.")

--- a/helper-cli/src/main/kotlin/commands/ListPackagesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListPackagesCommand.kt
@@ -51,7 +51,9 @@ class ListPackagesCommand : CliktCommand(
     ).split(",").default(emptyList())
 
     override fun run() {
-        val ortResult = ortFile.readValue<OrtResult>()
+        val ortResult = requireNotNull(ortFile.readValue<OrtResult>()) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }
 
         val licenseInfoResolver = ortResult.createLicenseInfoResolver()
 

--- a/helper-cli/src/main/kotlin/commands/MapCopyrightsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/MapCopyrightsCommand.kt
@@ -61,9 +61,11 @@ internal class MapCopyrightsCommand : CliktCommand(
     override fun run() {
         val processedCopyrightStatements = inputCopyrightGarbageFile.readLines().filterNot { it.isBlank() }
 
-        val unprocessedCopyrightStatements = ortFile
-            .readValue<OrtResult>()
-            .getUnprocessedCopyrightStatements(processedCopyrightStatements)
+        val ortResult = requireNotNull(ortFile.readValue<OrtResult>()) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }
+
+        val unprocessedCopyrightStatements = ortResult.getUnprocessedCopyrightStatements(processedCopyrightStatements)
 
         outputCopyrightsFile.writeText(unprocessedCopyrightStatements.joinToString(separator = "\n"))
     }

--- a/helper-cli/src/main/kotlin/commands/MergeRepositoryConfigurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/MergeRepositoryConfigurationsCommand.kt
@@ -55,7 +55,7 @@ internal class MergeRepositoryConfigurationsCommand : CliktCommand(
         var result = RepositoryConfiguration()
 
         inputRepositoryConfigurationFiles.forEach { file ->
-            val repositoryConfiguration = file.readValue<RepositoryConfiguration>()
+            val repositoryConfiguration = file.readValue() ?: RepositoryConfiguration()
             result = result.merge(repositoryConfiguration)
         }
 

--- a/helper-cli/src/main/kotlin/commands/RemoveConfigurationEntriesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/RemoveConfigurationEntriesCommand.kt
@@ -78,8 +78,11 @@ internal class RemoveConfigurationEntriesCommand : CliktCommand(
         .convert { it.absoluteFile.normalize() }
 
     override fun run() {
-        val repositoryConfiguration = repositoryConfigurationFile.readValue<RepositoryConfiguration>()
-        val ortResult = ortFile.readValue<OrtResult>().replaceConfig(repositoryConfiguration)
+        val repositoryConfiguration = repositoryConfigurationFile.readValue() ?: RepositoryConfiguration()
+
+        val ortResult = requireNotNull(ortFile.readValue<OrtResult>()) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }.replaceConfig(repositoryConfiguration)
 
         val pathExcludes = findFilesRecursive(sourceCodeDir).let { allFiles ->
             ortResult.getExcludes().paths.filter { pathExclude ->

--- a/helper-cli/src/main/kotlin/commands/SortRepositoryConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/SortRepositoryConfigurationCommand.kt
@@ -42,9 +42,7 @@ internal class SortRepositoryConfigurationCommand : CliktCommand(
         .convert { it.absoluteFile.normalize() }
 
     override fun run() {
-        repositoryConfigurationFile
-            .readValue<RepositoryConfiguration>()
-            .sortEntries()
-            .write(repositoryConfigurationFile)
+        repositoryConfigurationFile.readValue<RepositoryConfiguration>()
+            ?.sortEntries()?.write(repositoryConfigurationFile)
     }
 }

--- a/helper-cli/src/main/kotlin/commands/VerifySourceArtifactCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/VerifySourceArtifactCurationsCommand.kt
@@ -44,7 +44,7 @@ internal class VerifySourceArtifactCurationsCommand : CliktCommand(
         .convert { it.absoluteFile.normalize() }
 
     override fun run() {
-        val curations = packageCurationsFile.readValue<List<PackageCuration>>()
+        val curations = packageCurationsFile.readValue<List<PackageCuration>>().orEmpty()
 
         val failed = curations.filterNot { curation ->
             curation.data.sourceArtifact?.let { sourceArtifact ->

--- a/helper-cli/src/main/kotlin/commands/packageconfig/ExportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/ExportPathExcludesCommand.kt
@@ -69,14 +69,10 @@ class ExportPathExcludesCommand : CliktCommand(
     ).flag()
 
     override fun run() {
-        val globalPathExcludes = if (pathExcludesFile.isFile) {
-            pathExcludesFile.readValue<RepositoryPathExcludes>()
-        } else {
-            mapOf()
-        }
+        val globalPathExcludes = pathExcludesFile.takeIf { it.isFile }?.readValue<RepositoryPathExcludes>().orEmpty()
 
         val localPathExcludes = getPathExcludesByRepository(
-            pathExcludes = packageConfigurationFile.readValue<PackageConfiguration>().pathExcludes,
+            pathExcludes = packageConfigurationFile.readValue<PackageConfiguration>()?.pathExcludes.orEmpty(),
             nestedRepositories = findRepositories(sourceCodeDir)
         )
 

--- a/helper-cli/src/main/kotlin/commands/packageconfig/FindCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/FindCommand.kt
@@ -52,7 +52,7 @@ internal class FindCommand : CliktCommand(
     override fun run() {
         // TODO: There could be multiple package configurations matching the given identifier which is not handled.
         findPackageConfigurationFiles(packageConfigurationDir).find {
-            it.readValue<PackageConfiguration>().id == packageId
+            it.readValue<PackageConfiguration>()?.id == packageId
         }?.let {
             println(it.absolutePath)
         }

--- a/helper-cli/src/main/kotlin/commands/packageconfig/FormatCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/FormatCommand.kt
@@ -41,8 +41,6 @@ internal class FormatCommand : CliktCommand(
         .convert { it.absoluteFile.normalize() }
 
     override fun run() {
-        packageConfigurationFile
-            .readValue<PackageConfiguration>()
-            .write(packageConfigurationFile)
+        packageConfigurationFile.readValue<PackageConfiguration>()?.write(packageConfigurationFile)
     }
 }

--- a/helper-cli/src/main/kotlin/commands/packageconfig/ImportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/ImportLicenseFindingCurationsCommand.kt
@@ -82,8 +82,13 @@ class ImportLicenseFindingCurationsCommand : CliktCommand(
     private val findingCurationMatcher = FindingCurationMatcher()
 
     override fun run() {
-        val ortResult = ortFile.readValue<OrtResult>()
-        val packageConfiguration = packageConfigurationFile.readValue<PackageConfiguration>()
+        val ortResult = requireNotNull(ortFile.readValue<OrtResult>()) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }
+
+        val packageConfiguration = requireNotNull(packageConfigurationFile.readValue<PackageConfiguration>()) {
+            "The provided package configuration file '${packageConfigurationFile.canonicalPath}' has no content."
+        }
 
         val allLicenseFindings = ortResult.getScanResultFor(packageConfiguration)?.summary?.licenseFindings.orEmpty()
 

--- a/helper-cli/src/main/kotlin/commands/packageconfig/ImportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/ImportPathExcludesCommand.kt
@@ -70,7 +70,9 @@ class ImportPathExcludesCommand : CliktCommand(
     override fun run() {
         val allFiles = findFilesRecursive(sourceCodeDir)
 
-        val packageConfiguration = packageConfigurationFile.readValue<PackageConfiguration>()
+        val packageConfiguration = requireNotNull(packageConfigurationFile.readValue<PackageConfiguration>()) {
+            "The provided package configuration file '${packageConfigurationFile.canonicalPath}' has no content."
+        }
 
         val existingPathExcludes = packageConfiguration.pathExcludes
         val importedPathExcludes = importPathExcludes(sourceCodeDir, pathExcludesFile).filter { pathExclude ->

--- a/helper-cli/src/main/kotlin/commands/packageconfig/RemoveEntriesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/RemoveEntriesCommand.kt
@@ -57,8 +57,14 @@ internal class RemoveEntriesCommand : CliktCommand(
     private val findingsMatcher = FindingCurationMatcher()
 
     override fun run() {
-        val packageConfiguration = packageConfigurationFile.readValue<PackageConfiguration>()
-        val ortResult = ortFile.readValue<OrtResult>()
+        val packageConfiguration = requireNotNull(packageConfigurationFile.readValue<PackageConfiguration>()) {
+            "The provided package configuration file '${packageConfigurationFile.canonicalPath}' has no content."
+        }
+
+        val ortResult = requireNotNull(ortFile.readValue<OrtResult>()) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }
+
         val scanResult = ortResult.getScanResultFor(packageConfiguration)
 
         if (scanResult == null) {

--- a/helper-cli/src/main/kotlin/commands/packageconfig/SortCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/SortCommand.kt
@@ -42,9 +42,6 @@ internal class SortCommand : CliktCommand(
         .convert { it.absoluteFile.normalize() }
 
     override fun run() {
-        packageConfigurationFile
-            .readValue<PackageConfiguration>()
-            .sortEntries()
-            .write(packageConfigurationFile)
+        packageConfigurationFile.readValue<PackageConfiguration>()?.sortEntries()?.write(packageConfigurationFile)
     }
 }

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -835,7 +835,7 @@ internal fun importPathExcludes(sourceCodeDir: File, pathExcludesFile: File): Li
     println("Found ${repositoryPaths.size} repositories in ${repositoryPaths.values.sumBy { it.size }} locations.")
 
     println("Loading $pathExcludesFile...")
-    val pathExcludes = pathExcludesFile.readValue<RepositoryPathExcludes>()
+    val pathExcludes = pathExcludesFile.readValue<RepositoryPathExcludes>().orEmpty()
     println("Found ${pathExcludes.values.sumBy { it.size }} excludes for ${pathExcludes.size} repositories.")
 
     val result = mutableListOf<PathExclude>()
@@ -862,7 +862,7 @@ internal fun importLicenseFindingCurations(
     println("Found ${repositoryPaths.size} repositories in ${repositoryPaths.values.sumBy { it.size }} locations.")
 
     println("Loading $licenseFindingCurationsFile...")
-    val curations = licenseFindingCurationsFile.readValue<RepositoryLicenseFindingCurations>()
+    val curations = licenseFindingCurationsFile.readValue<RepositoryLicenseFindingCurations>().orEmpty()
     println("Found ${curations.values.sumBy { it.size }} curations for ${curations.size} repositories.")
 
     val result = mutableListOf<LicenseFindingCuration>()

--- a/model/src/main/kotlin/utils/SimplePackageConfigurationProvider.kt
+++ b/model/src/main/kotlin/utils/SimplePackageConfigurationProvider.kt
@@ -48,7 +48,7 @@ class SimplePackageConfigurationProvider(
          * configuration per [Identifier] and [Provenance].
          */
         fun forDirectory(directory: File): SimplePackageConfigurationProvider {
-            val entries = findPackageConfigurationFiles(directory).mapTo(mutableListOf()) { file ->
+            val entries = findPackageConfigurationFiles(directory).mapNotNullTo(mutableListOf()) { file ->
                 try {
                     file.readValue<PackageConfiguration>()
                 } catch (e: IOException) {
@@ -67,7 +67,7 @@ class SimplePackageConfigurationProvider(
          * file. Throws an exception if there is more than one configuration per [Identifier] and [Provenance].
          */
         fun forFile(file: File): SimplePackageConfigurationProvider {
-            val entries = file.readValue<List<PackageConfiguration>>()
+            val entries = file.readValue<List<PackageConfiguration>>().orEmpty()
 
             return SimplePackageConfigurationProvider(entries)
         }

--- a/model/src/test/kotlin/AdvisorResultContainerTest.kt
+++ b/model/src/test/kotlin/AdvisorResultContainerTest.kt
@@ -99,7 +99,7 @@ class AdvisorResultContainerTest : WordSpec() {
 
                 val result = resultsFile.readValue<OrtResult>()
 
-                result.advisor shouldNot beNull()
+                result?.advisor shouldNot beNull()
             }
 
             "be deserialized with vulnerabilities in format with references" {
@@ -107,7 +107,7 @@ class AdvisorResultContainerTest : WordSpec() {
 
                 val result = resultsFile.readValue<OrtResult>()
 
-                result.advisor shouldNot beNull()
+                result?.advisor shouldNot beNull()
             }
         }
     }

--- a/model/src/test/kotlin/ProjectTest.kt
+++ b/model/src/test/kotlin/ProjectTest.kt
@@ -39,7 +39,7 @@ import org.ossreviewtoolkit.utils.test.containExactly
 private fun readAnalyzerResult(analyzerResultFilename: String): Project =
     File("../analyzer/src/funTest/assets/projects/synthetic")
         .resolve(analyzerResultFilename)
-        .readValue<ProjectAnalyzerResult>().project
+        .readValue<ProjectAnalyzerResult>()?.project ?: Project.EMPTY
 
 private const val MANAGER = "MyManager"
 

--- a/model/src/test/kotlin/config/NexusIqConfigurationTest.kt
+++ b/model/src/test/kotlin/config/NexusIqConfigurationTest.kt
@@ -40,7 +40,7 @@ class NexusIqConfigurationTest : WordSpec({
             }.readValue<OrtConfiguration>()
 
             val expectedNexusIqConfig = referenceOrtConfig.advisor.nexusIq
-            val actualNexusIqConfiguration = rereadOrtConfig.advisor.nexusIq
+            val actualNexusIqConfiguration = rereadOrtConfig?.advisor?.nexusIq
 
             expectedNexusIqConfig.shouldBeInstanceOf<NexusIqConfiguration>()
             actualNexusIqConfiguration.shouldBeInstanceOf<NexusIqConfiguration>()

--- a/model/src/test/kotlin/config/ScannerConfigurationTest.kt
+++ b/model/src/test/kotlin/config/ScannerConfigurationTest.kt
@@ -40,7 +40,7 @@ class ScannerConfigurationTest : WordSpec({
             val file = createTempFile(suffix = ".yml").toFile().apply { deleteOnExit() }
 
             file.writeValue(ortConfig.scanner)
-            val loadedConfig = file.readValue<ScannerConfiguration>()
+            val loadedConfig = file.readValue() ?: ScannerConfiguration()
 
             // Note: loadedConfig cannot be directly compared to the original one, as there have been some changes:
             // Relative paths have been normalized, passwords do not get serialized, etc.

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -108,6 +108,10 @@ abstract class Scanner(
             "Read ORT result from '${ortFile.name}' (${ortFile.formatSizeInMib}) in ${duration.inMilliseconds}ms."
         }
 
+        requireNotNull(ortResult) {
+            "The provided ORT result file '${ortFile.canonicalPath}' has no content."
+        }
+
         if (ortResult.analyzer == null) {
             log.warn {
                 "Cannot run the scanner as the provided ORT result file '${ortFile.canonicalPath}' does not contain " +


### PR DESCRIPTION
Fixes #3861.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>