### PR TITLE
Write the dependency graph format for all package managers

### DIFF
--- a/analyzer/src/funTest/kotlin/GitRepoFunTest.kt
+++ b/analyzer/src/funTest/kotlin/GitRepoFunTest.kt
@@ -37,6 +37,7 @@ import org.ossreviewtoolkit.utils.Ci
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+import org.ossreviewtoolkit.utils.test.convertToDependencyGraph
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
@@ -67,10 +68,12 @@ class GitRepoFunTest : StringSpec() {
         "Analyzer correctly reports VcsInfo for git-repo projects".config(enabled = !Ci.isAzureWindows) {
             val ortResult = Analyzer(DEFAULT_ANALYZER_CONFIGURATION).analyze(outputDir)
             val actualResult = ortResult.withResolvedScopes().toYaml()
-            val expectedResult = patchExpectedResult(
-                File("src/funTest/assets/projects/external/git-repo-expected-output.yml"),
-                revision = REPO_REV,
-                path = outputDir.invariantSeparatorsPath
+            val expectedResult = convertToDependencyGraph(
+                patchExpectedResult(
+                    File("src/funTest/assets/projects/external/git-repo-expected-output.yml"),
+                    revision = REPO_REV,
+                    path = outputDir.invariantSeparatorsPath
+                )
             )
 
             patchActualResult(actualResult, patchStartAndEndTime = true) shouldBe expectedResult

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -37,7 +37,6 @@ import org.gradle.tooling.internal.consumer.DefaultGradleConnector
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.analyzer.PackageManagerResult
-import org.ossreviewtoolkit.analyzer.managers.utils.DependencyGraphBuilder
 import org.ossreviewtoolkit.analyzer.managers.utils.MavenSupport
 import org.ossreviewtoolkit.analyzer.managers.utils.identifier
 import org.ossreviewtoolkit.downloader.VersionControlSystem
@@ -51,6 +50,7 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
+import org.ossreviewtoolkit.model.utils.DependencyGraphBuilder
 import org.ossreviewtoolkit.utils.Os
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.temporaryProperties

--- a/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
@@ -26,7 +26,6 @@ import org.apache.maven.project.ProjectBuildingException
 import org.eclipse.aether.artifact.DefaultArtifact
 import org.eclipse.aether.repository.RemoteRepository
 
-import org.ossreviewtoolkit.analyzer.managers.utils.DependencyHandler
 import org.ossreviewtoolkit.analyzer.managers.utils.MavenSupport
 import org.ossreviewtoolkit.analyzer.managers.utils.identifier
 import org.ossreviewtoolkit.model.Identifier
@@ -35,6 +34,7 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.createAndLogIssue
+import org.ossreviewtoolkit.model.utils.DependencyHandler
 import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.showStackTrace
 

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -31,7 +31,6 @@ import org.eclipse.aether.repository.WorkspaceRepository
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.analyzer.PackageManagerResult
-import org.ossreviewtoolkit.analyzer.managers.utils.DependencyGraphBuilder
 import org.ossreviewtoolkit.analyzer.managers.utils.MavenSupport
 import org.ossreviewtoolkit.analyzer.managers.utils.identifier
 import org.ossreviewtoolkit.downloader.VersionControlSystem
@@ -43,6 +42,7 @@ import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
+import org.ossreviewtoolkit.model.utils.DependencyGraphBuilder
 import org.ossreviewtoolkit.utils.searchUpwardsForSubdirectory
 
 /**

--- a/analyzer/src/main/kotlin/managers/MavenDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/MavenDependencyHandler.kt
@@ -23,7 +23,6 @@ import org.apache.maven.project.MavenProject
 
 import org.eclipse.aether.graph.DependencyNode
 
-import org.ossreviewtoolkit.analyzer.managers.utils.DependencyHandler
 import org.ossreviewtoolkit.analyzer.managers.utils.MavenSupport
 import org.ossreviewtoolkit.analyzer.managers.utils.identifier
 import org.ossreviewtoolkit.model.Identifier
@@ -31,6 +30,7 @@ import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.createAndLogIssue
+import org.ossreviewtoolkit.model.utils.DependencyHandler
 import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.showStackTrace

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -33,7 +33,6 @@ import java.util.SortedSet
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.analyzer.PackageManagerResult
-import org.ossreviewtoolkit.analyzer.managers.utils.DependencyGraphBuilder
 import org.ossreviewtoolkit.analyzer.managers.utils.expandNpmShortcutUrl
 import org.ossreviewtoolkit.analyzer.managers.utils.hasNpmLockFile
 import org.ossreviewtoolkit.analyzer.managers.utils.mapDefinitionFilesForNpm
@@ -59,6 +58,7 @@ import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.readJsonFile
 import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.utils.DependencyGraphBuilder
 import org.ossreviewtoolkit.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.CommandLineTool
 import org.ossreviewtoolkit.utils.OkHttpClientHelper

--- a/analyzer/src/main/kotlin/managers/NpmDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/NpmDependencyHandler.kt
@@ -21,11 +21,11 @@ package org.ossreviewtoolkit.analyzer.managers
 
 import java.io.File
 
-import org.ossreviewtoolkit.analyzer.managers.utils.DependencyHandler
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
+import org.ossreviewtoolkit.model.utils.DependencyHandler
 
 /**
  * A data class storing information about a specific NPM module and its dependencies.

--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -119,7 +119,7 @@ class AnalyzerResultBuilderTest : WordSpec() {
                 val serializedMergedResults = yamlMapper.writeValueAsString(mergedResults)
                 val deserializedMergedResults = yamlMapper.readValue<AnalyzerResult>(serializedMergedResults)
 
-                deserializedMergedResults shouldBe mergedResults
+                deserializedMergedResults.withScopesResolved() shouldBe mergedResults
             }
 
             "be serialized and deserialized correctly with a dependency graph" {
@@ -157,6 +157,20 @@ class AnalyzerResultBuilderTest : WordSpec() {
                 val serializedResult2 = yamlMapper.writeValueAsString(deserializedResult)
 
                 serializedResult2 shouldBe serializedResult
+            }
+
+            "use the dependency graph representation on serialization" {
+                val mergedResults = AnalyzerResultBuilder()
+                    .addResult(analyzerResult1)
+                    .addResult(analyzerResult2)
+                    .build()
+
+                val serializedMergedResults = yamlMapper.writeValueAsString(mergedResults)
+                val resultTree = yamlMapper.readTree(serializedMergedResults)
+
+                resultTree["dependency_graphs"] shouldNotBeNull {
+                    count() shouldBe 2
+                }
             }
         }
 

--- a/analyzer/src/test/kotlin/managers/GradleDependencyHandlerTest.kt
+++ b/analyzer/src/test/kotlin/managers/GradleDependencyHandlerTest.kt
@@ -47,7 +47,6 @@ import org.apache.maven.project.ProjectBuildingException
 import org.eclipse.aether.artifact.DefaultArtifact
 import org.eclipse.aether.repository.RemoteRepository
 
-import org.ossreviewtoolkit.analyzer.managers.utils.DependencyGraphBuilder
 import org.ossreviewtoolkit.analyzer.managers.utils.MavenSupport
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
@@ -57,6 +56,7 @@ import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.utils.DependencyGraphBuilder
 
 /**
  * A test class to test the integration of the [Gradle] package manager with [DependencyGraphBuilder]. This class

--- a/cli/src/funTest/kotlin/OrtMainFunTest.kt
+++ b/cli/src/funTest/kotlin/OrtMainFunTest.kt
@@ -40,6 +40,7 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.redirectStdout
+import org.ossreviewtoolkit.utils.test.convertToDependencyGraph
 import org.ossreviewtoolkit.utils.test.createTestTempDir
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
@@ -114,11 +115,13 @@ class OrtMainFunTest : StringSpec() {
 
         "Analyzer creates correct output" {
             val analyzerOutputDir = outputDir.resolve("merged-results")
-            val expectedResult = patchExpectedResult(
-                projectDir.resolve("gradle-all-dependencies-expected-result.yml"),
-                url = vcsUrl,
-                revision = vcsRevision,
-                urlProcessed = normalizeVcsUrl(vcsUrl)
+            val expectedResult = convertToDependencyGraph(
+                patchExpectedResult(
+                    projectDir.resolve("gradle-all-dependencies-expected-result.yml"),
+                    url = vcsUrl,
+                    revision = vcsRevision,
+                    urlProcessed = normalizeVcsUrl(vcsUrl)
+                )
             )
 
             runMain(
@@ -136,11 +139,13 @@ class OrtMainFunTest : StringSpec() {
 
         "Package curation data file is applied correctly" {
             val analyzerOutputDir = outputDir.resolve("curations")
-            val expectedResult = patchExpectedResult(
-                projectDir.resolve("gradle-all-dependencies-expected-result-with-curations.yml"),
-                url = vcsUrl,
-                revision = vcsRevision,
-                urlProcessed = normalizeVcsUrl(vcsUrl)
+            val expectedResult = convertToDependencyGraph(
+                patchExpectedResult(
+                    projectDir.resolve("gradle-all-dependencies-expected-result-with-curations.yml"),
+                    url = vcsUrl,
+                    revision = vcsRevision,
+                    urlProcessed = normalizeVcsUrl(vcsUrl)
+                )
             )
 
             runMain(

--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -22,14 +22,21 @@ package org.ossreviewtoolkit.model
 import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
 
 import java.util.SortedMap
 import java.util.SortedSet
+
+import org.ossreviewtoolkit.model.utils.DependencyGraphConverter
 
 /**
  * A class that merges all information from individual [ProjectAnalyzerResult]s created for each found definition file.
  */
 @JsonIgnoreProperties(value = ["has_issues", /* Backwards-compatibility: */ "has_errors"], allowGetters = true)
+@JsonSerialize(using = AnalyzerResultSerializer::class)
 data class AnalyzerResult(
     /**
      * Sorted set of the projects, as they appear in the individual analyzer results.
@@ -120,4 +127,31 @@ data class AnalyzerResult(
         } else {
             this
         }
+}
+
+/**
+ * A custom serializer for [AnalyzerResult] instances.
+ *
+ * This serializer makes sure that [AnalyzerResult]s always use the dependency graph representation when they are
+ * serialized. This is achieved by processing the result by [DependencyGraphConverter] before it is written out.
+ */
+private class AnalyzerResultSerializer : StdSerializer<AnalyzerResult>(AnalyzerResult::class.java) {
+    override fun serialize(result: AnalyzerResult, gen: JsonGenerator, provider: SerializerProvider?) {
+        val resultWithGraph = DependencyGraphConverter.convert(result)
+
+        gen.writeStartObject()
+
+        with(resultWithGraph) {
+            gen.writeObjectField("projects", projects)
+            gen.writeObjectField("packages", packages)
+
+            if (issues.isNotEmpty()) {
+                gen.writeObjectField("issues", issues)
+            }
+
+            gen.writeObjectField("dependency_graphs", dependencyGraphs)
+        }
+
+        gen.writeEndObject()
+    }
 }

--- a/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.analyzer.managers.utils
+package org.ossreviewtoolkit.model.utils
 
 import org.ossreviewtoolkit.model.DependencyGraph
 import org.ossreviewtoolkit.model.DependencyReference

--- a/model/src/main/kotlin/utils/DependencyGraphConverter.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphConverter.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.utils
+
+import org.ossreviewtoolkit.model.AnalyzerResult
+import org.ossreviewtoolkit.model.DependencyGraph
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageLinkage
+import org.ossreviewtoolkit.model.PackageReference
+import org.ossreviewtoolkit.model.Project
+
+/**
+ * An object that supports the conversion of [AnalyzerResult]s to the dependency graph format.
+ *
+ * The main conversion function takes an [AnalyzerResult] and iterates over all projects contained in it. Each
+ * project that still uses the dependency tree representation (i.e. the set of scopes) is converted, and a dependency
+ * graph for the associated package manager is created.
+ *
+ * Via this converter, optimized results can be generated for package managers that do not yet support this format.
+ * This approach is, however, not ideal, because during the conversion both the dependency tree and the dependency
+ * graph need to be hold in memory. So this is rather a temporary solution until all package managers support the new
+ * format natively.
+ */
+object DependencyGraphConverter {
+    /**
+     * Convert the given [result], so that all dependencies are represented as dependency graphs. If the [result]
+     * already contains a dependency graph that covers all projects, it is returned as is.
+     */
+    fun convert(result: AnalyzerResult): AnalyzerResult {
+        val projectsToConvert = result.projectsWithScopes()
+        if (projectsToConvert.isEmpty()) return result
+
+        val graphs = buildDependencyGraphs(projectsToConvert)
+
+        return result.copy(
+            dependencyGraphs = result.dependencyGraphs + graphs,
+            projects = result.projects.mapTo(sortedSetOf()) { it.convertToScopeNames() }
+        )
+    }
+
+    /**
+     * Build [DependencyGraph]s for the given [projects]. The resulting map contains one graph for each package
+     * manager involved.
+     */
+    private fun buildDependencyGraphs(projects: List<Project>): Map<String, DependencyGraph> {
+        val graphs = mutableMapOf<String, DependencyGraph>()
+
+        projects.groupBy { it.id.type }.forEach { (type, projectsForType) ->
+            val builder = DependencyGraphBuilder(ScopesDependencyHandler)
+
+            projectsForType.forEach { project ->
+                project.scopes.forEach { scope ->
+                    val scopeName = DependencyGraph.qualifyScope(project, scope.name)
+                    scope.dependencies.forEach { dependency ->
+                        builder.addDependency(scopeName, dependency)
+                    }
+                }
+            }
+
+            graphs[type] = builder.build()
+        }
+
+        return graphs
+    }
+
+    /**
+     * Determine the projects in this [AnalyzerResult] that require a conversion. These are the projects that manage
+     * their dependencies in a scope structure.
+     */
+    private fun AnalyzerResult.projectsWithScopes(): List<Project> = projects.filter { it.scopeNames == null }
+
+    /**
+     * Convert the dependency representation used by this [Project] to the dependency graph format, i.e. a set of
+     * scope names. Return the same project if this format is already in use.
+     */
+    private fun Project.convertToScopeNames(): Project =
+        takeIf { scopeNames != null } ?: copy(
+            scopeNames = scopes.mapTo(sortedSetOf()) { it.name },
+            scopeDependencies = null
+        )
+
+    /**
+     * A special [DependencyHandler] implementation that operates on [PackageReference] objects. A
+     * [DependencyGraphBuilder] equipped with this handler is able to transform a dependency tree structure into an
+     * equivalent dependency graph.
+     */
+    private object ScopesDependencyHandler : DependencyHandler<PackageReference> {
+        override fun identifierFor(dependency: PackageReference): Identifier = dependency.id
+
+        override fun dependenciesFor(dependency: PackageReference): Collection<PackageReference> =
+            dependency.dependencies
+
+        override fun linkageFor(dependency: PackageReference): PackageLinkage = dependency.linkage
+
+        override fun createPackage(dependency: PackageReference, issues: MutableList<OrtIssue>): Package? = null
+    }
+}

--- a/model/src/main/kotlin/utils/DependencyHandler.kt
+++ b/model/src/main/kotlin/utils/DependencyHandler.kt
@@ -17,16 +17,15 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.analyzer.managers.utils
+package org.ossreviewtoolkit.model.utils
 
-import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 
 /**
- * An interface used by [DependencyGraphBuilder] to handle the specific representations of concrete [PackageManager]
+ * An interface used by [DependencyGraphBuilder] to handle the specific representations of concrete _PackageManager_
  * implementations in a generic way.
  *
  * A package manager may use its own, internal representation of a type [D] of a dependency. When constructing the

--- a/model/src/test/kotlin/utils/DependencyGraphConverterTest.kt
+++ b/model/src/test/kotlin/utils/DependencyGraphConverterTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.utils
+
+import io.kotest.assertions.fail
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
+import io.kotest.matchers.types.beTheSameInstanceAs
+
+import java.io.File
+import java.util.SortedSet
+
+import org.ossreviewtoolkit.model.AnalyzerResult
+import org.ossreviewtoolkit.model.CuratedPackage
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageReference
+import org.ossreviewtoolkit.model.Project
+import org.ossreviewtoolkit.model.ProjectAnalyzerResult
+import org.ossreviewtoolkit.model.Scope
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
+
+class DependencyGraphConverterTest : WordSpec({
+    "convertToDependencyGraphs" should {
+        "return the same result if no conversion is required" {
+            val resultFile = File("../model/src/test/assets/analyzer-result-with-dependency-graph.yml")
+            val ortResult = resultFile.readValue<OrtResult>()
+            val analyzerResult = ortResult.analyzer?.result
+
+            analyzerResult shouldNotBeNull {
+                val convertedResult = DependencyGraphConverter.convert(this)
+
+                convertedResult should beTheSameInstanceAs(this)
+            }
+        }
+
+        "convert a result to the dependency graph format" {
+            val mavenProject1 = createProject("Maven", index = 1)
+            val mavenProject2 = createProject("Maven", index = 2)
+            val goProject = createProject("GoMod", index = 3)
+
+            val result = createAnalyzerResult(
+                mavenProject1.createResult(),
+                mavenProject2.createResult(),
+                goProject.createResult()
+            )
+
+            val convertedResult = DependencyGraphConverter.convert(result)
+
+            convertedResult.dependencyGraphs.keys should containExactlyInAnyOrder("Maven", "GoMod")
+            convertedResult.projects.forEach {
+                it.scopeDependencies should beNull()
+                it.scopeNames shouldNot beNull()
+            }
+
+            convertedResult.withScopesResolved() shouldBe result
+            convertedResult.packages should beTheSameInstanceAs(result.packages)
+        }
+
+        "convert a result with a partial dependency graph" {
+            val gradleProject = createProject("Gradle", index = 1)
+            val goProject1 = createProject("GoMod", index = 2)
+            val goProject2 = createProject("GoMod", index = 3)
+
+            val orgResult = createAnalyzerResult(gradleProject.createResult())
+            val resultWithGraph = DependencyGraphConverter.convert(orgResult)
+            val mixedResult = resultWithGraph.copy(
+                projects = sortedSetOf(
+                    goProject1,
+                    goProject2
+                ).apply { addAll(resultWithGraph.projects) }
+            )
+
+            val convertedResult = DependencyGraphConverter.convert(mixedResult)
+
+            convertedResult.dependencyGraphs.keys should containExactlyInAnyOrder("Gradle", "GoMod")
+            convertedResult.getProject(gradleProject.id) should beTheSameInstanceAs(
+                resultWithGraph.getProject(gradleProject.id)
+            )
+        }
+    }
+})
+
+/**
+ * Create a test project with a (small) dependency tree. Use [managerName] and [index] to generate identifiers.
+ */
+private fun createProject(managerName: String, index: Int): Project {
+    val mainScope = Scope("main", createDependencies(managerName, index * 100, 4))
+    val testScope = Scope("test", createDependencies(managerName, index * 100 + 10, 8))
+
+    return Project.EMPTY.copy(
+        id = createIdentifier(managerName, index, forProject = true),
+        scopeDependencies = sortedSetOf(mainScope, testScope)
+    )
+}
+
+/**
+ * Create an identifier for a test project or package based on the given [managerName] and [index] and the
+ * [forProject] flag.
+ */
+private fun createIdentifier(managerName: String, index: Int, forProject: Boolean): Identifier =
+    Identifier(
+        type = managerName,
+        namespace = "test",
+        name = if (forProject) "project$index" else "pkg$index",
+        version = "1.$index"
+    )
+
+/**
+ * Create a set of [PackageReference]s with the size of [count] simulating the dependencies of a project. Use
+ * [managerName], [startIndex] to generate identifiers.
+ */
+private fun createDependencies(managerName: String, startIndex: Int, count: Int): SortedSet<PackageReference> =
+    (startIndex..(startIndex + count)).mapTo(sortedSetOf()) { index ->
+        PackageReference(createIdentifier(managerName, index, forProject = false))
+    }
+
+/**
+ * Construct an [AnalyzerResult] from the given sequence of [projectResults].
+ */
+private fun createAnalyzerResult(vararg projectResults: ProjectAnalyzerResult): AnalyzerResult {
+    val projects = projectResults.map { it.project }
+    val packages = projectResults.flatMap { it.packages }.map { CuratedPackage(it) }
+
+    return AnalyzerResult(projects.toSortedSet(), packages.toSortedSet())
+}
+
+/**
+ * Create a [ProjectAnalyzerResult] based on this test project.
+ */
+private fun Project.createResult(): ProjectAnalyzerResult {
+    val packages = scopes.flatMap { it.dependencies }.mapTo(sortedSetOf()) { ref ->
+        Package.EMPTY.copy(id = ref.id)
+    }
+
+    return ProjectAnalyzerResult(this, packages)
+}
+
+/**
+ * Return the project with the given [id] from this result or fail miserably if it cannot be found.
+ */
+private fun AnalyzerResult.getProject(id: Identifier): Project {
+    val project = projects.find { it.id == id }
+    return project ?: fail("Could not find project with ID $id.")
+}

--- a/scanner/src/funTest/kotlin/scanners/FileCounterScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/FileCounterScannerFunTest.kt
@@ -29,6 +29,7 @@ import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
+import org.ossreviewtoolkit.utils.test.convertToDependencyGraph
 import org.ossreviewtoolkit.utils.test.createTestTempDir
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
@@ -43,8 +44,10 @@ class FileCounterScannerFunTest : StringSpec() {
             outputDir = createTestTempDir()
 
             val analyzerResultFile = assetsDir.resolve("analyzer-result.yml")
-            val expectedResult = patchExpectedResult(
-                assetsDir.resolve("file-counter-expected-output-for-analyzer-result.yml")
+            val expectedResult = convertToDependencyGraph(
+                patchExpectedResult(
+                    assetsDir.resolve("file-counter-expected-output-for-analyzer-result.yml")
+                )
             )
 
             val scanner = FileCounter("FileCounter", ScannerConfiguration(), DownloaderConfiguration())

--- a/test-utils/src/main/kotlin/Utils.kt
+++ b/test-utils/src/main/kotlin/Utils.kt
@@ -93,4 +93,20 @@ fun patchActualResult(
 ): String =
     patchActualResult(yamlMapper.writeValueAsString(result), patchStartAndEndTime)
 
-fun readOrtResult(file: String) = File(file).let { it.mapper().readValue<OrtResult>(patchExpectedResult(it)) }
+fun patchActualResultObject(result: OrtResult, patchStartAndEndTime: Boolean = false): OrtResult =
+    yamlMapper.readValue(patchActualResult(result, patchStartAndEndTime))
+
+fun readOrtResult(file: String) = readOrtResult(File(file))
+
+fun readOrtResult(file: File) = file.mapper().readValue<OrtResult>(patchExpectedResult(file))
+
+/**
+ * Deserialize an [OrtResult] from the given [string representation][result] and then serialize it again. As for some
+ * of the components in the result custom serializers or deserializers are registered, this can cause some
+ * modifications and conversions on the original result. This function is also used to convert expected test results
+ * stored in the assets to the most recent serialization format.
+ */
+fun convertToDependencyGraph(result: String): String {
+    val ortResult = yamlMapper.readValue<OrtResult>(result)
+    return yamlMapper.writeValueAsString(ortResult)
+}


### PR DESCRIPTION
This PR is part of #4069. It adds a generic converter for analyzer results that generates dependency graphs if necessary. It also adds a custom serializer that triggers this conversion automatically before writing the analyzer result.

Adding the custom serializer was a bit problematic because the conversion logic is part of the `analyzer` module; so the serializer cannot be placed in `model` where the standard object mappers are created. I therefore introduced a mechanism via Java's `ServiceLoader` that allows customization of these mappers from other modules. If you have better suggestions, please let me know.

Note that there are still some quirks until #4069 is completely solved. Currently, there are format conversions when loading and saving ORT results in single steps. (These conversions may change the exact dependency graph representation, if projects are processed in a different order.) This will be solved when the dependency graph becomes the "native" format.