### PR TITLE
postgresql: Use default schema if not defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ ort {
     storages {
       postgresStorage {
         url = "jdbc:postgresql://example.com:5444/database"
-        schema = "schema"
+        schema = "public"
         username = "username"
         password = "password"
         sslmode = "verify-full"
@@ -510,7 +510,9 @@ ort {
 }
 ```
 
-While the specified schema already needs to exist, the _scanner_ will itself create a table called `scan_results` and
+The database needs to exist. If the schema is set to something else than the default of `public`, it needs to exist and be accessible by the configured username.
+
+The _scanner_ will itself create a table called `scan_results` and
 store the data in a [jsonb](https://www.postgresql.org/docs/current/datatype-json.html) column.
 
 If you do not want to use SSL set the `sslmode` to `disable`, other possible values are explained in the

--- a/model/src/main/kotlin/config/ScanStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/ScanStorageConfiguration.kt
@@ -74,7 +74,7 @@ data class PostgresStorageConfiguration(
     /**
      * The name of the database to use.
      */
-    val schema: String,
+    val schema: String = "public",
 
     /**
      * The username to use for authentication.

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -54,7 +54,7 @@ ort {
 
       postgresStorage {
         url = "url"
-        schema = "schema"
+        schema = "public"
         username = "user"
         password = "password"
       }
@@ -100,7 +100,7 @@ ort {
 
       postgres {
         url = "jdbc:postgresql://your-postgresql-server:5444/your-database"
-        schema = schema
+        schema = "public"
         username = username
         password = password
         sslmode = "required"
@@ -108,7 +108,7 @@ ort {
         sslkey = "/defaultdir/postgresql.pk8"
         sslrootcert = "/defaultdir/root.crt"
       }
-      
+
       sw360Configuration {
         restUrl = "https://your-sw360-rest-url"
         authUrl = "https://your-authentication-url"

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -75,7 +75,7 @@ class OrtConfigurationTest : WordSpec({
 
                     postgresStorage shouldNotBeNull {
                         url shouldBe "url"
-                        schema shouldBe "schema"
+                        schema shouldBe "public"
                         username shouldBe "user"
                         password shouldBe "password"
                     }
@@ -101,7 +101,7 @@ class OrtConfigurationTest : WordSpec({
                     val postgresStorage = this["postgres"]
                     postgresStorage.shouldBeInstanceOf<PostgresStorageConfiguration>()
                     postgresStorage.url shouldBe "jdbc:postgresql://your-postgresql-server:5444/your-database"
-                    postgresStorage.schema shouldBe "schema"
+                    postgresStorage.schema shouldBe "public"
                     postgresStorage.username shouldBe "username"
                     postgresStorage.password shouldBe "password"
                     postgresStorage.sslmode shouldBe "required"
@@ -146,7 +146,7 @@ class OrtConfigurationTest : WordSpec({
                     storages {
                       postgresStorage {
                         url = "postgresql://your-postgresql-server:5444/your-database"
-                        schema = schema
+                        schema = "public"
                         username = username
                         password = password
                       }
@@ -222,7 +222,7 @@ class OrtConfigurationTest : WordSpec({
                     storages {
                       postgresStorage {
                         url = "postgresql://your-postgresql-server:5444/your-database"
-                        schema = schema
+                        schema = "public"
                         username = ${'$'}{POSTGRES_USERNAME}
                         password = ${'$'}{POSTGRES_PASSWORD}
                       }
@@ -251,7 +251,7 @@ class OrtConfigurationTest : WordSpec({
             val user = "user"
             val password = "password"
             val url = "url"
-            val schema = "schema"
+            val schema = "public"
             val env = mapOf(
                 "ort.scanner.storages.postgresStorage.username" to user,
                 "ort.scanner.storages.postgresStorage.url" to url,


### PR DESCRIPTION
schema now is not required and always fallback on postgresql default
public schema.
Custom schemas need to be created and granted previously on database

Signed-off-by: Helio Chissini de Castro <helio@kde.org>

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/ort/blob/master/CONTRIBUTING.md). Thank you!
