### PR TITLE
Drop scopes with no dependencies from results

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -244,8 +244,6 @@ analyzer:
         path: ""
       homepage_url: "https://github.com/juliangruber/isarray"
       scopes:
-      - name: "dependencies"
-        dependencies: []
       - name: "devDependencies"
         dependencies:
         - id: "NPM::tape:2.13.4"

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-cli.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-cli.yml
@@ -16,8 +16,6 @@ project:
     path: "analyzer/src/funTest/assets/projects/external/multi-kotlin-project/cli"
   homepage_url: ""
   scopes:
-  - name: "annotationProcessor"
-    dependencies: []
   - name: "apiDependenciesMetadata"
     dependencies:
     - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
@@ -31,8 +29,6 @@ project:
       dependencies:
       - id: "Maven:org.jetbrains:annotations:13.0"
       - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "archives"
-    dependencies: []
   - name: "compile"
     dependencies:
     - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
@@ -59,10 +55,6 @@ project:
       dependencies:
       - id: "Maven:org.jetbrains:annotations:13.0"
       - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "compileOnly"
-    dependencies: []
-  - name: "compileOnlyDependenciesMetadata"
-    dependencies: []
   - name: "default"
     dependencies:
     - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
@@ -89,10 +81,6 @@ project:
       dependencies:
       - id: "Maven:org.jetbrains:annotations:13.0"
       - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "kapt"
-    dependencies: []
-  - name: "kaptTest"
-    dependencies: []
   - name: "kotlinCompilerClasspath"
     dependencies:
     - id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
@@ -111,10 +99,6 @@ project:
   - name: "kotlinCompilerPluginClasspath"
     dependencies:
     - id: "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
-  - name: "kotlinNativeCompilerPluginClasspath"
-    dependencies: []
-  - name: "kotlinScriptDef"
-    dependencies: []
   - name: "runtime"
     dependencies:
     - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
@@ -141,10 +125,6 @@ project:
       dependencies:
       - id: "Maven:org.jetbrains:annotations:13.0"
       - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "runtimeOnlyDependenciesMetadata"
-    dependencies: []
-  - name: "testAnnotationProcessor"
-    dependencies: []
   - name: "testApiDependenciesMetadata"
     dependencies:
     - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
@@ -184,10 +164,6 @@ project:
       dependencies:
       - id: "Maven:org.jetbrains:annotations:13.0"
       - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testCompileOnly"
-    dependencies: []
-  - name: "testCompileOnlyDependenciesMetadata"
-    dependencies: []
   - name: "testImplementationDependenciesMetadata"
     dependencies:
     - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
@@ -201,8 +177,6 @@ project:
       dependencies:
       - id: "Maven:org.jetbrains:annotations:13.0"
       - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testKotlinScriptDef"
-    dependencies: []
   - name: "testRuntime"
     dependencies:
     - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
@@ -229,8 +203,6 @@ project:
       dependencies:
       - id: "Maven:org.jetbrains:annotations:13.0"
       - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testRuntimeOnlyDependenciesMetadata"
-    dependencies: []
 packages:
 - id: "Maven:org.jetbrains:annotations:13.0"
   purl: "pkg:maven/org.jetbrains/annotations@13.0"

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-core.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-core.yml
@@ -16,16 +16,12 @@ project:
     path: "analyzer/src/funTest/assets/projects/external/multi-kotlin-project/core"
   homepage_url: ""
   scopes:
-  - name: "annotationProcessor"
-    dependencies: []
   - name: "apiDependenciesMetadata"
     dependencies:
     - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
       dependencies:
       - id: "Maven:org.jetbrains:annotations:13.0"
       - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "archives"
-    dependencies: []
   - name: "compile"
     dependencies:
     - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
@@ -38,10 +34,6 @@ project:
       dependencies:
       - id: "Maven:org.jetbrains:annotations:13.0"
       - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "compileOnly"
-    dependencies: []
-  - name: "compileOnlyDependenciesMetadata"
-    dependencies: []
   - name: "default"
     dependencies:
     - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
@@ -54,10 +46,6 @@ project:
       dependencies:
       - id: "Maven:org.jetbrains:annotations:13.0"
       - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "kapt"
