### PR TITLE
fossid-webapp: add credentials from netrc file to repo URL

### DIFF
--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -46,9 +46,9 @@ import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.createOrtTempDir
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.perf
+import org.ossreviewtoolkit.utils.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.safeMkdirs
-import org.ossreviewtoolkit.utils.stripCredentialsFromUrl
 import org.ossreviewtoolkit.utils.unpack
 
 /**
@@ -245,7 +245,7 @@ class Downloader(private val config: DownloaderConfiguration) {
         } catch (e: DownloadException) {
             // TODO: We should introduce something like a "strict" mode and only do these kind of fallbacks in
             //       non-strict mode.
-            val vcsUrlNoCredentials = pkg.vcsProcessed.url.stripCredentialsFromUrl()
+            val vcsUrlNoCredentials = pkg.vcsProcessed.url.replaceCredentialsInUri()
             if (vcsUrlNoCredentials != pkg.vcsProcessed.url) {
                 // Try once more with any user name / password stripped from the URL.
                 log.info {

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -67,7 +67,7 @@ import org.ossreviewtoolkit.spdx.SpdxExpression
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.utils.CopyrightStatementsProcessor
 import org.ossreviewtoolkit.utils.isSymbolicLink
-import org.ossreviewtoolkit.utils.stripCredentialsFromUrl
+import org.ossreviewtoolkit.utils.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.withoutPrefix
 
 const val ORTH_NAME = "orth"
@@ -100,7 +100,7 @@ internal fun findRepositoryPaths(directory: File): Map<String, Set<String>> {
     val result = mutableMapOf<String, MutableSet<String>>()
 
     findRepositories(directory).forEach { (path, vcs) ->
-        result.getOrPut(vcs.url.stripCredentialsFromUrl()) { mutableSetOf() } += path
+        result.getOrPut(vcs.url.replaceCredentialsInUri()) { mutableSetOf() } += path
     }
 
     return result

--- a/model/src/main/kotlin/config/PackageConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageConfiguration.kt
@@ -28,7 +28,7 @@ import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
-import org.ossreviewtoolkit.utils.stripCredentialsFromUrl
+import org.ossreviewtoolkit.utils.replaceCredentialsInUri
 
 /**
  * A configuration for a specific package and provenance. It allows to setup [PathExclude]s and
@@ -127,4 +127,4 @@ data class VcsMatcher(
 }
 
 private fun matchesWithoutCredentials(lhs: String, rhs: String): Boolean =
-    lhs.stripCredentialsFromUrl() == rhs.stripCredentialsFromUrl()
+    lhs.replaceCredentialsInUri() == rhs.replaceCredentialsInUri()

--- a/reporter/src/main/kotlin/utils/SpdxDocumentModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/SpdxDocumentModelMapper.kt
@@ -48,7 +48,7 @@ import org.ossreviewtoolkit.spdx.model.SpdxRelationship
 import org.ossreviewtoolkit.utils.Environment
 import org.ossreviewtoolkit.utils.ORT_FULL_NAME
 import org.ossreviewtoolkit.utils.ProcessedDeclaredLicense
-import org.ossreviewtoolkit.utils.stripCredentialsFromUrl
+import org.ossreviewtoolkit.utils.replaceCredentialsInUri
 
 /**
  * A class for mapping [OrtResult]s to [SpdxDocument]s.
@@ -271,7 +271,7 @@ private fun VcsInfo.toSpdxDownloadLocation(): String {
     return buildString {
         append(vcsTool)
         if (vcsTool.isNotEmpty()) append("+")
-        append(url.stripCredentialsFromUrl())
+        append(url.replaceCredentialsInUri())
         if (!resolvedRevision.isNullOrBlank()) append("@$resolvedRevision")
         if (path.isNotBlank()) append("#$path")
     }

--- a/utils/src/main/kotlin/Extensions.kt
+++ b/utils/src/main/kotlin/Extensions.kt
@@ -362,11 +362,13 @@ fun String.percentEncode(): String =
         .replace("%7E", "~")
 
 /**
- * Strip any user name / password off the URL represented by this [String]. Return the unmodified [String] if it does
- * not represent a URL or if it does not include a user name.
+ * Replace any user name / password in the URI represented by this [String] with [userInfo]. If [userInfo] is null, the
+ * user name / password are stripped. Return the unmodified [String] if it does not represent a URI.
  */
-fun String.stripCredentialsFromUrl() =
-    toUri { URI(it.scheme, null, it.host, it.port, it.path, it.query, it.fragment).toString() }.getOrDefault(this)
+fun String.replaceCredentialsInUri(userInfo: String? = null) =
+    toUri {
+        URI(it.scheme, userInfo, it.host, it.port, it.path, it.query, it.fragment).toString()
+    }.getOrDefault(this)
 
 /**
  * Return this string lower-cased except for the first character which is upper-cased.

--- a/utils/src/test/kotlin/ExtensionsTest.kt
+++ b/utils/src/test/kotlin/ExtensionsTest.kt
@@ -228,22 +228,22 @@ class ExtensionsTest : WordSpec({
 
     "String.stripCredentialsFromUrl" should {
         "strip the user name from a string representing a URL" {
-            "ssh://bot@gerrit.host.com:29418/parent/project".stripCredentialsFromUrl() shouldBe
+            "ssh://bot@gerrit.host.com:29418/parent/project".replaceCredentialsInUri() shouldBe
                     "ssh://gerrit.host.com:29418/parent/project"
         }
 
         "strip the user name and password from a string representing a URL" {
-            "ssh://bot:pass@gerrit.host.com:29418/parent/project".stripCredentialsFromUrl() shouldBe
+            "ssh://bot:pass@gerrit.host.com:29418/parent/project".replaceCredentialsInUri() shouldBe
                     "ssh://gerrit.host.com:29418/parent/project"
         }
 
         "not modify encodings in a URL" {
-            "ssh://bot@gerrit.host.com:29418/parent/project%20with%20spaces".stripCredentialsFromUrl() shouldBe
+            "ssh://bot@gerrit.host.com:29418/parent/project%20with%20spaces".replaceCredentialsInUri() shouldBe
                     "ssh://gerrit.host.com:29418/parent/project%20with%20spaces"
         }
 
         "not modify a string not representing a URL" {
-            "This is not a URL".stripCredentialsFromUrl() shouldBe "This is not a URL"
+            "This is not a URL".replaceCredentialsInUri() shouldBe "This is not a URL"
         }
     }
 


### PR DESCRIPTION
The usual way of dealyíng with repositories requiring authentication
in FossID is by adding the public key of the FossID instance in the
repository and using the SSH protocol.
Unfortunately, in several environments, SSH is not available or
forbidden and FossID has no mechanisms of managing HTTP credentials.
The usual workaround is to use a netrc file but this requires admin
access to the system running the FossID instance.
This commit is an alternative: it extracts credentials from the system
running ORT and prepends them to the repository URL, before giving it
to FossID.
Please note that doing so is highly insecure because the credentials
will be visible in FossID logs. Therefore this behavior is an opt-in
option that must be enabled with the scanner option
"credentialsFromNetrc".

Please note that I tried to write a functional test for this feature, but since `OrtAuthenticator` does not expose the `netrc` file configuration, this seems impossible to do it without creating a file `~/.netrc` with test contents, which taints the filesystem where the tests run (mocking seems also out of the question since the file names are not accessed through an interface).
Please advice if you have a suggestion.
