### PR TITLE
Dockerfile: Update the sbt Debian repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,8 +73,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
     apt-get update && \
     apt-get install -y --no-install-recommends gnupg software-properties-common && \
-    echo 'Acquire::https::dl.bintray.com::Verify-Peer "false";' | tee -a /etc/apt/apt.conf.d/00sbt && \
-    echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
+    echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
     curl -ksS "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key adv --import - && \
     curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     add-apt-repository ppa:git-core/ppa && \


### PR DESCRIPTION
See the updated instructions at [1]. This fixes the Docker image build.

[1] https://www.scala-sbt.org/1.x/docs/Installing-sbt-on-Linux.html#Ubuntu+and+other+Debian-based+distributions

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>