### PR TITLE
ScanCodeResultParserTest: Test other properties than the fileCount

### DIFF
--- a/scanner/src/test/kotlin/scanners/scancode/ScanCodeResultParserTest.kt
+++ b/scanner/src/test/kotlin/scanners/scancode/ScanCodeResultParserTest.kt
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.should
@@ -48,7 +49,9 @@ class ScanCodeResultParserTest : WordSpec({
 
             val summary = generateSummary(Instant.now(), Instant.now(), SpdxConstants.NONE, result)
 
-            summary.fileCount shouldBe 10
+            summary.licenseFindings.size shouldBe 4
+            summary.copyrightFindings.size shouldBe 4
+            summary.issues should beEmpty()
         }
     }
 
@@ -59,7 +62,9 @@ class ScanCodeResultParserTest : WordSpec({
 
             val summary = generateSummary(Instant.now(), Instant.now(), SpdxConstants.NONE, result)
 
-            summary.fileCount shouldBe 10
+            summary.licenseFindings.size shouldBe 4
+            summary.copyrightFindings.size shouldBe 4
+            summary.issues should beEmpty()
         }
     }
 


### PR DESCRIPTION
As a preparation for removing the fileCount, test other properties of a
ScanSummary.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>