### PR TITLE
Stop supporting overwriting declared licenses

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -459,12 +459,11 @@ analyzer:
         - "Steve Freeman"
         - "Tom Denley"
         declared_licenses:
-        - "curated license a"
-        - "curated license b"
+        - "New BSD License"
         declared_licenses_processed:
-          unmapped:
-          - "curated license a"
-          - "curated license b"
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            New BSD License: "BSD-3-Clause"
         description: "Curated description."
         homepage_url: "http://hamcrest.org/JavaHamcrest/"
         binary_artifact:
@@ -500,14 +499,6 @@ analyzer:
         curation:
           comment: "Fix description."
           description: "Curated description."
-      - base:
-          declared_licenses:
-          - "New BSD License"
-        curation:
-          comment: "Declared license in pom.xml is wrong."
-          declared_licenses:
-          - "curated license a"
-          - "curated license b"
     has_issues: true
 scanner: null
 advisor: null

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle/curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle/curations.yml
@@ -7,9 +7,3 @@
   curations:
     description: "Curated description."
     comment: "Fix description."
-- id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  curations:
-    declared_licenses:
-    - "curated license a"
-    - "curated license b"
-    comment: "Declared license in pom.xml is wrong."

--- a/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
@@ -116,7 +116,7 @@ class ClearlyDefinedPackageCurationProvider(server: Server = Server.PRODUCTION) 
         val declaredLicenseParsed = curation.licensed?.declared?.let { declaredLicense ->
             // Only take curations of good quality (i.e. those not using deprecated identifiers) and in particular none
             // that contain "OTHER" as a license, also see https://github.com/clearlydefined/curated-data/issues/7836.
-            runCatching { declaredLicense.toSpdx(SpdxExpression.Strictness.ALLOW_CURRENT) }.getOrNull()?.toString()
+            runCatching { declaredLicense.toSpdx(SpdxExpression.Strictness.ALLOW_CURRENT) }.getOrNull()
         }
 
         val sourceLocation = curation.described?.sourceLocation.toArtifactOrVcs()
