### PR TITLE
Dockerfile: Be explicit about the required frontend syntax version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.2
+
 # Copyright (C) 2020 Bosch Software Innovations GmbH
 # Copyright (C) 2021 Alliander N.V.
 #


### PR DESCRIPTION
This is a fixup for 8b07e14 which dropped this header completely, but
Azure DevOps seems to run a version of Docker that defaults to a
different frontend syntax version, so explicitly specify it again.

Also see [1].

[1] https://github.com/moby/buildkit/blob/fa632c5/frontend/dockerfile/docs/syntax.md#build-mounts-run---mount

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>