### PR TITLE
automatic-rebase: Refer to the action by repository and tag

### DIFF
--- a/.github/workflows/automatic-rebase.yml
+++ b/.github/workflows/automatic-rebase.yml
@@ -14,6 +14,6 @@ jobs:
       with:
         fetch-depth: 0
     - name: Rebase Branch
-      uses: docker://cirrusactions/rebase:latest
+      uses: cirrus-actions/rebase@1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is to align with the other used actions. As a side note, version
1.5 includes the fix for https://github.com/cirrus-actions/rebase/pull/78.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>