### PR TITLE
ON HOLD: AnalyzerCommand: Print the amount of PackageReference entries by project

### DIFF
--- a/model/src/main/kotlin/Scope.kt
+++ b/model/src/main/kotlin/Scope.kt
@@ -129,4 +129,13 @@ data class Scope(
 
         return result
     }
+
+    /**
+     * Return the amount of [PackageReference]s contained in this scope.
+      */
+    fun size(): Int {
+        fun PackageReference.size(): Int = 1 + dependencies.sumOf { it.size() }
+
+        return dependencies.sumOf { it.size() }
+    }
 }


### PR DESCRIPTION
For large analyzer results the call to `writeOrtResult()` may run out of
memory. In such cases the size of the Ort result is usually dominated by
the size of the package reference entries. Print the amount of entries
by project to ease debugging.
