### PR TITLE
fossid-webapp: use custom Jackson deserializer

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/Extensions.kt
+++ b/clients/fossid-webapp/src/main/kotlin/Extensions.kt
@@ -21,8 +21,6 @@
 
 package org.ossreviewtoolkit.clients.fossid
 
-import com.fasterxml.jackson.module.kotlin.convertValue
-
 private const val SCAN_GROUP = "scans"
 private const val PROJECT_GROUP = "projects"
 
@@ -46,20 +44,6 @@ fun <B : EntityResponseBody<T>, T> B?.checkResponse(operation: String, withDataC
 
     return this
 }
-
-/**
- * The list operations in FossID have inconsistent return types depending on the amount of entities returned.
- * This function streamlines these entities to a list.
- */
-inline fun <reified T : Any> EntityResponseBody<Any>.toList(): List<T> =
-    // The "list" operation returns different JSON depending on the amount of scans.
-    when (val data = data) {
-        is List<*> -> data.mapNotNull { it?.let { FossIdRestService.JSON_MAPPER.convertValue(it) } }
-        is Map<*, *> -> data.values.mapNotNull { it?.let { FossIdRestService.JSON_MAPPER.convertValue(it) } }
-        // The server sets "data" to "false" when there is no entry. Streamline this to an empty list.
-        is Boolean -> emptyList()
-        else -> error("Cannot process the returned values")
-    }
 
 /**
  * Get the project for the given [projectCode].

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
@@ -147,7 +147,7 @@ class FossIdClientNewProjectTest : StringSpec({
 
     "A scan can be deleted" {
         service.deleteScan("", "", SCAN_CODE) shouldNotBeNull {
-            checkResponse("delete scan", true)
+            checkResponse("delete scan")
 
             data shouldBe 2976
             message shouldContain "has been deleted"

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
@@ -156,7 +156,7 @@ class FossIdClientNewProjectTest : StringSpec({
 
     "Scan status can be queried" {
         service.checkScanStatus("", "", SCAN_CODE) shouldNotBeNull {
-            checkResponse("get scan status", false)
+            checkResponse("get scan status")
 
             data shouldNotBeNull {
                 state shouldBe ScanState.FINISHED

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
@@ -148,14 +148,14 @@ class FossIdClientReturnTypeTest : StringSpec({
         }
     }
 
-    "Pending files can be listed when there is some" {
+    "Pending files can be listed when there is none" {
         service.listPendingFiles("", "", SCAN_CODE_1) shouldNotBeNull {
             checkResponse("list pending files")
             toList<String>() should beEmpty()
         }
     }
 
-    "Pending files can be listed when there is none" {
+    "Pending files can be listed when there is some" {
         service.listPendingFiles("", "", SCAN_CODE_2) shouldNotBeNull {
             checkResponse("list pending files")
             toList<String>() shouldNot beEmpty()

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.maps.beEmpty as beEmptyMap
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
@@ -15,12 +16,6 @@ import org.ossreviewtoolkit.clients.fossid.listMarkedAsIdentifiedFiles
 import org.ossreviewtoolkit.clients.fossid.listPendingFiles
 import org.ossreviewtoolkit.clients.fossid.listScanResults
 import org.ossreviewtoolkit.clients.fossid.listScansForProject
-import org.ossreviewtoolkit.clients.fossid.model.Scan
-import org.ossreviewtoolkit.clients.fossid.model.identification.identifiedFiles.IdentifiedFile
-import org.ossreviewtoolkit.clients.fossid.model.identification.ignored.IgnoredFile
-import org.ossreviewtoolkit.clients.fossid.model.identification.markedAsIdentified.MarkedAsIdentifiedFile
-import org.ossreviewtoolkit.clients.fossid.model.result.FossIdScanResult
-import org.ossreviewtoolkit.clients.fossid.toList
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 /*
@@ -48,13 +43,10 @@ private const val SCAN_CODE_1 = "${PROJECT_CODE_1}_20201203_090342"
 private const val SCAN_CODE_2 = "${PROJECT_CODE_2}_20201203_090342"
 
 /**
- * As explained in the [toList] function, the FossID server is not consistent.
+ * The FossID server is not consistent.
  * It usually returns a List or a Map, but if there is no entry, it returns data:false.
- * The [toList] function abstracts this behaviour, but we nevertheless need a Kotlin representation that could be all
- * these types at once, to be able to deserialize them from JSON.
- * Therefore we use [org.ossreviewtoolkit.clients.fossid.EntityResponseBody] typed by [Any] to represent these
- * "multi-types" response objects.
- * This Test class tests this behaviour and the abstraction provided by [toList].
+ * This class tests the abstraction provided by the custom Jackson deserializer wired in
+ * [FossIdRestService.JSON_MAPPER].
  */
 class FossIdClientReturnTypeTest : StringSpec({
     val wiremock = WireMockServer(
@@ -81,84 +73,108 @@ class FossIdClientReturnTypeTest : StringSpec({
     "Scans for project can be listed when there is none" {
         service.listScansForProject("", "", PROJECT_CODE_1) shouldNotBeNull {
             checkResponse("list scans")
-            toList<Scan>() should beEmpty()
+            data shouldNotBeNull {
+                this should beEmptyMap()
+            }
         }
     }
 
     "Scans for project can be listed when there is some" {
         service.listScansForProject("", "", PROJECT_CODE_2) shouldNotBeNull {
             checkResponse("list scans")
-            toList<Scan>() shouldNot beEmpty()
+            data shouldNotBeNull {
+                this shouldNot beEmptyMap()
+            }
         }
     }
 
     "Scan results can be listed when there is none" {
         service.listScanResults("", "", SCAN_CODE_1) shouldNotBeNull {
             checkResponse("list scan results")
-            toList<FossIdScanResult>() should beEmpty()
+            data shouldNotBeNull {
+                this should beEmptyMap()
+            }
         }
     }
 
     "Scan results can be listed when there is some" {
         service.listScanResults("", "", SCAN_CODE_2) shouldNotBeNull {
             checkResponse("list scan results")
-            toList<FossIdScanResult>() shouldNot beEmpty()
+            data shouldNotBeNull {
+                this shouldNot beEmptyMap()
+            }
         }
     }
 
     "Identified files can be listed when there is none" {
         service.listIdentifiedFiles("", "", SCAN_CODE_1) shouldNotBeNull {
             checkResponse("list identified files")
-            toList<IdentifiedFile>() should beEmpty()
+            data shouldNotBeNull {
+                this should beEmptyMap()
+            }
         }
     }
 
     "Identified files can be listed when there is some" {
         service.listIdentifiedFiles("", "", SCAN_CODE_2) shouldNotBeNull {
             checkResponse("list identified files")
-            toList<IdentifiedFile>() shouldNot beEmpty()
+            data shouldNotBeNull {
+                this shouldNot beEmptyMap()
+            }
         }
     }
 
     "Marked as identified  files can be listed when there is none" {
         service.listMarkedAsIdentifiedFiles("", "", SCAN_CODE_1) shouldNotBeNull {
             checkResponse("list marked as identified files")
-            toList<MarkedAsIdentifiedFile>() should beEmpty()
+            data shouldNotBeNull {
+                this should beEmptyMap()
+            }
         }
     }
 
     "Marked as identified  files can be listed when there is some" {
         service.listMarkedAsIdentifiedFiles("", "", SCAN_CODE_2) shouldNotBeNull {
             checkResponse("list marked as identified files")
-            toList<MarkedAsIdentifiedFile>() shouldNot beEmpty()
+            data shouldNotBeNull {
+                this shouldNot beEmptyMap()
+            }
         }
     }
 
     "Ignored files can be listed when there is none" {
         service.listIgnoredFiles("", "", SCAN_CODE_1) shouldNotBeNull {
             checkResponse("list ignored files")
-            toList<IgnoredFile>() should beEmpty()
+            data shouldNotBeNull {
+                this should beEmpty()
+            }
         }
     }
 
     "Ignored files can be listed when there is some" {
         service.listIgnoredFiles("", "", SCAN_CODE_2) shouldNotBeNull {
             checkResponse("list ignored files")
-            toList<IgnoredFile>() shouldNot beEmpty()
+            data shouldNotBeNull {
+                this shouldNot beEmpty()
+            }
         }
     }
 
     "Pending files can be listed when there is none" {
         service.listPendingFiles("", "", SCAN_CODE_1) shouldNotBeNull {
             checkResponse("list pending files")
-            toList<String>() should beEmpty()
+            data shouldNotBeNull {
+                this should beEmptyMap()
+            }
         }
     }
 
     "Pending files can be listed when there is some" {
         service.listPendingFiles("", "", SCAN_CODE_2) shouldNotBeNull {
             checkResponse("list pending files")
-            toList<String>() shouldNot beEmpty()
+            data shouldNotBeNull {
+                this shouldNot beEmptyMap()
+            }
         }
     }
 })

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -42,13 +42,9 @@ import org.ossreviewtoolkit.clients.fossid.listIdentifiedFiles
 import org.ossreviewtoolkit.clients.fossid.listIgnoredFiles
 import org.ossreviewtoolkit.clients.fossid.listMarkedAsIdentifiedFiles
 import org.ossreviewtoolkit.clients.fossid.model.Project
-import org.ossreviewtoolkit.clients.fossid.model.identification.identifiedFiles.IdentifiedFile
-import org.ossreviewtoolkit.clients.fossid.model.identification.ignored.IgnoredFile
-import org.ossreviewtoolkit.clients.fossid.model.identification.markedAsIdentified.MarkedAsIdentifiedFile
 import org.ossreviewtoolkit.clients.fossid.model.status.DownloadStatus
 import org.ossreviewtoolkit.clients.fossid.model.status.ScanState
 import org.ossreviewtoolkit.clients.fossid.runScan
-import org.ossreviewtoolkit.clients.fossid.toList
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
@@ -334,23 +330,22 @@ class FossId(
      * Get the different kind of results from the scan with [scanCode]
      */
     private suspend fun getRawResults(scanCode: String): RawResults {
-        val responseIdentifiedFiles = service.listIdentifiedFiles(user, apiKey, scanCode)
-            .checkResponse("list identified files", true)
-        val identifiedFiles = responseIdentifiedFiles.toList<IdentifiedFile>()
+        val identifiedFiles = service.listIdentifiedFiles(user, apiKey, scanCode)
+            .checkResponse("list identified files")
+            .data!!.values.toList()
         log.info { "${identifiedFiles.size} identified files have been returned for scan code $scanCode." }
 
-        val responseMarkedAsIdentified = service.listMarkedAsIdentifiedFiles(user, apiKey, scanCode)
-            .checkResponse("list marked as identified files", true)
-        val markedAsIdentifiedFiles = responseMarkedAsIdentified.toList<MarkedAsIdentifiedFile>()
+        val markedAsIdentifiedFiles = service.listMarkedAsIdentifiedFiles(user, apiKey, scanCode)
+            .checkResponse("list marked as identified files")
+            .data!!.values.toList()
         log.info {
             "${markedAsIdentifiedFiles.size} marked as identified files have been returned for scan code $scanCode."
         }
 
         // The "match_type=ignore" info is already in the ScanResult, but here we also get the ignore reason.
-        val responseListIgnoredFiles = service.listIgnoredFiles(user, apiKey, scanCode)
-            .checkResponse("list ignored files", true)
-
-        val listIgnoredFiles = responseListIgnoredFiles.toList<IgnoredFile>()
+        val listIgnoredFiles = service.listIgnoredFiles(user, apiKey, scanCode)
+            .checkResponse("list ignored files")
+            .data!!
         return RawResults(identifiedFiles, markedAsIdentifiedFiles, listIgnoredFiles)
     }
 


### PR DESCRIPTION
The FossID server is not consistent. It usually returns a List or a Map,
but if there is no entry, it returns data:false.
Hence this commit wires a custom Jackson deserializer that abstracts
this behavior.
It also removes the previous toList() function who attempted at doing
this abstraction.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>
