### PR TITLE
Remove (some) references to JCenter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,20 +105,12 @@ val mergeDetektReports by tasks.registering(ReportMergeTask::class) {
 allprojects {
     buildscript {
         repositories {
-            // Explicitly add Maven Central as some plugins continue to have problems with JCenter, see
-            // https://github.com/detekt/detekt/issues/3062.
             mavenCentral()
-
-            jcenter()
         }
     }
 
     repositories {
-        // Work-around for JCenter not correctly proxying "maven-metadata.xml", see
-        // https://github.com/ben-manes/gradle-versions-plugin/issues/424#issuecomment-691628498.
         mavenCentral()
-
-        jcenter()
     }
 
     apply(plugin = "io.gitlab.arturbosch.detekt")

--- a/scripts/import_proxy_certs.sh
+++ b/scripts/import_proxy_certs.sh
@@ -22,7 +22,7 @@ if [ -z "$https_proxy" ]; then
     exit
 fi
 
-CONNECT_SERVER="jcenter.bintray.com:443"
+CONNECT_SERVER="repo.maven.apache.org:443"
 
 TEMP_DIR="$(mktemp -d)"
 FILE="$TEMP_DIR/proxy.crt"


### PR DESCRIPTION
Note that the test projects partly still refer to JCenter, but that probably is even a good idea, to verify that we can deal with projects that still refer to JCenter.