### PR TITLE
declared-license-mapping: Add "Apache License, ASL Version 2.0"

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -33,6 +33,7 @@
 "Apache License v2.0": Apache-2.0
 "Apache License": Apache-2.0
 "Apache License, 2.0": Apache-2.0
+"Apache License, ASL Version 2.0": Apache-2.0
 "Apache License, V2 or later": Apache-2.0
 "Apache License, V2.0 or later": Apache-2.0
 "Apache License, Version 2": Apache-2.0


### PR DESCRIPTION
As found in [1].

[1]: https://repo.maven.apache.org/maven2/org/sangria-graphql/macro-visit_2.13/0.1.3/macro-visit_2.13-0.1.3.pom

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>
