### PR TITLE
Enable dependabot only for github-actions and reporter-web-app

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  # Must be "/" for github-actions, see:
+  # https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#directory
+  directory: "/"
+  schedule:
+    interval: "daily"
+- package-ecosystem: "npm"
+  directory: "/reporter-web-app"
+  schedule:
+    interval: "daily"
+  labels:
+  - "reporter"


### PR DESCRIPTION
We do not want dependabot to update the dependencies of test projects.
As there is no option to disable dependabot for a directory, enable it
only for the projects where we want it to run.

Note that we do not enable dependabot for Gradle because it does not
support defining versios in gradle.propertes [1] and we manually check
for Gradle dependency updates using the `dependencyUpdates` Gradle task
on a regular basis.

[1] https://github.com/dependabot/dependabot-core/issues/1618