### PR TITLE
PackageManager: Improve log and issue messages

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -4321,10 +4321,10 @@ analyzer:
       'NPM::submodules/test-data-npm/long.js/package.json:':
       - timestamp: "1970-01-01T00:00:00Z"
         source: "NPM"
-        message: "Resolving dependencies for 'package.json' failed with: IllegalArgumentException:\
-          \ No lockfile found in 'submodules/test-data-npm/long.js'. This potentially\
-          \ results in unstable versions of dependencies. To allow this, enable support\
-          \ for dynamic versions."
+        message: "Resolving dependencies for 'submodules/test-data-npm/long.js/package.json'\
+          \ failed with: IllegalArgumentException: No lockfile found in 'submodules/test-data-npm/long.js'.\
+          \ This potentially results in unstable versions of dependencies. To allow\
+          \ this, enable support for dynamic versions."
         severity: "ERROR"
     has_issues: true
 scanner: null

--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -4321,7 +4321,7 @@ analyzer:
       'NPM::submodules/test-data-npm/long.js/package.json:':
       - timestamp: "1970-01-01T00:00:00Z"
         source: "NPM"
-        message: "Resolving dependencies for 'submodules/test-data-npm/long.js/package.json'\
+        message: "Resolving NPM dependencies for 'submodules/test-data-npm/long.js/package.json'\
           \ failed with: IllegalArgumentException: No lockfile found in 'submodules/test-data-npm/long.js'.\
           \ This potentially results in unstable versions of dependencies. To allow\
           \ this, enable support for dynamic versions."

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-no-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-no-lockfile.yml
@@ -20,7 +20,7 @@ packages: []
 issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "NPM"
-  message: "Resolving dependencies for 'src/funTest/assets/projects/synthetic/npm/no-lockfile/package.json'\
+  message: "Resolving NPM dependencies for 'src/funTest/assets/projects/synthetic/npm/no-lockfile/package.json'\
     \ failed with: IllegalArgumentException: No lockfile found in 'src/funTest/assets/projects/synthetic/npm/no-lockfile'.\
     \ This potentially results in unstable versions of dependencies. To allow this,\
     \ enable support for dynamic versions."

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-no-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-no-lockfile.yml
@@ -20,8 +20,8 @@ packages: []
 issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "NPM"
-  message: "Resolving dependencies for 'package.json' failed with: IllegalArgumentException:\
-    \ No lockfile found in 'src/funTest/assets/projects/synthetic/npm/no-lockfile'.\
+  message: "Resolving dependencies for 'src/funTest/assets/projects/synthetic/npm/no-lockfile/package.json'\
+    \ failed with: IllegalArgumentException: No lockfile found in 'src/funTest/assets/projects/synthetic/npm/no-lockfile'.\
     \ This potentially results in unstable versions of dependencies. To allow this,\
     \ enable support for dynamic versions."
   severity: "ERROR"

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -242,7 +242,7 @@ abstract class PackageManager(
                     val id = if (e is ProjectBuildingException && e.projectId?.isEmpty() == false) {
                         Identifier("Maven:${e.projectId}")
                     } else {
-                        val relativePath = definitionFile.absoluteFile.relativeTo(analysisRoot).invariantSeparatorsPath
+                        val relativePath = definitionFile.relativeTo(analysisRoot).invariantSeparatorsPath
                         Identifier.EMPTY.copy(type = managerName, name = relativePath)
                     }
 

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -256,7 +256,7 @@ abstract class PackageManager(
                     val errors = listOf(
                         createAndLogIssue(
                             source = managerName,
-                            message = "Resolving dependencies for '$relativePath' failed with: " +
+                            message = "Resolving $managerName dependencies for '$relativePath' failed with: " +
                                     e.collectMessagesAsString()
                         )
                     )

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -264,9 +264,7 @@ abstract class PackageManager(
                 }
             }
 
-            log.info {
-                "Resolving $managerName dependencies for '${definitionFile.name}' took ${duration.inSeconds}s."
-            }
+            log.info { "Resolving $managerName dependencies for '$definitionFile' took ${duration.inSeconds}s." }
         }
 
         afterResolution(definitionFiles)

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -238,11 +238,12 @@ abstract class PackageManager(
                 } catch (e: Exception) {
                     e.showStackTrace()
 
+                    val relativePath = definitionFile.relativeTo(analysisRoot).invariantSeparatorsPath
+
                     // In case of Maven we might be able to do better than inferring the name from the path.
                     val id = if (e is ProjectBuildingException && e.projectId?.isEmpty() == false) {
                         Identifier("Maven:${e.projectId}")
                     } else {
-                        val relativePath = definitionFile.relativeTo(analysisRoot).invariantSeparatorsPath
                         Identifier.EMPTY.copy(type = managerName, name = relativePath)
                     }
 
@@ -255,7 +256,7 @@ abstract class PackageManager(
                     val errors = listOf(
                         createAndLogIssue(
                             source = managerName,
-                            message = "Resolving dependencies for '${definitionFile.name}' failed with: " +
+                            message = "Resolving dependencies for '$relativePath' failed with: " +
                                     e.collectMessagesAsString()
                         )
                     )


### PR DESCRIPTION
Make some log and issue messages unambiguous, to enable better resolutions and for debugging.

Note: the change may break the matching of existing issue resolutions.