-    dependencies: []
-  - name: "kaptTest"
-    dependencies: []
   - name: "kotlinCompilerClasspath"
     dependencies:
     - id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
@@ -76,10 +64,6 @@ project:
   - name: "kotlinCompilerPluginClasspath"
     dependencies:
     - id: "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
-  - name: "kotlinNativeCompilerPluginClasspath"
-    dependencies: []
-  - name: "kotlinScriptDef"
-    dependencies: []
   - name: "runtime"
     dependencies:
     - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
@@ -92,10 +76,6 @@ project:
       dependencies:
       - id: "Maven:org.jetbrains:annotations:13.0"
       - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "runtimeOnlyDependenciesMetadata"
-    dependencies: []
-  - name: "testAnnotationProcessor"
-    dependencies: []
   - name: "testApiDependenciesMetadata"
     dependencies:
     - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
@@ -114,18 +94,12 @@ project:
       dependencies:
       - id: "Maven:org.jetbrains:annotations:13.0"
       - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testCompileOnly"
-    dependencies: []
-  - name: "testCompileOnlyDependenciesMetadata"
-    dependencies: []
   - name: "testImplementationDependenciesMetadata"
     dependencies:
     - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
       dependencies:
       - id: "Maven:org.jetbrains:annotations:13.0"
       - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testKotlinScriptDef"
-    dependencies: []
   - name: "testRuntime"
     dependencies:
     - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
@@ -138,8 +112,6 @@ project:
       dependencies:
       - id: "Maven:org.jetbrains:annotations:13.0"
       - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testRuntimeOnlyDependenciesMetadata"
-    dependencies: []
 packages:
 - id: "Maven:org.jetbrains:annotations:13.0"
   purl: "pkg:maven/org.jetbrains/annotations@13.0"

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-root.yml
@@ -39,8 +39,6 @@ project:
         dependencies:
         - id: "Maven:org.jetbrains:annotations:13.0"
         - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "default"
-    dependencies: []
 packages:
 - id: "Maven:org.jetbrains:annotations:13.0"
   purl: "pkg:maven/org.jetbrains/annotations@13.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -83,10 +83,6 @@ analyzer:
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
       homepage_url: ""
       scopes:
-      - name: "annotationProcessor"
-        dependencies: []
-      - name: "archives"
-        dependencies: []
       - name: "compile"
         dependencies:
         - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -105,8 +101,6 @@ analyzer:
             dependencies:
             - id: "Maven:org.apache.commons:commons-lang3:3.5"
           - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "compileOnly"
-        dependencies: []
       - name: "default"
         dependencies:
         - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -134,8 +128,6 @@ analyzer:
             dependencies:
             - id: "Maven:org.apache.commons:commons-lang3:3.5"
           - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testAnnotationProcessor"
-        dependencies: []
       - name: "testCompile"
         dependencies:
         - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -154,8 +146,6 @@ analyzer:
             dependencies:
             - id: "Maven:org.apache.commons:commons-lang3:3.5"
           - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompileOnly"
-        dependencies: []
       - name: "testRuntime"
         dependencies:
         - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -190,10 +180,6 @@ analyzer:
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
       homepage_url: ""
       scopes:
-      - name: "annotationProcessor"
-        dependencies: []
-      - name: "archives"
-        dependencies: []
       - name: "compile"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -206,8 +192,6 @@ analyzer:
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
         - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "compileOnly"
-        dependencies: []
       - name: "default"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -226,8 +210,6 @@ analyzer:
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
         - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testAnnotationProcessor"
-        dependencies: []
       - name: "testCompile"
         dependencies:
         - id: "Maven:junit:junit:4.12"
@@ -246,8 +228,6 @@ analyzer:
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
         - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompileOnly"
-        dependencies: []
       - name: "testRuntime"
         dependencies:
         - id: "Maven:junit:junit:4.12"
@@ -282,10 +262,6 @@ analyzer:
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
       homepage_url: ""
       scopes:
-      - name: "annotationProcessor"
-        dependencies: []
-      - name: "archives"
-        dependencies: []
       - name: "compile"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
@@ -306,8 +282,6 @@ analyzer:
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
             severity: "ERROR"
