### PR TITLE
declared-license-mapping: Add 'MIT License'

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -312,6 +312,7 @@
 "MIT / http://rem.mit-license.org": MIT
 "MIT Licence": MIT
 "MIT License (http://opensource.org/licenses/MIT)": MIT
+"MIT License": MIT
 "MIT Licensed. http://www.opensource.org/licenses/mit-license.php": MIT
 "MIT, 2-clause BSD": MIT AND BSD-2-Clause
 "MIT, 3-clause BSD": MIT AND BSD-3-Clause


### PR DESCRIPTION
The license was found in [1].

[1] https://github.com/alekzvik/shapely-geojson/blob/46a19f21729f5b40db1f704e2556df995824f3c8/setup.py#L50
