### PR TITLE
WorkingTree: Make clear that returned revisions are resolved

### DIFF
--- a/analyzer/src/funTest/kotlin/integration/DrupalIntegrationFunTest.kt
+++ b/analyzer/src/funTest/kotlin/integration/DrupalIntegrationFunTest.kt
@@ -43,10 +43,10 @@ class DrupalIntegrationFunTest : AbstractIntegrationSpec() {
         binaryArtifact = RemoteArtifact.EMPTY,
         sourceArtifact = RemoteArtifact.EMPTY,
         vcs = VcsInfo(
-            VcsType.GIT,
-            "https://github.com/drupal/drupal.git",
-            "4a765491d80d1bcb11e542ffafccf10aef05b853",
-            ""
+            type = VcsType.GIT,
+            url = "https://github.com/drupal/drupal.git",
+            revision = "4a765491d80d1bcb11e542ffafccf10aef05b853",
+            isResolvedRevision = true
         )
     )
 

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -172,7 +172,8 @@ class NuGetSupport(serviceIndexUrls: List<String> = listOf(DEFAULT_SERVICE_INDEX
             VcsInfo(
                 type = VcsType(it.type.orEmpty()),
                 url = it.url.orEmpty(),
-                revision = (it.commit ?: it.branch).orEmpty()
+                revision = (it.commit ?: it.branch).orEmpty(),
+                isResolvedRevision = it.commit != null
             )
         } ?: VcsInfo.EMPTY
 

--- a/analyzer/src/test/kotlin/managers/GoModTest.kt
+++ b/analyzer/src/test/kotlin/managers/GoModTest.kt
@@ -36,10 +36,11 @@ class GoModTest : WordSpec({
             id.toVcsInfo().type shouldBe VcsType.GIT
         }
 
-        "return null as resolved revision" {
+        "return an unresolved revision" {
             val id = Identifier("GoMod::github.com/chai2010/gettext-go:v1.0.0")
 
-            id.toVcsInfo().resolvedRevision shouldBe null
+            id.toVcsInfo().revision shouldBe "v1.0.0"
+            id.toVcsInfo().isResolvedRevision shouldBe false
         }
 
         "return the VCS URL and path for a package from a single module repository" {
@@ -65,12 +66,14 @@ class GoModTest : WordSpec({
             val id = Identifier("GoMod::github.com/Azure/go-autorest/autorest/date:v0.0.0-20191109021931-daa7c04131f5")
 
             id.toVcsInfo().revision shouldBe "daa7c04131f5"
+            id.toVcsInfo().isResolvedRevision shouldBe false
         }
 
         "return the SHA1 for a version with a '+incompatible' suffix" {
             val id = Identifier("GoMod::github.com/Azure/azure-sdk-for-go:v43.3.0+incompatible")
 
             id.toVcsInfo().revision shouldBe "v43.3.0"
+            id.toVcsInfo().isResolvedRevision shouldBe false
         }
     }
 

--- a/cli/src/funTest/assets/semver4j-analyzer-result.yml
+++ b/cli/src/funTest/assets/semver4j-analyzer-result.yml
@@ -196,8 +196,8 @@ scanner:
                 type: "Git"
                 url: "https://github.com/vdurmont/semver4j.git"
                 revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
-                resolved_revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
                 path: ""
+              resolved_revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
             scanner:
               name: "ScanCode"
               version: "3.2.1-rc2"
@@ -242,8 +242,8 @@ scanner:
                 type: "Git"
                 url: "https://github.com/junit-team/junit.git"
                 revision: "r4.12"
-                resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
                 path: ""
+              resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
             scanner:
               name: "ScanCode"
               version: "3.2.1-rc2"

--- a/downloader/src/funTest/kotlin/BabelFunTest.kt
+++ b/downloader/src/funTest/kotlin/BabelFunTest.kt
@@ -82,8 +82,8 @@ class BabelFunTest : StringSpec() {
                 vcsInfo.type shouldBe pkg.vcsProcessed.type
                 vcsInfo.url shouldBe pkg.vcsProcessed.url
                 vcsInfo.revision shouldBe "master"
-                vcsInfo.resolvedRevision shouldBe "cee4cde53e4f452d89229986b9368ecdb41e00da"
                 vcsInfo.path shouldBe pkg.vcsProcessed.path
+                resolvedRevision shouldBe "cee4cde53e4f452d89229986b9368ecdb41e00da"
             }
 
             workingTree shouldNotBeNull {

--- a/downloader/src/funTest/kotlin/BeanUtilsFunTest.kt
+++ b/downloader/src/funTest/kotlin/BeanUtilsFunTest.kt
@@ -73,8 +73,8 @@ class BeanUtilsFunTest : StringSpec() {
                 vcsInfo.type shouldBe VcsType.SUBVERSION
                 vcsInfo.url shouldBe vcsFromCuration.url
                 vcsInfo.revision shouldBe ""
-                vcsInfo.resolvedRevision shouldBe "928490"
                 vcsInfo.path shouldBe vcsFromCuration.path
+                resolvedRevision shouldBe "928490"
             }
         }
     }

--- a/downloader/src/funTest/kotlin/vcs/CvsWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/CvsWorkingTreeFunTest.kt
@@ -75,7 +75,7 @@ class CvsWorkingTreeFunTest : StringSpec() {
                 type = VcsType.CVS,
                 url = ":pserver:anonymous@a.cvs.sourceforge.net:/cvsroot/jhove",
                 revision = "449addc0d9e0ee7be48bfaa06f99a6f23cd3bae0",
-                resolvedRevision = null,
+                isResolvedRevision = true,
                 path = ""
             )
             workingTree.getNested() should beEmpty()

--- a/downloader/src/funTest/kotlin/vcs/GitWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitWorkingTreeFunTest.kt
@@ -73,7 +73,7 @@ class GitWorkingTreeFunTest : StringSpec() {
                 type = VcsType.GIT,
                 url = "https://github.com/naiquevin/pipdeptree.git",
                 revision = "6f70dd5508331b6cfcfe3c1b626d57d9836cfd7c",
-                resolvedRevision = null,
+                isResolvedRevision = true,
                 path = ""
             )
             workingTree.getNested() should beEmpty()

--- a/downloader/src/funTest/kotlin/vcs/MercurialWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/MercurialWorkingTreeFunTest.kt
@@ -71,7 +71,7 @@ class MercurialWorkingTreeFunTest : StringSpec() {
                 type = VcsType.MERCURIAL,
                 url = "https://bitbucket.org/facebook/lz4revlog",
                 revision = "422ca71c35132f1f55d20a13355708aec7669b50",
-                resolvedRevision = null,
+                isResolvedRevision = true,
                 path = ""
             )
             workingTree.getNested() should beEmpty()

--- a/downloader/src/funTest/kotlin/vcs/SubversionWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/SubversionWorkingTreeFunTest.kt
@@ -72,7 +72,7 @@ class SubversionWorkingTreeFunTest : StringSpec() {
                 type = VcsType.SUBVERSION,
                 url = "https://svn.code.sf.net/p/docutils/code/trunk/docutils",
                 revision = "8207",
-                resolvedRevision = null,
+                isResolvedRevision = true,
                 path = ""
             )
             workingTree.getNested() should beEmpty()

--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -37,7 +37,6 @@ import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.SourceCodeOrigin
 import org.ossreviewtoolkit.model.UnknownProvenance
-import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.utils.ORT_NAME
@@ -268,15 +267,9 @@ class Downloader(private val config: DownloaderConfiguration) {
             "Finished downloading source code revision '$resolvedRevision' to '${outputDirectory.absolutePath}'."
         }
 
-        val vcsInfo = VcsInfo(
-            type = applicableVcs.type,
-            url = pkg.vcsProcessed.url,
-            revision = pkg.vcsProcessed.revision,
-            resolvedRevision = resolvedRevision,
-            path = pkg.vcsProcessed.path
-        )
+        val vcsInfo = pkg.vcsProcessed.copy(type = applicableVcs.type)
 
-        return RepositoryProvenance(vcsInfo)
+        return RepositoryProvenance(vcsInfo, resolvedRevision)
     }
 
     /**

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -264,20 +264,22 @@ abstract class VersionControlSystem {
                 emptyRevisionCandidatesException.addSuppressed(it)
             }.isSuccess
 
-        if (!addGuessedRevision(pkg.id.name, pkg.id.version)) {
-            when {
-                pkg.id.type == "NPM" && pkg.id.namespace.isNotEmpty() -> {
-                    // Fallback for Lerna workspaces when scoped packages combined with independent versioning are used,
-                    // e.g. support Git tag of the format "@organisation/my-component@x.x.x".
-                    addGuessedRevision("${pkg.id.namespace}/${pkg.id.name}", pkg.id.version)
-                }
+        if (!pkg.vcsProcessed.isResolvedRevision) {
+            if (!addGuessedRevision(pkg.id.name, pkg.id.version)) {
+                when {
+                    pkg.id.type == "NPM" && pkg.id.namespace.isNotEmpty() -> {
+                        // Fallback for Lerna workspaces when scoped packages combined with independent versioning are
+                        // used, e.g. support Git tag of the format "@organisation/my-component@x.x.x".
+                        addGuessedRevision("${pkg.id.namespace}/${pkg.id.name}", pkg.id.version)
+                    }
 
-                pkg.id.type == "GoMod" && pkg.vcsProcessed.path.isNotEmpty() -> {
-                    // Fallback for GoMod packages from mono repos which use the tag format described in
-                    // https://golang.org/ref/mod#vcs-version.
-                    val tag = "${pkg.vcsProcessed.path}/${pkg.id.version}"
+                    pkg.id.type == "GoMod" && pkg.vcsProcessed.path.isNotEmpty() -> {
+                        // Fallback for GoMod packages from mono repos which use the tag format described in
+                        // https://golang.org/ref/mod#vcs-version.
+                        val tag = "${pkg.vcsProcessed.path}/${pkg.id.version}"
 
-                    if (tag in workingTree.listRemoteTags()) revisionCandidates += tag
+                        if (tag in workingTree.listRemoteTags()) revisionCandidates += tag
+                    }
                 }
             }
         }

--- a/downloader/src/main/kotlin/WorkingTree.kt
+++ b/downloader/src/main/kotlin/WorkingTree.kt
@@ -37,7 +37,8 @@ abstract class WorkingTree(val workingDir: File, val vcsType: VcsType) {
      * [workingDir] to [getRootPath]. It is not related to the path argument that was used for downloading, and at the
      * example of Git, it does not reflect the (single) path that was cloned in a sparse checkout.
      */
-    open fun getInfo() = VcsInfo(vcsType, getRemoteUrl(), getRevision(), path = getPathToRoot(workingDir))
+    open fun getInfo() =
+        VcsInfo(vcsType, getRemoteUrl(), getRevision(), isResolvedRevision = true, path = getPathToRoot(workingDir))
 
     /**
      * Return the map of nested repositories, for example Git submodules or Git-Repo modules. The key is the path to the

--- a/helper-cli/src/main/kotlin/commands/GeneratePackageConfigurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GeneratePackageConfigurationsCommand.kt
@@ -130,7 +130,7 @@ private fun createPackageConfiguration(id: Identifier, provenance: Provenance): 
                 vcs = VcsMatcher(
                     type = provenance.vcsInfo.type,
                     url = provenance.vcsInfo.url,
-                    revision = provenance.vcsInfo.resolvedRevision!!,
+                    revision = provenance.resolvedRevision,
                     path = provenance.vcsInfo.path.takeIf { provenance.vcsInfo.type == VcsType.GIT_REPO }
                 )
             )

--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -311,7 +311,7 @@ private fun Provenance.writeValueAsString(): String =
     when (this) {
         is ArtifactProvenance -> "url=${sourceArtifact.url}, hash=${sourceArtifact.hash.value}"
         is RepositoryProvenance -> {
-            "type=${vcsInfo.type}, url=${vcsInfo.url}, path=${vcsInfo.path}, revision=${vcsInfo.resolvedRevision}"
+            "type=${vcsInfo.type}, url=${vcsInfo.url}, path=${vcsInfo.path}, revision=$resolvedRevision"
         }
         else -> throw IllegalArgumentException("Provenance must have either a non-null source artifact or VCS info.")
     }

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -115,7 +115,7 @@ private fun applyCurationToPackage(targetPackage: CuratedPackage, curation: Pack
             type = it.type ?: base.vcs.type,
             url = it.url ?: base.vcs.url,
             revision = it.revision ?: base.vcs.revision,
-            resolvedRevision = it.resolvedRevision ?: base.vcs.resolvedRevision,
+            isResolvedRevision = it.isResolvedRevision ?: base.vcs.isResolvedRevision,
             path = it.path ?: base.vcs.path
         )
     } ?: base.vcs

--- a/model/src/main/kotlin/VcsInfoCurationData.kt
+++ b/model/src/main/kotlin/VcsInfoCurationData.kt
@@ -42,10 +42,18 @@ data class VcsInfoCurationData(
     val revision: String? = null,
 
     /**
-     * The VCS-specific revision resolved during downloading from the VCS. In contrast to [revision] this must not
-     * contain symbolic names like branches or tags.
+     * True if the [revision] was already resolved. Resolved means that the revision must be fixed and confirmed to be
+     * correct.
+     *
+     * Fixed means that the revision must not be a moving reference. For example, in the case of Git it must be the SHA1
+     * of a commit, not a branch or tag name, because those could be changed to reference a different revision.
+     *
+     * Confirmed to be correct means that there is reasonable certainty that the revision is correct. For example, if
+     * the revision is provided by a package manager it should not be marked as resolved if it comes from metadata
+     * provided by the user, because this could be wrong. But if the package manager confirms the revision somehow, for
+     * example by downloading the source code during the installation of dependencies, it can be marked as resolved.
      */
-    val resolvedRevision: String? = null,
+    val isResolvedRevision: Boolean? = null,
 
     /**
      * The path inside the VCS to take into account, if any. The actual meaning depends on the VCS type. For

--- a/model/src/main/kotlin/config/PackageConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageConfiguration.kt
@@ -96,7 +96,7 @@ data class VcsMatcher(
     val url: String,
 
     /**
-     * The [revision] to match for equality against [VcsInfo.resolvedRevision].
+     * The [revision] to match for equality against [RepositoryProvenance.resolvedRevision].
      */
     val revision: String,
 
@@ -125,7 +125,7 @@ data class VcsMatcher(
         type == provenance.vcsInfo.type &&
                 matchesWithoutCredentials(url, provenance.vcsInfo.url) &&
                 (path == null || path == provenance.vcsInfo.path) &&
-                revision == provenance.vcsInfo.resolvedRevision
+                revision == provenance.resolvedRevision
 }
 
 private fun matchesWithoutCredentials(lhs: String, rhs: String): Boolean =

--- a/model/src/main/kotlin/config/PackageConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageConfiguration.kt
@@ -76,13 +76,13 @@ data class PackageConfiguration(
         return when (provenance) {
             is UnknownProvenance -> false
             is ArtifactProvenance -> sourceArtifactUrl != null && sourceArtifactUrl == provenance.sourceArtifact.url
-            is RepositoryProvenance -> vcs != null && vcs.matches(provenance.vcsInfo)
+            is RepositoryProvenance -> vcs != null && vcs.matches(provenance)
         }
     }
 }
 
 /**
- * A matcher which matches its properties against [VcsInfo]s.
+ * A matcher which matches its properties against a [RepositoryProvenance].
  */
 data class VcsMatcher(
     /**
@@ -96,7 +96,7 @@ data class VcsMatcher(
     val url: String,
 
     /**
-     * The [url] to match for equality against [VcsInfo.resolvedRevision].
+     * The [revision] to match for equality against [VcsInfo.resolvedRevision].
      */
     val revision: String,
 
@@ -121,9 +121,11 @@ data class VcsMatcher(
         }
     }
 
-    fun matches(vcsInfo: VcsInfo): Boolean =
-        type == vcsInfo.type && matchesWithoutCredentials(url, vcsInfo.url) && (path == null || path == vcsInfo.path) &&
-                revision == vcsInfo.resolvedRevision
+    fun matches(provenance: RepositoryProvenance): Boolean =
+        type == provenance.vcsInfo.type &&
+                matchesWithoutCredentials(url, provenance.vcsInfo.url) &&
+                (path == null || path == provenance.vcsInfo.path) &&
+                revision == provenance.vcsInfo.resolvedRevision
 }
 
 private fun matchesWithoutCredentials(lhs: String, rhs: String): Boolean =

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -85,7 +85,7 @@ fun Identifier.toClearlyDefinedSourceLocation(
     sourceArtifact: RemoteArtifact?
 ): SourceLocation? {
     val vcsUrl = vcs?.url
-    val vcsRevision = vcs?.resolvedRevision
+    val vcsRevision = vcs?.revision
     val matchGroups = vcsUrl?.let { REG_GIT_URL.matchEntire(it)?.groupValues }
 
     return when {

--- a/model/src/main/kotlin/utils/FileArchiverFileStorage.kt
+++ b/model/src/main/kotlin/utils/FileArchiverFileStorage.kt
@@ -86,7 +86,7 @@ private fun KnownProvenance.hash(): String {
             // of the storage key. However, for Git-Repo that path must be part of the storage key because it denotes
             // the Git-Repo manifest location rather than the path to be (sparse) checked out.
             val path = vcsInfo.path.takeIf { vcsInfo.type == VcsType.GIT_REPO }.orEmpty()
-            "${vcsInfo.type}${vcsInfo.url}${vcsInfo.resolvedRevision}$path"
+            "${vcsInfo.type}${vcsInfo.url}${resolvedRevision}$path"
         }
     }
 

--- a/model/src/main/kotlin/utils/PostgresFileArchiverStorage.kt
+++ b/model/src/main/kotlin/utils/PostgresFileArchiverStorage.kt
@@ -131,7 +131,7 @@ private fun KnownProvenance.storageKey(): String =
             // of the storage key. However, for Git-Repo that path must be part of the storage key because it denotes
             // the Git-Repo manifest location rather than the path to be (sparse) checked out.
             val path = vcsInfo.path.takeIf { vcsInfo.type == VcsType.GIT_REPO }.orEmpty()
-            "vcs|${vcsInfo.type}|${vcsInfo.url}|${vcsInfo.resolvedRevision}|$path"
+            "vcs|${vcsInfo.type}|${vcsInfo.url}|$resolvedRevision|$path"
         }
     }
 

