### PR TITLE
Do not fail hard if an ORT result contains no analyzer result

### DIFF
--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -66,8 +66,13 @@ class Advisor(
             "Read ORT result from '${ortFile.name}' (${ortFile.formatSizeInMib}) in ${duration.inMilliseconds}ms."
         }
 
-        requireNotNull(ortResult.analyzer) {
-            "The provided ORT result file '${ortFile.canonicalPath}' does not contain an analyzer result."
+        if (ortResult.analyzer == null) {
+            log.warn {
+                "Cannot run the advisor as the provided ORT result file '${ortFile.canonicalPath}' does not contain " +
+                        "an analyzer result. No result will be added."
+            }
+
+            return ortResult
         }
 
         val providers = providerFactories.map { it.create(config) }

--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -180,15 +180,22 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
         when (input) {
             is FileType -> {
                 val ortFile = (input as FileType).file
-                val (analyzerResult, duration) = measureTimedValue { ortFile.readValue<OrtResult>().analyzer?.result }
+                val (ortResult, duration) = measureTimedValue { ortFile.readValue<OrtResult>() }
 
                 log.perf {
                     "Read ORT result from '${ortFile.name}' (${ortFile.formatSizeInMib}) in " +
                             "${duration.inMilliseconds}ms."
                 }
 
-                requireNotNull(analyzerResult) {
-                    "The provided ORT result file '${ortFile.canonicalPath}' does not contain an analyzer result."
+                val analyzerResult = ortResult.analyzer?.result
+
+                if (analyzerResult == null) {
+                    log.warn {
+                        "Cannot run the downloader as the provided ORT result file '${ortFile.canonicalPath}' does " +
+                                "not contain an analyzer result. Nothing will be downloaded."
+                    }
+
+                    throw ProgramResult(0)
                 }
 
                 val packages = mutableListOf<Package>().apply {

--- a/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
@@ -114,17 +114,12 @@ class ReportTableModelMapper(
         val issueSummaryRows = mutableMapOf<Identifier, IssueRow>()
         val summaryRows = mutableMapOf<Identifier, SummaryRow>()
 
-        requireNotNull(ortResult.analyzer?.result) {
-            "The provided ORT result does not contain an analyzer result."
-        }
-
-        val analyzerResult = ortResult.analyzer!!.result
+        val analyzerResult = ortResult.analyzer?.result
+        val analyzerIssuesForPackages = ortResult.getPackages().associateBy({ it.pkg.id }, { it.pkg.collectIssues() })
+        val scanRecord = ortResult.scanner?.results
         val excludes = ortResult.getExcludes()
 
-        val scanRecord = ortResult.scanner?.results
-        val analyzerIssuesForPackages = ortResult.getPackages().associateBy({ it.pkg.id }, { it.pkg.collectIssues() })
-
-        val projectTables = analyzerResult.projects.associateWith { project ->
+        val projectTables = analyzerResult?.projects?.associateWith { project ->
             val scopesForDependencies = project.getScopesForDependencies(excludes)
             val pathExcludes = excludes.findPathExcludes(project, ortResult)
 
@@ -224,7 +219,7 @@ class ReportTableModelMapper(
                 ortResult.getDefinitionFilePathRelativeToAnalyzerRoot(project),
                 pathExcludes
             )
-        }.toSortedMap()
+        }.orEmpty().toSortedMap()
 
         val issueSummaryTable = IssueTable(issueSummaryRows.values.toList().sortedBy { it.id })
 

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -108,8 +108,13 @@ abstract class Scanner(
             "Read ORT result from '${ortFile.name}' (${ortFile.formatSizeInMib}) in ${duration.inMilliseconds}ms."
         }
 
-        requireNotNull(ortResult.analyzer) {
-            "The provided ORT result file '${ortFile.canonicalPath}' does not contain an analyzer result."
+        if (ortResult.analyzer == null) {
+            log.warn {
+                "Cannot run the scanner as the provided ORT result file '${ortFile.canonicalPath}' does not contain " +
+                        "an analyzer result. No result will be added."
+            }
+
+            return ortResult
         }
 
         // Add the projects as packages to scan.


### PR DESCRIPTION
Pragmatically, when being asked to operate on empty input, then doing
nothing is the right thing to do, esp. in library code where the caller
should implement custom error handling.

However, as it is rather unusual to not even have an analyzer result in a
ORT result, still emit a warning in that case.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>