### PR TITLE
Maven: Switch to the dependency graph format

### DIFF
--- a/analyzer/src/funTest/kotlin/GitRepoFunTest.kt
+++ b/analyzer/src/funTest/kotlin/GitRepoFunTest.kt
@@ -66,7 +66,7 @@ class GitRepoFunTest : StringSpec() {
         // Disabled on Azure Windows because it fails for unknown reasons.
         "Analyzer correctly reports VcsInfo for git-repo projects".config(enabled = !Ci.isAzureWindows) {
             val ortResult = Analyzer(DEFAULT_ANALYZER_CONFIGURATION).analyze(outputDir)
-            val actualResult = ortResult.toYaml()
+            val actualResult = ortResult.withResolvedScopes().toYaml()
             val expectedResult = patchExpectedResult(
                 File("src/funTest/assets/projects/external/git-repo-expected-output.yml"),
                 revision = REPO_REV,

--- a/analyzer/src/funTest/kotlin/managers/MavenFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/MavenFunTest.kt
@@ -49,7 +49,7 @@ class MavenFunTest : StringSpec() {
             val pomFile = projectDir.resolve("pom.xml")
             val expectedResult = projectDir.parentFile.resolve("jgnash-expected-output.yml").readText()
 
-            val result = createMaven().resolveSingleProject(pomFile)
+            val result = createMaven().resolveSingleProject(pomFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -65,12 +65,12 @@ class MavenFunTest : StringSpec() {
             // jgnash-core depends on jgnash-resources, so we also have to pass the pom.xml of jgnash-resources to
             // resolveDependencies so that it is available in the Maven.projectsByIdentifier cache. Otherwise resolution
             // of transitive dependencies would not work.
-            val result = createMaven().resolveDependencies(listOf(pomFileCore, pomFileResources))
-                .projectResults[pomFileCore]
+            val managerResult = createMaven().resolveDependencies(listOf(pomFileCore, pomFileResources))
+            val result = managerResult.projectResults[pomFileCore]
 
             result.shouldNotBeNull()
             result should haveSize(1)
-            result.single().toYaml() shouldBe expectedResult
+            managerResult.resolveScopes(result.single()).toYaml() shouldBe expectedResult
         }
 
         "Root project dependencies are detected correctly" {
@@ -81,7 +81,7 @@ class MavenFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createMaven().resolveSingleProject(pomFile)
+            val result = createMaven().resolveSingleProject(pomFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -98,11 +98,12 @@ class MavenFunTest : StringSpec() {
             // app depends on lib, so we also have to pass the pom.xml of lib to resolveDependencies so that it is
             // available in the Maven.projectsByIdentifier cache. Otherwise resolution of transitive dependencies would
             // not work.
-            val result = createMaven().resolveDependencies(listOf(pomFileApp, pomFileLib)).projectResults[pomFileApp]
+            val managerResult = createMaven().resolveDependencies(listOf(pomFileApp, pomFileLib))
+            val result = managerResult.projectResults[pomFileApp]
 
             result.shouldNotBeNull()
             result should haveSize(1)
-            result.single().toYaml() shouldBe expectedResult
+            managerResult.resolveScopes(result.single()).toYaml() shouldBe expectedResult
         }
 
         "External dependencies are detected correctly" {
@@ -113,7 +114,7 @@ class MavenFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createMaven().resolveSingleProject(pomFile)
+            val result = createMaven().resolveSingleProject(pomFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -132,7 +133,7 @@ class MavenFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createMaven().resolveSingleProject(pomFile)
+            val result = createMaven().resolveSingleProject(pomFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -146,7 +147,7 @@ class MavenFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createMaven().resolveSingleProject(pomFile)
+            val result = createMaven().resolveSingleProject(pomFile, resolveScopes = true)
 
             patchActualResult(result.toYaml(), patchStartAndEndTime = true) shouldBe expectedResult
         }

--- a/analyzer/src/funTest/kotlin/managers/SbtFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/SbtFunTest.kt
@@ -46,7 +46,7 @@ class SbtFunTest : StringSpec({
 
         val ortResult = Analyzer(DEFAULT_ANALYZER_CONFIGURATION).analyze(projectDir, listOf(Sbt.Factory()))
 
-        val actualResult = ortResult.toYaml()
+        val actualResult = ortResult.withResolvedScopes().toYaml()
         val expectedResult = patchExpectedResult(expectedOutputFile)
 
         patchActualResult(actualResult, patchStartAndEndTime = true) shouldBe expectedResult
@@ -64,7 +64,7 @@ class SbtFunTest : StringSpec({
 
         val ortResult = Analyzer(DEFAULT_ANALYZER_CONFIGURATION).analyze(projectDir, listOf(Sbt.Factory()))
 
-        val actualResult = ortResult.toYaml()
+        val actualResult = ortResult.withResolvedScopes().toYaml()
         val expectedResult = patchExpectedResult(expectedOutputFile)
 
         patchActualResult(actualResult, patchStartAndEndTime = true) shouldBe expectedResult
@@ -85,7 +85,7 @@ class SbtFunTest : StringSpec({
 
         val ortResult = Analyzer(DEFAULT_ANALYZER_CONFIGURATION).analyze(projectDir, listOf(Sbt.Factory()))
 
-        val actualResult = ortResult.toYaml()
+        val actualResult = ortResult.withResolvedScopes().toYaml()
         val expectedResult = patchExpectedResult(
             expectedOutputFile,
             url = vcsUrl,

--- a/analyzer/src/main/kotlin/managers/MavenDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/MavenDependencyHandler.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers
+
+import org.apache.maven.project.MavenProject
+
+import org.eclipse.aether.graph.DependencyNode
+
+import org.ossreviewtoolkit.analyzer.managers.utils.DependencyHandler
+import org.ossreviewtoolkit.analyzer.managers.utils.MavenSupport
+import org.ossreviewtoolkit.analyzer.managers.utils.identifier
+import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageLinkage
+import org.ossreviewtoolkit.model.createAndLogIssue
+import org.ossreviewtoolkit.utils.collectMessagesAsString
+import org.ossreviewtoolkit.utils.log
+import org.ossreviewtoolkit.utils.showStackTrace
+
+/**
+ * A specialized [DependencyHandler] implementation for the dependency model of Maven.
+ */
+class MavenDependencyHandler(
+    /** The name of the associated package manager. */
+    val managerName: String,
+
+    /** The helper object to invoke Maven-related functionality. */
+    val support: MavenSupport,
+
+    /**
+     * A map with information about the local projects in the current Maven build. Dependencies pointing to projects
+     * sometimes need to be treated in a special way.
+     */
+    val localProjects: Map<String, MavenProject>,
+
+    /**
+     * A flag whether [SBT compatibility mode][Maven.enableSbtMode] is enabled.
+     */
+    val sbtMode: Boolean
+) : DependencyHandler<DependencyNode> {
+    override fun identifierFor(dependency: DependencyNode): String {
+        val id = dependency.identifier()
+        val type = if (isLocalProject(id)) managerName else "Maven"
+        return "$type:$id"
+    }
+
+    override fun dependenciesFor(dependency: DependencyNode): Collection<DependencyNode> {
+        val childrenWithoutToolDependencies = dependency.children.filterNot { node ->
+            TOOL_DEPENDENCIES.any(node.artifact.identifier()::startsWith)
+        }
+
+        if (childrenWithoutToolDependencies.size < dependency.children.size) {
+            log.info { "Omitting the Java < 1.9 system dependency on 'tools.jar'." }
+        }
+
+        return childrenWithoutToolDependencies
+    }
+
+    override fun linkageFor(dependency: DependencyNode): PackageLinkage =
+        if (isLocalProject(dependency)) PackageLinkage.PROJECT_DYNAMIC else PackageLinkage.DYNAMIC
+
+    override fun createPackage(
+        identifier: String,
+        dependency: DependencyNode,
+        issues: MutableList<OrtIssue>
+    ): Package? {
+        if (isLocalProject(dependency)) return null
+
+        return runCatching {
+            support.parsePackage(dependency.artifact, dependency.repositories, localProjects, sbtMode)
+        }.onFailure { e ->
+            e.showStackTrace()
+
+            issues += createAndLogIssue(
+                source = managerName,
+                message = "Could not get package information for dependency '" +
+                        "${dependency.artifact.identifier()}': ${e.collectMessagesAsString()}"
+            )
+        }.getOrNull()
+    }
+
+    /**
+     * Return a flag whether the given [dependency] references a project in the same multi-module build.
+     */
+    private fun isLocalProject(dependency: DependencyNode): Boolean = isLocalProject(dependency.identifier())
+
+    /**
+     * Return a flag whether the given [id] references a project in the same multi-module build.
+     */
+    private fun isLocalProject(id: String): Boolean = id in localProjects
+}
+
+/**
+ * A list with identifiers referencing 'tools.jar'. Artifacts with identifiers starting with these strings are
+ * filtered out by [dependenciesFor()].
+ */
+private val TOOL_DEPENDENCIES = listOf("com.sun:tools:", "jdk.tools:jdk.tools:")
+
+/**
+ * Convenience function to generate the Maven identifier for this [DependencyNode].
+ */
+private fun DependencyNode.identifier(): String = artifact.identifier()

--- a/analyzer/src/test/kotlin/managers/MavenDependencyHandlerTest.kt
+++ b/analyzer/src/test/kotlin/managers/MavenDependencyHandlerTest.kt
@@ -1,0 +1,255 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.haveSize
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.contain
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+
+import java.io.IOException
+
+import org.apache.maven.project.MavenProject
+import org.apache.maven.project.ProjectBuildingException
+
+import org.eclipse.aether.artifact.Artifact
+import org.eclipse.aether.graph.DependencyNode
+import org.eclipse.aether.repository.RemoteRepository
+
+import org.ossreviewtoolkit.analyzer.managers.utils.MavenSupport
+import org.ossreviewtoolkit.analyzer.managers.utils.identifier
+import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageLinkage
+import org.ossreviewtoolkit.model.Severity
+
+class MavenDependencyHandlerTest : WordSpec({
+    beforeSpec {
+        mockkStatic(Artifact::identifier)
+    }
+
+    "identifierFor" should {
+        "return the identifier for an external dependency" {
+            val dependency = createDependency(IDENTIFIER)
+
+            val handler = createHandler()
+
+            handler.identifierFor(dependency) shouldBe "Maven:$IDENTIFIER"
+        }
+
+        "return the identifier for an inter-project dependency" {
+            val dependency = createDependency(PROJECT_ID)
+
+            val handler = createHandler()
+
+            handler.identifierFor(dependency) shouldBe "$MANAGER_NAME:$PROJECT_ID"
+        }
+    }
+
+    "dependenciesFor" should {
+        "return the dependencies of a dependency node" {
+            val dependency = createDependency(IDENTIFIER)
+            val child1 = createDependency("child:dep:1")
+            val child2 = createDependency("child:dep:2")
+
+            every { dependency.children } returns listOf(child1, child2)
+
+            val handler = createHandler()
+
+            handler.dependenciesFor(dependency) should containExactly(child1, child2)
+        }
+
+        "filter out the dependency to com.sun:tools" {
+            val dependency = createDependency(IDENTIFIER)
+            val toolDep = createDependency("com.sun:tools:test-17")
+            val child = createDependency("child:dep:1")
+
+            every { dependency.children } returns listOf(toolDep, child)
+
+            val handler = createHandler()
+
+            handler.dependenciesFor(dependency) should containExactly(child)
+        }
+
+        "filter out the dependency to jdk.tools:jdk.tools" {
+            val dependency = createDependency(IDENTIFIER)
+            val toolDep = createDependency("jdk.tools:jdk.tools:17-beta")
+            val child = createDependency("child:dep:1")
+
+            every { dependency.children } returns listOf(child, toolDep)
+
+            val handler = createHandler()
+
+            handler.dependenciesFor(dependency) should containExactly(child)
+        }
+    }
+
+    "linkageFor" should {
+        "return PackageLinkage.DYNAMIC for an external dependency" {
+            val dependency = createDependency(IDENTIFIER)
+
+            val handler = createHandler()
+
+            handler.linkageFor(dependency) shouldBe PackageLinkage.DYNAMIC
+        }
+
+        "return PackageLinkage.PROJECT_DYNAMIC for an inter-project dependency" {
+            val dependency = createDependency(PROJECT_ID)
+
+            val handler = createHandler()
+
+            handler.linkageFor(dependency) shouldBe PackageLinkage.PROJECT_DYNAMIC
+        }
+    }
+
+    "createPackage" should {
+        "create a package for a dependency" {
+            val dependency = createDependency(IDENTIFIER)
+            val artifact = dependency.artifact
+            val repos = listOf(createRepository(), createRepository())
+            val pkg = mockk<Package>()
+            val issues = mutableListOf<OrtIssue>()
+
+            val handler = createHandler()
+
+            every { dependency.repositories } returns repos
+            every { handler.support.parsePackage(artifact, repos, LOCAL_PROJECTS) } returns pkg
+
+            handler.createPackage("Maven:$IDENTIFIER", dependency, issues) shouldBe pkg
+            issues should beEmpty()
+        }
+
+        "take the sbtMode flag into account" {
+            val dependency = createDependency(IDENTIFIER)
+            val artifact = dependency.artifact
+            val repos = listOf(createRepository())
+            val pkg = mockk<Package>()
+            val issues = mutableListOf<OrtIssue>()
+
+            val handler = createHandler(sbtMode = true)
+
+            every { dependency.repositories } returns repos
+            every { handler.support.parsePackage(artifact, repos, LOCAL_PROJECTS, sbtMode = true) } returns pkg
+
+            handler.createPackage("$MANAGER_NAME:$IDENTIFIER", dependency, issues) shouldBe pkg
+            issues should beEmpty()
+        }
+
+        "return null for a project dependency" {
+            val projectDependency = createDependency(PROJECT_ID)
+            val issues = mutableListOf<OrtIssue>()
+
+            val handler = createHandler()
+
+            handler.createPackage("$MANAGER_NAME:$PROJECT_ID", projectDependency, issues) should beNull()
+            issues should beEmpty()
+        }
+
+        "handle an exception from MavenSupport" {
+            val exception = ProjectBuildingException(
+                "BrokenProject", "Cannot parse pom.",
+                IOException("General failure when reading hard disk.")
+            )
+            val dependency = createDependency(IDENTIFIER)
+            val artifact = dependency.artifact
+            val repos = listOf(createRepository())
+            val issues = mutableListOf<OrtIssue>()
+
+            val handler = createHandler()
+
+            every { dependency.repositories } returns repos
+            every { handler.support.parsePackage(artifact, repos, LOCAL_PROJECTS) } throws exception
+
+            handler.createPackage("Maven:$IDENTIFIER", dependency, issues) should beNull()
+
+            issues should haveSize(1)
+            with(issues[0]) {
+                severity shouldBe Severity.ERROR
+                source shouldBe MANAGER_NAME
+                message should contain(IDENTIFIER)
+                message should contain(exception.message!!)
+            }
+        }
+    }
+})
+
+private const val MANAGER_NAME = "MavenTest"
+private const val IDENTIFIER = "org.apache.commons:commons-lang2:3.12"
+
+/**
+ * A map simulating local projects. This is required by [MavenSupport] when parsing packages.
+ */
+private val LOCAL_PROJECTS = mapOf(
+    "localProject1" to createProject(),
+    "localProject2" to createProject(),
+    "localProject3" to createProject()
+)
+
+/** ID of an inter-project dependency. */
+private val PROJECT_ID = LOCAL_PROJECTS.toList().first().first
+
+/**
+ * Return a mock [Artifact] that is prepared to return the given [identifier][id]. Note: For this to work, the
+ * `identifier()` extension function must have been mocked statically.
+ */
+private fun createArtifact(id: String): Artifact {
+    val artifact = mockk<Artifact>()
+    every { artifact.identifier() } returns id
+    return artifact
+}
+
+/**
+ * Return a mock [DependencyNode] with an [Artifact] that has the given [identifier][id].
+ */
+private fun createDependency(id: String): DependencyNode {
+    val artifact = createArtifact(id)
+    val node = mockk<DependencyNode>()
+    every { node.artifact } returns artifact
+    return node
+}
+
+/**
+ * Create the [MavenDependencyHandler] instance to be tested with mock dependencies and test data with the given
+ * [sbtMode] flag.
+ */
+private fun createHandler(sbtMode: Boolean = false): MavenDependencyHandler {
+    val mvn = mockk<MavenSupport>()
+    return MavenDependencyHandler(MANAGER_NAME, mvn, LOCAL_PROJECTS, sbtMode)
+}
+
+/**
+ * Convenience function to create a mock [RemoteRepository]. Note: This function solves some nasty false-positive
+ * warnings about explicit type arguments.
+ */
+private fun createRepository(): RemoteRepository = mockk()
+
+/**
+ * Convenience function to create a mock [MavenProject]. Note: This function solves some nasty false-positive
+ * warnings about explicit type arguments.
+ */
+private fun createProject(): MavenProject = mockk()


### PR DESCRIPTION
This PR is related to #3825. It converts the package manager implementation for Maven to the dependency graph format.