### PR TITLE
Global dependency graph

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-cli.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-cli.yml
@@ -15,95 +15,222 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/external/multi-kotlin-project/cli"
   homepage_url: ""
-  dependency_graph:
-    packages:
-    - "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-    - "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-    - "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - "Maven:org.jetbrains:annotations:13.0"
-    - "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
-    - "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
-    - "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
-    - "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
-    scope_roots:
-    - dependencies:
-      - pkg: 1
-        dependencies:
-        - pkg: 2
-        - pkg: 3
+  scopes:
+  - name: "annotationProcessor"
+    dependencies: []
+  - name: "apiDependenciesMetadata"
+    dependencies:
+    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
       linkage: "PROJECT_DYNAMIC"
-    - pkg: 4
       dependencies:
-      - pkg: 1
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
         dependencies:
-        - pkg: 2
-        - pkg: 3
-      - pkg: 5
-      - pkg: 6
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "archives"
+    dependencies: []
+  - name: "compile"
+    dependencies:
+    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
         dependencies:
-        - pkg: 1
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "compileClasspath"
+    dependencies:
+    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "compileOnly"
+    dependencies: []
+  - name: "compileOnlyDependenciesMetadata"
+    dependencies: []
+  - name: "default"
+    dependencies:
+    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "implementationDependenciesMetadata"
+    dependencies:
+    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "kapt"
+    dependencies: []
+  - name: "kaptTest"
+    dependencies: []
+  - name: "kotlinCompilerClasspath"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
           dependencies:
-          - pkg: 2
-          - pkg: 3
-    - pkg: 7
-    scopes:
-      annotationProcessor: []
-      apiDependenciesMetadata:
-      - root: 0
-      - root: 1
-      archives: []
-      compile:
-      - root: 0
-      - root: 1
-      compileClasspath:
-      - root: 0
-      - root: 1
-      compileOnly: []
-      compileOnlyDependenciesMetadata: []
-      default:
-      - root: 0
-      - root: 1
-      implementationDependenciesMetadata:
-      - root: 0
-      - root: 1
-      kapt: []
-      kaptTest: []
-      kotlinCompilerClasspath:
-      - root: 4
-      kotlinCompilerPluginClasspath:
-      - root: 7
-      kotlinNativeCompilerPluginClasspath: []
-      kotlinScriptDef: []
-      runtime:
-      - root: 0
-      - root: 1
-      runtimeClasspath:
-      - root: 0
-      - root: 1
-      runtimeOnlyDependenciesMetadata: []
-      testAnnotationProcessor: []
-      testApiDependenciesMetadata:
-      - root: 0
-      - root: 1
-      testCompile:
-      - root: 0
-      - root: 1
-      testCompileClasspath:
-      - root: 0
-      - root: 1
-      testCompileOnly: []
-      testCompileOnlyDependenciesMetadata: []
-      testImplementationDependenciesMetadata:
-      - root: 0
-      - root: 1
-      testKotlinScriptDef: []
-      testRuntime:
-      - root: 0
-      - root: 1
-      testRuntimeClasspath:
-      - root: 0
-      - root: 1
-      testRuntimeOnlyDependenciesMetadata: []
+          - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+          - id: "Maven:org.jetbrains:annotations:13.0"
+      - id: "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "kotlinCompilerPluginClasspath"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
+  - name: "kotlinNativeCompilerPluginClasspath"
+    dependencies: []
+  - name: "kotlinScriptDef"
+    dependencies: []
+  - name: "runtime"
+    dependencies:
+    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "runtimeClasspath"
+    dependencies:
+    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "runtimeOnlyDependenciesMetadata"
+    dependencies: []
+  - name: "testAnnotationProcessor"
+    dependencies: []
+  - name: "testApiDependenciesMetadata"
+    dependencies:
+    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "testCompile"
+    dependencies:
+    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "testCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "testCompileOnly"
+    dependencies: []
+  - name: "testCompileOnlyDependenciesMetadata"
+    dependencies: []
+  - name: "testImplementationDependenciesMetadata"
+    dependencies:
+    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "testKotlinScriptDef"
+    dependencies: []
+  - name: "testRuntime"
+    dependencies:
+    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "testRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "testRuntimeOnlyDependenciesMetadata"
+    dependencies: []
 packages:
 - id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
   purl: "pkg:maven/org.jetbrains.kotlin/kotlin-compiler-embeddable@1.3.11"

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-core.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-core.yml
@@ -15,73 +15,131 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/external/multi-kotlin-project/core"
   homepage_url: ""
-  dependency_graph:
-    packages:
-    - "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-    - "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - "Maven:org.jetbrains:annotations:13.0"
-    - "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
-    - "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
-    - "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
-    - "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
-    scope_roots:
-    - pkg: 3
+  scopes:
+  - name: "annotationProcessor"
+    dependencies: []
+  - name: "apiDependenciesMetadata"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
       dependencies:
-      - dependencies:
-        - pkg: 1
-        - pkg: 2
-      - pkg: 4
-      - pkg: 5
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "archives"
+    dependencies: []
+  - name: "compile"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "compileClasspath"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "compileOnly"
+    dependencies: []
+  - name: "compileOnlyDependenciesMetadata"
+    dependencies: []
+  - name: "default"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "implementationDependenciesMetadata"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "kapt"
+    dependencies: []
+  - name: "kaptTest"
+    dependencies: []
+  - name: "kotlinCompilerClasspath"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
         dependencies:
-        - dependencies:
-          - pkg: 1
-          - pkg: 2
-    - pkg: 6
-    scopes:
-      annotationProcessor: []
-      apiDependenciesMetadata:
-      - root: 0
-      archives: []
-      compile:
-      - root: 0
-      compileClasspath:
-      - root: 0
-      compileOnly: []
-      compileOnlyDependenciesMetadata: []
-      default:
-      - root: 0
-      implementationDependenciesMetadata:
-      - root: 0
-      kapt: []
-      kaptTest: []
-      kotlinCompilerClasspath:
-      - root: 3
-      kotlinCompilerPluginClasspath:
-      - root: 6
-      kotlinNativeCompilerPluginClasspath: []
-      kotlinScriptDef: []
-      runtime:
-      - root: 0
-      runtimeClasspath:
-      - root: 0
-      runtimeOnlyDependenciesMetadata: []
-      testAnnotationProcessor: []
-      testApiDependenciesMetadata:
-      - root: 0
-      testCompile:
-      - root: 0
-      testCompileClasspath:
-      - root: 0
-      testCompileOnly: []
-      testCompileOnlyDependenciesMetadata: []
-      testImplementationDependenciesMetadata:
-      - root: 0
-      testKotlinScriptDef: []
-      testRuntime:
-      - root: 0
-      testRuntimeClasspath:
-      - root: 0
-      testRuntimeOnlyDependenciesMetadata: []
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+          dependencies:
+          - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+          - id: "Maven:org.jetbrains:annotations:13.0"
+      - id: "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "kotlinCompilerPluginClasspath"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
+  - name: "kotlinNativeCompilerPluginClasspath"
+    dependencies: []
+  - name: "kotlinScriptDef"
+    dependencies: []
+  - name: "runtime"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "runtimeClasspath"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "runtimeOnlyDependenciesMetadata"
+    dependencies: []
+  - name: "testAnnotationProcessor"
+    dependencies: []
+  - name: "testApiDependenciesMetadata"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "testCompile"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "testCompileClasspath"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "testCompileOnly"
+    dependencies: []
+  - name: "testCompileOnlyDependenciesMetadata"
+    dependencies: []
+  - name: "testImplementationDependenciesMetadata"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "testKotlinScriptDef"
+    dependencies: []
+  - name: "testRuntime"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "testRuntimeClasspath"
+    dependencies:
+    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+      - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "testRuntimeOnlyDependenciesMetadata"
+    dependencies: []
 packages:
 - id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
   purl: "pkg:maven/org.jetbrains.kotlin/kotlin-compiler-embeddable@1.3.11"

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-root.yml
@@ -15,32 +15,32 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/external/multi-kotlin-project"
   homepage_url: ""
-  dependency_graph:
-    packages:
-    - "Gradle:org.gradle.kotlin.dsl.samples.multiproject:cli:1.0"
-    - "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-    - "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-    - "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - "Maven:org.jetbrains:annotations:13.0"
-    scope_roots:
-    - dependencies:
-      - pkg: 1
-        dependencies:
-        - pkg: 2
-          dependencies:
-          - pkg: 3
-          - pkg: 4
-        linkage: "PROJECT_DYNAMIC"
-      - pkg: 2
-        dependencies:
-        - pkg: 3
-        - pkg: 4
+  scopes:
+  - name: "archives"
+    dependencies:
+    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:cli:1.0"
       linkage: "PROJECT_DYNAMIC"
-    scopes:
-      archives:
-      - root: 0
-      - root: 1
-      default: []
+      dependencies:
+      - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+        linkage: "PROJECT_DYNAMIC"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+          dependencies:
+          - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+          - id: "Maven:org.jetbrains:annotations:13.0"
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+        dependencies:
+        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+        - id: "Maven:org.jetbrains:annotations:13.0"
+  - name: "default"
+    dependencies: []
 packages:
 - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
   purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib-common@1.3.11"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -66,10 +66,7 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
       homepage_url: ""
-      dependency_graph:
-        packages: []
-        scope_roots: []
-        scopes: {}
+      scopes: []
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:app:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
       declared_licenses: []
@@ -85,43 +82,98 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
       homepage_url: ""
-      dependency_graph:
-        packages:
-        - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-        - "Maven:org.apache.commons:commons-text:1.1"
-        - "Maven:org.apache.commons:commons-lang3:3.5"
-        - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-        scope_roots:
-        - dependencies:
-          - pkg: 1
-            dependencies:
-            - pkg: 2
-          - pkg: 3
+      scopes:
+      - name: "annotationProcessor"
+        dependencies: []
+      - name: "archives"
+        dependencies: []
+      - name: "compile"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
           linkage: "PROJECT_DYNAMIC"
-        scopes:
-          annotationProcessor: []
-          archives: []
-          compile:
-          - root: 0
-          compileClasspath:
-          - root: 0
-          compileOnly: []
-          default:
-          - root: 0
-          runtime:
-          - root: 0
-          runtimeClasspath:
-          - root: 0
-          testAnnotationProcessor: []
-          testCompile:
-          - root: 0
-          testCompileClasspath:
-          - root: 0
-          testCompileOnly: []
-          testRuntime:
-          - root: 0
-          testRuntimeClasspath:
-          - root: 0
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "compileClasspath"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "compileOnly"
+        dependencies: []
+      - name: "default"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "runtime"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "runtimeClasspath"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "testAnnotationProcessor"
+        dependencies: []
+      - name: "testCompile"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "testCompileClasspath"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "testCompileOnly"
+        dependencies: []
+      - name: "testRuntime"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "testRuntimeClasspath"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo/build.gradle"
       declared_licenses: []
@@ -137,53 +189,135 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
       homepage_url: ""
-      dependency_graph:
-        packages:
-        - "Unknown:org.apache.commons:commons-text:1.1"
-        - "Unknown:junit:junit:4.12"
-        scope_roots:
-        - issues:
+      scopes:
+      - name: "annotationProcessor"
+        dependencies: []
+      - name: "archives"
+        dependencies: []
+      - name: "compile"
+        dependencies:
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
             severity: "ERROR"
