### PR TITLE
SplitCurations: Ensure curations for one package are persisted into a single file

### DIFF
--- a/helper-cli/src/main/kotlin/commands/SplitCurations.kt
+++ b/helper-cli/src/main/kotlin/commands/SplitCurations.kt
@@ -58,17 +58,14 @@ internal class SplitCurations : CliktCommand(
         }
 
         val packageCurations = inputCurationsFile.readValue<List<PackageCuration>>()
+        val groupedCurations = packageCurations.groupBy {
+            outputCurationsDir.resolve(it.id.type.encodeOrUnknown())
+                .resolve(it.id.namespace.fileSystemEncode())
+                .resolve("${it.id.name.encodeOrUnknown()}.${inputCurationsFile.extension}")
+        }
 
-        packageCurations.forEach { curation ->
-            val type = curation.id.type.encodeOrUnknown()
-            val namespace = curation.id.namespace.fileSystemEncode()
-            val name = curation.id.name.encodeOrUnknown()
-
-            val outputFile = outputCurationsDir.resolve(type)
-                .resolve(namespace)
-                .resolve(name + ".${inputCurationsFile.extension}")
-
-            outputFile.writeValue(curation)
+        groupedCurations.forEach { (outputFile, curations) ->
+            outputFile.writeValue(curations)
         }
     }
 }


### PR DESCRIPTION
This is a fixup for 503842005511772b695ce23bdbd520cad0b9e658.
Curations also need to be persisted as a list, which is the required
format for the `--package-curations-dir` option.

