### PR TITLE
GoMod: Extract the revision from versions in "pseudo version" format

### DIFF
--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -189,7 +189,7 @@ class GoMod(
             VcsInfo(
                 type = VcsType.GIT,
                 url = "https://${id.name.removeSuffix("/")}.git",
-                revision = id.version
+                revision = getRevision(id.version)
             )
         } else {
             VcsInfo.EMPTY
@@ -285,4 +285,15 @@ private fun Collection<Edge>.toPackageReferenceForest(
     }
 
     return nodes.values.filter { it.incomingEdges.isEmpty() }.map { getPackageReference(it.id) }.toSortedSet()
+}
+
+// See https://golang.org/ref/mod#pseudo-versions.
+private val PSEUDO_VERSION_REGEX = "^v0.0.0-(?:[\\d]{14}-(?<sha1>[0-9a-f]+)$)".toRegex()
+
+internal fun getRevision(version: String): String {
+    PSEUDO_VERSION_REGEX.find(version)?.let { matchResult ->
+        return matchResult.groups["sha1"]!!.value
+    }
+
+    return version
 }

--- a/analyzer/src/test/kotlin/managers/GoModTest.kt
+++ b/analyzer/src/test/kotlin/managers/GoModTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+class GoModTest : WordSpec({
+    "getVersion" should {
+        "return the SHA1 from a 'pseudo version'" {
+            // See https://golang.org/ref/mod#pseudo-versions.
+            val version = "v0.0.0-20191109021931-daa7c04131f5"
+
+            getRevision(version) shouldBe "daa7c04131f5"
+        }
+    }
+})


### PR DESCRIPTION
See https://golang.org/ref/mod#pseudo-versions.