### PR TITLE
analyzer: Fail gracefully when dependency graph contains invalid IDs

### DIFF
--- a/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
@@ -28,6 +28,7 @@ import org.eclipse.aether.repository.RemoteRepository
 
 import org.ossreviewtoolkit.analyzer.managers.utils.DependencyHandler
 import org.ossreviewtoolkit.analyzer.managers.utils.MavenSupport
+import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
@@ -53,8 +54,13 @@ class GradleDependencyHandler(
      */
     var repositories: List<RemoteRepository> = emptyList()
 
-    override fun identifierFor(dependency: Dependency): String =
-        "${dependency.dependencyType()}:${dependency.groupId}:${dependency.artifactId}:${dependency.version}"
+    override fun identifierFor(dependency: Dependency): Identifier =
+        Identifier(
+            type = dependency.dependencyType(),
+            namespace = dependency.groupId,
+            name = dependency.artifactId,
+            version = dependency.version
+        )
 
     override fun dependenciesFor(dependency: Dependency): Collection<Dependency> = dependency.dependencies
 

--- a/analyzer/src/main/kotlin/managers/MavenDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/MavenDependencyHandler.kt
@@ -56,16 +56,13 @@ class MavenDependencyHandler(
      */
     val sbtMode: Boolean
 ) : DependencyHandler<DependencyNode> {
-    override fun identifierFor(dependency: DependencyNode): Identifier {
-        val id = dependency.identifier()
-
-        return Identifier(
-            type = if (isLocalProject(id)) managerName else "Maven",
+    override fun identifierFor(dependency: DependencyNode): Identifier =
+        Identifier(
+            type = if (isLocalProject(dependency.identifier())) managerName else "Maven",
             namespace = dependency.artifact.groupId,
             name = dependency.artifact.artifactId,
             version = dependency.artifact.version
         )
-    }
 
     override fun dependenciesFor(dependency: DependencyNode): Collection<DependencyNode> {
         val childrenWithoutToolDependencies = dependency.children.filterNot { node ->

--- a/analyzer/src/main/kotlin/managers/MavenDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/MavenDependencyHandler.kt
@@ -26,6 +26,7 @@ import org.eclipse.aether.graph.DependencyNode
 import org.ossreviewtoolkit.analyzer.managers.utils.DependencyHandler
 import org.ossreviewtoolkit.analyzer.managers.utils.MavenSupport
 import org.ossreviewtoolkit.analyzer.managers.utils.identifier
+import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
@@ -55,10 +56,15 @@ class MavenDependencyHandler(
      */
     val sbtMode: Boolean
 ) : DependencyHandler<DependencyNode> {
-    override fun identifierFor(dependency: DependencyNode): String {
+    override fun identifierFor(dependency: DependencyNode): Identifier {
         val id = dependency.identifier()
-        val type = if (isLocalProject(id)) managerName else "Maven"
-        return "$type:$id"
+
+        return Identifier(
+            type = if (isLocalProject(id)) managerName else "Maven",
+            namespace = dependency.artifact.groupId,
+            name = dependency.artifact.artifactId,
+            version = dependency.artifact.version
+        )
     }
 
     override fun dependenciesFor(dependency: DependencyNode): Collection<DependencyNode> {

--- a/analyzer/src/main/kotlin/managers/utils/DependencyGraphBuilder.kt
+++ b/analyzer/src/main/kotlin/managers/utils/DependencyGraphBuilder.kt
@@ -193,6 +193,7 @@ class DependencyGraphBuilder<D>(
         if (dependencyIndex != null) return dependencyIndex
 
         updateResolvedPackages(id, dependency, issues)
+
         return dependencyIds.size.also {
             dependencyIds += id
             dependencyIndexMapping[id] = it
@@ -209,6 +210,7 @@ class DependencyGraphBuilder<D>(
         }
 
         val compatibleReference = mappingForCompatibleFragment?.let { it[index] }
+
         return compatibleReference?.let { DependencyGraphSearchResult.Found(it) }
             ?: handleNoCompatibleDependencyInGraph(index)
     }
@@ -220,6 +222,7 @@ class DependencyGraphBuilder<D>(
      */
     private fun handleNoCompatibleDependencyInGraph(index: Int): DependencyGraphSearchResult {
         val mappingToInsert = referenceMappings.withIndex().find { index !in it.value }
+
         return mappingToInsert?.let { DependencyGraphSearchResult.NotFound(it.index) }
             ?: DependencyGraphSearchResult.Incompatible
     }
@@ -258,6 +261,7 @@ class DependencyGraphBuilder<D>(
         val fragmentMapping = mutableMapOf<Int, DependencyReference>()
         val dependencyIndex = RootDependencyIndex(index, referenceMappings.size)
         referenceMappings += fragmentMapping
+
         return insertIntoGraph(dependencyIndex, scopeName, dependency, issues, transitive)
     }
 
@@ -285,8 +289,8 @@ class DependencyGraphBuilder<D>(
             linkage = dependencyHandler.linkageFor(dependency),
             issues = issues
         )
-
         fragmentMapping[index.root] = ref
+
         return updateDirectDependencies(ref, transitive)
     }
 
@@ -306,6 +310,7 @@ class DependencyGraphBuilder<D>(
     private fun updateDirectDependencies(ref: DependencyReference, transitive: Boolean): DependencyReference {
         directDependencies.removeAll(ref.dependencies)
         if (!transitive) directDependencies += ref
+
         return ref
     }
 

--- a/analyzer/src/main/kotlin/managers/utils/DependencyGraphBuilder.kt
+++ b/analyzer/src/main/kotlin/managers/utils/DependencyGraphBuilder.kt
@@ -161,7 +161,7 @@ class DependencyGraphBuilder<D>(
     private fun addDependencyToGraph(scopeName: String, dependency: D, transitive: Boolean): DependencyReference {
         val identifier = dependencyHandler.identifierFor(dependency)
         val issues = dependencyHandler.issuesForDependency(dependency).toMutableList()
-        val index = updateDependencyMappingAndPackages(identifier, dependency, issues)
+        val index = updateDependencyMappingAndPackages(identifier.toCoordinates(), dependency, issues)
 
         val ref = when (val result = findDependencyInGraph(index, dependency)) {
             is DependencyGraphSearchResult.Found -> result.ref
@@ -234,7 +234,7 @@ class DependencyGraphBuilder<D>(
         if (ref.dependencies.size != dependencies.size) return false
 
         val dependencies1 = ref.dependencies.map { dependencyIds[it.pkg] }
-        val dependencies2 = dependencies.associateBy(dependencyHandler::identifierFor)
+        val dependencies2 = dependencies.associateBy { dependencyHandler.identifierFor(it).toCoordinates() }
         if (!dependencies2.keys.containsAll(dependencies1)) return false
 
         return ref.dependencies.all { refDep ->

--- a/analyzer/src/main/kotlin/managers/utils/DependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/utils/DependencyHandler.kt
@@ -36,11 +36,9 @@ import org.ossreviewtoolkit.model.PackageLinkage
  */
 interface DependencyHandler<D> {
     /**
-     * Construct a unique identifier for the given [dependency]. This identifier should be derived from the
-     * coordinates of the dependency. It is later converted to an [Identifier]; so it has to adhere to the
-     * string-representation of this class.
+     * Construct a unique identifier for the given [dependency].
      */
-    fun identifierFor(dependency: D): String
+    fun identifierFor(dependency: D): Identifier
 
     /**
      * Return a collection with the dependencies of the given [dependency]. [DependencyGraphBuilder] invokes this

--- a/analyzer/src/test/kotlin/managers/MavenDependencyHandlerTest.kt
+++ b/analyzer/src/test/kotlin/managers/MavenDependencyHandlerTest.kt
@@ -43,6 +43,7 @@ import org.eclipse.aether.repository.RemoteRepository
 
 import org.ossreviewtoolkit.analyzer.managers.utils.MavenSupport
 import org.ossreviewtoolkit.analyzer.managers.utils.identifier
+import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
@@ -59,7 +60,7 @@ class MavenDependencyHandlerTest : WordSpec({
 
             val handler = createHandler()
 
-            handler.identifierFor(dependency) shouldBe "Maven:$IDENTIFIER"
+            handler.identifierFor(dependency) shouldBe Identifier("Maven:$IDENTIFIER")
         }
 
         "return the identifier for an inter-project dependency" {
@@ -67,7 +68,7 @@ class MavenDependencyHandlerTest : WordSpec({
 
             val handler = createHandler()
 
-            handler.identifierFor(dependency) shouldBe "$MANAGER_NAME:$PROJECT_ID"
+            handler.identifierFor(dependency) shouldBe Identifier("$MANAGER_NAME:$PROJECT_ID")
         }
     }
 
@@ -218,8 +219,15 @@ private val PROJECT_ID = LOCAL_PROJECTS.toList().first().first
  * `identifier()` extension function must have been mocked statically.
  */
 private fun createArtifact(id: String): Artifact {
+    val parts = id.split(":")
     val artifact = mockk<Artifact>()
+
     every { artifact.identifier() } returns id
+    every { artifact.groupId } returns parts.getOrElse(0) { "" }
+    every { artifact.artifactId } returns parts.getOrElse(1) { "" }
+    every { artifact.version } returns parts.getOrElse(2) { "" }
+    every { artifact.identifier() } returns id
+
     return artifact
 }
 


### PR DESCRIPTION
The dependency graph representation uses `String` as type for the
package identifiers. The package managers Maven and Gradle which use this
dependency graph representation do not parse the identifiers of the
packages into `Identifier` instances until right after the analyzer
result creation. Actually, that parsing happens when
`ortResult.getProjects()` is called by the analyzer command, see [1].

As consequence, the pre-condition checks implemented in the constructor
of `Identifier` are executed after the analyzer result is created. When
that check fails the analyzer command exits with an exception, e.g.
without any result.

Change the return type of `GradleDependencyHandler.identifierFor()` to
`Identifier` to execute these checks as early as possible. This in fact
turns that uncaught runtime exception into a gracefully handled
OrtIssue. It is a fix-up for [2].

Note that the problem was observed for a Gradle project with two levels
of nested submodules.

[1] ./cli/src/main/kotlin/commands/AnalyzerCommand.kt:166
[2] 5086c686019f3048802f6e66fa9d57b1658fd306