-        - pkg: 1
+      - name: "compileClasspath"
+        dependencies:
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
+      - name: "compileOnly"
+        dependencies: []
+      - name: "default"
+        dependencies:
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
+      - name: "runtime"
+        dependencies:
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
+      - name: "runtimeClasspath"
+        dependencies:
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
+      - name: "testAnnotationProcessor"
+        dependencies: []
+      - name: "testCompile"
+        dependencies:
+        - id: "Unknown:junit:junit:4.12"
           issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
             severity: "ERROR"
-        scopes:
-          annotationProcessor: []
-          archives: []
-          compile:
-          - root: 0
-          compileClasspath:
-          - root: 0
-          compileOnly: []
-          default:
-          - root: 0
-          runtime:
-          - root: 0
-          runtimeClasspath:
-          - root: 0
-          testAnnotationProcessor: []
-          testCompile:
-          - root: 0
-          - root: 1
-          testCompileClasspath:
-          - root: 0
-          - root: 1
-          testCompileOnly: []
-          testRuntime:
-          - root: 0
-          - root: 1
-          testRuntimeClasspath:
-          - root: 0
-          - root: 1
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
+      - name: "testCompileClasspath"
+        dependencies:
+        - id: "Unknown:junit:junit:4.12"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency junit:junit:4.12 because no repositories are defined."
+            severity: "ERROR"
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
+      - name: "testCompileOnly"
+        dependencies: []
+      - name: "testRuntime"
+        dependencies:
+        - id: "Unknown:junit:junit:4.12"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency junit:junit:4.12 because no repositories are defined."
+            severity: "ERROR"
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
+      - name: "testRuntimeClasspath"
+        dependencies:
+        - id: "Unknown:junit:junit:4.12"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency junit:junit:4.12 because no repositories are defined."
+            severity: "ERROR"
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
       declared_licenses: []
@@ -199,57 +333,83 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
       homepage_url: ""
-      dependency_graph:
-        packages:
-        - "Maven:org.apache.commons:commons-text:1.1"
-        - "Maven:org.apache.commons:commons-lang3:3.5"
-        - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-        - "Maven:junit:junit:4.12"
-        - "Maven:org.hamcrest:hamcrest-core:1.3"
-        scope_roots:
-        - dependencies:
-          - pkg: 1
-        - pkg: 2
-        - pkg: 3
+      scopes:
+      - name: "annotationProcessor"
+        dependencies: []
+      - name: "archives"
+        dependencies: []
+      - name: "compile"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-text:1.1"
           dependencies:
-          - pkg: 4
-        scopes:
-          annotationProcessor: []
-          archives: []
-          compile:
-          - root: 0
-          - root: 2
-          compileClasspath:
-          - root: 0
-          - root: 2
-          compileOnly: []
-          default:
-          - root: 0
-          - root: 2
-          runtime:
-          - root: 0
-          - root: 2
-          runtimeClasspath:
-          - root: 0
-          - root: 2
-          testAnnotationProcessor: []
-          testCompile:
-          - root: 0
-          - root: 2
-          - root: 3
-          testCompileClasspath:
-          - root: 0
-          - root: 2
-          - root: 3
-          testCompileOnly: []
-          testRuntime:
-          - root: 0
-          - root: 2
-          - root: 3
-          testRuntimeClasspath:
-          - root: 0
-          - root: 2
-          - root: 3
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "compileClasspath"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "compileOnly"
+        dependencies: []
+      - name: "default"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "runtime"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "runtimeClasspath"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "testAnnotationProcessor"
+        dependencies: []
+      - name: "testCompile"
+        dependencies:
+        - id: "Maven:junit:junit:4.12"
+          dependencies:
+          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "testCompileClasspath"
+        dependencies:
+        - id: "Maven:junit:junit:4.12"
+          dependencies:
+          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "testCompileOnly"
+        dependencies: []
+      - name: "testRuntime"
+        dependencies:
+        - id: "Maven:junit:junit:4.12"
+          dependencies:
+          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "testRuntimeClasspath"
+        dependencies:
+        - id: "Maven:junit:junit:4.12"
+          dependencies:
+          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
     packages:
     - package:
         id: "Maven:junit:junit:4.12"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -66,10 +66,7 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
       homepage_url: ""
-      dependency_graph:
-        packages: []
-        scope_roots: []
-        scopes: {}
+      scopes: []
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:app:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
       declared_licenses: []
@@ -85,43 +82,98 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
       homepage_url: ""
-      dependency_graph:
-        packages:
-        - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-        - "Maven:org.apache.commons:commons-text:1.1"
-        - "Maven:org.apache.commons:commons-lang3:3.5"
-        - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-        scope_roots:
-        - dependencies:
-          - pkg: 1
-            dependencies:
-            - pkg: 2
-          - pkg: 3
+      scopes:
+      - name: "annotationProcessor"
+        dependencies: []
+      - name: "archives"
+        dependencies: []
+      - name: "compile"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
           linkage: "PROJECT_DYNAMIC"
-        scopes:
-          annotationProcessor: []
-          archives: []
-          compile:
-          - root: 0
-          compileClasspath:
-          - root: 0
-          compileOnly: []
-          default:
-          - root: 0
-          runtime:
-          - root: 0
-          runtimeClasspath:
-          - root: 0
-          testAnnotationProcessor: []
-          testCompile:
-          - root: 0
-          testCompileClasspath:
-          - root: 0
-          testCompileOnly: []
-          testRuntime:
-          - root: 0
-          testRuntimeClasspath:
-          - root: 0
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "compileClasspath"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "compileOnly"
+        dependencies: []
+      - name: "default"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "runtime"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "runtimeClasspath"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "testAnnotationProcessor"
+        dependencies: []
+      - name: "testCompile"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "testCompileClasspath"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "testCompileOnly"
+        dependencies: []
+      - name: "testRuntime"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "testRuntimeClasspath"
+        dependencies:
+        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+          linkage: "PROJECT_DYNAMIC"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo/build.gradle"
       declared_licenses: []
@@ -137,53 +189,135 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
       homepage_url: ""
-      dependency_graph:
-        packages:
-        - "Unknown:org.apache.commons:commons-text:1.1"
-        - "Unknown:junit:junit:4.12"
-        scope_roots:
-        - issues:
+      scopes:
+      - name: "annotationProcessor"
+        dependencies: []
+      - name: "archives"
+        dependencies: []
+      - name: "compile"
+        dependencies:
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
             severity: "ERROR"
-        - pkg: 1
+      - name: "compileClasspath"
+        dependencies:
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
+      - name: "compileOnly"
+        dependencies: []
+      - name: "default"
+        dependencies:
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
+      - name: "runtime"
+        dependencies:
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
+      - name: "runtimeClasspath"
+        dependencies:
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
+      - name: "testAnnotationProcessor"
+        dependencies: []
+      - name: "testCompile"
+        dependencies:
+        - id: "Unknown:junit:junit:4.12"
           issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "Gradle"
             message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
               \ dependency junit:junit:4.12 because no repositories are defined."
             severity: "ERROR"
-        scopes:
-          annotationProcessor: []
-          archives: []
-          compile:
-          - root: 0
-          compileClasspath:
-          - root: 0
-          compileOnly: []
-          default:
-          - root: 0
-          runtime:
-          - root: 0
-          runtimeClasspath:
-          - root: 0
-          testAnnotationProcessor: []
-          testCompile:
-          - root: 0
-          - root: 1
-          testCompileClasspath:
-          - root: 0
-          - root: 1
-          testCompileOnly: []
-          testRuntime:
-          - root: 0
-          - root: 1
-          testRuntimeClasspath:
-          - root: 0
-          - root: 1
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
+      - name: "testCompileClasspath"
+        dependencies:
+        - id: "Unknown:junit:junit:4.12"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency junit:junit:4.12 because no repositories are defined."
+            severity: "ERROR"
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
+      - name: "testCompileOnly"
+        dependencies: []
+      - name: "testRuntime"
+        dependencies:
+        - id: "Unknown:junit:junit:4.12"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency junit:junit:4.12 because no repositories are defined."
+            severity: "ERROR"
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
+      - name: "testRuntimeClasspath"
+        dependencies:
+        - id: "Unknown:junit:junit:4.12"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency junit:junit:4.12 because no repositories are defined."
+            severity: "ERROR"
+        - id: "Unknown:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
       declared_licenses: []
@@ -199,57 +333,83 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
       homepage_url: ""
-      dependency_graph:
-        packages:
-        - "Maven:org.apache.commons:commons-text:1.1"
-        - "Maven:org.apache.commons:commons-lang3:3.5"
-        - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-        - "Maven:junit:junit:4.12"
-        - "Maven:org.hamcrest:hamcrest-core:1.3"
-        scope_roots:
-        - dependencies:
-          - pkg: 1
-        - pkg: 2
-        - pkg: 3
+      scopes:
+      - name: "annotationProcessor"
+        dependencies: []
+      - name: "archives"
+        dependencies: []
+      - name: "compile"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-text:1.1"
           dependencies:
-          - pkg: 4
-        scopes:
-          annotationProcessor: []
-          archives: []
-          compile:
-          - root: 0
-          - root: 2
-          compileClasspath:
-          - root: 0
-          - root: 2
-          compileOnly: []
-          default:
-          - root: 0
-          - root: 2
-          runtime:
-          - root: 0
-          - root: 2
-          runtimeClasspath:
-          - root: 0
-          - root: 2
-          testAnnotationProcessor: []
-          testCompile:
-          - root: 0
-          - root: 2
-          - root: 3
-          testCompileClasspath:
-          - root: 0
-          - root: 2
-          - root: 3
-          testCompileOnly: []
-          testRuntime:
-          - root: 0
-          - root: 2
-          - root: 3
-          testRuntimeClasspath:
-          - root: 0
-          - root: 2
-          - root: 3
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "compileClasspath"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "compileOnly"
+        dependencies: []
+      - name: "default"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "runtime"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "runtimeClasspath"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "testAnnotationProcessor"
+        dependencies: []
+      - name: "testCompile"
+        dependencies:
+        - id: "Maven:junit:junit:4.12"
+          dependencies:
+          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "testCompileClasspath"
+        dependencies:
+        - id: "Maven:junit:junit:4.12"
+          dependencies:
+          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "testCompileOnly"
+        dependencies: []
+      - name: "testRuntime"
+        dependencies:
+        - id: "Maven:junit:junit:4.12"
+          dependencies:
+          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      - name: "testRuntimeClasspath"
+        dependencies:
+        - id: "Maven:junit:junit:4.12"
+          dependencies:
+          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
     packages:
     - package:
         id: "Maven:junit:junit:4.12"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
@@ -15,213 +15,445 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/app"
   homepage_url: ""
