### PR TITLE
GradleDependencyHandler: Inline Dependency.linkage()

### DIFF
--- a/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
@@ -77,7 +77,8 @@ class GradleDependencyHandler(
             }
         )
 
-    override fun linkageFor(dependency: Dependency): PackageLinkage = dependency.linkage()
+    override fun linkageFor(dependency: Dependency): PackageLinkage =
+        if (dependency.isProjectDependency()) PackageLinkage.PROJECT_DYNAMIC else PackageLinkage.DYNAMIC
 
     override fun createPackage(identifier: String, dependency: Dependency, issues: MutableList<OrtIssue>): Package? {
         // Only look for a package if there was no error resolving the dependency and it is no project dependency.
@@ -115,16 +116,6 @@ class GradleDependencyHandler(
             pomFile?.let { "Maven" } ?: "Unknown"
         }
 }
-
-/**
- * Determine the [PackageLinkage] for this [Dependency].
- */
-private fun Dependency.linkage() =
-    if (isProjectDependency()) {
-        PackageLinkage.PROJECT_DYNAMIC
-    } else {
-        PackageLinkage.DYNAMIC
-    }
 
 /**
  * Return a flag whether this dependency references another project in the current build.

--- a/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
@@ -51,7 +51,7 @@ class GradleDependencyHandler(
      * constructing the dependency graph of a project. As different projects may use different repositories, this
      * property is writable.
      */
-    var repositories: List<RemoteRepository> = emptyList()
+    var repositories = emptyList<RemoteRepository>()
 
     override fun identifierFor(dependency: Dependency): String =
         "${dependency.dependencyType()}:${dependency.groupId}:${dependency.artifactId}:${dependency.version}"

--- a/analyzer/src/main/kotlin/managers/MavenDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/MavenDependencyHandler.kt
@@ -48,12 +48,12 @@ class MavenDependencyHandler(
      * A map with information about the local projects in the current Maven build. Dependencies pointing to projects
      * sometimes need to be treated in a special way.
      */
-    val localProjects: Map<String, MavenProject>,
+    private val localProjects: Map<String, MavenProject>,
 
     /**
      * A flag whether [SBT compatibility mode][Maven.enableSbtMode] is enabled.
      */
-    val sbtMode: Boolean
+    private val sbtMode: Boolean
 ) : DependencyHandler<DependencyNode> {
     override fun identifierFor(dependency: DependencyNode): String {
         val id = dependency.identifier()


### PR DESCRIPTION
This aligns the implementation with MavenDependencyHandler.linkageFor()
for easier comparison.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>