### PR TITLE
FileFormat: Fix pretty-printing of (JSON) files

### DIFF
--- a/model/src/main/kotlin/FileFormat.kt
+++ b/model/src/main/kotlin/FileFormat.kt
@@ -89,5 +89,10 @@ inline fun <reified T : Any> File.readValue(): T = mapper().readValue(this)
  */
 inline fun <reified T : Any> File.writeValue(value: T, prettyPrint: Boolean = true) {
     parentFile.safeMkdirs()
-    mapper().apply { if (prettyPrint) writerWithDefaultPrettyPrinter() }.writeValue(this, value)
+
+    if (prettyPrint) {
+        mapper().writerWithDefaultPrettyPrinter().writeValue(this, value)
+    } else {
+        mapper().writeValue(this, value)
+    }
 }


### PR DESCRIPTION
If pretty-printing is enabled, writeValue() needs to be called on the
ObjectWriter, not on the ObjectMapper. This got broken in 3269e2e.

Fixes #3948.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>