-  dependency_graph:
-    packages:
-    - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-    - "Maven:com.squareup.okio:okio:1.14.0"
-    - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-    - "Maven:org.apache.commons:commons-text:1.2"
-    - "Maven:org.apache.commons:commons-lang3:3.7"
-    - "Maven:org.apache.commons:commons-compress:1.17"
-    - "Maven:junit:junit:4.12"
-    - "Maven:org.hamcrest:hamcrest-core:1.3"
-    - "Maven:org.apache.commons:commons-text:1.3"
-    scope_roots:
-    - dependencies:
-      - pkg: 1
-    - pkg: 2
+  scopes:
+  - name: "amazonDemoDebugAndroidTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "amazonDemoDebugAndroidTestCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       linkage: "PROJECT_DYNAMIC"
-    - pkg: 2
-      fragment: 1
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
       dependencies:
-      - pkg: 3
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+  - name: "amazonDemoDebugAndroidTestRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.2"
         dependencies:
-        - pkg: 4
-      - pkg: 5
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+  - name: "amazonDemoDebugAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "amazonDemoDebugCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       linkage: "PROJECT_DYNAMIC"
-    - pkg: 6
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
       dependencies:
-      - pkg: 7
-    - pkg: 2
-      fragment: 2
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+  - name: "amazonDemoDebugRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
       dependencies:
-      - pkg: 5
-      - pkg: 8
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.2"
         dependencies:
-        - pkg: 4
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+  - name: "amazonDemoDebugUnitTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "amazonDemoDebugUnitTestCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       linkage: "PROJECT_DYNAMIC"
-    scopes:
-      amazonDemoDebugAndroidTestAnnotationProcessorClasspath: []
-      amazonDemoDebugAndroidTestCompileClasspath:
-      - root: 0
-      - root: 2
-      amazonDemoDebugAndroidTestRuntimeClasspath:
-      - root: 0
-      - root: 2
-        fragment: 1
-      amazonDemoDebugAnnotationProcessorClasspath: []
-      amazonDemoDebugCompileClasspath:
-      - root: 0
-      - root: 2
-      amazonDemoDebugRuntimeClasspath:
-      - root: 0
-      - root: 2
-        fragment: 1
-      amazonDemoDebugUnitTestAnnotationProcessorClasspath: []
-      amazonDemoDebugUnitTestCompileClasspath:
-      - root: 0
-      - root: 2
-      - root: 6
-      amazonDemoDebugUnitTestRuntimeClasspath:
-      - root: 0
-      - root: 2
-        fragment: 1
-      - root: 6
-      amazonDemoDebugWearBundling: []
-      amazonDemoReleaseAnnotationProcessorClasspath: []
-      amazonDemoReleaseCompileClasspath:
-      - root: 0
-      - root: 2
-      amazonDemoReleaseRuntimeClasspath:
-      - root: 0
-      - root: 2
-        fragment: 1
-      amazonDemoReleaseUnitTestAnnotationProcessorClasspath: []
-      amazonDemoReleaseUnitTestCompileClasspath:
-      - root: 0
-      - root: 2
-      - root: 6
-      amazonDemoReleaseUnitTestRuntimeClasspath:
-      - root: 0
-      - root: 2
-        fragment: 1
-      - root: 6
-      amazonDemoReleaseWearBundling: []
-      amazonFullDebugAndroidTestAnnotationProcessorClasspath: []
-      amazonFullDebugAndroidTestCompileClasspath:
-      - root: 0
-      - root: 2
-      amazonFullDebugAndroidTestRuntimeClasspath:
-      - root: 0
-      - root: 2
-        fragment: 2
-      amazonFullDebugAnnotationProcessorClasspath: []
-      amazonFullDebugCompileClasspath:
-      - root: 0
-      - root: 2
-      amazonFullDebugRuntimeClasspath:
-      - root: 0
-      - root: 2
-        fragment: 2
-      amazonFullDebugUnitTestAnnotationProcessorClasspath: []
-      amazonFullDebugUnitTestCompileClasspath:
-      - root: 0
-      - root: 2
-      - root: 6
-      amazonFullDebugUnitTestRuntimeClasspath:
-      - root: 0
-      - root: 2
-        fragment: 2
-      - root: 6
-      amazonFullDebugWearBundling: []
-      amazonFullReleaseAnnotationProcessorClasspath: []
-      amazonFullReleaseCompileClasspath:
-      - root: 0
-      - root: 2
-      amazonFullReleaseRuntimeClasspath:
-      - root: 0
-      - root: 2
-        fragment: 2
-      amazonFullReleaseUnitTestAnnotationProcessorClasspath: []
-      amazonFullReleaseUnitTestCompileClasspath:
-      - root: 0
-      - root: 2
-      - root: 6
-      amazonFullReleaseUnitTestRuntimeClasspath:
-      - root: 0
-      - root: 2
-        fragment: 2
-      - root: 6
-      amazonFullReleaseWearBundling: []
-      androidTestUtil: []
-      archives: []
-      compile: []
-      default: []
-      googleDemoDebugAndroidTestAnnotationProcessorClasspath: []
-      googleDemoDebugAndroidTestCompileClasspath:
-      - root: 2
-      googleDemoDebugAndroidTestRuntimeClasspath:
-      - root: 2
-        fragment: 1
-      googleDemoDebugAnnotationProcessorClasspath: []
-      googleDemoDebugCompileClasspath:
-      - root: 2
-      googleDemoDebugRuntimeClasspath:
-      - root: 2
-        fragment: 1
-      googleDemoDebugUnitTestAnnotationProcessorClasspath: []
-      googleDemoDebugUnitTestCompileClasspath:
-      - root: 2
-      - root: 6
-      googleDemoDebugUnitTestRuntimeClasspath:
-      - root: 2
-        fragment: 1
-      - root: 6
-      googleDemoDebugWearBundling: []
-      googleDemoReleaseAnnotationProcessorClasspath: []
-      googleDemoReleaseCompileClasspath:
-      - root: 2
-      googleDemoReleaseRuntimeClasspath:
-      - root: 2
-        fragment: 1
-      googleDemoReleaseUnitTestAnnotationProcessorClasspath: []
-      googleDemoReleaseUnitTestCompileClasspath:
-      - root: 2
-      - root: 6
-      googleDemoReleaseUnitTestRuntimeClasspath:
-      - root: 2
-        fragment: 1
-      - root: 6
-      googleDemoReleaseWearBundling: []
-      googleFullDebugAndroidTestAnnotationProcessorClasspath: []
-      googleFullDebugAndroidTestCompileClasspath:
-      - root: 2
-      googleFullDebugAndroidTestRuntimeClasspath:
-      - root: 2
-        fragment: 2
-      googleFullDebugAnnotationProcessorClasspath: []
-      googleFullDebugCompileClasspath:
-      - root: 2
-      googleFullDebugRuntimeClasspath:
-      - root: 2
-        fragment: 2
-      googleFullDebugUnitTestAnnotationProcessorClasspath: []
-      googleFullDebugUnitTestCompileClasspath:
-      - root: 2
-      - root: 6
-      googleFullDebugUnitTestRuntimeClasspath:
-      - root: 2
-        fragment: 2
-      - root: 6
-      googleFullDebugWearBundling: []
-      googleFullReleaseAnnotationProcessorClasspath: []
-      googleFullReleaseCompileClasspath:
-      - root: 2
-      googleFullReleaseRuntimeClasspath:
-      - root: 2
-        fragment: 2
-      googleFullReleaseUnitTestAnnotationProcessorClasspath: []
-      googleFullReleaseUnitTestCompileClasspath:
-      - root: 2
-      - root: 6
-      googleFullReleaseUnitTestRuntimeClasspath:
-      - root: 2
-        fragment: 2
-      - root: 6
-      googleFullReleaseWearBundling: []
-      lintChecks: []
-      lintClassPath: []
-      testCompile: []
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  - name: "amazonDemoDebugUnitTestRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.2"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  - name: "amazonDemoDebugWearBundling"
+    dependencies: []
+  - name: "amazonDemoReleaseAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "amazonDemoReleaseCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+  - name: "amazonDemoReleaseRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.2"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+  - name: "amazonDemoReleaseUnitTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "amazonDemoReleaseUnitTestCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  - name: "amazonDemoReleaseUnitTestRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.2"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  - name: "amazonDemoReleaseWearBundling"
+    dependencies: []
+  - name: "amazonFullDebugAndroidTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "amazonFullDebugAndroidTestCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+  - name: "amazonFullDebugAndroidTestRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.3"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+  - name: "amazonFullDebugAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "amazonFullDebugCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+  - name: "amazonFullDebugRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.3"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+  - name: "amazonFullDebugUnitTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "amazonFullDebugUnitTestCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  - name: "amazonFullDebugUnitTestRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.3"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  - name: "amazonFullDebugWearBundling"
+    dependencies: []
+  - name: "amazonFullReleaseAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "amazonFullReleaseCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+  - name: "amazonFullReleaseRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.3"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+  - name: "amazonFullReleaseUnitTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "amazonFullReleaseUnitTestCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  - name: "amazonFullReleaseUnitTestRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.3"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+      dependencies:
+      - id: "Maven:com.squareup.okio:okio:1.14.0"
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  - name: "amazonFullReleaseWearBundling"
+    dependencies: []
+  - name: "androidTestUtil"
+    dependencies: []
+  - name: "archives"
+    dependencies: []
+  - name: "compile"
+    dependencies: []
+  - name: "default"
+    dependencies: []
+  - name: "googleDemoDebugAndroidTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "googleDemoDebugAndroidTestCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+  - name: "googleDemoDebugAndroidTestRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.2"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "googleDemoDebugAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "googleDemoDebugCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+  - name: "googleDemoDebugRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.2"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "googleDemoDebugUnitTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "googleDemoDebugUnitTestCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  - name: "googleDemoDebugUnitTestRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.2"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  - name: "googleDemoDebugWearBundling"
+    dependencies: []
+  - name: "googleDemoReleaseAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "googleDemoReleaseCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+  - name: "googleDemoReleaseRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.2"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "googleDemoReleaseUnitTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "googleDemoReleaseUnitTestCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  - name: "googleDemoReleaseUnitTestRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.2"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  - name: "googleDemoReleaseWearBundling"
+    dependencies: []
+  - name: "googleFullDebugAndroidTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "googleFullDebugAndroidTestCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+  - name: "googleFullDebugAndroidTestRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.3"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "googleFullDebugAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "googleFullDebugCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+  - name: "googleFullDebugRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.3"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "googleFullDebugUnitTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "googleFullDebugUnitTestCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  - name: "googleFullDebugUnitTestRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.3"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  - name: "googleFullDebugWearBundling"
+    dependencies: []
+  - name: "googleFullReleaseAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "googleFullReleaseCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+  - name: "googleFullReleaseRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.3"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "googleFullReleaseUnitTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "googleFullReleaseUnitTestCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  - name: "googleFullReleaseUnitTestRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-compress:1.17"
+      - id: "Maven:org.apache.commons:commons-text:1.3"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.7"
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  - name: "googleFullReleaseWearBundling"
+    dependencies: []
+  - name: "lintChecks"
+    dependencies: []
+  - name: "lintClassPath"
+    dependencies: []
+  - name: "testCompile"
+    dependencies: []
 packages:
 - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
   purl: "pkg:maven/com.squareup.okhttp3/okhttp@3.10.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
@@ -15,97 +15,161 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/lib"
   homepage_url: ""
