### PR TITLE
DependencyGraph: Consistently use Identifier as type for IDs

### DIFF
--- a/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
@@ -86,7 +86,11 @@ class GradleDependencyHandler(
     override fun linkageFor(dependency: Dependency): PackageLinkage =
         if (dependency.isProjectDependency()) PackageLinkage.PROJECT_DYNAMIC else PackageLinkage.DYNAMIC
 
-    override fun createPackage(identifier: String, dependency: Dependency, issues: MutableList<OrtIssue>): Package? {
+    override fun createPackage(
+        identifier: Identifier,
+        dependency: Dependency,
+        issues: MutableList<OrtIssue>
+    ): Package? {
         // Only look for a package if there was no error resolving the dependency and it is no project dependency.
         if (dependency.error != null || dependency.isProjectDependency()) return null
 
@@ -102,7 +106,7 @@ class GradleDependencyHandler(
 
             issues += createAndLogIssue(
                 source = managerName,
-                message = "Could not get package information for dependency '$identifier': " +
+                message = "Could not get package information for dependency '${identifier.toCoordinates()}': " +
                         e.collectMessagesAsString()
             )
 

--- a/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
@@ -87,7 +87,7 @@ class GradleDependencyHandler(
         if (dependency.isProjectDependency()) PackageLinkage.PROJECT_DYNAMIC else PackageLinkage.DYNAMIC
 
     override fun createPackage(
-        identifier: Identifier,
+        id: Identifier,
         dependency: Dependency,
         issues: MutableList<OrtIssue>
     ): Package? {
@@ -106,7 +106,7 @@ class GradleDependencyHandler(
 
             issues += createAndLogIssue(
                 source = managerName,
-                message = "Could not get package information for dependency '${identifier.toCoordinates()}': " +
+                message = "Could not get package information for dependency '${id.toCoordinates()}': " +
                         e.collectMessagesAsString()
             )
 

--- a/analyzer/src/main/kotlin/managers/MavenDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/MavenDependencyHandler.kt
@@ -80,7 +80,7 @@ class MavenDependencyHandler(
         if (isLocalProject(dependency)) PackageLinkage.PROJECT_DYNAMIC else PackageLinkage.DYNAMIC
 
     override fun createPackage(
-        identifier: Identifier,
+        id: Identifier,
         dependency: DependencyNode,
         issues: MutableList<OrtIssue>
     ): Package? {

--- a/analyzer/src/main/kotlin/managers/MavenDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/MavenDependencyHandler.kt
@@ -80,7 +80,7 @@ class MavenDependencyHandler(
         if (isLocalProject(dependency)) PackageLinkage.PROJECT_DYNAMIC else PackageLinkage.DYNAMIC
 
     override fun createPackage(
-        identifier: String,
+        identifier: Identifier,
         dependency: DependencyNode,
         issues: MutableList<OrtIssue>
     ): Package? {

--- a/analyzer/src/main/kotlin/managers/utils/DependencyGraphBuilder.kt
+++ b/analyzer/src/main/kotlin/managers/utils/DependencyGraphBuilder.kt
@@ -149,7 +149,7 @@ class DependencyGraphBuilder<D>(
      * Construct the [DependencyGraph] from the dependencies passed to this builder so far.
      */
     fun build(): DependencyGraph = DependencyGraph(
-        dependencyIds.map { it.toCoordinates() },
+        dependencyIds,
         directDependencies,
         scopeMapping
     )

--- a/analyzer/src/main/kotlin/managers/utils/DependencyGraphBuilder.kt
+++ b/analyzer/src/main/kotlin/managers/utils/DependencyGraphBuilder.kt
@@ -164,9 +164,9 @@ class DependencyGraphBuilder<D>(
      * [scopeName]. All the dependencies of this dependency are processed recursively.
      */
     private fun addDependencyToGraph(scopeName: String, dependency: D, transitive: Boolean): DependencyReference {
-        val identifier = dependencyHandler.identifierFor(dependency)
+        val id = dependencyHandler.identifierFor(dependency)
         val issues = dependencyHandler.issuesForDependency(dependency).toMutableList()
-        val index = updateDependencyMappingAndPackages(identifier, dependency, issues)
+        val index = updateDependencyMappingAndPackages(id, dependency, issues)
 
         val ref = when (val result = findDependencyInGraph(index, dependency)) {
             is DependencyGraphSearchResult.Found -> result.ref
@@ -303,8 +303,8 @@ class DependencyGraphBuilder<D>(
      * Construct a [Package] for the given [dependency]. Add the new package to the set managed by this object. If this
      * fails, record a corresponding message in [issues].
      */
-    private fun updateResolvedPackages(identifier: Identifier, dependency: D, issues: MutableList<OrtIssue>) {
-        dependencyHandler.createPackage(identifier, dependency, issues)?.let { resolvedPackages += it }
+    private fun updateResolvedPackages(id: Identifier, dependency: D, issues: MutableList<OrtIssue>) {
+        dependencyHandler.createPackage(id, dependency, issues)?.let { resolvedPackages += it }
     }
 
     /**

--- a/analyzer/src/main/kotlin/managers/utils/DependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/utils/DependencyHandler.kt
@@ -58,7 +58,7 @@ interface DependencyHandler<D> {
      * add a corresponding issue to the provided [issues] list. If the [dependency] does not map to a package, an
      * implementation should return *null*.
      */
-    fun createPackage(identifier: String, dependency: D, issues: MutableList<OrtIssue>): Package?
+    fun createPackage(identifier: Identifier, dependency: D, issues: MutableList<OrtIssue>): Package?
 
     /**
      * Return a collection with known issues for the given [dependency]. Some package manager implementations may

--- a/analyzer/src/main/kotlin/managers/utils/DependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/utils/DependencyHandler.kt
@@ -52,13 +52,13 @@ interface DependencyHandler<D> {
     fun linkageFor(dependency: D): PackageLinkage
 
     /**
-     * Create a [Package] to represent the [dependency] with the given [identifier]. This is used to populate the
+     * Create a [Package] to represent the [dependency] with the given [id]. This is used to populate the
      * packages in the analyzer result. The creation of a package may fail, e.g. if the dependency cannot be resolved.
      * In this case, a concrete implementation is expected to return a dummy [Package] with correct coordinates and
      * add a corresponding issue to the provided [issues] list. If the [dependency] does not map to a package, an
      * implementation should return *null*.
      */
-    fun createPackage(identifier: Identifier, dependency: D, issues: MutableList<OrtIssue>): Package?
+    fun createPackage(id: Identifier, dependency: D, issues: MutableList<OrtIssue>): Package?
 
     /**
      * Return a collection with known issues for the given [dependency]. Some package manager implementations may

--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -73,8 +73,8 @@ class AnalyzerResultBuilderTest : WordSpec() {
         scopeDependencies = null
     )
 
-    private val dependencies1 = listOf(package1.id.toCoordinates(), package2.id.toCoordinates())
-    private val dependencies2 = listOf(package3.id.toCoordinates())
+    private val dependencies1 = listOf(package1.id, package2.id)
+    private val dependencies2 = listOf(package3.id)
 
     private val depRef1 = DependencyReference(0)
     private val depRef2 = DependencyReference(1)

--- a/analyzer/src/test/kotlin/managers/GradleDependencyHandlerTest.kt
+++ b/analyzer/src/test/kotlin/managers/GradleDependencyHandlerTest.kt
@@ -306,7 +306,7 @@ class GradleDependencyHandlerTest : WordSpec({
             every { maven.parsePackage(any(), any(), any()) } throws exception
             val handler = GradleDependencyHandler(NAME, maven)
 
-            handler.createPackage(dep.toId().toCoordinates(), dep, issues) should beNull()
+            handler.createPackage(dep.toId(), dep, issues) should beNull()
 
             issues should haveSize(1)
             with(issues.first()) {

--- a/analyzer/src/test/kotlin/managers/MavenDependencyHandlerTest.kt
+++ b/analyzer/src/test/kotlin/managers/MavenDependencyHandlerTest.kt
@@ -141,7 +141,7 @@ class MavenDependencyHandlerTest : WordSpec({
             every { dependency.repositories } returns repos
             every { handler.support.parsePackage(artifact, repos, LOCAL_PROJECTS) } returns pkg
 
-            handler.createPackage("Maven:$IDENTIFIER", dependency, issues) shouldBe pkg
+            handler.createPackage(Identifier("Maven:$IDENTIFIER"), dependency, issues) shouldBe pkg
             issues should beEmpty()
         }
 
@@ -157,7 +157,7 @@ class MavenDependencyHandlerTest : WordSpec({
             every { dependency.repositories } returns repos
             every { handler.support.parsePackage(artifact, repos, LOCAL_PROJECTS, sbtMode = true) } returns pkg
 
-            handler.createPackage("$MANAGER_NAME:$IDENTIFIER", dependency, issues) shouldBe pkg
+            handler.createPackage(Identifier("$MANAGER_NAME:$IDENTIFIER"), dependency, issues) shouldBe pkg
             issues should beEmpty()
         }
 
@@ -167,7 +167,7 @@ class MavenDependencyHandlerTest : WordSpec({
 
             val handler = createHandler()
 
-            handler.createPackage("$MANAGER_NAME:$PROJECT_ID", projectDependency, issues) should beNull()
+            handler.createPackage(Identifier("$MANAGER_NAME:$PROJECT_ID"), projectDependency, issues) should beNull()
             issues should beEmpty()
         }
 
@@ -186,7 +186,7 @@ class MavenDependencyHandlerTest : WordSpec({
             every { dependency.repositories } returns repos
             every { handler.support.parsePackage(artifact, repos, LOCAL_PROJECTS) } throws exception
 
-            handler.createPackage("Maven:$IDENTIFIER", dependency, issues) should beNull()
+            handler.createPackage(Identifier("Maven:$IDENTIFIER"), dependency, issues) should beNull()
 
             issues should haveSize(1)
             with(issues[0]) {

--- a/model/src/main/kotlin/DependencyGraph.kt
+++ b/model/src/main/kotlin/DependencyGraph.kt
@@ -46,7 +46,7 @@ data class DependencyGraph(
      * A list with the identifiers of the packages that appear in the dependency graph. This list is used to resolve
      * the numeric indices contained in the [DependencyReference] objects.
      */
-    val packages: List<String>,
+    val packages: List<Identifier>,
 
     /**
      * Stores the dependency graph as a list of root nodes for the direct dependencies referenced by scopes. Starting
@@ -153,7 +153,7 @@ data class DependencyGraph(
             }
 
             PackageReference(
-                id = Identifier(packages[ref.pkg]),
+                id = packages[ref.pkg],
                 dependencies = dependencies,
                 linkage = ref.linkage,
                 issues = ref.issues

--- a/model/src/test/kotlin/DependencyGraphTest.kt
+++ b/model/src/test/kotlin/DependencyGraphTest.kt
@@ -51,8 +51,8 @@ class DependencyGraphTest : WordSpec({
             val scopes = graph.createScopes()
 
             scopes.map { it.name } should containExactly("p1:scope1", "p2:scope2")
-            scopeDependencies(scopes, "p1:scope1") shouldBe "${pkgId(ids[1])}${pkgId(ids[0])}"
-            scopeDependencies(scopes, "p2:scope2") shouldBe "${pkgId(ids[1])}${pkgId(ids[2])}"
+            scopeDependencies(scopes, "p1:scope1") shouldBe "${ids[1]}${ids[0]}"
+            scopeDependencies(scopes, "p2:scope2") shouldBe "${ids[1]}${ids[2]}"
         }
 
         "support restricting the scopes to a specific set" {
@@ -82,7 +82,7 @@ class DependencyGraphTest : WordSpec({
             val scopes = graph.createScopes(setOf(qualifiedScopeName))
 
             scopes.map { it.name } should containExactly(DependencyGraph.unqualifyScope(scopeName))
-            scopeDependencies(scopes, scopeName) shouldBe "${pkgId(ids[1])}${pkgId(ids[0])}"
+            scopeDependencies(scopes, scopeName) shouldBe "${ids[1]}${ids[0]}"
         }
 
         "construct a tree with multiple levels" {
@@ -101,8 +101,7 @@ class DependencyGraphTest : WordSpec({
             val graph = DependencyGraph(ids, fragments, scopeMap)
             val scopes = graph.createScopes()
 
-            scopeDependencies(scopes, "s") shouldBe "${pkgId(ids[3])}<${pkgId(ids[2])}<${pkgId(ids[1])}" +
-                    "${pkgId(ids[0])}>>"
+            scopeDependencies(scopes, "s") shouldBe "${ids[3]}<${ids[2]}<${ids[1]}${ids[0]}>>"
         }
 
         "construct scopes from different fragments" {
@@ -128,9 +127,8 @@ class DependencyGraphTest : WordSpec({
             val graph = DependencyGraph(ids, fragments, scopeMap)
             val scopes = graph.createScopes()
 
-            scopeDependencies(scopes, "s1") shouldBe "${pkgId(ids[2])}<${pkgId(ids[1])}${pkgId(ids[0])}>"
-            scopeDependencies(scopes, "s2") shouldBe "${pkgId(ids[2])}<${pkgId(ids[1])}<${pkgId(ids[3])}>" +
-                    "${pkgId(ids[0])}>"
+            scopeDependencies(scopes, "s1") shouldBe "${ids[2]}<${ids[1]}${ids[0]}>"
+            scopeDependencies(scopes, "s2") shouldBe "${ids[2]}<${ids[1]}<${ids[3]}>${ids[0]}>"
         }
 
         "deal with attributes of package references" {
@@ -204,12 +202,8 @@ private const val MANAGER_NAME = "TestManager"
 /**
  * Create an identifier string with the given [group], [artifact] ID and [version].
  */
-private fun id(group: String, artifact: String, version: String): String = "$MANAGER_NAME:$group:$artifact:$version"
-
-/**
- * Create an [Identifier] based on the given [id] string.
- */
-private fun pkgId(id: String): Identifier = Identifier(id)
+private fun id(group: String, artifact: String, version: String): Identifier =
+    Identifier("$MANAGER_NAME:$group:$artifact:$version")
 
 /**
  * Output the dependency tree of the given scope as a string.

--- a/model/src/test/kotlin/ProjectTest.kt
+++ b/model/src/test/kotlin/ProjectTest.kt
@@ -57,11 +57,11 @@ private val csvId = Identifier("$MANAGER:org.apache.commons:commons-csv:1.4")
  */
 private fun createDependencyGraph(qualified: Boolean = false): DependencyGraph {
     val dependencies = listOf(
-        langId.toDependencyId(),
-        textId.toDependencyId(),
-        strutsId.toDependencyId(),
-        csvId.toDependencyId(),
-        exampleId.toDependencyId()
+        langId,
+        textId,
+        strutsId,
+        csvId,
+        exampleId
     )
     val langRef = DependencyReference(0)
     val textRef = DependencyReference(1, dependencies = sortedSetOf(langRef))
@@ -80,11 +80,6 @@ private fun createDependencyGraph(qualified: Boolean = false): DependencyGraph {
 
     return DependencyGraph(dependencies, setOf(exampleRef, csvRef), scopeMapping)
 }
-
-/**
- * Construct the short reference from this [Identifier] used internally by the dependency graph.
- */
-private fun Identifier.toDependencyId() = "$MANAGER:$namespace:$name:$version"
 
 class ProjectTest : WordSpec({
     "init" should {


### PR DESCRIPTION
Change the Identifier type from String to Identifier in several classes related to the dependency graph and rename a few variables. See the individual commit messages.
