### PR TITLE
DependencyGraphBuilder: Return the managed packages as a sorted set

### DIFF
--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -121,7 +121,7 @@ class Gradle(
 
     override fun createPackageManagerResult(projectResults: Map<File, List<ProjectAnalyzerResult>>):
             PackageManagerResult =
-        PackageManagerResult(projectResults, graphBuilder.build(), graphBuilder.packages().toSortedSet())
+        PackageManagerResult(projectResults, graphBuilder.build(), graphBuilder.packages())
 
     override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val gradleSystemProperties = mutableListOf<Pair<String, String>>()

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -103,7 +103,7 @@ class Maven(
 
     override fun createPackageManagerResult(projectResults: Map<File, List<ProjectAnalyzerResult>>):
             PackageManagerResult =
-        PackageManagerResult(projectResults, graphBuilder.build(), graphBuilder.packages().toSortedSet())
+        PackageManagerResult(projectResults, graphBuilder.build(), graphBuilder.packages())
 
     override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile
@@ -149,7 +149,7 @@ class Maven(
             scopeNames = projectBuildingResult.dependencies.mapTo(sortedSetOf()) { it.dependency.scope }
         )
 
-        val packages = graphBuilder.packages().toSortedSet()
+        val packages = graphBuilder.packages()
         val issues = packages.mapNotNull { pkg ->
             if (pkg.description == "POM was created by Sonatype Nexus") {
                 createAndLogIssue(

--- a/analyzer/src/main/kotlin/managers/utils/DependencyGraphBuilder.kt
+++ b/analyzer/src/main/kotlin/managers/utils/DependencyGraphBuilder.kt
@@ -19,6 +19,8 @@
 
 package org.ossreviewtoolkit.analyzer.managers.utils
 
+import java.util.SortedSet
+
 import org.ossreviewtoolkit.model.DependencyGraph
 import org.ossreviewtoolkit.model.DependencyReference
 import org.ossreviewtoolkit.model.Identifier
@@ -153,9 +155,9 @@ class DependencyGraphBuilder<D>(
     )
 
     /**
-     * Return a set with all the packages that have been encountered for the current project.
+     * Return a sorted set with all the packages that have been encountered for the current project.
      */
-    fun packages(): Set<Package> = resolvedPackages
+    fun packages(): SortedSet<Package> = resolvedPackages.toSortedSet()
 
     /**
      * Update the dependency graph by adding the given [dependency], which may be [transitive], for the scope with name


### PR DESCRIPTION
When constructing analyzer results the packages typically need to be
provided as a sorted set. So far, all PackageManager implementations
making use of DependencyGraphBuilder do this conversion manually.
Simplify this by changing the return type of the packages() function
from Set<Package> to SortedSet<Package>.

