### PR TITLE
Don't use a sorted set for shared packages in PackageManagerResult

### DIFF
--- a/analyzer/src/funTest/kotlin/managers/Extensions.kt
+++ b/analyzer/src/funTest/kotlin/managers/Extensions.kt
@@ -68,5 +68,5 @@ fun PackageManagerResult.resolveScopes(projectResult: ProjectAnalyzerResult): Pr
 /**
  * Return only those packages from the given set of [allPackages] that are referenced by this [Project].
  */
-private fun Project.filterReferencedPackages(allPackages: SortedSet<Package>): SortedSet<Package> =
+private fun Project.filterReferencedPackages(allPackages: Set<Package>): SortedSet<Package> =
     collectDependencies().run { allPackages.filter { it.id in this }.toSortedSet() }

--- a/analyzer/src/main/kotlin/PackageManagerResult.kt
+++ b/analyzer/src/main/kotlin/PackageManagerResult.kt
@@ -20,7 +20,6 @@
 package org.ossreviewtoolkit.analyzer
 
 import java.io.File
-import java.util.SortedSet
 
 import org.ossreviewtoolkit.model.DependencyGraph
 import org.ossreviewtoolkit.model.Package
@@ -49,5 +48,5 @@ data class PackageManagerResult(
      * produce a shared [DependencyGraph] typically do not collect packages on a project-level, but globally. Such
      * packages can be stored in this property.
      */
-    val sharedPackages: SortedSet<Package> = sortedSetOf()
+    val sharedPackages: Set<Package> = sortedSetOf()
 )

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -119,9 +119,8 @@ class Gradle(
     private val dependencyHandler = GradleDependencyHandler(managerName, maven)
     private val graphBuilder = DependencyGraphBuilder(dependencyHandler)
 
-    override fun createPackageManagerResult(projectResults: Map<File, List<ProjectAnalyzerResult>>):
-            PackageManagerResult =
-        PackageManagerResult(projectResults, graphBuilder.build(), graphBuilder.packages().toSortedSet())
+    override fun createPackageManagerResult(projectResults: Map<File, List<ProjectAnalyzerResult>>) =
+        PackageManagerResult(projectResults, graphBuilder.build(), graphBuilder.packages())
 
     override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val gradleSystemProperties = mutableListOf<Pair<String, String>>()

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -101,9 +101,8 @@ class Maven(
         graphBuilder = DependencyGraphBuilder(dependencyHandler)
     }
 
-    override fun createPackageManagerResult(projectResults: Map<File, List<ProjectAnalyzerResult>>):
-            PackageManagerResult =
-        PackageManagerResult(projectResults, graphBuilder.build(), graphBuilder.packages().toSortedSet())
+    override fun createPackageManagerResult(projectResults: Map<File, List<ProjectAnalyzerResult>>) =
+        PackageManagerResult(projectResults, graphBuilder.build(), graphBuilder.packages())
 
     override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -347,9 +347,8 @@ open class Npm(
         ortProxySelector.removeProxyOrigin(managerName)
     }
 
-    override fun createPackageManagerResult(projectResults: Map<File, List<ProjectAnalyzerResult>>):
-            PackageManagerResult =
-        PackageManagerResult(projectResults, graphBuilder.build(), graphBuilder.packages().toSortedSet())
+    override fun createPackageManagerResult(projectResults: Map<File, List<ProjectAnalyzerResult>>) =
+        PackageManagerResult(projectResults, graphBuilder.build(), graphBuilder.packages())
 
     override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         val workingDir = definitionFile.parentFile

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -401,7 +401,7 @@ class Pub(
                 .resolveDependencies(listOf(packageFile)).run {
                     projectResults.getValue(packageFile).map { result ->
                         val project = result.project.withResolvedScopes(dependencyGraph)
-                        result.copy(project = project, packages = sharedPackages)
+                        result.copy(project = project, packages = sharedPackages.toSortedSet())
                     }
                 }
         }


### PR DESCRIPTION
This is a minor simplification/optimization for package managers using the dependency graph format. Refer to the commit messages for further details.