### PR TITLE
Docker: Conditionally start ssh agent for SSH downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -166,4 +166,5 @@ RUN tar xf /opt/ort.tar -C /opt/ort --strip-components 1 && \
 COPY --from=build /usr/local/src/ort/helper-cli/build/scripts/orth /opt/ort/bin/
 COPY --from=build /usr/local/src/ort/helper-cli/build/libs/helper-cli-*.jar /opt/ort/lib/
 
-ENTRYPOINT ["/opt/ort/bin/ort"]
+COPY scripts/entrypoint.sh /opt/scripts/entrypoint.sh
+ENTRYPOINT ["/opt/scripts/entrypoint.sh"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2021 Bosch.IO GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+set -euo pipefail
+
+if [[ -f /root/.ssh/id_rsa ]]; then
+  eval $(ssh-agent -s)
+  ssh-add /root/.ssh/id_rsa
+fi
+
+opt/ort/bin/ort "$@"


### PR DESCRIPTION
We want to run ORT within a Kubernetes pod, but we also need to be able to resolve repositories by SSH since some packages have a download link as SSH-link. 

Previously, we would start an agent on the host and then just share the socket with the container, but this is not as simple in a Kubernetes setup. Therefore we need a way to open an ssh agent within the container, which is what this PR is about.

The PR will only change anything if an identity file is mounted into the Docker container.