### PR TITLE
Cargo: Map the license-file property to an unknown license

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/cargo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/cargo-expected-output.yml
@@ -7,9 +7,10 @@ project:
   - "anon"
   declared_licenses:
   - "Apache-2.0"
+  - "LicenseRef-ort-unknown-license-reference"
   - "MIT"
   declared_licenses_processed:
-    spdx_expression: "Apache-2.0 OR MIT"
+    spdx_expression: "Apache-2.0 OR LicenseRef-ort-unknown-license-reference OR MIT"
   vcs:
     type: ""
     url: ""
@@ -257,8 +258,10 @@ packages:
   purl: "pkg:cargo/fuchsia-cprng@0.1.1"
   authors:
   - "Erick Tryzelaar"
-  declared_licenses: []
-  declared_licenses_processed: {}
+  declared_licenses:
+  - "LicenseRef-ort-unknown-license-reference"
+  declared_licenses_processed:
+    spdx_expression: "LicenseRef-ort-unknown-license-reference"
   description: "Rust crate for the Fuchsia cryptographically secure pseudorandom number\
     \ generator"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/cargo/Cargo.toml
+++ b/analyzer/src/funTest/assets/projects/synthetic/cargo/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["anon <anon@example.org>", "Another Author", "<mail.only@example.org>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
+license-file = "LICENSE"
 homepage = "https://example.org"
 
 [dependencies]

--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -236,10 +236,21 @@ private fun checksumKeyOf(metadata: JsonNode): String {
 
 private fun extractCargoId(node: JsonNode) = node["id"].textValueOrEmpty()
 
-private fun extractDeclaredLicenses(node: JsonNode): SortedSet<String> =
-    node["license"].textValueOrEmpty().split('/')
+private fun extractDeclaredLicenses(node: JsonNode): SortedSet<String> {
+    val declaredLicenses = node["license"].textValueOrEmpty().split('/')
         .map { it.trim() }
         .filterTo(sortedSetOf()) { it.isNotEmpty() }
+
+    // Cargo allows to declare non-SPDX licenses only by referencing a license file. If a license file is specified, add
+    // an unknown declared license to indicate that there is a declared license but we cannot know which it is at this
+    // point.
+    // See: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields
+    if (node["license_file"].textValueOrEmpty().isNotBlank()) {
+        declaredLicenses += "LicenseRef-ort-unknown-license-reference"
+    }
+
+    return declaredLicenses
+}
 
 private fun processDeclaredLicenses(licenses: Set<String>): ProcessedDeclaredLicense =
     // While the previously used "/" was not explicit about the intended license operator, the community consensus


### PR DESCRIPTION
Cargo allows to declare non-SPDX licenses only by referencing a license
file. If the `license-file` property is used, map the value to
`LicenseRef-ort-unknown-license-reference` to indiciate that some
license is declared, instead of ignoring the property. This
implementation is similar to how the "SEE LICENSE IN ..." values are
handled in NPM.