### PR TITLE
Bower: Allow to run as root, for use in Docker

### DIFF
--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -264,7 +264,7 @@ class Bower(
         }
     }
 
-    private fun installDependencies(workingDir: File) = run(workingDir, "install")
+    private fun installDependencies(workingDir: File) = run(workingDir, "--allow-root", "install")
 
-    private fun listDependencies(workingDir: File) = run(workingDir, "list", "--json").stdout
+    private fun listDependencies(workingDir: File) = run(workingDir, "--allow-root", "list", "--json").stdout
 }


### PR DESCRIPTION
This is a quick work-around for #3764 and should be reverted once a
proper fix is in place.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>