### PR TITLE
Adapt more clients to the dependency navigator API

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -616,3 +616,8 @@ private fun parseAuthors(pubspec: JsonNode): SortedSet<String> =
     (listOfNotNull(pubspec["author"]) + pubspec["authors"]?.toList().orEmpty()).mapNotNullTo(sortedSetOf()) {
         parseAuthorString(it.textValue())
     }
+
+private fun ProjectAnalyzerResult.collectPackagesByScope(scopeName: String): List<Package> {
+    val scope = project.scopes.find { it.name == scopeName } ?: return emptyList()
+    return packages.filter { it.id in scope }
+}

--- a/evaluator/build.gradle.kts
+++ b/evaluator/build.gradle.kts
@@ -18,6 +18,8 @@
  * License-Filename: LICENSE
  */
 
+val mockkVersion: String by project
+
 plugins {
     // Apply core plugins.
     `java-library`
@@ -27,4 +29,6 @@ dependencies {
     api(project(":model"))
 
     implementation(project(":utils"))
+
+    testImplementation("io.mockk:mockk:$mockkVersion")
 }

--- a/evaluator/src/main/kotlin/DependencyRule.kt
+++ b/evaluator/src/main/kotlin/DependencyRule.kt
@@ -19,18 +19,17 @@
 
 package org.ossreviewtoolkit.evaluator
 
+import org.ossreviewtoolkit.model.DependencyNode
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCurationResult
 import org.ossreviewtoolkit.model.PackageLinkage
-import org.ossreviewtoolkit.model.PackageReference
 import org.ossreviewtoolkit.model.Project
-import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.licenses.ResolvedLicenseInfo
 import org.ossreviewtoolkit.spdx.enumSetOf
 
 /**
- * A [Rule] to check a single [dependency][PackageReference].
+ * A [Rule] to check a single [dependency][DependencyNode].
  */
 class DependencyRule(
     ruleSet: RuleSet,
@@ -40,16 +39,16 @@ class DependencyRule(
     resolvedLicenseInfo: ResolvedLicenseInfo,
 
     /**
-     * The [dependency][PackageReference] to check.
+     * The [dependency][DependencyNode] to check.
      */
-    val dependency: PackageReference,
+    val dependency: DependencyNode,
 
     /**
      * The ancestors of the [dependency] in the dependency tree, sorted from farthest to closest: The first entry is the
      * direct dependency of a project, the last entry (at index `level - 1`) is a direct parent of this [dependency].
      * If the list is empty it means that this dependency is a direct dependency.
      */
-    val ancestors: List<PackageReference>,
+    val ancestors: List<DependencyNode>,
 
     /**
      * The level of the [dependency] inside the dependency tree. Starts with 0 for a direct dependency of a project.
@@ -57,9 +56,9 @@ class DependencyRule(
     val level: Int,
 
     /**
-     * The [Scope] that contains the [dependency].
+     * The [name][scopeName] of the scope that contains the [dependency].
      */
-    val scope: Scope,
+    val scopeName: String,
 
     /**
      * The [Project] that contains the [dependency].
@@ -68,10 +67,10 @@ class DependencyRule(
 ) : PackageRule(ruleSet, name, pkg, curations, resolvedLicenseInfo) {
     override val description =
         "Evaluating rule '$name' for dependency '${dependency.id.toCoordinates()}' " +
-                "(project=${project.id.toCoordinates()}, scope=${scope.name}, level=$level)."
+                "(project=${project.id.toCoordinates()}, scope=$scopeName, level=$level)."
 
     override fun issueSource() =
-        "$name - ${pkg.id.toCoordinates()} (dependency of ${project.id.toCoordinates()} in scope ${scope.name})"
+        "$name - ${pkg.id.toCoordinates()} (dependency of ${project.id.toCoordinates()} in scope $scopeName)"
 
     /**
      * A [RuleMatcher] that checks if the level of the [dependency] inside the dependency tree equals [level].

--- a/evaluator/src/test/kotlin/DependencyRuleTest.kt
+++ b/evaluator/src/test/kotlin/DependencyRuleTest.kt
@@ -38,7 +38,7 @@ class DependencyRuleTest : WordSpec() {
             dependency = dependency,
             ancestors = emptyList(),
             level = 0,
-            scope = scopeIncluded,
+            scopeName = scopeIncluded.name,
             project = projectIncluded
         )
 

--- a/evaluator/src/test/kotlin/TestData.kt
+++ b/evaluator/src/test/kotlin/TestData.kt
@@ -115,6 +115,11 @@ val packageMetaDataOnly = Package.EMPTY.copy(
     isMetaDataOnly = true
 )
 
+val packageDependency = Package.EMPTY.copy(
+    id = Identifier("Maven:org.ossreviewtoolkit:common-lib:1.0"),
+    declaredLicenses = declaredLicenses
+)
+
 val allPackages = listOf(
     packageExcluded,
     packageDynamicallyLinked,
@@ -123,7 +128,8 @@ val allPackages = listOf(
     packageWithOnlyConcludedLicense,
     packageWithOnlyDeclaredLicense,
     packageWithConcludedAndDeclaredLicense,
-    packageMetaDataOnly
+    packageMetaDataOnly,
+    packageDependency
 )
 
 val scopeExcluded = Scope(
@@ -147,7 +153,7 @@ val scopeIncluded = Scope(
     dependencies = sortedSetOf(
         packageWithoutLicense.toReference(),
         packageWithOnlyConcludedLicense.toReference(),
-        packageWithOnlyDeclaredLicense.toReference(),
+        packageWithOnlyDeclaredLicense.toReference(dependencies = sortedSetOf(packageDependency.toReference())),
         packageWithConcludedAndDeclaredLicense.toReference(),
         packageRefDynamicallyLinked,
         packageRefStaticallyLinked,

--- a/model/src/main/kotlin/ProjectAnalyzerResult.kt
+++ b/model/src/main/kotlin/ProjectAnalyzerResult.kt
@@ -45,9 +45,4 @@ data class ProjectAnalyzerResult(
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val issues: List<OrtIssue> = emptyList()
-) {
-    fun collectPackagesByScope(scopeName: String): List<Package> {
-        val scope = project.scopes.find { it.name == scopeName } ?: return emptyList()
-        return packages.filter { it.id in scope }
-    }
-}
+)

--- a/model/src/main/kotlin/config/Excludes.kt
+++ b/model/src/main/kotlin/config/Excludes.kt
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Project
-import org.ossreviewtoolkit.model.Scope
 
 /**
  * Defines which parts of a repository should be excluded.
@@ -60,19 +59,9 @@ data class Excludes(
     fun findScopeExcludes(scopeName: String): List<ScopeExclude> = scopes.filter { it.matches(scopeName) }
 
     /**
-     * Return the [ScopeExclude]s for the provided [scope].
-     */
-    fun findScopeExcludes(scope: Scope): List<ScopeExclude> = findScopeExcludes(scope.name)
-
-    /**
      * True if any [path exclude][paths] matches [path].
      */
     fun isPathExcluded(path: String) = paths.any { it.matches(path) }
-
-    /**
-     * True if the [scope] is excluded by this [Excludes] configuration.
-     */
-    fun isScopeExcluded(scope: Scope): Boolean = isScopeExcluded(scope.name)
 
     /**
      * True if the scope with the given [scopeName] is excluded by this [Excludes] configuration.

--- a/model/src/test/kotlin/DependencyTreeNavigatorTest.kt
+++ b/model/src/test/kotlin/DependencyTreeNavigatorTest.kt
@@ -30,6 +30,7 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
+import io.kotest.matchers.types.beTheSameInstanceAs
 
 import java.io.File
 import java.time.Instant
@@ -474,6 +475,14 @@ class DependencyTreeNavigatorTest : WordSpec() {
                         )
                     )
                 )
+            }
+        }
+
+        "dependency nodes" should {
+            "return themselves as stable reference" {
+                val dependencies = navigator.directDependencies(testProject, "compile")
+
+                dependencies.forEach { it.getStableReference() should beTheSameInstanceAs(it) }
             }
         }
     }

--- a/model/src/test/kotlin/config/ExcludesTest.kt
+++ b/model/src/test/kotlin/config/ExcludesTest.kt
@@ -130,7 +130,7 @@ class ExcludesTest : WordSpec() {
             "return an empty list if there are no matching scope excludes" {
                 val excludes = Excludes(scopes = listOf(scopeExclude2))
 
-                excludes.findScopeExcludes(scope1) should beEmpty()
+                excludes.findScopeExcludes(scope1.name) should beEmpty()
             }
 
             "find the correct scope excludes" {
@@ -138,7 +138,7 @@ class ExcludesTest : WordSpec() {
                     scopes = listOf(scopeExclude1, scopeExclude2)
                 )
 
-                val scopeExcludes = excludes.findScopeExcludes(scope1)
+                val scopeExcludes = excludes.findScopeExcludes(scope1.name)
 
                 scopeExcludes should containExactly(scopeExclude1)
             }
@@ -482,21 +482,18 @@ class ExcludesTest : WordSpec() {
             "return true if the scope is excluded" {
                 val excludes = Excludes(scopes = listOf(scopeExclude1))
 
-                excludes.isScopeExcluded(scope1) shouldBe true
                 excludes.isScopeExcluded(scope1.name) shouldBe true
             }
 
             "return true if the scope is excluded using a regex" {
                 val excludes = Excludes(scopes = listOf(scopeExclude1.copy(pattern = "sc.*")))
 
-                excludes.isScopeExcluded(scope1) shouldBe true
                 excludes.isScopeExcluded(scope1.name) shouldBe true
             }
 
             "return false if the scope is not excluded" {
                 val excludes = Excludes()
 
-                excludes.isScopeExcluded(scope1) shouldBe false
                 excludes.isScopeExcluded(scope1.name) shouldBe false
             }
         }


### PR DESCRIPTION
This is a follow-up PR to #4166. It addresses further consumers of dependency information in an `OrtResult`.