### PR TITLE
Helper: Use underscore for package-curations if no namespace exists

### DIFF
--- a/helper-cli/src/main/kotlin/HelperMain.kt
+++ b/helper-cli/src/main/kotlin/HelperMain.kt
@@ -46,7 +46,7 @@ import org.ossreviewtoolkit.helper.commands.SubtractScanResultsCommand
 import org.ossreviewtoolkit.helper.commands.TransformResultCommand
 import org.ossreviewtoolkit.helper.commands.VerifySourceArtifactCurationsCommand
 import org.ossreviewtoolkit.helper.commands.packageconfig.PackageConfigurationCommand
-import org.ossreviewtoolkit.helper.commands.packagecuration.PackageCurationCommand
+import org.ossreviewtoolkit.helper.commands.packagecuration.PackageCurationsCommand
 import org.ossreviewtoolkit.helper.commands.repoconfig.RepositoryConfigurationCommand
 import org.ossreviewtoolkit.helper.common.ORTH_NAME
 import org.ossreviewtoolkit.utils.printStackTrace
@@ -84,7 +84,7 @@ internal class HelperMain : CliktCommand(name = ORTH_NAME, epilog = "* denotes r
             MapCopyrightsCommand(),
             MergeRepositoryConfigurationsCommand(),
             PackageConfigurationCommand(),
-            PackageCurationCommand(),
+            PackageCurationsCommand(),
             RepositoryConfigurationCommand(),
             SetLabelsCommand(),
             SubtractScanResultsCommand(),

--- a/helper-cli/src/main/kotlin/commands/packagecuration/PackageCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packagecuration/PackageCurationsCommand.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.helper.commands.packagecuration
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.subcommands
 
-internal class PackageCurationCommand : CliktCommand() {
+internal class PackageCurationsCommand : CliktCommand() {
     init {
         subcommands(
             CreateCommand(),

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -126,7 +126,7 @@ internal fun findRepositories(directory: File): Map<String, VcsInfo> {
  */
 internal fun getSplitCurationFile(parent: File, packageId: Identifier, fileExtension: String) =
     parent.resolve(packageId.type.encodeOrUnknown())
-        .resolve(packageId.namespace.fileSystemEncode())
+        .resolve(packageId.namespace.ifBlank { "_" }.fileSystemEncode())
         .resolve("${packageId.name.encodeOrUnknown()}.$fileExtension")
 
 /**


### PR DESCRIPTION
See commits