### PR TITLE
FreemarkerTemplateProcessor: Use LicenseView constants directly

### DIFF
--- a/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
@@ -26,8 +26,6 @@ import freemarker.template.TemplateExceptionHandler
 import java.io.File
 import java.util.SortedMap
 
-import kotlin.reflect.full.memberProperties
-
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.OrtIssue
@@ -120,6 +118,7 @@ class FreemarkerTemplateProcessor(
             "packages" to packages,
             "ortResult" to input.ortResult,
             "licenseTextProvider" to input.licenseTextProvider,
+            "LicenseView" to LicenseView,
             "helper" to TemplateHelper(input.ortResult, input.licenseClassifications, input.resolutionProvider),
             "projectsAsPackages" to projectsAsPackages
         )
@@ -254,15 +253,6 @@ class FreemarkerTemplateProcessor(
             licenses.filter { resolvedLicense ->
                 licenseClassifications[resolvedLicense.license]?.contains(category) ?: true
             }
-
-        /**
-         * Return a [LicenseView] constant by name to make them easily available to the Freemarker templates.
-         */
-        @Suppress("UNUSED") // This function is used in the templates.
-        fun licenseView(name: String): LicenseView =
-            LicenseView.Companion::class.memberProperties
-                .first { it.name == name }
-                .get(LicenseView.Companion) as LicenseView
 
         /**
          * Merge the [ResolvedLicense]s of multiple [models] and filter them using [licenseView] and

--- a/reporter/src/main/resources/templates/asciidoc/disclosure_document.ftl
+++ b/reporter/src/main/resources/templates/asciidoc/disclosure_document.ftl
@@ -114,10 +114,10 @@ for a concluded license those statements are kept.
 --]
 [#assign
 resolvedLicenses =
-    helper.licenseView("CONCLUDED_OR_DECLARED_AND_DETECTED")
+    LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED
       .filter(
           package.licensesNotInLicenseFiles(
-            helper.licenseView("CONCLUDED_OR_DECLARED_AND_DETECTED")
+            LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED
                 .filter(package.license, package.licenseChoices).licenses
           )
       )
@@ -153,7 +153,7 @@ Append the text of all licenses that have been listed in the above lists for lic
 [appendix]
 == License Texts
 
-[#assign mergedLicenses = helper.mergeLicenses(projects + packages, helper.licenseView("CONCLUDED_OR_DECLARED_AND_DETECTED"), true)]
+[#assign mergedLicenses = helper.mergeLicenses(projects + packages, LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED, true)]
 [#list mergedLicenses as resolvedLicense]
 === ${resolvedLicense.license}
 

--- a/reporter/src/main/resources/templates/notice/default.ftl
+++ b/reporter/src/main/resources/templates/notice/default.ftl
@@ -97,7 +97,7 @@ notice files, and filter all licenses that are contained in the license files al
 --]
 [#assign
 resolvedLicenses = helper.filterForCategory(
-    helper.licenseView("CONCLUDED_OR_DECLARED_AND_DETECTED").filter(package.licensesNotInLicenseFiles()),
+    LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED.filter(package.licensesNotInLicenseFiles()),
     "include-in-notice-file"
 )]
 [#if resolvedLicenses?has_content]

--- a/reporter/src/main/resources/templates/notice/summary.ftl
+++ b/reporter/src/main/resources/templates/notice/summary.ftl
@@ -37,7 +37,7 @@ cannot have concluded licenses. If copyrights were detected for a concluded lice
 filter all licenses that are configured not to be included in notice files.
 --]
 [#assign mergedLicenses = helper.filterForCategory(
-    helper.mergeLicenses(projects + packages, helper.licenseView("CONCLUDED_OR_DECLARED_AND_DETECTED")),
+    helper.mergeLicenses(projects + packages, LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED),
     "include-in-notice-file"
 )]
 [#list mergedLicenses as resolvedLicense]


### PR DESCRIPTION
Instead of searching for it by name.
