### PR TITLE
Pub: Update the Flutter download URL

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -210,7 +210,7 @@ class Pub(
             else -> throw IllegalArgumentException("Unsupported operating system.")
         }
 
-        val url = "https://storage.googleapis.com/flutter_infra/releases/stable/$archive"
+        val url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/$archive"
 
         log.info { "Downloading flutter-$flutterVersion from $url... " }
 


### PR DESCRIPTION
Newer releases of Flutter are only available from the updated URL. Note
that older releases can be downloaded from the updated URL as well.