@@ -124,7 +124,7 @@ class ClearlyDefinedPackageCurationProvider(server: Server = Server.PRODUCTION) 
         val pkgCuration = PackageCuration(
             id = pkgId,
             data = PackageCurationData(
-                declaredLicenses = declaredLicenseParsed?.let { sortedSetOf(it) },
+                concludedLicense = declaredLicenseParsed,
                 homepageUrl = curation.described?.projectWebsite?.toString(),
                 sourceArtifact = sourceLocation as? RemoteArtifact,
                 vcs = sourceLocation as? VcsInfoCurationData,

--- a/analyzer/src/main/kotlin/curation/Sw360PackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/Sw360PackageCurationProvider.kt
@@ -26,6 +26,7 @@ import org.eclipse.sw360.clients.adapter.SW360Connection
 import org.eclipse.sw360.clients.adapter.SW360ConnectionFactory
 import org.eclipse.sw360.clients.config.SW360ClientConfig
 import org.eclipse.sw360.clients.rest.resource.attachments.SW360AttachmentType
+import org.eclipse.sw360.clients.rest.resource.licenses.SW360SparseLicense
 import org.eclipse.sw360.clients.rest.resource.releases.SW360ClearingState
 import org.eclipse.sw360.clients.rest.resource.releases.SW360Release
 import org.eclipse.sw360.http.HttpClientFactoryImpl
@@ -40,6 +41,8 @@ import org.ossreviewtoolkit.model.PackageCurationData
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.config.Sw360StorageConfiguration
 import org.ossreviewtoolkit.model.jsonMapper
+import org.ossreviewtoolkit.spdx.SpdxExpression
+import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
 
 /**
  * A [PackageCurationProvider] for curated package meta-data from the configured SW360 instance using the REST API.
@@ -62,8 +65,7 @@ class Sw360PackageCurationProvider(sw360Configuration: Sw360StorageConfiguration
                     PackageCuration(
                         id = pkgId,
                         data = PackageCurationData(
-                            declaredLicenses = sw360Release.embedded?.licenses
-                                ?.mapNotNullTo(sortedSetOf()) { it?.shortName },
+                            concludedLicense = sw360Release.embedded?.licenses.orEmpty().toSpdx(),
                             homepageUrl = getHomepageOfRelease(sw360Release).orEmpty(),
                             binaryArtifact = getAttachmentAsRemoteArtifact(sw360Release, SW360AttachmentType.BINARY)
                                 ?: RemoteArtifact.EMPTY,
@@ -113,3 +115,6 @@ class Sw360PackageCurationProvider(sw360Configuration: Sw360StorageConfiguration
         return SW360ConnectionFactory().newConnection(sw360ClientConfig)
     }
 }
+
+private fun Collection<SW360SparseLicense>.toSpdx(): SpdxExpression? =
+    DeclaredLicenseProcessor.process(mapTo(mutableSetOf()) { it.shortName }).spdxExpression

--- a/analyzer/src/test/assets/package-curations.yml
+++ b/analyzer/src/test/assets/package-curations.yml
@@ -1,9 +1,6 @@
 ---
 - id: "Maven:org.hamcrest:hamcrest-core:1.3"
   curations:
-    declared_licenses:
-    - "license a"
-    - "license b"
     description: "description"
     homepage_url: "http://home.page"
     binary_artifact:

--- a/analyzer/src/test/kotlin/curation/ClearlyDefinedPackageCurationProviderTest.kt
+++ b/analyzer/src/test/kotlin/curation/ClearlyDefinedPackageCurationProviderTest.kt
@@ -27,6 +27,7 @@ import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.spdx.toSpdx
 
 class ClearlyDefinedPackageCurationProviderTest : WordSpec({
     "The production server" should {
@@ -37,9 +38,8 @@ class ClearlyDefinedPackageCurationProviderTest : WordSpec({
             val curations = provider.getCurationsFor(identifier)
 
             curations should haveSize(1)
-            curations.first().data.declaredLicenses shouldBe sortedSetOf(
-                "CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0"
-            )
+            curations.first().data.concludedLicense shouldBe
+                    "CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0".toSpdx()
         }
 
         "return no curation for a non-existing dummy NPM package" {
@@ -60,7 +60,7 @@ class ClearlyDefinedPackageCurationProviderTest : WordSpec({
             val curations = provider.getCurationsFor(identifier)
 
             curations should haveSize(1)
-            curations.first().data.declaredLicenses shouldBe sortedSetOf("Apache-1.0")
+            curations.first().data.concludedLicense shouldBe "Apache-1.0".toSpdx()
         }
 
         "return no curation for a non-existing dummy Maven package" {

--- a/cli/src/funTest/assets/semver4j-analyzer-result.yml
+++ b/cli/src/funTest/assets/semver4j-analyzer-result.yml
@@ -123,14 +123,7 @@ analyzer:
             url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
             revision: ""
             path: ""
-        curations:
-          - base:
-              declared_licenses:
-                - "New BSD License"
-            curation:
-              declared_licenses:
-                - "BSD-3-Clause"
-              comment: "Provided by ClearlyDefined."
+        curations: []
       - package:
           id: "Maven:org.mockito:mockito-all:1.10.19"
           purl: "pkg:maven/org.mockito/mockito-all@1.10.19"
@@ -160,14 +153,7 @@ analyzer:
             url: ""
             revision: ""
             path: ""
-        curations:
-          - base:
-              declared_licenses:
-                - "The MIT License"
-            curation:
-              declared_licenses:
-                - "MIT"
-              comment: "Provided by ClearlyDefined."
+        curations: []
     has_issues: false
 scanner:
   start_time: "2020-10-26T20:00:50.163356Z"

--- a/cli/src/main/kotlin/commands/UploadCurationsCommand.kt
+++ b/cli/src/main/kotlin/commands/UploadCurationsCommand.kt
@@ -165,7 +165,7 @@ private fun PackageCuration.toContributionPatch(): ContributionPatch? {
         removedDefinitions = false
     )
 
-    val licenseExpression = data.concludedLicense?.toString() ?: data.declaredLicenses?.joinToString(" AND ")
+    val licenseExpression = data.concludedLicense?.toString()
 
     val described = Described(
         projectWebsite = data.homepageUrl?.let { URI(it) },

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -164,7 +164,6 @@ data class Package(
 
         return PackageCurationData(
             authors = authors.takeIf { it != other.authors },
-            declaredLicenses = declaredLicenses.takeIf { it != other.declaredLicenses },
             description = description.takeIf { it != other.description },
             homepageUrl = homepageUrl.takeIf { it != other.homepageUrl },
             binaryArtifact = binaryArtifact.takeIf { it != other.binaryArtifact },

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.model
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 
 import java.util.SortedSet
@@ -31,6 +32,7 @@ import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
  * package with corrections. This is required because the meta data provided by a package can be wrong (e.g. outdated
  * VCS data) or incomplete.
  */
+@JsonIgnoreProperties(value = [/* Backwards-compatibility: */ "declared_licenses"])
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class PackageCurationData(
     /**

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -45,12 +45,6 @@ data class PackageCurationData(
     val authors: SortedSet<String>? = null,
 
     /**
-     * The list of licenses the authors have declared for this package. This does not necessarily correspond to the
-     * licenses as detected by a scanner. Both need to be taken into account for any conclusions.
-     */
-    val declaredLicenses: SortedSet<String>? = null,
-
-    /**
      * The concluded license as an [SpdxExpression]. It can be used to correct the [declared licenses of a package]
      * [Package.declaredLicenses] in case the found in the packages metadata or the licenses detected by a scanner do
      * not match reality.
@@ -125,14 +119,13 @@ private fun applyCurationToPackage(targetPackage: CuratedPackage, curation: Pack
     } ?: base.vcs
 
     val authors = curation.authors ?: base.authors
-    val declaredLicenses = curation.declaredLicenses ?: base.declaredLicenses
     val declaredLicenseMapping = targetPackage.getDeclaredLicenseMapping() + curation.declaredLicenseMapping
-    val declaredLicensesProcessed = DeclaredLicenseProcessor.process(declaredLicenses, declaredLicenseMapping)
+    val declaredLicensesProcessed = DeclaredLicenseProcessor.process(base.declaredLicenses, declaredLicenseMapping)
 
     val pkg = Package(
         id = base.id,
         authors = authors,
-        declaredLicenses = declaredLicenses,
+        declaredLicenses = base.declaredLicenses,
         declaredLicensesProcessed = declaredLicensesProcessed,
         concludedLicense = curation.concludedLicense ?: base.concludedLicense,
         description = curation.description ?: base.description,

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -51,8 +51,9 @@ data class PackageCurationData(
     val declaredLicenses: SortedSet<String>? = null,
 
     /**
-     * The concluded license as an [SpdxExpression]. It can be used to correct the license of a package in case the
-     * [declaredLicenses] found in the packages metadata or the licenses detected by a scanner do not match reality.
+     * The concluded license as an [SpdxExpression]. It can be used to correct the [declared licenses of a package]
+     * [Package.declaredLicenses] in case the found in the packages metadata or the licenses detected by a scanner do
+     * not match reality.
      */
     val concludedLicense: SpdxExpression? = null,
 

--- a/model/src/main/kotlin/licenses/DefaultLicenseInfoProvider.kt
+++ b/model/src/main/kotlin/licenses/DefaultLicenseInfoProvider.kt
@@ -70,7 +70,9 @@ class DefaultLicenseInfoProvider(
                 authors = pkg.authors,
                 licenses = pkg.declaredLicenses,
                 processed = pkg.declaredLicensesProcessed,
-                appliedCurations = curations.filter { it.curation.declaredLicenses != null }
+                appliedCurations = curations.filter {
+                    it.curation.declaredLicenses != null || it.curation.declaredLicenseMapping.isNotEmpty()
+                }
             )
         } ?: DeclaredLicenseInfo(
             authors = sortedSetOf(),

--- a/model/src/main/kotlin/licenses/DefaultLicenseInfoProvider.kt
+++ b/model/src/main/kotlin/licenses/DefaultLicenseInfoProvider.kt
@@ -70,9 +70,7 @@ class DefaultLicenseInfoProvider(
                 authors = pkg.authors,
                 licenses = pkg.declaredLicenses,
                 processed = pkg.declaredLicensesProcessed,
-                appliedCurations = curations.filter {
-                    it.curation.declaredLicenses != null || it.curation.declaredLicenseMapping.isNotEmpty()
-                }
+                appliedCurations = curations.filter { it.curation.declaredLicenseMapping.isNotEmpty() }
             )
         } ?: DeclaredLicenseInfo(
             authors = sortedSetOf(),

--- a/model/src/test/assets/advisor-result-initial.yml
+++ b/model/src/test/assets/advisor-result-initial.yml
@@ -150,14 +150,7 @@ analyzer:
           url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
           revision: ""
           path: ""
-      curations:
-      - base:
-          declared_licenses:
-          - "New BSD License"
-        curation:
-          declared_licenses:
-          - "BSD-3-Clause"
-          comment: "Provided by ClearlyDefined."
+      curations: []
     - package:
         id: "Maven:org.mockito:mockito-all:1.10.19"
         purl: "pkg:maven/org.mockito/mockito-all@1.10.19"
@@ -189,14 +182,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
-      curations:
-      - base:
-          declared_licenses:
-          - "The MIT License"
-        curation:
-          declared_licenses:
-          - "MIT"
-          comment: "Provided by ClearlyDefined."
+      curations: []
     has_issues: false
 scanner:
   start_time: "2021-03-30T01:25:55.052430Z"

--- a/model/src/test/assets/advisor-result-vulnerability-refs.yml
+++ b/model/src/test/assets/advisor-result-vulnerability-refs.yml
@@ -184,14 +184,7 @@ analyzer:
           url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
           revision: ""
           path: ""
-      curations:
-      - base:
-          declared_licenses:
-          - "New BSD License"
-        curation:
-          declared_licenses:
-          - "BSD-3-Clause"
-          comment: "Provided by ClearlyDefined."
+      curations: []
     - package:
         id: "Maven:org.mockito:mockito-all:1.10.19"
         purl: "pkg:maven/org.mockito/mockito-all@1.10.19"
@@ -223,14 +216,7 @@ analyzer:
           url: ""
           revision: ""
           path: ""
-      curations:
-      - base:
-          declared_licenses:
-          - "The MIT License"
-        curation:
-          declared_licenses:
-          - "MIT"
-          comment: "Provided by ClearlyDefined."
+      curations: []
     has_issues: false
 scanner:
   start_time: "2021-03-30T01:25:55.052430Z"

--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -40,7 +40,7 @@ class PackageCurationTest : WordSpec({
                     version = "1.3"
                 ),
                 authors = sortedSetOf(),
-                declaredLicenses = sortedSetOf(),
+                declaredLicenses = sortedSetOf("license a", "license b"),
                 description = "",
                 homepageUrl = "",
                 binaryArtifact = RemoteArtifact.EMPTY,
@@ -54,7 +54,6 @@ class PackageCurationTest : WordSpec({
                 id = pkg.id,
                 data = PackageCurationData(
                     authors = sortedSetOf("author 1", "author 2"),
-                    declaredLicenses = sortedSetOf("license a", "license b"),
                     declaredLicenseMapping = mapOf("license a" to "Apache-2.0".toSpdx()),
                     concludedLicense = "license1 OR license2".toSpdx(),
                     description = "description",
@@ -84,7 +83,7 @@ class PackageCurationTest : WordSpec({
             with(curatedPkg.pkg) {
                 id.toCoordinates() shouldBe pkg.id.toCoordinates()
                 authors shouldBe curation.data.authors
-                declaredLicenses shouldBe curation.data.declaredLicenses
+                declaredLicenses shouldBe pkg.declaredLicenses
                 declaredLicensesProcessed.spdxExpression shouldBe "Apache-2.0".toSpdx()
                 declaredLicensesProcessed.unmapped should containExactlyInAnyOrder("license b")
                 concludedLicense shouldBe curation.data.concludedLicense

--- a/model/src/test/kotlin/PackageTest.kt
+++ b/model/src/test/kotlin/PackageTest.kt
@@ -75,7 +75,6 @@ class PackageTest : StringSpec({
         diff.binaryArtifact shouldBe pkg.binaryArtifact
         diff.comment should beNull()
         diff.authors shouldBe pkg.authors
-        diff.declaredLicenses shouldBe pkg.declaredLicenses
         diff.homepageUrl shouldBe pkg.homepageUrl
         diff.sourceArtifact shouldBe pkg.sourceArtifact
         diff.vcs shouldBe pkg.vcs.toCuration()
@@ -104,7 +103,6 @@ class PackageTest : StringSpec({
         diff.binaryArtifact should beNull()
         diff.comment should beNull()
         diff.authors should beNull()
-        diff.declaredLicenses should beNull()
         diff.homepageUrl should beNull()
         diff.sourceArtifact should beNull()
         diff.vcs should beNull()


### PR DESCRIPTION
Removing or fixing broken declared licenses coming from the package meta data is supported by using a "declared license mapping" curation. Adding a declared license which wasn't declared in the original packages' meta data does not make sense,
because the curated package wouldn't reflect reality anymore. Therefore the overwriting is not needed as all valid declared license fixes can be achieved using the mapping approach. Since using a mapping is also superior in any regard remove the means to overwrite a declared license.