-      - name: "compileOnly"
-        dependencies: []
       - name: "default"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
@@ -338,8 +312,6 @@ analyzer:
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
             severity: "ERROR"
-      - name: "testAnnotationProcessor"
-        dependencies: []
       - name: "testCompile"
         dependencies:
         - id: "Unknown:junit:junit:4.12"
@@ -374,8 +346,6 @@ analyzer:
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
             severity: "ERROR"
-      - name: "testCompileOnly"
-        dependencies: []
       - name: "testRuntime"
         dependencies:
         - id: "Unknown:junit:junit:4.12"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -83,10 +83,6 @@ analyzer:
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
       homepage_url: ""
       scopes:
-      - name: "annotationProcessor"
-        dependencies: []
-      - name: "archives"
-        dependencies: []
       - name: "compile"
         dependencies:
         - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -105,8 +101,6 @@ analyzer:
             dependencies:
             - id: "Maven:org.apache.commons:commons-lang3:3.5"
           - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "compileOnly"
-        dependencies: []
       - name: "default"
         dependencies:
         - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -134,8 +128,6 @@ analyzer:
             dependencies:
             - id: "Maven:org.apache.commons:commons-lang3:3.5"
           - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testAnnotationProcessor"
-        dependencies: []
       - name: "testCompile"
         dependencies:
         - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -154,8 +146,6 @@ analyzer:
             dependencies:
             - id: "Maven:org.apache.commons:commons-lang3:3.5"
           - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompileOnly"
-        dependencies: []
       - name: "testRuntime"
         dependencies:
         - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -190,10 +180,6 @@ analyzer:
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
       homepage_url: ""
       scopes:
-      - name: "annotationProcessor"
-        dependencies: []
-      - name: "archives"
-        dependencies: []
       - name: "compile"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -206,8 +192,6 @@ analyzer:
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
         - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "compileOnly"
-        dependencies: []
       - name: "default"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -226,8 +210,6 @@ analyzer:
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
         - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testAnnotationProcessor"
-        dependencies: []
       - name: "testCompile"
         dependencies:
         - id: "Maven:junit:junit:4.12"
@@ -246,8 +228,6 @@ analyzer:
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
         - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompileOnly"
-        dependencies: []
       - name: "testRuntime"
         dependencies:
         - id: "Maven:junit:junit:4.12"
@@ -282,10 +262,6 @@ analyzer:
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
       homepage_url: ""
       scopes:
-      - name: "annotationProcessor"
-        dependencies: []
-      - name: "archives"
-        dependencies: []
       - name: "compile"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
@@ -306,8 +282,6 @@ analyzer:
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
             severity: "ERROR"
-      - name: "compileOnly"
-        dependencies: []
       - name: "default"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
@@ -338,8 +312,6 @@ analyzer:
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
             severity: "ERROR"
-      - name: "testAnnotationProcessor"
-        dependencies: []
       - name: "testCompile"
         dependencies:
         - id: "Unknown:junit:junit:4.12"
@@ -374,8 +346,6 @@ analyzer:
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
             severity: "ERROR"
-      - name: "testCompileOnly"
-        dependencies: []
       - name: "testRuntime"
         dependencies:
         - id: "Unknown:junit:junit:4.12"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
@@ -16,8 +16,6 @@ project:
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/app"
   homepage_url: ""
   scopes:
-  - name: "amazonDemoDebugAndroidTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "amazonDemoDebugAndroidTestCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -37,8 +35,6 @@ project:
     - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
       dependencies:
       - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoDebugAnnotationProcessorClasspath"
-    dependencies: []
   - name: "amazonDemoDebugCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -58,8 +54,6 @@ project:
     - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
       dependencies:
       - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoDebugUnitTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "amazonDemoDebugUnitTestCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -85,10 +79,6 @@ project:
     - id: "Maven:junit:junit:4.12"
       dependencies:
       - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonDemoDebugWearBundling"
-    dependencies: []
-  - name: "amazonDemoReleaseAnnotationProcessorClasspath"
-    dependencies: []
   - name: "amazonDemoReleaseCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -108,8 +98,6 @@ project:
     - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
       dependencies:
       - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoReleaseUnitTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "amazonDemoReleaseUnitTestCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -135,10 +123,6 @@ project:
     - id: "Maven:junit:junit:4.12"
       dependencies:
       - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonDemoReleaseWearBundling"
