### PR TITLE
Revert "OrtAuthenticator : In .netrc, raise 'machine' precedence"

### DIFF
--- a/utils/src/main/kotlin/OrtAuthenticator.kt
+++ b/utils/src/main/kotlin/OrtAuthenticator.kt
@@ -127,31 +127,20 @@ fun getNetrcAuthentication(contents: String, machine: String): PasswordAuthentic
 
     val iterator = lines.joinToString(" ").split(Regex("\\s+")).iterator()
 
+    var machineFound = false
     var login: String? = null
     var password: String? = null
-    var currentMachine: String? = null
-    val credentialsPerMachine = mutableMapOf<String, Pair<String, String>>()
 
     while (iterator.hasNext()) {
         when (iterator.next()) {
-            "machine" -> currentMachine = iterator.next()
-            "login" -> login = iterator.next()
-            "password" -> password = iterator.next()
-            "default" -> currentMachine = "default"
+            "machine" -> machineFound = iterator.hasNext() && iterator.next() == machine
+            "login" -> login = if (machineFound && iterator.hasNext()) iterator.next() else null
+            "password" -> password = if (machineFound && iterator.hasNext()) iterator.next() else null
+            "default" -> machineFound = true
         }
 
-        if (currentMachine != null && login != null && password != null) {
-            credentialsPerMachine[currentMachine] = login to password
-        }
+        if (login != null && password != null) return PasswordAuthentication(login, password.toCharArray())
     }
 
-    credentialsPerMachine[machine]?.let {
-        OrtAuthenticator.log.debug { "Found .netrc entry for $machine." }
-        return PasswordAuthentication(it.first, it.second.toCharArray())
-    }
-
-    return credentialsPerMachine["default"]?.let {
-        OrtAuthenticator.log.debug { "Using default .netrc entry for $machine." }
-        PasswordAuthentication(it.first, it.second.toCharArray())
-    }
+    return null
 }

--- a/utils/src/test/kotlin/OrtAuthenticatorTest.kt
+++ b/utils/src/test/kotlin/OrtAuthenticatorTest.kt
@@ -66,20 +66,6 @@ class OrtAuthenticatorTest : WordSpec({
             }
         }
 
-        "prefer machine-specific entries over the default" {
-            val authentication = getNetrcAuthentication("""
-                default login foo password bar
-                machine github.com
-                login git
-                password hub
-            """.trimIndent(), "github.com")
-
-            authentication shouldNotBeNull {
-                userName shouldBe "git"
-                password shouldBe "hub".toCharArray()
-            }
-        }
-
         "ignore superfluous statements" {
             val authentication = getNetrcAuthentication("""
                 machine "# A funky way to add comments."


### PR DESCRIPTION
This reverts commit c5c5c4f. As it turns out, the original
implementation to always use the first matching entry is exactly how the
Git CLI behaves. ORT aims to be compatible to the Git CLI to avoid confusion
when it is being used as a fallback for the JGit implementation.

But more importantly, after careful rereading of [1] and esp. [2], the
behavior seems to also be in line with the documentation: When saying "It
must be the last entry (after all machine entries); otherwise, entries
that follow it will be ignored" it is not supposed to mean that not
having the default entry last would be a syntax error, but that it
simply does not make sense, because all entries after a default entry
are irrelevant.

[1] https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html
[2] https://www.ibm.com/docs/en/aix/7.2?topic=formats-netrc-file-format-tcpip

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>