### PR TITLE
Dockerfile: Remove the experimental syntax header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# syntax = docker/dockerfile:experimental
-
 # Copyright (C) 2020 Bosch Software Innovations GmbH
 # Copyright (C) 2021 Alliander N.V.
 #


### PR DESCRIPTION
This does not seem to be required anymore with recent Docker versions,
and removing it simplifies upcoming Copyright header checking logic.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>