### PR TITLE
Provenance: Fix deserialization

### DIFF
--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.deser.BeanDeserializer
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.module.kotlin.treeToValue
 
@@ -45,7 +44,6 @@ object UnknownProvenance : Provenance() {
     override fun matches(pkg: Package): Boolean = false
 }
 
-@JsonDeserialize(using = BeanDeserializer::class)
 sealed class KnownProvenance : Provenance() {
     /**
      * The time when the source code was downloaded.

--- a/model/src/test/kotlin/ProvenanceTest.kt
+++ b/model/src/test/kotlin/ProvenanceTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import com.fasterxml.jackson.module.kotlin.readValue
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.utils.normalizeLineBreaks
+
+class ProvenanceTest : WordSpec({
+    "UnknownProvenance" should {
+        val provenance = UnknownProvenance
+        val json = jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(provenance)
+
+        "be serializable" {
+            json shouldBe "{ }"
+        }
+
+        "be deserializable as Provenance" {
+            jsonMapper.readValue<Provenance>(json) shouldBe UnknownProvenance
+        }
+
+        "be deserializable as UnknownProvenance" {
+            jsonMapper.readValue<UnknownProvenance>(json) shouldBe UnknownProvenance
+        }
+    }
+
+    "ArtifactProvenance" should {
+        val provenance = ArtifactProvenance(
+            sourceArtifact = RemoteArtifact(
+                url = "url",
+                hash = Hash("value", HashAlgorithm.UNKNOWN)
+            )
+        )
+
+        val json = jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(provenance)
+
+        "be serializable" {
+            json.normalizeLineBreaks() shouldBe """
+                {
+                  "download_time" : "1970-01-01T00:00:00Z",
+                  "source_artifact" : {
+                    "url" : "url",
+                    "hash" : {
+                      "value" : "value",
+                      "algorithm" : "UNKNOWN"
+                    }
+                  }
+                }
+            """.trimIndent()
+        }
+
+        "be deserializable as Provenance" {
+            jsonMapper.readValue<Provenance>(json) shouldBe provenance
+        }
+
+        "be deserializable as KnownProvenance" {
+            jsonMapper.readValue<KnownProvenance>(json) shouldBe provenance
+        }
+
+        "be deserializable as ArtifactProvenance" {
+            jsonMapper.readValue<ArtifactProvenance>(json) shouldBe provenance
+        }
+    }
+
+    "RepositoryProvenance" should {
+        val provenance = RepositoryProvenance(
+            vcsInfo = VcsInfo(
+                type = VcsType.UNKNOWN,
+                url = "url",
+                revision = "revision",
+                resolvedRevision = "resolvedRevision",
+                path = "path"
+            ),
+            originalVcsInfo = VcsInfo(
+                type = VcsType.UNKNOWN,
+                url = "originalUrl",
+                revision = "originalRevision",
+                path = "originalPath"
+            )
+        )
+
+        val json = jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(provenance)
+
+        "be serializable" {
+            json.normalizeLineBreaks() shouldBe """
+                {
+                  "download_time" : "1970-01-01T00:00:00Z",
+                  "vcs_info" : {
+                    "type" : "",
+                    "url" : "url",
+                    "revision" : "revision",
+                    "resolved_revision" : "resolvedRevision",
+                    "path" : "path"
+                  },
+                  "original_vcs_info" : {
+                    "type" : "",
+                    "url" : "originalUrl",
+                    "revision" : "originalRevision",
+                    "path" : "originalPath"
+                  }
+                }
+            """.trimIndent()
+        }
+
+        "be serializable and deserializable as Provenance" {
+            jsonMapper.readValue<Provenance>(json) shouldBe provenance
+        }
+
+        "be serializable and deserializable as KnownProvenance" {
+            jsonMapper.readValue<KnownProvenance>(json) shouldBe provenance
+        }
+
+        "be serializable and deserializable as ArtifactProvenance" {
+            jsonMapper.readValue<RepositoryProvenance>(json) shouldBe provenance
+        }
+    }
+})


### PR DESCRIPTION
Deserialization of the `Provenance` class failed if the target type was
`KnownProvenance`, because the `BeanDeserializer` configured for this
class does not have a default constructor.

Remove the annoation that configured `BeanDeserializer` for
`KnownProvenance`, because it was a left-over from testing and not
required anyway.

Also add a test case to make sure that provenance objects can properly
be serialized and deserialized.