### PR TITLE
CocoaPods: Gracefully handle absent Podspecs

### DIFF
--- a/analyzer/src/main/kotlin/managers/CocoaPods.kt
+++ b/analyzer/src/main/kotlin/managers/CocoaPods.kt
@@ -204,7 +204,7 @@ class CocoaPods(
 
         val podspecFile = podspecCommand.stdout.trim().let { File(it) }
 
-        podspecFile.readValue<Podspec>().withSubspecs().associateByTo(podspecCache, { it.name })
+        podspecFile.readValue<Podspec>().withSubspecs().associateByTo(podspecCache) { it.name }
 
         return podspecCache.getValue(id.name)
     }


### PR DESCRIPTION
Don't throw a NPE in case a Podspec cannot be found in the default Specs
repository. Use an empty package instead. This is particularly important
in case the Podfile uses non-default Specs repositories, which are not
yet supported in ORT.