### PR TITLE
sw360-integration: Fix curated fields to include `concludedLicenses`

### DIFF
--- a/docs/sw360-integration.md
+++ b/docs/sw360-integration.md
@@ -60,7 +60,7 @@ If you prefer to use the SW360 web frontend to correct package metadata instead 
 
 Note:
 
-1. Currently only the SW360 fields `declaredLicenses`, `homepageUrl`, `binaryArtifact` and `sourceArtifact` are used for curations, all
+1. Currently only the SW360 fields `concludedLicenses`, `homepageUrl`, `binaryArtifact` and `sourceArtifact` are used for curations, all
    other SW360 fields are ignored as there are no corresponding fields for them in ORT.
 2. A release in SW360 needs to be in the approved clearing state, otherwise the curated data will not be used.
 


### PR DESCRIPTION
This is a fixup for 097d88a where the behavior was changed.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>