### PR TITLE
HowToFixTextProvider: Add more packages to the default imports

### DIFF
--- a/reporter/src/main/kotlin/HowToFixTextProvider.kt
+++ b/reporter/src/main/kotlin/HowToFixTextProvider.kt
@@ -50,7 +50,11 @@ fun interface HowToFixTextProvider {
 private class HowToFixScriptRunner(ortResult: OrtResult) : ScriptRunner() {
     override val preface = """
             import org.ossreviewtoolkit.model.*
+            import org.ossreviewtoolkit.model.config.*
+            import org.ossreviewtoolkit.model.licenses.*
+            import org.ossreviewtoolkit.model.utils.*
             import org.ossreviewtoolkit.reporter.HowToFixTextProvider
+            import org.ossreviewtoolkit.utils.*
 
         """.trimIndent()
 


### PR DESCRIPTION
Add more default imports to the `HowToFixTextProvider` scripts so that
they can use the same model classes and utility functions as evaluator
scripts.