### PR TITLE
RepositoryProvenance: Remove the `originalVcsInfo` property

### DIFF
--- a/cli/src/funTest/assets/semver4j-analyzer-result.yml
+++ b/cli/src/funTest/assets/semver4j-analyzer-result.yml
@@ -198,11 +198,6 @@ scanner:
                 revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
                 resolved_revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
                 path: ""
-              original_vcs_info:
-                type: "Git"
-                url: "https://github.com/vdurmont/semver4j.git"
-                revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
-                path: ""
             scanner:
               name: "ScanCode"
               version: "3.2.1-rc2"
@@ -248,11 +243,6 @@ scanner:
                 url: "https://github.com/junit-team/junit.git"
                 revision: "r4.12"
                 resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
-                path: ""
-              original_vcs_info:
-                type: "Git"
-                url: "https://github.com/junit-team/junit.git"
-                revision: "r4.12"
                 path: ""
             scanner:
               name: "ScanCode"

--- a/downloader/src/funTest/kotlin/BeanUtilsFunTest.kt
+++ b/downloader/src/funTest/kotlin/BeanUtilsFunTest.kt
@@ -72,7 +72,7 @@ class BeanUtilsFunTest : StringSpec() {
             provenance.shouldBeTypeOf<RepositoryProvenance>().apply {
                 vcsInfo.type shouldBe VcsType.SUBVERSION
                 vcsInfo.url shouldBe vcsFromCuration.url
-                vcsInfo.revision shouldBe "928490"
+                vcsInfo.revision shouldBe ""
                 vcsInfo.resolvedRevision shouldBe "928490"
                 vcsInfo.path shouldBe vcsFromCuration.path
             }

--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -276,7 +276,7 @@ class Downloader(private val config: DownloaderConfiguration) {
             path = pkg.vcsProcessed.path
         )
 
-        return RepositoryProvenance(vcsInfo, pkg.vcsProcessed)
+        return RepositoryProvenance(vcsInfo)
     }
 
     /**

--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -271,7 +271,7 @@ class Downloader(private val config: DownloaderConfiguration) {
         val vcsInfo = VcsInfo(
             type = applicableVcs.type,
             url = pkg.vcsProcessed.url,
-            revision = pkg.vcsProcessed.revision.takeIf { it.isNotBlank() } ?: resolvedRevision,
+            revision = pkg.vcsProcessed.revision,
             resolvedRevision = resolvedRevision,
             path = pkg.vcsProcessed.path
         )

--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -262,15 +262,17 @@ class Downloader(private val config: DownloaderConfiguration) {
                 throw e
             }
         }
-        val revision = workingTree.getRevision()
+        val resolvedRevision = workingTree.getRevision()
 
-        log.info { "Finished downloading source code revision '$revision' to '${outputDirectory.absolutePath}'." }
+        log.info {
+            "Finished downloading source code revision '$resolvedRevision' to '${outputDirectory.absolutePath}'."
+        }
 
         val vcsInfo = VcsInfo(
             type = applicableVcs.type,
             url = pkg.vcsProcessed.url,
-            revision = pkg.vcsProcessed.revision.takeIf { it.isNotBlank() } ?: revision,
-            resolvedRevision = revision,
+            revision = pkg.vcsProcessed.revision.takeIf { it.isNotBlank() } ?: resolvedRevision,
+            resolvedRevision = resolvedRevision,
             path = pkg.vcsProcessed.path
         )
 

--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -276,7 +276,7 @@ class Downloader(private val config: DownloaderConfiguration) {
             path = pkg.vcsProcessed.path
         )
 
-        return RepositoryProvenance(vcsInfo, pkg.vcsProcessed.takeIf { it != vcsInfo })
+        return RepositoryProvenance(vcsInfo, pkg.vcsProcessed)
     }
 
     /**

--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -82,7 +82,7 @@ data class RepositoryProvenance(
 
         // If pkg.vcsProcessed equals originalVcsInfo or vcsInfo this provenance was definitely created when
         // downloading this package.
-        if (pkg.vcsProcessed == originalVcsInfo || pkg.vcsProcessed == vcsInfo) return true
+        if (pkg.vcsProcessed == originalVcsInfo || pkg.vcsProcessed.equalsIgnoreResolvedRevision(vcsInfo)) return true
 
         return listOf(pkg.vcs, pkg.vcsProcessed).any {
             if (it.resolvedRevision != null) {
@@ -114,3 +114,6 @@ private class ProvenanceDeserializer : StdDeserializer<Provenance>(Provenance::c
         }
     }
 }
+
+private fun VcsInfo.equalsIgnoreResolvedRevision(other: VcsInfo): Boolean =
+    copy(resolvedRevision = "") == other.copy(resolvedRevision = "")

--- a/model/src/main/kotlin/ScanResult.kt
+++ b/model/src/main/kotlin/ScanResult.kt
@@ -53,10 +53,7 @@ data class ScanResult(
         val summary = summary.filterByPath(path)
 
         return if (provenance is RepositoryProvenance) {
-            val vcsProvenance = provenance.copy(
-                vcsInfo = provenance.vcsInfo.copy(path = path),
-                originalVcsInfo = provenance.originalVcsInfo?.copy(path = path)
-            )
+            val vcsProvenance = provenance.copy(vcsInfo = provenance.vcsInfo.copy(path = path))
 
             ScanResult(vcsProvenance, scanner, summary)
         } else {

--- a/model/src/main/kotlin/ScanResult.kt
+++ b/model/src/main/kotlin/ScanResult.kt
@@ -47,10 +47,8 @@ data class ScanResult(
      * Filter all detected licenses and copyrights from the [summary] which are underneath [path], and set the [path]
      * for [provenance]. Findings which [RootLicenseMatcher] assigns as root license files for [path] are also kept.
      */
