### PR TITLE
GradleDependencyHandler: Remove the creation of a dummy package

### DIFF
--- a/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
@@ -28,7 +28,6 @@ import org.eclipse.aether.repository.RemoteRepository
 
 import org.ossreviewtoolkit.analyzer.managers.utils.DependencyHandler
 import org.ossreviewtoolkit.analyzer.managers.utils.MavenSupport
-import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
@@ -96,14 +95,7 @@ class GradleDependencyHandler(
                         e.collectMessagesAsString()
             )
 
-            Package.EMPTY.copy(
-                id = Identifier(
-                    type = "Maven",
-                    namespace = dependency.groupId,
-                    name = dependency.artifactId,
-                    version = dependency.version
-                )
-            )
+            null
         }
     }
 


### PR DESCRIPTION
Change the exception handling when resolving packages to not create a
dummy package for a failed resolution. That way the affected package
is still listed in the dependency graph, but is no longer contained in
the project's list of packages.

The new behavior is in-line with the Maven package manager
implementation.
