### PR TITLE
LocalScanner: Name temporary directories also after the provenance

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -320,7 +320,7 @@ abstract class LocalScanner(
 
         try {
             missingArchives.forEach { (pkg, provenance) ->
-                val downloadDirectory = tempDirectory.resolve(pkg.id.toPath())
+                val downloadDirectory = tempDirectory.resolve(pkg.id.toPath()).resolve(provenance.javaClass.simpleName)
                 val downloadProvenance = Downloader(downloaderConfig).download(pkg, downloadDirectory)
 
                 if (downloadProvenance == provenance) {


### PR DESCRIPTION
Esp. when having reconfigured the sourceCodeOrigins, it can happen that
the stored scan results contain multiple results for the same package
with different provenance. If also createMissingArchives is enabled,
this could have led to name clashes in the created temporary
directories. Solve that by adding another directory level that is named
after the provenance.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>