### PR TITLE
Composer : ignore platform specific requirements

### DIFF
--- a/analyzer/src/main/kotlin/managers/Composer.kt
+++ b/analyzer/src/main/kotlin/managers/Composer.kt
@@ -356,6 +356,6 @@ class Composer(
 
         // The "install" command creates a "composer.lock" file (if not yet present) except for projects without any
         // dependencies, see https://getcomposer.org/doc/01-basic-usage.md#installing-without-composer-lock.
-        run(workingDir, "install")
+        run(workingDir, "install", "--ignore-platform-reqs")
     }
 }


### PR DESCRIPTION
The --ignore-platform-reqs option allows to avoid install failures due to PHP version mismatch or absent PHP extensions (e.g. gd, dom, etc.) cf . https://getcomposer.org/doc/03-cli.md#install-i Fix issue #4109

Signed-off-by: Camille Moulin <cmoulin@inno3.fr>

