### PR TITLE
AnalyzerResult: Take hasIssues property into account on serialization

### DIFF
--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -171,6 +171,8 @@ class AnalyzerResultBuilderTest : WordSpec() {
                 resultTree["dependency_graphs"] shouldNotBeNull {
                     count() shouldBe 2
                 }
+
+                resultTree["has_issues"].asBoolean() shouldBe true
             }
         }
 

--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -149,6 +149,7 @@ private class AnalyzerResultSerializer : StdSerializer<AnalyzerResult>(AnalyzerR
             }
 
             gen.writeObjectField("dependency_graphs", dependencyGraphs)
+            gen.writeBooleanField("has_issues", hasIssues)
         }
 
         gen.writeEndObject()


### PR DESCRIPTION
This fixes a regression introduced in d76ec51 with the custom
serializer for AnalyzerResult; the property was overlooked then.

