### PR TITLE
vulnerability_report.ftl: Adapt to changes in vulnerability model

### DIFF
--- a/reporter/src/main/resources/templates/asciidoc/vulnerability_report.ftl
+++ b/reporter/src/main/resources/templates/asciidoc/vulnerability_report.ftl
@@ -19,8 +19,11 @@ Package: *${id.toCoordinates()}*
 
 [#list helper.filterForUnresolvedVulnerabilities(result.vulnerabilities) as vulnerability]
 
-** [#if vulnerability.url??]${vulnerability.url}[${vulnerability.id}][#else]${vulnerability.id}[/#if],
-    Severity: ${vulnerability.severity}
+** ${vulnerability.id} +
+   [#list vulnerability.references as reference]
+   Source: ${reference.url},
+   Severity: [#if reference.severity??]${reference.severity} (${reference.scoringSystem})[#else]UNKNOWN[/#if] +
+   [/#list]
 
 [/#list]
 


### PR DESCRIPTION
Recent changes on the model of vulnerabilities broke this template, as
it now references fields that no longer exist. Change the generation
of vulnerabilities to include all vulnerability references.