--- a/model/src/test/assets/advisor-result-initial.yml
+++ b/model/src/test/assets/advisor-result-initial.yml
@@ -238,8 +238,8 @@ scanner:
             type: "Git"
             url: "https://github.com/vdurmont/semver4j.git"
             revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
-            resolved_revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
             path: ""
+          resolved_revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
         scanner:
           name: "ScanCode"
           version: "3.2.1-rc2"
@@ -283,8 +283,8 @@ scanner:
             type: "Git"
             url: "https://github.com/junit-team/junit4.git"
             revision: "r4.12"
-            resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
             path: ""
+          resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
         scanner:
           name: "ScanCode"
           version: "3.2.1-rc2"
@@ -353,8 +353,8 @@ scanner:
             type: "Git"
             url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
             revision: "36d525e1e425006939a77aec5183aecd7c775b05"
-            resolved_revision: "36d525e1e425006939a77aec5183aecd7c775b05"
             path: ""
+          resolved_revision: "36d525e1e425006939a77aec5183aecd7c775b05"
         scanner:
           name: "ScanCode"
           version: "3.2.1-rc2"

--- a/model/src/test/assets/advisor-result-vulnerability-refs.yml
+++ b/model/src/test/assets/advisor-result-vulnerability-refs.yml
@@ -272,8 +272,8 @@ scanner:
             type: "Git"
             url: "https://github.com/vdurmont/semver4j.git"
             revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
