### PR TITLE
Support some GoMod style Git tag format for guessing revisions

### DIFF
--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -261,10 +261,22 @@ abstract class VersionControlSystem {
                 false
             }
 
-        if (!addGuessedRevision(pkg.id.name, pkg.id.version) && pkg.id.type == "NPM" && pkg.id.namespace.isNotEmpty()) {
-            // Fallback for Lerna workspaces when scoped packages combined with independent versioning are used, e.g.
-            // support Git tag of the format "@organisation/my-component@x.x.x".
-            addGuessedRevision("${pkg.id.namespace}/${pkg.id.name}", pkg.id.version)
+        if (!addGuessedRevision(pkg.id.name, pkg.id.version)) {
+            when {
+                pkg.id.type == "NPM" && pkg.id.namespace.isNotEmpty() -> {
+                    // Fallback for Lerna workspaces when scoped packages combined with independent versioning are used,
+                    // e.g. support Git tag of the format "@organisation/my-component@x.x.x".
+                    addGuessedRevision("${pkg.id.namespace}/${pkg.id.name}", pkg.id.version)
+                }
+
+                pkg.id.type == "GoMod" && pkg.vcsProcessed.path.isNotEmpty() -> {
+                    // Fallback for GoMod packages from mono repos which use the tag format described in
+                    // https://golang.org/ref/mod#vcs-version.
+                    val tag = "${pkg.vcsProcessed.path}/${pkg.id.version}"
+
+                    if (tag in workingTree.listRemoteTags()) revisionCandidates += tag
+                }
+            }
         }
 
         if (revisionCandidates.isEmpty()) {


### PR DESCRIPTION
When a GoMod package originates from a monorepo, the Git tag must
contain the module path as prefix [1]. For example, the Git tag for
package `GoMod::github.com/Azure/go-autorest/autorest/date:v0.1.0` is
`autorest/date/v0.1.0`.

Executing filterVersionNames() for above package throws an IOException
for above package, because it finds multiple matching tags. Add a
fallback to "${pkg.vcsProcessed.path}/${pkg.id.version}/" to fix that
problem.

The handling differes a bit compared the one for Lerna directly above, so that it works also in case one module is in a parent directory of another. In this case the Git tags share a common prefix, so addGuessedRevision() would not work.

Note: Mapping symbolic names to versions in GoMod is complex [1,2,3].
So, it would be better to let the original code / tool perform that
mapping rather than re-implenting in ORT.

[1] https://golang.org/ref/mod#vcs-version
[2] https://golang.org/ref/mod#vcs-pseudo
[3] https://golang.org/ref/mod#vcs-branch
