### PR TITLE
VulnerableCode: Simplify VulnerabilityReference.toModel()

### DIFF
--- a/advisor/src/main/kotlin/advisors/VulnerableCode.kt
+++ b/advisor/src/main/kotlin/advisors/VulnerableCode.kt
@@ -116,7 +116,7 @@ class VulnerableCode(
      */
     private fun VulnerableCodeService.VulnerabilityReference.toModel(): List<VulnerabilityReference> {
         val sourceUri = URI(url)
-        return scores.map { VulnerabilityReference(sourceUri, it.scoringSystem, it.value) }.takeUnless { it.isEmpty() }
-            ?: listOf(VulnerabilityReference(sourceUri, null, null))
+        if (scores.isEmpty()) return listOf(VulnerabilityReference(sourceUri, null, null))
+        return scores.map { VulnerabilityReference(sourceUri, it.scoringSystem, it.value) }
     }
 }


### PR DESCRIPTION
Check for the scores to be empty already before the mapping to clarify
the intention.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>