-    fun filterByPath(path: String): ScanResult {
-        if (path.isBlank()) return this
-
-        return ScanResult(
+    fun filterByPath(path: String): ScanResult =
+        takeIf { path.isBlank() } ?: ScanResult(
             provenance = if (provenance is RepositoryProvenance) {
                 provenance.copy(vcsInfo = provenance.vcsInfo.copy(path = path))
             } else {
@@ -59,7 +57,6 @@ data class ScanResult(
             scanner = scanner,
             summary = summary.filterByPath(path),
         )
-    }
 
     /**
      * Return a [ScanResult] whose [summary] contains only findings from the [provenance]'s [VcsInfo.path].

--- a/model/src/main/kotlin/ScanResult.kt
+++ b/model/src/main/kotlin/ScanResult.kt
@@ -50,15 +50,15 @@ data class ScanResult(
     fun filterByPath(path: String): ScanResult {
         if (path.isBlank()) return this
 
-        val summary = summary.filterByPath(path)
-
-        return if (provenance is RepositoryProvenance) {
-            val vcsProvenance = provenance.copy(vcsInfo = provenance.vcsInfo.copy(path = path))
-
-            ScanResult(vcsProvenance, scanner, summary)
-        } else {
-            ScanResult(provenance, scanner, summary)
-        }
+        return ScanResult(
+            provenance = if (provenance is RepositoryProvenance) {
+                provenance.copy(vcsInfo = provenance.vcsInfo.copy(path = path))
+            } else {
+                provenance
+            },
+            scanner = scanner,
+            summary = summary.filterByPath(path),
+        )
     }
 
     /**

--- a/model/src/test/assets/advisor-result-initial.yml
+++ b/model/src/test/assets/advisor-result-initial.yml
@@ -240,11 +240,6 @@ scanner:
             revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
             resolved_revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
             path: ""
-          original_vcs_info:
-            type: "Git"
-            url: "https://github.com/vdurmont/semver4j.git"
-            revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
-            path: ""
         scanner:
           name: "ScanCode"
           version: "3.2.1-rc2"
@@ -289,11 +284,6 @@ scanner:
             url: "https://github.com/junit-team/junit4.git"
             revision: "r4.12"
             resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
-            path: ""
-          original_vcs_info:
-            type: "Git"
-            url: "https://github.com/junit-team/junit4.git"
-            revision: "r4.12"
             path: ""
         scanner:
           name: "ScanCode"
@@ -364,11 +354,6 @@ scanner:
             url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
             revision: "36d525e1e425006939a77aec5183aecd7c775b05"
             resolved_revision: "36d525e1e425006939a77aec5183aecd7c775b05"
-            path: ""
-          original_vcs_info:
-            type: "Git"
-            url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
-            revision: ""
             path: ""
         scanner:
           name: "ScanCode"

--- a/model/src/test/assets/advisor-result-vulnerability-refs.yml
+++ b/model/src/test/assets/advisor-result-vulnerability-refs.yml
@@ -274,11 +274,6 @@ scanner:
             revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
             resolved_revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
             path: ""
-          original_vcs_info:
-            type: "Git"
-            url: "https://github.com/vdurmont/semver4j.git"
-            revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
-            path: ""
         scanner:
           name: "ScanCode"
           version: "3.2.1-rc2"
@@ -323,11 +318,6 @@ scanner:
             url: "https://github.com/junit-team/junit4.git"
             revision: "r4.12"
             resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
-            path: ""
-          original_vcs_info:
-            type: "Git"
-            url: "https://github.com/junit-team/junit4.git"
-            revision: "r4.12"
             path: ""
         scanner:
           name: "ScanCode"
@@ -398,11 +388,6 @@ scanner:
             url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
             revision: "36d525e1e425006939a77aec5183aecd7c775b05"
             resolved_revision: "36d525e1e425006939a77aec5183aecd7c775b05"
-            path: ""
-          original_vcs_info:
-            type: "Git"
-            url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
-            revision: ""
             path: ""
         scanner:
           name: "ScanCode"

--- a/model/src/test/kotlin/ProvenanceTest.kt
+++ b/model/src/test/kotlin/ProvenanceTest.kt
@@ -89,12 +89,6 @@ class ProvenanceTest : WordSpec({
                 revision = "revision",
                 resolvedRevision = "resolvedRevision",
                 path = "path"
-            ),
-            originalVcsInfo = VcsInfo(
-                type = VcsType.UNKNOWN,
-                url = "originalUrl",
-                revision = "originalRevision",
-                path = "originalPath"
             )
         )
 
@@ -109,12 +103,6 @@ class ProvenanceTest : WordSpec({
                     "revision" : "revision",
                     "resolved_revision" : "resolvedRevision",
                     "path" : "path"
-                  },
-                  "original_vcs_info" : {
-                    "type" : "",
-                    "url" : "originalUrl",
-                    "revision" : "originalRevision",
-                    "path" : "originalPath"
                   }
                 }
             """.trimIndent()

--- a/reporter-web-app/public/index.html
+++ b/reporter-web-app/public/index.html
@@ -1788,12 +1788,6 @@
                   "revision" : "47b62ac45e9b176a2af35532d0eea4968bb9eb6d",
                   "resolved_revision" : "47b62ac45e9b176a2af35532d0eea4968bb9eb6d",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/jshttp/mime-types.git",
-                  "revision" : "47b62ac45e9b176a2af35532d0eea4968bb9eb6d",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -1813,12 +1807,6 @@
                   "url" : "https://github.com/acornjs/acorn-jsx.git",
                   "revision" : "52a64313bb95aba5fbfddd1b0256aa0fce229bb2",
                   "resolved_revision" : "52a64313bb95aba5fbfddd1b0256aa0fce229bb2",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/acornjs/acorn-jsx.git",
-                  "revision" : "52a64313bb95aba5fbfddd1b0256aa0fce229bb2",
                   "path" : ""
                 }
               },
@@ -1840,12 +1828,6 @@
                   "revision" : "54efb62138c54f523413fb6a6c00c57c81e81f54",
                   "resolved_revision" : "54efb62138c54f523413fb6a6c00c57c81e81f54",
                   "path" : "acorn"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/acornjs/acorn.git",
-                  "revision" : "",
-                  "path" : "acorn"
                 }
               },
               "scanner" : {
@@ -1865,12 +1847,6 @@
                   "url" : "https://github.com/sindresorhus/aggregate-error.git",
                   "revision" : "d5bb4ac02a43f005ec7ad45f6e62919d7ebed0e5",
                   "resolved_revision" : "d5bb4ac02a43f005ec7ad45f6e62919d7ebed0e5",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/aggregate-error.git",
-                  "revision" : "d5bb4ac02a43f005ec7ad45f6e62919d7ebed0e5",
                   "path" : ""
                 }
               },
@@ -1892,12 +1868,6 @@
                   "revision" : "cf88d1dc22283dffbfbfed472507fc219b3bdbbb",
                   "resolved_revision" : "cf88d1dc22283dffbfbfed472507fc219b3bdbbb",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/ajv-validator/ajv.git",
-                  "revision" : "cf88d1dc22283dffbfbfed472507fc219b3bdbbb",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -1917,12 +1887,6 @@
                   "url" : "https://github.com/doowb/ansi-colors.git",
                   "revision" : "d2a3fcdcd6babdd8c9429fa9277a858e2fc97e3b",
                   "resolved_revision" : "d2a3fcdcd6babdd8c9429fa9277a858e2fc97e3b",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/doowb/ansi-colors.git",
-                  "revision" : "d2a3fcdcd6babdd8c9429fa9277a858e2fc97e3b",
                   "path" : ""
                 }
               },
@@ -1944,12 +1908,6 @@
                   "revision" : "2e6a4359b10e4b0320e6dad9857ea04f0decbda4",
                   "resolved_revision" : "2e6a4359b10e4b0320e6dad9857ea04f0decbda4",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/ansi-escapes.git",
-                  "revision" : "2e6a4359b10e4b0320e6dad9857ea04f0decbda4",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -1969,12 +1927,6 @@
                   "url" : "https://github.com/chalk/ansi-regex.git",
                   "revision" : "0a8cc19946c03c38520fe8c086b8adb66f9cce0b",
                   "resolved_revision" : "0a8cc19946c03c38520fe8c086b8adb66f9cce0b",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/chalk/ansi-regex.git",
-                  "revision" : "0a8cc19946c03c38520fe8c086b8adb66f9cce0b",
                   "path" : ""
                 }
               },
@@ -1996,12 +1948,6 @@
                   "revision" : "a079ab2d30cfb752a3f247dcf358d0a591c288c5",
                   "resolved_revision" : "a079ab2d30cfb752a3f247dcf358d0a591c288c5",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/chalk/ansi-regex.git",
-                  "revision" : "a079ab2d30cfb752a3f247dcf358d0a591c288c5",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2021,12 +1967,6 @@
                   "url" : "https://github.com/chalk/ansi-regex.git",
                   "revision" : "2b56fb0c7a07108e5b54241e8faec160d393aedb",
                   "resolved_revision" : "2b56fb0c7a07108e5b54241e8faec160d393aedb",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/chalk/ansi-regex.git",
-                  "revision" : "2b56fb0c7a07108e5b54241e8faec160d393aedb",
                   "path" : ""
                 }
               },
@@ -2048,12 +1988,6 @@
                   "revision" : "de7527a86c1cf49906b0eb32a0de1402d849ccc2",
                   "resolved_revision" : "de7527a86c1cf49906b0eb32a0de1402d849ccc2",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/chalk/ansi-styles.git",
-                  "revision" : "de7527a86c1cf49906b0eb32a0de1402d849ccc2",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2073,12 +2007,6 @@
                   "url" : "https://github.com/chalk/ansi-styles.git",
                   "revision" : "74d421cf32342ac6ec7b507bd903a9e1105f74d7",
                   "resolved_revision" : "74d421cf32342ac6ec7b507bd903a9e1105f74d7",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/chalk/ansi-styles.git",
-                  "revision" : "74d421cf32342ac6ec7b507bd903a9e1105f74d7",
                   "path" : ""
                 }
               },
@@ -2100,12 +2028,6 @@
                   "revision" : "e0ec3c077d6fd64753b0c9f149614f78c9d54285",
                   "resolved_revision" : "e0ec3c077d6fd64753b0c9f149614f78c9d54285",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/micromatch/anymatch.git",
-                  "revision" : "e0ec3c077d6fd64753b0c9f149614f78c9d54285",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2125,12 +2047,6 @@
                   "url" : "https://github.com/istanbuljs/append-transform.git",
                   "revision" : "3c2618eb953a5de61099452f2b4764a1e1d10674",
                   "resolved_revision" : "3c2618eb953a5de61099452f2b4764a1e1d10674",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/istanbuljs/append-transform.git",
-                  "revision" : "3c2618eb953a5de61099452f2b4764a1e1d10674",
                   "path" : ""
                 }
               },
@@ -2152,12 +2068,6 @@
                   "revision" : "30223c16191e877bf027b15b12daf077b9b55b84",
                   "resolved_revision" : "30223c16191e877bf027b15b12daf077b9b55b84",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/substack/node-archy.git",
-                  "revision" : "30223c16191e877bf027b15b12daf077b9b55b84",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2177,12 +2087,6 @@
                   "url" : "https://github.com/nodeca/argparse.git",
                   "revision" : "ea45e14bad13b9e4a10af28f11fb7e731079ab72",
                   "resolved_revision" : "ea45e14bad13b9e4a10af28f11fb7e731079ab72",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/nodeca/argparse.git",
-                  "revision" : "ea45e14bad13b9e4a10af28f11fb7e731079ab72",
                   "path" : ""
                 }
               },
@@ -2204,12 +2108,6 @@
                   "revision" : "b83a70df057b7bcf03f51fcf6741620539024952",
                   "resolved_revision" : "b83a70df057b7bcf03f51fcf6741620539024952",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/es-shims/array-includes.git",
-                  "revision" : "b83a70df057b7bcf03f51fcf6741620539024952",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2229,12 +2127,6 @@
                   "url" : "https://github.com/es-shims/Array.prototype.flat.git",
                   "revision" : "33c7855d8eb6d63133bd6321b208cf691e6c0a2a",
                   "resolved_revision" : "33c7855d8eb6d63133bd6321b208cf691e6c0a2a",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/es-shims/Array.prototype.flat.git",
-                  "revision" : "33c7855d8eb6d63133bd6321b208cf691e6c0a2a",
                   "path" : ""
                 }
               },
@@ -2256,12 +2148,6 @@
                   "revision" : "20d5f406d37af3697145eb415355a89fdd4a2279",
                   "resolved_revision" : "20d5f406d37af3697145eb415355a89fdd4a2279",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/kevva/astral-regex.git",
-                  "revision" : "20d5f406d37af3697145eb415355a89fdd4a2279",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2281,12 +2167,6 @@
                   "url" : "https://github.com/wooorm/bail.git",
                   "revision" : "2628e331be0feef42b66cf546f468f3e92670dd4",
                   "resolved_revision" : "2628e331be0feef42b66cf546f468f3e92670dd4",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/bail.git",
-                  "revision" : "2628e331be0feef42b66cf546f468f3e92670dd4",
                   "path" : ""
                 }
               },
@@ -2308,12 +2188,6 @@
                   "revision" : "d701a549a7653a874eebce7eca25d3577dc868ac",
                   "resolved_revision" : "d701a549a7653a874eebce7eca25d3577dc868ac",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/juliangruber/balanced-match.git",
-                  "revision" : "d701a549a7653a874eebce7eca25d3577dc868ac",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2333,12 +2207,6 @@
                   "url" : "https://github.com/sindresorhus/binary-extensions.git",
                   "revision" : "4c81c9a9f3a4921f35bcedeb3b91e18902c859f7",
                   "resolved_revision" : "4c81c9a9f3a4921f35bcedeb3b91e18902c859f7",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/binary-extensions.git",
-                  "revision" : "4c81c9a9f3a4921f35bcedeb3b91e18902c859f7",
                   "path" : ""
                 }
               },
@@ -2360,12 +2228,6 @@
                   "revision" : "01a21de7441549d26ac0c0a9ff91385d16e5c21c",
                   "resolved_revision" : "01a21de7441549d26ac0c0a9ff91385d16e5c21c",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/juliangruber/brace-expansion.git",
-                  "revision" : "01a21de7441549d26ac0c0a9ff91385d16e5c21c",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2385,12 +2247,6 @@
                   "url" : "https://github.com/micromatch/braces.git",
                   "revision" : "25791512d219b284bd62bb068cae85d8e68bd05b",
                   "resolved_revision" : "25791512d219b284bd62bb068cae85d8e68bd05b",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/micromatch/braces.git",
-                  "revision" : "25791512d219b284bd62bb068cae85d8e68bd05b",
                   "path" : ""
                 }
               },
@@ -2412,12 +2268,6 @@
                   "revision" : "456b7f33c2d535fc88cf732d1a0e2d48a7600a1b",
                   "resolved_revision" : "456b7f33c2d535fc88cf732d1a0e2d48a7600a1b",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/kumavis/browser-stdout.git",
-                  "revision" : "456b7f33c2d535fc88cf732d1a0e2d48a7600a1b",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2437,12 +2287,6 @@
                   "url" : "https://github.com/istanbuljs/caching-transform.git",
                   "revision" : "961cc0dab59f4327795446eb41e700c067d0b87d",
                   "resolved_revision" : "961cc0dab59f4327795446eb41e700c067d0b87d",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/istanbuljs/caching-transform.git",
-                  "revision" : "961cc0dab59f4327795446eb41e700c067d0b87d",
                   "path" : ""
                 }
               },
@@ -2464,12 +2308,6 @@
                   "revision" : "f89815af2e0255094283c86977f1e679a8fb411b",
                   "resolved_revision" : "f89815af2e0255094283c86977f1e679a8fb411b",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/callsites.git",
-                  "revision" : "f89815af2e0255094283c86977f1e679a8fb411b",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2489,12 +2327,6 @@
                   "url" : "https://github.com/sindresorhus/camelcase.git",
                   "revision" : "cbe5a519ec6745adbb5283d5ee8c5c9889050d74",
                   "resolved_revision" : "cbe5a519ec6745adbb5283d5ee8c5c9889050d74",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/camelcase.git",
-                  "revision" : "cbe5a519ec6745adbb5283d5ee8c5c9889050d74",
                   "path" : ""
                 }
               },
@@ -2516,12 +2348,6 @@
                   "revision" : "9776a2ae5b5b1712ccf16416b55f47e575a81fb9",
                   "resolved_revision" : "9776a2ae5b5b1712ccf16416b55f47e575a81fb9",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/chalk/chalk.git",
-                  "revision" : "9776a2ae5b5b1712ccf16416b55f47e575a81fb9",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2541,12 +2367,6 @@
                   "url" : "https://github.com/chalk/chalk.git",
                   "revision" : "4c3df8847256f9f2471f0af74100b21afc12949f",
                   "resolved_revision" : "4c3df8847256f9f2471f0af74100b21afc12949f",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/chalk/chalk.git",
-                  "revision" : "4c3df8847256f9f2471f0af74100b21afc12949f",
                   "path" : ""
                 }
               },
@@ -2568,12 +2388,6 @@
                   "revision" : "a983fb63050ae146da051e5bf3c579809d122297",
                   "resolved_revision" : "a983fb63050ae146da051e5bf3c579809d122297",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/character-entities-legacy.git",
-                  "revision" : "a983fb63050ae146da051e5bf3c579809d122297",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2593,12 +2407,6 @@
                   "url" : "https://github.com/wooorm/character-entities.git",
                   "revision" : "2980174764642927ff8643393d3ecbb5ee7483e6",
                   "resolved_revision" : "2980174764642927ff8643393d3ecbb5ee7483e6",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/character-entities.git",
-                  "revision" : "2980174764642927ff8643393d3ecbb5ee7483e6",
                   "path" : ""
                 }
               },
@@ -2620,12 +2428,6 @@
                   "revision" : "9f6490130b554f70c655517af887250db28daef4",
                   "resolved_revision" : "9f6490130b554f70c655517af887250db28daef4",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/character-reference-invalid.git",
-                  "revision" : "9f6490130b554f70c655517af887250db28daef4",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2645,12 +2447,6 @@
                   "url" : "ssh://git@github.com/runk/node-chardet.git",
                   "revision" : "5156e3063ae8e8ba7f0d599378d024a4f403993c",
                   "resolved_revision" : "5156e3063ae8e8ba7f0d599378d024a4f403993c",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/runk/node-chardet.git",
-                  "revision" : "5156e3063ae8e8ba7f0d599378d024a4f403993c",
                   "path" : ""
                 }
               },
@@ -2672,12 +2468,6 @@
                   "revision" : "ccf759aac9af8a484924aeacd1e1a5280f508a75",
                   "resolved_revision" : "ccf759aac9af8a484924aeacd1e1a5280f508a75",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/paulmillr/chokidar.git",
-                  "revision" : "ccf759aac9af8a484924aeacd1e1a5280f508a75",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2697,12 +2487,6 @@
                   "url" : "https://github.com/sindresorhus/clean-stack.git",
                   "revision" : "91440c5a1615354fb9419354650937c434eb9f49",
                   "resolved_revision" : "91440c5a1615354fb9419354650937c434eb9f49",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/clean-stack.git",
-                  "revision" : "91440c5a1615354fb9419354650937c434eb9f49",
                   "path" : ""
                 }
               },
@@ -2724,12 +2508,6 @@
                   "revision" : "49edacfb841a9dac691972c2aa5d40dba8e0b56b",
                   "resolved_revision" : "49edacfb841a9dac691972c2aa5d40dba8e0b56b",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/cli-cursor.git",
-                  "revision" : "49edacfb841a9dac691972c2aa5d40dba8e0b56b",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2749,12 +2527,6 @@
                   "url" : "ssh://git@github.com/knownasilya/cli-width.git",
                   "revision" : "c96cf6e8b9a02256ded31e412490e29dbad30603",
                   "resolved_revision" : "c96cf6e8b9a02256ded31e412490e29dbad30603",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/knownasilya/cli-width.git",
-                  "revision" : "c96cf6e8b9a02256ded31e412490e29dbad30603",
                   "path" : ""
                 }
               },
@@ -2776,12 +2548,6 @@
                   "revision" : "e49b32f3358d0269663f80d4e2a81c9936af3ba9",
                   "resolved_revision" : "e49b32f3358d0269663f80d4e2a81c9936af3ba9",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/yargs/cliui.git",
-                  "revision" : "e49b32f3358d0269663f80d4e2a81c9936af3ba9",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2801,12 +2567,6 @@
                   "url" : "ssh://git@github.com/yargs/cliui.git",
                   "revision" : "7761da3e8cddd1f49024252a6b0195a94565b357",
                   "resolved_revision" : "7761da3e8cddd1f49024252a6b0195a94565b357",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/yargs/cliui.git",
-                  "revision" : "7761da3e8cddd1f49024252a6b0195a94565b357",
                   "path" : ""
                 }
               },
@@ -2828,12 +2588,6 @@
                   "revision" : "27d6d182f649b2a27f958fffa7d974ed30ebce97",
                   "resolved_revision" : "27d6d182f649b2a27f958fffa7d974ed30ebce97",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/collapse-white-space.git",
-                  "revision" : "27d6d182f649b2a27f958fffa7d974ed30ebce97",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2853,12 +2607,6 @@
                   "url" : "https://github.com/Qix-/color-convert.git",
                   "revision" : "99dc5da127d3d17d0ff8d13a995fd2d6aab404aa",
                   "resolved_revision" : "99dc5da127d3d17d0ff8d13a995fd2d6aab404aa",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/Qix-/color-convert.git",
-                  "revision" : "99dc5da127d3d17d0ff8d13a995fd2d6aab404aa",
                   "path" : ""
                 }
               },
@@ -2880,12 +2628,6 @@
                   "revision" : "e1cb7846258e1d7aa25873814684d4fbbbca53ed",
                   "resolved_revision" : "e1cb7846258e1d7aa25873814684d4fbbbca53ed",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/Qix-/color-convert.git",
-                  "revision" : "e1cb7846258e1d7aa25873814684d4fbbbca53ed",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2905,12 +2647,6 @@
                   "url" : "ssh://git@github.com/dfcreative/color-name.git",
                   "revision" : "cb7d4629b00fe38564f741a0779f6ad84d8007a2",
                   "resolved_revision" : "cb7d4629b00fe38564f741a0779f6ad84d8007a2",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/dfcreative/color-name.git",
-                  "revision" : "cb7d4629b00fe38564f741a0779f6ad84d8007a2",
                   "path" : ""
                 }
               },
@@ -2932,12 +2668,6 @@
                   "revision" : "4536ce5944f56659a2dfb2198eaf81b5ad5f2ad9",
                   "resolved_revision" : "4536ce5944f56659a2dfb2198eaf81b5ad5f2ad9",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/colorjs/color-name.git",
-                  "revision" : "4536ce5944f56659a2dfb2198eaf81b5ad5f2ad9",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2958,12 +2688,6 @@
                   "revision" : "57797b60db24c60029f7593995241749b1704902",
                   "resolved_revision" : "57797b60db24c60029f7593995241749b1704902",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/substack/node-commondir.git",
-                  "revision" : "57797b60db24c60029f7593995241749b1704902",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -2983,12 +2707,6 @@
                   "url" : "https://github.com/substack/node-concat-map.git",
                   "revision" : "0be8682c13068fde1caf1d75c201069d91260bcd",
                   "resolved_revision" : "0be8682c13068fde1caf1d75c201069d91260bcd",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/substack/node-concat-map.git",
-                  "revision" : "",
                   "path" : ""
                 }
               },
@@ -3030,12 +2748,6 @@
                   "revision" : "9e9a7a9b652c30878c9c9aa591d861a9fdf61a7e",
                   "resolved_revision" : "9e9a7a9b652c30878c9c9aa591d861a9fdf61a7e",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/thlorenz/convert-source-map.git",
-                  "revision" : "9e9a7a9b652c30878c9c9aa591d861a9fdf61a7e",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3055,12 +2767,6 @@
                   "url" : "ssh://git@github.com/moxystudio/node-cross-spawn.git",
                   "revision" : "301187a05b7509aa1d6ff35d8ff6d6064f597bc9",
                   "resolved_revision" : "301187a05b7509aa1d6ff35d8ff6d6064f597bc9",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/moxystudio/node-cross-spawn.git",
-                  "revision" : "301187a05b7509aa1d6ff35d8ff6d6064f597bc9",
                   "path" : ""
                 }
               },
@@ -3082,12 +2788,6 @@
                   "revision" : "7bc42bc409d9da6ad691df8d1d5ef69003bf1dc3",
                   "resolved_revision" : "7bc42bc409d9da6ad691df8d1d5ef69003bf1dc3",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/moxystudio/node-cross-spawn.git",
-                  "revision" : "7bc42bc409d9da6ad691df8d1d5ef69003bf1dc3",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3107,12 +2807,6 @@
                   "url" : "https://github.com/visionmedia/debug.git",
                   "revision" : "13abeae468fea297d0dccc50bc55590809241083",
                   "resolved_revision" : "13abeae468fea297d0dccc50bc55590809241083",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/visionmedia/debug.git",
-                  "revision" : "13abeae468fea297d0dccc50bc55590809241083",
                   "path" : ""
                 }
               },
@@ -3134,12 +2828,6 @@
                   "revision" : "a7a17c9955460435592de2a4d3c722e9b32047a8",
                   "resolved_revision" : "a7a17c9955460435592de2a4d3c722e9b32047a8",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/visionmedia/debug.git",
-                  "revision" : "a7a17c9955460435592de2a4d3c722e9b32047a8",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3159,12 +2847,6 @@
                   "url" : "https://github.com/visionmedia/debug.git",
                   "revision" : "68b4dc8d8549d3924673c38fccc5d594f0a38da1",
                   "resolved_revision" : "68b4dc8d8549d3924673c38fccc5d594f0a38da1",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/visionmedia/debug.git",
-                  "revision" : "68b4dc8d8549d3924673c38fccc5d594f0a38da1",
                   "path" : ""
                 }
               },
@@ -3186,12 +2868,6 @@
                   "revision" : "95980ab6fb44c40eaca7792bdf93aff7c210c805",
                   "resolved_revision" : "95980ab6fb44c40eaca7792bdf93aff7c210c805",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/decamelize.git",
-                  "revision" : "95980ab6fb44c40eaca7792bdf93aff7c210c805",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3211,12 +2887,6 @@
                   "url" : "https://github.com/thlorenz/deep-is.git",
                   "revision" : "f126057628423458636dec9df3d621843b9ac55e",
                   "resolved_revision" : "f126057628423458636dec9df3d621843b9ac55e",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/thlorenz/deep-is.git",
-                  "revision" : "f126057628423458636dec9df3d621843b9ac55e",
                   "path" : ""
                 }
               },
@@ -3238,12 +2908,6 @@
                   "revision" : "8ad71fa5481e5117b1e44e76e83bb53c08f401f0",
                   "resolved_revision" : "8ad71fa5481e5117b1e44e76e83bb53c08f401f0",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/avajs/default-require-extensions.git",
-                  "revision" : "8ad71fa5481e5117b1e44e76e83bb53c08f401f0",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3263,12 +2927,6 @@
                   "url" : "https://github.com/ljharb/define-properties.git",
                   "revision" : "e5478e3d2880b90a97daa62d76abed34d91154dd",
                   "resolved_revision" : "e5478e3d2880b90a97daa62d76abed34d91154dd",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/ljharb/define-properties.git",
-                  "revision" : "e5478e3d2880b90a97daa62d76abed34d91154dd",
                   "path" : ""
                 }
               },
@@ -3290,12 +2948,6 @@
                   "revision" : "e9ab94893a77f1f7d7ea8483b873083e6c6a390a",
                   "resolved_revision" : "e9ab94893a77f1f7d7ea8483b873083e6c6a390a",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/kpdecker/jsdiff.git",
-                  "revision" : "e9ab94893a77f1f7d7ea8483b873083e6c6a390a",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3315,12 +2967,6 @@
                   "url" : "https://github.com/eslint/doctrine.git",
                   "revision" : "dcd631feb5dd5bcd0899dd35548da2752ea2263e",
                   "resolved_revision" : "dcd631feb5dd5bcd0899dd35548da2752ea2263e",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/eslint/doctrine.git",
-                  "revision" : "dcd631feb5dd5bcd0899dd35548da2752ea2263e",
                   "path" : ""
                 }
               },
@@ -3342,12 +2988,6 @@
                   "revision" : "42434ca1f85b264a88afcfd317487a7417e6004b",
                   "resolved_revision" : "42434ca1f85b264a88afcfd317487a7417e6004b",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/eslint/doctrine.git",
-                  "revision" : "42434ca1f85b264a88afcfd317487a7417e6004b",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3367,12 +3007,6 @@
                   "url" : "https://github.com/mathiasbynens/emoji-regex.git",
                   "revision" : "3cbaf44e18f4996464ce97f1484ef425bbe8864a",
                   "resolved_revision" : "3cbaf44e18f4996464ce97f1484ef425bbe8864a",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/mathiasbynens/emoji-regex.git",
-                  "revision" : "3cbaf44e18f4996464ce97f1484ef425bbe8864a",
                   "path" : ""
                 }
               },
@@ -3394,12 +3028,6 @@
                   "revision" : "a9f2e514523d4c0931974aff5059052da10c52c5",
                   "resolved_revision" : "a9f2e514523d4c0931974aff5059052da10c52c5",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/mathiasbynens/emoji-regex.git",
-                  "revision" : "a9f2e514523d4c0931974aff5059052da10c52c5",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3419,12 +3047,6 @@
                   "url" : "https://github.com/qix-/node-error-ex.git",
                   "revision" : "3953ebb9e4a33287e67676a70a8ad72bbbe38075",
                   "resolved_revision" : "3953ebb9e4a33287e67676a70a8ad72bbbe38075",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/qix-/node-error-ex.git",
-                  "revision" : "3953ebb9e4a33287e67676a70a8ad72bbbe38075",
                   "path" : ""
                 }
               },
@@ -3446,12 +3068,6 @@
                   "revision" : "977e31c1427131852d28b36f4cca7085b1d4760d",
                   "resolved_revision" : "977e31c1427131852d28b36f4cca7085b1d4760d",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/ljharb/es-abstract.git",
-                  "revision" : "977e31c1427131852d28b36f4cca7085b1d4760d",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3471,12 +3087,6 @@
                   "url" : "https://github.com/ljharb/es-to-primitive.git",
                   "revision" : "fc864b766689e70707a0b86a136b0ec0021e4d17",
                   "resolved_revision" : "fc864b766689e70707a0b86a136b0ec0021e4d17",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/ljharb/es-to-primitive.git",
-                  "revision" : "fc864b766689e70707a0b86a136b0ec0021e4d17",
                   "path" : ""
                 }
               },
@@ -3498,12 +3108,6 @@
                   "revision" : "5b553293429bac6b15d8caeab8a4174faeb38fa0",
                   "resolved_revision" : "5b553293429bac6b15d8caeab8a4174faeb38fa0",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/bjyoungblood/es6-error.git",
-                  "revision" : "5b553293429bac6b15d8caeab8a4174faeb38fa0",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3523,12 +3127,6 @@
                   "url" : "https://github.com/sindresorhus/escape-string-regexp.git",
                   "revision" : "db124a3e1aae9d692c4899e42a5c6c3e329eaa20",
                   "resolved_revision" : "db124a3e1aae9d692c4899e42a5c6c3e329eaa20",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/escape-string-regexp.git",
-                  "revision" : "db124a3e1aae9d692c4899e42a5c6c3e329eaa20",
                   "path" : ""
                 }
               },
@@ -3550,12 +3148,6 @@
                   "revision" : "3f4a3fed2c5d5fdf03e5c32e6c87d2fdc3ea4282",
                   "resolved_revision" : "3f4a3fed2c5d5fdf03e5c32e6c87d2fdc3ea4282",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/standard/eslint-config-standard.git",
-                  "revision" : "3f4a3fed2c5d5fdf03e5c32e6c87d2fdc3ea4282",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3575,12 +3167,6 @@
                   "url" : "https://github.com/benmosher/eslint-plugin-import.git",
                   "revision" : "4a38ef4f65d7cbc241527eea45ad48db14c75a70",
                   "resolved_revision" : "4a38ef4f65d7cbc241527eea45ad48db14c75a70",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/benmosher/eslint-plugin-import.git",
-                  "revision" : "",
                   "path" : ""
                 }
               },
@@ -3622,12 +3208,6 @@
                   "revision" : "d86abb11c0c10fc1695cc5545ef5ab4f1b78581a",
                   "resolved_revision" : "d86abb11c0c10fc1695cc5545ef5ab4f1b78581a",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/mysticatea/eslint-plugin-es.git",
-                  "revision" : "d86abb11c0c10fc1695cc5545ef5ab4f1b78581a",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3647,12 +3227,6 @@
                   "url" : "https://github.com/benmosher/eslint-plugin-import.git",
                   "revision" : "71ca88f0a1e7e1270f1c1f9633d3ae8f136f58e1",
                   "resolved_revision" : "71ca88f0a1e7e1270f1c1f9633d3ae8f136f58e1",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/benmosher/eslint-plugin-import.git",
-                  "revision" : "71ca88f0a1e7e1270f1c1f9633d3ae8f136f58e1",
                   "path" : ""
                 }
               },
@@ -3674,12 +3248,6 @@
                   "revision" : "66b565b3763c30dcbc193e4bb74aee976860335d",
                   "resolved_revision" : "66b565b3763c30dcbc193e4bb74aee976860335d",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/eslint/eslint-plugin-markdown.git",
-                  "revision" : "66b565b3763c30dcbc193e4bb74aee976860335d",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3699,12 +3267,6 @@
                   "url" : "https://github.com/mysticatea/eslint-plugin-node.git",
                   "revision" : "4a348e7d24e0d806d7873f293c91a922d0316d14",
                   "resolved_revision" : "4a348e7d24e0d806d7873f293c91a922d0316d14",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/mysticatea/eslint-plugin-node.git",
-                  "revision" : "4a348e7d24e0d806d7873f293c91a922d0316d14",
                   "path" : ""
                 }
               },
@@ -3746,12 +3308,6 @@
                   "revision" : "116eb98b8cd26a04edcfa758e9513a9422f35b5e",
                   "resolved_revision" : "116eb98b8cd26a04edcfa758e9513a9422f35b5e",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/standard/eslint-plugin-standard.git",
-                  "revision" : "116eb98b8cd26a04edcfa758e9513a9422f35b5e",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3771,12 +3327,6 @@
                   "url" : "https://github.com/eslint/eslint-scope.git",
                   "revision" : "38b4b1fe5bcfb47b37ecc2a7707699632af56e05",
                   "resolved_revision" : "38b4b1fe5bcfb47b37ecc2a7707699632af56e05",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/eslint/eslint-scope.git",
-                  "revision" : "38b4b1fe5bcfb47b37ecc2a7707699632af56e05",
                   "path" : ""
                 }
               },
@@ -3798,12 +3348,6 @@
                   "revision" : "23f4ddc58eda5e6aec3d6a43c6266acbe19345cd",
                   "resolved_revision" : "23f4ddc58eda5e6aec3d6a43c6266acbe19345cd",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/mysticatea/eslint-utils.git",
-                  "revision" : "23f4ddc58eda5e6aec3d6a43c6266acbe19345cd",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3823,12 +3367,6 @@
                   "url" : "https://github.com/mysticatea/eslint-utils.git",
                   "revision" : "23709f84c8e21f1a38f61ad689c82a8763e0737f",
                   "resolved_revision" : "23709f84c8e21f1a38f61ad689c82a8763e0737f",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/mysticatea/eslint-utils.git",
-                  "revision" : "23709f84c8e21f1a38f61ad689c82a8763e0737f",
                   "path" : ""
                 }
               },
@@ -3850,12 +3388,6 @@
                   "revision" : "80a3ee826297902d8fb777706670622536889eaf",
                   "resolved_revision" : "80a3ee826297902d8fb777706670622536889eaf",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/eslint/eslint-visitor-keys.git",
-                  "revision" : "80a3ee826297902d8fb777706670622536889eaf",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3875,12 +3407,6 @@
                   "url" : "https://github.com/eslint/eslint.git",
                   "revision" : "9738f8cc864d769988ccf42bb70f524444df1349",
                   "resolved_revision" : "9738f8cc864d769988ccf42bb70f524444df1349",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/eslint/eslint.git",
-                  "revision" : "9738f8cc864d769988ccf42bb70f524444df1349",
                   "path" : ""
                 }
               },
@@ -3902,12 +3428,6 @@
                   "revision" : "6b7d0b8100537dcd5c84a7fb17bbe28edcabe05d",
                   "resolved_revision" : "6b7d0b8100537dcd5c84a7fb17bbe28edcabe05d",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/eslint/espree.git",
-                  "revision" : "6b7d0b8100537dcd5c84a7fb17bbe28edcabe05d",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3927,12 +3447,6 @@
                   "url" : "https://github.com/jquery/esprima.git",
                   "revision" : "0ed4b8afdf2abd416f738977672c6232836f410a",
                   "resolved_revision" : "0ed4b8afdf2abd416f738977672c6232836f410a",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/jquery/esprima.git",
-                  "revision" : "0ed4b8afdf2abd416f738977672c6232836f410a",
                   "path" : ""
                 }
               },
@@ -3954,12 +3468,6 @@
                   "revision" : "a48262deb20861568acf1bca0b7e02867e0b2c48",
                   "resolved_revision" : "a48262deb20861568acf1bca0b7e02867e0b2c48",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/estools/esquery.git",
-                  "revision" : "a48262deb20861568acf1bca0b7e02867e0b2c48",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -3979,12 +3487,6 @@
                   "url" : "https://github.com/estools/esrecurse.git",
                   "revision" : "8ceb63797813d9ac69572a671b95cf58ffdf35b6",
                   "resolved_revision" : "8ceb63797813d9ac69572a671b95cf58ffdf35b6",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/estools/esrecurse.git",
-                  "revision" : "8ceb63797813d9ac69572a671b95cf58ffdf35b6",
                   "path" : ""
                 }
               },
@@ -4006,12 +3508,6 @@
                   "revision" : "54d608c4ce0eb36d9bade685edcc3177e90e9f3c",
                   "resolved_revision" : "54d608c4ce0eb36d9bade685edcc3177e90e9f3c",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/estools/estraverse.git",
-                  "revision" : "54d608c4ce0eb36d9bade685edcc3177e90e9f3c",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4031,12 +3527,6 @@
                   "url" : "ssh://git@github.com/estools/estraverse.git",
                   "revision" : "8958cbfaf467afdef3306790dec90b86d01d0b8e",
                   "resolved_revision" : "8958cbfaf467afdef3306790dec90b86d01d0b8e",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/estools/estraverse.git",
-                  "revision" : "8958cbfaf467afdef3306790dec90b86d01d0b8e",
                   "path" : ""
                 }
               },
@@ -4058,12 +3548,6 @@
                   "revision" : "8c2741c0154723fb92da137a0c97845b03b0943a",
                   "resolved_revision" : "8c2741c0154723fb92da137a0c97845b03b0943a",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/estools/esutils.git",
-                  "revision" : "8c2741c0154723fb92da137a0c97845b03b0943a",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4083,12 +3567,6 @@
                   "url" : "https://github.com/justmoon/node-extend.git",
                   "revision" : "8d106d23931c0802e8b88188b0aac433e13358d9",
                   "resolved_revision" : "8d106d23931c0802e8b88188b0aac433e13358d9",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/justmoon/node-extend.git",
-                  "revision" : "8d106d23931c0802e8b88188b0aac433e13358d9",
                   "path" : ""
                 }
               },
@@ -4110,12 +3588,6 @@
                   "revision" : "3069d69f023f7e46ab06a01791d256655ccf634e",
                   "resolved_revision" : "3069d69f023f7e46ab06a01791d256655ccf634e",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/mrkmg/node-external-editor.git",
-                  "revision" : "3069d69f023f7e46ab06a01791d256655ccf634e",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4135,12 +3607,6 @@
                   "url" : "https://github.com/epoberezkin/fast-deep-equal.git",
                   "revision" : "d807ffc5013e710deb1c63d463a03f729bcd144d",
                   "resolved_revision" : "d807ffc5013e710deb1c63d463a03f729bcd144d",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/epoberezkin/fast-deep-equal.git",
-                  "revision" : "d807ffc5013e710deb1c63d463a03f729bcd144d",
                   "path" : ""
                 }
               },
@@ -4162,12 +3628,6 @@
                   "revision" : "b3ab8bdfb91cb182c93475c2c3518d6224672bb4",
                   "resolved_revision" : "b3ab8bdfb91cb182c93475c2c3518d6224672bb4",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/epoberezkin/fast-json-stable-stringify.git",
-                  "revision" : "b3ab8bdfb91cb182c93475c2c3518d6224672bb4",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4187,12 +3647,6 @@
                   "url" : "https://github.com/hiddentao/fast-levenshtein.git",
                   "revision" : "5bffe7151f99fb02f319f70a004e653105a760fb",
                   "resolved_revision" : "5bffe7151f99fb02f319f70a004e653105a760fb",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/hiddentao/fast-levenshtein.git",
-                  "revision" : "5bffe7151f99fb02f319f70a004e653105a760fb",
                   "path" : ""
                 }
               },
@@ -4214,12 +3668,6 @@
                   "revision" : "add96242a5467efdcca234433a21da6554df6410",
                   "resolved_revision" : "add96242a5467efdcca234433a21da6554df6410",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/figures.git",
-                  "revision" : "add96242a5467efdcca234433a21da6554df6410",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4239,12 +3687,6 @@
                   "url" : "https://github.com/royriojas/file-entry-cache.git",
                   "revision" : "03f700c99b76133dc14648b465a1550ec2930e5c",
                   "resolved_revision" : "03f700c99b76133dc14648b465a1550ec2930e5c",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/royriojas/file-entry-cache.git",
-                  "revision" : "03f700c99b76133dc14648b465a1550ec2930e5c",
                   "path" : ""
                 }
               },
@@ -4266,12 +3708,6 @@
                   "revision" : "39f421b499d5c97b62e955c179fa34c062aab2a5",
                   "resolved_revision" : "39f421b499d5c97b62e955c179fa34c062aab2a5",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/jonschlinkert/fill-range.git",
-                  "revision" : "39f421b499d5c97b62e955c179fa34c062aab2a5",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4291,12 +3727,6 @@
                   "url" : "https://github.com/avajs/find-cache-dir.git",
                   "revision" : "c35ae06d3ac6158d37bc8b559d54295fce40e667",
                   "resolved_revision" : "c35ae06d3ac6158d37bc8b559d54295fce40e667",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/avajs/find-cache-dir.git",
-                  "revision" : "c35ae06d3ac6158d37bc8b559d54295fce40e667",
                   "path" : ""
                 }
               },
@@ -4318,12 +3748,6 @@
                   "revision" : "10202fb1621f0c277d5d5eeaf01c1c32b008fbef",
                   "resolved_revision" : "10202fb1621f0c277d5d5eeaf01c1c32b008fbef",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/find-up.git",
-                  "revision" : "10202fb1621f0c277d5d5eeaf01c1c32b008fbef",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4343,12 +3767,6 @@
                   "url" : "https://github.com/sindresorhus/find-up.git",
                   "revision" : "2319b79a9e728fc13fc1a1a15e84bf5df100719e",
                   "resolved_revision" : "2319b79a9e728fc13fc1a1a15e84bf5df100719e",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/find-up.git",
-                  "revision" : "2319b79a9e728fc13fc1a1a15e84bf5df100719e",
                   "path" : ""
                 }
               },
@@ -4370,12 +3788,6 @@
                   "revision" : "6c32f0caed1684ef778053b6f79b13a772e22ba4",
                   "resolved_revision" : "6c32f0caed1684ef778053b6f79b13a772e22ba4",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/find-up.git",
-                  "revision" : "6c32f0caed1684ef778053b6f79b13a772e22ba4",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4395,12 +3807,6 @@
                   "url" : "https://github.com/royriojas/flat-cache.git",
                   "revision" : "9e95cdca746ccc5c066d277f1edde9c9b9f95348",
                   "resolved_revision" : "9e95cdca746ccc5c066d277f1edde9c9b9f95348",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/royriojas/flat-cache.git",
-                  "revision" : "9e95cdca746ccc5c066d277f1edde9c9b9f95348",
                   "path" : ""
                 }
               },
@@ -4422,12 +3828,6 @@
                   "revision" : "32432ddde3f08c44cc9e9e4f01616cd3fbf355bf",
                   "resolved_revision" : "32432ddde3f08c44cc9e9e4f01616cd3fbf355bf",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/hughsk/flat.git",
-                  "revision" : "32432ddde3f08c44cc9e9e4f01616cd3fbf355bf",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4447,12 +3847,6 @@
                   "url" : "https://github.com/WebReflection/flatted.git",
                   "revision" : "5e3ec39a3e613e70c56f3775c790ddebdbc363a6",
                   "resolved_revision" : "5e3ec39a3e613e70c56f3775c790ddebdbc363a6",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/WebReflection/flatted.git",
-                  "revision" : "5e3ec39a3e613e70c56f3775c790ddebdbc363a6",
                   "path" : ""
                 }
               },
@@ -4474,12 +3868,6 @@
                   "revision" : "efba8bb6d7607b5c3b0d3e3897c73727577c8b45",
                   "resolved_revision" : "efba8bb6d7607b5c3b0d3e3897c73727577c8b45",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/tapjs/foreground-child.git",
-                  "revision" : "efba8bb6d7607b5c3b0d3e3897c73727577c8b45",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4499,12 +3887,6 @@
                   "url" : "https://github.com/feross/fromentries.git",
                   "revision" : "5d2cedaa77f1c1b985b5c78e84a638073366dde1",
                   "resolved_revision" : "5d2cedaa77f1c1b985b5c78e84a638073366dde1",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/feross/fromentries.git",
-                  "revision" : "5d2cedaa77f1c1b985b5c78e84a638073366dde1",
                   "path" : ""
                 }
               },
@@ -4526,12 +3908,6 @@
                   "revision" : "03e7c884431fe185dfebbc9b771aeca339c1807a",
                   "resolved_revision" : "03e7c884431fe185dfebbc9b771aeca339c1807a",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/isaacs/fs.realpath.git",
-                  "revision" : "03e7c884431fe185dfebbc9b771aeca339c1807a",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4551,12 +3927,6 @@
                   "url" : "https://github.com/Raynos/function-bind.git",
                   "revision" : "1213f807066d1cb8d39a0592d5118f4b1f03de4a",
                   "resolved_revision" : "1213f807066d1cb8d39a0592d5118f4b1f03de4a",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/Raynos/function-bind.git",
-                  "revision" : "1213f807066d1cb8d39a0592d5118f4b1f03de4a",
                   "path" : ""
                 }
               },
@@ -4618,12 +3988,6 @@
                   "revision" : "2383bf9e98ed3c568ff69d7586cf59c0f1dcb9d3",
                   "resolved_revision" : "2383bf9e98ed3c568ff69d7586cf59c0f1dcb9d3",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/stefanpenner/get-caller-file.git",
-                  "revision" : "2383bf9e98ed3c568ff69d7586cf59c0f1dcb9d3",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4643,12 +4007,6 @@
                   "url" : "https://github.com/cfware/get-package-type.git",
                   "revision" : "53f035a197b349125e43f60c8b8896664daf3942",
                   "resolved_revision" : "53f035a197b349125e43f60c8b8896664daf3942",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/cfware/get-package-type.git",
-                  "revision" : "53f035a197b349125e43f60c8b8896664daf3942",
                   "path" : ""
                 }
               },
@@ -4670,12 +4028,6 @@
                   "revision" : "6ce8d11f2f1ed8e80a9526b1dc8cf3aa71f43474",
                   "resolved_revision" : "6ce8d11f2f1ed8e80a9526b1dc8cf3aa71f43474",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/gulpjs/glob-parent.git",
-                  "revision" : "6ce8d11f2f1ed8e80a9526b1dc8cf3aa71f43474",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4695,12 +4047,6 @@
                   "url" : "https://github.com/isaacs/node-glob.git",
                   "revision" : "8882c8fccabbe459465e73cc2581e121a5fdd25b",
                   "resolved_revision" : "8882c8fccabbe459465e73cc2581e121a5fdd25b",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/isaacs/node-glob.git",
-                  "revision" : "8882c8fccabbe459465e73cc2581e121a5fdd25b",
                   "path" : ""
                 }
               },
@@ -4722,12 +4068,6 @@
                   "revision" : "f5a57d3d6e19b324522a3fa5bdd5075fd1aa79d1",
                   "resolved_revision" : "f5a57d3d6e19b324522a3fa5bdd5075fd1aa79d1",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/isaacs/node-glob.git",
-                  "revision" : "f5a57d3d6e19b324522a3fa5bdd5075fd1aa79d1",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4747,12 +4087,6 @@
                   "url" : "https://github.com/sindresorhus/globals.git",
                   "revision" : "6bf39e6d2aaf5b107a840fd18f29be45760f2749",
                   "resolved_revision" : "6bf39e6d2aaf5b107a840fd18f29be45760f2749",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/globals.git",
-                  "revision" : "6bf39e6d2aaf5b107a840fd18f29be45760f2749",
                   "path" : ""
                 }
               },
@@ -4774,12 +4108,6 @@
                   "revision" : "92bbb85fc797e03465fbf6e69fb881be4f07e23d",
                   "resolved_revision" : "92bbb85fc797e03465fbf6e69fb881be4f07e23d",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/globals.git",
-                  "revision" : "92bbb85fc797e03465fbf6e69fb881be4f07e23d",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4799,12 +4127,6 @@
                   "url" : "https://github.com/isaacs/node-graceful-fs.git",
                   "revision" : "5a29f6c50ccdb412cb198b06ee248e65f365145b",
                   "resolved_revision" : "5a29f6c50ccdb412cb198b06ee248e65f365145b",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/isaacs/node-graceful-fs.git",
-                  "revision" : "5a29f6c50ccdb412cb198b06ee248e65f365145b",
                   "path" : ""
                 }
               },
@@ -4826,12 +4148,6 @@
                   "revision" : "95393c8da0d8bab06522a5eb36658a639c24a621",
                   "resolved_revision" : "95393c8da0d8bab06522a5eb36658a639c24a621",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/tj/node-growl.git",
-                  "revision" : "95393c8da0d8bab06522a5eb36658a639c24a621",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4851,12 +4167,6 @@
                   "url" : "https://github.com/sindresorhus/has-flag.git",
                   "revision" : "8b2ca7e693b2c742b29f2399194077b64b9ff781",
                   "resolved_revision" : "8b2ca7e693b2c742b29f2399194077b64b9ff781",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/has-flag.git",
-                  "revision" : "8b2ca7e693b2c742b29f2399194077b64b9ff781",
                   "path" : ""
                 }
               },
@@ -4878,12 +4188,6 @@
                   "revision" : "474aa39afca7333d356c022fc5be4d31732bbba3",
                   "resolved_revision" : "474aa39afca7333d356c022fc5be4d31732bbba3",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/has-flag.git",
-                  "revision" : "474aa39afca7333d356c022fc5be4d31732bbba3",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4903,12 +4207,6 @@
                   "url" : "https://github.com/ljharb/has-symbols.git",
                   "revision" : "132fe9ce5c2e443e0570606d4568a242eb86b5f5",
                   "resolved_revision" : "132fe9ce5c2e443e0570606d4568a242eb86b5f5",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/ljharb/has-symbols.git",
-                  "revision" : "132fe9ce5c2e443e0570606d4568a242eb86b5f5",
                   "path" : ""
                 }
               },
@@ -4930,12 +4228,6 @@
                   "revision" : "4edf96f2dec87ad6b6e68482e8f6d7c8eb7e07e6",
                   "resolved_revision" : "4edf96f2dec87ad6b6e68482e8f6d7c8eb7e07e6",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/tarruda/has.git",
-                  "revision" : "4edf96f2dec87ad6b6e68482e8f6d7c8eb7e07e6",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -4955,12 +4247,6 @@
                   "url" : "https://github.com/sindresorhus/hasha.git",
                   "revision" : "c93f8230153a35d1bbe5a3d274a688107792d2ec",
                   "resolved_revision" : "c93f8230153a35d1bbe5a3d274a688107792d2ec",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/hasha.git",
-                  "revision" : "c93f8230153a35d1bbe5a3d274a688107792d2ec",
                   "path" : ""
                 }
               },
@@ -4982,12 +4268,6 @@
                   "revision" : "36afe179392226cf1b6ccdb16ebbb7a5a844d93a",
                   "resolved_revision" : "36afe179392226cf1b6ccdb16ebbb7a5a844d93a",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/mathiasbynens/he.git",
-                  "revision" : "36afe179392226cf1b6ccdb16ebbb7a5a844d93a",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5007,12 +4287,6 @@
                   "url" : "https://github.com/npm/hosted-git-info.git",
                   "revision" : "afeaefdd86ba9bb5044be3c1554a666d007cf19a",
                   "resolved_revision" : "afeaefdd86ba9bb5044be3c1554a666d007cf19a",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/npm/hosted-git-info.git",
-                  "revision" : "afeaefdd86ba9bb5044be3c1554a666d007cf19a",
                   "path" : ""
                 }
               },
@@ -5034,12 +4308,6 @@
                   "revision" : "88f420ad94369f9be46c24ca52eb77e3da224f37",
                   "resolved_revision" : "88f420ad94369f9be46c24ca52eb77e3da224f37",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/WebReflection/html-escaper.git",
-                  "revision" : "88f420ad94369f9be46c24ca52eb77e3da224f37",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5059,12 +4327,6 @@
                   "url" : "https://github.com/ashtuchkin/iconv-lite.git",
                   "revision" : "efbbb0937ca8dda1c14e0b69958b9d6f20771f7a",
                   "resolved_revision" : "efbbb0937ca8dda1c14e0b69958b9d6f20771f7a",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/ashtuchkin/iconv-lite.git",
-                  "revision" : "efbbb0937ca8dda1c14e0b69958b9d6f20771f7a",
                   "path" : ""
                 }
               },
@@ -5086,12 +4348,6 @@
                   "revision" : "56976cef6d5ec0e5651910801669f9aa3daa8120",
                   "resolved_revision" : "56976cef6d5ec0e5651910801669f9aa3daa8120",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/kaelzhang/node-ignore.git",
-                  "revision" : "56976cef6d5ec0e5651910801669f9aa3daa8120",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5111,12 +4367,6 @@
                   "url" : "ssh://git@github.com/kaelzhang/node-ignore.git",
                   "revision" : "a1f29fbadf258f630cdf45bd59e6fda5540e3169",
                   "resolved_revision" : "a1f29fbadf258f630cdf45bd59e6fda5540e3169",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/kaelzhang/node-ignore.git",
-                  "revision" : "a1f29fbadf258f630cdf45bd59e6fda5540e3169",
                   "path" : ""
                 }
               },
@@ -5138,12 +4388,6 @@
                   "revision" : "8a7a217edee030110b0412853c64a37f6d055fac",
                   "resolved_revision" : "8a7a217edee030110b0412853c64a37f6d055fac",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/import-fresh.git",
-                  "revision" : "8a7a217edee030110b0412853c64a37f6d055fac",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5163,12 +4407,6 @@
                   "url" : "https://github.com/jensyt/imurmurhash-js.git",
                   "revision" : "9f40361c7e2835a9b7b8eaa1cbab2a9f94ee22a2",
                   "resolved_revision" : "9f40361c7e2835a9b7b8eaa1cbab2a9f94ee22a2",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/jensyt/imurmurhash-js.git",
-                  "revision" : "",
                   "path" : ""
                 }
               },
@@ -5190,12 +4428,6 @@
                   "revision" : "99280aa24669a3fab303bb231d6caafd7d5029d3",
                   "resolved_revision" : "99280aa24669a3fab303bb231d6caafd7d5029d3",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/indent-string.git",
-                  "revision" : "99280aa24669a3fab303bb231d6caafd7d5029d3",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5215,12 +4447,6 @@
                   "url" : "https://github.com/npm/inflight.git",
                   "revision" : "a547881738c8f57b27795e584071d67cf6ac1a57",
                   "resolved_revision" : "a547881738c8f57b27795e584071d67cf6ac1a57",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/npm/inflight.git",
-                  "revision" : "a547881738c8f57b27795e584071d67cf6ac1a57",
                   "path" : ""
                 }
               },
@@ -5242,12 +4468,6 @@
                   "revision" : "9a2c29400c6d491e0b7beefe0c32efa3b462545d",
                   "resolved_revision" : "9a2c29400c6d491e0b7beefe0c32efa3b462545d",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/isaacs/inherits.git",
-                  "revision" : "9a2c29400c6d491e0b7beefe0c32efa3b462545d",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5267,12 +4487,6 @@
                   "url" : "https://github.com/SBoudrias/Inquirer.js.git",
                   "revision" : "808d5538531c1ca1c34f832d77bc98dfd0ba4000",
                   "resolved_revision" : "808d5538531c1ca1c34f832d77bc98dfd0ba4000",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/SBoudrias/Inquirer.js.git",
-                  "revision" : "808d5538531c1ca1c34f832d77bc98dfd0ba4000",
                   "path" : ""
                 }
               },
@@ -5294,12 +4508,6 @@
                   "revision" : "a2b5486bec2543d16782b2d56f79e70bd1075c51",
                   "resolved_revision" : "a2b5486bec2543d16782b2d56f79e70bd1075c51",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/is-alphabetical.git",
-                  "revision" : "a2b5486bec2543d16782b2d56f79e70bd1075c51",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5319,12 +4527,6 @@
                   "url" : "https://github.com/wooorm/is-alphanumerical.git",
                   "revision" : "76c8c4d9baec221aa7b358df1afd2a78dda0d46b",
                   "resolved_revision" : "76c8c4d9baec221aa7b358df1afd2a78dda0d46b",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/is-alphanumerical.git",
-                  "revision" : "76c8c4d9baec221aa7b358df1afd2a78dda0d46b",
                   "path" : ""
                 }
               },
@@ -5346,12 +4548,6 @@
                   "revision" : "53f22aa6ce557d7d31a3d1152a590a2df220df9d",
                   "resolved_revision" : "53f22aa6ce557d7d31a3d1152a590a2df220df9d",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/qix-/node-is-arrayish.git",
-                  "revision" : "53f22aa6ce557d7d31a3d1152a590a2df220df9d",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5371,12 +4567,6 @@
                   "url" : "https://github.com/sindresorhus/is-binary-path.git",
                   "revision" : "efe99d8b3d0ef825925e8b986d047e39bee173c3",
                   "resolved_revision" : "efe99d8b3d0ef825925e8b986d047e39bee173c3",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/is-binary-path.git",
-                  "revision" : "efe99d8b3d0ef825925e8b986d047e39bee173c3",
                   "path" : ""
                 }
               },
@@ -5398,12 +4588,6 @@
                   "revision" : "1e84e7ee31cf6b660b12500f3111a05501da387f",
                   "resolved_revision" : "1e84e7ee31cf6b660b12500f3111a05501da387f",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/feross/is-buffer.git",
-                  "revision" : "1e84e7ee31cf6b660b12500f3111a05501da387f",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5423,12 +4607,6 @@
                   "url" : "https://github.com/feross/is-buffer.git",
                   "revision" : "65d2f6ba6c4e336be90c3cb6a656a69ce8f24210",
                   "resolved_revision" : "65d2f6ba6c4e336be90c3cb6a656a69ce8f24210",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/feross/is-buffer.git",
-                  "revision" : "65d2f6ba6c4e336be90c3cb6a656a69ce8f24210",
                   "path" : ""
                 }
               },
@@ -5450,12 +4628,6 @@
                   "revision" : "bdc653e087abca51127759d313387b46235ec9d8",
                   "resolved_revision" : "bdc653e087abca51127759d313387b46235ec9d8",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/ljharb/is-callable.git",
-                  "revision" : "bdc653e087abca51127759d313387b46235ec9d8",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5475,12 +4647,6 @@
                   "url" : "https://github.com/ljharb/is-date-object.git",
                   "revision" : "e7e895d71f6820547627ce21a719632c17f3700f",
                   "resolved_revision" : "e7e895d71f6820547627ce21a719632c17f3700f",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/ljharb/is-date-object.git",
-                  "revision" : "e7e895d71f6820547627ce21a719632c17f3700f",
                   "path" : ""
                 }
               },
@@ -5502,12 +4668,6 @@
                   "revision" : "eccc588e219ad3067099fc5f5f2e3950eccdc41e",
                   "resolved_revision" : "eccc588e219ad3067099fc5f5f2e3950eccdc41e",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/is-decimal.git",
-                  "revision" : "eccc588e219ad3067099fc5f5f2e3950eccdc41e",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5527,12 +4687,6 @@
                   "url" : "https://github.com/jonschlinkert/is-extglob.git",
                   "revision" : "10a74787acbe79abf02141c5d487950d1b197b15",
                   "resolved_revision" : "10a74787acbe79abf02141c5d487950d1b197b15",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/jonschlinkert/is-extglob.git",
-                  "revision" : "10a74787acbe79abf02141c5d487950d1b197b15",
                   "path" : ""
                 }
               },
@@ -5554,12 +4708,6 @@
                   "revision" : "e94a78056056c5546f2bf4c4cf812a2163a46dae",
                   "resolved_revision" : "e94a78056056c5546f2bf4c4cf812a2163a46dae",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/is-fullwidth-code-point.git",
-                  "revision" : "e94a78056056c5546f2bf4c4cf812a2163a46dae",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5579,12 +4727,6 @@
                   "url" : "https://github.com/sindresorhus/is-fullwidth-code-point.git",
                   "revision" : "80e5e314d86e5f76bd1b0573aa9d33e615a372db",
                   "resolved_revision" : "80e5e314d86e5f76bd1b0573aa9d33e615a372db",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/is-fullwidth-code-point.git",
-                  "revision" : "80e5e314d86e5f76bd1b0573aa9d33e615a372db",
                   "path" : ""
                 }
               },
@@ -5606,12 +4748,6 @@
                   "revision" : "4ac6a0cb019fa39141457946c2d455f281f73659",
                   "resolved_revision" : "4ac6a0cb019fa39141457946c2d455f281f73659",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/micromatch/is-glob.git",
-                  "revision" : "4ac6a0cb019fa39141457946c2d455f281f73659",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5631,12 +4767,6 @@
                   "url" : "https://github.com/wooorm/is-hexadecimal.git",
                   "revision" : "32211606f81b71f134830764d5079a45536cc8fd",
                   "resolved_revision" : "32211606f81b71f134830764d5079a45536cc8fd",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/is-hexadecimal.git",
-                  "revision" : "32211606f81b71f134830764d5079a45536cc8fd",
                   "path" : ""
                 }
               },
@@ -5658,12 +4788,6 @@
                   "revision" : "98e8ff1da1a89f93d1397a24d7413ed15421c139",
                   "resolved_revision" : "98e8ff1da1a89f93d1397a24d7413ed15421c139",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/jonschlinkert/is-number.git",
-                  "revision" : "98e8ff1da1a89f93d1397a24d7413ed15421c139",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5683,12 +4807,6 @@
                   "url" : "https://github.com/sindresorhus/is-plain-obj.git",
                   "revision" : "b687098cc30d85bbec07f1633dee4c2d6acb1aa5",
                   "resolved_revision" : "b687098cc30d85bbec07f1633dee4c2d6acb1aa5",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/is-plain-obj.git",
-                  "revision" : "b687098cc30d85bbec07f1633dee4c2d6acb1aa5",
                   "path" : ""
                 }
               },
@@ -5710,12 +4828,6 @@
                   "revision" : "b8086365dabb5933a0b5471c9ebf63ed4f4136ee",
                   "resolved_revision" : "b8086365dabb5933a0b5471c9ebf63ed4f4136ee",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/ljharb/is-regex.git",
-                  "revision" : "b8086365dabb5933a0b5471c9ebf63ed4f4136ee",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5735,12 +4847,6 @@
                   "url" : "https://github.com/sindresorhus/is-stream.git",
                   "revision" : "1a70a7f985a00bf25de8437e68c849bf0e434bfb",
                   "resolved_revision" : "1a70a7f985a00bf25de8437e68c849bf0e434bfb",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/is-stream.git",
-                  "revision" : "1a70a7f985a00bf25de8437e68c849bf0e434bfb",
                   "path" : ""
                 }
               },
@@ -5762,12 +4868,6 @@
                   "revision" : "fdf72b6bf93438b8e7a54345467ab8cf35ef56e2",
                   "resolved_revision" : "fdf72b6bf93438b8e7a54345467ab8cf35ef56e2",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/ljharb/is-string.git",
-                  "revision" : "fdf72b6bf93438b8e7a54345467ab8cf35ef56e2",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5787,12 +4887,6 @@
                   "url" : "https://github.com/inspect-js/is-symbol.git",
                   "revision" : "f42e0be5f676e6c82c83c9cad70f1fbb3b81c8ca",
                   "resolved_revision" : "f42e0be5f676e6c82c83c9cad70f1fbb3b81c8ca",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/inspect-js/is-symbol.git",
-                  "revision" : "f42e0be5f676e6c82c83c9cad70f1fbb3b81c8ca",
                   "path" : ""
                 }
               },
@@ -5814,12 +4908,6 @@
                   "revision" : "0617cfa871686cf541af62b144f130488f44f6fe",
                   "resolved_revision" : "0617cfa871686cf541af62b144f130488f44f6fe",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/hughsk/is-typedarray.git",
-                  "revision" : "0617cfa871686cf541af62b144f130488f44f6fe",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5839,12 +4927,6 @@
                   "url" : "https://github.com/wooorm/is-whitespace-character.git",
                   "revision" : "433a8149f14c0a1db3a66224b2757ef9f8611e94",
                   "resolved_revision" : "433a8149f14c0a1db3a66224b2757ef9f8611e94",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/is-whitespace-character.git",
-                  "revision" : "433a8149f14c0a1db3a66224b2757ef9f8611e94",
                   "path" : ""
                 }
               },
@@ -5866,12 +4948,6 @@
                   "revision" : "4dcfff4ed9e36ad761a1a24d3899c832382d7254",
                   "resolved_revision" : "4dcfff4ed9e36ad761a1a24d3899c832382d7254",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/jonschlinkert/is-windows.git",
-                  "revision" : "4dcfff4ed9e36ad761a1a24d3899c832382d7254",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5891,12 +4967,6 @@
                   "url" : "https://github.com/wooorm/is-word-character.git",
                   "revision" : "c69ac2f7221ff5b515fd1f61424738dd6dcb96f2",
                   "resolved_revision" : "c69ac2f7221ff5b515fd1f61424738dd6dcb96f2",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/is-word-character.git",
-                  "revision" : "c69ac2f7221ff5b515fd1f61424738dd6dcb96f2",
                   "path" : ""
                 }
               },
@@ -5918,12 +4988,6 @@
                   "revision" : "2a23a281f369e9ae06394c0fb4d2381355a6ba33",
                   "resolved_revision" : "2a23a281f369e9ae06394c0fb4d2381355a6ba33",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/juliangruber/isarray.git",
-                  "revision" : "2a23a281f369e9ae06394c0fb4d2381355a6ba33",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -5943,12 +5007,6 @@
                   "url" : "https://github.com/isaacs/isexe.git",
                   "revision" : "10f8be491aab2e158c7e20df64a7f90ab5b5475c",
                   "resolved_revision" : "10f8be491aab2e158c7e20df64a7f90ab5b5475c",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/isaacs/isexe.git",
-                  "revision" : "10f8be491aab2e158c7e20df64a7f90ab5b5475c",
                   "path" : ""
                 }
               },
@@ -5970,12 +5028,6 @@
                   "revision" : "5319df684b508ff6fb19fe8b9a6147a3c5924e4b",
                   "resolved_revision" : "5319df684b508ff6fb19fe8b9a6147a3c5924e4b",
                   "path" : "packages/istanbul-lib-coverage"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/istanbuljs/istanbuljs.git",
-                  "revision" : "5319df684b508ff6fb19fe8b9a6147a3c5924e4b",
-                  "path" : "packages/istanbul-lib-coverage"
                 }
               },
               "scanner" : {
@@ -5995,12 +5047,6 @@
                   "url" : "ssh://git@github.com/istanbuljs/istanbuljs.git",
                   "revision" : "5319df684b508ff6fb19fe8b9a6147a3c5924e4b",
                   "resolved_revision" : "5319df684b508ff6fb19fe8b9a6147a3c5924e4b",
-                  "path" : "packages/istanbul-lib-hook"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/istanbuljs/istanbuljs.git",
-                  "revision" : "5319df684b508ff6fb19fe8b9a6147a3c5924e4b",
                   "path" : "packages/istanbul-lib-hook"
                 }
               },
@@ -6022,12 +5068,6 @@
                   "revision" : "2c6f0e24680d050503d404de0ebff53467fefbff",
                   "resolved_revision" : "2c6f0e24680d050503d404de0ebff53467fefbff",
                   "path" : "packages/istanbul-lib-instrument"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/istanbuljs/istanbuljs.git",
-                  "revision" : "2c6f0e24680d050503d404de0ebff53467fefbff",
-                  "path" : "packages/istanbul-lib-instrument"
                 }
               },
               "scanner" : {
@@ -6047,12 +5087,6 @@
                   "url" : "https://github.com/istanbuljs/istanbul-lib-processinfo.git",
                   "revision" : "5c356cd1a541c1b22a72a6ce5e09070386162dee",
                   "resolved_revision" : "5c356cd1a541c1b22a72a6ce5e09070386162dee",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/istanbuljs/istanbul-lib-processinfo.git",
-                  "revision" : "5c356cd1a541c1b22a72a6ce5e09070386162dee",
                   "path" : ""
                 }
               },
@@ -6074,12 +5108,6 @@
                   "revision" : "5319df684b508ff6fb19fe8b9a6147a3c5924e4b",
                   "resolved_revision" : "5319df684b508ff6fb19fe8b9a6147a3c5924e4b",
                   "path" : "packages/istanbul-lib-report"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/istanbuljs/istanbuljs.git",
-                  "revision" : "5319df684b508ff6fb19fe8b9a6147a3c5924e4b",
-                  "path" : "packages/istanbul-lib-report"
                 }
               },
               "scanner" : {
@@ -6099,12 +5127,6 @@
                   "url" : "ssh://git@github.com/istanbuljs/istanbuljs.git",
                   "revision" : "5319df684b508ff6fb19fe8b9a6147a3c5924e4b",
                   "resolved_revision" : "5319df684b508ff6fb19fe8b9a6147a3c5924e4b",
-                  "path" : "packages/istanbul-lib-source-maps"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/istanbuljs/istanbuljs.git",
-                  "revision" : "5319df684b508ff6fb19fe8b9a6147a3c5924e4b",
                   "path" : "packages/istanbul-lib-source-maps"
                 }
               },
@@ -6126,12 +5148,6 @@
                   "revision" : "73c25ce79f91010d1ff073aa6ff3fd01114f90db",
                   "resolved_revision" : "73c25ce79f91010d1ff073aa6ff3fd01114f90db",
                   "path" : "packages/istanbul-reports"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/istanbuljs/istanbuljs.git",
-                  "revision" : "73c25ce79f91010d1ff073aa6ff3fd01114f90db",
-                  "path" : "packages/istanbul-reports"
                 }
               },
               "scanner" : {
@@ -6151,12 +5167,6 @@
                   "url" : "https://github.com/lydell/js-tokens.git",
                   "revision" : "0eb6e9daee32160ab0fca979b6dc91a1991b720c",
                   "resolved_revision" : "0eb6e9daee32160ab0fca979b6dc91a1991b720c",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/lydell/js-tokens.git",
-                  "revision" : "0eb6e9daee32160ab0fca979b6dc91a1991b720c",
                   "path" : ""
                 }
               },
@@ -6178,12 +5188,6 @@
                   "revision" : "665aadda42349dcae869f12040d9b10ef18d12da",
                   "resolved_revision" : "665aadda42349dcae869f12040d9b10ef18d12da",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/nodeca/js-yaml.git",
-                  "revision" : "665aadda42349dcae869f12040d9b10ef18d12da",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -6203,12 +5207,6 @@
                   "url" : "https://github.com/nodeca/js-yaml.git",
                   "revision" : "34e5072f43fd36b08aaaad433da73c10d47c41e5",
                   "resolved_revision" : "34e5072f43fd36b08aaaad433da73c10d47c41e5",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/nodeca/js-yaml.git",
-                  "revision" : "34e5072f43fd36b08aaaad433da73c10d47c41e5",
                   "path" : ""
                 }
               },
@@ -6230,12 +5228,6 @@
                   "revision" : "5169a48f015437b7cdaffecaa10db52f155dace7",
                   "resolved_revision" : "5169a48f015437b7cdaffecaa10db52f155dace7",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/mathiasbynens/jsesc.git",
-                  "revision" : "5169a48f015437b7cdaffecaa10db52f155dace7",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -6255,12 +5247,6 @@
                   "url" : "https://github.com/epoberezkin/json-schema-traverse.git",
                   "revision" : "bc898eeee723833fc9d604523e00014350bcc4e1",
                   "resolved_revision" : "bc898eeee723833fc9d604523e00014350bcc4e1",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/epoberezkin/json-schema-traverse.git",
-                  "revision" : "bc898eeee723833fc9d604523e00014350bcc4e1",
                   "path" : ""
                 }
               },
@@ -6282,12 +5268,6 @@
                   "revision" : "c0b3c36d976c54e31a814c492cd1c2557a4d3758",
                   "resolved_revision" : "c0b3c36d976c54e31a814c492cd1c2557a4d3758",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/samn/json-stable-stringify.git",
-                  "revision" : "c0b3c36d976c54e31a814c492cd1c2557a4d3758",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -6307,12 +5287,6 @@
                   "url" : "https://github.com/json5/json5.git",
                   "revision" : "32bb2cdae4864b2ac80a6d9b4045efc4cc54f47a",
                   "resolved_revision" : "32bb2cdae4864b2ac80a6d9b4045efc4cc54f47a",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/json5/json5.git",
-                  "revision" : "32bb2cdae4864b2ac80a6d9b4045efc4cc54f47a",
                   "path" : ""
                 }
               },
@@ -6334,12 +5308,6 @@
                   "revision" : "a92b9acf928282ba81134b4ae8e6a5f29e1f5e1e",
                   "resolved_revision" : "a92b9acf928282ba81134b4ae8e6a5f29e1f5e1e",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/gkz/levn.git",
-                  "revision" : "a92b9acf928282ba81134b4ae8e6a5f29e1f5e1e",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -6359,12 +5327,6 @@
                   "url" : "https://github.com/sindresorhus/load-json-file.git",
                   "revision" : "49620f12bce627dc2459a08f5ef18cd2ff151eb2",
                   "resolved_revision" : "49620f12bce627dc2459a08f5ef18cd2ff151eb2",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/load-json-file.git",
-                  "revision" : "49620f12bce627dc2459a08f5ef18cd2ff151eb2",
                   "path" : ""
                 }
               },
@@ -6386,12 +5348,6 @@
                   "revision" : "a30b86df0934329c66ff6a2be395db03d65478b8",
                   "resolved_revision" : "a30b86df0934329c66ff6a2be395db03d65478b8",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/locate-path.git",
-                  "revision" : "a30b86df0934329c66ff6a2be395db03d65478b8",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -6412,12 +5368,6 @@
                   "revision" : "d6f19ffa31544161ee94118963deb3b683418151",
                   "resolved_revision" : "d6f19ffa31544161ee94118963deb3b683418151",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/locate-path.git",
-                  "revision" : "d6f19ffa31544161ee94118963deb3b683418151",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -6437,12 +5387,6 @@
                   "url" : "https://github.com/sindresorhus/locate-path.git",
                   "revision" : "630c0bbd609055c1895089c715649e21000a1ab7",
                   "resolved_revision" : "630c0bbd609055c1895089c715649e21000a1ab7",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/locate-path.git",
-                  "revision" : "630c0bbd609055c1895089c715649e21000a1ab7",
                   "path" : ""
                 }
               },
@@ -6484,12 +5428,6 @@
                   "revision" : "f2e7063ee409ff40a60b14370c58dceee1a2efd4",
                   "resolved_revision" : "f2e7063ee409ff40a60b14370c58dceee1a2efd4",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/lodash/lodash.git",
-                  "revision" : "f2e7063ee409ff40a60b14370c58dceee1a2efd4",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -6509,12 +5447,6 @@
                   "url" : "https://github.com/sindresorhus/log-symbols.git",
                   "revision" : "1f4ac6ef31cb4c7c4c4c67b7d6f9db712d4c0186",
                   "resolved_revision" : "1f4ac6ef31cb4c7c4c4c67b7d6f9db712d4c0186",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/log-symbols.git",
-                  "revision" : "1f4ac6ef31cb4c7c4c4c67b7d6f9db712d4c0186",
                   "path" : ""
                 }
               },
@@ -6536,12 +5468,6 @@
                   "revision" : "6d029fe1f75f1a02fcdd7a67f34eadf0941a424f",
                   "resolved_revision" : "6d029fe1f75f1a02fcdd7a67f34eadf0941a424f",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/make-dir.git",
-                  "revision" : "6d029fe1f75f1a02fcdd7a67f34eadf0941a424f",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -6561,12 +5487,6 @@
                   "url" : "https://github.com/wooorm/markdown-escapes.git",
                   "revision" : "3134eb6b85e27d568e587eb2290340c3f189427b",
                   "resolved_revision" : "3134eb6b85e27d568e587eb2290340c3f189427b",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/markdown-escapes.git",
-                  "revision" : "3134eb6b85e27d568e587eb2290340c3f189427b",
                   "path" : ""
                 }
               },
@@ -6588,12 +5508,6 @@
                   "revision" : "661ef0cf02b2800c5c5c6dc273c0a0b9eb3c410b",
                   "resolved_revision" : "661ef0cf02b2800c5c5c6dc273c0a0b9eb3c410b",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/jshttp/mime-db.git",
-                  "revision" : "661ef0cf02b2800c5c5c6dc273c0a0b9eb3c410b",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -6613,12 +5527,6 @@
                   "url" : "https://github.com/sindresorhus/mimic-fn.git",
                   "revision" : "d29f5387f4c19814a042d03a780ff4481ceac5a3",
                   "resolved_revision" : "d29f5387f4c19814a042d03a780ff4481ceac5a3",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/mimic-fn.git",
-                  "revision" : "d29f5387f4c19814a042d03a780ff4481ceac5a3",
                   "path" : ""
                 }
               },
@@ -6640,12 +5548,6 @@
                   "revision" : "e46989a323d5f0aa4781eff5e2e6e7aafa223321",
                   "resolved_revision" : "e46989a323d5f0aa4781eff5e2e6e7aafa223321",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/isaacs/minimatch.git",
-                  "revision" : "e46989a323d5f0aa4781eff5e2e6e7aafa223321",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -6665,12 +5567,6 @@
                   "url" : "https://github.com/substack/minimist.git",
                   "revision" : "aeb3e27dae0412de5c0494e9563a5f10c82cc7a9",
                   "resolved_revision" : "aeb3e27dae0412de5c0494e9563a5f10c82cc7a9",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/substack/minimist.git",
-                  "revision" : "aeb3e27dae0412de5c0494e9563a5f10c82cc7a9",
                   "path" : ""
                 }
               },
@@ -6692,12 +5588,6 @@
                   "revision" : "d784e70d1eb3fc73bcda52f22f57ec55c00c2525",
                   "resolved_revision" : "d784e70d1eb3fc73bcda52f22f57ec55c00c2525",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/substack/node-mkdirp.git",
-                  "revision" : "d784e70d1eb3fc73bcda52f22f57ec55c00c2525",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -6717,12 +5607,6 @@
                   "url" : "https://github.com/substack/node-mkdirp.git",
                   "revision" : "049cf185c9e91727bc505b796a2d16a4fe70d64d",
                   "resolved_revision" : "049cf185c9e91727bc505b796a2d16a4fe70d64d",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/substack/node-mkdirp.git",
-                  "revision" : "049cf185c9e91727bc505b796a2d16a4fe70d64d",
                   "path" : ""
                 }
               },
@@ -6744,12 +5628,6 @@
                   "revision" : "7c09e634267ddc18d1ec08a4bfd999efa317d684",
                   "resolved_revision" : "7c09e634267ddc18d1ec08a4bfd999efa317d684",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/mochajs/mocha.git",
-                  "revision" : "7c09e634267ddc18d1ec08a4bfd999efa317d684",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -6769,12 +5647,6 @@
                   "url" : "https://github.com/zeit/ms.git",
                   "revision" : "9b88d1568a52ec9bb67ecc8d2aa224fa38fd41f4",
                   "resolved_revision" : "9b88d1568a52ec9bb67ecc8d2aa224fa38fd41f4",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/zeit/ms.git",
-                  "revision" : "9b88d1568a52ec9bb67ecc8d2aa224fa38fd41f4",
                   "path" : ""
                 }
               },
@@ -6796,12 +5668,6 @@
                   "revision" : "fe0bae301a6c41f68a01595658a4f4f0dcba0e84",
                   "resolved_revision" : "fe0bae301a6c41f68a01595658a4f4f0dcba0e84",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/zeit/ms.git",
-                  "revision" : "fe0bae301a6c41f68a01595658a4f4f0dcba0e84",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -6821,12 +5687,6 @@
                   "url" : "https://github.com/zeit/ms.git",
                   "revision" : "7920885eb232fbe7a5efdab956d3e7c507c92ddf",
                   "resolved_revision" : "7920885eb232fbe7a5efdab956d3e7c507c92ddf",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/zeit/ms.git",
-                  "revision" : "7920885eb232fbe7a5efdab956d3e7c507c92ddf",
                   "path" : ""
                 }
               },
@@ -6848,12 +5708,6 @@
                   "revision" : "aa4a4baeaff5eeec83b5717738a44642f6948a9f",
                   "resolved_revision" : "aa4a4baeaff5eeec83b5717738a44642f6948a9f",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/isaacs/mute-stream.git",
-                  "revision" : "aa4a4baeaff5eeec83b5717738a44642f6948a9f",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -6873,12 +5727,6 @@
                   "url" : "https://github.com/litejs/natural-compare-lite.git",
                   "revision" : "eec83eee67cfac84d6db30cdd65363f155673770",
                   "resolved_revision" : "eec83eee67cfac84d6db30cdd65363f155673770",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/litejs/natural-compare-lite.git",
-                  "revision" : "eec83eee67cfac84d6db30cdd65363f155673770",
                   "path" : ""
                 }
               },
@@ -6900,12 +5748,6 @@
                   "revision" : "87013431e0877520763863f77dcb77dfd11eb2a9",
                   "resolved_revision" : "87013431e0877520763863f77dcb77dfd11eb2a9",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/electerious/nice-try.git",
-                  "revision" : "87013431e0877520763863f77dcb77dfd11eb2a9",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -6925,12 +5767,6 @@
                   "url" : "https://github.com/boneskull/node-environment-flags.git",
                   "revision" : "fbf451941e4721392c7c346de843514d7ad14a95",
                   "resolved_revision" : "fbf451941e4721392c7c346de843514d7ad14a95",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/boneskull/node-environment-flags.git",
-                  "revision" : "fbf451941e4721392c7c346de843514d7ad14a95",
                   "path" : ""
                 }
               },
@@ -6952,12 +5788,6 @@
                   "revision" : "f59d60cb94bafc4f4259d598ec26b543d293586d",
                   "resolved_revision" : "f59d60cb94bafc4f4259d598ec26b543d293586d",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/cfware/node-preload.git",
-                  "revision" : "f59d60cb94bafc4f4259d598ec26b543d293586d",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -6977,12 +5807,6 @@
                   "url" : "https://github.com/npm/normalize-package-data.git",
                   "revision" : "dedb606de22fa4bdf21c3679dece5fd07b4a0b1a",
                   "resolved_revision" : "dedb606de22fa4bdf21c3679dece5fd07b4a0b1a",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/npm/normalize-package-data.git",
-                  "revision" : "dedb606de22fa4bdf21c3679dece5fd07b4a0b1a",
                   "path" : ""
                 }
               },
@@ -7004,12 +5828,6 @@
                   "revision" : "0979eb807a1725d83d5a996347d41067cf773d1f",
                   "resolved_revision" : "0979eb807a1725d83d5a996347d41067cf773d1f",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/jonschlinkert/normalize-path.git",
-                  "revision" : "0979eb807a1725d83d5a996347d41067cf773d1f",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7029,12 +5847,6 @@
                   "url" : "ssh://git@github.com/istanbuljs/nyc.git",
                   "revision" : "d9a76d5f9c1df5920684f5e43abe95ded361075e",
                   "resolved_revision" : "d9a76d5f9c1df5920684f5e43abe95ded361075e",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/istanbuljs/nyc.git",
-                  "revision" : "d9a76d5f9c1df5920684f5e43abe95ded361075e",
                   "path" : ""
                 }
               },
@@ -7056,12 +5868,6 @@
                   "revision" : "a89774b252c91612203876984bbd6addbe3b5a0e",
                   "resolved_revision" : "a89774b252c91612203876984bbd6addbe3b5a0e",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/object-assign.git",
-                  "revision" : "a89774b252c91612203876984bbd6addbe3b5a0e",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7081,12 +5887,6 @@
                   "url" : "https://github.com/inspect-js/object-inspect.git",
                   "revision" : "6b0a54dee12b2361056590a1d3a3feecac3f7db5",
                   "resolved_revision" : "6b0a54dee12b2361056590a1d3a3feecac3f7db5",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/inspect-js/object-inspect.git",
-                  "revision" : "6b0a54dee12b2361056590a1d3a3feecac3f7db5",
                   "path" : ""
                 }
               },
@@ -7108,12 +5908,6 @@
                   "revision" : "ba2c1989270c7de969aa8498fc3b7c8e677806f3",
                   "resolved_revision" : "ba2c1989270c7de969aa8498fc3b7c8e677806f3",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/ljharb/object-keys.git",
-                  "revision" : "ba2c1989270c7de969aa8498fc3b7c8e677806f3",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7133,12 +5927,6 @@
                   "url" : "https://github.com/ljharb/object.assign.git",
                   "revision" : "5fd74aee40aba36e9a8eb0c329abd33a07b93164",
                   "resolved_revision" : "5fd74aee40aba36e9a8eb0c329abd33a07b93164",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/ljharb/object.assign.git",
-                  "revision" : "5fd74aee40aba36e9a8eb0c329abd33a07b93164",
                   "path" : ""
                 }
               },
@@ -7160,12 +5948,6 @@
                   "revision" : "cbe9a13b3e153d4f16c7c2002904dc4dee9f26d4",
                   "resolved_revision" : "cbe9a13b3e153d4f16c7c2002904dc4dee9f26d4",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/es-shims/object.getownpropertydescriptors.git",
-                  "revision" : "cbe9a13b3e153d4f16c7c2002904dc4dee9f26d4",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7185,12 +5967,6 @@
                   "url" : "https://github.com/es-shims/Object.values.git",
                   "revision" : "e00dd4a6b6aef218167b4e20c959d43adcc33f2b",
                   "resolved_revision" : "e00dd4a6b6aef218167b4e20c959d43adcc33f2b",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/es-shims/Object.values.git",
-                  "revision" : "e00dd4a6b6aef218167b4e20c959d43adcc33f2b",
                   "path" : ""
                 }
               },
@@ -7212,12 +5988,6 @@
                   "revision" : "0e614d9f5a7e6f0305c625f6b581f6d80b33b8a6",
                   "resolved_revision" : "0e614d9f5a7e6f0305c625f6b581f6d80b33b8a6",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/isaacs/once.git",
-                  "revision" : "0e614d9f5a7e6f0305c625f6b581f6d80b33b8a6",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7237,12 +6007,6 @@
                   "url" : "https://github.com/sindresorhus/onetime.git",
                   "revision" : "4fa3c9a40798476514fec36a1720dc85b897cc04",
                   "resolved_revision" : "4fa3c9a40798476514fec36a1720dc85b897cc04",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/onetime.git",
-                  "revision" : "4fa3c9a40798476514fec36a1720dc85b897cc04",
                   "path" : ""
                 }
               },
@@ -7264,12 +6028,6 @@
                   "revision" : "80318611b86ad28a38671f811d6c80bf564cdbda",
                   "resolved_revision" : "80318611b86ad28a38671f811d6c80bf564cdbda",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/gkz/optionator.git",
-                  "revision" : "80318611b86ad28a38671f811d6c80bf564cdbda",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7289,12 +6047,6 @@
                   "url" : "https://github.com/sindresorhus/os-tmpdir.git",
                   "revision" : "1abf9cf5611b4be7377060ea67054b45cbf6813c",
                   "resolved_revision" : "1abf9cf5611b4be7377060ea67054b45cbf6813c",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/os-tmpdir.git",
-                  "revision" : "1abf9cf5611b4be7377060ea67054b45cbf6813c",
                   "path" : ""
                 }
               },
@@ -7316,12 +6068,6 @@
                   "revision" : "cf076d73844ebbfda8ae4e184fc436396998ecb2",
                   "resolved_revision" : "cf076d73844ebbfda8ae4e184fc436396998ecb2",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/p-limit.git",
-                  "revision" : "cf076d73844ebbfda8ae4e184fc436396998ecb2",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7341,12 +6087,6 @@
                   "url" : "https://github.com/sindresorhus/p-limit.git",
                   "revision" : "a11f02bc5c04490b7c3de2663d866c211fb915ea",
                   "resolved_revision" : "a11f02bc5c04490b7c3de2663d866c211fb915ea",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/p-limit.git",
-                  "revision" : "a11f02bc5c04490b7c3de2663d866c211fb915ea",
                   "path" : ""
                 }
               },
@@ -7368,12 +6108,6 @@
                   "revision" : "6300abb6451f04bbaa760f42844ec1c501d79120",
                   "resolved_revision" : "6300abb6451f04bbaa760f42844ec1c501d79120",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/p-locate.git",
-                  "revision" : "6300abb6451f04bbaa760f42844ec1c501d79120",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7393,12 +6127,6 @@
                   "url" : "https://github.com/sindresorhus/p-locate.git",
                   "revision" : "d37f108c0b04779e307b4e7203981caa367bac57",
                   "resolved_revision" : "d37f108c0b04779e307b4e7203981caa367bac57",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/p-locate.git",
-                  "revision" : "d37f108c0b04779e307b4e7203981caa367bac57",
                   "path" : ""
                 }
               },
@@ -7420,12 +6148,6 @@
                   "revision" : "a650b26e49713a8cca58f669a7f8aef9b655554c",
                   "resolved_revision" : "a650b26e49713a8cca58f669a7f8aef9b655554c",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/p-locate.git",
-                  "revision" : "a650b26e49713a8cca58f669a7f8aef9b655554c",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7445,12 +6167,6 @@
                   "url" : "https://github.com/sindresorhus/p-map.git",
                   "revision" : "a8c06732e440214da89c410fa8d0cd74e110868e",
                   "resolved_revision" : "a8c06732e440214da89c410fa8d0cd74e110868e",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/p-map.git",
-                  "revision" : "a8c06732e440214da89c410fa8d0cd74e110868e",
                   "path" : ""
                 }
               },
@@ -7472,12 +6188,6 @@
                   "revision" : "8a6f2c232b80e12c138714e553fc8dd6313604c2",
                   "resolved_revision" : "8a6f2c232b80e12c138714e553fc8dd6313604c2",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/p-try.git",
-                  "revision" : "8a6f2c232b80e12c138714e553fc8dd6313604c2",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7497,12 +6207,6 @@
                   "url" : "https://github.com/sindresorhus/p-try.git",
                   "revision" : "e80e2e130b2d16807345be02aa03541e6e085952",
                   "resolved_revision" : "e80e2e130b2d16807345be02aa03541e6e085952",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/p-try.git",
-                  "revision" : "e80e2e130b2d16807345be02aa03541e6e085952",
                   "path" : ""
                 }
               },
@@ -7524,12 +6228,6 @@
                   "revision" : "6afce110db308d4ed70dbdb5658fc4ec50522c86",
                   "resolved_revision" : "6afce110db308d4ed70dbdb5658fc4ec50522c86",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/novemberborn/package-hash.git",
-                  "revision" : "6afce110db308d4ed70dbdb5658fc4ec50522c86",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7549,12 +6247,6 @@
                   "url" : "https://github.com/sindresorhus/parent-module.git",
                   "revision" : "48267d001c4d215ba21a701a6882dba30fb8d614",
                   "resolved_revision" : "48267d001c4d215ba21a701a6882dba30fb8d614",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/parent-module.git",
-                  "revision" : "48267d001c4d215ba21a701a6882dba30fb8d614",
                   "path" : ""
                 }
               },
@@ -7576,12 +6268,6 @@
                   "revision" : "3fd80962ca032e5782210ca915b639f005e85a15",
                   "resolved_revision" : "3fd80962ca032e5782210ca915b639f005e85a15",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/parse-entities.git",
-                  "revision" : "3fd80962ca032e5782210ca915b639f005e85a15",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7601,12 +6287,6 @@
                   "url" : "https://github.com/sindresorhus/parse-json.git",
                   "revision" : "419b0cbb83e67af53f9fd3f7ff98605ea2020eb6",
                   "resolved_revision" : "419b0cbb83e67af53f9fd3f7ff98605ea2020eb6",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/parse-json.git",
-                  "revision" : "419b0cbb83e67af53f9fd3f7ff98605ea2020eb6",
                   "path" : ""
                 }
               },
@@ -7628,12 +6308,6 @@
                   "revision" : "4696c60a8b2b9ac61902aa9eab7cb326ab6005c8",
                   "resolved_revision" : "4696c60a8b2b9ac61902aa9eab7cb326ab6005c8",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/path-exists.git",
-                  "revision" : "4696c60a8b2b9ac61902aa9eab7cb326ab6005c8",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7653,12 +6327,6 @@
                   "url" : "https://github.com/sindresorhus/path-exists.git",
                   "revision" : "26b1adf80aa6761a7db35927a20cf59e0fd1a00d",
                   "resolved_revision" : "26b1adf80aa6761a7db35927a20cf59e0fd1a00d",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/path-exists.git",
-                  "revision" : "26b1adf80aa6761a7db35927a20cf59e0fd1a00d",
                   "path" : ""
                 }
               },
@@ -7680,12 +6348,6 @@
                   "revision" : "edc91d348b21dac2ab65ea2fbec2868e2eff5eb6",
                   "resolved_revision" : "edc91d348b21dac2ab65ea2fbec2868e2eff5eb6",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/path-is-absolute.git",
-                  "revision" : "edc91d348b21dac2ab65ea2fbec2868e2eff5eb6",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7705,12 +6367,6 @@
                   "url" : "https://github.com/sindresorhus/path-key.git",
                   "revision" : "d60207f9ab9dc9e60d49c87faacf415a4946287c",
                   "resolved_revision" : "d60207f9ab9dc9e60d49c87faacf415a4946287c",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/path-key.git",
-                  "revision" : "d60207f9ab9dc9e60d49c87faacf415a4946287c",
                   "path" : ""
                 }
               },
@@ -7732,12 +6388,6 @@
                   "revision" : "caea269db3a5eb0c09c793f4be5435312971d2fa",
                   "resolved_revision" : "caea269db3a5eb0c09c793f4be5435312971d2fa",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/path-key.git",
-                  "revision" : "caea269db3a5eb0c09c793f4be5435312971d2fa",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7757,12 +6407,6 @@
                   "url" : "https://github.com/jbgutierrez/path-parse.git",
                   "revision" : "97efc90ce24455d23ec6acedf47589df46e48ea0",
                   "resolved_revision" : "97efc90ce24455d23ec6acedf47589df46e48ea0",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/jbgutierrez/path-parse.git",
-                  "revision" : "97efc90ce24455d23ec6acedf47589df46e48ea0",
                   "path" : ""
                 }
               },
@@ -7784,12 +6428,6 @@
                   "revision" : "ef08bdbd35fa01342ef6d80f2e8eb8b9c2cccc30",
                   "resolved_revision" : "ef08bdbd35fa01342ef6d80f2e8eb8b9c2cccc30",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/path-type.git",
-                  "revision" : "ef08bdbd35fa01342ef6d80f2e8eb8b9c2cccc30",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7809,12 +6447,6 @@
                   "url" : "https://github.com/micromatch/picomatch.git",
                   "revision" : "aed790f037736f5c760f7b120935714d21503fe9",
                   "resolved_revision" : "aed790f037736f5c760f7b120935714d21503fe9",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/micromatch/picomatch.git",
-                  "revision" : "aed790f037736f5c760f7b120935714d21503fe9",
                   "path" : ""
                 }
               },
@@ -7836,12 +6468,6 @@
                   "revision" : "2dd0d8b880e4ebcc5cc33ae126b02647418e4440",
                   "resolved_revision" : "2dd0d8b880e4ebcc5cc33ae126b02647418e4440",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/pify.git",
-                  "revision" : "2dd0d8b880e4ebcc5cc33ae126b02647418e4440",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7861,12 +6487,6 @@
                   "url" : "https://github.com/sindresorhus/pkg-dir.git",
                   "revision" : "c18df2945cd928787f3290042a6c69352b4e13a5",
                   "resolved_revision" : "c18df2945cd928787f3290042a6c69352b4e13a5",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/pkg-dir.git",
-                  "revision" : "c18df2945cd928787f3290042a6c69352b4e13a5",
                   "path" : ""
                 }
               },
@@ -7888,12 +6508,6 @@
                   "revision" : "e25e5342c5ec425bb4a2c93787a880c29cbf0a49",
                   "resolved_revision" : "e25e5342c5ec425bb4a2c93787a880c29cbf0a49",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/pkg-dir.git",
-                  "revision" : "e25e5342c5ec425bb4a2c93787a880c29cbf0a49",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7913,12 +6527,6 @@
                   "url" : "https://github.com/gkz/prelude-ls.git",
                   "revision" : "d69be8fd8a682321ba24eced17caf3a1b8ca73b8",
                   "resolved_revision" : "d69be8fd8a682321ba24eced17caf3a1b8ca73b8",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/gkz/prelude-ls.git",
-                  "revision" : "d69be8fd8a682321ba24eced17caf3a1b8ca73b8",
                   "path" : ""
                 }
               },
@@ -7940,12 +6548,6 @@
                   "revision" : "333106fa246ae4577ce010f8a5405d38061ec359",
                   "resolved_revision" : "333106fa246ae4577ce010f8a5405d38061ec359",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/cfware/process-on-spawn.git",
-                  "revision" : "333106fa246ae4577ce010f8a5405d38061ec359",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -7965,12 +6567,6 @@
                   "url" : "https://github.com/visionmedia/node-progress.git",
                   "revision" : "0790207ef077cbfb7ebde24a1dd9895ebf4643e1",
                   "resolved_revision" : "0790207ef077cbfb7ebde24a1dd9895ebf4643e1",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/visionmedia/node-progress.git",
-                  "revision" : "0790207ef077cbfb7ebde24a1dd9895ebf4643e1",
                   "path" : ""
                 }
               },
@@ -7992,12 +6588,6 @@
                   "revision" : "68df855dc42d1086ada161331b3074468e8d848d",
                   "resolved_revision" : "68df855dc42d1086ada161331b3074468e8d848d",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/bestiejs/punycode.js.git",
-                  "revision" : "68df855dc42d1086ada161331b3074468e8d848d",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8017,12 +6607,6 @@
                   "url" : "https://github.com/sindresorhus/read-pkg-up.git",
                   "revision" : "3b8a594ab581f000f705e43e8abdb1a23e8822f2",
                   "resolved_revision" : "3b8a594ab581f000f705e43e8abdb1a23e8822f2",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/read-pkg-up.git",
-                  "revision" : "3b8a594ab581f000f705e43e8abdb1a23e8822f2",
                   "path" : ""
                 }
               },
@@ -8044,12 +6628,6 @@
                   "revision" : "c1664a2f42d1f1898b7648534576e6dcfa1f48c8",
                   "resolved_revision" : "c1664a2f42d1f1898b7648534576e6dcfa1f48c8",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/read-pkg.git",
-                  "revision" : "c1664a2f42d1f1898b7648534576e6dcfa1f48c8",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8069,12 +6647,6 @@
                   "url" : "https://github.com/paulmillr/readdirp.git",
                   "revision" : "cdfb3df2192e0721be258b28c19b9be1d43fcdd0",
                   "resolved_revision" : "cdfb3df2192e0721be258b28c19b9be1d43fcdd0",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/paulmillr/readdirp.git",
-                  "revision" : "cdfb3df2192e0721be258b28c19b9be1d43fcdd0",
                   "path" : ""
                 }
               },
@@ -8096,12 +6668,6 @@
                   "revision" : "d68b435cbf6d37e3fa6af186965a7b6c738bf685",
                   "resolved_revision" : "d68b435cbf6d37e3fa6af186965a7b6c738bf685",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/mysticatea/regexpp.git",
-                  "revision" : "d68b435cbf6d37e3fa6af186965a7b6c738bf685",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8121,12 +6687,6 @@
                   "url" : "https://github.com/mysticatea/regexpp.git",
                   "revision" : "5563cf33c4976d01a348472b818221fc199bbeb6",
                   "resolved_revision" : "5563cf33c4976d01a348472b818221fc199bbeb6",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/mysticatea/regexpp.git",
-                  "revision" : "5563cf33c4976d01a348472b818221fc199bbeb6",
                   "path" : ""
                 }
               },
@@ -8148,12 +6708,6 @@
                   "revision" : "696e6ac92340120fe4b26fce4152f0197b45183b",
                   "resolved_revision" : "696e6ac92340120fe4b26fce4152f0197b45183b",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/novemberborn/release-zalgo.git",
-                  "revision" : "696e6ac92340120fe4b26fce4152f0197b45183b",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8173,12 +6727,6 @@
                   "url" : "https://github.com/remarkjs/remark.git",
                   "revision" : "ef6cb06bb20ecca558f8878f2fec3a5831e11dd2",
                   "resolved_revision" : "ef6cb06bb20ecca558f8878f2fec3a5831e11dd2",
-                  "path" : "packages/remark-parse"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/remarkjs/remark.git",
-                  "revision" : "",
                   "path" : "packages/remark-parse"
                 }
               },
@@ -8200,12 +6748,6 @@
                   "revision" : "1a95c5d99a02999ccd2cf4663959a18bd2def7b8",
                   "resolved_revision" : "1a95c5d99a02999ccd2cf4663959a18bd2def7b8",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/jonschlinkert/repeat-string.git",
-                  "revision" : "1a95c5d99a02999ccd2cf4663959a18bd2def7b8",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8225,12 +6767,6 @@
                   "url" : "https://github.com/gulpjs/replace-ext.git",
                   "revision" : "adaec75e316f1c375dc7a2cb51c7b762b135cc0e",
                   "resolved_revision" : "adaec75e316f1c375dc7a2cb51c7b762b135cc0e",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/gulpjs/replace-ext.git",
-                  "revision" : "adaec75e316f1c375dc7a2cb51c7b762b135cc0e",
                   "path" : ""
                 }
               },
@@ -8252,12 +6788,6 @@
                   "revision" : "cc71c23dd0c16cefd26855303c16ca1b9b50a36d",
                   "resolved_revision" : "cc71c23dd0c16cefd26855303c16ca1b9b50a36d",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/troygoode/node-require-directory.git",
-                  "revision" : "cc71c23dd0c16cefd26855303c16ca1b9b50a36d",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8277,12 +6807,6 @@
                   "url" : "ssh://git@github.com/yargs/require-main-filename.git",
                   "revision" : "1acaf42e8ababa22c191319b319f25df833ffd79",
                   "resolved_revision" : "1acaf42e8ababa22c191319b319f25df833ffd79",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/yargs/require-main-filename.git",
-                  "revision" : "1acaf42e8ababa22c191319b319f25df833ffd79",
                   "path" : ""
                 }
               },
@@ -8304,12 +6828,6 @@
                   "revision" : "60cd04e69135b96b98b848fff719b1276a5610c0",
                   "resolved_revision" : "60cd04e69135b96b98b848fff719b1276a5610c0",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/resolve-from.git",
-                  "revision" : "60cd04e69135b96b98b848fff719b1276a5610c0",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8329,12 +6847,6 @@
                   "url" : "https://github.com/sindresorhus/resolve-from.git",
                   "revision" : "53f4a1b40f972dbfc4dda9627d24068000eae897",
                   "resolved_revision" : "53f4a1b40f972dbfc4dda9627d24068000eae897",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/resolve-from.git",
-                  "revision" : "53f4a1b40f972dbfc4dda9627d24068000eae897",
                   "path" : ""
                 }
               },
@@ -8356,12 +6868,6 @@
                   "revision" : "3a76ef8d2cc232fc4d4246e0748506258a104484",
                   "resolved_revision" : "3a76ef8d2cc232fc4d4246e0748506258a104484",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/browserify/resolve.git",
-                  "revision" : "3a76ef8d2cc232fc4d4246e0748506258a104484",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8381,12 +6887,6 @@
                   "url" : "https://github.com/sindresorhus/restore-cursor.git",
                   "revision" : "32accb3425dbcde0b303583b9137857451b67045",
                   "resolved_revision" : "32accb3425dbcde0b303583b9137857451b67045",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/restore-cursor.git",
-                  "revision" : "32accb3425dbcde0b303583b9137857451b67045",
                   "path" : ""
                 }
               },
@@ -8408,12 +6908,6 @@
                   "revision" : "9442819908e52f2c32620e8fa609d7a5d472cc2c",
                   "resolved_revision" : "9442819908e52f2c32620e8fa609d7a5d472cc2c",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/isaacs/rimraf.git",
-                  "revision" : "9442819908e52f2c32620e8fa609d7a5d472cc2c",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8433,12 +6927,6 @@
                   "url" : "https://github.com/isaacs/rimraf.git",
                   "revision" : "8c10fb8d685d5cc35708e0ffc4dac9ec5dd5b444",
                   "resolved_revision" : "8c10fb8d685d5cc35708e0ffc4dac9ec5dd5b444",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/isaacs/rimraf.git",
-                  "revision" : "8c10fb8d685d5cc35708e0ffc4dac9ec5dd5b444",
                   "path" : ""
                 }
               },
@@ -8460,12 +6948,6 @@
                   "revision" : "f3e0a18abf6e9569abfcf327daa9351c95f109b1",
                   "resolved_revision" : "f3e0a18abf6e9569abfcf327daa9351c95f109b1",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/SBoudrias/run-async.git",
-                  "revision" : "f3e0a18abf6e9569abfcf327daa9351c95f109b1",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8485,12 +6967,6 @@
                   "url" : "https://github.com/reactivex/rxjs.git",
                   "revision" : "a4bcb84bbcd59abc6c4e811b57a15124757db2f2",
                   "resolved_revision" : "a4bcb84bbcd59abc6c4e811b57a15124757db2f2",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/reactivex/rxjs.git",
-                  "revision" : "",
                   "path" : ""
                 }
               },
@@ -8512,12 +6988,6 @@
                   "revision" : "649435cc8e2d1f3ecdc7caf323f1cb1187307a16",
                   "resolved_revision" : "649435cc8e2d1f3ecdc7caf323f1cb1187307a16",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/feross/safe-buffer.git",
-                  "revision" : "649435cc8e2d1f3ecdc7caf323f1cb1187307a16",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8537,12 +7007,6 @@
                   "url" : "https://github.com/ChALkeR/safer-buffer.git",
                   "revision" : "e8ac214944eda30e1e6c6b7d7e7f6a21cf7dce7c",
                   "resolved_revision" : "e8ac214944eda30e1e6c6b7d7e7f6a21cf7dce7c",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/ChALkeR/safer-buffer.git",
-                  "revision" : "e8ac214944eda30e1e6c6b7d7e7f6a21cf7dce7c",
                   "path" : ""
                 }
               },
@@ -8564,12 +7028,6 @@
                   "revision" : "c83c18cf84f9ccaea3431c929bb285fd168c01e4",
                   "resolved_revision" : "c83c18cf84f9ccaea3431c929bb285fd168c01e4",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/npm/node-semver.git",
-                  "revision" : "c83c18cf84f9ccaea3431c929bb285fd168c01e4",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8589,12 +7047,6 @@
                   "url" : "https://github.com/npm/node-semver.git",
                   "revision" : "0eeceecfba490d136eb3ccae3a8dc118a28565a0",
                   "resolved_revision" : "0eeceecfba490d136eb3ccae3a8dc118a28565a0",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/npm/node-semver.git",
-                  "revision" : "0eeceecfba490d136eb3ccae3a8dc118a28565a0",
                   "path" : ""
                 }
               },
@@ -8616,12 +7068,6 @@
                   "revision" : "7eec10577b5fff264de477ba3b9d07f404946eff",
                   "resolved_revision" : "7eec10577b5fff264de477ba3b9d07f404946eff",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/yargs/set-blocking.git",
-                  "revision" : "7eec10577b5fff264de477ba3b9d07f404946eff",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8641,12 +7087,6 @@
                   "url" : "https://github.com/kevva/shebang-command.git",
                   "revision" : "01de9b7d355f21e00417650a6fb1eb56321bc23c",
                   "resolved_revision" : "01de9b7d355f21e00417650a6fb1eb56321bc23c",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/kevva/shebang-command.git",
-                  "revision" : "01de9b7d355f21e00417650a6fb1eb56321bc23c",
                   "path" : ""
                 }
               },
@@ -8668,12 +7108,6 @@
                   "revision" : "003c4c7d6882d029aa8b3e5777716d726894d734",
                   "resolved_revision" : "003c4c7d6882d029aa8b3e5777716d726894d734",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/kevva/shebang-command.git",
-                  "revision" : "003c4c7d6882d029aa8b3e5777716d726894d734",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8693,12 +7127,6 @@
                   "url" : "https://github.com/sindresorhus/shebang-regex.git",
                   "revision" : "cb774c70d5f569479ca997abf8ee7e558e617284",
                   "resolved_revision" : "cb774c70d5f569479ca997abf8ee7e558e617284",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/shebang-regex.git",
-                  "revision" : "cb774c70d5f569479ca997abf8ee7e558e617284",
                   "path" : ""
                 }
               },
@@ -8720,12 +7148,6 @@
                   "revision" : "27a9a6f0f85c04b9c37a43cf7503fdb58f5ae8d6",
                   "resolved_revision" : "27a9a6f0f85c04b9c37a43cf7503fdb58f5ae8d6",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/shebang-regex.git",
-                  "revision" : "27a9a6f0f85c04b9c37a43cf7503fdb58f5ae8d6",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8745,12 +7167,6 @@
                   "url" : "https://github.com/tapjs/signal-exit.git",
                   "revision" : "bb32fe5e3126e9bb55acf83168628839d3a81ea6",
                   "resolved_revision" : "bb32fe5e3126e9bb55acf83168628839d3a81ea6",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/tapjs/signal-exit.git",
-                  "revision" : "bb32fe5e3126e9bb55acf83168628839d3a81ea6",
                   "path" : ""
                 }
               },
@@ -8772,12 +7188,6 @@
                   "revision" : "bfb33a3eb13f2d3b8023f37ddb421eff3ea7a3ae",
                   "resolved_revision" : "bfb33a3eb13f2d3b8023f37ddb421eff3ea7a3ae",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/chalk/slice-ansi.git",
-                  "revision" : "bfb33a3eb13f2d3b8023f37ddb421eff3ea7a3ae",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8797,12 +7207,6 @@
                   "url" : "ssh://git@github.com/mozilla/source-map.git",
                   "revision" : "326dd955a366569759d9537ef5f0f167c89d92d2",
                   "resolved_revision" : "326dd955a366569759d9537ef5f0f167c89d92d2",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/mozilla/source-map.git",
-                  "revision" : "326dd955a366569759d9537ef5f0f167c89d92d2",
                   "path" : ""
                 }
               },
@@ -8824,12 +7228,6 @@
                   "revision" : "ac518d2f21818146f3310557bd51c13d8cff2ba8",
                   "resolved_revision" : "ac518d2f21818146f3310557bd51c13d8cff2ba8",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/mozilla/source-map.git",
-                  "revision" : "ac518d2f21818146f3310557bd51c13d8cff2ba8",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8849,12 +7247,6 @@
                   "url" : "https://github.com/istanbuljs/spawn-wrap.git",
                   "revision" : "c1c6cea28dc9d6760ae2c4eebeff8a60a80d7fd7",
                   "resolved_revision" : "c1c6cea28dc9d6760ae2c4eebeff8a60a80d7fd7",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/istanbuljs/spawn-wrap.git",
-                  "revision" : "c1c6cea28dc9d6760ae2c4eebeff8a60a80d7fd7",
                   "path" : ""
                 }
               },
@@ -8876,12 +7268,6 @@
                   "revision" : "24954c75aba5ace68365345154ff21bcd3580302",
                   "resolved_revision" : "24954c75aba5ace68365345154ff21bcd3580302",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/jslicense/spdx-correct.js.git",
-                  "revision" : "24954c75aba5ace68365345154ff21bcd3580302",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8901,12 +7287,6 @@
                   "url" : "https://github.com/kemitchell/spdx-exceptions.json.git",
                   "revision" : "b1405b421074aae250f5cfefc1adff1c6085b293",
                   "resolved_revision" : "b1405b421074aae250f5cfefc1adff1c6085b293",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/kemitchell/spdx-exceptions.json.git",
-                  "revision" : "b1405b421074aae250f5cfefc1adff1c6085b293",
                   "path" : ""
                 }
               },
@@ -8928,12 +7308,6 @@
                   "revision" : "d7daff468ce455f636838a8375d8699cf36be64d",
                   "resolved_revision" : "d7daff468ce455f636838a8375d8699cf36be64d",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/jslicense/spdx-expression-parse.js.git",
-                  "revision" : "d7daff468ce455f636838a8375d8699cf36be64d",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -8953,12 +7327,6 @@
                   "url" : "https://github.com/shinnn/spdx-license-ids.git",
                   "revision" : "2bc004aae6f30d625d3aad95eac09d9aaf1c97cc",
                   "resolved_revision" : "2bc004aae6f30d625d3aad95eac09d9aaf1c97cc",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/shinnn/spdx-license-ids.git",
-                  "revision" : "2bc004aae6f30d625d3aad95eac09d9aaf1c97cc",
                   "path" : ""
                 }
               },
@@ -8980,12 +7348,6 @@
                   "revision" : "747b806c2dab5b64d5c9958c42884946a187c3b1",
                   "resolved_revision" : "747b806c2dab5b64d5c9958c42884946a187c3b1",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/alexei/sprintf.js.git",
-                  "revision" : "747b806c2dab5b64d5c9958c42884946a187c3b1",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9005,12 +7367,6 @@
                   "url" : "https://github.com/wooorm/state-toggle.git",
                   "revision" : "c0f63ed146ecc0fa8dea34a7ccfea013a753d470",
                   "resolved_revision" : "c0f63ed146ecc0fa8dea34a7ccfea013a753d470",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/state-toggle.git",
-                  "revision" : "c0f63ed146ecc0fa8dea34a7ccfea013a753d470",
                   "path" : ""
                 }
               },
@@ -9032,12 +7388,6 @@
                   "revision" : "74d8d552b465692790c41169b123409669d41079",
                   "resolved_revision" : "74d8d552b465692790c41169b123409669d41079",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/string-width.git",
-                  "revision" : "74d8d552b465692790c41169b123409669d41079",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9057,12 +7407,6 @@
                   "url" : "https://github.com/sindresorhus/string-width.git",
                   "revision" : "3b3da68dfea82e193f9d6deee77224cf8e5c3803",
                   "resolved_revision" : "3b3da68dfea82e193f9d6deee77224cf8e5c3803",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/string-width.git",
-                  "revision" : "3b3da68dfea82e193f9d6deee77224cf8e5c3803",
                   "path" : ""
                 }
               },
@@ -9084,12 +7428,6 @@
                   "revision" : "34bca56b5b301b46fef0258aba4446792d794dab",
                   "resolved_revision" : "34bca56b5b301b46fef0258aba4446792d794dab",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/string-width.git",
-                  "revision" : "34bca56b5b301b46fef0258aba4446792d794dab",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9109,12 +7447,6 @@
                   "url" : "https://github.com/es-shims/String.prototype.trimEnd.git",
                   "revision" : "db875b3155c8711b9ee6ab4f8ed0653c94879416",
                   "resolved_revision" : "db875b3155c8711b9ee6ab4f8ed0653c94879416",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/es-shims/String.prototype.trimEnd.git",
-                  "revision" : "db875b3155c8711b9ee6ab4f8ed0653c94879416",
                   "path" : ""
                 }
               },
@@ -9136,12 +7468,6 @@
                   "revision" : "7ce7634165aa317a3a28f09be576237167f052be",
                   "resolved_revision" : "7ce7634165aa317a3a28f09be576237167f052be",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/es-shims/String.prototype.trimStart.git",
-                  "revision" : "7ce7634165aa317a3a28f09be576237167f052be",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9161,12 +7487,6 @@
                   "url" : "https://github.com/chalk/strip-ansi.git",
                   "revision" : "c299056a42b31d7a479d6a89b41318b2a2462cc7",
                   "resolved_revision" : "c299056a42b31d7a479d6a89b41318b2a2462cc7",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/chalk/strip-ansi.git",
-                  "revision" : "c299056a42b31d7a479d6a89b41318b2a2462cc7",
                   "path" : ""
                 }
               },
@@ -9188,12 +7508,6 @@
                   "revision" : "b9c492921b72c48f93568565dbdc929cf63c20e1",
                   "resolved_revision" : "b9c492921b72c48f93568565dbdc929cf63c20e1",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/chalk/strip-ansi.git",
-                  "revision" : "b9c492921b72c48f93568565dbdc929cf63c20e1",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9213,12 +7527,6 @@
                   "url" : "https://github.com/chalk/strip-ansi.git",
                   "revision" : "59533da99981f9d550de1ae0eb9d1a93c2383be3",
                   "resolved_revision" : "59533da99981f9d550de1ae0eb9d1a93c2383be3",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/chalk/strip-ansi.git",
-                  "revision" : "59533da99981f9d550de1ae0eb9d1a93c2383be3",
                   "path" : ""
                 }
               },
@@ -9240,12 +7548,6 @@
                   "revision" : "8258d09a069a5d5eb3d787c1d5d29737df1c8bba",
                   "resolved_revision" : "8258d09a069a5d5eb3d787c1d5d29737df1c8bba",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/strip-bom.git",
-                  "revision" : "8258d09a069a5d5eb3d787c1d5d29737df1c8bba",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9265,12 +7567,6 @@
                   "url" : "https://github.com/sindresorhus/strip-bom.git",
                   "revision" : "9aef0f38ffefca91d3852c82cd6366e5d36d6dd1",
                   "resolved_revision" : "9aef0f38ffefca91d3852c82cd6366e5d36d6dd1",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/strip-bom.git",
-                  "revision" : "9aef0f38ffefca91d3852c82cd6366e5d36d6dd1",
                   "path" : ""
                 }
               },
@@ -9292,12 +7588,6 @@
                   "revision" : "1aef99eaa70d07981156e8aaa722e750c3b4eaf9",
                   "resolved_revision" : "1aef99eaa70d07981156e8aaa722e750c3b4eaf9",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/strip-json-comments.git",
-                  "revision" : "1aef99eaa70d07981156e8aaa722e750c3b4eaf9",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9317,12 +7607,6 @@
                   "url" : "https://github.com/sindresorhus/strip-json-comments.git",
                   "revision" : "6355b5792682c7c7a2480e5cbe73fc7ad578e432",
                   "resolved_revision" : "6355b5792682c7c7a2480e5cbe73fc7ad578e432",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/strip-json-comments.git",
-                  "revision" : "6355b5792682c7c7a2480e5cbe73fc7ad578e432",
                   "path" : ""
                 }
               },
@@ -9344,12 +7628,6 @@
                   "revision" : "7759fc135b1be07cb7411178d7b1ac33d367fec8",
                   "resolved_revision" : "7759fc135b1be07cb7411178d7b1ac33d367fec8",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/chalk/supports-color.git",
-                  "revision" : "7759fc135b1be07cb7411178d7b1ac33d367fec8",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9369,12 +7647,6 @@
                   "url" : "https://github.com/chalk/supports-color.git",
                   "revision" : "bfbe6692d549b423230292946756f3fdd79a808e",
                   "resolved_revision" : "bfbe6692d549b423230292946756f3fdd79a808e",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/chalk/supports-color.git",
-                  "revision" : "bfbe6692d549b423230292946756f3fdd79a808e",
                   "path" : ""
                 }
               },
@@ -9396,12 +7668,6 @@
                   "revision" : "c5edf46896d1fc1826cb1183a60d61eecb65d749",
                   "resolved_revision" : "c5edf46896d1fc1826cb1183a60d61eecb65d749",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/chalk/supports-color.git",
-                  "revision" : "c5edf46896d1fc1826cb1183a60d61eecb65d749",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9421,12 +7687,6 @@
                   "url" : "https://github.com/gajus/table.git",
                   "revision" : "db1ad68d74b8e859448deebaeb823da39e40fa98",
                   "resolved_revision" : "db1ad68d74b8e859448deebaeb823da39e40fa98",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/gajus/table.git",
-                  "revision" : "db1ad68d74b8e859448deebaeb823da39e40fa98",
                   "path" : ""
                 }
               },
@@ -9448,12 +7708,6 @@
                   "revision" : "b788e7bd7cfdec8b471ad7b79d0d4a44975e2e99",
                   "resolved_revision" : "b788e7bd7cfdec8b471ad7b79d0d4a44975e2e99",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/istanbuljs/test-exclude.git",
-                  "revision" : "b788e7bd7cfdec8b471ad7b79d0d4a44975e2e99",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9473,12 +7727,6 @@
                   "url" : "https://github.com/substack/text-table.git",
                   "revision" : "2f7f2baf205b0caf5b30f9ab665fdce267197fbd",
                   "resolved_revision" : "2f7f2baf205b0caf5b30f9ab665fdce267197fbd",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/substack/text-table.git",
-                  "revision" : "",
                   "path" : ""
                 }
               },
@@ -9500,12 +7748,6 @@
                   "revision" : "2c5a6f9a0cc54da759b6e10964f2081c358e49dc",
                   "resolved_revision" : "2c5a6f9a0cc54da759b6e10964f2081c358e49dc",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/dominictarr/through.git",
-                  "revision" : "2c5a6f9a0cc54da759b6e10964f2081c358e49dc",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9525,12 +7767,6 @@
                   "url" : "https://github.com/raszi/node-tmp.git",
                   "revision" : "0900dd5b112ac7a482e4bdf3cb002bfe1b3acf77",
                   "resolved_revision" : "0900dd5b112ac7a482e4bdf3cb002bfe1b3acf77",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/raszi/node-tmp.git",
-                  "revision" : "0900dd5b112ac7a482e4bdf3cb002bfe1b3acf77",
                   "path" : ""
                 }
               },
@@ -9552,12 +7788,6 @@
                   "revision" : "5b2ddf09843cacf5e9c2f9403155ef5a742edd83",
                   "resolved_revision" : "5b2ddf09843cacf5e9c2f9403155ef5a742edd83",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/to-fast-properties.git",
-                  "revision" : "5b2ddf09843cacf5e9c2f9403155ef5a742edd83",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9578,12 +7808,6 @@
                   "revision" : "c05ef9ec07e7703d146467934098ecbde9d0bd95",
                   "resolved_revision" : "c05ef9ec07e7703d146467934098ecbde9d0bd95",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/micromatch/to-regex-range.git",
-                  "revision" : "c05ef9ec07e7703d146467934098ecbde9d0bd95",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9603,12 +7827,6 @@
                   "url" : "https://github.com/wooorm/trim-trailing-lines.git",
                   "revision" : "95c93d3233a99384b336b9160e352586bbf16eee",
                   "resolved_revision" : "95c93d3233a99384b336b9160e352586bbf16eee",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/trim-trailing-lines.git",
-                  "revision" : "95c93d3233a99384b336b9160e352586bbf16eee",
                   "path" : ""
                 }
               },
@@ -9650,12 +7868,6 @@
                   "revision" : "d483c425940c998f57245f138007b3f7d23be8f9",
                   "resolved_revision" : "d483c425940c998f57245f138007b3f7d23be8f9",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "",
-                  "url" : "https://github.com/component/trim.git",
-                  "revision" : "",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9675,12 +7887,6 @@
                   "url" : "https://github.com/wooorm/trough.git",
                   "revision" : "1e1ccc351816677c62202bd66aa385a572eafa1a",
                   "resolved_revision" : "1e1ccc351816677c62202bd66aa385a572eafa1a",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/trough.git",
-                  "revision" : "1e1ccc351816677c62202bd66aa385a572eafa1a",
                   "path" : ""
                 }
               },
@@ -9702,12 +7908,6 @@
                   "revision" : "b7e9c51bf7fb01865e8eec136fc30098c6144bb8",
                   "resolved_revision" : "b7e9c51bf7fb01865e8eec136fc30098c6144bb8",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/Microsoft/tslib.git",
-                  "revision" : "b7e9c51bf7fb01865e8eec136fc30098c6144bb8",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9727,12 +7927,6 @@
                   "url" : "https://github.com/gkz/type-check.git",
                   "revision" : "0ab04e7a660485d0cc3aa87e95f2f9a6464cf8e6",
                   "resolved_revision" : "0ab04e7a660485d0cc3aa87e95f2f9a6464cf8e6",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/gkz/type-check.git",
-                  "revision" : "0ab04e7a660485d0cc3aa87e95f2f9a6464cf8e6",
                   "path" : ""
                 }
               },
@@ -9754,12 +7948,6 @@
                   "revision" : "74d8d4aa2b616ab55869372fb52e45947bd9df3c",
                   "resolved_revision" : "74d8d4aa2b616ab55869372fb52e45947bd9df3c",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/type-fest.git",
-                  "revision" : "74d8d4aa2b616ab55869372fb52e45947bd9df3c",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9779,12 +7967,6 @@
                   "url" : "https://github.com/sindresorhus/type-fest.git",
                   "revision" : "92c02842eaa4f56b8dec183d10c85bcb0d447bd8",
                   "resolved_revision" : "92c02842eaa4f56b8dec183d10c85bcb0d447bd8",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/sindresorhus/type-fest.git",
-                  "revision" : "92c02842eaa4f56b8dec183d10c85bcb0d447bd8",
                   "path" : ""
                 }
               },
@@ -9806,12 +7988,6 @@
                   "revision" : "328a952e480a143bdc3fc98a2133490e28e2b3a2",
                   "resolved_revision" : "328a952e480a143bdc3fc98a2133490e28e2b3a2",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/feross/typedarray-to-buffer.git",
-                  "revision" : "328a952e480a143bdc3fc98a2133490e28e2b3a2",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9831,12 +8007,6 @@
                   "url" : "https://github.com/wooorm/unherit.git",
                   "revision" : "2e64baeea9450acd28bd50d1a0bf87ee067e06d3",
                   "resolved_revision" : "2e64baeea9450acd28bd50d1a0bf87ee067e06d3",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/wooorm/unherit.git",
-                  "revision" : "2e64baeea9450acd28bd50d1a0bf87ee067e06d3",
                   "path" : ""
                 }
               },
@@ -9858,12 +8028,6 @@
                   "revision" : "f3cc0cced79b86018bbeec58391bafeab18da944",
                   "resolved_revision" : "f3cc0cced79b86018bbeec58391bafeab18da944",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/unifiedjs/unified.git",
-                  "revision" : "f3cc0cced79b86018bbeec58391bafeab18da944",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9883,12 +8047,6 @@
                   "url" : "https://github.com/syntax-tree/unist-util-is.git",
                   "revision" : "aee63b5e0b0062e3d2fcb6a1fc3d32c274dea160",
                   "resolved_revision" : "aee63b5e0b0062e3d2fcb6a1fc3d32c274dea160",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/syntax-tree/unist-util-is.git",
-                  "revision" : "aee63b5e0b0062e3d2fcb6a1fc3d32c274dea160",
                   "path" : ""
                 }
               },
@@ -9910,12 +8068,6 @@
                   "revision" : "5a94c592a85f4e691b0be93e4d2922d3557d2867",
                   "resolved_revision" : "5a94c592a85f4e691b0be93e4d2922d3557d2867",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/syntax-tree/unist-util-remove-position.git",
-                  "revision" : "5a94c592a85f4e691b0be93e4d2922d3557d2867",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9935,12 +8087,6 @@
                   "url" : "https://github.com/syntax-tree/unist-util-stringify-position.git",
                   "revision" : "9a20ab40be4981b0b9ceec762a6f100fb276939c",
                   "resolved_revision" : "9a20ab40be4981b0b9ceec762a6f100fb276939c",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/syntax-tree/unist-util-stringify-position.git",
-                  "revision" : "9a20ab40be4981b0b9ceec762a6f100fb276939c",
                   "path" : ""
                 }
               },
@@ -9962,12 +8108,6 @@
                   "revision" : "74da40a04af87f881314999d5b4ff7740ce5ac31",
                   "resolved_revision" : "74da40a04af87f881314999d5b4ff7740ce5ac31",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/syntax-tree/unist-util-visit-parents.git",
-                  "revision" : "74da40a04af87f881314999d5b4ff7740ce5ac31",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -9987,12 +8127,6 @@
                   "url" : "https://github.com/syntax-tree/unist-util-visit.git",
                   "revision" : "c0309c28042225908adb91d80ab482c03b829539",
                   "resolved_revision" : "c0309c28042225908adb91d80ab482c03b829539",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/syntax-tree/unist-util-visit.git",
-                  "revision" : "c0309c28042225908adb91d80ab482c03b829539",
                   "path" : ""
                 }
               },
@@ -10014,12 +8148,6 @@
                   "revision" : "7cb6f9ccfa441f88de122e782fd34a27e3076057",
                   "resolved_revision" : "7cb6f9ccfa441f88de122e782fd34a27e3076057",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/garycourt/uri-js.git",
-                  "revision" : "7cb6f9ccfa441f88de122e782fd34a27e3076057",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -10039,12 +8167,6 @@
                   "url" : "https://github.com/uuidjs/uuid.git",
                   "revision" : "3df73a98f07c0a38a94bcaf1ecde0e384dc3b126",
                   "resolved_revision" : "3df73a98f07c0a38a94bcaf1ecde0e384dc3b126",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/uuidjs/uuid.git",
-                  "revision" : "3df73a98f07c0a38a94bcaf1ecde0e384dc3b126",
                   "path" : ""
                 }
               },
@@ -10066,12 +8188,6 @@
                   "revision" : "bbe82785151c68da3e05e32ba223e878d50a745d",
                   "resolved_revision" : "bbe82785151c68da3e05e32ba223e878d50a745d",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/zertosh/v8-compile-cache.git",
-                  "revision" : "bbe82785151c68da3e05e32ba223e878d50a745d",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -10091,12 +8207,6 @@
                   "url" : "https://github.com/kemitchell/validate-npm-package-license.js.git",
                   "revision" : "6bbe26201fa7e5c7281516b04b9f3f4cc6db145c",
                   "resolved_revision" : "6bbe26201fa7e5c7281516b04b9f3f4cc6db145c",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/kemitchell/validate-npm-package-license.js.git",
-                  "revision" : "6bbe26201fa7e5c7281516b04b9f3f4cc6db145c",
                   "path" : ""
                 }
               },
@@ -10118,12 +8228,6 @@
                   "revision" : "d0262408af6c830fd37374e21a7521211b6d9bbd",
                   "resolved_revision" : "d0262408af6c830fd37374e21a7521211b6d9bbd",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/vfile/vfile-location.git",
-                  "revision" : "d0262408af6c830fd37374e21a7521211b6d9bbd",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -10143,12 +8247,6 @@
                   "url" : "https://github.com/vfile/vfile-message.git",
                   "revision" : "c7ea8c0d236299e9ff39faac89e230b178263f58",
                   "resolved_revision" : "c7ea8c0d236299e9ff39faac89e230b178263f58",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/vfile/vfile-message.git",
-                  "revision" : "c7ea8c0d236299e9ff39faac89e230b178263f58",
                   "path" : ""
                 }
               },
@@ -10170,12 +8268,6 @@
                   "revision" : "542a7fd62abf83224e59c5364903915867e0902f",
                   "resolved_revision" : "542a7fd62abf83224e59c5364903915867e0902f",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/vfile/vfile.git",
-                  "revision" : "542a7fd62abf83224e59c5364903915867e0902f",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -10195,12 +8287,6 @@
                   "url" : "https://github.com/nexdrew/which-module.git",
                   "revision" : "7f78f42d0761133263c3947a3b24dde324a467ce",
                   "resolved_revision" : "7f78f42d0761133263c3947a3b24dde324a467ce",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/nexdrew/which-module.git",
-                  "revision" : "7f78f42d0761133263c3947a3b24dde324a467ce",
                   "path" : ""
                 }
               },
@@ -10222,12 +8308,6 @@
                   "revision" : "563406d75b97f97a33e506b9cc7a82b268332b6f",
                   "resolved_revision" : "563406d75b97f97a33e506b9cc7a82b268332b6f",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/isaacs/node-which.git",
-                  "revision" : "563406d75b97f97a33e506b9cc7a82b268332b6f",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -10247,12 +8327,6 @@
                   "url" : "https://github.com/isaacs/node-which.git",
                   "revision" : "6a822d836de79f92fb3170f685a6e283fbfeff87",
                   "resolved_revision" : "6a822d836de79f92fb3170f685a6e283fbfeff87",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/isaacs/node-which.git",
-                  "revision" : "6a822d836de79f92fb3170f685a6e283fbfeff87",
                   "path" : ""
                 }
               },
@@ -10274,12 +8348,6 @@
                   "revision" : "6b766c9874a1e5157eda2ac75b90ccc01b313620",
                   "resolved_revision" : "6b766c9874a1e5157eda2ac75b90ccc01b313620",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/iarna/wide-align.git",
-                  "revision" : "6b766c9874a1e5157eda2ac75b90ccc01b313620",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -10299,12 +8367,6 @@
                   "url" : "https://github.com/jonschlinkert/word-wrap.git",
                   "revision" : "cdab7f263a0af97df0626043d908aa087d3d3089",
                   "resolved_revision" : "cdab7f263a0af97df0626043d908aa087d3d3089",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/jonschlinkert/word-wrap.git",
-                  "revision" : "cdab7f263a0af97df0626043d908aa087d3d3089",
                   "path" : ""
                 }
               },
@@ -10326,12 +8388,6 @@
                   "revision" : "2a1a55446d67c55a29e84173e99eb6abc91c937c",
                   "resolved_revision" : "2a1a55446d67c55a29e84173e99eb6abc91c937c",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/chalk/wrap-ansi.git",
-                  "revision" : "2a1a55446d67c55a29e84173e99eb6abc91c937c",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -10351,12 +8407,6 @@
                   "url" : "https://github.com/chalk/wrap-ansi.git",
                   "revision" : "a28eb7d6cdbf91bccb56d04d095ca9463c15d3db",
                   "resolved_revision" : "a28eb7d6cdbf91bccb56d04d095ca9463c15d3db",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/chalk/wrap-ansi.git",
-                  "revision" : "a28eb7d6cdbf91bccb56d04d095ca9463c15d3db",
                   "path" : ""
                 }
               },
@@ -10378,12 +8428,6 @@
                   "revision" : "71d91b6dc5bdeac37e218c2cf03f9ab55b60d214",
                   "resolved_revision" : "71d91b6dc5bdeac37e218c2cf03f9ab55b60d214",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/npm/wrappy.git",
-                  "revision" : "71d91b6dc5bdeac37e218c2cf03f9ab55b60d214",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -10404,12 +8448,6 @@
                   "revision" : "eb8dff15f83f16be1e0b89be54fa80200356614a",
                   "resolved_revision" : "eb8dff15f83f16be1e0b89be54fa80200356614a",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/npm/write-file-atomic.git",
-                  "revision" : "eb8dff15f83f16be1e0b89be54fa80200356614a",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -10429,12 +8467,6 @@
                   "url" : "https://github.com/jonschlinkert/write.git",
                   "revision" : "6a48d4e363510c52653fabc25f620a484d6058bf",
                   "resolved_revision" : "6a48d4e363510c52653fabc25f620a484d6058bf",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/jonschlinkert/write.git",
-                  "revision" : "6a48d4e363510c52653fabc25f620a484d6058bf",
                   "path" : ""
                 }
               },
@@ -10476,12 +8508,6 @@
                   "revision" : "3a17d584296d013a56d9c4b01f96ca8b2b96d6e1",
                   "resolved_revision" : "3a17d584296d013a56d9c4b01f96ca8b2b96d6e1",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/Matt-Esch/x-is-string.git",
-                  "revision" : "3a17d584296d013a56d9c4b01f96ca8b2b96d6e1",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -10501,12 +8527,6 @@
                   "url" : "https://github.com/Raynos/xtend.git",
                   "revision" : "37816c0e2e25da2901d584442235946d5cd8c80d",
                   "resolved_revision" : "37816c0e2e25da2901d584442235946d5cd8c80d",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/Raynos/xtend.git",
-                  "revision" : "37816c0e2e25da2901d584442235946d5cd8c80d",
                   "path" : ""
                 }
               },
@@ -10528,12 +8548,6 @@
                   "revision" : "45d2568800d6c57be045e76dc4984b2ef3432233",
                   "resolved_revision" : "45d2568800d6c57be045e76dc4984b2ef3432233",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/yargs/y18n.git",
-                  "revision" : "45d2568800d6c57be045e76dc4984b2ef3432233",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -10553,12 +8567,6 @@
                   "url" : "ssh://git@github.com/yargs/yargs-parser.git",
                   "revision" : "034e7c0ebf1047a866eb84b529aeea9216669d4a",
                   "resolved_revision" : "034e7c0ebf1047a866eb84b529aeea9216669d4a",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/yargs/yargs-parser.git",
-                  "revision" : "034e7c0ebf1047a866eb84b529aeea9216669d4a",
                   "path" : ""
                 }
               },
@@ -10580,12 +8588,6 @@
                   "revision" : "d301a5645627a30cc1721de647a6cc65bb89a426",
                   "resolved_revision" : "d301a5645627a30cc1721de647a6cc65bb89a426",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/yargs/yargs-parser.git",
-                  "revision" : "",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -10605,12 +8607,6 @@
                   "url" : "ssh://git@github.com/yargs/yargs-unparser.git",
                   "revision" : "707b456935e881fe63a670d895ac15950cf1bbb5",
                   "resolved_revision" : "707b456935e881fe63a670d895ac15950cf1bbb5",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "ssh://git@github.com/yargs/yargs-unparser.git",
-                  "revision" : "707b456935e881fe63a670d895ac15950cf1bbb5",
                   "path" : ""
                 }
               },
@@ -10632,12 +8628,6 @@
                   "revision" : "c5547b1333ab1821152d0a334a278fcb5496a0a6",
                   "resolved_revision" : "c5547b1333ab1821152d0a334a278fcb5496a0a6",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/yargs/yargs.git",
-                  "revision" : "c5547b1333ab1821152d0a334a278fcb5496a0a6",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -10657,12 +8647,6 @@
                   "url" : "https://github.com/yargs/yargs.git",
                   "revision" : "0b519a4672c8493d72838292ed0d60b63b88f33e",
                   "resolved_revision" : "0b519a4672c8493d72838292ed0d60b63b88f33e",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/yargs/yargs.git",
-                  "revision" : "0b519a4672c8493d72838292ed0d60b63b88f33e",
                   "path" : ""
                 }
               },
@@ -10684,12 +8668,6 @@
                   "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "resolved_revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "path" : "packages/babel-code-frame"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
-                  "path" : "packages/babel-code-frame"
                 }
               },
               "scanner" : {
@@ -10709,12 +8687,6 @@
                   "url" : "https://github.com/babel/babel.git",
                   "revision" : "e51139d7fd850e7f5b8cd6aafb17cc88b7010218",
                   "resolved_revision" : "e51139d7fd850e7f5b8cd6aafb17cc88b7010218",
-                  "path" : "packages/babel-core"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "e51139d7fd850e7f5b8cd6aafb17cc88b7010218",
                   "path" : "packages/babel-core"
                 }
               },
@@ -10736,12 +8708,6 @@
                   "revision" : "e51139d7fd850e7f5b8cd6aafb17cc88b7010218",
                   "resolved_revision" : "e51139d7fd850e7f5b8cd6aafb17cc88b7010218",
                   "path" : "packages/babel-generator"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "e51139d7fd850e7f5b8cd6aafb17cc88b7010218",
-                  "path" : "packages/babel-generator"
                 }
               },
               "scanner" : {
@@ -10761,12 +8727,6 @@
                   "url" : "https://github.com/babel/babel.git",
                   "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "resolved_revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
-                  "path" : "packages/babel-helper-function-name"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "path" : "packages/babel-helper-function-name"
                 }
               },
@@ -10788,12 +8748,6 @@
                   "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "resolved_revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "path" : "packages/babel-helper-get-function-arity"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
-                  "path" : "packages/babel-helper-get-function-arity"
                 }
               },
               "scanner" : {
@@ -10813,12 +8767,6 @@
                   "url" : "https://github.com/babel/babel.git",
                   "revision" : "45fdb87747051f59c39e27e064558afdd76c4f71",
                   "resolved_revision" : "45fdb87747051f59c39e27e064558afdd76c4f71",
-                  "path" : "packages/babel-helper-member-expression-to-functions"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "",
                   "path" : "packages/babel-helper-member-expression-to-functions"
                 }
               },
@@ -10840,12 +8788,6 @@
                   "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "resolved_revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "path" : "packages/babel-helper-module-imports"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
-                  "path" : "packages/babel-helper-module-imports"
                 }
               },
               "scanner" : {
@@ -10865,12 +8807,6 @@
                   "url" : "https://github.com/babel/babel.git",
                   "revision" : "45fdb87747051f59c39e27e064558afdd76c4f71",
                   "resolved_revision" : "45fdb87747051f59c39e27e064558afdd76c4f71",
-                  "path" : "packages/babel-helper-module-transforms"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "",
                   "path" : "packages/babel-helper-module-transforms"
                 }
               },
@@ -10892,12 +8828,6 @@
                   "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "resolved_revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "path" : "packages/babel-helper-optimise-call-expression"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
-                  "path" : "packages/babel-helper-optimise-call-expression"
                 }
               },
               "scanner" : {
@@ -10917,12 +8847,6 @@
                   "url" : "https://github.com/babel/babel.git",
                   "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "resolved_revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
-                  "path" : "packages/babel-helper-replace-supers"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "path" : "packages/babel-helper-replace-supers"
                 }
               },
@@ -10944,12 +8868,6 @@
                   "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "resolved_revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "path" : "packages/babel-helper-simple-access"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
-                  "path" : "packages/babel-helper-simple-access"
                 }
               },
               "scanner" : {
@@ -10969,12 +8887,6 @@
                   "url" : "https://github.com/babel/babel.git",
                   "revision" : "45fdb87747051f59c39e27e064558afdd76c4f71",
                   "resolved_revision" : "45fdb87747051f59c39e27e064558afdd76c4f71",
-                  "path" : "packages/babel-helper-split-export-declaration"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "",
                   "path" : "packages/babel-helper-split-export-declaration"
                 }
               },
@@ -10996,12 +8908,6 @@
                   "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "resolved_revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "path" : "packages/babel-helper-validator-identifier"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
-                  "path" : "packages/babel-helper-validator-identifier"
                 }
               },
               "scanner" : {
@@ -11021,12 +8927,6 @@
                   "url" : "https://github.com/babel/babel.git",
                   "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "resolved_revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
-                  "path" : "packages/babel-helpers"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "path" : "packages/babel-helpers"
                 }
               },
@@ -11048,12 +8948,6 @@
                   "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "resolved_revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "path" : "packages/babel-highlight"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
-                  "path" : "packages/babel-highlight"
                 }
               },
               "scanner" : {
@@ -11073,12 +8967,6 @@
                   "url" : "https://github.com/babel/babel.git",
                   "revision" : "af64ccb2b00bc7574943674996c2f0507cdbfb6f",
                   "resolved_revision" : "af64ccb2b00bc7574943674996c2f0507cdbfb6f",
-                  "path" : "packages/babel-parser"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "af64ccb2b00bc7574943674996c2f0507cdbfb6f",
                   "path" : "packages/babel-parser"
                 }
               },
@@ -11100,12 +8988,6 @@
                   "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "resolved_revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
                   "path" : "packages/babel-template"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "7fd40d86a0d03ff0e9c3ea16b29689945433d4df",
-                  "path" : "packages/babel-template"
                 }
               },
               "scanner" : {
@@ -11125,12 +9007,6 @@
                   "url" : "https://github.com/babel/babel.git",
                   "revision" : "af64ccb2b00bc7574943674996c2f0507cdbfb6f",
                   "resolved_revision" : "af64ccb2b00bc7574943674996c2f0507cdbfb6f",
-                  "path" : "packages/babel-traverse"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "af64ccb2b00bc7574943674996c2f0507cdbfb6f",
                   "path" : "packages/babel-traverse"
                 }
               },
@@ -11152,12 +9028,6 @@
                   "revision" : "af64ccb2b00bc7574943674996c2f0507cdbfb6f",
                   "resolved_revision" : "af64ccb2b00bc7574943674996c2f0507cdbfb6f",
                   "path" : "packages/babel-types"
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/babel/babel.git",
-                  "revision" : "af64ccb2b00bc7574943674996c2f0507cdbfb6f",
-                  "path" : "packages/babel-types"
                 }
               },
               "scanner" : {
@@ -11178,12 +9048,6 @@
                   "revision" : "2033a007672d90669c48c79e6a2d63a3cd0851a7",
                   "resolved_revision" : "2033a007672d90669c48c79e6a2d63a3cd0851a7",
                   "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/istanbuljs/load-nyc-config.git",
-                  "revision" : "2033a007672d90669c48c79e6a2d63a3cd0851a7",
-                  "path" : ""
                 }
               },
               "scanner" : {
@@ -11203,12 +9067,6 @@
                   "url" : "https://github.com/istanbuljs/schema.git",
                   "revision" : "61c69da39a0af8f4387ba8aa1eddb633227c3938",
                   "resolved_revision" : "61c69da39a0af8f4387ba8aa1eddb633227c3938",
-                  "path" : ""
-                },
-                "original_vcs_info" : {
-                  "type" : "Git",
-                  "url" : "https://github.com/istanbuljs/schema.git",
-                  "revision" : "61c69da39a0af8f4387ba8aa1eddb633227c3938",
                   "path" : ""
                 }
               },

--- a/reporter-web-app/src/models/Provenance.js
+++ b/reporter-web-app/src/models/Provenance.js
@@ -25,8 +25,6 @@ class Provenance {
 
     #vcsInfo = new VcsInfo();
 
-    #originalVcsInfo = new VcsInfo();
-
     constructor(obj) {
         if (obj instanceof Object) {
             if (obj.source_artifact || obj.sourceArtifact) {
@@ -35,10 +33,6 @@ class Provenance {
 
             if (obj.vcs_info || obj.vcsInfo) {
                 this.#vcsInfo = obj.vcs_info || obj.vcsInfo;
-            }
-
-            if (obj.original_vcs_info || obj.originalVcsInfo) {
-                this.#originalVcsInfo = obj.original_vcs_info || obj.originalVcsInfo;
             }
         }
     }
@@ -49,10 +43,6 @@ class Provenance {
 
     get vcsInfo() {
         return this.#vcsInfo;
-    }
-
-    get originalVcsInfo() {
-        return this.#originalVcsInfo;
     }
 }
 

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
@@ -86,8 +86,7 @@ abstract class AbstractStorageFunTest : WordSpec() {
 
     private val provenanceEmpty = UnknownProvenance
     private val provenanceWithoutRevision = RepositoryProvenance(
-        vcsInfo = pkgWithoutRevision.vcsProcessed.copy(resolvedRevision = "resolvedRevision"),
-        originalVcsInfo = pkgWithoutRevision.vcsProcessed
+        vcsInfo = pkgWithoutRevision.vcsProcessed.copy(resolvedRevision = "resolvedRevision")
     )
     private val provenanceWithSourceArtifact1 = ArtifactProvenance(sourceArtifact = sourceArtifact1)
     private val provenanceWithSourceArtifact2 = ArtifactProvenance(sourceArtifact = sourceArtifact2)


### PR DESCRIPTION
The purpose of the provenance is to point to some code location. That
location is either a source artifact, a VCS location / revision or
an unknown location.

The main use case in ORT for provenance is to describe what has been
downloaded or scanned. For that purpose the original VCS information is
irrelevant. Remove it to make provenance be usable for that single
purpose. If it should become necessary to also have the original
provenance a separate attribute can be added elsewhere.

Note that finding a scan result for a given package does not involve the
`originalVcsInfo`, in fact all its attribute values are contained also
in `vcsInfo` except for the `resolvedRevision`.

Note: The change is marked as breaking, because "old" scan result storage entries for packages without a revision in their meta-data won't be matched anymore. They would then "automatically" be re-scanned.