-  dependency_graph:
-    packages:
-    - "Maven:org.apache.commons:commons-text:1.2"
-    - "Maven:org.apache.commons:commons-lang3:3.7"
-    - "Maven:org.apache.commons:commons-compress:1.17"
-    - "Maven:org.apache.commons:commons-text:1.3"
-    scope_roots:
-    - dependencies:
-      - pkg: 1
-    - pkg: 2
-    - pkg: 3
+  scopes:
+  - name: "androidTestUtil"
+    dependencies: []
+  - name: "archives"
+    dependencies: []
+  - name: "compile"
+    dependencies: []
+  - name: "default"
+    dependencies: []
+  - name: "demoDebugAndroidTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "demoDebugAndroidTestCompileClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.2"
       dependencies:
-      - pkg: 1
-    scopes:
-      androidTestUtil: []
-      archives: []
-      compile: []
-      default: []
-      demoDebugAndroidTestAnnotationProcessorClasspath: []
-      demoDebugAndroidTestCompileClasspath:
-      - root: 0
-      - root: 2
-      demoDebugAndroidTestRuntimeClasspath:
-      - root: 0
-      - root: 2
-      demoDebugAnnotationProcessorClasspath: []
-      demoDebugCompileClasspath:
-      - root: 0
-      - root: 2
-      demoDebugRuntimeClasspath:
-      - root: 0
-      - root: 2
-      demoDebugUnitTestAnnotationProcessorClasspath: []
-      demoDebugUnitTestCompileClasspath:
-      - root: 0
-      - root: 2
-      demoDebugUnitTestRuntimeClasspath:
-      - root: 0
-      - root: 2
-      demoReleaseAnnotationProcessorClasspath: []
-      demoReleaseCompileClasspath:
-      - root: 0
-      - root: 2
-      demoReleaseRuntimeClasspath:
-      - root: 0
-      - root: 2
-      demoReleaseUnitTestAnnotationProcessorClasspath: []
-      demoReleaseUnitTestCompileClasspath:
-      - root: 0
-      - root: 2
-      demoReleaseUnitTestRuntimeClasspath:
-      - root: 0
-      - root: 2
-      fullDebugAndroidTestAnnotationProcessorClasspath: []
-      fullDebugAndroidTestCompileClasspath:
-      - root: 3
-      - root: 2
-      fullDebugAndroidTestRuntimeClasspath:
-      - root: 3
-      - root: 2
-      fullDebugAnnotationProcessorClasspath: []
-      fullDebugCompileClasspath:
-      - root: 3
-      - root: 2
-      fullDebugRuntimeClasspath:
-      - root: 3
-      - root: 2
-      fullDebugUnitTestAnnotationProcessorClasspath: []
-      fullDebugUnitTestCompileClasspath:
-      - root: 3
-      - root: 2
-      fullDebugUnitTestRuntimeClasspath:
-      - root: 3
-      - root: 2
-      fullReleaseAnnotationProcessorClasspath: []
-      fullReleaseCompileClasspath:
-      - root: 3
-      - root: 2
-      fullReleaseRuntimeClasspath:
-      - root: 3
-      - root: 2
-      fullReleaseUnitTestAnnotationProcessorClasspath: []
-      fullReleaseUnitTestCompileClasspath:
-      - root: 3
-      - root: 2
-      fullReleaseUnitTestRuntimeClasspath:
-      - root: 3
-      - root: 2
-      lintChecks: []
-      lintClassPath: []
-      testCompile: []
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "demoDebugAndroidTestRuntimeClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.2"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "demoDebugAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "demoDebugCompileClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.2"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "demoDebugRuntimeClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.2"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "demoDebugUnitTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "demoDebugUnitTestCompileClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.2"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "demoDebugUnitTestRuntimeClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.2"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "demoReleaseAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "demoReleaseCompileClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.2"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "demoReleaseRuntimeClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.2"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "demoReleaseUnitTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "demoReleaseUnitTestCompileClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.2"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "demoReleaseUnitTestRuntimeClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.2"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "fullDebugAndroidTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "fullDebugAndroidTestCompileClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.3"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "fullDebugAndroidTestRuntimeClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.3"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "fullDebugAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "fullDebugCompileClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.3"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "fullDebugRuntimeClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.3"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "fullDebugUnitTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "fullDebugUnitTestCompileClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.3"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "fullDebugUnitTestRuntimeClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.3"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "fullReleaseAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "fullReleaseCompileClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.3"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "fullReleaseRuntimeClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.3"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "fullReleaseUnitTestAnnotationProcessorClasspath"
+    dependencies: []
+  - name: "fullReleaseUnitTestCompileClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.3"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "fullReleaseUnitTestRuntimeClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-compress:1.17"
+    - id: "Maven:org.apache.commons:commons-text:1.3"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  - name: "lintChecks"
+    dependencies: []
+  - name: "lintClassPath"
+    dependencies: []
+  - name: "testCompile"
+    dependencies: []
 packages:
 - id: "Maven:org.apache.commons:commons-compress:1.17"
   purl: "pkg:maven/org.apache.commons/commons-compress@1.17"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
@@ -15,8 +15,5 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android"
   homepage_url: ""
-  dependency_graph:
-    packages: []
-    scope_roots: []
-    scopes: {}
+  scopes: []
 packages: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
@@ -15,35 +15,72 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
   homepage_url: ""
-  dependency_graph:
-    identifier_list:
-    - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-    - "Maven:org.apache.commons:commons-text:1.1"
-    - "Maven:org.apache.commons:commons-lang3:3.5"
-    - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-    scope-roots:
-    - dependencies:
-      - pkg: 1
-        dependencies:
-        - pkg: 2
-      - pkg: 3
+  scopes:
+  - name: "archives"
+    dependencies: []
+  - name: "compile"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       linkage: "PROJECT_DYNAMIC"
-    scopes:
-      archives: []
-      compile:
-      - root: 0
-      compileOnly:
-      - root: 0
-      default:
-      - root: 0
-      runtime:
-      - root: 0
-      testCompile:
-      - root: 0
-      testCompileOnly:
-      - root: 0
-      testRuntime:
-      - root: 0
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "compileOnly"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "default"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "runtime"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testCompile"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testCompileOnly"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testRuntime"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
 packages:
 - id: "Maven:org.apache.commons:commons-lang3:3.5"
   purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
@@ -15,34 +15,58 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
   homepage_url: ""
-  dependency_graph:
-    packages:
-    - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-    - "Maven:org.apache.commons:commons-text:1.1"
-    - "Maven:org.apache.commons:commons-lang3:3.5"
-    - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-    scope-roots:
-    - dependencies:
-      - pkg: 1
-        dependencies:
-        - pkg: 2
-      - pkg: 3
+  scopes:
+  - name: "archives"
+    dependencies: []
+  - name: "compile"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       linkage: "PROJECT_DYNAMIC"
-    scopes:
-      archives: []
-      compile:
-      - root: 0
-      compileOnly: []
-      default:
-      - root: 0
-      runtime:
-      - root: 0
-      testCompile:
-      - root: 0
-      testCompileOnly: []
-      testRuntime:
-      - root: 0
-    manager_name: "Gradle"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "compileOnly"
+    dependencies: []
+  - name: "default"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "runtime"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testCompile"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testCompileOnly"
+    dependencies: []
+  - name: "testRuntime"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
 packages:
 - id: "Maven:org.apache.commons:commons-lang3:3.5"
   purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -15,43 +15,98 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
   homepage_url: ""
-  dependency_graph:
-    packages:
-    - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-    - "Maven:org.apache.commons:commons-text:1.1"
-    - "Maven:org.apache.commons:commons-lang3:3.5"
-    - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-    scope_roots:
-    - dependencies:
-      - pkg: 1
-        dependencies:
-        - pkg: 2
-      - pkg: 3
+  scopes:
+  - name: "annotationProcessor"
+    dependencies: []
+  - name: "archives"
+    dependencies: []
+  - name: "compile"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       linkage: "PROJECT_DYNAMIC"
-    scopes:
-      annotationProcessor: []
-      archives: []
-      compile:
-      - root: 0
-      compileClasspath:
-      - root: 0
-      compileOnly: []
-      default:
-      - root: 0
-      runtime:
-      - root: 0
-      runtimeClasspath:
-      - root: 0
-      testAnnotationProcessor: []
-      testCompile:
-      - root: 0
-      testCompileClasspath:
-      - root: 0
-      testCompileOnly: []
-      testRuntime:
-      - root: 0
-      testRuntimeClasspath:
-      - root: 0
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "compileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "compileOnly"
+    dependencies: []
+  - name: "default"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "runtime"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "runtimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testAnnotationProcessor"
+    dependencies: []
+  - name: "testCompile"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testCompileOnly"
+    dependencies: []
+  - name: "testRuntime"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
 packages:
 - id: "Maven:org.apache.commons:commons-lang3:3.5"
   purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -15,51 +15,133 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
   homepage_url: ""
-  dependency_graph:
-    packages:
-    - "Unknown:org.apache.commons:commons-text:1.1"
-    - "Unknown:junit:junit:4.12"
-    scope_roots:
-    - issues:
+  scopes:
+  - name: "annotationProcessor"
+    dependencies: []
+  - name: "archives"
+    dependencies: []
+  - name: "compile"
+    dependencies:
+    - id: "Unknown:org.apache.commons:commons-text:1.1"
+      issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
           \ dependency org.apache.commons:commons-text:1.1 because no repositories\
           \ are defined."
         severity: "ERROR"
-    - pkg: 1
+  - name: "compileClasspath"
+    dependencies:
+    - id: "Unknown:org.apache.commons:commons-text:1.1"
+      issues:
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "Gradle"
+        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+          \ are defined."
+        severity: "ERROR"
+  - name: "compileOnly"
+    dependencies: []
+  - name: "default"
+    dependencies:
+    - id: "Unknown:org.apache.commons:commons-text:1.1"
+      issues:
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "Gradle"
+        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+          \ are defined."
+        severity: "ERROR"
+  - name: "runtime"
+    dependencies:
+    - id: "Unknown:org.apache.commons:commons-text:1.1"
+      issues:
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "Gradle"
+        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+          \ are defined."
+        severity: "ERROR"
+  - name: "runtimeClasspath"
+    dependencies:
+    - id: "Unknown:org.apache.commons:commons-text:1.1"
+      issues:
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "Gradle"
+        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+          \ are defined."
+        severity: "ERROR"
+  - name: "testAnnotationProcessor"
+    dependencies: []
+  - name: "testCompile"
+    dependencies:
+    - id: "Unknown:junit:junit:4.12"
       issues:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "Gradle"
         message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
           \ dependency junit:junit:4.12 because no repositories are defined."
         severity: "ERROR"
