### PR TITLE
declared-license-mapping: Add the Solace Software EULA

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -369,6 +369,7 @@
 "Ruby's": Ruby
 "SIL OPEN FONT LICENSE Version 1.1": OFL-1.1
 "SIL Open Font License 1.1 (OFL-1.1)": OFL-1.1
+"SOLACE CORPORATION LICENSE AGREEMENT": LicenseRef-ort-Solace-Software-EULA
 "Scala License": Apache-2.0 AND BSD-3-Clause AND MIT
 "Sequence Library License (BSD-like)": BSD-3-Clause
 "Similar to Apache License but with the acknowledgment clause removed": LicenseRef-scancode-jdom


### PR DESCRIPTION
As seen e.g. in

https://repo1.maven.org/maven2/com/solacesystems/solsuite/10.8.1/solsuite-10.8.1.pom

Use the "ort" LicensRef namespace for now as also ScanCode does not
recognize the license yet, see

https://github.com/nexB/scancode-toolkit/issues/2498

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>