### PR TITLE
GoMod: Use the source artifact URL only as fallback

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
@@ -106,7 +106,7 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://proxy.golang.org/github.com/fatih/color/@v/v1.7.0.zip"
+    url: ""
     hash:
       value: ""
       algorithm: ""
@@ -132,7 +132,7 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://proxy.golang.org/github.com/golang/protobuf/@v/v1.2.0.zip"
+    url: ""
     hash:
       value: ""
       algorithm: ""
@@ -158,7 +158,7 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://proxy.golang.org/github.com/hashicorp/errwrap/@v/v1.0.0.zip"
+    url: ""
     hash:
       value: ""
       algorithm: ""
@@ -184,7 +184,7 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://proxy.golang.org/github.com/hashicorp/go-multierror/@v/v1.0.0.zip"
+    url: ""
     hash:
       value: ""
       algorithm: ""
@@ -210,7 +210,7 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://proxy.golang.org/github.com/mattn/go-colorable/@v/v0.1.4.zip"
+    url: ""
     hash:
       value: ""
       algorithm: ""
@@ -236,7 +236,7 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://proxy.golang.org/github.com/mattn/go-isatty/@v/v0.0.10.zip"
+    url: ""
     hash:
       value: ""
       algorithm: ""
@@ -262,7 +262,7 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://proxy.golang.org/github.com/mattn/go-isatty/@v/v0.0.8.zip"
+    url: ""
     hash:
       value: ""
       algorithm: ""

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -185,17 +185,24 @@ class GoMod(
         return result
     }
 
-    private fun createPackage(id: Identifier): Package =
-        Package(
+    private fun createPackage(id: Identifier): Package {
+        val vcsInfo = id.toVcsInfo()
+
+        return Package(
             id = Identifier(managerName, "", id.name, id.version),
             authors = sortedSetOf(), // Go mod doesn't support author information.
             declaredLicenses = sortedSetOf(), // Go mod doesn't support declared licenses.
             description = "",
             homepageUrl = "",
             binaryArtifact = RemoteArtifact.EMPTY,
-            sourceArtifact = getSourceArtifactForPackage(id),
-            vcs = id.toVcsInfo()
+            sourceArtifact = if (vcsInfo == VcsInfo.EMPTY) {
+                getSourceArtifactForPackage(id)
+            } else {
+                RemoteArtifact.EMPTY
+            },
+            vcs = vcsInfo
         )
+    }
 
     private fun getSourceArtifactForPackage(id: Identifier): RemoteArtifact {
         /**


### PR DESCRIPTION
Using the source artifact URL pointing to a GO proxy is more fragile
compared to using the VCS info. So, avoid using / scanning that source
artifact URL by setting it only in case the VCS info is not available.
