### PR TITLE
SpdxExpression: Add a function to sort expressions lexicographically

### DIFF
--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -631,7 +631,7 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
               </dl>
               <em>Effective License:</em>
               <dl>
-                <dd>GPL-3.0-only WITH GCC-exception-3.1 AND CC-BY-NC-3.0 AND Apache-2.0 AND MIT</dd>
+                <dd>Apache-2.0 AND CC-BY-NC-3.0 AND GPL-3.0-only WITH GCC-exception-3.1 AND MIT</dd>
               </dl>
             </td><td>
               <ul></ul>
@@ -680,7 +680,7 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
               </dl>
               <em>Effective License:</em>
               <dl>
-                <dd>GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause AND LicenseRef-test-Apache-2.0-multi-line AND LicenseRef-test-Apache-2.0-single-line OR MIT AND LicenseRef-test-Apache-2.0-multi-line AND LicenseRef-test-Apache-2.0-single-line</dd>
+                <dd>BSD-3-Clause AND GPL-2.0-only WITH Classpath-exception-2.0 AND LicenseRef-test-Apache-2.0-multi-line AND LicenseRef-test-Apache-2.0-single-line OR LicenseRef-test-Apache-2.0-multi-line AND LicenseRef-test-Apache-2.0-single-line AND MIT</dd>
               </dl>
             </td><td>
               <ul></ul>

--- a/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
@@ -157,7 +157,7 @@ class ReportTableModelMapper(
                         LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED,
                         ortResult.getPackageLicenseChoices(id),
                         ortResult.getRepositoryLicenseChoices()
-                    ),
+                    )?.sort(),
                     analyzerIssues = analyzerIssues.map { it.toResolvableIssue() },
                     scanIssues = scanIssues.map { it.toResolvableIssue() }
                 ).also { row ->

--- a/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
+++ b/spdx-utils/src/test/kotlin/SpdxExpressionTest.kt
@@ -315,6 +315,24 @@ class SpdxExpressionTest : WordSpec() {
             }
         }
 
+        "sort()" should {
+            "not change already sorted expressions" {
+                "a AND b".toSpdx().sort() should beString("a AND b")
+                "(a OR b) AND (c OR d)".toSpdx().sort() should beString("(a OR b) AND (c OR d)")
+            }
+
+            "correctly sort simple expressions" {
+                "b AND a".toSpdx().sort() should beString("a AND b")
+                "b OR a".toSpdx().sort() should beString("a OR b")
+                "c AND b AND a".toSpdx().sort() should beString("a AND b AND c")
+            }
+
+            "correctly sort a complex expression" {
+                "(h OR g) AND (f OR e) OR (c OR d) AND (a OR b)".toSpdx().sort() should
+                        beString("(a OR b) AND (c OR d) OR (e OR f) AND (g OR h)")
+            }
+        }
+
         "validChoices()" should {
             "list the valid choices for a complex expression" {
                 "(a OR b) AND c AND (d OR e)".toSpdx().validChoices() should containExactlyInAnyOrder(


### PR DESCRIPTION
Add a function to sort SPDX expressions lexicographically and use it for the effective license in the Static HTML reporter for a start.
