### PR TITLE
GoMod: Fix determining the VCS info for packages from mono repos

### DIFF
--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -184,18 +184,8 @@ class GoMod(
         return result
     }
 
-    private fun createPackage(id: Identifier): Package {
-        val vcsFromId = if (id.name.startsWith("github.com")) {
-            VcsInfo(
-                type = VcsType.GIT,
-                url = "https://${id.name.removeSuffix("/")}.git",
-                revision = getRevision(id.version)
-            )
-        } else {
-            VcsInfo.EMPTY
-        }
-
-        return Package(
+    private fun createPackage(id: Identifier): Package =
+        Package(
             id = Identifier(managerName, "", id.name, id.version),
             authors = sortedSetOf(), // Go mod doesn't support author information.
             declaredLicenses = sortedSetOf(), // Go mod doesn't support declared licenses.
@@ -203,9 +193,8 @@ class GoMod(
             homepageUrl = "",
             binaryArtifact = RemoteArtifact.EMPTY,
             sourceArtifact = getSourceArtifactForPackage(id),
-            vcs = vcsFromId
+            vcs = id.toVcsInfo()
         )
-    }
 
     private fun getSourceArtifactForPackage(id: Identifier): RemoteArtifact {
         /**
@@ -297,3 +286,14 @@ internal fun getRevision(version: String): String {
 
     return version
 }
+
+internal fun Identifier.toVcsInfo(): VcsInfo =
+    if (name.startsWith("github.com")) {
+        VcsInfo(
+            type = VcsType.GIT,
+            url = "https://${name.removeSuffix("/")}.git",
+            revision = getRevision(version)
+        )
+    } else {
+        VcsInfo.EMPTY
+    }

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -279,7 +279,7 @@ private fun Collection<Edge>.toPackageReferenceForest(
 // See https://golang.org/ref/mod#pseudo-versions.
 private val PSEUDO_VERSION_REGEX = "^v0.0.0-(?:[\\d]{14}-(?<sha1>[0-9a-f]+)$)".toRegex()
 
-internal fun getRevision(version: String): String {
+private fun getRevision(version: String): String {
     PSEUDO_VERSION_REGEX.find(version)?.let { matchResult ->
         return matchResult.groups["sha1"]!!.value
     }

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -24,6 +24,7 @@ import java.util.SortedSet
 
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
+import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
@@ -35,7 +36,6 @@ import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.VcsInfo
-import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.CommandLineTool
@@ -289,11 +289,10 @@ internal fun getRevision(version: String): String {
 
 internal fun Identifier.toVcsInfo(): VcsInfo =
     if (name.startsWith("github.com")) {
-        VcsInfo(
-            type = VcsType.GIT,
-            url = "https://${name.removeSuffix("/")}.git",
-            revision = getRevision(version)
-        )
+        val projectUrl = "https://${name.removeSuffix("/")}"
+        val vcsInfo = VcsHost.toVcsInfo(projectUrl)
+
+        vcsInfo.copy(revision = getRevision(version))
     } else {
         VcsInfo.EMPTY
     }

--- a/analyzer/src/test/kotlin/managers/GoModTest.kt
+++ b/analyzer/src/test/kotlin/managers/GoModTest.kt
@@ -44,13 +44,12 @@ class GoModTest : WordSpec({
             }
         }
 
-        "return the VCS URL and path for a package from a mono repository".config(enabled = false) {
+        "return the VCS URL and path for a package from a mono repository" {
             val id = Identifier("GoMod::github.com/Azure/go-autorest/autorest/date:v0.1.0")
 
-            // FIXME: The url should actually be https://github.com/Azure/go-autorest.git.
             with(id.toVcsInfo()) {
-                path shouldBe ""
-                url shouldBe "https://github.com/Azure/go-autorest/autorest/date.git"
+                path shouldBe "autorest/date"
+                url shouldBe "https://github.com/Azure/go-autorest.git"
             }
         }
     }

--- a/analyzer/src/test/kotlin/managers/GoModTest.kt
+++ b/analyzer/src/test/kotlin/managers/GoModTest.kt
@@ -22,6 +22,8 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
+import org.ossreviewtoolkit.model.Identifier
+
 class GoModTest : WordSpec({
     "getVersion" should {
         "return the SHA1 from a 'pseudo version'" {
@@ -29,6 +31,17 @@ class GoModTest : WordSpec({
             val version = "v0.0.0-20191109021931-daa7c04131f5"
 
             getRevision(version) shouldBe "daa7c04131f5"
+        }
+    }
+
+    "toVcsInfo" should {
+        "return the VCS URL and path for a package from a single module repository" {
+            val id = Identifier("GoMod::github.com/chai2010/gettext-go:v1.0.0")
+
+            with(id.toVcsInfo()) {
+                path shouldBe ""
+                url shouldBe "https://github.com/chai2010/gettext-go.git"
+            }
         }
     }
 })

--- a/analyzer/src/test/kotlin/managers/GoModTest.kt
+++ b/analyzer/src/test/kotlin/managers/GoModTest.kt
@@ -23,6 +23,7 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.VcsType
 
 class GoModTest : WordSpec({
     "getVersion" should {
@@ -35,6 +36,18 @@ class GoModTest : WordSpec({
     }
 
     "toVcsInfo" should {
+        "return the VCS type 'Git'" {
+            val id = Identifier("GoMod::github.com/chai2010/gettext-go:v1.0.0")
+
+            id.toVcsInfo().type shouldBe VcsType.GIT
+        }
+
+        "return null as resolved revision" {
+            val id = Identifier("GoMod::github.com/chai2010/gettext-go:v1.0.0")
+
+            id.toVcsInfo().resolvedRevision shouldBe null
+        }
+
         "return the VCS URL and path for a package from a single module repository" {
             val id = Identifier("GoMod::github.com/chai2010/gettext-go:v1.0.0")
 

--- a/analyzer/src/test/kotlin/managers/GoModTest.kt
+++ b/analyzer/src/test/kotlin/managers/GoModTest.kt
@@ -43,5 +43,15 @@ class GoModTest : WordSpec({
                 url shouldBe "https://github.com/chai2010/gettext-go.git"
             }
         }
+
+        "return the VCS URL and path for a package from a mono repository".config(enabled = false) {
+            val id = Identifier("GoMod::github.com/Azure/go-autorest/autorest/date:v0.1.0")
+
+            // FIXME: The url should actually be https://github.com/Azure/go-autorest.git.
+            with(id.toVcsInfo()) {
+                path shouldBe ""
+                url shouldBe "https://github.com/Azure/go-autorest/autorest/date.git"
+            }
+        }
     }
 })

--- a/analyzer/src/test/kotlin/managers/GoModTest.kt
+++ b/analyzer/src/test/kotlin/managers/GoModTest.kt
@@ -26,15 +26,6 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.VcsType
 
 class GoModTest : WordSpec({
-    "getVersion" should {
-        "return the SHA1 from a 'pseudo version'" {
-            // See https://golang.org/ref/mod#pseudo-versions.
-            val version = "v0.0.0-20191109021931-daa7c04131f5"
-
-            getRevision(version) shouldBe "daa7c04131f5"
-        }
-    }
-
     "toVcsInfo" should {
         "return the VCS type 'Git'" {
             val id = Identifier("GoMod::github.com/chai2010/gettext-go:v1.0.0")
@@ -64,6 +55,13 @@ class GoModTest : WordSpec({
                 path shouldBe "autorest/date"
                 url shouldBe "https://github.com/Azure/go-autorest.git"
             }
+        }
+
+        "return the SHA1 from a 'pseudo version'" {
+            // See https://golang.org/ref/mod#pseudo-versions.
+            val id = Identifier("GoMod::github.com/Azure/go-autorest/autorest/date:v0.0.0-20191109021931-daa7c04131f5")
+
+            id.toVcsInfo().revision shouldBe "daa7c04131f5"
         }
     }
 })


### PR DESCRIPTION
Properly determine VCS URL and path if the package resides in a subdirectory of the Git repository.