### PR TITLE
Dockerfile: Fix an issue with the GoMod support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,6 +137,7 @@ RUN /opt/ort/bin/import_proxy_certs.sh && \
     tar -C /opt -xzf go$GO_VERSION.linux-amd64.tar.gz && \
     rm go$GO_VERSION.linux-amd64.tar.gz && \
     mkdir -p $GOPATH/bin && \
+    chmod a+rw $GOPATH -R \
     curl -ksS https://raw.githubusercontent.com/golang/dep/v$GO_DEP_VERSION/install.sh | sh && \
     curl -ksS https://raw.githubusercontent.com/commercialhaskell/stack/v$HASKELL_STACK_VERSION/etc/scripts/get-stack.sh | sh && \
     # Install SDKs required for analysis.


### PR DESCRIPTION
When running ORT in the docker image as non-root user, GoMod fails with
[1] when running [2]. Grant the required file system permissions to fix
that issue.

[1] `go: writing go.mod cache: mkdir /go/pkg: permission denied`
[2] `go mod vendor -v`


