### PR TITLE
AbstractStorageFunTest Improvements

### DIFF
--- a/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
@@ -84,17 +84,15 @@ abstract class AbstractStorageFunTest : WordSpec() {
 
     private val pkgWithoutRevision = pkg1.copy(vcs = vcsWithoutRevision, vcsProcessed = vcsWithoutRevision.normalize())
 
-    private val provenanceWithSourceArtifact1 = ArtifactProvenance(sourceArtifact = sourceArtifact1)
-    private val provenanceWithVcsInfo1 = RepositoryProvenance(vcsInfo = vcs1)
-
-    private val provenanceWithSourceArtifact2 = ArtifactProvenance(sourceArtifact = sourceArtifact2)
-    private val provenanceWithVcsInfo2 = RepositoryProvenance(vcsInfo = vcs2)
-
+    private val provenanceEmpty = UnknownProvenance
     private val provenanceWithOriginalVcsInfo = RepositoryProvenance(
         vcsInfo = vcs1,
         originalVcsInfo = pkgWithoutRevision.vcsProcessed
     )
-    private val provenanceEmpty = UnknownProvenance
+    private val provenanceWithSourceArtifact1 = ArtifactProvenance(sourceArtifact = sourceArtifact1)
+    private val provenanceWithSourceArtifact2 = ArtifactProvenance(sourceArtifact = sourceArtifact2)
+    private val provenanceWithVcsInfo1 = RepositoryProvenance(vcsInfo = vcs1)
+    private val provenanceWithVcsInfo2 = RepositoryProvenance(vcsInfo = vcs2)
 
     private val scannerDetails1 = ScannerDetails("name 1", "1.0.0", "config 1")
     private val scannerDetails2 = ScannerDetails("name 2", "2.0.0", "config 2")

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
@@ -85,8 +85,8 @@ abstract class AbstractStorageFunTest : WordSpec() {
     private val pkgWithoutRevision = pkg1.copy(vcs = vcsWithoutRevision, vcsProcessed = vcsWithoutRevision.normalize())
 
     private val provenanceEmpty = UnknownProvenance
-    private val provenanceWithOriginalVcsInfo = RepositoryProvenance(
-        vcsInfo = vcs1,
+    private val provenanceWithoutRevision = RepositoryProvenance(
+        vcsInfo = pkgWithoutRevision.vcsProcessed.copy(resolvedRevision = "resolvedRevision"),
         originalVcsInfo = pkgWithoutRevision.vcsProcessed
     )
     private val provenanceWithSourceArtifact1 = ArtifactProvenance(sourceArtifact = sourceArtifact1)
@@ -312,8 +312,8 @@ abstract class AbstractStorageFunTest : WordSpec() {
                 )
             }
 
-            "find a scan result if the revision was detected from a version" {
-                val scanResult = ScanResult(provenanceWithOriginalVcsInfo, scannerDetails1, scanSummaryWithFiles)
+            "find a scan result if the revision was resolved from a version" {
+                val scanResult = ScanResult(provenanceWithoutRevision, scannerDetails1, scanSummaryWithFiles)
 
                 storage.add(id1, scanResult) should beSuccess()
                 val readResult = storage.read(pkgWithoutRevision, criteriaForDetails(scannerDetails1))
@@ -547,8 +547,8 @@ abstract class AbstractStorageFunTest : WordSpec() {
                 }
             }
 
-            "find a scan result if the revision was detected from a version" {
-                val scanResult = ScanResult(provenanceWithOriginalVcsInfo, scannerDetails1, scanSummaryWithFiles)
+            "find a scan result if the revision was resolved from a version" {
+                val scanResult = ScanResult(provenanceWithoutRevision, scannerDetails1, scanSummaryWithFiles)
 
                 val addResult = storage.add(id1, scanResult)
                 val readResult = storage.read(listOf(pkgWithoutRevision), criteriaForDetails(scannerDetails1))

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
@@ -71,14 +71,14 @@ abstract class AbstractStorageFunTest : WordSpec() {
     private val pkg1 = Package.EMPTY.copy(
         id = id1,
         sourceArtifact = sourceArtifact1,
-        vcs = vcs1,
+        vcs = vcs1.copy(resolvedRevision = null),
         vcsProcessed = vcs1.normalize()
     )
 
     private val pkg2 = Package.EMPTY.copy(
         id = id2,
         sourceArtifact = sourceArtifact2,
-        vcs = vcs2,
+        vcs = vcs2.copy(resolvedRevision = null),
         vcsProcessed = vcs2.normalize()
     )
 

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
@@ -55,11 +55,9 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.scanner.ScannerCriteria
 
-abstract class AbstractStorageFunTest : WordSpec() {
-    private companion object {
-        val DUMMY_TEXT_LOCATION = TextLocation("fakepath", 13, 21)
-    }
+private val DUMMY_TEXT_LOCATION = TextLocation("fakepath", 13, 21)
 
+abstract class AbstractStorageFunTest : WordSpec() {
     private val id1 = Identifier("type", "namespace", "name1", "version")
     private val id2 = Identifier("type", "namespace", "name2", "version")
 

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
@@ -24,6 +24,7 @@ import com.vdurmont.semver4j.Semver
 
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.test.TestCase
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
@@ -136,6 +137,13 @@ abstract class AbstractStorageFunTest : WordSpec() {
         mutableListOf()
     )
 
+    private lateinit var storage: ScanResultsStorage
+
+    override fun beforeTest(testCase: TestCase) {
+        super.beforeTest(testCase)
+        storage = createStorage()
+    }
+
     abstract fun createStorage(): ScanResultsStorage
 
     /**
@@ -152,7 +160,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
     init {
         "Adding a scan result" should {
             "succeed for a valid scan result" {
-                val storage = createStorage()
                 val scanResult = ScanResult(provenanceWithSourceArtifact1, scannerDetails1, scanSummaryWithFiles)
 
                 val addResult = storage.add(id1, scanResult)
@@ -164,7 +171,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
             }
 
             "fail if the fileCount is 0" {
-                val storage = createStorage()
                 val scanResult = ScanResult(provenanceWithSourceArtifact1, scannerDetails1, scanSummaryWithoutFiles)
 
                 val addResult = storage.add(id1, scanResult)
@@ -178,7 +184,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
             }
 
             "fail if provenance information is missing" {
-                val storage = createStorage()
                 val scanResult = ScanResult(provenanceEmpty, scannerDetails1, scanSummaryWithFiles)
 
                 val addResult = storage.add(id1, scanResult)
@@ -194,7 +199,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
 
         "Reading a scan result" should {
             "find all scan results for an id" {
-                val storage = createStorage()
                 val scanResult1 = ScanResult(provenanceWithSourceArtifact1, scannerDetails1, scanSummaryWithFiles)
                 val scanResult2 = ScanResult(provenanceWithSourceArtifact1, scannerDetails2, scanSummaryWithFiles)
 
@@ -207,7 +211,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
             }
 
             "find all scan results for a specific scanner" {
-                val storage = createStorage()
                 val scanResult1 = ScanResult(provenanceWithSourceArtifact1, scannerDetails1, scanSummaryWithFiles)
                 val scanResult2 = ScanResult(provenanceWithVcsInfo1, scannerDetails1, scanSummaryWithFiles)
                 val scanResult3 = ScanResult(provenanceWithSourceArtifact1, scannerDetails2, scanSummaryWithFiles)
@@ -222,7 +225,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
             }
 
             "find all scan results for scanners with names matching a pattern" {
-                val storage = createStorage()
                 val detailsCompatibleOtherScanner = scannerDetails1.copy(name = "name 2")
                 val detailsIncompatibleOtherScanner = scannerDetails1.copy(name = "other Scanner name")
                 val scanResult1 = ScanResult(provenanceWithSourceArtifact1, scannerDetails1, scanSummaryWithFiles)
@@ -242,7 +244,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
             }
 
             "find all scan results for compatible scanners" {
-                val storage = createStorage()
                 val scanResult = ScanResult(provenanceWithSourceArtifact1, scannerDetails1, scanSummaryWithFiles)
                 val scanResultCompatible1 =
                     ScanResult(provenanceWithSourceArtifact1, scannerDetailsCompatibleVersion1, scanSummaryWithFiles)
@@ -269,7 +270,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
             }
 
             "find all scan results for a scanner in a version range" {
-                val storage = createStorage()
                 val scanResult = ScanResult(provenanceWithSourceArtifact1, scannerDetails1, scanSummaryWithFiles)
                 val scanResultCompatible1 =
                     ScanResult(provenanceWithSourceArtifact1, scannerDetailsCompatibleVersion1, scanSummaryWithFiles)
@@ -295,7 +295,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
             }
 
             "find only packages with matching provenance" {
-                val storage = createStorage()
                 val scanResultSourceArtifactMatching =
                     ScanResult(provenanceWithSourceArtifact1, scannerDetails1, scanSummaryWithFiles)
                 val scanResultVcsMatching = ScanResult(provenanceWithVcsInfo1, scannerDetails1, scanSummaryWithFiles)
@@ -326,7 +325,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
             }
 
             "find a scan result if the revision was detected from a version" {
-                val storage = createStorage()
                 val scanResult = ScanResult(provenanceWithOriginalVcsInfo, scannerDetails1, scanSummaryWithFiles)
 
                 storage.add(id1, scanResult) should beSuccess()
@@ -339,7 +337,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
 
         "Reading scan results for multiple packages" should {
             "find all scan results for a specific scanner" {
-                val storage = createStorage()
                 val scanResult1 = ScanResult(provenanceWithSourceArtifact1, scannerDetails1, scanSummaryWithFiles)
                 val scanResult2 = ScanResult(provenanceWithVcsInfo1, scannerDetails1, scanSummaryWithFiles)
                 val scanResult3 = ScanResult(provenanceWithSourceArtifact1, scannerDetails2, scanSummaryWithFiles)
@@ -367,7 +364,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
             }
 
             "find all scan results for scanners with names matching a pattern" {
-                val storage = createStorage()
                 val detailsCompatibleOtherScanner = scannerDetails1.copy(name = "name 2")
                 val detailsIncompatibleOtherScanner = scannerDetails1.copy(name = "other Scanner name")
                 val scanResult1 = ScanResult(provenanceWithSourceArtifact1, scannerDetails1, scanSummaryWithFiles)
@@ -402,8 +398,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
             }
 
             "find all scan results for compatible scanners" {
-                val storage = createStorage()
-
                 val scanResult1 = ScanResult(provenanceWithSourceArtifact1, scannerDetails1, scanSummaryWithFiles)
                 val scanResult1Compatible1 =
                     ScanResult(provenanceWithSourceArtifact1, scannerDetailsCompatibleVersion1, scanSummaryWithFiles)
@@ -452,8 +446,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
             }
 
             "find all scan results for a scanner in a version range" {
-                val storage = createStorage()
-
                 val scanResult1 = ScanResult(provenanceWithSourceArtifact1, scannerDetails1, scanSummaryWithFiles)
                 val scanResult1Compatible1 =
                     ScanResult(provenanceWithSourceArtifact1, scannerDetailsCompatibleVersion1, scanSummaryWithFiles)
@@ -506,8 +498,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
             }
 
             "find only packages with matching provenance" {
-                val storage = createStorage()
-
                 val scanResultSourceArtifactMatching1 =
                     ScanResult(provenanceWithSourceArtifact1, scannerDetails1, scanSummaryWithFiles)
                 val scanResultVcsMatching1 = ScanResult(provenanceWithVcsInfo1, scannerDetails1, scanSummaryWithFiles)
@@ -570,7 +560,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
             }
 
             "find a scan result if the revision was detected from a version" {
-                val storage = createStorage()
                 val scanResult = ScanResult(provenanceWithOriginalVcsInfo, scannerDetails1, scanSummaryWithFiles)
 
                 val addResult = storage.add(id1, scanResult)

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
@@ -86,9 +86,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
 
     private val pkgWithoutRevision = pkg1.copy(vcs = vcsWithoutRevision, vcsProcessed = vcsWithoutRevision.normalize())
 
-    private val downloadTime1 = Instant.EPOCH + Duration.ofDays(1)
-    private val downloadTime2 = Instant.EPOCH + Duration.ofDays(2)
-
     private val provenanceWithSourceArtifact1 = ArtifactProvenance(sourceArtifact = sourceArtifact1)
     private val provenanceWithVcsInfo1 = RepositoryProvenance(vcsInfo = vcs1)
 
@@ -107,14 +104,9 @@ abstract class AbstractStorageFunTest : WordSpec() {
     private val scannerDetailsCompatibleVersion2 = ScannerDetails("name 1", "1.0.1-alpha.1", "config 1")
     private val scannerDetailsIncompatibleVersion = ScannerDetails("name 1", "1.1.0", "config 1")
 
-    private val scannerStartTime1 = downloadTime1 + Duration.ofMinutes(1)
-    private val scannerEndTime1 = scannerStartTime1 + Duration.ofMinutes(1)
-    private val scannerStartTime2 = downloadTime2 + Duration.ofMinutes(1)
-    private val scannerEndTime2 = scannerStartTime2 + Duration.ofMinutes(1)
-
     private val scanSummaryWithFiles = ScanSummary(
-        startTime = scannerStartTime1,
-        endTime = scannerEndTime1,
+        startTime = Instant.EPOCH + Duration.ofMinutes(1),
+        endTime = Instant.EPOCH + Duration.ofMinutes(2),
         fileCount = 1,
         packageVerificationCode = "packageVerificationCode",
         licenseFindings = sortedSetOf(
@@ -128,8 +120,8 @@ abstract class AbstractStorageFunTest : WordSpec() {
         )
     )
     private val scanSummaryWithoutFiles = ScanSummary(
-        startTime = scannerStartTime2,
-        endTime = scannerEndTime2,
+        startTime = Instant.EPOCH + Duration.ofMinutes(3),
+        endTime = Instant.EPOCH + Duration.ofMinutes(4),
         fileCount = 0,
         packageVerificationCode = "packageVerificationCode",
         licenseFindings = sortedSetOf(),

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
@@ -116,25 +116,25 @@ abstract class AbstractStorageFunTest : WordSpec() {
     private val error2 = OrtIssue(source = "source-2", message = "error-2")
 
     private val scanSummaryWithFiles = ScanSummary(
-        scannerStartTime1,
-        scannerEndTime1,
-        1,
-        "packageVerificationCode",
-        sortedSetOf(
+        startTime = scannerStartTime1,
+        endTime = scannerEndTime1,
+        fileCount = 1,
+        packageVerificationCode = "packageVerificationCode",
+        licenseFindings = sortedSetOf(
             LicenseFinding("license-1.1", DUMMY_TEXT_LOCATION),
             LicenseFinding("license-1.2", DUMMY_TEXT_LOCATION)
         ),
-        sortedSetOf(),
-        mutableListOf(error1, error2)
+        copyrightFindings = sortedSetOf(),
+        issues = mutableListOf(error1, error2)
     )
     private val scanSummaryWithoutFiles = ScanSummary(
-        scannerStartTime2,
-        scannerEndTime2,
-        0,
-        "packageVerificationCode",
-        sortedSetOf(),
-        sortedSetOf(),
-        mutableListOf()
+        startTime = scannerStartTime2,
+        endTime = scannerEndTime2,
+        fileCount = 0,
+        packageVerificationCode = "packageVerificationCode",
+        licenseFindings = sortedSetOf(),
+        copyrightFindings = sortedSetOf(),
+        issues = mutableListOf()
     )
 
     private lateinit var storage: ScanResultsStorage

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
@@ -112,9 +112,6 @@ abstract class AbstractStorageFunTest : WordSpec() {
     private val scannerStartTime2 = downloadTime2 + Duration.ofMinutes(1)
     private val scannerEndTime2 = scannerStartTime2 + Duration.ofMinutes(1)
 
-    private val error1 = OrtIssue(source = "source-1", message = "error-1")
-    private val error2 = OrtIssue(source = "source-2", message = "error-2")
-
     private val scanSummaryWithFiles = ScanSummary(
         startTime = scannerStartTime1,
         endTime = scannerEndTime1,
@@ -125,7 +122,10 @@ abstract class AbstractStorageFunTest : WordSpec() {
             LicenseFinding("license-1.2", DUMMY_TEXT_LOCATION)
         ),
         copyrightFindings = sortedSetOf(),
-        issues = mutableListOf(error1, error2)
+        issues = mutableListOf(
+            OrtIssue(source = "source-1", message = "error-1"),
+            OrtIssue(source = "source-2", message = "error-2")
+        )
     )
     private val scanSummaryWithoutFiles = ScanSummary(
         startTime = scannerStartTime2,


### PR DESCRIPTION
The main goal of this PR is to prepare for the removal of `RepositoryProvenance.originalVcsInfo`.
Therefore two setups of two test cases which deal with that `originalVcsInfo` are improved.
These preparations can be found in the top-most two commits.

All other commits below are miscellaneous improvements to the code.
