### PR TITLE
AnalyzerResult: Collect issues from dependency graphs

### DIFF
--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -90,6 +90,14 @@ data class AnalyzerResult(
             }
         }
 
+        dependencyGraphs.values.forEach { graph ->
+            graph.collectIssues().forEach { (id, issues) ->
+                if (issues.isNotEmpty()) {
+                    collectedIssues.getOrPut(id) { mutableSetOf() } += issues
+                }
+            }
+        }
+
         return collectedIssues
     }
 

--- a/model/src/main/kotlin/DependencyGraph.kt
+++ b/model/src/main/kotlin/DependencyGraph.kt
@@ -166,6 +166,27 @@ data class DependencyGraph(
             )
         }
     }
+
+    /**
+     * Return a map of all de-duplicated [OrtIssue]s associated by [Identifier].
+     */
+    fun collectIssues(): Map<Identifier, Set<OrtIssue>> {
+        val collectedIssues = mutableMapOf<Identifier, MutableSet<OrtIssue>>()
+
+        fun addIssues(ref: DependencyReference) {
+            if (ref.issues.isNotEmpty()) {
+                collectedIssues.getOrPut(packages[ref.pkg]) { mutableSetOf() } += ref.issues
+            }
+
+            ref.dependencies.forEach { addIssues(it) }
+        }
+
+        for (ref in scopeRoots) {
+            addIssues(ref)
+        }
+
+        return collectedIssues
+    }
 }
 
 /**


### PR DESCRIPTION
Add a function to collect issues from a `DependencyGraph` and use it in
the `AnalyzerResult` to collect issues also from graphs without having
to resolve them first.

Fixes #4105.