### PR TITLE
Add ORT helper command to create a new curation in the correct directory structure

### DIFF
--- a/helper-cli/src/main/kotlin/HelperMain.kt
+++ b/helper-cli/src/main/kotlin/HelperMain.kt
@@ -42,11 +42,11 @@ import org.ossreviewtoolkit.helper.commands.ListStoredScanResultsCommand
 import org.ossreviewtoolkit.helper.commands.MapCopyrightsCommand
 import org.ossreviewtoolkit.helper.commands.MergeRepositoryConfigurationsCommand
 import org.ossreviewtoolkit.helper.commands.SetLabelsCommand
-import org.ossreviewtoolkit.helper.commands.SplitCurationsCommand
 import org.ossreviewtoolkit.helper.commands.SubtractScanResultsCommand
 import org.ossreviewtoolkit.helper.commands.TransformResultCommand
 import org.ossreviewtoolkit.helper.commands.VerifySourceArtifactCurationsCommand
 import org.ossreviewtoolkit.helper.commands.packageconfig.PackageConfigurationCommand
+import org.ossreviewtoolkit.helper.commands.packagecuration.PackageCurationCommand
 import org.ossreviewtoolkit.helper.commands.repoconfig.RepositoryConfigurationCommand
 import org.ossreviewtoolkit.helper.common.ORTH_NAME
 import org.ossreviewtoolkit.utils.printStackTrace
