### PR TITLE
reference: Remove unnecessary comma from downloader configuration

### DIFF
--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -40,7 +40,8 @@ ort {
     includedLicenseCategories: [
       "category-a",
       "category-b"
-    ],
+    ]
+
     sourceCodeOrigins: [
       "VCS", "ARTIFACT"
     ]


### PR DESCRIPTION
To maintain consistency with the other configurations.