-    dependencies: []
-  - name: "amazonFullDebugAndroidTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "amazonFullDebugAndroidTestCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -158,8 +142,6 @@ project:
     - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
       dependencies:
       - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullDebugAnnotationProcessorClasspath"
-    dependencies: []
   - name: "amazonFullDebugCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -179,8 +161,6 @@ project:
     - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
       dependencies:
       - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullDebugUnitTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "amazonFullDebugUnitTestCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -206,10 +186,6 @@ project:
     - id: "Maven:junit:junit:4.12"
       dependencies:
       - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonFullDebugWearBundling"
-    dependencies: []
-  - name: "amazonFullReleaseAnnotationProcessorClasspath"
-    dependencies: []
   - name: "amazonFullReleaseCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -229,8 +205,6 @@ project:
     - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
       dependencies:
       - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullReleaseUnitTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "amazonFullReleaseUnitTestCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -256,18 +230,6 @@ project:
     - id: "Maven:junit:junit:4.12"
       dependencies:
       - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonFullReleaseWearBundling"
-    dependencies: []
-  - name: "androidTestUtil"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
-    dependencies: []
-  - name: "default"
-    dependencies: []
-  - name: "googleDemoDebugAndroidTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "googleDemoDebugAndroidTestCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -281,8 +243,6 @@ project:
       - id: "Maven:org.apache.commons:commons-text:1.2"
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleDemoDebugAnnotationProcessorClasspath"
-    dependencies: []
   - name: "googleDemoDebugCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -296,8 +256,6 @@ project:
       - id: "Maven:org.apache.commons:commons-text:1.2"
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleDemoDebugUnitTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "googleDemoDebugUnitTestCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -317,10 +275,6 @@ project:
     - id: "Maven:junit:junit:4.12"
       dependencies:
       - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleDemoDebugWearBundling"
-    dependencies: []
-  - name: "googleDemoReleaseAnnotationProcessorClasspath"
-    dependencies: []
   - name: "googleDemoReleaseCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -334,8 +288,6 @@ project:
       - id: "Maven:org.apache.commons:commons-text:1.2"
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleDemoReleaseUnitTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "googleDemoReleaseUnitTestCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -355,10 +307,6 @@ project:
     - id: "Maven:junit:junit:4.12"
       dependencies:
       - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleDemoReleaseWearBundling"
-    dependencies: []
-  - name: "googleFullDebugAndroidTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "googleFullDebugAndroidTestCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -372,8 +320,6 @@ project:
       - id: "Maven:org.apache.commons:commons-text:1.3"
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleFullDebugAnnotationProcessorClasspath"
-    dependencies: []
   - name: "googleFullDebugCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -387,8 +333,6 @@ project:
       - id: "Maven:org.apache.commons:commons-text:1.3"
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleFullDebugUnitTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "googleFullDebugUnitTestCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -408,10 +352,6 @@ project:
     - id: "Maven:junit:junit:4.12"
       dependencies:
       - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleFullDebugWearBundling"
-    dependencies: []
-  - name: "googleFullReleaseAnnotationProcessorClasspath"
-    dependencies: []
   - name: "googleFullReleaseCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -425,8 +365,6 @@ project:
       - id: "Maven:org.apache.commons:commons-text:1.3"
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleFullReleaseUnitTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "googleFullReleaseUnitTestCompileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -446,14 +384,6 @@ project:
     - id: "Maven:junit:junit:4.12"
       dependencies:
       - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleFullReleaseWearBundling"
-    dependencies: []
-  - name: "lintChecks"
-    dependencies: []
-  - name: "lintClassPath"
-    dependencies: []
-  - name: "testCompile"
-    dependencies: []
 packages:
 - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
   purl: "pkg:maven/com.squareup.okhttp3/okhttp@3.10.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
@@ -16,16 +16,6 @@ project:
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/lib"
   homepage_url: ""
   scopes:
