### PR TITLE
UploadResultToSw360Command: Add a new command line option to attach sources

### DIFF
--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -37,8 +37,6 @@ import com.github.ajalt.clikt.parameters.options.switch
 import com.github.ajalt.clikt.parameters.types.enum
 import com.github.ajalt.clikt.parameters.types.file
 
-import java.io.File
-
 import org.ossreviewtoolkit.cli.GlobalOptions
 import org.ossreviewtoolkit.cli.GroupTypes.FileType
 import org.ossreviewtoolkit.cli.GroupTypes.StringType
@@ -61,19 +59,17 @@ import org.ossreviewtoolkit.model.licenses.LicenseClassifications
 import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
 import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.model.licenses.ResolvedLicenseInfo
-import org.ossreviewtoolkit.model.licenses.orEmpty
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.utils.createLicenseInfoResolver
-import org.ossreviewtoolkit.spdx.VCS_DIRECTORIES
 import org.ossreviewtoolkit.spdx.model.LicenseChoice
 import org.ossreviewtoolkit.utils.ArchiveType
 import org.ossreviewtoolkit.utils.ORT_LICENSE_CLASSIFICATIONS_FILENAME
+import org.ossreviewtoolkit.utils.archive
 import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.encodeOrUnknown
 import org.ossreviewtoolkit.utils.expandTilde
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.ortConfigDirectory
-import org.ossreviewtoolkit.utils.packZip
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.showStackTrace
 
@@ -370,20 +366,5 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
             .filter { it.id in effectiveLicenses }
             .flatMap { it.categories }
             .toSet()
-    }
-}
-
-private fun archive(inputDir: File, zipFile: File, prefix: String = ""): Result<File> {
-    return runCatching {
-        inputDir.packZip(
-            zipFile,
-            prefix,
-            directoryFilter = { it.name !in VCS_DIRECTORIES },
-            fileFilter = { it != zipFile }
-        )
-
-        zipFile
-    }.onFailure {
-        it.showStackTrace()
     }
 }

--- a/utils/src/main/kotlin/Utils.kt
+++ b/utils/src/main/kotlin/Utils.kt
@@ -26,6 +26,8 @@ import java.security.Permission
 
 import kotlin.reflect.full.memberProperties
 
+import org.ossreviewtoolkit.spdx.VCS_DIRECTORIES
+
 /**
  * The directory to store ORT (read-only) configuration in.
  */
@@ -63,6 +65,25 @@ val ortDataDirectory by lazy {
  * Global variable that gets toggled by a command line parameter parsed in the main entry points of the modules.
  */
 var printStackTrace = false
+
+/**
+ * Archive the contents of [inputDir], omitting common [VCS_DIRECTORIES], to [zipFile] where an optional [prefix] is
+ * added to each file. Return a [Result] wrapping the [zipFile] on success, or an exception of failure.
+ */
+fun archive(inputDir: File, zipFile: File, prefix: String = ""): Result<File> {
+    return runCatching {
+        inputDir.packZip(
+            zipFile,
+            prefix,
+            directoryFilter = { it.name !in VCS_DIRECTORIES },
+            fileFilter = { it != zipFile }
+        )
+
+        zipFile
+    }.onFailure {
+        it.showStackTrace()
+    }
+}
 
 /**
  * Return whether [T] (usually an instance of a data class) has any non-null property.


### PR DESCRIPTION
Add a new command line option --attach-sources in order to attach sources
of packages if they exist. The Downloader is used to download the sources of
the package and it's packed as a ZIP file in a temporary directory.

Resolves #3998.

Signed-off-by: Onur Demirci <onur.demirci@bosch.io>
