### PR TITLE
flutter: update version to v2.0.6

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -75,7 +75,7 @@ private const val GRADLE_VERSION = "5.6.4"
 private const val PUB_LOCK_FILE = "pubspec.lock"
 
 private val flutterCommand = if (Os.isWindows) "flutter.bat" else "flutter"
-private val pubCommand = if (Os.isWindows) "pub.bat" else "pub"
+private val pubCommand = if (Os.isWindows) "pub.bat" else "dart pub"
 
 private val flutterVersion = Os.env["FLUTTER_VERSION"] ?: "2.0.6-stable"
 private val flutterInstallDir = "$ortToolsDirectory/flutter-$flutterVersion"

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -77,7 +77,7 @@ private const val PUB_LOCK_FILE = "pubspec.lock"
 private val flutterCommand = if (Os.isWindows) "flutter.bat" else "flutter"
 private val pubCommand = if (Os.isWindows) "pub.bat" else "pub"
 
-private val flutterVersion = Os.env["FLUTTER_VERSION"] ?: "v1.12.13+hotfix.9-stable"
+private val flutterVersion = Os.env["FLUTTER_VERSION"] ?: "2.0.6-stable"
 private val flutterInstallDir = "$ortToolsDirectory/flutter-$flutterVersion"
 
 private val flutterHome by lazy {


### PR DESCRIPTION
Signed-off-by: Jeroen Knoops <jeroen.knoops@gmail.com>

- Update version of default flutter to 2.0.6
- Change call to `pub` to `dart pub` resolving the error below.

## Error running `pub`
```
06:31:07.727 [DefaultDispatcher-worker-2] ERROR org.ossreviewtoolkit.analyzer.managers.Pub - Resolving dependencies for 'pubspec.yaml' failed with: IOException: Cannot run program "pub"
```
