### PR TITLE
GitHub: Validate the wrapper only if it was changed

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,6 +1,9 @@
 name: Validate Gradle Wrapper
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+    - '**/gradle-wrapper.*'
 
 jobs:
   validation:


### PR DESCRIPTION
Unfortunately, the same is not possible for individual jobs / steps yet
[1], but we might consider using [2] eventually, e.g. to only run the
github-action-markdown-link-check when Markdown files were changed.

[1] https://github.com/actions/runner/issues/456
[2] https://github.com/dorny/paths-filter

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>