### PR TITLE
OrtMain: Fix adding up the count of severe issues

### DIFF
--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -81,8 +81,8 @@ fun concludeSeverityStats(counts: Map<Severity, Int>, threshold: Severity, sever
     var severeIssueCount = 0
 
     fun getSeverityCount(severity: Severity) =
-        counts.getOrDefault(severity, 0).also {
-            if (it > 0 && severity >= threshold) ++severeIssueCount
+        counts.getOrDefault(severity, 0).also { count ->
+            if (severity >= threshold) severeIssueCount += count
         }
 
     val hintCount = getSeverityCount(Severity.HINT)


### PR DESCRIPTION
This is a fixup for 17085cb. While at it, remove a not strictly
necessary check for the count to be greater than 0.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>