### PR TITLE
helper-cli: Add a command to export curations from package configs

### DIFF
--- a/helper-cli/src/main/kotlin/commands/ExportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ExportLicenseFindingCurationsCommand.kt
@@ -26,17 +26,14 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import java.io.File
-
 import org.ossreviewtoolkit.helper.common.RepositoryLicenseFindingCurations
 import org.ossreviewtoolkit.helper.common.getLicenseFindingCurationsByRepository
 import org.ossreviewtoolkit.helper.common.mergeLicenseFindingCurations
 import org.ossreviewtoolkit.helper.common.replaceConfig
+import org.ossreviewtoolkit.helper.common.writeAsYaml
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.readValue
-import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.expandTilde
-import org.ossreviewtoolkit.utils.safeMkdirs
 
 internal class ExportLicenseFindingCurationsCommand : CliktCommand(
     help = "Export the license finding curations to a file which maps repository URLs to the license finding " +
@@ -88,18 +85,4 @@ internal class ExportLicenseFindingCurationsCommand : CliktCommand(
             .mergeLicenseFindingCurations(localLicenseFindingCurations, updateOnlyExisting = updateOnlyExisting)
             .writeAsYaml(licenseFindingCurationsFile)
     }
-}
-
-/**
- * Serialize this [RepositoryLicenseFindingCurations] to the given [targetFile] as YAML.
- */
-private fun RepositoryLicenseFindingCurations.writeAsYaml(targetFile: File) {
-    targetFile.parentFile.apply { safeMkdirs() }
-
-    yamlMapper.writeValue(
-        targetFile,
-        mapValues { (_, curations) ->
-            curations.sortedBy { it.path.removePrefix("*").removePrefix("*") }
-        }.toSortedMap()
-    )
 }

--- a/helper-cli/src/main/kotlin/commands/ExportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ExportLicenseFindingCurationsCommand.kt
@@ -29,7 +29,7 @@ import com.github.ajalt.clikt.parameters.types.file
 import java.io.File
 
 import org.ossreviewtoolkit.helper.common.RepositoryLicenseFindingCurations
-import org.ossreviewtoolkit.helper.common.getRepositoryLicenseFindingCurations
+import org.ossreviewtoolkit.helper.common.getLicenseFindingCurationsByRepository
 import org.ossreviewtoolkit.helper.common.mergeLicenseFindingCurations
 import org.ossreviewtoolkit.helper.common.replaceConfig
 import org.ossreviewtoolkit.model.OrtResult
