### PR TITLE
fossid-webapp: Fix regression in response deserialization

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/EntityResponseBody.kt
+++ b/clients/fossid-webapp/src/main/kotlin/EntityResponseBody.kt
@@ -29,3 +29,7 @@ class EntityResponseBody<T>(
 )
 
 typealias MapResponseBody<T> = EntityResponseBody<Map<String, T>>
+
+typealias PolymorphicResponseBody<T> = EntityResponseBody<PolymorphicList<T>>
+
+class PolymorphicList<T>(data: List<T> = listOf()) : List<T> by data

--- a/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
+++ b/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
@@ -23,18 +23,16 @@ package org.ossreviewtoolkit.clients.fossid
 
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.JsonToken
-import com.fasterxml.jackson.databind.BeanDescription
-import com.fasterxml.jackson.databind.DeserializationConfig
+import com.fasterxml.jackson.databind.BeanProperty
 import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
-import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier
-import com.fasterxml.jackson.databind.deser.std.DelegatingDeserializer
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.json.JsonMapper
-import com.fasterxml.jackson.databind.type.CollectionType
-import com.fasterxml.jackson.databind.type.MapType
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 
 import okhttp3.OkHttpClient
@@ -65,44 +63,52 @@ interface FossIdRestService {
             // FossID has a bug in get_results/scan.
             // Sometimes the match_type is "ignored", sometimes it is "Ignored".
             .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
-            .registerModule(kotlinModule().setDeserializerModifier(FossIdDeserializerModifier()))
+            .registerModule(kotlinModule()
+                .addDeserializer(PolymorphicList::class.java, PolymorphicListDeserializer()))
 
         /**
          * A class to modify the standard Jackson deserialization to deal with inconsistencies in responses
          * sent by the FossID server.
          * FossID usually returns data as a List or Map, but in case of no entries it returns a Boolean (which is set to
-         * false). To handle this special case, this class makes sure that a custom deserializer is used for lists or
-         * maps that detects such a result and converts it to an empty list or map, respective. That way, the FossID
-         * service interface can use meaningful result types.
+         * false). This custom deserializer streamLines the result:
+         * - maps are converted to lists by ignoring the keys
+         * - empty list is returned when the result is Boolean
+         * - to address a FossID bug in get_all_scans operation, arrays are converted to list.
          */
-        private class FossIdDeserializerModifier : BeanDeserializerModifier() {
-            override fun modifyMapDeserializer(
-                config: DeserializationConfig,
-                type: MapType,
-                beanDesc: BeanDescription,
-                deserializer: JsonDeserializer<*>
-            ): JsonDeserializer<*> = FalseValueDeserializer(deserializer) { mutableMapOf<Any, Any>() }
+        private class PolymorphicListDeserializer(val boundType: JavaType? = null) :
+            StdDeserializer<PolymorphicList<Any>>(PolymorphicList::class.java), ContextualDeserializer {
+            override fun deserialize(p: JsonParser, ctxt: DeserializationContext): PolymorphicList<Any> {
+                requireNotNull(boundType) {
+                    "The PolymorphicListDeserializer needs a type to deserialize values!"
+                }
+                return when (p.currentToken) {
+                    JsonToken.VALUE_FALSE -> PolymorphicList()
+                    JsonToken.START_ARRAY -> {
+                        val arrayType = JSON_MAPPER.typeFactory.constructArrayType(boundType)
+                        val array = JSON_MAPPER.readValue<Array<Any>>(p, arrayType)
+                        PolymorphicList(array.toList())
+                    }
+                    JsonToken.START_OBJECT -> {
+                        val mapType = JSON_MAPPER.typeFactory.constructMapType(
+                            LinkedHashMap::class.java,
+                            String::class.java,
+                            boundType.rawClass
+                        )
+                        val map = JSON_MAPPER.readValue<Map<Any, Any>>(p, mapType)
+                        // we keep only the values of the map: when the FossID functions which return a PolymorphicList
+                        // return a map, this is always the list of elements grouped by id. Since the ids are also
+                        // present in the elements themselves, we don't lose any information by discarding the keys.
+                        PolymorphicList(map.values.toList())
+                    }
+                    else -> throw IllegalStateException("FossID returned a type not handled by this deserializer!")
+                }
+            }
 
-            override fun modifyCollectionDeserializer(
-                config: DeserializationConfig?,
-                type: CollectionType?,
-                beanDesc: BeanDescription?,
-                deserializer: JsonDeserializer<*>
-            ): JsonDeserializer<*> = FalseValueDeserializer(deserializer) { mutableListOf<Any>() }
-        }
-
-        /**
-         * Custom Jackson deserializer that abstracts the behaviour explained above. [creator] is a function that
-         * creates the 'replacement' object when a Boolean value set to false is received. When not, the standard
-         * Kotlin/Jackson deserializer is called by delegation.
-         */
-        private class FalseValueDeserializer(delegate: JsonDeserializer<*>, private val creator: () -> Any) :
-            DelegatingDeserializer(delegate) {
-            override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Any =
-                if (p.currentToken == JsonToken.VALUE_FALSE) creator() else super.deserialize(p, ctxt)
-
-            override fun newDelegatingInstance(newDelegatee: JsonDeserializer<*>): JsonDeserializer<*> =
-                FalseValueDeserializer(newDelegatee, creator)
+            override fun createContextual(ctxt: DeserializationContext?, property: BeanProperty?): JsonDeserializer<*> {
+                // Extract the type from the property, i.e. the T in PolymorphicList.data<T>
+                val type = property?.member?.type?.bindings?.getBoundType(0)
+                return PolymorphicListDeserializer(type)
+            }
         }
 
         /**
@@ -124,7 +130,7 @@ interface FossIdRestService {
     suspend fun getProject(@Body body: PostRequestBody): EntityResponseBody<Project>
 
     @POST("api.php")
-    suspend fun listScansForProject(@Body body: PostRequestBody): MapResponseBody<Scan>
+    suspend fun listScansForProject(@Body body: PostRequestBody): PolymorphicResponseBody<Scan>
 
     @POST("api.php")
     suspend fun createProject(@Body body: PostRequestBody): MapResponseBody<String>
@@ -148,19 +154,20 @@ interface FossIdRestService {
     suspend fun checkScanStatus(@Body body: PostRequestBody): EntityResponseBody<ScanStatus>
 
     @POST("api.php")
-    suspend fun listScanResults(@Body body: PostRequestBody): MapResponseBody<FossIdScanResult>
+    suspend fun listScanResults(@Body body: PostRequestBody): PolymorphicResponseBody<FossIdScanResult>
 
     @POST("api.php")
-    suspend fun listIdentifiedFiles(@Body body: PostRequestBody): MapResponseBody<IdentifiedFile>
+    suspend fun listIdentifiedFiles(@Body body: PostRequestBody): PolymorphicResponseBody<IdentifiedFile>
 
     @POST("api.php")
-    suspend fun listMarkedAsIdentifiedFiles(@Body body: PostRequestBody): MapResponseBody<MarkedAsIdentifiedFile>
+    suspend fun listMarkedAsIdentifiedFiles(@Body body: PostRequestBody):
+            PolymorphicResponseBody<MarkedAsIdentifiedFile>
 
     @POST("api.php")
-    suspend fun listIgnoredFiles(@Body body: PostRequestBody): EntityResponseBody<List<IgnoredFile>>
+    suspend fun listIgnoredFiles(@Body body: PostRequestBody): PolymorphicResponseBody<IgnoredFile>
 
     @POST("api.php")
-    suspend fun listPendingFiles(@Body body: PostRequestBody): MapResponseBody<String>
+    suspend fun listPendingFiles(@Body body: PostRequestBody): PolymorphicResponseBody<String>
 
     @GET("index.php?form=login")
     suspend fun getLoginPage(): ResponseBody

--- a/clients/fossid-webapp/src/test/assets/return-type/mappings/apiphp-list_scan_for_project_exaclty_one.json
+++ b/clients/fossid-webapp/src/test/assets/return-type/mappings/apiphp-list_scan_for_project_exaclty_one.json
@@ -1,0 +1,26 @@
+{
+  "id" : "4680754e-1daa-4d1e-84ff-cfba5a66715d",
+  "name" : "apiphp",
+  "request" : {
+    "url" : "/api.php",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"action\":\"get_all_scans\",\"group\":\"projects\",\"data\":{\"username\":\"\",\"key\":\"\",\"project_code\":\"semver4j_3\"}}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : true
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{  \"operation\": \"get_all_scans\",  \"status\": \"1\",  \"data\": [    {      \"0\": \"3496\",      \"id\": \"3496\",      \"1\": \"2021-06-01 10:15:30\",      \"created\": \"2021-06-01 10:15:30\",      \"2\": null,      \"updated\": null,      \"3\": \"143\",      \"user_id\": \"143\",      \"4\": \"937\",      \"project_id\": \"937\",      \"5\": \"mockito_20210601_101530\",      \"code\": \"mockito_20210601_101530\",      \"6\": \"mockito_20210601_101530\",      \"name\": \"mockito_20210601_101530\",      \"7\": \"\",      \"description\": \"\",      \"8\": \"\",      \"comment\": \"\",      \"9\": null,      \"is_archived\": null,      \"10\": \"\",      \"target_path\": \"\",      \"11\": null,      \"is_blind_audit\": null,      \"12\": null,      \"files_not_scanned\": null,      \"13\": null,      \"pending_items\": null,      \"14\": null,      \"is_from_report\": null,      \"15\": \"https:\\/\\/github.com\\/mockito\\/mockito.git\",      \"git_repo_url\": \"https:\\/\\/github.com\\/mockito\\/mockito.git\",      \"16\": \"HEAD\",      \"git_branch\": \"HEAD\",      \"17\": null,      \"imported_metadata\": null,      \"18\": \"1\",      \"has_file_extension\": \"1\",      \"19\": \"if_no_fullmatch\",      \"jar_extraction\": \"if_no_fullmatch\",      \"20\": null,      \"any_archives_expanded\": null,      \"21\": null,      \"uploaded_files\": null    }  ]}",
+    "headers" : {
+      "Content-Type" : "text/html; charset=UTF-8",
+      "Date" : "Thu, 03 Dec 2020 08:03:42 GMT",
+      "Server" : "Apache/2.4.38 (Debian)",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "4680754e-1daa-4d1e-84ff-cfba5a66715d",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
@@ -22,7 +22,7 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.maps.beEmpty
+import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.maps.shouldContain
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
@@ -103,7 +103,7 @@ class FossIdClientNewProjectTest : StringSpec({
         service.listScansForProject("", "", PROJECT_CODE) shouldNotBeNull {
             checkResponse("list scans")
             data shouldNotBeNull {
-                this should beEmpty()
+                isEmpty() shouldBe true
             }
         }
     }
@@ -165,7 +165,7 @@ class FossIdClientNewProjectTest : StringSpec({
             checkResponse("list scan results")
             data shouldNotBeNull {
                 size shouldBe 58
-                values.last().localPath shouldBe "pom.xml"
+                last().localPath shouldBe "pom.xml"
             }
         }
     }
@@ -174,18 +174,16 @@ class FossIdClientNewProjectTest : StringSpec({
         service.listIdentifiedFiles("", "", SCAN_CODE) shouldNotBeNull {
             checkResponse("list identified files")
             data shouldNotBeNull {
-                with(values) {
-                    size shouldBe 40
-                    last().should {
-                        it.file.shouldNotBeNull {
-                            path shouldBe "LICENSE.md"
-                            licenseIdentifier shouldBe "MIT"
-                            licenseIsFoss shouldBe true
-                            licenseIsCopyleft shouldBe true
-                        }
-
-                        it.identificationCopyright shouldBe "• David Gundersen (2016)\n"
+                size shouldBe 40
+                last().should {
+                    it.file.shouldNotBeNull {
+                        path shouldBe "LICENSE.md"
+                        licenseIdentifier shouldBe "MIT"
+                        licenseIsFoss shouldBe true
+                        licenseIsCopyleft shouldBe true
                     }
+
+                    it.identificationCopyright shouldBe "• David Gundersen (2016)\n"
                 }
             }
         }
@@ -217,10 +215,8 @@ class FossIdClientNewProjectTest : StringSpec({
         service.listPendingFiles("", "", SCAN_CODE) shouldNotBeNull {
             checkResponse("list pending files")
             data shouldNotBeNull {
-                values.should {
-                    it.size shouldBe 2
-                    it.first() shouldBe "src/extra_file.txt"
-                }
+                size shouldBe 2
+                first() shouldBe "src/extra_file.txt"
             }
         }
     }

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
@@ -4,9 +4,10 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.beEmpty
-import io.kotest.matchers.maps.beEmpty as beEmptyMap
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
+import io.kotest.matchers.types.shouldBeTypeOf
 
 import org.ossreviewtoolkit.clients.fossid.FossIdRestService
 import org.ossreviewtoolkit.clients.fossid.checkResponse
@@ -16,6 +17,11 @@ import org.ossreviewtoolkit.clients.fossid.listMarkedAsIdentifiedFiles
 import org.ossreviewtoolkit.clients.fossid.listPendingFiles
 import org.ossreviewtoolkit.clients.fossid.listScanResults
 import org.ossreviewtoolkit.clients.fossid.listScansForProject
+import org.ossreviewtoolkit.clients.fossid.model.Scan
+import org.ossreviewtoolkit.clients.fossid.model.identification.identifiedFiles.IdentifiedFile
+import org.ossreviewtoolkit.clients.fossid.model.identification.ignored.IgnoredFile
+import org.ossreviewtoolkit.clients.fossid.model.identification.markedAsIdentified.MarkedAsIdentifiedFile
+import org.ossreviewtoolkit.clients.fossid.model.result.FossIdScanResult
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 /*
@@ -39,6 +45,7 @@ import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 private const val PROJECT_CODE_1 = "semver4j"
 private const val PROJECT_CODE_2 = "semver4j_2"
+private const val PROJECT_CODE_3 = "semver4j_3"
 private const val SCAN_CODE_1 = "${PROJECT_CODE_1}_20201203_090342"
 private const val SCAN_CODE_2 = "${PROJECT_CODE_2}_20201203_090342"
 
@@ -74,7 +81,19 @@ class FossIdClientReturnTypeTest : StringSpec({
         service.listScansForProject("", "", PROJECT_CODE_1) shouldNotBeNull {
             checkResponse("list scans")
             data shouldNotBeNull {
-                this should beEmptyMap()
+                this should beEmpty()
+            }
+        }
+    }
+
+    "Scans for project can be listed when there is exactly one" {
+        service.listScansForProject("", "", PROJECT_CODE_3) shouldNotBeNull {
+            checkResponse("list scans")
+            data shouldNotBeNull {
+                size shouldBe 1
+                forEach {
+                    it.shouldBeTypeOf<Scan>()
+                }
             }
         }
     }
@@ -83,7 +102,8 @@ class FossIdClientReturnTypeTest : StringSpec({
         service.listScansForProject("", "", PROJECT_CODE_2) shouldNotBeNull {
             checkResponse("list scans")
             data shouldNotBeNull {
-                this shouldNot beEmptyMap()
+                this shouldNot beEmpty()
+                this[0].shouldBeTypeOf<Scan>()
             }
         }
     }
@@ -92,7 +112,7 @@ class FossIdClientReturnTypeTest : StringSpec({
         service.listScanResults("", "", SCAN_CODE_1) shouldNotBeNull {
             checkResponse("list scan results")
             data shouldNotBeNull {
-                this should beEmptyMap()
+                this should beEmpty()
             }
         }
     }
@@ -101,7 +121,10 @@ class FossIdClientReturnTypeTest : StringSpec({
         service.listScanResults("", "", SCAN_CODE_2) shouldNotBeNull {
             checkResponse("list scan results")
             data shouldNotBeNull {
-                this shouldNot beEmptyMap()
+                this shouldNot beEmpty()
+                forEach {
+                    it.shouldBeTypeOf<FossIdScanResult>()
+                }
             }
         }
     }
@@ -110,7 +133,7 @@ class FossIdClientReturnTypeTest : StringSpec({
         service.listIdentifiedFiles("", "", SCAN_CODE_1) shouldNotBeNull {
             checkResponse("list identified files")
             data shouldNotBeNull {
-                this should beEmptyMap()
+                this should beEmpty()
             }
         }
     }
@@ -119,7 +142,10 @@ class FossIdClientReturnTypeTest : StringSpec({
         service.listIdentifiedFiles("", "", SCAN_CODE_2) shouldNotBeNull {
             checkResponse("list identified files")
             data shouldNotBeNull {
-                this shouldNot beEmptyMap()
+                this shouldNot beEmpty()
+                forEach {
+                    it.shouldBeTypeOf<IdentifiedFile>()
+                }
             }
         }
     }
@@ -128,7 +154,7 @@ class FossIdClientReturnTypeTest : StringSpec({
         service.listMarkedAsIdentifiedFiles("", "", SCAN_CODE_1) shouldNotBeNull {
             checkResponse("list marked as identified files")
             data shouldNotBeNull {
-                this should beEmptyMap()
+                this should beEmpty()
             }
         }
     }
@@ -137,7 +163,10 @@ class FossIdClientReturnTypeTest : StringSpec({
         service.listMarkedAsIdentifiedFiles("", "", SCAN_CODE_2) shouldNotBeNull {
             checkResponse("list marked as identified files")
             data shouldNotBeNull {
-                this shouldNot beEmptyMap()
+                this shouldNot beEmpty()
+                forEach {
+                    it.shouldBeTypeOf<MarkedAsIdentifiedFile>()
+                }
             }
         }
     }
@@ -156,6 +185,9 @@ class FossIdClientReturnTypeTest : StringSpec({
             checkResponse("list ignored files")
             data shouldNotBeNull {
                 this shouldNot beEmpty()
+                forEach {
+                    it.shouldBeTypeOf<IgnoredFile>()
+                }
             }
         }
     }
@@ -164,7 +196,7 @@ class FossIdClientReturnTypeTest : StringSpec({
         service.listPendingFiles("", "", SCAN_CODE_1) shouldNotBeNull {
             checkResponse("list pending files")
             data shouldNotBeNull {
-                this should beEmptyMap()
+                this should beEmpty()
             }
         }
     }
@@ -173,7 +205,10 @@ class FossIdClientReturnTypeTest : StringSpec({
         service.listPendingFiles("", "", SCAN_CODE_2) shouldNotBeNull {
             checkResponse("list pending files")
             data shouldNotBeNull {
-                this shouldNot beEmptyMap()
+                this shouldNot beEmpty()
+                forEach {
+                    it.shouldBeTypeOf<String>()
+                }
             }
         }
     }

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -360,12 +360,12 @@ class FossId(
     private suspend fun getRawResults(scanCode: String): RawResults {
         val identifiedFiles = service.listIdentifiedFiles(user, apiKey, scanCode)
             .checkResponse("list identified files")
-            .data!!.values.toList()
+            .data!!
         log.info { "${identifiedFiles.size} identified files have been returned for scan code $scanCode." }
 
         val markedAsIdentifiedFiles = service.listMarkedAsIdentifiedFiles(user, apiKey, scanCode)
             .checkResponse("list marked as identified files")
-            .data!!.values.toList()
+            .data!!
         log.info {
             "${markedAsIdentifiedFiles.size} marked as identified files have been returned for scan code $scanCode."
         }


### PR DESCRIPTION
This bug addresses a regression introduced by https://github.com/oss-review-toolkit/ort/pull/4045.

The FossID `get_all_scans` operation has a bug and returns an array if only one scan is returned, otherwise a map.
We have to handle this case, plus the one the other PR was dealing with i.e. handling `data:false` when there is no result.

The result is a new Jackson serializer that handles all these cases.

This commit also contains a new test exhibiting the bug.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>


