### PR TITLE
TemplateHelper: Generate human-readable string for vulnerability scores

### DIFF
--- a/model/src/main/kotlin/Vulnerability.kt
+++ b/model/src/main/kotlin/Vulnerability.kt
@@ -51,58 +51,6 @@ data class Vulnerability(
             "A Vulnerability must have at least one reference."
         }
     }
-
-    /**
-     * The rating attaches human-readable semantics to the score number according to CVSS version 2, see
-     * https://www.balbix.com/insights/cvss-v2-vs-cvss-v3/#CVSSv3-Scoring-Scale-vs-CVSSv2-6.
-     */
-    enum class Cvss2Rating(private val upperBound: Float) {
-        LOW(4.0f),
-        MEDIUM(7.0f),
-        HIGH(10.0f);
-
-        companion object {
-            /**
-             * Get the [Cvss2Rating] from a [score], or null if the [score] does not map to any [Cvss2Rating].
-             */
-            fun fromScore(score: Float): Cvss2Rating? =
-                when {
-                    score < 0.0f || score > HIGH.upperBound -> null
-                    score < LOW.upperBound -> LOW
-                    score < MEDIUM.upperBound -> MEDIUM
-                    score <= HIGH.upperBound -> HIGH
-                    else -> null
-                }
-        }
-    }
-
-    /**
-     * The rating attaches human-readable semantics to the score number according to CVSS version 3, see
-     * https://www.first.org/cvss/v3.0/specification-document#Qualitative-Severity-Rating-Scale.
-     */
-    enum class Cvss3Rating(private val upperBound: Float) {
-        NONE(0.0f),
-        LOW(4.0f),
-        MEDIUM(7.0f),
-        HIGH(9.0f),
-        CRITICAL(10.0f);
-
-        companion object {
-            /**
-             * Get the [Cvss3Rating] from a [score], or null if the [score] does not map to any [Cvss3Rating].
-             */
-            fun fromScore(score: Float): Cvss3Rating? =
-                when {
-                    score < 0.0f || score > CRITICAL.upperBound -> null
-                    score == NONE.upperBound -> NONE
-                    score < LOW.upperBound -> LOW
-                    score < MEDIUM.upperBound -> MEDIUM
-                    score < HIGH.upperBound -> HIGH
-                    score <= CRITICAL.upperBound -> CRITICAL
-                    else -> null
-                }
-        }
-    }
 }
 
 /**

--- a/model/src/main/kotlin/VulnerabilityReference.kt
+++ b/model/src/main/kotlin/VulnerabilityReference.kt
@@ -49,4 +49,56 @@ data class VulnerabilityReference(
      * severity.
      */
     val severity: String?
-)
+) {
+    /**
+     * The rating attaches human-readable semantics to the score number according to CVSS version 2, see
+     * https://www.balbix.com/insights/cvss-v2-vs-cvss-v3/#CVSSv3-Scoring-Scale-vs-CVSSv2-6.
+     */
+    enum class Cvss2Rating(private val upperBound: Float) {
+        LOW(4.0f),
+        MEDIUM(7.0f),
+        HIGH(10.0f);
+
+        companion object {
+            /**
+             * Get the [Cvss2Rating] from a [score], or null if the [score] does not map to any [Cvss2Rating].
+             */
+            fun fromScore(score: Float): Cvss2Rating? =
+                when {
+                    score < 0.0f || score > HIGH.upperBound -> null
+                    score < LOW.upperBound -> LOW
+                    score < MEDIUM.upperBound -> MEDIUM
+                    score <= HIGH.upperBound -> HIGH
+                    else -> null
+                }
+        }
+    }
+
+    /**
+     * The rating attaches human-readable semantics to the score number according to CVSS version 3, see
+     * https://www.first.org/cvss/v3.0/specification-document#Qualitative-Severity-Rating-Scale.
+     */
+    enum class Cvss3Rating(private val upperBound: Float) {
+        NONE(0.0f),
+        LOW(4.0f),
+        MEDIUM(7.0f),
+        HIGH(9.0f),
+        CRITICAL(10.0f);
+
+        companion object {
+            /**
+             * Get the [Cvss3Rating] from a [score], or null if the [score] does not map to any [Cvss3Rating].
+             */
+            fun fromScore(score: Float): Cvss3Rating? =
+                when {
+                    score < 0.0f || score > CRITICAL.upperBound -> null
+                    score == NONE.upperBound -> NONE
+                    score < LOW.upperBound -> LOW
+                    score < MEDIUM.upperBound -> MEDIUM
+                    score < HIGH.upperBound -> HIGH
+                    score <= CRITICAL.upperBound -> CRITICAL
+                    else -> null
+                }
+        }
+    }
+}

--- a/model/src/main/kotlin/VulnerabilityReference.kt
+++ b/model/src/main/kotlin/VulnerabilityReference.kt
@@ -50,6 +50,18 @@ data class VulnerabilityReference(
      */
     val severity: String?
 ) {
+    companion object {
+        /**
+         * Return a human-readable string that is determined based on the given score and scoring system.
+         */
+        fun getSeverityString(scoringSystem: String?, severity: String) =
+            when (scoringSystem) {
+                "CVSS2" -> Cvss2Rating.fromScore(severity.toFloat())?.name?.toLowerCase()
+                "CVSS3" -> Cvss3Rating.fromScore(severity.toFloat())?.name?.toLowerCase()
+                else -> "unknown"
+            }
+    }
+
     /**
      * The rating attaches human-readable semantics to the score number according to CVSS version 2, see
      * https://www.balbix.com/insights/cvss-v2-vs-cvss-v3/#CVSSv3-Scoring-Scale-vs-CVSSv2-6.

--- a/model/src/test/kotlin/VulnerabilityTest.kt
+++ b/model/src/test/kotlin/VulnerabilityTest.kt
@@ -27,8 +27,8 @@ import io.kotest.matchers.shouldBe
 
 import java.lang.IllegalArgumentException
 
-import org.ossreviewtoolkit.model.Vulnerability.Cvss2Rating
-import org.ossreviewtoolkit.model.Vulnerability.Cvss3Rating
+import org.ossreviewtoolkit.model.VulnerabilityReference.Cvss2Rating
+import org.ossreviewtoolkit.model.VulnerabilityReference.Cvss3Rating
 
 class VulnerabilityTest : StringSpec({
     "The CVSS 2 rating should be correct for a given score" {

--- a/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
@@ -37,6 +37,7 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.Vulnerability
+import org.ossreviewtoolkit.model.VulnerabilityReference
 import org.ossreviewtoolkit.model.licenses.DefaultLicenseInfoProvider
 import org.ossreviewtoolkit.model.licenses.LicenseClassifications
 import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
@@ -120,7 +121,8 @@ class FreemarkerTemplateProcessor(
             "licenseTextProvider" to input.licenseTextProvider,
             "LicenseView" to LicenseView,
             "helper" to TemplateHelper(input.ortResult, input.licenseClassifications, input.resolutionProvider),
-            "projectsAsPackages" to projectsAsPackages
+            "projectsAsPackages" to projectsAsPackages,
+            "vulnerabilityReference" to VulnerabilityReference
         )
 
         val freemarkerConfig = Configuration(Configuration.VERSION_2_3_30).apply {


### PR DESCRIPTION
Add a helper method to generate human-readable string based on the
given score and scoring system of a vulnerability. This method can
be used in the template files in order to provide further information
about the vulnerabilities in the report.