-            resolved_revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
             path: ""
+          resolved_revision: "7653e418d610ffcd2811bcb55fd72d00d420950b"
         scanner:
           name: "ScanCode"
           version: "3.2.1-rc2"
@@ -317,8 +317,8 @@ scanner:
             type: "Git"
             url: "https://github.com/junit-team/junit4.git"
             revision: "r4.12"
-            resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
             path: ""
+          resolved_revision: "64155f8a9babcfcf4263cf4d08253a1556e75481"
         scanner:
           name: "ScanCode"
           version: "3.2.1-rc2"
@@ -387,8 +387,8 @@ scanner:
             type: "Git"
             url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
             revision: "36d525e1e425006939a77aec5183aecd7c775b05"
-            resolved_revision: "36d525e1e425006939a77aec5183aecd7c775b05"
             path: ""
+          resolved_revision: "36d525e1e425006939a77aec5183aecd7c775b05"
         scanner:
           name: "ScanCode"
           version: "3.2.1-rc2"

--- a/model/src/test/assets/expected-scan-results.yml
+++ b/model/src/test/assets/expected-scan-results.yml
@@ -52,8 +52,8 @@ results:
       type: "type"
       url: "url"
       revision: "revision"
-      resolved_revision: "resolvedRevision"
       path: "path"