-  - name: "androidTestUtil"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
-    dependencies: []
-  - name: "default"
-    dependencies: []
-  - name: "demoDebugAndroidTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "demoDebugAndroidTestCompileClasspath"
     dependencies:
     - id: "Maven:org.apache.commons:commons-compress:1.17"
@@ -38,8 +28,6 @@ project:
     - id: "Maven:org.apache.commons:commons-text:1.2"
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoDebugAnnotationProcessorClasspath"
-    dependencies: []
   - name: "demoDebugCompileClasspath"
     dependencies:
     - id: "Maven:org.apache.commons:commons-compress:1.17"
@@ -52,8 +40,6 @@ project:
     - id: "Maven:org.apache.commons:commons-text:1.2"
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoDebugUnitTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "demoDebugUnitTestCompileClasspath"
     dependencies:
     - id: "Maven:org.apache.commons:commons-compress:1.17"
@@ -66,8 +52,6 @@ project:
     - id: "Maven:org.apache.commons:commons-text:1.2"
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoReleaseAnnotationProcessorClasspath"
-    dependencies: []
   - name: "demoReleaseCompileClasspath"
     dependencies:
     - id: "Maven:org.apache.commons:commons-compress:1.17"
@@ -80,8 +64,6 @@ project:
     - id: "Maven:org.apache.commons:commons-text:1.2"
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoReleaseUnitTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "demoReleaseUnitTestCompileClasspath"
     dependencies:
     - id: "Maven:org.apache.commons:commons-compress:1.17"
@@ -94,8 +76,6 @@ project:
     - id: "Maven:org.apache.commons:commons-text:1.2"
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullDebugAndroidTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "fullDebugAndroidTestCompileClasspath"
     dependencies:
     - id: "Maven:org.apache.commons:commons-compress:1.17"
@@ -108,8 +88,6 @@ project:
     - id: "Maven:org.apache.commons:commons-text:1.3"
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullDebugAnnotationProcessorClasspath"
-    dependencies: []
   - name: "fullDebugCompileClasspath"
     dependencies:
     - id: "Maven:org.apache.commons:commons-compress:1.17"
@@ -122,8 +100,6 @@ project:
     - id: "Maven:org.apache.commons:commons-text:1.3"
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullDebugUnitTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "fullDebugUnitTestCompileClasspath"
     dependencies:
     - id: "Maven:org.apache.commons:commons-compress:1.17"
@@ -136,8 +112,6 @@ project:
     - id: "Maven:org.apache.commons:commons-text:1.3"
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullReleaseAnnotationProcessorClasspath"
-    dependencies: []
   - name: "fullReleaseCompileClasspath"
     dependencies:
     - id: "Maven:org.apache.commons:commons-compress:1.17"
@@ -150,8 +124,6 @@ project:
     - id: "Maven:org.apache.commons:commons-text:1.3"
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullReleaseUnitTestAnnotationProcessorClasspath"
-    dependencies: []
   - name: "fullReleaseUnitTestCompileClasspath"
     dependencies:
     - id: "Maven:org.apache.commons:commons-compress:1.17"
@@ -164,12 +136,6 @@ project:
     - id: "Maven:org.apache.commons:commons-text:1.3"
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "lintChecks"
-    dependencies: []
-  - name: "lintClassPath"
-    dependencies: []
-  - name: "testCompile"
-    dependencies: []
 packages:
 - id: "Maven:org.apache.commons:commons-compress:1.17"
   purl: "pkg:maven/org.apache.commons/commons-compress@1.17"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
@@ -16,8 +16,6 @@ project:
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
   homepage_url: ""
   scopes:
-  - name: "archives"
-    dependencies: []
   - name: "compile"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
@@ -16,8 +16,6 @@ project:
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
   homepage_url: ""
   scopes:
-  - name: "archives"
-    dependencies: []
   - name: "compile"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -27,8 +25,6 @@ project:
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.5"
       - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileOnly"
-    dependencies: []
   - name: "default"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -56,8 +52,6 @@ project:
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.5"
       - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileOnly"
-    dependencies: []
   - name: "testRuntime"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -16,10 +16,6 @@ project:
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
   homepage_url: ""
   scopes:
