### PR TITLE
downloader: Return a Result object from updateWorkingTree()

### DIFF
--- a/downloader/src/main/kotlin/vcs/Cvs.kt
+++ b/downloader/src/main/kotlin/vcs/Cvs.kt
@@ -184,5 +184,7 @@ class Cvs : VersionControlSystem(), CommandLineTool {
         runCatching {
             // Checkout the working tree of the desired revision.
             run(workingTree.workingDir, "checkout", "-r", revision, path.takeUnless { it.isEmpty() } ?: ".")
-        }.isSuccess
+        }.map {
+            revision
+        }
 }

--- a/downloader/src/main/kotlin/vcs/Subversion.kt
+++ b/downloader/src/main/kotlin/vcs/Subversion.kt
@@ -178,7 +178,7 @@ class Subversion : VersionControlSystem() {
     }
 
     override fun updateWorkingTree(workingTree: WorkingTree, revision: String, path: String, recursive: Boolean) =
-        try {
+        runCatching {
             revision.toLongOrNull()?.let { numericRevision ->
                 // This code path updates the working tree to a numeric revision.
                 val svnRevision = SVNRevision.create(numericRevision)
@@ -226,15 +226,15 @@ class Subversion : VersionControlSystem() {
             }
 
             true
-        } catch (e: SVNException) {
-            e.showStackTrace()
+        }.onFailure {
+            it.showStackTrace()
 
             log.warn {
                 "Failed to update the $type working tree at '${workingTree.workingDir}' to revision '$revision':\n" +
-                        e.collectMessagesAsString()
+                        it.collectMessagesAsString()
             }
-
-            false
+        }.map {
+            revision
         }
 }
 


### PR DESCRIPTION
Instead of just a Boolean, return a Result object encapsulating the
originally requested revsion for convenience, or any occurred exception.
This eases the debugging of download failures.

Resolves #3952.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>