### PR TITLE
DatabaseUtils: Use this transaction in tableExists()

### DIFF
--- a/model/src/main/kotlin/utils/DatabaseUtils.kt
+++ b/model/src/main/kotlin/utils/DatabaseUtils.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.Deferred
 
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.Transaction
-import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.experimental.suspendedTransactionAsync
 import org.jetbrains.exposed.sql.transactions.transaction
 
@@ -100,7 +99,7 @@ object DatabaseUtils {
      * Return true if and only if a table named [tableName] exists.
      */
     fun Transaction.tableExists(tableName: String): Boolean =
-        tableName in TransactionManager.current().db.dialect.allTablesNames().map { it.substringAfterLast(".") }
+        tableName in db.dialect.allTablesNames().map { it.substringAfterLast(".") }
 
     /**
      * Start a new transaction to execute the given [statement] on this [Database].


### PR DESCRIPTION
The tableExists() extension function uses TransactionManager.current()
to access the database connection. This is causing a warning because
the receiver of the extension function is not used. Fix this by
implicitly referencing this transaction, which also seems more natural
and makes sure that actually the correct database connection is used.
