### PR TITLE
SpdxDocumentFile: Remove superfluous parentheses in an expression

### DIFF
--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -144,8 +144,8 @@ private fun resolveExternalDocumentReference(
 
     if (uri.scheme.equals("file", ignoreCase = true) || !uri.isAbsolute) {
         val referencedFile = workingDir.resolve(uri.path)
-        val spdxFile = (referencedFile.takeIf { it.isFile }
-            ?: throw IllegalArgumentException("The local file URI '$uri' does not point to an existing file."))
+        val spdxFile = referencedFile.takeIf { it.isFile }
+            ?: throw IllegalArgumentException("The local file URI '$uri' does not point to an existing file.")
         return SpdxModelMapper.read(spdxFile)
     }
 


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>