### PR TITLE
azure-pipelines: Make prepending to PATH on Linux more robust

### DIFF
--- a/.azure-pipelines/LinuxAnalyzerTest.yml
+++ b/.azure-pipelines/LinuxAnalyzerTest.yml
@@ -22,7 +22,6 @@ jobs:
       sudo npm install -g bower@$BOWER_VERSION
 
       # Install Python packages.
-      export PATH=$PATH:~/.local/bin
       pip install --user \
         conan==$CONAN_VERSION \
         pipenv==$PYTHON_PIPENV_VERSION \
@@ -36,17 +35,18 @@ jobs:
       rustup default $RUST_VERSION
 
       # Install git-repo.
-      curl https://storage.googleapis.com/git-repo-downloads/repo > ~/.local/bin/repo
-      chmod a+x ~/.local/bin/repo
+      mkdir -p $HOME/.local/bin
+      curl https://storage.googleapis.com/git-repo-downloads/repo > $HOME/.local/bin/repo
+      chmod a+x $HOME/.local/bin/repo
 
-      # Install Go Dep.
-      mkdir -p ~/go/bin
-      export PATH=$PATH:~/go/bin
+      # Install Go Dep (requires the GOBIN directory to already exist).
+      mkdir -p $HOME/go/bin
       curl https://raw.githubusercontent.com/golang/dep/v$GO_DEP_VERSION/install.sh | sh
 
       # Update PATH for next steps, see:
       # https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#prependpath-prepend-a-path-to-the--path-environment-variable
-      echo "##vso[task.setvariable variable=path;]$PATH"
+      echo "##vso[task.prependpath]$HOME/.local/bin"
+      echo "##vso[task.prependpath]$HOME/go/bin"
     displayName: Install Required Tools
 
   # Clone repository.

--- a/.azure-pipelines/LinuxTest.yml
+++ b/.azure-pipelines/LinuxTest.yml
@@ -19,13 +19,13 @@ jobs:
       sudo apt-get -qq remove mono-devel
 
       # Install git-repo.
-      export PATH=$PATH:~/.local/bin
-      curl https://storage.googleapis.com/git-repo-downloads/repo > ~/.local/bin/repo
-      chmod a+x ~/.local/bin/repo
+      mkdir -p $HOME/.local/bin
+      curl https://storage.googleapis.com/git-repo-downloads/repo > $HOME/.local/bin/repo
+      chmod a+x $HOME/.local/bin/repo
 
       # Update PATH for next steps, see:
       # https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#prependpath-prepend-a-path-to-the--path-environment-variable
-      echo "##vso[task.setvariable variable=path;]$PATH"
+      echo "##vso[task.prependpath]$HOME/.local/bin"
     displayName: Install Required Tools
 
   # Clone repository.


### PR DESCRIPTION
Do not unnecessarily export PATH, but just prepend to it in the end
using the dedicated Azure logging command. Ensure that directories being
downloaded to exist. Prefer $HOME over ~ as the latter does not get
expanded in all scenarios.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>