### PR TITLE
ListLicensesCommand: Drop hard-coded allowed enum values

### DIFF
--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -88,7 +88,7 @@ internal class ListLicensesCommand : CliktCommand(
     private val offendingSeverity by option(
         "--offending-severity",
         help = "Set the severities to use filtering enabled by --offending-only, specified as comma-separated " +
-                "values. Allowed values: ERROR,WARNING,HINT."
+                "values."
     ).enum<Severity>().split(",").default(enumValues<Severity>().asList())
 
     private val omitExcluded by option(


### PR DESCRIPTION
When calling

    ./gradlew :helper-cli:run --args="list-licenses --help"

clikt already displays these as

    --offending-severity [HINT|WARNING|ERROR]

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>