### PR TITLE
Gradle: Upgrade to Kotlin 1.5.20-RC

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 detektPluginVersion = 1.17.1
 dokkaPluginVersion = 1.4.32
-kotlinPluginVersion = 1.5.10
+kotlinPluginVersion = 1.5.20-RC
 shadowPluginVersion = 7.0.0
 svntoolsPluginVersion = 3.1
 taskinfoPluginVersion = 1.1.1


### PR DESCRIPTION
This fixes a race condition in the Kotlin compiler in conjunction with
Gradle [1][2] that we occasionally run into [3].

[1] https://github.com/JetBrains/kotlin/releases/tag/v1.5.20-RC
[2] https://youtrack.jetbrains.com/issue/KT-46820
[3] https://dev.azure.com/oss-review-toolkit/ort/_build/results?buildId=4660&view=logs&j=fa363831-c637-5773-1163-373ecf422174&t=7d0e4a4e-4b6c-5bd7-aae6-5d2ee8f765e2&l=189

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>