### PR TITLE
helper-cli: Add command to delete entries from postgres scan storage

### DIFF
--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -21,6 +21,8 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 val cliktVersion: String by project
+val exposedVersion: String by project
+val hikariVersion: String by project
 val jsltVersion: String by project
 val log4jCoreVersion: String by project
 
@@ -82,6 +84,8 @@ dependencies {
 
     implementation("com.github.ajalt.clikt:clikt:$cliktVersion")
     implementation("com.schibsted.spt.data:jslt:$jsltVersion")
+    implementation("com.zaxxer:HikariCP:$hikariVersion")
     implementation("org.apache.logging.log4j:log4j-core:$log4jCoreVersion")
     implementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jCoreVersion")
+    implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
 }

--- a/helper-cli/src/main/kotlin/HelperMain.kt
+++ b/helper-cli/src/main/kotlin/HelperMain.kt
@@ -49,6 +49,7 @@ import org.ossreviewtoolkit.helper.commands.VerifySourceArtifactCurationsCommand
 import org.ossreviewtoolkit.helper.commands.packageconfig.PackageConfigurationCommand
 import org.ossreviewtoolkit.helper.commands.packagecuration.PackageCurationsCommand
 import org.ossreviewtoolkit.helper.commands.repoconfig.RepositoryConfigurationCommand
+import org.ossreviewtoolkit.helper.commands.scanstorage.ScanStorageCommand
 import org.ossreviewtoolkit.helper.common.ORTH_NAME
 import org.ossreviewtoolkit.utils.printStackTrace
 