@@ -71,10 +71,12 @@ internal class ExportLicenseFindingCurationsCommand : CliktCommand(
     ).flag()
 
     override fun run() {
-        val localLicenseFindingCurations = ortFile
-            .readValue<OrtResult>()
-            .replaceConfig(repositoryConfigurationFile)
-            .getRepositoryLicenseFindingCurations()
+        val ortResult = ortFile.readValue<OrtResult>().replaceConfig(repositoryConfigurationFile)
+
+        val localLicenseFindingCurations = getLicenseFindingCurationsByRepository(
+            curations = ortResult.repository.config.curations.licenseFindings,
+            nestedRepositories = ortResult.repository.nestedRepositories
+        )
 
         val globalLicenseFindingCurations = if (licenseFindingCurationsFile.isFile) {
             licenseFindingCurationsFile.readValue<RepositoryLicenseFindingCurations>()

--- a/helper-cli/src/main/kotlin/commands/ExportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ExportPathExcludesCommand.kt
@@ -26,17 +26,14 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import java.io.File
-
 import org.ossreviewtoolkit.helper.common.RepositoryPathExcludes
 import org.ossreviewtoolkit.helper.common.getRepositoryPathExcludes
 import org.ossreviewtoolkit.helper.common.mergePathExcludes
 import org.ossreviewtoolkit.helper.common.replaceConfig
+import org.ossreviewtoolkit.helper.common.writeAsYaml
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.readValue
-import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.expandTilde
-import org.ossreviewtoolkit.utils.safeMkdirs
 
 internal class ExportPathExcludesCommand : CliktCommand(
     help = "Export the path excludes to a path excludes file which maps repository URLs to the path excludes for the " +
@@ -86,18 +83,4 @@ internal class ExportPathExcludesCommand : CliktCommand(
             .mergePathExcludes(localPathExcludes, updateOnlyExisting = updateOnlyExisting)
             .writeAsYaml(pathExcludesFile)
     }
-}
-
-/**
- * Serialize this [RepositoryPathExcludes] to the given [targetFile] as YAML.
- */
-internal fun RepositoryPathExcludes.writeAsYaml(targetFile: File) {
-    targetFile.parentFile.apply { safeMkdirs() }
-
-    yamlMapper.writeValue(
-        targetFile,
-        mapValues { (_, pathExcludes) ->
-            pathExcludes.sortedBy { it.pattern }
-        }.toSortedMap()
-    )
 }

--- a/helper-cli/src/main/kotlin/commands/packageconfig/ExportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/ExportLicenseFindingCurationsCommand.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands.packageconfig
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.file
+
+import org.ossreviewtoolkit.helper.common.RepositoryLicenseFindingCurations
+import org.ossreviewtoolkit.helper.common.findRepositories
+import org.ossreviewtoolkit.helper.common.getLicenseFindingCurationsByRepository
+import org.ossreviewtoolkit.helper.common.mergeLicenseFindingCurations
+import org.ossreviewtoolkit.helper.common.writeAsYaml
+import org.ossreviewtoolkit.model.config.PackageConfiguration
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.utils.expandTilde
+
+internal class ExportLicenseFindingCurationsCommand : CliktCommand(
+    help = "Export the license finding curations to a file which maps repository URLs to the license finding " +
+            "curations for the respective repository."
+) {
+    private val packageConfigurationFile by option(
+        "--package-configuration-file",
+        help = "The package configuration."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val sourceCodeDir by option(
+        "--source-code-dir",
+        help = "A directory containing the sources corresponding to the provided package configuration."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = false, canBeDir = true, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val updateOnlyExisting by option(
+        "--update-only-existing",
+        help = "If enabled, only entries are imported for which an entry already exists which differs only in terms " +
+                "of its concluded license, comment or reason."
+    ).flag()
+
+    private val licenseFindingCurationsFile by option(
+        "--license-finding-curations-file",
+        help = "The output license finding curations file."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    override fun run() {
+        val localLicenseFindingCurations = getLicenseFindingCurationsByRepository(
+            curations = packageConfigurationFile.readValue<PackageConfiguration>().licenseFindingCurations,
+            nestedRepositories = findRepositories(sourceCodeDir)
+        )
+
+        val globalLicenseFindingCurations = licenseFindingCurationsFile.takeIf { it.isFile }
+            ?.readValue<RepositoryLicenseFindingCurations>().orEmpty()
+
+        globalLicenseFindingCurations
+            .mergeLicenseFindingCurations(localLicenseFindingCurations, updateOnlyExisting = updateOnlyExisting)
+            .writeAsYaml(licenseFindingCurationsFile)
+    }
+}

--- a/helper-cli/src/main/kotlin/commands/packageconfig/ExportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/ExportPathExcludesCommand.kt
@@ -26,11 +26,11 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.commands.writeAsYaml
 import org.ossreviewtoolkit.helper.common.RepositoryPathExcludes
 import org.ossreviewtoolkit.helper.common.findRepositories
 import org.ossreviewtoolkit.helper.common.getPathExcludesByRepository
 import org.ossreviewtoolkit.helper.common.mergePathExcludes
+import org.ossreviewtoolkit.helper.common.writeAsYaml
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.expandTilde

--- a/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
@@ -29,6 +29,7 @@ internal class PackageConfigurationCommand : CliktCommand(
         subcommands(
             FindCommand(),
             FormatCommand(),
+            ExportLicenseFindingCurationsCommand(),
             ExportPathExcludesCommand(),
             ImportLicenseFindingCurationsCommand(),
             ImportPathExcludesCommand(),

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -610,6 +610,21 @@ internal fun RepositoryLicenseFindingCurations.mergeLicenseFindingCurations(
 }
 
 /**
+ * Serialize this [RepositoryLicenseFindingCurations] to the given [targetFile] as YAML.
+ */
+@JvmName("writeRepositoryLicenseFindingCurationsAsYaml")
+internal fun RepositoryLicenseFindingCurations.writeAsYaml(targetFile: File) {
+    targetFile.parentFile.apply { safeMkdirs() }
+
+    yamlMapper.writeValue(
+        targetFile,
+        mapValues { (_, curations) ->
+            curations.sortedBy { it.path.removePrefix("*").removePrefix("*") }
+        }.toSortedMap()
+    )
+}
+
+/**
  * Merge the given [RepositoryPathExcludes] replacing entries with equal [PathExclude.pattern].
  * If the given [updateOnlyExisting] is true then only entries with matching [PathExclude.pattern] are merged.
  */
@@ -652,6 +667,7 @@ internal fun RepositoryPathExcludes.mergePathExcludes(
 /**
  * Serialize this [RepositoryPathExcludes] to the given [targetFile] as YAML.
  */
+@JvmName("writeRepositoryPathExcludesAsYaml")
 internal fun RepositoryPathExcludes.writeAsYaml(targetFile: File) {
     targetFile.parentFile.apply { safeMkdirs() }
 

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -347,13 +347,15 @@ internal fun OrtResult.getLicenseFindingsById(
 }
 
 /**
- * Return all license finding curations from this [OrtResult] represented as [RepositoryPathExcludes].
+ * Return all license finding curations from [curations] represented as [RepositoryLicenseFindingCurations].
  */
-internal fun OrtResult.getRepositoryLicenseFindingCurations(): RepositoryLicenseFindingCurations {
+internal fun getLicenseFindingCurationsByRepository(
+    curations: Collection<LicenseFindingCuration>,
+    nestedRepositories: Map<String, VcsInfo>
+): RepositoryLicenseFindingCurations {
     val result = mutableMapOf<String, MutableList<LicenseFindingCuration>>()
-    val curations = repository.config.curations.licenseFindings
 
-    repository.nestedRepositories.forEach { (path, vcs) ->
+    nestedRepositories.forEach { (path, vcs) ->
         val pathExcludesForRepository = result.getOrPut(vcs.url) { mutableListOf() }
         curations.forEach { curation ->
             curation.path.withoutPrefix("$path/")?.let {

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -648,6 +648,20 @@ internal fun RepositoryPathExcludes.mergePathExcludes(
 }
 
 /**
+ * Serialize this [RepositoryPathExcludes] to the given [targetFile] as YAML.
+ */
+internal fun RepositoryPathExcludes.writeAsYaml(targetFile: File) {
+    targetFile.parentFile.apply { safeMkdirs() }
+
+    yamlMapper.writeValue(
+        targetFile,
+        mapValues { (_, pathExcludes) ->
+            pathExcludes.sortedBy { it.pattern }
+        }.toSortedMap()
+    )
+}
+
+/**
  * Merge the given [IssueResolution]s replacing entries with equal [IssueResolution.message].
  */
 internal fun Collection<IssueResolution>.mergeIssueResolutions(


### PR DESCRIPTION
This enables a workflow similar to what we already have for repository configurations.