### PR TITLE
VcsHost: Replace usage of deprecated `toLowerCase()` with `lowercase()`

### DIFF
--- a/downloader/src/main/kotlin/VcsHost.kt
+++ b/downloader/src/main/kotlin/VcsHost.kt
@@ -241,7 +241,7 @@ enum class VcsHost(
             }
 
         override fun toArchiveDownloadUrlInternal(userOrOrg: String, project: String, vcsInfo: VcsInfo) =
-            "https://${vcsInfo.type.toString().toLowerCase()}.$hostname/~$userOrOrg/$project/archive/" +
+            "https://${vcsInfo.type.toString().lowercase()}.$hostname/~$userOrOrg/$project/archive/" +
                     "${vcsInfo.revision}.tar.gz"
     };
 


### PR DESCRIPTION
See: https://kotlinlang.org/docs/whatsnew15.html#stable-locale-agnostic-api-for-upper-lowercasing-text.

