### PR TITLE
declared-license-mapping: Remove the entry for "BSD License"

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -79,7 +79,6 @@
 "BSD Licence 3": BSD-3-Clause
 "BSD License 3": BSD-3-Clause
 "BSD License for HSQL": BSD-3-Clause
-"BSD License": BSD-3-Clause
 "BSD New license": BSD-3-Clause
 "BSD New": BSD-3-Clause
 "BSD Three Clause License": BSD-3-Clause


### PR DESCRIPTION
The key cannot be mapped because the value is ambigious. For example,
the string "BSD License" in [1] most likely refers to "BSD-2-Clause"
[2].

[1] https://github.com/testing-cabal/mock/blob/3.0.5/setup.cfg#L8
[2] https://github.com/testing-cabal/mock/blob/3.0.5/LICENSE.txt

Signed-off-by: Frank Viernau <frank.viernau@here.com>

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/ort/blob/master/CONTRIBUTING.md). Thank you!