@@ -87,6 +88,7 @@ internal class HelperMain : CliktCommand(name = ORTH_NAME, epilog = "* denotes r
             PackageConfigurationCommand(),
             PackageCurationsCommand(),
             RepositoryConfigurationCommand(),
+            ScanStorageCommand(),
             SetDependencyRepresentationCommand(),
             SetLabelsCommand(),
             SubtractScanResultsCommand(),

--- a/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/PackageConfigurationCommand.kt
@@ -19,10 +19,10 @@
 
 package org.ossreviewtoolkit.helper.commands.packageconfig
 
-import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.NoOpCliktCommand
 import com.github.ajalt.clikt.core.subcommands
 
-internal class PackageConfigurationCommand : CliktCommand(
+internal class PackageConfigurationCommand : NoOpCliktCommand(
     help = "Commands for working with package configurations."
 ) {
     init {
@@ -37,9 +37,5 @@ internal class PackageConfigurationCommand : CliktCommand(
             SortCommand(),
             RemoveEntriesCommand()
         )
-    }
-
-    override fun run() {
-        // Intentionally empty, because all logic is implemented inside the sub commands..
     }
 }

--- a/helper-cli/src/main/kotlin/commands/packagecuration/PackageCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packagecuration/PackageCurationsCommand.kt
@@ -19,10 +19,10 @@
 
 package org.ossreviewtoolkit.helper.commands.packagecuration
 
-import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.NoOpCliktCommand
 import com.github.ajalt.clikt.core.subcommands
 
-internal class PackageCurationsCommand : CliktCommand(
+internal class PackageCurationsCommand : NoOpCliktCommand(
     help = "Commands for working with package curations."
 ) {
     init {
@@ -31,9 +31,5 @@ internal class PackageCurationsCommand : CliktCommand(
             SetCommand(),
             SplitCommand()
         )
-    }
-
-    override fun run() {
-        // Intentionally empty, because all logic is implemented inside the sub commands.
     }
 }

--- a/helper-cli/src/main/kotlin/commands/repoconfig/RepositoryConfigurationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/repoconfig/RepositoryConfigurationCommand.kt
@@ -19,10 +19,10 @@
 
 package org.ossreviewtoolkit.helper.commands.repoconfig
 
-import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.NoOpCliktCommand
 import com.github.ajalt.clikt.core.subcommands
 
-class RepositoryConfigurationCommand : CliktCommand(
+class RepositoryConfigurationCommand : NoOpCliktCommand(
     help = "Commands for working with package configurations."
 ) {
     init {
@@ -38,9 +38,5 @@ class RepositoryConfigurationCommand : CliktCommand(
             RemoveEntriesCommand(),
             SortCommand()
         )
-    }
-
-    override fun run() {
-        // Intentionally empty, because all logic is implemented inside the sub commands..
     }
 }

--- a/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands.scanstorage
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.associate
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.split
+import com.github.ajalt.clikt.parameters.types.file
+
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.isNotNull
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
+import org.jetbrains.exposed.sql.compoundAnd
+import org.jetbrains.exposed.sql.compoundOr
+import org.jetbrains.exposed.sql.deleteWhere
+
+import org.ossreviewtoolkit.helper.common.ORTH_NAME
+import org.ossreviewtoolkit.model.SourceCodeOrigin
+import org.ossreviewtoolkit.model.config.OrtConfiguration
+import org.ossreviewtoolkit.model.config.PostgresStorageConfiguration
+import org.ossreviewtoolkit.model.utils.DatabaseUtils
+import org.ossreviewtoolkit.model.utils.DatabaseUtils.transaction
+import org.ossreviewtoolkit.model.utils.rawParam
+import org.ossreviewtoolkit.scanner.storages.utils.ScanResults
+import org.ossreviewtoolkit.utils.ORT_CONFIG_FILENAME
+import org.ossreviewtoolkit.utils.expandTilde
+import org.ossreviewtoolkit.utils.log
+import org.ossreviewtoolkit.utils.ortConfigDirectory
+
+internal class DeleteCommand : CliktCommand(
+    help = "Removes stored scan results matching the options or all results if no options are given."
+) {
+    private val configFile by option(
+        "--config",
+        help = "The path to the ORT configuration file that configures the scan results storage."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .default(ortConfigDirectory.resolve(ORT_CONFIG_FILENAME))
+
+    private val configArguments by option(
+        "-P",
+        help = "Override a key-value pair in the configuration file. For example: " +
+                "-P scanner.postgresStorage.schema=testSchema"
+    ).associate()
+
+    private val sourceCodeOrigins by option(
+        "--source-code-origins",
+        help = "The origin of the scan results that should be deleted."
+    ).convert { SourceCodeOrigin.valueOf(it) }
+        .split(",")
+        .default(emptyList())
+
+    private val packageType by option(
+        "--package-type",
+        help = "The package manager type to delete from the scan storage. Like 'Maven' or 'NPM'."
+    )
+
+    override fun run() {
+        val database = initDatabase(OrtConfiguration.load(configArguments, configFile))
+
+        val provenanceKeys = sourceCodeOrigins.map { origin ->
+            when (origin) {
+                SourceCodeOrigin.ARTIFACT -> "source_artifact"
+                SourceCodeOrigin.VCS -> "vcs_info"
+            }
+        }
+
+        val typeCondition = packageType?.let { ScanResults.identifier like "$it:%" }
+        val provenanceConditions = provenanceKeys.map { key ->
+                rawParam("scan_result->'provenance'->>'$key'").isNotNull()
+            }.takeIf { it.isNotEmpty() }?.compoundOr()
+
+        val conditions = listOfNotNull(typeCondition, provenanceConditions)
+        if (conditions.isEmpty()) {
+            // Default to the safe option to not delete anything if no conditions are given.
+            println("Not specified what entries to delete. Not deleting anything.")
+
+            return
+        }
+
+        val condition = conditions.compoundAnd()
+        database.transaction {
+            ScanResults.deleteWhere { condition }
+        }
+
+        log.info { "Successfully deleted stored scan results." }
+    }
+
+    private fun initDatabase(config: OrtConfiguration): Database {
+        val storageConfig = config.scanner.storages?.get("postgresStorage") as? PostgresStorageConfiguration
+            ?: throw IllegalArgumentException("postgresStorage not configured.")
+
+        log.info {
+            "Using Postgres storage with URL '${storageConfig.url}' and schema '${storageConfig.schema}'."
+        }
+
+        val dataSource = DatabaseUtils.createHikariDataSource(
+            config = storageConfig,
+            applicationNameSuffix = ORTH_NAME,
+            maxPoolSize = 1
+        )
+
+        return Database.connect(dataSource)
+    }
+}

--- a/helper-cli/src/main/kotlin/commands/scanstorage/ScanStorageCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/scanstorage/ScanStorageCommand.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands.scanstorage
+
+import com.github.ajalt.clikt.core.NoOpCliktCommand
+import com.github.ajalt.clikt.core.subcommands
+
+class ScanStorageCommand : NoOpCliktCommand(
+    help = "Commands for working with scan storages."
+) {
+    init {
+        subcommands(
+            DeleteCommand()
+        )
+    }
+}


### PR DESCRIPTION
While this is quite a specific command, it is required for https://github.com/oss-review-toolkit/ort/issues/2848.

Inconsistencies in the scan storage caused by switching the prefered source can be cleaned up using this `helper-cli` command.