### PR TITLE
GoMod: Handle the version suffix '+incompatible'

### DIFF
--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -280,6 +280,8 @@ private fun Collection<Edge>.toPackageReferenceForest(
 private val PSEUDO_VERSION_REGEX = "^v0.0.0-(?:[\\d]{14}-(?<sha1>[0-9a-f]+)$)".toRegex()
 
 private fun getRevision(version: String): String {
+    if (version.endsWith("+incompatible")) return getRevision(version.removeSuffix("+incompatible"))
+
     PSEUDO_VERSION_REGEX.find(version)?.let { matchResult ->
         return matchResult.groups["sha1"]!!.value
     }

--- a/analyzer/src/test/kotlin/managers/GoModTest.kt
+++ b/analyzer/src/test/kotlin/managers/GoModTest.kt
@@ -63,5 +63,11 @@ class GoModTest : WordSpec({
 
             id.toVcsInfo().revision shouldBe "daa7c04131f5"
         }
+
+        "return the SHA1 for a version with a '+incompatible' suffix" {
+            val id = Identifier("GoMod::github.com/Azure/azure-sdk-for-go:v43.3.0+incompatible")
+
+            id.toVcsInfo().revision shouldBe "v43.3.0"
+        }
     }
 })


### PR DESCRIPTION
GoMod: Handle the version suffix '+incompatible'

The '+incompatible' suffix is just an indication about compatibility for
the package manager. In particular there won't be any Git tags which
contain that suffix in their name. Just drop the suffix to make the
version guessing / matching to remote tags work. See also [1].

[1] https://golang.org/ref/mod#incompatible-versions