### PR TITLE
Severity: Swap ordering of enum members

### DIFF
--- a/model/src/main/kotlin/Severity.kt
+++ b/model/src/main/kotlin/Severity.kt
@@ -22,13 +22,13 @@ package org.ossreviewtoolkit.model
 import org.apache.logging.log4j.Level
 
 /**
- * A generic class describing a severity, e.g. of issues.
+ * A generic class describing a severity, e.g. of issues, sorted from least severe to most severe.
  */
 enum class Severity {
     /**
-     * An error is something that has to be addressed.
+     * A hint is something that is provided for information only.
      */
-    ERROR,
+    HINT,
 
     /**
      * A warning is something that should be addressed.
@@ -36,17 +36,17 @@ enum class Severity {
     WARNING,
 
     /**
-     * A hint is something that is provided for information only.
+     * An error is something that has to be addressed.
      */
-    HINT;
+    ERROR;
 
     /**
      * Map the [Severity] to a Log4j [Level].
      */
     fun toLog4jLevel(): Level =
         when (this) {
-            ERROR -> Level.ERROR
-            WARNING -> Level.WARN
             HINT -> Level.INFO
+            WARNING -> Level.WARN
+            ERROR -> Level.ERROR
         }
 }

--- a/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
@@ -42,15 +42,13 @@ import org.ossreviewtoolkit.reporter.utils.ReportTableModel.ResolvableViolation
 import org.ossreviewtoolkit.reporter.utils.ReportTableModel.SummaryRow
 import org.ossreviewtoolkit.reporter.utils.ReportTableModel.SummaryTable
 
-private val VIOLATION_COMPARATOR = compareBy<ResolvableViolation>(
-    { it.isResolved },
-    { it.violation.severity },
-    { it.violation.rule },
-    { it.violation.pkg },
-    { it.violation.license.toString() },
-    { it.violation.message },
-    { it.resolutionDescription }
-)
+private val VIOLATION_COMPARATOR = compareBy<ResolvableViolation> { it.isResolved }
+    .thenByDescending { it.violation.severity }
+    .thenBy { it.violation.rule }
+    .thenBy { it.violation.pkg }
+    .thenBy { it.violation.license.toString() }
+    .thenBy { it.violation.message }
+    .thenBy { it.resolutionDescription }
 
 private fun Collection<ResolvableIssue>.filterUnresolved() = filter { !it.isResolved }
 


### PR DESCRIPTION
This way a more natural comparison like "severity > Severity.HINT" can
be done.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>