### PR TITLE
PackageCurationData: Make the comment go first

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -491,23 +491,23 @@ analyzer:
       - base:
           homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
         curation:
-          homepage_url: "http://hamcrest.org/JavaHamcrest/"
           comment: "Use the actual homepage instead of the GitHub page."
+          homepage_url: "http://hamcrest.org/JavaHamcrest/"
       - base:
           description: "This is the core API of hamcrest matcher framework to be used\
             \ by third-party framework providers. This includes the a foundation set\
             \ of matcher implementations for common operations."
         curation:
-          description: "Curated description."
           comment: "Fix description."
+          description: "Curated description."
       - base:
           declared_licenses:
           - "New BSD License"
         curation:
+          comment: "Declared license in pom.xml is wrong."
           declared_licenses:
           - "curated license a"
           - "curated license b"
-          comment: "Declared license in pom.xml is wrong."
     has_issues: true
 scanner: null
 advisor: null

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -34,6 +34,12 @@ import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class PackageCurationData(
     /**
+     * A plain-text comment about this curation. Should contain information about how and why the curation was
+     * created.
+     */
+    val comment: String? = null,
+
+    /**
      * The list of authors of this package.
      */
     val authors: SortedSet<String>? = null,
@@ -74,12 +80,6 @@ data class PackageCurationData(
      * VCS-related information.
      */
     val vcs: VcsInfoCurationData? = null,
-
-    /**
-     * A plain-text comment about this curation. Should contain information about how and why the curation was
-     * created.
-     */
-    val comment: String? = null,
 
     /**
      * Whether the package is meta data only.

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -512,8 +512,8 @@
     "curations" : [ {
       "base" : { },
       "curation" : {
-        "concluded_license" : "GPL-2.0-only OR MIT",
-        "comment" : "Foobar is an imaginary dependency and offers a license choice"
+        "comment" : "Foobar is an imaginary dependency and offers a license choice",
+        "concluded_license" : "GPL-2.0-only OR MIT"
       }
     } ],
     "paths" : [ 1 ],
@@ -564,8 +564,8 @@
     "curations" : [ {
       "base" : { },
       "curation" : {
-        "concluded_license" : "MPL-2.0 OR EPL-1.0",
-        "comment" : "H2 database offers a license choice"
+        "comment" : "H2 database offers a license choice",
+        "concluded_license" : "MPL-2.0 OR EPL-1.0"
       }
     } ],
     "paths" : [ 2 ],

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -447,8 +447,8 @@ packages:
   curations:
   - base: {}
     curation:
-      concluded_license: "GPL-2.0-only OR MIT"
       comment: "Foobar is an imaginary dependency and offers a license choice"
+      concluded_license: "GPL-2.0-only OR MIT"
   paths:
   - 1
   levels:
@@ -496,8 +496,8 @@ packages:
   curations:
   - base: {}
     curation:
-      concluded_license: "MPL-2.0 OR EPL-1.0"
       comment: "H2 database offers a license choice"
+      concluded_license: "MPL-2.0 OR EPL-1.0"
   paths:
   - 2
   levels:


### PR DESCRIPTION
The comment is different than the other fields in this class as it is
not patch data, but metadata about the patch. So make it stand out by
moving it to the top. As a wanted side effect, this also makes the comment
go first when rewriting curation files to normalize formatting. And having
the comments first in a file's entry is also good practice, to first
explain why a curation is needed, and then define it, similar to Git
commit messages that explain what the patch is doing.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>