### PR TITLE
Invalidate Azure build caches

### DIFF
--- a/.azure-pipelines/LinuxAnalyzerTest.yml
+++ b/.azure-pipelines/LinuxAnalyzerTest.yml
@@ -57,9 +57,9 @@ jobs:
   # Gradle build cache, see: https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | analyzer-test | gradle-caches | v2 | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
+      key: '"$(Agent.OS)" | analyzer-test | gradle-caches | v3 | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
       restoreKeys: |
-        "$(Agent.OS)" | analyzer-test | gradle-caches | v2
+        "$(Agent.OS)" | analyzer-test | gradle-caches | v3
       path: $(GRADLE_USER_HOME)/caches
     displayName: Cache Gradle Caches
 

--- a/.azure-pipelines/LinuxTest.yml
+++ b/.azure-pipelines/LinuxTest.yml
@@ -36,9 +36,9 @@ jobs:
   # Gradle build cache, see: https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | test | gradle-caches | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
+      key: '"$(Agent.OS)" | test | gradle-caches | v1 | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
       restoreKeys: |
-        "$(Agent.OS)" | test | gradle-caches
+        "$(Agent.OS)" | test | gradle-caches | v1
       path: $(GRADLE_USER_HOME)/caches
     displayName: Cache Gradle Caches
 

--- a/.azure-pipelines/WindowsAnalyzerTest.yml
+++ b/.azure-pipelines/WindowsAnalyzerTest.yml
@@ -53,9 +53,9 @@ jobs:
   # Gradle build cache, see: https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | analyzer-test | gradle-caches | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
+      key: '"$(Agent.OS)" | analyzer-test | gradle-caches | v1 | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
       restoreKeys: |
-        "$(Agent.OS)" | analyzer-test | gradle-caches
+        "$(Agent.OS)" | analyzer-test | gradle-caches | v1
       path: $(GRADLE_USER_HOME)/caches
     displayName: Cache Gradle Caches
 

--- a/.azure-pipelines/WindowsTest.yml
+++ b/.azure-pipelines/WindowsTest.yml
@@ -26,9 +26,9 @@ jobs:
   # Gradle build cache, see: https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops
   - task: Cache@2
     inputs:
-      key: '"$(Agent.OS)" | test | gradle-caches | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
+      key: '"$(Agent.OS)" | test | gradle-caches | v1 | gradle.properties, settings.gradle.kts, **/build.gradle.kts'
       restoreKeys: |
-        "$(Agent.OS)" | test | gradle-caches
+        "$(Agent.OS)" | test | gradle-caches | v1
       path: $(GRADLE_USER_HOME)/caches
     displayName: Cache Gradle Caches
 

--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
@@ -91,7 +91,7 @@ packages:
   description: "Simplistic port-like solution for developers. It provides a standard\
     \ and simplified way to compile against dependency libraries without messing up\
     \ your system."
-  homepage_url: "http://github.com/flavorjones/mini_portile"
+  homepage_url: "https://github.com/flavorjones/mini_portile"
   binary_artifact:
     url: ""
     hash:


### PR DESCRIPTION
Invalidate the Azure cache for Gradle, as the Gradle build cache seems
to be corrupt due to Kotlin compiler backend changes.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>