-    scopes:
-      annotationProcessor: []
-      archives: []
-      compile:
-      - root: 0
-      compileClasspath:
-      - root: 0
-      compileOnly: []
-      default:
-      - root: 0
-      runtime:
-      - root: 0
-      runtimeClasspath:
-      - root: 0
-      testAnnotationProcessor: []
-      testCompile:
-      - root: 0
-      - root: 1
-      testCompileClasspath:
-      - root: 0
-      - root: 1
-      testCompileOnly: []
-      testRuntime:
-      - root: 0
-      - root: 1
-      testRuntimeClasspath:
-      - root: 0
-      - root: 1
+    - id: "Unknown:org.apache.commons:commons-text:1.1"
+      issues:
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "Gradle"
+        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+          \ are defined."
+        severity: "ERROR"
+  - name: "testCompileClasspath"
+    dependencies:
+    - id: "Unknown:junit:junit:4.12"
+      issues:
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "Gradle"
+        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+          \ dependency junit:junit:4.12 because no repositories are defined."
+        severity: "ERROR"
+    - id: "Unknown:org.apache.commons:commons-text:1.1"
+      issues:
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "Gradle"
+        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+          \ are defined."
+        severity: "ERROR"
+  - name: "testCompileOnly"
+    dependencies: []
+  - name: "testRuntime"
+    dependencies:
+    - id: "Unknown:junit:junit:4.12"
+      issues:
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "Gradle"
+        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+          \ dependency junit:junit:4.12 because no repositories are defined."
+        severity: "ERROR"
+    - id: "Unknown:org.apache.commons:commons-text:1.1"
+      issues:
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "Gradle"
+        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+          \ are defined."
+        severity: "ERROR"
+  - name: "testRuntimeClasspath"
+    dependencies:
+    - id: "Unknown:junit:junit:4.12"
+      issues:
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "Gradle"
+        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+          \ dependency junit:junit:4.12 because no repositories are defined."
+        severity: "ERROR"
+    - id: "Unknown:org.apache.commons:commons-text:1.1"
+      issues:
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "Gradle"
+        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+          \ are defined."
+        severity: "ERROR"
 packages: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -15,57 +15,83 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
   homepage_url: ""
-  dependency_graph:
-    packages:
-    - "Maven:org.apache.commons:commons-text:1.1"
-    - "Maven:org.apache.commons:commons-lang3:3.5"
-    - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-    - "Maven:junit:junit:4.12"
-    - "Maven:org.hamcrest:hamcrest-core:1.3"
-    scope_roots:
-    - dependencies:
-      - pkg: 1
-    - pkg: 2
-    - pkg: 3
+  scopes:
+  - name: "annotationProcessor"
+    dependencies: []
+  - name: "archives"
+    dependencies: []
+  - name: "compile"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-text:1.1"
       dependencies:
-      - pkg: 4
-    scopes:
-      annotationProcessor: []
-      archives: []
-      compile:
-      - root: 0
-      - root: 2
-      compileClasspath:
-      - root: 0
-      - root: 2
-      compileOnly: []
-      default:
-      - root: 0
-      - root: 2
-      runtime:
-      - root: 0
-      - root: 2
-      runtimeClasspath:
-      - root: 0
-      - root: 2
-      testAnnotationProcessor: []
-      testCompile:
-      - root: 0
-      - root: 2
-      - root: 3
-      testCompileClasspath:
-      - root: 0
-      - root: 2
-      - root: 3
-      testCompileOnly: []
-      testRuntime:
-      - root: 0
-      - root: 2
-      - root: 3
-      testRuntimeClasspath:
-      - root: 0
-      - root: 2
-      - root: 3
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "compileClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "compileOnly"
+    dependencies: []
+  - name: "default"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "runtime"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "runtimeClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testAnnotationProcessor"
+    dependencies: []
+  - name: "testCompile"
+    dependencies:
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testCompileClasspath"
+    dependencies:
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testCompileOnly"
+    dependencies: []
+  - name: "testRuntime"
+    dependencies:
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testRuntimeClasspath"
+    dependencies:
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
 packages:
 - id: "Maven:junit:junit:4.12"
   purl: "pkg:maven/junit/junit@4.12"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
@@ -15,8 +15,5 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   homepage_url: ""
-  dependency_graph:
-    packages: []
-    scope_roots: []
-    scopes: {}
+  scopes: []
 packages: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
@@ -15,51 +15,96 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/app"
   homepage_url: ""
-  dependency_graph:
-    packages:
-    - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-    - "Maven:org.apache.commons:commons-text:1.1"
-    - "Maven:org.apache.commons:commons-lang3:3.5"
-    - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-    scope_roots:
-    - dependencies:
-      - pkg: 1
-        dependencies:
-        - pkg: 2
-      - pkg: 3
+  scopes:
+  - name: "annotationProcessor"
+    dependencies: []
+  - name: "archives"
+    dependencies: []
+  - name: "compile"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       linkage: "PROJECT_DYNAMIC"
-    - fragment: 1
       dependencies:
-      - pkg: 1
+      - id: "Maven:org.apache.commons:commons-text:1.1"
         dependencies:
-        - pkg: 2
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "compileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       linkage: "PROJECT_DYNAMIC"
-    scopes:
-      annotationProcessor: []
-      archives: []
-      compile:
-      - root: 0
-      compileClasspath:
-      - root: 0
-        fragment: 1
-      compileOnly: []
-      default:
-      - root: 0
-      runtime:
-      - root: 0
-      runtimeClasspath:
-      - root: 0
-      testAnnotationProcessor: []
-      testCompile:
-      - root: 0
-      testCompileClasspath:
-      - root: 0
-        fragment: 1
-      testCompileOnly: []
-      testRuntime:
-      - root: 0
-      testRuntimeClasspath:
-      - root: 0
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+  - name: "compileOnly"
+    dependencies: []
+  - name: "default"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "runtime"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "runtimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testAnnotationProcessor"
+    dependencies: []
+  - name: "testCompile"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testCompileClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+  - name: "testCompileOnly"
+    dependencies: []
+  - name: "testRuntime"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testRuntimeClasspath"
+    dependencies:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      linkage: "PROJECT_DYNAMIC"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-text:1.1"
+        dependencies:
+        - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
 packages:
 - id: "Maven:org.apache.commons:commons-lang3:3.5"
   purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
@@ -15,47 +15,61 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/lib"
   homepage_url: ""
-  dependency_graph:
-    packages:
-    - "Maven:org.apache.commons:commons-text:1.1"
-    - "Maven:org.apache.commons:commons-lang3:3.5"
-    - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-    - "Maven:junit:junit:4.12"
-    - "Maven:org.hamcrest:hamcrest-core:1.3"
-    scope_roots:
-    - dependencies:
-      - pkg: 1
-    - pkg: 2
-    - pkg: 3
+  scopes:
+  - name: "annotationProcessor"
+    dependencies: []
+  - name: "archives"
+    dependencies: []
+  - name: "compile"
+    dependencies: []
+  - name: "compileClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-text:1.1"
       dependencies:
-      - pkg: 4
-    scopes:
-      annotationProcessor: []
-      archives: []
-      compile: []
-      compileClasspath:
-      - root: 0
-      - root: 2
-      compileOnly: []
-      default:
-      - root: 0
-      - root: 2
-      runtime: []
-      runtimeClasspath:
-      - root: 0
-      - root: 2
-      testAnnotationProcessor: []
-      testCompile: []
-      testCompileClasspath:
-      - root: 0
-      - root: 2
-      - root: 3
-      testCompileOnly: []
-      testRuntime: []
-      testRuntimeClasspath:
-      - root: 0
-      - root: 2
-      - root: 3
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "compileOnly"
+    dependencies: []
+  - name: "default"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "runtime"
+    dependencies: []
+  - name: "runtimeClasspath"
+    dependencies:
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testAnnotationProcessor"
+    dependencies: []
+  - name: "testCompile"
+    dependencies: []
+  - name: "testCompileClasspath"
+    dependencies:
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  - name: "testCompileOnly"
+    dependencies: []
+  - name: "testRuntime"
+    dependencies: []
+  - name: "testRuntimeClasspath"
+    dependencies:
+    - id: "Maven:junit:junit:4.12"
+      dependencies:
+      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      dependencies:
+      - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
 packages:
 - id: "Maven:junit:junit:4.12"
   purl: "pkg:maven/junit/junit@4.12"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-root.yml
@@ -15,8 +15,5 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library"
   homepage_url: ""
-  dependency_graph:
-    packages: []
-    scope_roots: []
-    scopes: {}
+  scopes: []
 packages: []

--- a/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
+++ b/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
@@ -128,8 +128,8 @@ abstract class AbstractIntegrationSpec : StringSpec() {
                 val results = manager.create(USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
                     .resolveDependencies(files)
 
-                results.size shouldBe files.size
-                results.values.flatten().forAll { result ->
+                results.projectResults.size shouldBe files.size
+                results.projectResults.values.flatten().forAll { result ->
                     VersionControlSystem.forType(result.project.vcsProcessed.type) shouldBe
                             VersionControlSystem.forType(pkg.vcs.type)
                     result.project.vcsProcessed.url shouldBe pkg.vcs.url

--- a/analyzer/src/funTest/kotlin/managers/Extensions.kt
+++ b/analyzer/src/funTest/kotlin/managers/Extensions.kt
@@ -32,7 +32,7 @@ import org.ossreviewtoolkit.model.yamlMapper
 fun Any?.toYaml() = yamlMapper.writeValueAsString(this)!!
 
 fun PackageManager.resolveSingleProject(definitionFile: File): ProjectAnalyzerResult =
-    resolveDependencies(listOf(definitionFile))[definitionFile].let { result ->
+    resolveDependencies(listOf(definitionFile)).projectResults[definitionFile].let { result ->
         result.shouldNotBeNull()
         result should haveSize(1)
         result.single()

--- a/analyzer/src/funTest/kotlin/managers/Extensions.kt
+++ b/analyzer/src/funTest/kotlin/managers/Extensions.kt
@@ -31,9 +31,12 @@ import org.ossreviewtoolkit.model.yamlMapper
 
 fun Any?.toYaml() = yamlMapper.writeValueAsString(this)!!
 
-fun PackageManager.resolveSingleProject(definitionFile: File): ProjectAnalyzerResult =
-    resolveDependencies(listOf(definitionFile)).projectResults[definitionFile].let { result ->
-        result.shouldNotBeNull()
-        result should haveSize(1)
-        result.single()
+fun PackageManager.resolveSingleProject(definitionFile: File, resolveScopes: Boolean = false): ProjectAnalyzerResult =
+    resolveDependencies(listOf(definitionFile)).projectResults[definitionFile].let { resultList ->
+        resultList.shouldNotBeNull()
+        resultList should haveSize(1)
+        val result = resultList.single()
+
+        if (resolveScopes) result.copy(project = result.project.withResolvedScopes())
+        else result
     }

--- a/analyzer/src/funTest/kotlin/managers/GradleAndroidFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleAndroidFunTest.kt
@@ -47,7 +47,7 @@ class GradleAndroidFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile)
+            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -60,7 +60,7 @@ class GradleAndroidFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile)
+            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -73,7 +73,7 @@ class GradleAndroidFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile)
+            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }

--- a/analyzer/src/funTest/kotlin/managers/GradleFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleFunTest.kt
@@ -63,7 +63,7 @@ class GradleFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile)
+            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -76,7 +76,7 @@ class GradleFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile)
+            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -89,7 +89,7 @@ class GradleFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile)
+            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -102,7 +102,7 @@ class GradleFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile)
+            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
 
             patchActualResult(result.toYaml()) shouldBe expectedResult
         }
