### PR TITLE
Docker/Azure: Avoid cloning the CocoaPods Git repository

### DIFF
--- a/.azure-pipelines/LinuxAnalyzerTest.yml
+++ b/.azure-pipelines/LinuxAnalyzerTest.yml
@@ -43,10 +43,9 @@ jobs:
       mkdir -p $HOME/go/bin
       curl https://raw.githubusercontent.com/golang/dep/v$GO_DEP_VERSION/install.sh | sh
 
-      # Install 'CocoaPods'. As https://github.com/CocoaPods/CocoaPods/pull/10609 is needed but not yet released, make a
-      # build from the latest revision of the master branch.
-      git clone https://github.com/CocoaPods/CocoaPods.git
-      cd CocoaPods
+      # Install 'CocoaPods'. As https://github.com/CocoaPods/CocoaPods/pull/10609 is needed but not yet released.
+      curl -ksSL https://github.com/CocoaPods/CocoaPods/archive/9461b346aeb8cba6df71fd4e71661688138ec21b.tar.gz | tar -zxC .
+      cd CocoaPods-9461b346aeb8cba6df71fd4e71661688138ec21b
       gem build cocoapods.gemspec
       sudo gem install cocoapods-1.10.1.gem
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -150,15 +150,14 @@ RUN /opt/ort/bin/import_proxy_certs.sh && \
         SDK_MANAGER_PROXY_OPTIONS="--proxy=http --proxy_host=${PROXY_HOST_AND_PORT%:*} --proxy_port=${PROXY_HOST_AND_PORT##*:}"; \
     fi && \
     yes | $ANDROID_HOME/cmdline-tools/bin/sdkmanager $SDK_MANAGER_PROXY_OPTIONS --sdk_root=$ANDROID_HOME "platform-tools" && \
-    # Install 'CocoaPods'. As https://github.com/CocoaPods/CocoaPods/pull/10609 is needed but not yet released, make a
-    # build from the latest revision of the master branch.
-    git clone https://github.com/CocoaPods/CocoaPods.git && \
-        cd CocoaPods && \
-        git checkout 9461b346aeb8cba6df71fd4e71661688138ec21b && \
-        gem build cocoapods.gemspec && \
-        gem install cocoapods-1.10.1.gem && \
-        cd .. && \
-        rm -rf CocoaPods && \
+    # Install 'CocoaPods'. As https://github.com/CocoaPods/CocoaPods/pull/10609 is needed but not yet released.
+    curl -ksSL https://github.com/CocoaPods/CocoaPods/archive/9461b346aeb8cba6df71fd4e71661688138ec21b.tar.gz | \
+          tar -zxC . && \
+          cd CocoaPods-9461b346aeb8cba6df71fd4e71661688138ec21b && \
+          gem build cocoapods.gemspec && \
+          gem install cocoapods-1.10.1.gem && \
+          cd .. && \
+          rm -rf CocoaPods-9461b346aeb8cba6df71fd4e71661688138ec21b && \
     # Add scanners (in versions known to work).
     curl -ksSL https://github.com/nexB/scancode-toolkit/archive/v$SCANCODE_VERSION.tar.gz | \
         tar -zxC /usr/local && \


### PR DESCRIPTION
Download the archive instead of cloning the repository to reduce
execution time.
