### PR TITLE
DependencyGraphConverter: Take issues of dependencies into account

### DIFF
--- a/model/src/main/kotlin/utils/DependencyGraphConverter.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphConverter.kt
@@ -112,5 +112,8 @@ object DependencyGraphConverter {
         override fun linkageFor(dependency: PackageReference): PackageLinkage = dependency.linkage
 
         override fun createPackage(dependency: PackageReference, issues: MutableList<OrtIssue>): Package? = null
+
+        override fun issuesForDependency(dependency: PackageReference): Collection<OrtIssue> =
+            dependency.issues
     }
 }


### PR DESCRIPTION
DependencyGraphConverter missed the issues stored at PackageReferences
when constructing a DependencyGraph. By overriding the
issuesForDependency() function in the private ScopesDependencyHandler
class, they are now preserved.

