### PR TITLE
WIP postgres: Overhaul configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ ort {
     storages {
       postgresStorage {
         url = "jdbc:postgresql://example.com:5444/database"
-        schema = "schema"
+        schema = "public"
         username = "username"
         password = "password"
         sslmode = "verify-full"
@@ -510,7 +510,9 @@ ort {
 }
 ```
 
-While the specified schema already needs to exist, the _scanner_ will itself create a table called `scan_results` and
+The database needs to exist. If the schema is defined and is not the default postgress _public_, it need to be previously created and grant usage for the specific database user. Left schema entry empty will always default to _public_.
+
+The _scanner_ will itself create a table called `scan_results` and
 store the data in a [jsonb](https://www.postgresql.org/docs/current/datatype-json.html) column.
 
 If you do not want to use SSL set the `sslmode` to `disable`, other possible values are explained in the

--- a/model/src/main/kotlin/config/ScanStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/ScanStorageConfiguration.kt
@@ -74,7 +74,7 @@ data class PostgresStorageConfiguration(
     /**
      * The name of the database to use.
      */
-    val schema: String,
+    val schema: String = "public",
 
     /**
      * The username to use for authentication.

--- a/model/src/main/kotlin/utils/DatabaseUtils.kt
+++ b/model/src/main/kotlin/utils/DatabaseUtils.kt
@@ -42,10 +42,6 @@ object DatabaseUtils {
             "URL for PostgreSQL storage is missing."
         }
 
-        require(config.schema.isNotBlank()) {
-            "Schema for PostgreSQL storage is missing."
-        }
-
         require(config.username.isNotBlank()) {
             "Username for PostgreSQL storage is missing."
         }

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -54,7 +54,7 @@ ort {
 
       postgresStorage {
         url = "url"
-        schema = "schema"
+        schema = "public"
         username = "user"
         password = "password"
       }
@@ -100,8 +100,8 @@ ort {
 
       postgres {
         url = "jdbc:postgresql://your-postgresql-server:5444/your-database"
-        schema = schema
-        username = username
+        schema = "public"
+        username = username 
         password = password
         sslmode = "required"
         sslcert = "/defaultdir/postgresql.crt"

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -75,7 +75,7 @@ class OrtConfigurationTest : WordSpec({
 
                     postgresStorage shouldNotBeNull {
                         url shouldBe "url"
-                        schema shouldBe "schema"
+                        schema shouldBe "public"
                         username shouldBe "user"
                         password shouldBe "password"
                     }
@@ -101,7 +101,7 @@ class OrtConfigurationTest : WordSpec({
                     val postgresStorage = this["postgres"]
                     postgresStorage.shouldBeInstanceOf<PostgresStorageConfiguration>()
                     postgresStorage.url shouldBe "jdbc:postgresql://your-postgresql-server:5444/your-database"
-                    postgresStorage.schema shouldBe "schema"
+                    postgresStorage.schema shouldBe "public"
                     postgresStorage.username shouldBe "username"
                     postgresStorage.password shouldBe "password"
                     postgresStorage.sslmode shouldBe "required"
@@ -146,7 +146,7 @@ class OrtConfigurationTest : WordSpec({
                     storages {
                       postgresStorage {
                         url = "postgresql://your-postgresql-server:5444/your-database"
-                        schema = schema
+                        schema = "public"
                         username = username
                         password = password
                       }
@@ -222,7 +222,7 @@ class OrtConfigurationTest : WordSpec({
                     storages {
                       postgresStorage {
                         url = "postgresql://your-postgresql-server:5444/your-database"
-                        schema = schema
+                        schema = "public"
                         username = ${'$'}{POSTGRES_USERNAME}
                         password = ${'$'}{POSTGRES_PASSWORD}
                       }
@@ -251,7 +251,7 @@ class OrtConfigurationTest : WordSpec({
             val user = "user"
             val password = "password"
             val url = "url"
-            val schema = "schema"
+            val schema = "public"
             val env = mapOf(
                 "ort.scanner.storages.postgresStorage.username" to user,
                 "ort.scanner.storages.postgresStorage.url" to url,


### PR DESCRIPTION
By default, Postgres define the public schema as available for every
created database. Newly created databases can benefit of this as not
usual create custom schema on test databases.

Signed-off-by: Helio Chissini de Castro <helio@kde.org>

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/ort/blob/master/CONTRIBUTING.md). Thank you!
