### PR TITLE
getPathFromEnvironment: Support basic expansion of nested environment variables

### DIFF
--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -172,14 +172,28 @@ fun getCommonFileParent(files: Collection<File>): File? =
  * Return the full path to the given executable file if it is in the system's PATH environment, or null otherwise.
  */
 fun getPathFromEnvironment(executable: String): File? {
+    fun String.expandVariable(referencePattern: Regex, groupName: String): String =
+        replace(referencePattern) {
+            val variableName = it.groups[groupName]!!.value
+            Os.env[variableName] ?: variableName
+        }
+
     val paths = Os.env["PATH"]?.splitToSequence(File.pathSeparatorChar).orEmpty()
 
     return if (Os.isWindows) {
+        val referencePattern = Regex("%(?<reference>\\w+)%")
+
         paths.mapNotNull { path ->
-            resolveWindowsExecutable(File(path, executable))
+            val expandedPath = path.expandVariable(referencePattern, "reference")
+            resolveWindowsExecutable(File(expandedPath, executable))
         }.firstOrNull()
     } else {
-        paths.map { path -> File(path, executable) }.find { it.isFile }
+        val referencePattern = Regex("\\$\\{?(?<reference>\\w+)}?")
+
+        paths.map { path ->
+            val expandedPath = path.expandVariable(referencePattern, "reference")
+            File(expandedPath, executable)
+        }.find { it.isFile }
     }
 }
 


### PR DESCRIPTION
For simplicity, only support word-like characters in environment
variables names to be expanded. While on specific OSes also other
characters are valid as part of environment variable names (including
e.g. "\0"), these are edge-cases that should barely occur in reality,
and if so, it is probably not good practice anyway.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>