### PR TITLE
Gradle: Replace custom "fatJar" code with the "shadow" plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,7 @@
 detektPluginVersion = 1.17.1
 dokkaPluginVersion = 1.4.32
 kotlinPluginVersion = 1.4.32
+shadowPluginVersion = 7.0.0
 svntoolsPluginVersion = 3.1
 taskinfoPluginVersion = 1.1.1
 versionsPluginVersion = 0.38.0


### PR DESCRIPTION
The custom "fatJar" code causes Kotlin 1.5 to hang with Gradle 7 [1].
Work around that by using the anyway more powerful "shadow" plugin [2].

[1] https://youtrack.jetbrains.com/issue/KT-46559#focus=Comments-27-4909120.0-0
[2] https://github.com/johnrengelman/shadow

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>