### PR TITLE
analyzer: Remove the obsolete "experimental" state from GoMod

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,8 +330,7 @@ Currently, the following package managers are supported:
   [limitations](https://github.com/oss-review-toolkit/ort/pull/1303#issue-253860146))
 * [Glide](https://github.com/Masterminds/glide) (Go)
 * [Godep](https://github.com/tools/godep) (Go)
-* [GoMod](https://github.com/golang/go/wiki/Modules) (Go, *experimental* as only proxy-based source artifacts but no VCS
-  locations are supported)
+* [GoMod](https://github.com/golang/go/wiki/Modules) (Go)
 * [Gradle](https://gradle.org/) (Java)
 * [Maven](http://maven.apache.org/) (Java)
 * [NPM](https://www.npmjs.com/) (Node.js)

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -46,9 +46,7 @@ import org.ossreviewtoolkit.utils.stashDirectories
 import org.ossreviewtoolkit.utils.withoutSuffix
 
 /**
- * The [Go Modules](https://github.com/golang/go/wiki/Modules) package manager for Go. The implementation is
- * experimental since it lacks resolving VCS locations and also the way source artifact URLs are crafted needs to proof
- * being useful. It seems favorable to adjust the implementation to only set VCS but not source artifact URLs.
+ * The [Go Modules](https://github.com/golang/go/wiki/Modules) package manager for Go.
  *
  * Note: The file `go.sum` is not a lockfile as go modules already allows for reproducible builds without that file.
  * Thus no logic for handling the [AnalyzerConfiguration.allowDynamicVersions] is needed.


### PR DESCRIPTION
Meanwhile VCS detection capababilities have been added which are not
identical to / using the originial (GoMod) tool, but are good enough to
remove the experimental state.