### PR TITLE
Gradle: Update the URL to the repo hosting the API tooling

### DIFF
--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -37,7 +37,7 @@ plugins {
 repositories {
     exclusiveContent {
         forRepository {
-            maven("https://repo.gradle.org/gradle/libs-releases-local/")
+            maven("https://repo.gradle.org/artifactory/libs-releases-local/")
         }
 
         filter {

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -64,7 +64,7 @@ repositories {
     // https://github.com/gradle/gradle/issues/4106.
     exclusiveContent {
         forRepository {
-            maven("https://repo.gradle.org/gradle/libs-releases-local/")
+            maven("https://repo.gradle.org/artifactory/libs-releases-local/")
         }
 
         filter {

--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -55,7 +55,7 @@ repositories {
     // https://github.com/gradle/gradle/issues/4106.
     exclusiveContent {
         forRepository {
-            maven("https://repo.gradle.org/gradle/libs-releases-local/")
+            maven("https://repo.gradle.org/artifactory/libs-releases-local/")
         }
 
         filter {


### PR DESCRIPTION
The URL seems to have changed as part of migrating away from JCenter.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>