### PR TITLE
Remove a superfluous import of kotlin.IllegalArgumentException

### DIFF
--- a/reporter/src/funTest/kotlin/reporters/AsciiDocTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/AsciiDocTemplateReporterFunTest.kt
@@ -26,7 +26,6 @@ import io.kotest.matchers.should
 
 import java.io.File
 
-import kotlin.IllegalArgumentException
 import kotlin.io.path.createTempDirectory
 
 import org.ossreviewtoolkit.model.OrtResult


### PR DESCRIPTION
The "kotlin" package is in the list of default imports, see

https://kotlinlang.org/docs/packages.html#default-imports

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>