-  - name: "annotationProcessor"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
   - name: "compile"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -38,8 +34,6 @@ project:
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.5"
       - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileOnly"
-    dependencies: []
   - name: "default"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -67,8 +61,6 @@ project:
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.5"
       - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testAnnotationProcessor"
-    dependencies: []
   - name: "testCompile"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -87,8 +79,6 @@ project:
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.5"
       - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileOnly"
-    dependencies: []
   - name: "testRuntime"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -16,10 +16,6 @@ project:
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
   homepage_url: ""
   scopes:
-  - name: "annotationProcessor"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
   - name: "compile"
     dependencies:
     - id: "Unknown:org.apache.commons:commons-text:1.1"
@@ -40,8 +36,6 @@ project:
           \ dependency org.apache.commons:commons-text:1.1 because no repositories\
           \ are defined."
         severity: "ERROR"
-  - name: "compileOnly"
-    dependencies: []
   - name: "default"
     dependencies:
     - id: "Unknown:org.apache.commons:commons-text:1.1"
@@ -72,8 +66,6 @@ project:
           \ dependency org.apache.commons:commons-text:1.1 because no repositories\
           \ are defined."
         severity: "ERROR"
-  - name: "testAnnotationProcessor"
-    dependencies: []
   - name: "testCompile"
     dependencies:
     - id: "Unknown:junit:junit:4.12"
@@ -108,8 +100,6 @@ project:
           \ dependency org.apache.commons:commons-text:1.1 because no repositories\
           \ are defined."
         severity: "ERROR"
-  - name: "testCompileOnly"
-    dependencies: []
   - name: "testRuntime"
     dependencies:
     - id: "Unknown:junit:junit:4.12"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -16,10 +16,6 @@ project:
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
   homepage_url: ""
   scopes:
-  - name: "annotationProcessor"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
   - name: "compile"
     dependencies:
     - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -32,8 +28,6 @@ project:
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.5"
     - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileOnly"
-    dependencies: []
   - name: "default"
     dependencies:
     - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -52,8 +46,6 @@ project:
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.5"
     - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testAnnotationProcessor"
-    dependencies: []
   - name: "testCompile"
     dependencies:
     - id: "Maven:junit:junit:4.12"
@@ -72,8 +64,6 @@ project:
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.5"
     - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileOnly"
-    dependencies: []
   - name: "testRuntime"
     dependencies:
     - id: "Maven:junit:junit:4.12"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
@@ -16,10 +16,6 @@ project:
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/app"
   homepage_url: ""
   scopes:
-  - name: "annotationProcessor"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
   - name: "compile"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -37,8 +33,6 @@ project:
       - id: "Maven:org.apache.commons:commons-text:1.1"
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.5"
-  - name: "compileOnly"
-    dependencies: []
   - name: "default"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -66,8 +60,6 @@ project:
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.5"
       - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testAnnotationProcessor"
-    dependencies: []
   - name: "testCompile"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -85,8 +77,6 @@ project:
       - id: "Maven:org.apache.commons:commons-text:1.1"
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.5"
-  - name: "testCompileOnly"
-    dependencies: []
   - name: "testRuntime"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
@@ -16,38 +16,24 @@ project:
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/lib"
   homepage_url: ""
   scopes:
-  - name: "annotationProcessor"
-    dependencies: []
-  - name: "archives"
-    dependencies: []
-  - name: "compile"
-    dependencies: []
   - name: "compileClasspath"
     dependencies:
     - id: "Maven:org.apache.commons:commons-text:1.1"
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.5"
     - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileOnly"
-    dependencies: []
   - name: "default"
     dependencies:
     - id: "Maven:org.apache.commons:commons-text:1.1"
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.5"
     - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtime"
-    dependencies: []
   - name: "runtimeClasspath"
     dependencies:
     - id: "Maven:org.apache.commons:commons-text:1.1"
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.5"
     - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testAnnotationProcessor"
-    dependencies: []
-  - name: "testCompile"
-    dependencies: []
   - name: "testCompileClasspath"
     dependencies:
     - id: "Maven:junit:junit:4.12"
@@ -57,10 +43,6 @@ project:
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.5"
     - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileOnly"
