### PR TITLE
GitRepo: Downgrade repo to 2.13.8

### DIFF
--- a/downloader/src/main/kotlin/vcs/GitRepo.kt
+++ b/downloader/src/main/kotlin/vcs/GitRepo.kt
@@ -46,7 +46,7 @@ import org.ossreviewtoolkit.utils.withoutPrefix
 /**
  * The branch of git-repo to use. This allows to override git-repo's default of using the "stable" branch.
  */
-private const val GIT_REPO_BRANCH = "stable"
+private const val GIT_REPO_BRANCH = "v2.13.8"
 
 /**
  * The minimal manifest structure as used by the wrapping "manifest.xml" file as of repo version 2.4. For the full


### PR DESCRIPTION
For all 2.14 releases of repo until the current stable release 2.14.2
running sync with the `--fetch-submodules` option fails, for example for
the project used in `GitRepoFunTest` with these errors:

```
$ repo sync -c --force-sync --fetch-submodules

Fetching: 100% (2/2), done in 4.304s
Garbage collecting: 100% (2/2), done in 0.004s
Fetching: 100% (2/2), done in 0.010s
Garbage collecting: 100% (2/2), done in 0.004s
error: submodules/commons-text/: Cannot checkout oss-review-toolkit/ort-test-data-git-submodules/commons-text due to missing network sync; Run `repo sync -n oss-review-toolkit/ort-test-data-git-submodules/commons-text` first.
error: Cannot checkout oss-review-toolkit/ort-test-data-git-submodules/commons-text
error: submodules/test-data-npm/: Cannot checkout oss-review-toolkit/ort-test-data-git-submodules/test-data-npm due to missing network sync; Run `repo sync -n oss-review-toolkit/ort-test-data-git-submodules/test-data-npm` first.
error: Cannot checkout oss-review-toolkit/ort-test-data-git-submodules/test-data-npm

error: Unable to fully sync the tree.
error: Checking out local projects failed.
Failing repos:
submodules/commons-text
submodules/test-data-npm
Try re-running with "-j1 --fail-fast" to exit at the first error.
```

This issue does not occur with version 2.13.8, and also not with the
current master branch. Therefore temporarily downgrade to 2.13.8 with
the hope that the next release works again.