+    resolved_revision: "resolvedRevision"
   scanner:
     name: "name 2"
     version: "version 2"

--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -70,7 +70,7 @@ class PackageCurationTest : WordSpec({
                         type = VcsType.GIT,
                         url = "http://url.git",
                         revision = "revision",
-                        resolvedRevision = "resolvedRevision",
+                        isResolvedRevision = true,
                         path = "path"
                     ),
                     isMetaDataOnly = true,
@@ -119,7 +119,7 @@ class PackageCurationTest : WordSpec({
                     type = VcsType.GIT,
                     url = "http://url.git",
                     revision = "revision",
-                    resolvedRevision = "resolvedRevision",
+                    isResolvedRevision = true,
                     path = "path"
                 ),
                 isMetaDataOnly = false,
@@ -151,7 +151,7 @@ class PackageCurationTest : WordSpec({
                     type = pkg.vcs.type,
                     url = curation.data.vcs!!.url!!,
                     revision = pkg.vcs.revision,
-                    resolvedRevision = pkg.vcs.resolvedRevision,
+                    isResolvedRevision = true,
                     path = pkg.vcs.path
                 )
                 isMetaDataOnly shouldBe false

--- a/model/src/test/kotlin/ProvenanceTest.kt
+++ b/model/src/test/kotlin/ProvenanceTest.kt
@@ -87,9 +87,9 @@ class ProvenanceTest : WordSpec({
                 type = VcsType.UNKNOWN,
                 url = "url",
                 revision = "revision",
-                resolvedRevision = "resolvedRevision",
                 path = "path"
-            )
+            ),
+            resolvedRevision = "resolvedRevision"
         )
 
         val json = jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(provenance)
@@ -101,9 +101,9 @@ class ProvenanceTest : WordSpec({
                     "type" : "",
                     "url" : "url",
                     "revision" : "revision",
-                    "resolved_revision" : "resolvedRevision",
                     "path" : "path"
-                  }
+                  },
+                  "resolved_revision" : "resolvedRevision"
                 }
             """.trimIndent()
         }

--- a/model/src/test/kotlin/ScanResultContainerTest.kt
+++ b/model/src/test/kotlin/ScanResultContainerTest.kt
@@ -40,7 +40,8 @@ class ScanResultContainerTest : WordSpec() {
         sourceArtifact = RemoteArtifact("url", Hash.create("hash"))
     )
     private val provenance2 = RepositoryProvenance(
-        vcsInfo = VcsInfo(VcsType("type"), "url", "revision", "resolvedRevision", "path")
+        vcsInfo = VcsInfo(VcsType("type"), "url", "revision", false, "path"),
+        resolvedRevision = "resolvedRevision"
     )
 
     private val scannerDetails1 = ScannerDetails("name 1", "version 1", "config 1")

--- a/model/src/test/kotlin/VcsInfoTest.kt
+++ b/model/src/test/kotlin/VcsInfoTest.kt
@@ -117,7 +117,7 @@ class VcsInfoTest : WordSpec({
                 type = VcsType("type"),
                 url = "url",
                 revision = "revision",
-                resolvedRevision = "resolvedRevision",
+                isResolvedRevision = true,
                 path = "path"
             )
 
@@ -125,7 +125,7 @@ class VcsInfoTest : WordSpec({
                 type = VcsType("type"),
                 url = "url",
                 revision = "revision",
-                resolvedRevision = "resolvedRevision",
+                isResolvedRevision = true,
                 path = "path"
             )
 

--- a/model/src/test/kotlin/config/PackageConfigurationTest.kt
+++ b/model/src/test/kotlin/config/PackageConfigurationTest.kt
@@ -56,9 +56,9 @@ class PackageConfigurationTest : WordSpec({
                     vcsInfo = VcsInfo(
                         type = VcsType.GIT,
                         url = "ssh://git@host/repo.git",
-                        revision = "",
-                        resolvedRevision = "12345678"
-                    )
+                        revision = ""
+                    ),
+                    resolvedRevision = "12345678"
                 )
             ) shouldBe true
         }
@@ -72,9 +72,9 @@ class PackageConfigurationTest : WordSpec({
                     vcsInfo = VcsInfo(
                         type = VcsType.GIT,
                         url = "ssh://git@host/repo.git",
-                        revision = "",
-                        resolvedRevision = "12345678"
-                    )
+                        revision = ""
+                    ),
+                    resolvedRevision = "12345678"
                 )
             ) shouldBe false
         }
@@ -88,9 +88,9 @@ class PackageConfigurationTest : WordSpec({
                     vcsInfo = VcsInfo(
                         type = VcsType.GIT,
                         url = "ssh://host/repo.git",
-                        revision = "",
-                        resolvedRevision = "12345678"
-                    )
+                        revision = ""
+                    ),
+                    resolvedRevision = "12345678"
                 )
             ) shouldBe true
         }
@@ -104,9 +104,9 @@ class PackageConfigurationTest : WordSpec({
                     vcsInfo = VcsInfo(
                         type = VcsType.GIT,
                         url = "ssh://git@host/repo.git",
-                        revision = "12345678",
-                        resolvedRevision = "12"
-                    )
+                        revision = "12345678"
+                    ),
+                    resolvedRevision = "12"
                 )
             ) shouldBe false
         }

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -73,10 +73,12 @@ class LicenseInfoResolverTest : WordSpec() {
         val vcsInfo = VcsInfo(
             type = VcsType.GIT,
             url = "https://github.com/oss-review-toolkit/ort.git",
-            revision = "master",
+            revision = "master"
+        )
+        val provenance = RepositoryProvenance(
+            vcsInfo = vcsInfo,
             resolvedRevision = "0000000000000000000000000000000000000000"
         )
-        val provenance = RepositoryProvenance(vcsInfo = vcsInfo)
 
         "resolveLicenseInfo()" should {
             "resolve declared licenses" {

--- a/model/src/test/kotlin/utils/FileArchiverTest.kt
+++ b/model/src/test/kotlin/utils/FileArchiverTest.kt
@@ -37,9 +37,9 @@ private val PROVENANCE = RepositoryProvenance(
     vcsInfo = VcsInfo(
         type = VcsType.GIT,
         url = "url",
-        revision = "0000000000000000000000000000000000000000",
-        resolvedRevision = "0000000000000000000000000000000000000000"
-    )
+        revision = "0000000000000000000000000000000000000000"
+    ),
+    resolvedRevision = "0000000000000000000000000000000000000000"
 )
 
 class FileArchiverTest : StringSpec() {

--- a/model/src/test/kotlin/utils/PostgresFileArchiverStorageTest.kt
+++ b/model/src/test/kotlin/utils/PostgresFileArchiverStorageTest.kt
@@ -45,9 +45,9 @@ private val VCS_PROVENANCE = RepositoryProvenance(
     vcsInfo = VcsInfo(
         type = VcsType.GIT,
         url = "url",
-        revision = "0000000000000000000000000000000000000000",
-        resolvedRevision = "0000000000000000000000000000000000000000"
-    )
+        revision = "0000000000000000000000000000000000000000"
+    ),
+    resolvedRevision = "0000000000000000000000000000000000000000"
 )
 
 private fun File.readTextAndDelete(): String {

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -99,9 +99,9 @@
         "type" : "Git",
         "url" : "https://github.com/oss-review-toolkit/ort.git",
         "revision" : "master",
-        "resolved_revision" : "3dcca3e6ee0dea120922f90495bf04b4e09ae455",
         "path" : "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
-      }
+      },
+      "resolved_revision" : "3dcca3e6ee0dea120922f90495bf04b4e09ae455",
     },
     "scanner" : {
       "name" : "FakeScanner",
@@ -120,9 +120,9 @@
         "type" : "Git",
         "url" : "https://example.com/git",
         "revision" : "master",
-        "resolved_revision" : "0000000000000000000000000000000000000000",
         "path" : "project"
-      }
+      },
+      "resolved_revision" : "0000000000000000000000000000000000000000",
     },
     "scanner" : {
       "name" : "FakeScanner",

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -78,8 +78,8 @@ scan_results:
       type: "Git"
       url: "https://github.com/oss-review-toolkit/ort.git"
       revision: "master"
-      resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
       path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
+    resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
   scanner:
     name: "FakeScanner"
     version: "1.0"
@@ -96,8 +96,8 @@ scan_results:
       type: "Git"
       url: "https://example.com/git"
       revision: "master"
-      resolved_revision: "0000000000000000000000000000000000000000"
       path: "project"
+    resolved_revision: "0000000000000000000000000000000000000000"
   scanner:
     name: "FakeScanner"
     version: "1.0"

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -346,8 +346,8 @@ scanner:
             type: "Git"
             url: "https://github.com/oss-review-toolkit/ort.git"
             revision: "master"
-            resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
             path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
+          resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
         scanner:
           name: "FakeScanner"
           version: "1.0"
@@ -399,8 +399,8 @@ scanner:
             type: "Git"
             url: "https://example.com/git"
             revision: "master"
-            resolved_revision: "0000000000000000000000000000000000000000"
             path: "project"
+          resolved_revision: "0000000000000000000000000000000000000000"
         scanner:
           name: "FakeScanner"
           version: "1.0"

--- a/reporter/src/funTest/kotlin/reporters/SpdxDocumentReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/SpdxDocumentReporterFunTest.kt
@@ -131,7 +131,6 @@ private fun createOrtResult(): OrtResult {
     val analyzedVcs = VcsInfo(
         type = VcsType.GIT,
         revision = "master",
-        resolvedRevision = "10203040",
         url = "https://github.com/path/first-project.git",
         path = ""
     )
@@ -210,7 +209,6 @@ private fun createOrtResult(): OrtResult {
                             vcs = VcsInfo(
                                 type = VcsType.GIT,
                                 revision = "master",
-                                resolvedRevision = "deadbeef",
                                 url = "ssh://git@github.com/path/first-package-repo.git",
                                 path = "project-path"
                             )
@@ -319,10 +317,10 @@ private fun createOrtResult(): OrtResult {
                                 vcsInfo = VcsInfo(
                                     type = VcsType.GIT,
                                     revision = "master",
-                                    resolvedRevision = "deadbeef",
                                     url = "ssh://git@github.com/path/first-package-repo.git",
                                     path = "project-path"
-                                )
+                                ),
+                                resolvedRevision = "deadbeef"
                             ),
                             scanner = ScannerDetails.EMPTY,
                             summary = ScanSummary(

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -139,7 +139,6 @@ class StaticHtmlReporter : Reporter {
 
                     div {
                         with(reportTableModel.vcsInfo) {
-                            val revision = resolvedRevision ?: revision
                             +"Scanned revision $revision of $type repository $url"
                         }
                     }

--- a/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
@@ -411,7 +411,7 @@ private fun OrtResult.getRepositoryPath(provenance: RepositoryProvenance): Strin
     repository.nestedRepositories.forEach { (path, vcsInfo) ->
         if (vcsInfo.type == provenance.vcsInfo.type
             && vcsInfo.url == provenance.vcsInfo.url
-            && vcsInfo.revision == provenance.vcsInfo.resolvedRevision) {
+            && vcsInfo.revision == provenance.resolvedRevision) {
             return "/$path/"
         }
     }

--- a/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/utils/FreemarkerTemplateProcessor.kt
@@ -366,9 +366,9 @@ internal fun OrtResult.deduplicateProjectScanResults(targetProjects: Set<Identif
         val repositoryPath = getRepositoryPath(getProject(id)!!.vcsProcessed)
 
         getScanResultsForId(id).forEach { scanResult ->
-            val vcsInfo = (scanResult.provenance as? RepositoryProvenance)?.vcsInfo
-            val vcsPath = vcsInfo?.path.orEmpty()
-            val isGitRepo = vcsInfo?.type == VcsType.GIT_REPO
+            val vcsInfo = (scanResult.provenance as RepositoryProvenance).vcsInfo
+            val vcsPath = vcsInfo.path
+            val isGitRepo = vcsInfo.type == VcsType.GIT_REPO
 
             val findingPaths = with(scanResult.summary) {
                 copyrightFindings.mapTo(mutableSetOf()) { it.location.path } + licenseFindings.map { it.location.path }

--- a/reporter/src/main/kotlin/utils/SpdxDocumentModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/SpdxDocumentModelMapper.kt
@@ -272,7 +272,7 @@ private fun VcsInfo.toSpdxDownloadLocation(): String {
         append(vcsTool)
         if (vcsTool.isNotEmpty()) append("+")
         append(url.replaceCredentialsInUri())
-        if (!resolvedRevision.isNullOrBlank()) append("@$resolvedRevision")
+        if (revision.isNotBlank()) append("@$revision")
         if (path.isNotBlank()) append("#$path")
     }
 }

--- a/reporter/src/test/kotlin/utils/FreeMarkerTemplateProcessorTest.kt
+++ b/reporter/src/test/kotlin/utils/FreeMarkerTemplateProcessorTest.kt
@@ -77,7 +77,7 @@ private fun scanResults(
 
     return listOf(
         ScanResult(
-            provenance = RepositoryProvenance(vcsInfo = vcsInfo),
+            provenance = RepositoryProvenance(vcsInfo = vcsInfo, resolvedRevision = vcsInfo.revision),
             scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
             summary = ScanSummary(
                 startTime = Instant.EPOCH,
@@ -95,15 +95,13 @@ private val PROJECT_VCS_INFO = VcsInfo(
     type = VcsType.GIT_REPO,
     url = "ssh://git@host/manifests/repo",
     path = "path/to/manifest.xml",
-    revision = "deadbeaf44444444333333332222222211111111",
-    resolvedRevision = "deadbeaf44444444333333332222222211111111"
+    revision = "deadbeaf44444444333333332222222211111111"
 )
 private val NESTED_VCS_INFO = VcsInfo(
     type = VcsType.GIT,
     url = "ssh://git@host/project/repo",
     path = "",
-    revision = "0000000000000000000000000000000000000000",
-    resolvedRevision = "0000000000000000000000000000000000000000"
+    revision = "0000000000000000000000000000000000000000"
 )
 
 private val ORT_RESULT = OrtResult(

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
@@ -64,21 +64,21 @@ abstract class AbstractStorageFunTest : WordSpec() {
     private val sourceArtifact1 = RemoteArtifact("url1", Hash.create("0123456789abcdef0123456789abcdef01234567"))
     private val sourceArtifact2 = RemoteArtifact("url2", Hash.create("0123456789abcdef0123456789abcdef01234567"))
 
-    private val vcs1 = VcsInfo(VcsType("type"), "url1", "revision", "resolvedRevision", "path")
-    private val vcs2 = VcsInfo(VcsType("type"), "url2", "revision", "resolvedRevision", "path")
-    private val vcsWithoutRevision = VcsInfo(VcsType("type"), "url", "", "")
+    private val vcs1 = VcsInfo(VcsType("type"), "url1", "revision", false, "path")
+    private val vcs2 = VcsInfo(VcsType("type"), "url2", "revision", false, "path")
+    private val vcsWithoutRevision = VcsInfo(VcsType("type"), "url", "")
 
     private val pkg1 = Package.EMPTY.copy(
         id = id1,
         sourceArtifact = sourceArtifact1,
-        vcs = vcs1.copy(resolvedRevision = null),
+        vcs = vcs1,
         vcsProcessed = vcs1.normalize()
     )
 
     private val pkg2 = Package.EMPTY.copy(
         id = id2,
         sourceArtifact = sourceArtifact2,
-        vcs = vcs2.copy(resolvedRevision = null),
+        vcs = vcs2,
         vcsProcessed = vcs2.normalize()
     )
 
@@ -86,12 +86,13 @@ abstract class AbstractStorageFunTest : WordSpec() {
 
     private val provenanceEmpty = UnknownProvenance
     private val provenanceWithoutRevision = RepositoryProvenance(
-        vcsInfo = pkgWithoutRevision.vcsProcessed.copy(resolvedRevision = "resolvedRevision")
+        vcsInfo = pkgWithoutRevision.vcsProcessed,
+        resolvedRevision = "resolvedRevision"
     )
     private val provenanceWithSourceArtifact1 = ArtifactProvenance(sourceArtifact = sourceArtifact1)
     private val provenanceWithSourceArtifact2 = ArtifactProvenance(sourceArtifact = sourceArtifact2)
-    private val provenanceWithVcsInfo1 = RepositoryProvenance(vcsInfo = vcs1)
-    private val provenanceWithVcsInfo2 = RepositoryProvenance(vcsInfo = vcs2)
+    private val provenanceWithVcsInfo1 = RepositoryProvenance(vcsInfo = vcs1, resolvedRevision = "resolvedRevision")
+    private val provenanceWithVcsInfo2 = RepositoryProvenance(vcsInfo = vcs2, resolvedRevision = "resolvedRevision")
 
     private val scannerDetails1 = ScannerDetails("name 1", "1.0.0", "config 1")
     private val scannerDetails2 = ScannerDetails("name 2", "2.0.0", "config 2")
@@ -292,7 +293,8 @@ abstract class AbstractStorageFunTest : WordSpec() {
                 val scanResultSourceArtifactNonMatching =
                     ScanResult(provenanceSourceArtifactNonMatching, scannerDetails1, scanSummaryWithFiles)
                 val provenanceVcsNonMatching = provenanceWithVcsInfo1.copy(
-                    vcsInfo = vcs1.copy(revision = "revision2", resolvedRevision = "resolvedRevision2")
+                    vcsInfo = vcs1.copy(revision = "revision2"),
+                    resolvedRevision = "resolvedRevision2"
                 )
                 val scanResultVcsNonMatching =
                     ScanResult(provenanceVcsNonMatching, scannerDetails1, scanSummaryWithFiles)
@@ -495,7 +497,8 @@ abstract class AbstractStorageFunTest : WordSpec() {
                 val scanResultSourceArtifactNonMatching1 =
                     ScanResult(provenanceSourceArtifactNonMatching1, scannerDetails1, scanSummaryWithFiles)
                 val provenanceVcsNonMatching1 = provenanceWithVcsInfo1.copy(
-                    vcsInfo = vcs1.copy(revision = "revision2", resolvedRevision = "resolvedRevision2")
+                    vcsInfo = vcs1.copy(revision = "revision2"),
+                    resolvedRevision = "resolvedRevision2"
                 )
                 val scanResultVcsNonMatching1 =
                     ScanResult(provenanceVcsNonMatching1, scannerDetails1, scanSummaryWithFiles)
@@ -511,7 +514,8 @@ abstract class AbstractStorageFunTest : WordSpec() {
                 val scanResultSourceArtifactNonMatching2 =
                     ScanResult(provenanceSourceArtifactNonMatching2, scannerDetails1, scanSummaryWithFiles)
                 val provenanceVcsNonMatching2 = provenanceWithVcsInfo2.copy(
-                    vcsInfo = vcs2.copy(revision = "revision2", resolvedRevision = "resolvedRevision2")
+                    vcsInfo = vcs2.copy(revision = "revision2"),
+                    resolvedRevision = "resolvedRevision2"
                 )
                 val scanResultVcsNonMatching2 =
                     ScanResult(provenanceVcsNonMatching2, scannerDetails1, scanSummaryWithFiles)

--- a/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
+++ b/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
@@ -71,7 +71,7 @@ private fun ClearlyDefinedService.SourceLocation.toCoordinates(): ClearlyDefined
  * Convert a [VcsInfo] to a [VcsInfoCurationData] object.
  */
 private fun VcsInfo.toVcsInfoCurationData(): VcsInfoCurationData =
-    VcsInfoCurationData(type, url, revision, resolvedRevision, path)
+    VcsInfoCurationData(type, url, revision, isResolvedRevision, path)
 
 /**
  * Generate the coordinates for ClearlyDefined based on the [id], the [vcs], and a [sourceArtifact].
@@ -226,7 +226,8 @@ class ClearlyDefinedStorage(
                                 url = sourceLocation.url.orEmpty(),
                                 revision = sourceLocation.revision,
                                 path = sourceLocation.path.orEmpty()
-                            )
+                            ),
+                            resolvedRevision = sourceLocation.revision
                         )
                     }
 

--- a/scanner/src/test/kotlin/storages/ClearlyDefinedStorageTest.kt
+++ b/scanner/src/test/kotlin/storages/ClearlyDefinedStorageTest.kt
@@ -349,7 +349,6 @@ class ClearlyDefinedStorageTest : WordSpec({
             val vcsGit = VcsInfo(
                 VcsType.GIT,
                 "https://github.com/$NAMESPACE/$NAME.git",
-                VERSION,
                 COMMIT
             )
             val pkg = TEST_PACKAGE.copy(vcs = vcsGit)
@@ -364,7 +363,7 @@ class ClearlyDefinedStorageTest : WordSpec({
         }
 
         "only use VCS info pointing to GitHub" {
-            val vcs = VcsInfo(VcsType.GIT, "https://gitlab.com/foo/bar.git", VERSION, COMMIT)
+            val vcs = VcsInfo(VcsType.GIT, "https://gitlab.com/foo/bar.git", COMMIT)
             val pkg = TEST_PACKAGE.copy(vcs = vcs)
             val tools = listOf(toolUrl(COORDINATES, "scancode", SCANCODE_VERSION))
             stubHarvestTools(wiremock, COORDINATES, tools)


### PR DESCRIPTION
WIP: This depends on #4132 to be merged first.

Revisions returned by the working tree are already resolved, so change
the implementation of `getInfo()` to set `isResolvedRevision` to true.
This will affect the VCS properties of projects, because
`PackageManager.processProjectVcs()` merges the VCS infromation captured
from metadata with the VCS information of the working tree.

As a result, the ORT downloader will not try to guess revisions for
projects anymore and instead only use the (resolved) revisions provided
by the analyzer.
