### PR TITLE
FreemarkerTemplateProcessor: Make hasUnresolved*() take a threshold

### DIFF
--- a/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
@@ -33,6 +33,7 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
@@ -300,21 +301,26 @@ class FreemarkerTemplateProcessor(
         fun isLicensePresent(license: ResolvedLicense): Boolean = SpdxConstants.isPresent(license.license.toString())
 
         /**
-         * Return `true` if there are any unresolved [OrtIssue]s, or `false` otherwise.
+         * Return `true` if there are any unresolved [OrtIssue]s whose severity is equal to or greater than the
+         * [threshold], or `false` otherwise.
          */
+        @JvmOverloads
         @Suppress("UNUSED") // This function is used in the templates.
-        fun hasUnresolvedIssues() =
+        fun hasUnresolvedIssues(threshold: Severity = Severity.HINT) =
             ortResult.collectIssues().values.flatten().any { issue ->
-                resolutionProvider.getIssueResolutionsFor(issue).isEmpty()
+                issue.severity >= threshold && resolutionProvider.getIssueResolutionsFor(issue).isEmpty()
             }
 
         /**
-         * Return `true` if there are any unresolved [RuleViolation]s, or `false` otherwise.
+         * Return `true` if there are any unresolved [RuleViolation]s whose severity is equal to or greater than the
+         * [threshold], or `false` otherwise.
          */
+        @JvmOverloads
         @Suppress("UNUSED") // This function is used in the templates.
-        fun hasUnresolvedRuleViolations() =
+        fun hasUnresolvedRuleViolations(threshold: Severity = Severity.HINT) =
             ortResult.evaluator?.violations?.any { violation ->
-                resolutionProvider.getRuleViolationResolutionsFor(violation).isEmpty()
+                violation.severity >= threshold && resolutionProvider.getRuleViolationResolutionsFor(violation)
+                    .isEmpty()
             } ?: false
 
         /**

--- a/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
@@ -288,7 +288,7 @@ class FreemarkerTemplateProcessor(
          * Return a list of [ResolvedLicense]s where all duplicate entries for a single license in [licenses] are
          * merged. The returned list is sorted by license identifier.
          */
-        // This function is used in the templates and needs to be public.
+        @Suppress("MemberVisibilityCanBePrivate") // This function is used in the templates.
         fun mergeResolvedLicenses(licenses: List<ResolvedLicense>): List<ResolvedLicense> =
             licenses.groupBy { it.license }
                 .map { (_, licenses) -> licenses.merge() }
@@ -297,7 +297,7 @@ class FreemarkerTemplateProcessor(
         /**
          * Return true if and only if the given [license] is not one of the special cases _NONE_ or _NOASSERTION_.
          */
-        @Suppress("WEAKER_ACCESS") // This function is used in the templates.
+        @Suppress("MemberVisibilityCanBePrivate") // This function is used in the templates.
         fun isLicensePresent(license: ResolvedLicense): Boolean = SpdxConstants.isPresent(license.license.toString())
 
         /**


### PR DESCRIPTION
This is useful to eventually ignore hints only.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>