### PR TITLE
Helper curations commands: Use block comments

### DIFF
--- a/helper-cli/src/main/kotlin/commands/packagecuration/SplitCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packagecuration/SplitCommand.kt
@@ -26,11 +26,16 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
+import org.ossreviewtoolkit.helper.common.createBlockYamlMapper
 import org.ossreviewtoolkit.helper.common.getSplitCurationFile
+import org.ossreviewtoolkit.helper.common.wrapAt
 import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.readValue
-import org.ossreviewtoolkit.model.writeValue
 import org.ossreviewtoolkit.utils.expandTilde
+import org.ossreviewtoolkit.utils.safeMkdirs
+
+// Wrap at column 120 minus 6 spaces of indentation.
+private const val COMMENT_WRAP_COLUMN = 120 - 6
 
 internal class SplitCommand : CliktCommand(
     help = "Split a single curations file into a directory structure using the format '<type>/<namespace>/<name>.yml'."
@@ -61,8 +66,24 @@ internal class SplitCommand : CliktCommand(
             getSplitCurationFile(outputCurationsDir, it.id, inputCurationsFile.extension)
         }
 
+        val mapper = createBlockYamlMapper()
         groupedCurations.forEach { (outputFile, curations) ->
-            outputFile.writeValue(curations)
+            curations.forEach { originalCuration ->
+                val comment = originalCuration.data.comment?.wrapAt(COMMENT_WRAP_COLUMN)
+
+                val curation = if (comment != null) {
+                    // Ensure at least a single "\n" is contained in the comment to force the YAML mapper to use block
+                    // quotes.
+                    originalCuration.copy(data = originalCuration.data.copy(comment = "$comment\n"))
+                } else {
+                    originalCuration
+                }
+
+                val text = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(listOf(curation))
+
+                outputFile.parentFile.safeMkdirs()
+                outputFile.writeText(text)
+            }
         }
     }
 }


### PR DESCRIPTION
Ensure that curations created via `helper-cli` use a block comment.