### PR TITLE
fossid-webapp: Change some extension functions return type

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/Extensions.kt
+++ b/clients/fossid-webapp/src/main/kotlin/Extensions.kt
@@ -23,6 +23,8 @@ package org.ossreviewtoolkit.clients.fossid
 
 import com.fasterxml.jackson.module.kotlin.convertValue
 
+import org.ossreviewtoolkit.clients.fossid.model.Scan
+
 private const val SCAN_GROUP = "scans"
 private const val PROJECT_GROUP = "projects"
 
@@ -76,10 +78,12 @@ suspend fun FossIdRestService.getProject(user: String, apiKey: String, projectCo
  *
  * The HTTP request is sent with [user] and [apiKey] as credentials.
  */
-suspend fun FossIdRestService.listScansForProject(user: String, apiKey: String, projectCode: String) =
-    listScansForProject(
-        PostRequestBody("get_all_scans", PROJECT_GROUP, user, apiKey, "project_code" to projectCode)
-    )
+suspend fun FossIdRestService.listScansForProject(user: String, apiKey: String, projectCode: String): List<Scan> {
+    val body = PostRequestBody("get_all_scans", PROJECT_GROUP, user, apiKey, "project_code" to projectCode)
+    return listScansForProject(body)
+        .checkResponse("list scans")
+        .toList()
+}
 
 /**
  * Create a new project with the given [projectCode], [projectName] and optional [comment].

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
@@ -44,7 +44,6 @@ import org.ossreviewtoolkit.clients.fossid.listMarkedAsIdentifiedFiles
 import org.ossreviewtoolkit.clients.fossid.listPendingFiles
 import org.ossreviewtoolkit.clients.fossid.listScanResults
 import org.ossreviewtoolkit.clients.fossid.listScansForProject
-import org.ossreviewtoolkit.clients.fossid.model.Scan
 import org.ossreviewtoolkit.clients.fossid.model.identification.identifiedFiles.IdentifiedFile
 import org.ossreviewtoolkit.clients.fossid.model.identification.ignored.IgnoredFile
 import org.ossreviewtoolkit.clients.fossid.model.identification.markedAsIdentified.MarkedAsIdentifiedFile
@@ -106,10 +105,7 @@ class FossIdClientNewProjectTest : StringSpec({
     }
 
     "Scans for project can be listed when there is no scan" {
-        service.listScansForProject("", "", PROJECT_CODE) shouldNotBeNull {
-            checkResponse("list scans")
-            toList<Scan>() should beEmpty()
-        }
+        service.listScansForProject("", "", PROJECT_CODE) should beEmpty()
     }
 
     "Scan can be created" {

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
@@ -15,7 +15,6 @@ import org.ossreviewtoolkit.clients.fossid.listMarkedAsIdentifiedFiles
 import org.ossreviewtoolkit.clients.fossid.listPendingFiles
 import org.ossreviewtoolkit.clients.fossid.listScanResults
 import org.ossreviewtoolkit.clients.fossid.listScansForProject
-import org.ossreviewtoolkit.clients.fossid.model.Scan
 import org.ossreviewtoolkit.clients.fossid.model.identification.identifiedFiles.IdentifiedFile
 import org.ossreviewtoolkit.clients.fossid.model.identification.ignored.IgnoredFile
 import org.ossreviewtoolkit.clients.fossid.model.identification.markedAsIdentified.MarkedAsIdentifiedFile
@@ -79,17 +78,11 @@ class FossIdClientReturnTypeTest : StringSpec({
     }
 
     "Scans for project can be listed when there is none" {
-        service.listScansForProject("", "", PROJECT_CODE_1) shouldNotBeNull {
-            checkResponse("list scans")
-            toList<Scan>() should beEmpty()
-        }
+        service.listScansForProject("", "", PROJECT_CODE_1) should beEmpty()
     }
 
     "Scans for project can be listed when there is some" {
-        service.listScansForProject("", "", PROJECT_CODE_2) shouldNotBeNull {
-            checkResponse("list scans")
-            toList<Scan>() shouldNot beEmpty()
-        }
+        service.listScansForProject("", "", PROJECT_CODE_2) shouldNot beEmpty()
     }
 
     "Scan results can be listed when there is none" {


### PR DESCRIPTION
As explained in the toList function, the FossID server is not
consistent. It usually returns a List or a Map, but if there is no
entry, it returns data:false.
The toList function abstracts this behaviour, but we nevertheless need
a Kotlin representation that could be all these types at once, to be
able to deserialize them from JSON.
That's why we are forced to use EntityPostResponseBody<Any> in
several functions. However such generic placeholder is not nice for
API users. Therefore this commit changes the return type of the
extension functions and inline the toList call.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>