@@ -119,7 +119,7 @@ class GradleFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile)
+            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -175,7 +175,7 @@ class GradleFunTest : StringSpec() {
                     revision = vcsRevision
                 )
 
-                val result = createGradle().resolveSingleProject(packageFile)
+                val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
 
                 result.toYaml() shouldBe expectedResult
             }

--- a/analyzer/src/funTest/kotlin/managers/GradleKotlinScriptFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleKotlinScriptFunTest.kt
@@ -46,7 +46,7 @@ class GradleKotlinScriptFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile)
+            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -59,7 +59,7 @@ class GradleKotlinScriptFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile)
+            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -72,7 +72,7 @@ class GradleKotlinScriptFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile)
+            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }

--- a/analyzer/src/funTest/kotlin/managers/GradleLibraryFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleLibraryFunTest.kt
@@ -46,7 +46,7 @@ class GradleLibraryFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile)
+            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -59,7 +59,7 @@ class GradleLibraryFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile)
+            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -72,7 +72,7 @@ class GradleLibraryFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile)
+            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }

--- a/analyzer/src/funTest/kotlin/managers/MavenFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/MavenFunTest.kt
@@ -65,7 +65,8 @@ class MavenFunTest : StringSpec() {
             // jgnash-core depends on jgnash-resources, so we also have to pass the pom.xml of jgnash-resources to
             // resolveDependencies so that it is available in the Maven.projectsByIdentifier cache. Otherwise resolution
             // of transitive dependencies would not work.
-            val result = createMaven().resolveDependencies(listOf(pomFileCore, pomFileResources))[pomFileCore]
+            val result = createMaven().resolveDependencies(listOf(pomFileCore, pomFileResources))
+                .projectResults[pomFileCore]
 
             result.shouldNotBeNull()
             result should haveSize(1)
@@ -97,7 +98,7 @@ class MavenFunTest : StringSpec() {
             // app depends on lib, so we also have to pass the pom.xml of lib to resolveDependencies so that it is
             // available in the Maven.projectsByIdentifier cache. Otherwise resolution of transitive dependencies would
             // not work.
-            val result = createMaven().resolveDependencies(listOf(pomFileApp, pomFileLib))[pomFileApp]
+            val result = createMaven().resolveDependencies(listOf(pomFileApp, pomFileLib)).projectResults[pomFileApp]
 
             result.shouldNotBeNull()
             result should haveSize(1)

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -135,7 +135,7 @@ class Analyzer(private val config: AnalyzerConfiguration) {
                     val results = manager.resolveDependencies(files)
 
                     // By convention, project ids must be of the type of the respective package manager.
-                    results.onEach { (_, result) ->
+                    results.projectResults.onEach { (_, result) ->
                         val invalidProjects = result.filter { it.project.id.type != manager.managerName }
                         require(invalidProjects.isEmpty()) {
                             val projectString = invalidProjects.joinToString { "'${it.project.id.toCoordinates()}'" }

--- a/analyzer/src/main/kotlin/AnalyzerResultBuilder.kt
+++ b/analyzer/src/main/kotlin/AnalyzerResultBuilder.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.analyzer
 
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.CuratedPackage
+import org.ossreviewtoolkit.model.DependencyGraph
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.Package
@@ -34,8 +35,9 @@ class AnalyzerResultBuilder(private val curationProvider: PackageCurationProvide
     private val projects = sortedSetOf<Project>()
     private val packages = sortedSetOf<CuratedPackage>()
     private val issues = sortedMapOf<Identifier, List<OrtIssue>>()
+    private val dependencyGraphs = sortedMapOf<String, DependencyGraph>()
 
-    fun build() = AnalyzerResult(projects, packages, issues)
+    fun build() = AnalyzerResult(projects, packages, issues, dependencyGraphs)
 
     fun addResult(projectAnalyzerResult: ProjectAnalyzerResult): AnalyzerResultBuilder {
         // TODO: It might be, e.g. in the case of PIP "requirements.txt" projects, that different projects with
@@ -88,6 +90,15 @@ class AnalyzerResultBuilder(private val curationProvider: PackageCurationProvide
             }
         }
 
+        return this
+    }
+
+    /**
+     * Add a [DependencyGraph][graph] with all dependencies detected by the [PackageManager] with the given
+     * [name][packageManagerName] to the result produced by this builder.
+     */
+    fun addDependencyGraph(packageManagerName: String, graph: DependencyGraph): AnalyzerResultBuilder {
+        dependencyGraphs[packageManagerName] = graph
         return this
     }
 }

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -50,7 +50,6 @@ import org.ossreviewtoolkit.utils.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.showStackTrace
 
 typealias ManagedProjectFiles = Map<PackageManagerFactory, List<File>>
-typealias ResolutionResult = MutableMap<File, List<ProjectAnalyzerResult>>
 
 /**
  * A class representing a package manager that handles software dependencies. The package manager is referred to by its
@@ -209,7 +208,7 @@ abstract class PackageManager(
      * for all [definitionFiles] which were found by searching the [analysisRoot] directory. By convention, the
      * [definitionFiles] must be absolute.
      */
-    open fun resolveDependencies(definitionFiles: List<File>): ResolutionResult {
+    open fun resolveDependencies(definitionFiles: List<File>): PackageManagerResult {
         definitionFiles.forEach { definitionFile ->
             requireNotNull(definitionFile.relativeToOrNull(analysisRoot)) {
                 "'$definitionFile' must be an absolute path below '$analysisRoot'."
@@ -263,7 +262,7 @@ abstract class PackageManager(
 
         afterResolution(definitionFiles)
 
-        return result
+        return PackageManagerResult(result)
     }
 
     /**

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -204,6 +204,15 @@ abstract class PackageManager(
     protected open fun afterResolution(definitionFiles: List<File>) {}
 
     /**
+     * Generate the final result to be returned by this package manager. This function is called at the very end of the
+     * execution of this package manager (after [afterResolution]) with the [projectResults] created for the single
+     * definition files that have been processed. It can be overridden by sub classes to add additional data to the
+     * result. This base implementation produces a result that contains only the passed in map with project results.
+     */
+    protected open fun createPackageManagerResult(projectResults: Map<File, List<ProjectAnalyzerResult>>):
+            PackageManagerResult = PackageManagerResult(projectResults)
+
+    /**
      * Return a tree of resolved dependencies (not necessarily declared dependencies, in case conflicts were resolved)
      * for all [definitionFiles] which were found by searching the [analysisRoot] directory. By convention, the
      * [definitionFiles] must be absolute.
@@ -262,7 +271,7 @@ abstract class PackageManager(
 
         afterResolution(definitionFiles)
 
-        return PackageManagerResult(result)
+        return createPackageManagerResult(result)
     }
 
     /**

--- a/analyzer/src/main/kotlin/PackageManagerResult.kt
+++ b/analyzer/src/main/kotlin/PackageManagerResult.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer
+
+import java.io.File
+import java.util.SortedSet
+
+import org.ossreviewtoolkit.model.DependencyGraph
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.ProjectAnalyzerResult
+
+/**
+ * A data class representing the result of the execution of a [PackageManager]. An instance contains the single
+ * results produced for the definition files the package manager supports. If there are global results (i.e. data that
+ * is shared between the single project results), they are stored here as well.
+ */
+data class PackageManagerResult(
+    /**
+     * A map with the [ProjectAnalyzerResult]s created for the single definition files.
+     */
+    val projectResults: Map<File, List<ProjectAnalyzerResult>>,
+
+    /**
+     * An optional global [DependencyGraph]. If supported by the package manager, this graph contains all the
+     * dependencies referenced by any of the processed definition files. This allows for a significant reduction of
+     * redundancy in the dependency data.
+     */
+    val dependencyGraph: DependencyGraph? = null,
+
+    /**
+     * A set with [Package]s shared across the projects analyzed by this [PackageManager]. Package managers that
+     * produce a shared [DependencyGraph] typically do not collect packages on a project-level, but globally. Such
+     * packages can be stored in this property.
+     */
+    val sharedPackages: SortedSet<Package> = sortedSetOf()
+)

--- a/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
@@ -44,11 +44,15 @@ class GradleDependencyHandler(
     val managerName: String,
 
     /** The helper object to resolve packages via Maven. */
-    private val maven: MavenSupport,
-
-    /** A list with repositories to use when resolving packages. */
-    private val repositories: List<RemoteRepository>
+    private val maven: MavenSupport
 ) : DependencyHandler<Dependency> {
+    /**
+     * A list with repositories to use when resolving packages. This list must be set before using this handler for
+     * constructing the dependency graph of a project. As different projects may use different repositories, this
+     * property is writable.
+     */
+    var repositories: List<RemoteRepository> = emptyList()
+
     override fun identifierFor(dependency: Dependency): String =
         "${dependency.dependencyType()}:${dependency.groupId}:${dependency.artifactId}:${dependency.version}"
 

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -398,8 +398,12 @@ class Pub(
         return analyzerResultCacheAndroid.getOrPut(packageName) {
             // Use the latest 5.x Gradle version as Flutter / its Android Gradle plugin does not support Gradle 6 yet.
             Gradle("Gradle", androidDir, analyzerConfig, repoConfig, GRADLE_VERSION)
-                .resolveDependencies(listOf(packageFile))
-                .projectResults.getValue(packageFile)
+                .resolveDependencies(listOf(packageFile)).run {
+                    projectResults.getValue(packageFile).map { result ->
+                        val project = result.project.withResolvedScopes(dependencyGraph)
+                        result.copy(project = project, packages = sharedPackages)
+                    }
+                }
         }
     }
 

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -399,7 +399,7 @@ class Pub(
             // Use the latest 5.x Gradle version as Flutter / its Android Gradle plugin does not support Gradle 6 yet.
             Gradle("Gradle", androidDir, analyzerConfig, repoConfig, GRADLE_VERSION)
                 .resolveDependencies(listOf(packageFile))
-                .getValue(packageFile)
+                .projectResults.getValue(packageFile)
         }
     }
 

--- a/analyzer/src/test/kotlin/managers/GradleDependencyHandlerTest.kt
+++ b/analyzer/src/test/kotlin/managers/GradleDependencyHandlerTest.kt
@@ -304,7 +304,7 @@ class GradleDependencyHandlerTest : WordSpec({
             val issues = mutableListOf<OrtIssue>()
 
             every { maven.parsePackage(any(), any(), any()) } throws exception
-            val handler = GradleDependencyHandler(NAME, maven, remoteRepositories)
+            val handler = GradleDependencyHandler(NAME, maven)
 
             handler.createPackage(dep.toId().toCoordinates(), dep, issues) should beNull()
 
@@ -353,7 +353,8 @@ private fun createDependency(
  * this class.
  */
 private fun createGraphBuilder(): DependencyGraphBuilder<Dependency> {
-    val dependencyHandler = GradleDependencyHandler(NAME, createMavenSupport(), remoteRepositories)
+    val dependencyHandler = GradleDependencyHandler(NAME, createMavenSupport())
+    dependencyHandler.repositories = remoteRepositories
     return DependencyGraphBuilder(dependencyHandler)
 }
 

--- a/cli/src/funTest/assets/analyzer-result-with-dependency-graph.yml
+++ b/cli/src/funTest/assets/analyzer-result-with-dependency-graph.yml
@@ -1,0 +1,215 @@
+---
+repository:
+  vcs:
+    type: "Git"
+    url: "https://github.com/vdurmont/semver4j.git"
+    revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/vdurmont/semver4j.git"
+    revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+    path: ""
+  config: {}
+analyzer:
+  start_time: "2021-04-26T05:48:05.390356Z"
+  end_time: "2021-04-26T05:48:13.604832Z"
+  environment:
+    ort_version: "9d23fdf"
+    java_version: "11.0.8"
+    os: "Linux"
+    processors: 4
+    max_memory: 12884901888
+    variables:
+      JAVA_HOME: "/opt/java/openjdk"
+      ANDROID_HOME: "/opt/android-sdk"
+      GOPATH: "/go"
+    tool_versions: {}
+  config:
+    ignore_tool_versions: false
+    allow_dynamic_versions: false
+  result:
+    projects:
+      - id: "Maven:com.vdurmont:semver4j:3.1.0"
+        definition_file_path: "pom.xml"
+        authors:
+          - "Vincent DURMONT"
+        declared_licenses:
+          - "The MIT License"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+          mapped:
+            The MIT License: "MIT"
+        vcs:
+          type: "Git"
+          url: "git@github.com:vdurmont/semver4j.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/vdurmont/semver4j.git"
+          revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+          path: ""
+        homepage_url: "https://github.com/vdurmont/semver4j"
+        scope_names:
+          - "test"
+    packages:
+      - package:
+          id: "Maven:junit:junit:4.12"
+          purl: "pkg:maven/junit/junit@4.12"
+          authors:
+            - "David Saff"
+            - "JUnit"
+            - "Kevin Cooney"
+            - "Marc Philipp"
+            - "Stefan Birkner"
+          declared_licenses:
+            - "Eclipse Public License 1.0"
+          declared_licenses_processed:
+            spdx_expression: "EPL-1.0"
+            mapped:
+              Eclipse Public License 1.0: "EPL-1.0"
+          concluded_license: "EPL-1.0"
+          description: "JUnit is a unit testing framework for Java, created by Erich\
+          \ Gamma and Kent Beck."
+          homepage_url: "http://junit.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
+            hash:
+              value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+            hash:
+              value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "https://github.com/junit-team/junit4.git"
+            revision: "r4.12"
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/junit-team/junit4.git"
+            revision: "r4.12"
+            path: ""
+        curations:
+          - base:
+              vcs:
+                type: "Git"
+                url: "git://github.com/junit-team/junit.git"
+                revision: "r4.12"
+                path: ""
+            curation:
+              comment: "ScanCode claims to find some NOASSERTION and Apache-2.0 in the\
+            \ FAQ and the pom.xml, both are false-positives."
+              concluded_license: "EPL-1.0"
+              vcs:
+                type: "Git"
+                url: "https://github.com/junit-team/junit4.git"
+                revision: "r4.12"
+      - package:
+          id: "Maven:org.hamcrest:hamcrest-core:1.3"
+          purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
+          authors:
+            - "Joe Walnes"
+            - "Nat Pryce"
+            - "Neil Dunn"
+            - "Steve Freeman"
+            - "Tom Denley"
+          declared_licenses:
+            - "BSD-3-Clause"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+          description: "This is the core API of hamcrest matcher framework to be used\
+          \ by third-party framework providers. This includes the a foundation set\
+          \ of matcher implementations for common operations."
+          homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
+            hash:
+              value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+            hash:
+              value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:hamcrest/JavaHamcrest.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
+            revision: ""
+            path: ""
+        curations:
+          - base:
+              declared_licenses:
+                - "New BSD License"
+            curation:
+              comment: "Provided by ClearlyDefined."
+              declared_licenses:
+                - "BSD-3-Clause"
+      - package:
+          id: "Maven:org.mockito:mockito-all:1.10.19"
+          purl: "pkg:maven/org.mockito/mockito-all@1.10.19"
+          authors:
+            - "Szczepan Faber"
+          declared_licenses:
+            - "MIT"
+          declared_licenses_processed:
+            spdx_expression: "MIT"
+          description: "Mock objects library for java"
+          homepage_url: "http://www.mockito.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/mockito/mockito-all/1.10.19/mockito-all-1.10.19.jar"
+            hash:
+              value: "539df70269cc254a58cccc5d8e43286b4a73bf30"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/mockito/mockito-all/1.10.19/mockito-all-1.10.19-sources.jar"
+            hash:
+              value: "8269667b73d9616600359a9b0ba1b1c7d0cf7a97"
+              algorithm: "SHA-1"
+          vcs:
+            type: ""
+            url: ""
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: ""
+            url: ""
+            revision: ""
+            path: ""
+        curations:
+          - base:
+              declared_licenses:
+                - "The MIT License"
+            curation:
+              comment: "Provided by ClearlyDefined."
+              declared_licenses:
+                - "MIT"
+    dependency_graphs:
+      Maven:
+        packages:
+          - "Maven:junit:junit:4.12"
+          - "Maven:org.hamcrest:hamcrest-core:1.3"
+          - "Maven:org.mockito:mockito-all:1.10.19"
+        scope_roots:
+          - dependencies:
+              - pkg: 1
+          - pkg: 2
+        scopes:
+          com.vdurmont:semver4j:3.1.0:test:
+            - root: 0
+            - root: 2
+    has_issues: false
+scanner: null
+advisor: null
+evaluator: null
+labels:
+  applicationCategory: "BT05 Client application"
+  projectName: "Semver4jNewDependencyGraphShared"

--- a/cli/src/funTest/kotlin/OrtMainFunTest.kt
+++ b/cli/src/funTest/kotlin/OrtMainFunTest.kt
@@ -25,11 +25,16 @@ import com.github.ajalt.clikt.core.ProgramResult
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
 
 import java.io.File
 
+import org.ossreviewtoolkit.commands.AdvisorCommand
 import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.normalizeVcsUrl
@@ -37,6 +42,7 @@ import org.ossreviewtoolkit.utils.redirectStdout
 import org.ossreviewtoolkit.utils.test.createTestTempDir
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 /**
  * A test for the main entry point of the application.
@@ -158,6 +164,23 @@ class OrtMainFunTest : StringSpec() {
                     "--rules-file", "build.gradle.kts",
                     "--rules-resource", "DUMMY"
                 )
+            }
+        }
+
+        "Commands load OrtResults with resolved scopes" {
+            val cmd = AdvisorCommand()
+            val resultFile = File("src/funTest/assets/analyzer-result-with-dependency-graph.yml")
+
+            val result = cmd.readOrtResult(resultFile)
+
+            result.analyzer?.result shouldNotBeNull {
+                dependencyGraphs.keys should beEmpty()
+            }
+
+            val project = result.getProject(Identifier("Maven:com.vdurmont:semver4j:3.1.0"))
+
+            project shouldNotBeNull {
+                scopes shouldNot beEmpty()
             }
         }
     }

--- a/cli/src/funTest/kotlin/OrtMainFunTest.kt
+++ b/cli/src/funTest/kotlin/OrtMainFunTest.kt
@@ -30,6 +30,8 @@ import io.kotest.matchers.shouldBe
 import java.io.File
 
 import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.redirectStdout
 import org.ossreviewtoolkit.utils.test.createTestTempDir
@@ -118,9 +120,11 @@ class OrtMainFunTest : StringSpec() {
                 "-i", projectDir.resolve("gradle").absolutePath,
                 "-o", analyzerOutputDir.path
             )
-            val analyzerResult = analyzerOutputDir.resolve("analyzer-result.yml").readText()
 
-            patchActualResult(analyzerResult, patchStartAndEndTime = true) shouldBe expectedResult
+            val analyzerResult = analyzerOutputDir.resolve("analyzer-result.yml").readValue<OrtResult>()
+            val resolvedResult = analyzerResult.withResolvedScopes()
+
+            patchActualResult(resolvedResult, patchStartAndEndTime = true) shouldBe expectedResult
         }
 
         "Package curation data file is applied correctly" {
@@ -139,9 +143,11 @@ class OrtMainFunTest : StringSpec() {
                 "-o", analyzerOutputDir.path,
                 "--package-curations-file", projectDir.resolve("gradle/curations.yml").toString()
             )
-            val analyzerResult = analyzerOutputDir.resolve("analyzer-result.yml").readText()
 
-            patchActualResult(analyzerResult, patchStartAndEndTime = true) shouldBe expectedResult
+            val analyzerResult = analyzerOutputDir.resolve("analyzer-result.yml").readValue<OrtResult>()
+            val resolvedResult = analyzerResult.withResolvedScopes()
+
+            patchActualResult(resolvedResult, patchStartAndEndTime = true) shouldBe expectedResult
         }
 
         "Passing mutually exclusive evaluator options fails" {

--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -219,12 +219,13 @@ class OrtMain : CliktCommand(name = ORT_NAME, invokeWithoutSubcommand = true) {
 }
 
 /**
- * Read [ortFile] into an [OrtResult] and return it.
+ * Read [ortFile] into an [OrtResult] and return it. Make sure that information about project scopes is available
+ * (by calling [OrtResult.withResolvedScopes]), so that it can be processed.
  */
 fun CliktCommand.readOrtResult(ortFile: File): OrtResult {
     log.debug { "Input ORT result file has SHA-1 hash ${HashAlgorithm.SHA1.calculate(ortFile)}." }
 
-    val (ortResult, duration) = measureTimedValue { ortFile.readValue<OrtResult>() }
+    val (ortResult, duration) = measureTimedValue { ortFile.readValue<OrtResult>().withResolvedScopes() }
 
     log.perf {
         "Read ORT result from '${ortFile.name}' (${ortFile.formatSizeInMib}) in ${duration.inMilliseconds}ms."

--- a/model/src/main/kotlin/DependencyGraph.kt
+++ b/model/src/main/kotlin/DependencyGraph.kt
@@ -61,6 +61,33 @@ data class DependencyGraph(
      */
     val scopes: Map<String, List<RootDependencyIndex>>
 ) {
+    companion object {
+        /**
+         * Return a name for the given [scope][scopeName] that is qualified with parts of the identifier of the given
+         * [project]. This is used to ensure that the scope names are unique when constructing a dependency graph from
+         * multiple projects.
+         */
+        fun qualifyScope(project: Project, scopeName: String): String =
+            qualifyScope(project.id, scopeName)
+
+        /**
+         * Return a name for the given [scope][scopeName] that is qualified with parts of the given [projectId]. This
+         * is used to ensure that the scope names are unique when constructing a dependency graph from multiple
+         * projects.
+         */
+        fun qualifyScope(projectId: Identifier, scopeName: String): String =
+            "${projectId.namespace}:${projectId.name}:${projectId.version}:$scopeName"
+
+        /**
+         * Extract the plain (un-qualified) scope name from the given qualified [scopeName]. If the passed in
+         * [scopeName] is not qualified, return it unchanged.
+         */
+        fun unqualifyScope(scopeName: String): String =
+            // To handle the case that the scope contains the separator character, cut off the parts for the
+            // namespace, the name, and the version.
+            scopeName.split(':', limit = 4).getOrElse(3) { scopeName }
+    }
+
     /**
      * Transform the data stored in this object to the classical layout of dependency information, which is a set of
      * [Scope]s referencing the packages they depend on.

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -372,7 +372,7 @@ data class OrtResult(
      */
     @JsonIgnore
     fun getProjects(omitExcluded: Boolean = false): Set<Project> =
-        analyzer?.result?.projects.orEmpty().filterTo(mutableSetOf()) { project ->
+        analyzer?.result?.withScopesResolved()?.projects.orEmpty().filterTo(mutableSetOf()) { project ->
             !omitExcluded || !isExcluded(project.id)
         }
 
@@ -461,9 +461,7 @@ data class OrtResult(
     fun withResolvedScopes(): OrtResult =
         copy(
             analyzer = analyzer?.copy(
-                result = analyzer.result.copy(
-                    projects = analyzer.result.projects.mapTo(sortedSetOf()) { it.withResolvedScopes() }
-                )
+                result = analyzer.result.withScopesResolved()
             )
         )
 }

--- a/model/src/test/assets/analyzer-result-with-dependency-graph.yml
+++ b/model/src/test/assets/analyzer-result-with-dependency-graph.yml
@@ -1,0 +1,215 @@
+---
+repository:
+  vcs:
+    type: "Git"
+    url: "https://github.com/vdurmont/semver4j.git"
+    revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/vdurmont/semver4j.git"
+    revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+    path: ""
+  config: {}
+analyzer:
+  start_time: "2021-04-26T05:48:05.390356Z"
+  end_time: "2021-04-26T05:48:13.604832Z"
+  environment:
+    ort_version: "9d23fdf"
+    java_version: "11.0.8"
+    os: "Linux"
+    processors: 4
+    max_memory: 12884901888
+    variables:
+      JAVA_HOME: "/opt/java/openjdk"
+      ANDROID_HOME: "/opt/android-sdk"
+      GOPATH: "/go"
+    tool_versions: {}
+  config:
+    ignore_tool_versions: false
+    allow_dynamic_versions: false
+  result:
+    projects:
+      - id: "Maven:com.vdurmont:semver4j:3.1.0"
+        definition_file_path: "pom.xml"
+        authors:
+          - "Vincent DURMONT"
+        declared_licenses:
+          - "The MIT License"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+          mapped:
+            The MIT License: "MIT"
+        vcs:
+          type: "Git"
+          url: "git@github.com:vdurmont/semver4j.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/vdurmont/semver4j.git"
+          revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
+          path: ""
+        homepage_url: "https://github.com/vdurmont/semver4j"
+        scope_names:
+          - "test"
+    packages:
+      - package:
+          id: "Maven:junit:junit:4.12"
+          purl: "pkg:maven/junit/junit@4.12"
+          authors:
+            - "David Saff"
+            - "JUnit"
+            - "Kevin Cooney"
+            - "Marc Philipp"
+            - "Stefan Birkner"
+          declared_licenses:
+            - "Eclipse Public License 1.0"
+          declared_licenses_processed:
+            spdx_expression: "EPL-1.0"
+            mapped:
+              Eclipse Public License 1.0: "EPL-1.0"
+          concluded_license: "EPL-1.0"
+          description: "JUnit is a unit testing framework for Java, created by Erich\
+          \ Gamma and Kent Beck."
+          homepage_url: "http://junit.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
+            hash:
+              value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+            hash:
+              value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "https://github.com/junit-team/junit4.git"
+            revision: "r4.12"
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/junit-team/junit4.git"
+            revision: "r4.12"
+            path: ""
+        curations:
+          - base:
+              vcs:
+                type: "Git"
+                url: "git://github.com/junit-team/junit.git"
+                revision: "r4.12"
+                path: ""
+            curation:
+              comment: "ScanCode claims to find some NOASSERTION and Apache-2.0 in the\
+            \ FAQ and the pom.xml, both are false-positives."
+              concluded_license: "EPL-1.0"
+              vcs:
+                type: "Git"
+                url: "https://github.com/junit-team/junit4.git"
+                revision: "r4.12"
+      - package:
+          id: "Maven:org.hamcrest:hamcrest-core:1.3"
+          purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
+          authors:
+            - "Joe Walnes"
+            - "Nat Pryce"
+            - "Neil Dunn"
+            - "Steve Freeman"
+            - "Tom Denley"
+          declared_licenses:
+            - "BSD-3-Clause"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+          description: "This is the core API of hamcrest matcher framework to be used\
+          \ by third-party framework providers. This includes the a foundation set\
+          \ of matcher implementations for common operations."
+          homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
+            hash:
+              value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+            hash:
+              value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:hamcrest/JavaHamcrest.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
+            revision: ""
+            path: ""
+        curations:
+          - base:
+              declared_licenses:
+                - "New BSD License"
+            curation:
+              comment: "Provided by ClearlyDefined."
+              declared_licenses:
+                - "BSD-3-Clause"
+      - package:
+          id: "Maven:org.mockito:mockito-all:1.10.19"
+          purl: "pkg:maven/org.mockito/mockito-all@1.10.19"
+          authors:
+            - "Szczepan Faber"
+          declared_licenses:
+            - "MIT"
+          declared_licenses_processed:
+            spdx_expression: "MIT"
+          description: "Mock objects library for java"
+          homepage_url: "http://www.mockito.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/mockito/mockito-all/1.10.19/mockito-all-1.10.19.jar"
+            hash:
+              value: "539df70269cc254a58cccc5d8e43286b4a73bf30"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/mockito/mockito-all/1.10.19/mockito-all-1.10.19-sources.jar"
+            hash:
+              value: "8269667b73d9616600359a9b0ba1b1c7d0cf7a97"
+              algorithm: "SHA-1"
+          vcs:
+            type: ""
+            url: ""
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: ""
+            url: ""
+            revision: ""
+            path: ""
+        curations:
+          - base:
+              declared_licenses:
+                - "The MIT License"
+            curation:
+              comment: "Provided by ClearlyDefined."
+              declared_licenses:
+                - "MIT"
+    dependency_graphs:
+      Maven:
+        packages:
+          - "Maven:junit:junit:4.12"
+          - "Maven:org.hamcrest:hamcrest-core:1.3"
+          - "Maven:org.mockito:mockito-all:1.10.19"
+        scope_roots:
+          - dependencies:
+              - pkg: 1
+          - pkg: 2
+        scopes:
+          com.vdurmont:semver4j:3.1.0:test:
+            - root: 0
+            - root: 2
+    has_issues: false
+scanner: null
+advisor: null
+evaluator: null
+labels:
+  applicationCategory: "BT05 Client application"
+  projectName: "Semver4jNewDependencyGraphShared"

--- a/model/src/test/kotlin/DependencyGraphTest.kt
+++ b/model/src/test/kotlin/DependencyGraphTest.kt
@@ -128,6 +128,44 @@ class DependencyGraphTest : WordSpec({
             pkgRefLang.linkage shouldBe PackageLinkage.PROJECT_DYNAMIC
         }
     }
+
+    "qualifyScope" should {
+        "qualify a scope name with a project identifier" {
+            val scopeName = "compile"
+            val projectId = Identifier("Maven", "namespace", "name", "version")
+            val project = Project(
+                id = projectId,
+                definitionFilePath = "/some/path/pom.xml",
+                declaredLicenses = sortedSetOf(),
+                homepageUrl = "https://project.example.org",
+                vcs = VcsInfo.EMPTY
+            )
+
+            val qualifiedScopeName = DependencyGraph.qualifyScope(project, scopeName)
+
+            qualifiedScopeName shouldBe "namespace:name:version:$scopeName"
+        }
+    }
+
+    "unqualifyScope" should {
+        "remove the project prefix from a qualified scope name" {
+            val qualifiedScopeName = "namespace:name:version:scope"
+
+            DependencyGraph.unqualifyScope(qualifiedScopeName) shouldBe "scope"
+        }
+
+        "handle a scope name that is not qualified" {
+            val unqualifiedScopeName = "justAScope"
+
+            DependencyGraph.unqualifyScope(unqualifiedScopeName) shouldBe unqualifiedScopeName
+        }
+
+        "handle a scope name that contains a colon" {
+            val qualifiedScopeName = "namespace:name:version:scope:with:colons"
+
+            DependencyGraph.unqualifyScope(qualifiedScopeName) shouldBe "scope:with:colons"
+        }
+    }
 })
 
 /** The name of the dependency manager used by tests. */

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -21,18 +21,22 @@ package org.ossreviewtoolkit.model
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.shouldMatch
 
+import java.io.File
 import java.lang.IllegalArgumentException
 
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.utils.Environment
 import org.ossreviewtoolkit.utils.test.readOrtResult
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class OrtResultTest : WordSpec({
     "collectDependencies" should {
@@ -140,6 +144,19 @@ class OrtResultTest : WordSpec({
             }
 
             e.message shouldMatch "The .* of project .* cannot be found in .*"
+        }
+    }
+
+    "projects" should {
+        "return projects with resolved scopes" {
+            val resultFile = File("src/test/assets/analyzer-result-with-dependency-graph.yml")
+            val result = resultFile.readValue<OrtResult>()
+
+            val project = result.getProject(Identifier("Maven:com.vdurmont:semver4j:3.1.0"))
+
+            project.shouldNotBeNull {
+                scopes shouldNot beEmpty()
+            }
         }
     }
 })

--- a/test-utils/src/main/kotlin/Utils.kt
+++ b/test-utils/src/main/kotlin/Utils.kt
@@ -31,6 +31,7 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.mapper
+import org.ossreviewtoolkit.model.yamlMapper
 
 val DEFAULT_ANALYZER_CONFIGURATION = AnalyzerConfiguration(ignoreToolVersions = false, allowDynamicVersions = false)
 val DEFAULT_REPOSITORY_CONFIGURATION = RepositoryConfiguration()
@@ -86,5 +87,11 @@ fun patchActualResult(
         .replace(TIMESTAMP_REGEX) { "${it.groupValues[1]}: \"${Instant.EPOCH}\"" }
         .replaceIf(patchStartAndEndTime, START_AND_END_TIME_REGEX) { "${it.groupValues[1]}: \"${Instant.EPOCH}\"" }
 }
+
+fun patchActualResult(
+    result: OrtResult,
+    patchStartAndEndTime: Boolean = false
+): String =
+    patchActualResult(yamlMapper.writeValueAsString(result), patchStartAndEndTime)
 
 fun readOrtResult(file: String) = File(file).let { it.mapper().readValue<OrtResult>(patchExpectedResult(it)) }


### PR DESCRIPTION
Change the DependencyGraph format to be global for a package manager result, i.e. combine the dependencies of multiple projects.

Note: The new approach is not that different from the old one, but there is some shift in the responsibility of dependency information: The dependency graph is no longer maintained by a project, but projects only have references to the shared dependency graph. This also affects the conversion of an `OrtResult` from the graph format to the classic structure with project scopes, which is expected by the components that operate on dependency data.

The intension of this PR is to keep the single changes small without breaking any tests. To achieve this, some redundancy had to be introduced temporarily. Especially the `Project` class is added a new dependency-related property, and the obsolete one is removed only later after other components have been reworked. If this is not desired, some commits can be squashed, but then there is a rather big bang change.