### PR TITLE
Downloader: Limit archiving source code to configured categories

### DIFF
--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,13 +51,24 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.licenses.LicenseCategorization
+import org.ossreviewtoolkit.model.licenses.LicenseClassifications
+import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
+import org.ossreviewtoolkit.model.licenses.LicenseView
+import org.ossreviewtoolkit.model.licenses.ResolvedLicenseInfo
+import org.ossreviewtoolkit.model.licenses.orEmpty
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.utils.createLicenseInfoResolver
 import org.ossreviewtoolkit.readOrtResult
 import org.ossreviewtoolkit.spdx.VCS_DIRECTORIES
+import org.ossreviewtoolkit.spdx.model.LicenseChoice
 import org.ossreviewtoolkit.utils.ArchiveType
+import org.ossreviewtoolkit.utils.ORT_LICENSE_CLASSIFICATIONS_FILENAME
 import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.encodeOrUnknown
 import org.ossreviewtoolkit.utils.expandTilde
 import org.ossreviewtoolkit.utils.log
+import org.ossreviewtoolkit.utils.ortConfigDirectory
 import org.ossreviewtoolkit.utils.packZip
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.showStackTrace
@@ -99,6 +111,16 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
         help = "The VCS path if '--project-url' points to a VCS. Ignored if '--ort-file' is also specified. " +
                 "(default: the empty root path)"
     ).default("").inputGroup()
+
+    private val licenseClassificationsFile by option(
+        "--license-classifications-file",
+        help = "A file containing the license classifications that are used to limit downloads if the included " +
+                "categories are specified in the 'ort.conf' file. If not specified, all packages are downloaded."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .default(ortConfigDirectory.resolve(ORT_LICENSE_CLASSIFICATIONS_FILENAME))
+        .configurationGroup()
 
     private val outputDir by option(
         "--output-dir", "-o",
@@ -198,7 +220,28 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
                     }
                 }
 