@@ -84,9 +84,9 @@ internal class HelperMain : CliktCommand(name = ORTH_NAME, epilog = "* denotes r
             MapCopyrightsCommand(),
             MergeRepositoryConfigurationsCommand(),
             PackageConfigurationCommand(),
+            PackageCurationCommand(),
             RepositoryConfigurationCommand(),
             SetLabelsCommand(),
-            SplitCurationsCommand(),
             SubtractScanResultsCommand(),
             TransformResultCommand(),
             VerifySourceArtifactCurationsCommand()

--- a/helper-cli/src/main/kotlin/HelperMain.kt
+++ b/helper-cli/src/main/kotlin/HelperMain.kt
@@ -42,7 +42,7 @@ import org.ossreviewtoolkit.helper.commands.ListStoredScanResultsCommand
 import org.ossreviewtoolkit.helper.commands.MapCopyrightsCommand
 import org.ossreviewtoolkit.helper.commands.MergeRepositoryConfigurationsCommand
 import org.ossreviewtoolkit.helper.commands.SetLabelsCommand
-import org.ossreviewtoolkit.helper.commands.SplitCurations
+import org.ossreviewtoolkit.helper.commands.SplitCurationsCommand
 import org.ossreviewtoolkit.helper.commands.SubtractScanResultsCommand
 import org.ossreviewtoolkit.helper.commands.TransformResultCommand
 import org.ossreviewtoolkit.helper.commands.VerifySourceArtifactCurationsCommand
@@ -86,7 +86,7 @@ internal class HelperMain : CliktCommand(name = ORTH_NAME, epilog = "* denotes r
             PackageConfigurationCommand(),
             RepositoryConfigurationCommand(),
             SetLabelsCommand(),
-            SplitCurations(),
+            SplitCurationsCommand(),
             SubtractScanResultsCommand(),
             TransformResultCommand(),
             VerifySourceArtifactCurationsCommand()

--- a/helper-cli/src/main/kotlin/commands/SplitCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/SplitCurationsCommand.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.encodeOrUnknown
 import org.ossreviewtoolkit.utils.expandTilde
 import org.ossreviewtoolkit.utils.fileSystemEncode
 
-internal class SplitCurations : CliktCommand(
+internal class SplitCurationsCommand : CliktCommand(
     help = "Split a single curations file into a directory structure using the format '<type>/<namespace>/<name>.yml'."
 ) {
     private val inputCurationsFile by option(

--- a/helper-cli/src/main/kotlin/commands/packagecuration/CreateCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packagecuration/CreateCommand.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands.packagecuration
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.UsageError
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.file
+
+import java.io.IOException
+
+import org.ossreviewtoolkit.helper.common.getSplitCurationFile
+import org.ossreviewtoolkit.model.FileFormat
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.PackageCuration
+import org.ossreviewtoolkit.model.PackageCurationData
+import org.ossreviewtoolkit.model.writeValue
+import org.ossreviewtoolkit.utils.expandTilde
+
+internal class CreateCommand : CliktCommand(
+    help = "Create a curation file for a package id using a hierarchical directory structure."
+) {
+    private val packageId by option(
+        "--package-id",
+        help = "The target package id for which a curation should be generated."
+    ).convert { Identifier(it) }
+        .required()
+
+    private val outputDir by option(
+        "--package-curations-dir",
+        help = "The output package curations directory."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = false, canBeDir = true, mustBeWritable = true, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    override fun run() {
+        val outputFile = getSplitCurationFile(outputDir, packageId, FileFormat.YAML.fileExtension)
+
+        if (outputFile.exists()) {
+            throw UsageError("File ${outputFile.absolutePath} already exists.")
+        }
+
+        try {
+            outputFile.parentFile.mkdirs()
+            outputFile.writeValue(listOf(
+                // Adding an empty comment to avoid `{}` for an empty PackageCurationData.
+                PackageCuration(packageId, PackageCurationData(comment = ""))
+            ))
+        } catch (e: IOException) {
+            throw IOException("Failed to create ${outputFile.absoluteFile}.", e)
+        }
+
+        println("${outputFile.absoluteFile} created.")
+    }
+}

--- a/helper-cli/src/main/kotlin/commands/packagecuration/PackageCurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packagecuration/PackageCurationCommand.kt
@@ -25,6 +25,7 @@ import com.github.ajalt.clikt.core.subcommands
 internal class PackageCurationCommand : CliktCommand() {
     init {
         subcommands(
+            CreateCommand(),
             SplitCommand()
         )
     }

--- a/helper-cli/src/main/kotlin/commands/packagecuration/PackageCurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packagecuration/PackageCurationCommand.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands.packagecuration
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.subcommands
+
+internal class PackageCurationCommand : CliktCommand() {
+    init {
+        subcommands(
+            SplitCommand()
+        )
+    }
+
+    override fun run() {
+        // Intentionally empty, because all logic is implemented inside the sub commands.
+    }
+}

--- a/helper-cli/src/main/kotlin/commands/packagecuration/SplitCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packagecuration/SplitCommand.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.helper.commands
+package org.ossreviewtoolkit.helper.commands.packagecuration
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.UsageError
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.encodeOrUnknown
 import org.ossreviewtoolkit.utils.expandTilde
 import org.ossreviewtoolkit.utils.fileSystemEncode
 
-internal class SplitCurationsCommand : CliktCommand(
+internal class SplitCommand : CliktCommand(
     help = "Split a single curations file into a directory structure using the format '<type>/<namespace>/<name>.yml'."
 ) {
     private val inputCurationsFile by option(

--- a/helper-cli/src/main/kotlin/commands/packagecuration/SplitCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packagecuration/SplitCommand.kt
@@ -26,12 +26,11 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
+import org.ossreviewtoolkit.helper.common.getSplitCurationFile
 import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.writeValue
-import org.ossreviewtoolkit.utils.encodeOrUnknown
 import org.ossreviewtoolkit.utils.expandTilde
-import org.ossreviewtoolkit.utils.fileSystemEncode
 
 internal class SplitCommand : CliktCommand(
     help = "Split a single curations file into a directory structure using the format '<type>/<namespace>/<name>.yml'."
@@ -59,9 +58,7 @@ internal class SplitCommand : CliktCommand(
 
         val packageCurations = inputCurationsFile.readValue<List<PackageCuration>>()
         val groupedCurations = packageCurations.groupBy {
-            outputCurationsDir.resolve(it.id.type.encodeOrUnknown())
-                .resolve(it.id.namespace.fileSystemEncode())
-                .resolve("${it.id.name.encodeOrUnknown()}.${inputCurationsFile.extension}")
+            getSplitCurationFile(outputCurationsDir, it.id, inputCurationsFile.extension)
         }
 
         groupedCurations.forEach { (outputFile, curations) ->

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -66,6 +66,8 @@ import org.ossreviewtoolkit.model.writeValue
 import org.ossreviewtoolkit.spdx.SpdxExpression
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.utils.CopyrightStatementsProcessor
+import org.ossreviewtoolkit.utils.encodeOrUnknown
+import org.ossreviewtoolkit.utils.fileSystemEncode
 import org.ossreviewtoolkit.utils.isSymbolicLink
 import org.ossreviewtoolkit.utils.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.withoutPrefix
@@ -118,6 +120,14 @@ internal fun findRepositories(directory: File): Map<String, VcsInfo> {
 
     return ortResult.repository.nestedRepositories
 }
+
+/**
+ * Build the file for the split curations.
+ */
+internal fun getSplitCurationFile(parent: File, packageId: Identifier, fileExtension: String) =
+    parent.resolve(packageId.type.encodeOrUnknown())
+        .resolve(packageId.namespace.fileSystemEncode())
+        .resolve("${packageId.name.encodeOrUnknown()}.$fileExtension")
 
 /**
  * Return an approximation for the Set-Cover Problem, see https://en.wikipedia.org/wiki/Set_cover_problem.


### PR DESCRIPTION
The directory structure from split-curations is reused.
