### PR TITLE
VulnerabilityReference: Rewrite getSeverityString() to match more systems

### DIFF
--- a/model/src/main/kotlin/VulnerabilityReference.kt
+++ b/model/src/main/kotlin/VulnerabilityReference.kt
@@ -52,14 +52,15 @@ data class VulnerabilityReference(
 ) {
     companion object {
         /**
-         * Return a human-readable string that is determined based on the given score and scoring system.
+         * Return a human-readable string that is determined based on the given [scoringSystem] and [severity].
          */
-        fun getSeverityString(scoringSystem: String?, severity: String) =
-            when (scoringSystem) {
-                "CVSS2" -> Cvss2Rating.fromScore(severity.toFloat())?.name?.lowercase()
-                "CVSS3" -> Cvss3Rating.fromScore(severity.toFloat())?.name?.lowercase()
-                else -> "unknown"
-            }
+        @Suppress("UNUSED") // This function is used in the templates.
+        fun getSeverityString(scoringSystem: String?, severity: String?) =
+            when (scoringSystem?.uppercase()) {
+                "CVSS2", "CVSSV2" -> severity?.toFloatOrNull()?.let { Cvss2Rating.fromScore(it)?.toString() }
+                "CVSS3", "CVSSV3" -> severity?.toFloatOrNull()?.let { Cvss3Rating.fromScore(it)?.toString() }
+                else -> null
+            } ?: "UNKNOWN"
     }
 
     /**


### PR DESCRIPTION
A VulnerabilityReference has a nullable severity, so also handle that in
in getSeverityString(), and generalize the scoring system matching to be
able to handle more cases.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>