### PR TITLE
GeneratePackageConfigurationsCommand: Fix VCS path generation

### DIFF
--- a/helper-cli/src/main/kotlin/commands/GeneratePackageConfigurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GeneratePackageConfigurationsCommand.kt
@@ -121,7 +121,7 @@ private fun createPackageConfiguration(id: Identifier, provenance: Provenance): 
                     type = provenance.vcsInfo.type,
                     url = provenance.vcsInfo.url,
                     revision = provenance.vcsInfo.resolvedRevision!!,
-                    path = provenance.vcsInfo.path.takeIf { provenance.vcsInfo.type == VcsType.GIT_REPO }.orEmpty()
+                    path = provenance.vcsInfo.path.takeIf { provenance.vcsInfo.type == VcsType.GIT_REPO }
                 )
             )
         }


### PR DESCRIPTION
The VCS path must be null for all VCS types except for "Git-Repo".
This is a fix-up for 4d94d93e89240977024deaf80d9af3620c1a4dd0.