### PR TITLE
AnalyzerResult: Remove a superfluous isNotEmpty() check

### DIFF
--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -92,9 +92,7 @@ data class AnalyzerResult(
 
         dependencyGraphs.values.forEach { graph ->
             graph.collectIssues().forEach { (id, issues) ->
-                if (issues.isNotEmpty()) {
-                    collectedIssues.getOrPut(id) { mutableSetOf() } += issues
-                }
+                collectedIssues.getOrPut(id) { mutableSetOf() } += issues
             }
         }
 


### PR DESCRIPTION
The map returned by DependencyGraph.collectIssues() associates only
those packages to issues that actually have issues, so this check is
unnecessary here. This is a fixup for 71b8949.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>