-    dependencies: []
-  - name: "testRuntime"
-    dependencies: []
   - name: "testRuntimeClasspath"
     dependencies:
     - id: "Maven:junit:junit:4.12"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -2302,8 +2302,6 @@ project:
       - id: "NPM::v8flags:2.1.1"
         dependencies:
         - id: "NPM::user-home:1.1.1"
-  - name: "devDependencies"
-    dependencies: []
 packages:
 - id: "NPM::abbrev:1.1.1"
   purl: "pkg:npm/abbrev@1.1.1"

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces-expected-output.yml
@@ -26,8 +26,6 @@ project:
     - id: "NPM:@here:harp-fetch:0.3.6"
       dependencies:
       - id: "NPM::node-fetch:2.6.0"
-  - name: "devDependencies"
-    dependencies: []
 packages:
 - id: "NPM::node-fetch:2.6.0"
   purl: "pkg:npm/node-fetch@2.6.0"

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -246,9 +246,6 @@ class Gradle(
                             dependency
                         )
                     }
-
-                    // Make sure that scopes without dependencies are recorded.
-                    graphBuilder.addScope(DependencyGraph.qualifyScope(projectId, configuration.name))
                 }
 
                 val project = Project(

--- a/analyzer/src/main/kotlin/managers/utils/DependencyGraphBuilder.kt
+++ b/analyzer/src/main/kotlin/managers/utils/DependencyGraphBuilder.kt
@@ -128,14 +128,6 @@ class DependencyGraphBuilder<D>(
     private val directDependencies = mutableSetOf<DependencyReference>()
 
     /**
-     * Add the scope with the given [scopeName] to this builder. In most cases, it is not necessary to add scopes
-     * explicitly, as they are recorded automatically by _addDependency()_. However, if there are scopes without
-     * dependencies, this function can be used to include them into the builder result.
-     */
-    fun addScope(scopeName: String): DependencyGraphBuilder<D> =
-        apply { scopeMapping.putIfAbsent(scopeName, emptyList()) }
-
-    /**
      * Add the given [dependency] for the scope with the given [scopeName] to this builder. This function needs to be
      * called all the direct dependencies of all scopes. That way the builder gets sufficient information to construct
      * the [DependencyGraph].

--- a/analyzer/src/test/kotlin/managers/GradleDependencyHandlerTest.kt
+++ b/analyzer/src/test/kotlin/managers/GradleDependencyHandlerTest.kt
@@ -22,11 +22,9 @@ package org.ossreviewtoolkit.analyzer.managers
 import Dependency
 
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.haveSize
-import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.beNull
@@ -56,11 +54,9 @@ import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageReference
 import org.ossreviewtoolkit.model.RemoteArtifact
-import org.ossreviewtoolkit.model.RootDependencyIndex
 import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.VcsInfo
-import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 /**
  * A test class to test the integration of the [Gradle] package manager with [DependencyGraphBuilder]. This class
@@ -271,36 +267,6 @@ class GradleDependencyHandlerTest : WordSpec({
             refConfigExclude.checkDependencies(depLang)
             refConfigExclude.dependencies.findDependency(depLang) shouldBeSameInstanceAs refConfigFull
                 .dependencies.findDependency(depLang)
-        }
-
-        "support scopes without dependencies" {
-            val scope = "EmptyScope"
-
-            val graph = createGraphBuilder()
-                .addScope(scope)
-                .build()
-
-            with(graph) {
-                scopeRoots should beEmpty()
-                scopes.keys shouldContainExactly setOf(scope)
-                scopes[scope] shouldNotBeNull {
-                    this should beEmpty()
-                }
-            }
-        }
-
-        "not override a scope's dependencies when adding it again" {
-            val scope = "compile"
-            val dep = createDependency("org.apache.commons", "commons-lang3", "3.11")
-
-            val graph = createGraphBuilder()
-                .addDependency(scope, dep)
-                .addScope(scope)
-                .build()
-
-            graph.scopes[scope] shouldNotBeNull {
-                this should containExactly(RootDependencyIndex(0))
-            }
         }
 
         "support adding packages directly" {


### PR DESCRIPTION
Slightly simplify the code of affected package managers to construct the dependency graph. Adapt the expected test results accordingly.
