### PR TITLE
declared-license-mapping: Add LGPL-2.1 mapping

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -252,6 +252,7 @@
 "GNU Lesser General Public License 2.1": LGPL-2.1-only
 "GNU Lesser General Public License Version 2.1": LGPL-2.1-only
 "GNU Lesser General Public License Version 2.1, February 1999": LGPL-2.1-only
+"GNU Lesser General Public License v2 (LGPLv2)": LGPL-2.1-only
 "GNU Lesser General Public License v2 or later (LGPLv2+)": LGPL-2.0-or-later
 "GNU Lesser General Public License v3 (LGPLv3)": LGPL-3.0-only
 "GNU Lesser General Public License v3 or later (LGPLv3+)": LGPL-3.0-or-later


### PR DESCRIPTION
Found "GNU Lesser General Public License v2 (LGPLv2)" in [1].

[1]: https://github.com/PyCQA/astroid/blob/v2.5.6/setup.cfg#L15

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>