-                val packageDownloadDirs = packages.associateWith { outputDir.resolve(it.id.toPath()) }
+                val includedLicenseCategories = globalOptionsForSubcommands.config.downloader.includedLicenseCategories
+
+                val packageDownloadDirs =
+                    if (includedLicenseCategories.isNotEmpty() && licenseClassificationsFile.isFile) {
+                        val licenseCategorizations =
+                            licenseClassificationsFile.readValue<LicenseClassifications>().orEmpty().categorizations
+                        val licenseInfoResolver = ortResult.createLicenseInfoResolver()
+
+                        packages.filter { pkg ->
+                        // A package is only downloaded if its license is part of a category that is part of the
+                        // DownloaderConfiguration's includedLicenseCategories.
+                        getLicenseCategoriesForPackage(
+                            pkg,
+                            licenseCategorizations,
+                            licenseInfoResolver,
+                            ortResult.getRepositoryLicenseChoices(),
+                            ortResult.getPackageLicenseChoices(pkg.id)
+                        ).any { it in includedLicenseCategories }
+                    }
+                } else {
+                    packages
+                }.associateWith { outputDir.resolve(it.id.toPath()) }
 
                 packageDownloadDirs.forEach { (pkg, dir) ->
                     try {
@@ -282,6 +325,28 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
             log.error { "Failure summary:\n\n${failureMessages.joinToString("\n\n")}" }
             throw ProgramResult(1)
         }
+    }
+
+    /**
+     * Retrieve the license categories for the [package][pkg] based on its [effective license]
+     * [ResolvedLicenseInfo.effectiveLicense].
+     */
+    private fun getLicenseCategoriesForPackage(
+        pkg: Package,
+        licenseCategorizations: List<LicenseCategorization>,
+        licenseInfoResolver: LicenseInfoResolver,
+        vararg licenseChoices: List<LicenseChoice>
+    ): Set<String> {
+        val resolvedLicenseInfo = licenseInfoResolver.resolveLicenseInfo(pkg.id)
+        val effectiveLicenses = resolvedLicenseInfo.effectiveLicense(
+            LicenseView.ALL,
+            *licenseChoices
+        )?.decompose().orEmpty()
+
+        return licenseCategorizations
+            .filter { it.id in effectiveLicenses }
+            .flatMap { it.categories }
+            .toSet()
     }
 
     private fun archive(pkg: Package, inputDir: File): Boolean {

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -116,7 +116,7 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate ORT re
 
     private val licenseClassificationsFile by option(
         "--license-classifications-file",
-        help = "A file containing the license classificationsm which are passed as parameter to the rules script."
+        help = "A file containing the license classifications which are passed as parameter to the rules script."
     ).convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
         .convert { it.absoluteFile.normalize() }

--- a/downloader/src/funTest/kotlin/DownloaderFunTest.kt
+++ b/downloader/src/funTest/kotlin/DownloaderFunTest.kt
@@ -114,7 +114,7 @@ class DownloaderFunTest : StringSpec() {
 
         "Falls back to downloading source package when download from VCS fails".config(tags = setOf(ExpensiveTag)) {
             val downloaderConfiguration = DownloaderConfiguration(
-                listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT)
+                sourceCodeOrigins = listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT)
             )
 
             val pkg = Package(
@@ -155,7 +155,7 @@ class DownloaderFunTest : StringSpec() {
 
         "Falls back to downloading from VCS when source package download fails".config(tags = setOf(ExpensiveTag)) {
             val downloaderConfiguration = DownloaderConfiguration(
-                listOf(SourceCodeOrigin.ARTIFACT, SourceCodeOrigin.VCS)
+                sourceCodeOrigins = listOf(SourceCodeOrigin.ARTIFACT, SourceCodeOrigin.VCS)
             )
 
             val pkg = Package(

--- a/model/src/main/kotlin/config/DownloaderConfiguration.kt
+++ b/model/src/main/kotlin/config/DownloaderConfiguration.kt
@@ -20,9 +20,16 @@
 package org.ossreviewtoolkit.model.config
 
 import org.ossreviewtoolkit.model.SourceCodeOrigin
+import org.ossreviewtoolkit.model.licenses.LicenseCategory
 import org.ossreviewtoolkit.spdx.getDuplicates
 
 data class DownloaderConfiguration(
+    /**
+     * The [categories][LicenseCategory] licenses of packages need to be part of in order to get included into the
+     * download.
+     */
+    val includedLicenseCategories: List<String> = emptyList(),
+
     /**
      * Configuration of the considered source code origins and their priority order.
      */

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -36,6 +36,11 @@ ort {
   }
 
   downloader {
+    // Only used by the CLI tool when the '--license-classifications-file' option is specified.
+    includedLicenseCategories: [
+      "category-a",
+      "category-b"
+    ],
     sourceCodeOrigins: [
       "VCS", "ARTIFACT"
     ]

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -23,6 +23,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.TestConfiguration
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.extensions.system.withEnvironment
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.nulls.beNull
@@ -61,6 +62,7 @@ class OrtConfigurationTest : WordSpec({
             }
 
             ortConfig.downloader shouldNotBeNull {
+                includedLicenseCategories should containExactly("category-a", "category-b")
                 sourceCodeOrigins shouldBe listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT)
             }
 

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -63,7 +63,7 @@ class OrtConfigurationTest : WordSpec({
 
             ortConfig.downloader shouldNotBeNull {
                 includedLicenseCategories should containExactly("category-a", "category-b")
-                sourceCodeOrigins shouldBe listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT)
+                sourceCodeOrigins should containExactly(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT)
             }
 
             with(ortConfig.scanner) {


### PR DESCRIPTION
This PR adds a configuration to `ort.conf` that enables the user to limit the packages that are bundled in the source code bundle.

If no categories are configured, the implementation falls back to archive all packaged. This has the the benefit of providing backwards compatibility to the current archive functionality and it doesn't force the user to add a configuration to use the archive functionality.