### PR TITLE
Dockerfile: Prevent user input for add-apt-repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # syntax = docker/dockerfile:experimental
 
 # Copyright (C) 2020 Bosch Software Innovations GmbH
+# Copyright (C) 2021 Alliander N.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -76,7 +77,7 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
     echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
     curl -ksS "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key adv --import - && \
     curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-    add-apt-repository ppa:git-core/ppa && \
+    add-apt-repository -y ppa:git-core/ppa && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         # Install general tools required by this Dockerfile.


### PR DESCRIPTION
Adding the `-y` flag prevents the `add-apt-repository` command from requesting
user input for conformation for adding the git-core repository. This request for
user input was blocking the Docker build as it kept waiting.

The issue of user input occured when building with `podman` version 1.6.2 on
Ubuntu 20.04.2 LTS.

Closes #3969

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/ort/blob/master/CONTRIBUTING.md). Thank you!
