### PR TITLE
Add a DependencyNavigator implementation for dependency graphs

### DIFF
--- a/analyzer/src/test/kotlin/managers/GradleDependencyHandlerTest.kt
+++ b/analyzer/src/test/kotlin/managers/GradleDependencyHandlerTest.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.analyzer.managers
 import Dependency
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.haveSize
@@ -57,6 +58,7 @@ import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.utils.DependencyGraphBuilder
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 /**
  * A test class to test the integration of the [Gradle] package manager with [DependencyGraphBuilder]. This class
@@ -78,7 +80,10 @@ class GradleDependencyHandlerTest : WordSpec({
                 .addDependency(scope2, dep1)
                 .build()
 
-            graph.scopeRoots shouldHaveSize 3
+            graph.nodes shouldNotBeNull {
+                this shouldHaveSize 3
+            }
+
             val scopes = graph.createScopes()
             scopes.map { it.name } should containExactlyInAnyOrder(scope1, scope2)
 
@@ -168,10 +173,13 @@ class GradleDependencyHandlerTest : WordSpec({
                 .addDependency(scope2, dep4)
                 .build()
 
-            graph.scopeRoots shouldHaveSize 2
-            graph.scopeRoots.all { it.fragment == 0 } shouldBe true
-            val scopes = graph.createScopes()
+            graph.scopeRoots should beEmpty()
+            graph.nodes shouldNotBeNull {
+                this shouldHaveSize 5
+                all { it.fragment == 0 } shouldBe true
+            }
 
+            val scopes = graph.createScopes()
             val scopeDependencies1 = scopeDependencies(scopes, scope1)
             scopeDependencies1.identifiers() should containExactly(dep5.toId(), dep3.toId(), dep1.toId())
             val dep5Pkg = scopeDependencies1.findDependency(dep5)

--- a/model/src/main/kotlin/DependencyGraphNavigator.kt
+++ b/model/src/main/kotlin/DependencyGraphNavigator.kt
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+/**
+ * A [DependencyNavigator] implementation based on the dependency graph format. It obtains the information about a
+ * project's dependencies from the shared [DependencyGraph] stored in the [OrtResult].
+ */
+class DependencyGraphNavigator(ortResult: OrtResult) : DependencyNavigator {
+    /** The map with shared dependency graphs from the associated result. */
+    private val graphs: Map<String, DependencyGraph> =
+        requireNotNull(ortResult.analyzer?.result?.dependencyGraphs?.takeIf { it.isNotEmpty() }) {
+            "No dependency graph available to initialize DependencyGraphNavigator."
+        }
+
+    /**
+     * A data structure allowing fast access to a specific [DependencyReference] based on its index and fragment.
+     */
+    private val graphDependencyRefMappings: Map<String, Array<MutableList<DependencyGraphNode>>> by lazy {
+        graphs.mapValues { it.value.dependencyRefMapping() }
+    }
+
+    override fun scopeNames(project: Project): Set<String> = project.scopeNames.orEmpty()
+
+    override fun directDependencies(project: Project, scopeName: String): Sequence<DependencyNode> {
+        val graph = graphForManager(project.managerName)
+        val rootDependencies = graph.scopes[DependencyGraph.qualifyScope(project, scopeName)].orEmpty().map { root ->
+            referenceFor(project.managerName, root)
+        }
+
+        return dependenciesSequence(graph, rootDependencies)
+    }
+
+    override fun dependenciesForScope(
+        project: Project,
+        scopeName: String,
+        maxDepth: Int,
+        matcher: DependencyMatcher
+    ): Set<Identifier> {
+        val dependencyIds = mutableSetOf<Identifier>()
+        collectDependencies(directDependencies(project, scopeName), maxDepth, matcher, dependencyIds)
+        return dependencyIds
+    }
+
+    override fun packageDependencies(
+        project: Project,
+        packageId: Identifier,
+        maxDepth: Int,
+        matcher: DependencyMatcher
+    ): Set<Identifier> {
+        val dependencies = mutableSetOf<Identifier>()
+
+        fun traverse(node: DependencyNode) {
+            if (node.id == packageId) {
+                node.visitDependencies { collectDependencies(it, maxDepth, matcher, dependencies) }
+            }
+
+            node.visitDependencies { dependencies ->
+                dependencies.forEach(::traverse)
+            }
+        }
+
+        scopeNames(project).forEach { scope ->
+            directDependencies(project, scope).forEach(::traverse)
+        }
+
+        return dependencies
+    }
+
+    /**
+     * Return the [DependencyGraph] for the given [package manager][manager] or throw an exception if no such graph
+     * exists.
+     */
+    private fun graphForManager(manager: String): DependencyGraph =
+        requireNotNull(graphs[manager]) { "No DependencyGraph for package manager '$manager' available." }
+
+    /**
+     * Resolve a [DependencyGraphNode] in the [DependencyGraph] for the specified [package manager][manager] with the
+     * given [pkgIndex] and [fragment]. Throw an exception if no such node can be found.
+     */
+    private fun referenceFor(manager: String, pkgIndex: Int, fragment: Int): DependencyGraphNode =
+        requireNotNull(graphDependencyRefMappings[manager])[pkgIndex].find { it.fragment == fragment }
+            ?: throw IllegalArgumentException(
+                "Could not resolve a DependencyReference for index = $pkgIndex and fragment $fragment."
+            )
+
+    /**
+     * Resolve a [DependencyGraphNode] in the [DependencyGraph] for the specified [package manager][manager] that
+     * corresponds to the given [rootIndex]. Throw an exception if no such reference can be found.
+     */
+    private fun referenceFor(manager: String, rootIndex: RootDependencyIndex): DependencyGraphNode =
+        referenceFor(manager, rootIndex.root, rootIndex.fragment)
+}
+
+/**
+ * An internal class supporting the efficient traversal of a structure of [DependencyGraphNode]s.
+ *
+ * The idea behind this class is that only a single instance is created for traversing a collection of
+ * [DependencyGraphNode]s. Like a database cursor, this instance moves on to the next node in the collection. It
+ * implements the [DependencyNode] interface by delegating to the properties of the current [DependencyGraphNode].
+ * That way it is not necessary to wrap all the graph nodes in the collection to iterate over into adapter objects.
+ */
+private class DependencyRefCursor(
+    /** The [DependencyGraph] that owns the references to traverse. */
+    val graph: DependencyGraph,
+
+    /** The [DependencyGraphNode]s to traverse. */
+    val nodes: Collection<DependencyGraphNode> = emptyList(),
+
+    /**
+     * An optional initial value for the current node. This is mainly used it this instance acts as an adapter
+     * for a single [DependencyGraphNode].
+     */
+    val initCurrent: DependencyGraphNode? = null
+) : DependencyNode {
+    /** An [Iterator] for doing the actual traversal. */
+    private val nodesIterator = nodes.iterator()
+
+    /** Points to the current element of the traversal. */
+    private var current: DependencyGraphNode = initCurrent ?: nodesIterator.next()
+
+    override val id: Identifier
+        get() = graph.packages[current.pkg]
+
+    override val linkage: PackageLinkage
+        get() = current.linkage
+
+    override val issues: List<OrtIssue>
+        get() = current.issues
+
+    override fun <T> visitDependencies(block: (Sequence<DependencyNode>) -> T): T =
+        block(dependenciesSequence(graph, graph.dependencies.getValue(current)))
+
+    override fun getStableReference(): DependencyNode = DependencyRefCursor(graph, initCurrent = current)
+
+    /**
+     * Return a sequence of [DependencyNode]s that is implemented based on this instance. This sequence allows access
+     * to the properties of the [DependencyReference]s passed to this instance, although each sequence element is a
+     * reference to *this*.
+     */
+    fun asSequence(): Sequence<DependencyNode> =
+        generateSequence(this) {
+            if (nodesIterator.hasNext()) {
+                current = nodesIterator.next()
+                this
+            } else {
+                null
+            }
+        }
+
+    /**
+     * Check for equality with [other]. The check is implemented as a reference comparison to the current node. As the
+     * nodes in the dependency graph have been de-duplicated, a reference comparison is sufficient. Note that this
+     * implementation is not necessarily consistent when comparing nodes during an iteration; but it works correctly
+     * for stable references.
+     */
+    override fun equals(other: Any?): Boolean = (other as? DependencyRefCursor)?.current == current
+
+    /**
+     * Return a hash code for this object. The hash code is obtained from the current node, which is aligned to the
+     * [equals] implementation.
+     */
+    override fun hashCode(): Int = current.hashCode()
+}
+
+/**
+ * Return the name of the package manager that constructed this [Project]. This is required to find the
+ * [DependencyGraph] for this project.
+ */
+private val Project.managerName: String
+    get() = id.type
+
+/**
+ * Construct a data structure that allows fast access to all [DependencyGraphNode]s contained in this
+ * [DependencyGraph] based on its index and fragment. This structure is used to lookup specific nodes, typically
+ * the entry points in the graph (i.e. the roots of the dependency trees referenced by the single scopes). The
+ * structure is an array whose index corresponds to the index of the [DependencyNode]. Under an index multiple
+ * nodes can be listed for the different fragments.
+ */
+private fun DependencyGraph.dependencyRefMapping(): Array<MutableList<DependencyGraphNode>> {
+    val nodesArray = Array<MutableList<DependencyGraphNode>>(packages.size) { mutableListOf() }
+
+    fun addNode(node: DependencyGraphNode) {
+        nodesArray[node.pkg] += node
+        dependencies[node]?.forEach(::addNode)
+    }
+
+    dependencies.keys.forEach(::addNode)
+    return nodesArray
+}
+
+/**
+ * Generate a sequence that allows accessing the given [dependencies] from the provided [graph] via the
+ * [DependencyNode] interface.
+ */
+private fun dependenciesSequence(
+    graph: DependencyGraph,
+    dependencies: Collection<DependencyGraphNode>
+): Sequence<DependencyNode> =
+    dependencies.takeIf { it.isNotEmpty() }?.let {
+        DependencyRefCursor(graph, it).asSequence()
+    }.orEmpty()
+
+/**
+ * Traverse the given [nodes] recursively up to the given [maxDepth], filter using [matcher] and adds all identifiers
+ * found to [ids].
+ */
+private fun collectDependencies(
+    nodes: Sequence<DependencyNode>,
+    maxDepth: Int,
+    matcher: DependencyMatcher,
+    ids: MutableSet<Identifier>
+) {
+    if (maxDepth != 0) {
+        nodes.forEach { node ->
+            if (matcher(node)) ids += node.id
+
+            node.visitDependencies { collectDependencies(it, maxDepth - 1, matcher, ids) }
+        }
+    }
+}

--- a/model/src/main/kotlin/DependencyNavigator.kt
+++ b/model/src/main/kotlin/DependencyNavigator.kt
@@ -204,7 +204,7 @@ interface DependencyNavigator {
         val queue = LinkedList<QueueItem>()
         val result = sortedMapOf<Identifier, List<Identifier>>()
 
-        nodes.forEach { queue.offer(QueueItem(it, emptyList())) }
+        nodes.forEach { queue.offer(QueueItem(it.getStableReference(), emptyList())) }
 
         while (queue.isNotEmpty()) {
             val item = queue.poll()
@@ -215,7 +215,7 @@ interface DependencyNavigator {
 
             val newParents = item.parents + item.pkgRef.id
             item.pkgRef.visitDependencies { dependencyNodes ->
-                dependencyNodes.forEach { node -> queue.offer(QueueItem(node, newParents)) }
+                dependencyNodes.forEach { node -> queue.offer(QueueItem(node.getStableReference(), newParents)) }
             }
         }
 

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -372,7 +372,7 @@ data class OrtResult(
      */
     @JsonIgnore
     fun getProjects(omitExcluded: Boolean = false): Set<Project> =
-        analyzer?.result?.withScopesResolved()?.projects.orEmpty().filterTo(mutableSetOf()) { project ->
+        analyzer?.result?.projects.orEmpty().filterTo(mutableSetOf()) { project ->
             !omitExcluded || !isExcluded(project.id)
         }
 

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -97,7 +97,7 @@ data class OrtResult(
 
     /** An object that can be used to navigate the dependency information contained in this result. */
     @get:JsonIgnore
-    val dependencyNavigator: DependencyNavigator = DependencyTreeNavigator
+    val dependencyNavigator: DependencyNavigator by lazy { createDependencyNavigator() }
 
     private data class ProjectEntry(val project: Project, val isExcluded: Boolean)
 
@@ -463,4 +463,12 @@ data class OrtResult(
                 result = analyzer.result.withScopesResolved()
             )
         )
+
+    /**
+     * Create the [DependencyNavigator] for this [OrtResult]. The concrete navigator implementation depends on the
+     * format, in which dependency information is stored.
+     */
+    private fun createDependencyNavigator(): DependencyNavigator =
+        DependencyTreeNavigator.takeIf { analyzer?.result?.dependencyGraphs.isNullOrEmpty() }
+            ?: DependencyGraphNavigator(this)
 }

--- a/model/src/test/assets/result-with-issues-graph-old.yml
+++ b/model/src/test/assets/result-with-issues-graph-old.yml
@@ -1,0 +1,1375 @@
+---
+repository:
+  vcs:
+    type: "Git"
+    url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+    revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+    revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+    path: ""
+  config: {}
+analyzer:
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  environment:
+    ort_version: "HEAD"
+    java_version: "<REPLACE_JAVA>"
+    os: "<REPLACE_OS>"
+    processors: 4
+    max_memory: 4096
+    variables: {}
+    tool_versions: {}
+  config:
+    ignore_tool_versions: false
+    allow_dynamic_versions: false
+  result:
+    projects:
+    - id: "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
+      definition_file_path: "common/target-scala-2.12-common_2.12-0.1-SNAPSHOT.pom"
+      authors:
+      - "com.pbassiner"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        path: "common"
+      homepage_url: ""
+      scope_names:
+      - "compile"
+      - "test"
+    - id: "SBT:com.pbassiner:multi1_2.12:0.1-SNAPSHOT"
+      definition_file_path: "multi1/target-scala-2.12-multi1_2.12-0.1-SNAPSHOT.pom"
+      authors:
+      - "com.pbassiner"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        path: "multi1"
+      homepage_url: ""
+      scope_names:
+      - "compile"
+      - "test"
+    - id: "SBT:com.pbassiner:multi2_2.12:0.1-SNAPSHOT"
+      definition_file_path: "multi2/target-scala-2.12-multi2_2.12-0.1-SNAPSHOT.pom"
+      authors:
+      - "com.pbassiner"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        path: "multi2"
+      homepage_url: ""
+      scope_names:
+      - "compile"
+      - "test"
+    - id: "SBT:com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT"
+      definition_file_path: "target-scala-2.12-sbt-multi-project-example_2.12-0.1-SNAPSHOT.pom"
+      authors:
+      - "com.pbassiner"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        path: ""
+      homepage_url: ""
+      scope_names:
+      - "compile"
+    packages:
+    - package:
+        id: "Maven:ch.qos.logback:logback-classic:1.2.3"
+        purl: "pkg:maven/ch.qos.logback/logback-classic@1.2.3"
+        authors:
+        - "Ceki Gulcu"
+        - "Joern Huxhorn"
+        - "QOS.ch"
+        declared_licenses:
+        - "Eclipse Public License - v 1.0"
+        - "GNU Lesser General Public License"
+        declared_licenses_processed:
+          spdx_expression: "EPL-1.0 OR LGPL-2.1-or-later"
+          mapped:
+            Eclipse Public License - v 1.0: "EPL-1.0"
+            GNU Lesser General Public License: "LGPL-2.1-or-later"
+        description: "logback-classic module"
+        homepage_url: "http://logback.qos.ch/logback-classic"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar"
+          hash:
+            value: "7c4f3c474fb2c041d8028740440937705ebb473a"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3-sources.jar"
+          hash:
+            value: "cfd5385e0c5ed1c8a5dce57d86e79cf357153a64"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:ceki/logback.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/ceki/logback.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:ch.qos.logback:logback-core:1.2.3"
+        purl: "pkg:maven/ch.qos.logback/logback-core@1.2.3"
+        authors:
+        - "Ceki Gulcu"
+        - "Joern Huxhorn"
+        - "QOS.ch"
+        declared_licenses:
+        - "Eclipse Public License - v 1.0"
+        - "GNU Lesser General Public License"
+        declared_licenses_processed:
+          spdx_expression: "EPL-1.0 OR LGPL-2.1-or-later"
+          mapped:
+            Eclipse Public License - v 1.0: "EPL-1.0"
+            GNU Lesser General Public License: "LGPL-2.1-or-later"
+        description: "logback-core module"
+        homepage_url: "http://logback.qos.ch/logback-core"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar"
+          hash:
+            value: "864344400c3d4d92dfeb0a305dc87d953677c03c"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3-sources.jar"
+          hash:
+            value: "3ebabe69eba0196af9ad3a814f723fb720b9101e"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:ceki/logback.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/ceki/logback.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.chuusai:shapeless_2.12:2.3.2"
+        purl: "pkg:maven/com.chuusai/shapeless_2.12@2.3.2"
+        authors:
+        - "Miles Sabin"
+        - "com.chuusai"
+        declared_licenses:
+        - "Apache 2"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache 2: "Apache-2.0"
+        description: "core"
+        homepage_url: "https://github.com/milessabin/shapeless"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2.jar"
+          hash:
+            value: "27e115ffed7917b456e54891de67173f4a68d5f1"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2-sources.jar"
+          hash:
+            value: "6d83fa4fa6d25b1e8d8cd9d9d551c05c745633b1"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:milessabin/shapeless.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/milessabin/shapeless.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
+        purl: "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.8.0"
+        authors:
+        - "Christopher Currie"
+        - "FasterXML"
+        - "Paul Brown"
+        - "Tatu Saloranta"
+        declared_licenses:
+        - "The Apache Software License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
+        description: "Core annotations used for value types, used by Jackson data\
+          \ binding package."
+        homepage_url: "http://github.com/FasterXML/jackson"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.8.0/jackson-annotations-2.8.0.jar"
+          hash:
+            value: "45b426f7796b741035581a176744d91090e2e6fb"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.8.0/jackson-annotations-2.8.0-sources.jar"
+          hash:
+            value: "29a1a95363d497e856c0a7d682e4f7973e334068"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:FasterXML/jackson-annotations.git"
+          revision: "jackson-annotations-2.8.0"
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/FasterXML/jackson-annotations.git"
+          revision: "jackson-annotations-2.8.0"
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
+        purl: "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.8.9"
+        authors:
+        - "Christopher Currie"
+        - "FasterXML"
+        - "Paul Brown"
+        - "Tatu Saloranta"
+        declared_licenses:
+        - "The Apache Software License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
+        description: "Core Jackson abstractions, basic JSON streaming API implementation"
+        homepage_url: "https://github.com/FasterXML/jackson-core"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.8.9/jackson-core-2.8.9.jar"
+          hash:
+            value: "569b1752705da98f49aabe2911cc956ff7d8ed9d"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.8.9/jackson-core-2.8.9-sources.jar"
+          hash:
+            value: "8cf3613202ddcd495137f8cb944e2da69964a641"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:FasterXML/jackson-core.git"
+          revision: "jackson-core-2.8.9"
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/FasterXML/jackson-core.git"
+          revision: "jackson-core-2.8.9"
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9"
+        purl: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.9"
+        authors:
+        - "Christopher Currie"
+        - "FasterXML"
+        - "Paul Brown"
+        - "Tatu Saloranta"
+        declared_licenses:
+        - "The Apache Software License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
+        description: "General data-binding functionality for Jackson: works on core\
+          \ streaming API"
+        homepage_url: "http://github.com/FasterXML/jackson"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.8.9/jackson-databind-2.8.9.jar"
+          hash:
+            value: "4dfca3975be3c1a98eacb829e70f02e9a71bc159"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.8.9/jackson-databind-2.8.9-sources.jar"
+          hash:
+            value: "98e1b4171628d8f230f6a60b248de84ed04fab0d"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:FasterXML/jackson-databind.git"
+          revision: "jackson-databind-2.8.9"
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/FasterXML/jackson-databind.git"
+          revision: "jackson-databind-2.8.9"
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.github.julien-truffaut:monocle-core_2.12:1.4.0"
+        purl: "pkg:maven/com.github.julien-truffaut/monocle-core_2.12@1.4.0"
+        authors:
+        - "Ilan Godik"
+        - "Julien Truffaut"
+        - "Kenji Yoshida"
+        - "Naoki Aoyama"
+        - "com.github.julien-truffaut"
+        declared_licenses:
+        - "MIT"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+        description: "core"
+        homepage_url: "https://github.com/julien-truffaut/Monocle"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-core_2.12/1.4.0/monocle-core_2.12-1.4.0.jar"
+          hash:
+            value: "219da9cc75878a75c888e38ad883fe4d30a7651d"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-core_2.12/1.4.0/monocle-core_2.12-1.4.0-sources.jar"
+          hash:
+            value: "37d333798ca15a03f5dfbb02f133d5b6b8e57b8c"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:julien-truffaut/Monocle.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/julien-truffaut/Monocle.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.github.julien-truffaut:monocle-macro_2.12:1.4.0"
+        purl: "pkg:maven/com.github.julien-truffaut/monocle-macro_2.12@1.4.0"
+        authors:
+        - "Ilan Godik"
+        - "Julien Truffaut"
+        - "Kenji Yoshida"
+        - "Naoki Aoyama"
+        - "com.github.julien-truffaut"
+        declared_licenses:
+        - "MIT"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+        description: "macros"
+        homepage_url: "https://github.com/julien-truffaut/Monocle"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-macro_2.12/1.4.0/monocle-macro_2.12-1.4.0.jar"
+          hash:
+            value: "319242d130983fec319a2e2d4f8e7741b809b5a0"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-macro_2.12/1.4.0/monocle-macro_2.12-1.4.0-sources.jar"
+          hash:
+            value: "e7ce64d7973ad64f3fa872b931a31c8c25de59b3"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:julien-truffaut/Monocle.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/julien-truffaut/Monocle.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.github.pureconfig:pureconfig-macros_2.12:0.8.0"
+        purl: "pkg:maven/com.github.pureconfig/pureconfig-macros_2.12@0.8.0"
+        authors:
+        - "Rui Gonçalves"
+        - "com.github.pureconfig"
+        declared_licenses:
+        - "Mozilla Public License, version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "MPL-2.0"
+          mapped:
+            Mozilla Public License, version 2.0: "MPL-2.0"
+        description: "pureconfig-macros"
+        homepage_url: "https://github.com/pureconfig/pureconfig"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig-macros_2.12/0.8.0/pureconfig-macros_2.12-0.8.0.jar"
+          hash:
+            value: "eea0e86f18c08e7fd00c90626f4f17a9ee6ef088"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig-macros_2.12/0.8.0/pureconfig-macros_2.12-0.8.0-sources.jar"
+          hash:
+            value: "7411f96540756236648b48347827b6ba2622e5e0"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:pureconfig/pureconfig.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/pureconfig/pureconfig.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.github.pureconfig:pureconfig_2.12:0.8.0"
+        purl: "pkg:maven/com.github.pureconfig/pureconfig_2.12@0.8.0"
+        authors:
+        - "Derek Morr"
+        - "Joao Azevedo"
+        - "Leif Wickland"
+        - "Mario Pastorelli"
+        - "Rui Gonçalves"
+        - "com.github.pureconfig"
+        declared_licenses:
+        - "Mozilla Public License, version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "MPL-2.0"
+          mapped:
+            Mozilla Public License, version 2.0: "MPL-2.0"
+        description: "pureconfig"
+        homepage_url: "https://github.com/pureconfig/pureconfig"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig_2.12/0.8.0/pureconfig_2.12-0.8.0.jar"
+          hash:
+            value: "891fde63cda086f593bffddb0b47933abc75523f"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig_2.12/0.8.0/pureconfig_2.12-0.8.0-sources.jar"
+          hash:
+            value: "fa6de3ab2dd82543fb37288626687a9a6c1a67a2"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:pureconfig/pureconfig.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/pureconfig/pureconfig.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.typesafe:config:1.3.1"
+        purl: "pkg:maven/com.typesafe/config@1.3.1"
+        authors:
+        - "Havoc Pennington"
+        - "com.typesafe"
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+        description: "config"
+        homepage_url: "https://github.com/typesafehub/config"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/config/1.3.1/config-1.3.1.jar"
+          hash:
+            value: "2cf7a6cc79732e3bdf1647d7404279900ca63eb0"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/config/1.3.1/config-1.3.1-sources.jar"
+          hash:
+            value: "a27878630ff503b63ed25ff2a25fa8ef888740b3"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/typesafehub/config.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/typesafehub/config.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.typesafe:ssl-config-core_2.12:0.2.2"
+        purl: "pkg:maven/com.typesafe/ssl-config-core_2.12@0.2.2"
+        authors:
+        - "Konrad Malawski"
+        - "Will Sargent"
+        - "com.typesafe"
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+        description: "ssl-config-core"
+        homepage_url: "https://github.com/typesafehub/ssl-config"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/ssl-config-core_2.12/0.2.2/ssl-config-core_2.12-0.2.2.jar"
+          hash:
+            value: "8a357d491f7f94c5b4b1e0b27644e1306cc8742d"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/ssl-config-core_2.12/0.2.2/ssl-config-core_2.12-0.2.2-sources.jar"
+          hash:
+            value: "1baaec9149929d0970330aa80aca73e3f1f15624"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/typesafehub/ssl-config.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/typesafehub/ssl-config.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"
+        purl: "pkg:maven/com.typesafe.akka/akka-actor_2.12@2.5.6"
+        authors:
+        - "Akka Contributors"
+        - "Lightbend Inc."
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+        description: "akka-actor"
+        homepage_url: "http://akka.io/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.6/akka-actor_2.12-2.5.6.jar"
+          hash:
+            value: "1e9f4c1829d3ce5640c17164b1756d1e98eb7af3"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.6/akka-actor_2.12-2.5.6-sources.jar"
+          hash:
+            value: "9642cf6f2a774d781e2f2a2e5de152971bfd714e"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:akka/akka.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/akka/akka.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"
+        purl: "pkg:maven/com.typesafe.akka/akka-stream_2.12@2.5.6"
+        authors:
+        - "Akka Contributors"
+        - "Lightbend Inc."
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+        description: "akka-stream"
+        homepage_url: "http://akka.io/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-stream_2.12/2.5.6/akka-stream_2.12-2.5.6.jar"
+          hash:
+            value: "876aa1471ac773a3dd02f70c1e511a9a014b3491"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-stream_2.12/2.5.6/akka-stream_2.12-2.5.6-sources.jar"
+          hash:
+            value: "14459df7523aea2cfd04080fe88eccd20897bcc5"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:akka/akka.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/akka/akka.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2"
+        purl: "pkg:maven/com.typesafe.scala-logging/scala-logging_2.12@3.7.2"
+        authors:
+        - "Heiko Seeberger"
+        - "Mathias Bogaert"
+        - "com.typesafe.scala-logging"
+        declared_licenses:
+        - "Apache 2.0 License"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache 2.0 License: "Apache-2.0"
+        description: "scala-logging"
+        homepage_url: "https://github.com/typesafehub/scala-logging"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.7.2/scala-logging_2.12-3.7.2.jar"
+          hash:
+            value: "a1dc97509765287faa4747f7cb411f0b85dc9a34"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.7.2/scala-logging_2.12-3.7.2-sources.jar"
+          hash:
+            value: "a5f760917b60283e37c84bf3db2aeaf976980ad3"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/typesafehub/scala-logging.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/typesafehub/scala-logging.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:net.logstash.logback:logstash-logback-encoder:4.11"
+        purl: "pkg:maven/net.logstash.logback/logstash-logback-encoder@4.11"
+        authors:
+        - "John E. Vincent"
+        - "Nokia"
+        - "Phil Clay"
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        - "MIT License"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0 OR MIT"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+            MIT License: "MIT"
+        description: "Logback encoder which will output events as Logstash-compatible\
+          \ JSON"
+        homepage_url: "https://github.com/logstash/logstash-logback-encoder"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/net/logstash/logback/logstash-logback-encoder/4.11/logstash-logback-encoder-4.11.jar"
+          hash:
+            value: "163b6b046de5414ac17c83cbd6cb619e541fc69a"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/net/logstash/logback/logstash-logback-encoder/4.11/logstash-logback-encoder-4.11-sources.jar"
+          hash:
+            value: "8b889d5eb55aabfa5d9aa9cad95529668f3edb2b"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:logstash/logstash-logback-encoder.git"
+          revision: "logstash-logback-encoder-4.11"
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/logstash/logstash-logback-encoder.git"
+          revision: "logstash-logback-encoder-4.11"
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.reactivestreams:reactive-streams:1.0.1"
+        purl: "pkg:maven/org.reactivestreams/reactive-streams@1.0.1"
+        authors:
+        - "Reactive Streams SIG"
+        declared_licenses:
+        - "CC0"
+        declared_licenses_processed:
+          spdx_expression: "CC0-1.0"
+          mapped:
+            CC0: "CC0-1.0"
+        description: "A Protocol for Asynchronous Non-Blocking Data Sequence"
+        homepage_url: "http://www.reactive-streams.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/reactivestreams/reactive-streams/1.0.1/reactive-streams-1.0.1.jar"
+          hash:
+            value: "1b1c911686eb40179219466e6a59b634b9d7a748"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/reactivestreams/reactive-streams/1.0.1/reactive-streams-1.0.1-sources.jar"
+          hash:
+            value: "af471e34e448bd4f1c183e9b26c85679be11035c"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:reactive-streams/reactive-streams.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/reactive-streams/reactive-streams.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang:scala-compiler:2.12.3"
+        purl: "pkg:maven/org.scala-lang/scala-compiler@2.12.3"
+        authors:
+        - "LAMP/EPFL"
+        - "Lightbend, Inc."
+        declared_licenses:
+        - "BSD 3-Clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-Clause: "BSD-3-Clause"
+        description: "Compiler for the Scala Programming Language"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-compiler/2.12.3/scala-compiler-2.12.3.jar"
+          hash:
+            value: "b6b9ca202fc8405260d30e703b9790e91c75cd85"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-compiler/2.12.3/scala-compiler-2.12.3-sources.jar"
+          hash:
+            value: "b8fe133c260f72b7fe9889195e19efeeab1b8087"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang:scala-library:2.12.3"
+        purl: "pkg:maven/org.scala-lang/scala-library@2.12.3"
+        authors:
+        - "LAMP/EPFL"
+        - "Lightbend, Inc."
+        declared_licenses:
+        - "BSD 3-Clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-Clause: "BSD-3-Clause"
+        description: "Standard library for the Scala Programming Language"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.12.3/scala-library-2.12.3.jar"
+          hash:
+            value: "f2e496f21af2d80b48e0a61773f84c3a76a0d06f"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.12.3/scala-library-2.12.3-sources.jar"
+          hash:
+            value: "499c91b0a64bc706eee174481a3b7dde81b3591d"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang:scala-reflect:2.12.2"
+        purl: "pkg:maven/org.scala-lang/scala-reflect@2.12.2"
+        authors:
+        - "LAMP/EPFL"
+        - "Lightbend, Inc."
+        declared_licenses:
+        - "BSD 3-Clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-Clause: "BSD-3-Clause"
+        description: "Compiler for the Scala Programming Language"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-reflect/2.12.2/scala-reflect-2.12.2.jar"
+          hash:
+            value: "fa13c13351566738ff156ef8a56b869868f4b77e"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-reflect/2.12.2/scala-reflect-2.12.2-sources.jar"
+          hash:
+            value: "a8808be417014e233b25ee44439f725e1f5e92a4"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0"
+        purl: "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.12@0.8.0"
+        authors:
+        - "EPFL"
+        - "Typesafe, Inc."
+        - "org.scala-lang.modules"
+        declared_licenses:
+        - "BSD 3-clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-clause: "BSD-3-Clause"
+        description: "scala-java8-compat"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0.jar"
+          hash:
+            value: "1e6f1e745bf6d3c34d1e2ab150653306069aaf34"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0-sources.jar"
+          hash:
+            value: "0a33ce48278b9e3bbea8aed726e3c0abad3afadd"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala-java8-compat.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala-java8-compat.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
+        purl: "pkg:maven/org.scala-lang.modules/scala-parser-combinators_2.12@1.0.4"
+        authors:
+        - "EPFL"
+        - "Typesafe, Inc."
+        - "org.scala-lang.modules"
+        declared_licenses:
+        - "BSD 3-clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-clause: "BSD-3-Clause"
+        description: "scala-parser-combinators"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4.jar"
+          hash:
+            value: "7c5f25a2d40ea7651452f0f0d1d4c12dabffcb8b"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4-sources.jar"
+          hash:
+            value: "9ec2f46c07d355853654af38e8b06e15ccca8cd0"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala-parser-combinators.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala-parser-combinators.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
+        purl: "pkg:maven/org.scala-lang.modules/scala-xml_2.12@1.0.5"
+        authors:
+        - "EPFL"
+        - "Typesafe, Inc."
+        - "org.scala-lang.modules"
+        declared_licenses:
+        - "BSD 3-clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-clause: "BSD-3-Clause"
+        description: "scala-xml"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.5/scala-xml_2.12-1.0.5.jar"
+          hash:
+            value: "a2b2afbeea86818a911b05851bb11d7d4840bb75"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.5/scala-xml_2.12-1.0.5-sources.jar"
+          hash:
+            value: "d12864d1a73aa540f7b624c8a92a5f48783c342c"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala-xml.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala-xml.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-sbt:test-interface:1.0"
+        purl: "pkg:maven/org.scala-sbt/test-interface@1.0"
+        authors:
+        - "Bill Venners"
+        - "Chua Chee Seng"
+        - "Josh Cough"
+        - "Mark Harrah"
+        - "org.scala-sbt"
+        declared_licenses:
+        - "BSD"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD: "BSD-3-Clause"
+        description: "Uniform test interface to Scala/Java test frameworks (specs,\
+          \ ScalaCheck, ScalaTest, JUnit and other)"
+        homepage_url: "http://www.scala-sbt.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"
+          hash:
+            value: "0a3f14d010c4cb32071f863d97291df31603b521"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar"
+          hash:
+            value: "d44b23e9e3419ad0e00b91bba764a48d43075000"
+            algorithm: "SHA-1"
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/sbt/test-interface.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scalacheck:scalacheck_2.12:1.13.5"
+        purl: "pkg:maven/org.scalacheck/scalacheck_2.12@1.13.5"
+        authors:
+        - "Rickard Nilsson"
+        - "org.scalacheck"
+        declared_licenses:
+        - "BSD-style"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD-style: "BSD-3-Clause"
+        description: "scalacheck"
+        homepage_url: "http://www.scalacheck.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalacheck/scalacheck_2.12/1.13.5/scalacheck_2.12-1.13.5.jar"
+          hash:
+            value: "fff972ccaa0d83ca53bfdbbd0763c1059281fb76"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalacheck/scalacheck_2.12/1.13.5/scalacheck_2.12-1.13.5-sources.jar"
+          hash:
+            value: "d0e1376902de65c7fa327f455b61d5d71957d78e"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:rickynils/scalacheck.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/rickynils/scalacheck.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scalactic:scalactic_2.12:3.0.4"
+        purl: "pkg:maven/org.scalactic/scalactic_2.12@3.0.4"
+        authors:
+        - "Bill Venners"
+        - "Chua Chee Seng"
+        - "George Berger"
+        - "org.scalactic"
+        declared_licenses:
+        - "the Apache License, ASL Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            the Apache License, ASL Version 2.0: "Apache-2.0"
+        description: "scalactic"
+        homepage_url: "http://www.scalatest.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalactic/scalactic_2.12/3.0.4/scalactic_2.12-3.0.4.jar"
+          hash:
+            value: "e75f0f9c77aa391e01797cfc42fb82fd7c7d59a5"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalactic/scalactic_2.12/3.0.4/scalactic_2.12-3.0.4-sources.jar"
+          hash:
+            value: "9f7f02217c7d2f14c6b1982493c39243a20b749d"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:scalatest/scalatest.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/scalatest/scalatest.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scalatest:scalatest_2.12:3.0.4"
+        purl: "pkg:maven/org.scalatest/scalatest_2.12@3.0.4"
+        authors:
+        - "Bill Venners"
+        - "Chua Chee Seng"
+        - "George Berger"
+        - "org.scalatest"
+        declared_licenses:
+        - "the Apache License, ASL Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            the Apache License, ASL Version 2.0: "Apache-2.0"
+        description: "scalatest"
+        homepage_url: "http://www.scalatest.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalatest/scalatest_2.12/3.0.4/scalatest_2.12-3.0.4.jar"
+          hash:
+            value: "87d68f3d06dbf698fd0084c0a8b8996864d15465"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalatest/scalatest_2.12/3.0.4/scalatest_2.12-3.0.4-sources.jar"
+          hash:
+            value: "ba669c2c9b7092151e2a19e975b1bf2a2e7a5fda"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:scalatest/scalatest.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/scalatest/scalatest.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scalaz:scalaz-core_2.12:7.2.8"
+        purl: "pkg:maven/org.scalaz/scalaz-core_2.12@7.2.8"
+        authors:
+        - "Alexey Romanov"
+        - "Daniel Peebles"
+        - "Edward Kmett"
+        - "Jason Zaugg"
+        - "Kris Nuttycombe"
+        - "Lars Hupel"
+        - "Paul Chiusano"
+        - "Richard Wallace"
+        - "Runar Bjarnason"
+        - "Tony Morris"
+        - "org.scalaz"
+        declared_licenses:
+        - "BSD-style"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD-style: "BSD-3-Clause"
+        description: "scalaz-core"
+        homepage_url: "http://scalaz.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalaz/scalaz-core_2.12/7.2.8/scalaz-core_2.12-7.2.8.jar"
+          hash:
+            value: "2922d47f6dc7aba452634fe674087b6221b90dbf"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalaz/scalaz-core_2.12/7.2.8/scalaz-core_2.12-7.2.8-sources.jar"
+          hash:
+            value: "c94295a434f26b5650ec0fcbf93c9d2c7aada88e"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:scalaz/scalaz.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/scalaz/scalaz.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
+        purl: "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.25"
+        authors:
+        - "Ceki Gulcu"
+        - "QOS.ch"
+        declared_licenses:
+        - "MIT License"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+          mapped:
+            MIT License: "MIT"
+        description: "JCL 1.2 implemented over SLF4J"
+        homepage_url: "http://www.slf4j.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25.jar"
+          hash:
+            value: "f8c32b13ff142a513eeb5b6330b1588dcb2c0461"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25-sources.jar"
+          hash:
+            value: "ffd0827a7c67d5915b7dc611afbda56a1f247191"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:qos-ch/slf4j.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/qos-ch/slf4j.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.slf4j:slf4j-api:1.7.25"
+        purl: "pkg:maven/org.slf4j/slf4j-api@1.7.25"
+        authors:
+        - "Ceki Gulcu"
+        - "QOS.ch"
+        declared_licenses:
+        - "MIT License"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+          mapped:
+            MIT License: "MIT"
+        description: "The slf4j API"
+        homepage_url: "http://www.slf4j.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
+          hash:
+            value: "da76ca59f6a57ee3102f8f9bd9cee742973efa8a"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25-sources.jar"
+          hash:
+            value: "962153db4a9ea71b79d047dfd1b2a0d80d8f4739"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:qos-ch/slf4j.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/qos-ch/slf4j.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.typelevel:macro-compat_2.12:1.1.1"
+        purl: "pkg:maven/org.typelevel/macro-compat_2.12@1.1.1"
+        authors:
+        - "Miles Sabin"
+        - "org.typelevel"
+        declared_licenses:
+        - "Apache 2"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache 2: "Apache-2.0"
+        description: "core"
+        homepage_url: "https://github.com/milessabin/macro-compat"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1.jar"
+          hash:
+            value: "ed809d26ef4237d7c079ae6cf7ebd0dfa7986adf"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1-sources.jar"
+          hash:
+            value: "ade6d6ec81975cf514b0f9e2061614f2799cfe97"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:milessabin/macro-compat.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/milessabin/macro-compat.git"
+          revision: ""
+          path: ""
+      curations: []
+    dependency_graphs:
+      SBT:
+        packages:
+        - "Maven:ch.qos.logback:logback-classic:1.2.3"
+        - "Maven:ch.qos.logback:logback-core:1.2.3"
+        - "Maven:org.slf4j:slf4j-api:1.7.25"
+        - "Maven:com.typesafe:config:1.3.1"
+        - "Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"
+        - "Maven:com.typesafe:ssl-config-core_2.12:0.2.2"
+        - "Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"
+        - "Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0"
+        - "Maven:org.reactivestreams:reactive-streams:1.0.1"
+        - "Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2"
+        - "Maven:org.scala-lang:scala-reflect:2.12.2"
+        - "Maven:net.logstash.logback:logstash-logback-encoder:4.11"
+        - "Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9"
+        - "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
+        - "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
+        - "Maven:org.scala-lang:scala-library:2.12.3"
+        - "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
+        - "Maven:org.scalacheck:scalacheck_2.12:1.13.5"
+        - "Maven:org.scala-sbt:test-interface:1.0"
+        - "Maven:org.scalatest:scalatest_2.12:3.0.4"
+        - "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
+        - "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
+        - "Maven:org.scalactic:scalactic_2.12:3.0.4"
+        - "Maven:com.github.julien-truffaut:monocle-core_2.12:1.4.0"
+        - "Maven:org.scalaz:scalaz-core_2.12:7.2.8"
+        - "Maven:com.github.julien-truffaut:monocle-macro_2.12:1.4.0"
+        - "Maven:org.typelevel:macro-compat_2.12:1.1.1"
+        - "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
+        - "Maven:com.github.pureconfig:pureconfig_2.12:0.8.0"
+        - "Maven:com.chuusai:shapeless_2.12:2.3.2"
+        - "Maven:com.github.pureconfig:pureconfig-macros_2.12:0.8.0"
+        - "Maven:org.scala-lang:scala-compiler:2.12.3"
+        scope_roots:
+        - dependencies:
+          - pkg: 1
+          - pkg: 2
+        - pkg: 3
+        - pkg: 4
+          dependencies:
+          - pkg: 5
+          - pkg: 6
+            dependencies:
+            - pkg: 7
+              issues:
+              - timestamp: "1970-01-01T00:00:00Z"
+                source: "Gradle"
+                message: "Test issue 1"
+                severity: "ERROR"
+          - pkg: 8
+        - pkg: 9
+          dependencies:
+          - pkg: 10
+        - pkg: 11
+          dependencies:
+          - pkg: 12
+            dependencies:
+            - pkg: 13
+            - pkg: 14
+        - pkg: 15
+        - pkg: 16
+        - pkg: 17
+          dependencies:
+          - pkg: 18
+        - pkg: 19
+          dependencies:
+          - pkg: 20
+          - pkg: 21
+          - pkg: 22
+            issues:
+            - timestamp: "1970-01-01T00:00:00Z"
+              source: "Gradle"
+              message: "Test issue 2"
+              severity: "ERROR"
+        - pkg: 23
+          dependencies:
+          - pkg: 24
+        - pkg: 25
+          dependencies:
+          - pkg: 26
+        - pkg: 27
+          linkage: "PROJECT_DYNAMIC"
+        - pkg: 28
+          dependencies:
+          - pkg: 29
+          - pkg: 30
+            dependencies:
+            - pkg: 26
+            - pkg: 31
+        scopes:
+          com.pbassiner:common_2.12:0.1-SNAPSHOT:compile:
+          - root: 0
+          - root: 3
+          - root: 4
+          - root: 9
+          - root: 11
+          - root: 15
+          - root: 16
+          com.pbassiner:common_2.12:0.1-SNAPSHOT:test:
+          - root: 17
+          - root: 19
+          com.pbassiner:multi1_2.12:0.1-SNAPSHOT:compile:
+          - root: 0
+          - root: 23
+          - root: 25
+          - root: 3
+          - root: 4
+          - root: 9
+          - root: 11
+          - root: 15
+          - root: 16
+          - root: 27
+          com.pbassiner:multi1_2.12:0.1-SNAPSHOT:test:
+          - root: 17
+          - root: 19
+          com.pbassiner:multi2_2.12:0.1-SNAPSHOT:compile:
+          - root: 0
+          - root: 28
+          - root: 3
+          - root: 4
+          - root: 9
+          - root: 11
+          - root: 15
+          - root: 16
+          - root: 27
+          com.pbassiner:multi2_2.12:0.1-SNAPSHOT:test:
+          - root: 17
+          - root: 19
+          com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT:compile:
+          - root: 15
+    has_issues: true
+scanner: null
+advisor: null
+evaluator: null

--- a/model/src/test/assets/result-with-issues-graph.yml
+++ b/model/src/test/assets/result-with-issues-graph.yml
@@ -1,0 +1,1404 @@
+---
+repository:
+  vcs:
+    type: "Git"
+    url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+    revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+    revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+    path: ""
+  config: {}
+analyzer:
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  environment:
+    ort_version: "HEAD"
+    java_version: "<REPLACE_JAVA>"
+    os: "<REPLACE_OS>"
+    processors: 4
+    max_memory: 4096
+    variables: {}
+    tool_versions: {}
+  config:
+    ignore_tool_versions: false
+    allow_dynamic_versions: false
+  result:
+    projects:
+    - id: "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
+      definition_file_path: "common/target-scala-2.12-common_2.12-0.1-SNAPSHOT.pom"
+      authors:
+      - "com.pbassiner"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        path: "common"
+      homepage_url: ""
+      scope_names:
+      - "compile"
+      - "test"
+    - id: "SBT:com.pbassiner:multi1_2.12:0.1-SNAPSHOT"
+      definition_file_path: "multi1/target-scala-2.12-multi1_2.12-0.1-SNAPSHOT.pom"
+      authors:
+      - "com.pbassiner"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        path: "multi1"
+      homepage_url: ""
+      scope_names:
+      - "compile"
+      - "test"
+    - id: "SBT:com.pbassiner:multi2_2.12:0.1-SNAPSHOT"
+      definition_file_path: "multi2/target-scala-2.12-multi2_2.12-0.1-SNAPSHOT.pom"
+      authors:
+      - "com.pbassiner"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        path: "multi2"
+      homepage_url: ""
+      scope_names:
+      - "compile"
+      - "test"
+    - id: "SBT:com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT"
+      definition_file_path: "target-scala-2.12-sbt-multi-project-example_2.12-0.1-SNAPSHOT.pom"
+      authors:
+      - "com.pbassiner"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        path: ""
+      homepage_url: ""
+      scope_names:
+      - "compile"
+    packages:
+    - package:
+        id: "Maven:ch.qos.logback:logback-classic:1.2.3"
+        purl: "pkg:maven/ch.qos.logback/logback-classic@1.2.3"
+        authors:
+        - "Ceki Gulcu"
+        - "Joern Huxhorn"
+        - "QOS.ch"
+        declared_licenses:
+        - "Eclipse Public License - v 1.0"
+        - "GNU Lesser General Public License"
+        declared_licenses_processed:
+          spdx_expression: "EPL-1.0 OR LGPL-2.1-or-later"
+          mapped:
+            Eclipse Public License - v 1.0: "EPL-1.0"
+            GNU Lesser General Public License: "LGPL-2.1-or-later"
+        description: "logback-classic module"
+        homepage_url: "http://logback.qos.ch/logback-classic"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar"
+          hash:
+            value: "7c4f3c474fb2c041d8028740440937705ebb473a"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3-sources.jar"
+          hash:
+            value: "cfd5385e0c5ed1c8a5dce57d86e79cf357153a64"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:ceki/logback.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/ceki/logback.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:ch.qos.logback:logback-core:1.2.3"
+        purl: "pkg:maven/ch.qos.logback/logback-core@1.2.3"
+        authors:
+        - "Ceki Gulcu"
+        - "Joern Huxhorn"
+        - "QOS.ch"
+        declared_licenses:
+        - "Eclipse Public License - v 1.0"
+        - "GNU Lesser General Public License"
+        declared_licenses_processed:
+          spdx_expression: "EPL-1.0 OR LGPL-2.1-or-later"
+          mapped:
+            Eclipse Public License - v 1.0: "EPL-1.0"
+            GNU Lesser General Public License: "LGPL-2.1-or-later"
+        description: "logback-core module"
+        homepage_url: "http://logback.qos.ch/logback-core"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar"
+          hash:
+            value: "864344400c3d4d92dfeb0a305dc87d953677c03c"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3-sources.jar"
+          hash:
+            value: "3ebabe69eba0196af9ad3a814f723fb720b9101e"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:ceki/logback.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/ceki/logback.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.chuusai:shapeless_2.12:2.3.2"
+        purl: "pkg:maven/com.chuusai/shapeless_2.12@2.3.2"
+        authors:
+        - "Miles Sabin"
+        - "com.chuusai"
+        declared_licenses:
+        - "Apache 2"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache 2: "Apache-2.0"
+        description: "core"
+        homepage_url: "https://github.com/milessabin/shapeless"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2.jar"
+          hash:
+            value: "27e115ffed7917b456e54891de67173f4a68d5f1"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2-sources.jar"
+          hash:
+            value: "6d83fa4fa6d25b1e8d8cd9d9d551c05c745633b1"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:milessabin/shapeless.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/milessabin/shapeless.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
+        purl: "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.8.0"
+        authors:
+        - "Christopher Currie"
+        - "FasterXML"
+        - "Paul Brown"
+        - "Tatu Saloranta"
+        declared_licenses:
+        - "The Apache Software License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
+        description: "Core annotations used for value types, used by Jackson data\
+          \ binding package."
+        homepage_url: "http://github.com/FasterXML/jackson"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.8.0/jackson-annotations-2.8.0.jar"
+          hash:
+            value: "45b426f7796b741035581a176744d91090e2e6fb"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.8.0/jackson-annotations-2.8.0-sources.jar"
+          hash:
+            value: "29a1a95363d497e856c0a7d682e4f7973e334068"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:FasterXML/jackson-annotations.git"
+          revision: "jackson-annotations-2.8.0"
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/FasterXML/jackson-annotations.git"
+          revision: "jackson-annotations-2.8.0"
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
+        purl: "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.8.9"
+        authors:
+        - "Christopher Currie"
+        - "FasterXML"
+        - "Paul Brown"
+        - "Tatu Saloranta"
+        declared_licenses:
+        - "The Apache Software License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
+        description: "Core Jackson abstractions, basic JSON streaming API implementation"
+        homepage_url: "https://github.com/FasterXML/jackson-core"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.8.9/jackson-core-2.8.9.jar"
+          hash:
+            value: "569b1752705da98f49aabe2911cc956ff7d8ed9d"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.8.9/jackson-core-2.8.9-sources.jar"
+          hash:
+            value: "8cf3613202ddcd495137f8cb944e2da69964a641"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:FasterXML/jackson-core.git"
+          revision: "jackson-core-2.8.9"
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/FasterXML/jackson-core.git"
+          revision: "jackson-core-2.8.9"
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9"
+        purl: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.9"
+        authors:
+        - "Christopher Currie"
+        - "FasterXML"
+        - "Paul Brown"
+        - "Tatu Saloranta"
+        declared_licenses:
+        - "The Apache Software License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
+        description: "General data-binding functionality for Jackson: works on core\
+          \ streaming API"
+        homepage_url: "http://github.com/FasterXML/jackson"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.8.9/jackson-databind-2.8.9.jar"
+          hash:
+            value: "4dfca3975be3c1a98eacb829e70f02e9a71bc159"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.8.9/jackson-databind-2.8.9-sources.jar"
+          hash:
+            value: "98e1b4171628d8f230f6a60b248de84ed04fab0d"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:FasterXML/jackson-databind.git"
+          revision: "jackson-databind-2.8.9"
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/FasterXML/jackson-databind.git"
+          revision: "jackson-databind-2.8.9"
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.github.julien-truffaut:monocle-core_2.12:1.4.0"
+        purl: "pkg:maven/com.github.julien-truffaut/monocle-core_2.12@1.4.0"
+        authors:
+        - "Ilan Godik"
+        - "Julien Truffaut"
+        - "Kenji Yoshida"
+        - "Naoki Aoyama"
+        - "com.github.julien-truffaut"
+        declared_licenses:
+        - "MIT"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+        description: "core"
+        homepage_url: "https://github.com/julien-truffaut/Monocle"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-core_2.12/1.4.0/monocle-core_2.12-1.4.0.jar"
+          hash:
+            value: "219da9cc75878a75c888e38ad883fe4d30a7651d"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-core_2.12/1.4.0/monocle-core_2.12-1.4.0-sources.jar"
+          hash:
+            value: "37d333798ca15a03f5dfbb02f133d5b6b8e57b8c"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:julien-truffaut/Monocle.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/julien-truffaut/Monocle.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.github.julien-truffaut:monocle-macro_2.12:1.4.0"
+        purl: "pkg:maven/com.github.julien-truffaut/monocle-macro_2.12@1.4.0"
+        authors:
+        - "Ilan Godik"
+        - "Julien Truffaut"
+        - "Kenji Yoshida"
+        - "Naoki Aoyama"
+        - "com.github.julien-truffaut"
+        declared_licenses:
+        - "MIT"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+        description: "macros"
+        homepage_url: "https://github.com/julien-truffaut/Monocle"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-macro_2.12/1.4.0/monocle-macro_2.12-1.4.0.jar"
+          hash:
+            value: "319242d130983fec319a2e2d4f8e7741b809b5a0"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-macro_2.12/1.4.0/monocle-macro_2.12-1.4.0-sources.jar"
+          hash:
+            value: "e7ce64d7973ad64f3fa872b931a31c8c25de59b3"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:julien-truffaut/Monocle.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/julien-truffaut/Monocle.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.github.pureconfig:pureconfig-macros_2.12:0.8.0"
+        purl: "pkg:maven/com.github.pureconfig/pureconfig-macros_2.12@0.8.0"
+        authors:
+        - "Rui Gonçalves"
+        - "com.github.pureconfig"
+        declared_licenses:
+        - "Mozilla Public License, version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "MPL-2.0"
+          mapped:
+            Mozilla Public License, version 2.0: "MPL-2.0"
+        description: "pureconfig-macros"
+        homepage_url: "https://github.com/pureconfig/pureconfig"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig-macros_2.12/0.8.0/pureconfig-macros_2.12-0.8.0.jar"
+          hash:
+            value: "eea0e86f18c08e7fd00c90626f4f17a9ee6ef088"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig-macros_2.12/0.8.0/pureconfig-macros_2.12-0.8.0-sources.jar"
+          hash:
+            value: "7411f96540756236648b48347827b6ba2622e5e0"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:pureconfig/pureconfig.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/pureconfig/pureconfig.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.github.pureconfig:pureconfig_2.12:0.8.0"
+        purl: "pkg:maven/com.github.pureconfig/pureconfig_2.12@0.8.0"
+        authors:
+        - "Derek Morr"
+        - "Joao Azevedo"
+        - "Leif Wickland"
+        - "Mario Pastorelli"
+        - "Rui Gonçalves"
+        - "com.github.pureconfig"
+        declared_licenses:
+        - "Mozilla Public License, version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "MPL-2.0"
+          mapped:
+            Mozilla Public License, version 2.0: "MPL-2.0"
+        description: "pureconfig"
+        homepage_url: "https://github.com/pureconfig/pureconfig"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig_2.12/0.8.0/pureconfig_2.12-0.8.0.jar"
+          hash:
+            value: "891fde63cda086f593bffddb0b47933abc75523f"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig_2.12/0.8.0/pureconfig_2.12-0.8.0-sources.jar"
+          hash:
+            value: "fa6de3ab2dd82543fb37288626687a9a6c1a67a2"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:pureconfig/pureconfig.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/pureconfig/pureconfig.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.typesafe:config:1.3.1"
+        purl: "pkg:maven/com.typesafe/config@1.3.1"
+        authors:
+        - "Havoc Pennington"
+        - "com.typesafe"
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+        description: "config"
+        homepage_url: "https://github.com/typesafehub/config"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/config/1.3.1/config-1.3.1.jar"
+          hash:
+            value: "2cf7a6cc79732e3bdf1647d7404279900ca63eb0"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/config/1.3.1/config-1.3.1-sources.jar"
+          hash:
+            value: "a27878630ff503b63ed25ff2a25fa8ef888740b3"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/typesafehub/config.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/typesafehub/config.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.typesafe:ssl-config-core_2.12:0.2.2"
+        purl: "pkg:maven/com.typesafe/ssl-config-core_2.12@0.2.2"
+        authors:
+        - "Konrad Malawski"
+        - "Will Sargent"
+        - "com.typesafe"
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+        description: "ssl-config-core"
+        homepage_url: "https://github.com/typesafehub/ssl-config"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/ssl-config-core_2.12/0.2.2/ssl-config-core_2.12-0.2.2.jar"
+          hash:
+            value: "8a357d491f7f94c5b4b1e0b27644e1306cc8742d"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/ssl-config-core_2.12/0.2.2/ssl-config-core_2.12-0.2.2-sources.jar"
+          hash:
+            value: "1baaec9149929d0970330aa80aca73e3f1f15624"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/typesafehub/ssl-config.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/typesafehub/ssl-config.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"
+        purl: "pkg:maven/com.typesafe.akka/akka-actor_2.12@2.5.6"
+        authors:
+        - "Akka Contributors"
+        - "Lightbend Inc."
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+        description: "akka-actor"
+        homepage_url: "http://akka.io/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.6/akka-actor_2.12-2.5.6.jar"
+          hash:
+            value: "1e9f4c1829d3ce5640c17164b1756d1e98eb7af3"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.6/akka-actor_2.12-2.5.6-sources.jar"
+          hash:
+            value: "9642cf6f2a774d781e2f2a2e5de152971bfd714e"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:akka/akka.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/akka/akka.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"
+        purl: "pkg:maven/com.typesafe.akka/akka-stream_2.12@2.5.6"
+        authors:
+        - "Akka Contributors"
+        - "Lightbend Inc."
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+        description: "akka-stream"
+        homepage_url: "http://akka.io/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-stream_2.12/2.5.6/akka-stream_2.12-2.5.6.jar"
+          hash:
+            value: "876aa1471ac773a3dd02f70c1e511a9a014b3491"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-stream_2.12/2.5.6/akka-stream_2.12-2.5.6-sources.jar"
+          hash:
+            value: "14459df7523aea2cfd04080fe88eccd20897bcc5"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:akka/akka.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/akka/akka.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2"
+        purl: "pkg:maven/com.typesafe.scala-logging/scala-logging_2.12@3.7.2"
+        authors:
+        - "Heiko Seeberger"
+        - "Mathias Bogaert"
+        - "com.typesafe.scala-logging"
+        declared_licenses:
+        - "Apache 2.0 License"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache 2.0 License: "Apache-2.0"
+        description: "scala-logging"
+        homepage_url: "https://github.com/typesafehub/scala-logging"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.7.2/scala-logging_2.12-3.7.2.jar"
+          hash:
+            value: "a1dc97509765287faa4747f7cb411f0b85dc9a34"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.7.2/scala-logging_2.12-3.7.2-sources.jar"
+          hash:
+            value: "a5f760917b60283e37c84bf3db2aeaf976980ad3"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/typesafehub/scala-logging.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/typesafehub/scala-logging.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:net.logstash.logback:logstash-logback-encoder:4.11"
+        purl: "pkg:maven/net.logstash.logback/logstash-logback-encoder@4.11"
+        authors:
+        - "John E. Vincent"
+        - "Nokia"
+        - "Phil Clay"
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        - "MIT License"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0 OR MIT"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+            MIT License: "MIT"
+        description: "Logback encoder which will output events as Logstash-compatible\
+          \ JSON"
+        homepage_url: "https://github.com/logstash/logstash-logback-encoder"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/net/logstash/logback/logstash-logback-encoder/4.11/logstash-logback-encoder-4.11.jar"
+          hash:
+            value: "163b6b046de5414ac17c83cbd6cb619e541fc69a"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/net/logstash/logback/logstash-logback-encoder/4.11/logstash-logback-encoder-4.11-sources.jar"
+          hash:
+            value: "8b889d5eb55aabfa5d9aa9cad95529668f3edb2b"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:logstash/logstash-logback-encoder.git"
+          revision: "logstash-logback-encoder-4.11"
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/logstash/logstash-logback-encoder.git"
+          revision: "logstash-logback-encoder-4.11"
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.reactivestreams:reactive-streams:1.0.1"
+        purl: "pkg:maven/org.reactivestreams/reactive-streams@1.0.1"
+        authors:
+        - "Reactive Streams SIG"
+        declared_licenses:
+        - "CC0"
+        declared_licenses_processed:
+          spdx_expression: "CC0-1.0"
+          mapped:
+            CC0: "CC0-1.0"
+        description: "A Protocol for Asynchronous Non-Blocking Data Sequence"
+        homepage_url: "http://www.reactive-streams.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/reactivestreams/reactive-streams/1.0.1/reactive-streams-1.0.1.jar"
+          hash:
+            value: "1b1c911686eb40179219466e6a59b634b9d7a748"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/reactivestreams/reactive-streams/1.0.1/reactive-streams-1.0.1-sources.jar"
+          hash:
+            value: "af471e34e448bd4f1c183e9b26c85679be11035c"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:reactive-streams/reactive-streams.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/reactive-streams/reactive-streams.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang:scala-compiler:2.12.3"
+        purl: "pkg:maven/org.scala-lang/scala-compiler@2.12.3"
+        authors:
+        - "LAMP/EPFL"
+        - "Lightbend, Inc."
+        declared_licenses:
+        - "BSD 3-Clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-Clause: "BSD-3-Clause"
+        description: "Compiler for the Scala Programming Language"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-compiler/2.12.3/scala-compiler-2.12.3.jar"
+          hash:
+            value: "b6b9ca202fc8405260d30e703b9790e91c75cd85"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-compiler/2.12.3/scala-compiler-2.12.3-sources.jar"
+          hash:
+            value: "b8fe133c260f72b7fe9889195e19efeeab1b8087"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang:scala-library:2.12.3"
+        purl: "pkg:maven/org.scala-lang/scala-library@2.12.3"
+        authors:
+        - "LAMP/EPFL"
+        - "Lightbend, Inc."
+        declared_licenses:
+        - "BSD 3-Clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-Clause: "BSD-3-Clause"
+        description: "Standard library for the Scala Programming Language"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.12.3/scala-library-2.12.3.jar"
+          hash:
+            value: "f2e496f21af2d80b48e0a61773f84c3a76a0d06f"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.12.3/scala-library-2.12.3-sources.jar"
+          hash:
+            value: "499c91b0a64bc706eee174481a3b7dde81b3591d"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang:scala-reflect:2.12.2"
+        purl: "pkg:maven/org.scala-lang/scala-reflect@2.12.2"
+        authors:
+        - "LAMP/EPFL"
+        - "Lightbend, Inc."
+        declared_licenses:
+        - "BSD 3-Clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-Clause: "BSD-3-Clause"
+        description: "Compiler for the Scala Programming Language"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-reflect/2.12.2/scala-reflect-2.12.2.jar"
+          hash:
+            value: "fa13c13351566738ff156ef8a56b869868f4b77e"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-reflect/2.12.2/scala-reflect-2.12.2-sources.jar"
+          hash:
+            value: "a8808be417014e233b25ee44439f725e1f5e92a4"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0"
+        purl: "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.12@0.8.0"
+        authors:
+        - "EPFL"
+        - "Typesafe, Inc."
+        - "org.scala-lang.modules"
+        declared_licenses:
+        - "BSD 3-clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-clause: "BSD-3-Clause"
+        description: "scala-java8-compat"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0.jar"
+          hash:
+            value: "1e6f1e745bf6d3c34d1e2ab150653306069aaf34"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0-sources.jar"
+          hash:
+            value: "0a33ce48278b9e3bbea8aed726e3c0abad3afadd"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala-java8-compat.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala-java8-compat.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
+        purl: "pkg:maven/org.scala-lang.modules/scala-parser-combinators_2.12@1.0.4"
+        authors:
+        - "EPFL"
+        - "Typesafe, Inc."
+        - "org.scala-lang.modules"
+        declared_licenses:
+        - "BSD 3-clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-clause: "BSD-3-Clause"
+        description: "scala-parser-combinators"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4.jar"
+          hash:
+            value: "7c5f25a2d40ea7651452f0f0d1d4c12dabffcb8b"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4-sources.jar"
+          hash:
+            value: "9ec2f46c07d355853654af38e8b06e15ccca8cd0"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala-parser-combinators.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala-parser-combinators.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
+        purl: "pkg:maven/org.scala-lang.modules/scala-xml_2.12@1.0.5"
+        authors:
+        - "EPFL"
+        - "Typesafe, Inc."
+        - "org.scala-lang.modules"
+        declared_licenses:
+        - "BSD 3-clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-clause: "BSD-3-Clause"
+        description: "scala-xml"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.5/scala-xml_2.12-1.0.5.jar"
+          hash:
+            value: "a2b2afbeea86818a911b05851bb11d7d4840bb75"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.5/scala-xml_2.12-1.0.5-sources.jar"
+          hash:
+            value: "d12864d1a73aa540f7b624c8a92a5f48783c342c"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala-xml.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala-xml.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-sbt:test-interface:1.0"
+        purl: "pkg:maven/org.scala-sbt/test-interface@1.0"
+        authors:
+        - "Bill Venners"
+        - "Chua Chee Seng"
+        - "Josh Cough"
+        - "Mark Harrah"
+        - "org.scala-sbt"
+        declared_licenses:
+        - "BSD"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD: "BSD-3-Clause"
+        description: "Uniform test interface to Scala/Java test frameworks (specs,\
+          \ ScalaCheck, ScalaTest, JUnit and other)"
+        homepage_url: "http://www.scala-sbt.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"
+          hash:
+            value: "0a3f14d010c4cb32071f863d97291df31603b521"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar"
+          hash:
+            value: "d44b23e9e3419ad0e00b91bba764a48d43075000"
+            algorithm: "SHA-1"
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/sbt/test-interface.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scalacheck:scalacheck_2.12:1.13.5"
+        purl: "pkg:maven/org.scalacheck/scalacheck_2.12@1.13.5"
+        authors:
+        - "Rickard Nilsson"
+        - "org.scalacheck"
+        declared_licenses:
+        - "BSD-style"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD-style: "BSD-3-Clause"
+        description: "scalacheck"
+        homepage_url: "http://www.scalacheck.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalacheck/scalacheck_2.12/1.13.5/scalacheck_2.12-1.13.5.jar"
+          hash:
+            value: "fff972ccaa0d83ca53bfdbbd0763c1059281fb76"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalacheck/scalacheck_2.12/1.13.5/scalacheck_2.12-1.13.5-sources.jar"
+          hash:
+            value: "d0e1376902de65c7fa327f455b61d5d71957d78e"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:rickynils/scalacheck.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/rickynils/scalacheck.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scalactic:scalactic_2.12:3.0.4"
+        purl: "pkg:maven/org.scalactic/scalactic_2.12@3.0.4"
+        authors:
+        - "Bill Venners"
+        - "Chua Chee Seng"
+        - "George Berger"
+        - "org.scalactic"
+        declared_licenses:
+        - "the Apache License, ASL Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            the Apache License, ASL Version 2.0: "Apache-2.0"
+        description: "scalactic"
+        homepage_url: "http://www.scalatest.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalactic/scalactic_2.12/3.0.4/scalactic_2.12-3.0.4.jar"
+          hash:
+            value: "e75f0f9c77aa391e01797cfc42fb82fd7c7d59a5"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalactic/scalactic_2.12/3.0.4/scalactic_2.12-3.0.4-sources.jar"
+          hash:
+            value: "9f7f02217c7d2f14c6b1982493c39243a20b749d"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:scalatest/scalatest.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/scalatest/scalatest.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scalatest:scalatest_2.12:3.0.4"
+        purl: "pkg:maven/org.scalatest/scalatest_2.12@3.0.4"
+        authors:
+        - "Bill Venners"
+        - "Chua Chee Seng"
+        - "George Berger"
+        - "org.scalatest"
+        declared_licenses:
+        - "the Apache License, ASL Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            the Apache License, ASL Version 2.0: "Apache-2.0"
+        description: "scalatest"
+        homepage_url: "http://www.scalatest.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalatest/scalatest_2.12/3.0.4/scalatest_2.12-3.0.4.jar"
+          hash:
+            value: "87d68f3d06dbf698fd0084c0a8b8996864d15465"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalatest/scalatest_2.12/3.0.4/scalatest_2.12-3.0.4-sources.jar"
+          hash:
+            value: "ba669c2c9b7092151e2a19e975b1bf2a2e7a5fda"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:scalatest/scalatest.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/scalatest/scalatest.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scalaz:scalaz-core_2.12:7.2.8"
+        purl: "pkg:maven/org.scalaz/scalaz-core_2.12@7.2.8"
+        authors:
+        - "Alexey Romanov"
+        - "Daniel Peebles"
+        - "Edward Kmett"
+        - "Jason Zaugg"
+        - "Kris Nuttycombe"
+        - "Lars Hupel"
+        - "Paul Chiusano"
+        - "Richard Wallace"
+        - "Runar Bjarnason"
+        - "Tony Morris"
+        - "org.scalaz"
+        declared_licenses:
+        - "BSD-style"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD-style: "BSD-3-Clause"
+        description: "scalaz-core"
+        homepage_url: "http://scalaz.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalaz/scalaz-core_2.12/7.2.8/scalaz-core_2.12-7.2.8.jar"
+          hash:
+            value: "2922d47f6dc7aba452634fe674087b6221b90dbf"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalaz/scalaz-core_2.12/7.2.8/scalaz-core_2.12-7.2.8-sources.jar"
+          hash:
+            value: "c94295a434f26b5650ec0fcbf93c9d2c7aada88e"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:scalaz/scalaz.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/scalaz/scalaz.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
+        purl: "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.25"
+        authors:
+        - "Ceki Gulcu"
+        - "QOS.ch"
+        declared_licenses:
+        - "MIT License"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+          mapped:
+            MIT License: "MIT"
+        description: "JCL 1.2 implemented over SLF4J"
+        homepage_url: "http://www.slf4j.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25.jar"
+          hash:
+            value: "f8c32b13ff142a513eeb5b6330b1588dcb2c0461"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25-sources.jar"
+          hash:
+            value: "ffd0827a7c67d5915b7dc611afbda56a1f247191"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:qos-ch/slf4j.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/qos-ch/slf4j.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.slf4j:slf4j-api:1.7.25"
+        purl: "pkg:maven/org.slf4j/slf4j-api@1.7.25"
+        authors:
+        - "Ceki Gulcu"
+        - "QOS.ch"
+        declared_licenses:
+        - "MIT License"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+          mapped:
+            MIT License: "MIT"
+        description: "The slf4j API"
+        homepage_url: "http://www.slf4j.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
+          hash:
+            value: "da76ca59f6a57ee3102f8f9bd9cee742973efa8a"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25-sources.jar"
+          hash:
+            value: "962153db4a9ea71b79d047dfd1b2a0d80d8f4739"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:qos-ch/slf4j.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/qos-ch/slf4j.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.typelevel:macro-compat_2.12:1.1.1"
+        purl: "pkg:maven/org.typelevel/macro-compat_2.12@1.1.1"
+        authors:
+        - "Miles Sabin"
+        - "org.typelevel"
+        declared_licenses:
+        - "Apache 2"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache 2: "Apache-2.0"
+        description: "core"
+        homepage_url: "https://github.com/milessabin/macro-compat"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1.jar"
+          hash:
+            value: "ed809d26ef4237d7c079ae6cf7ebd0dfa7986adf"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1-sources.jar"
+          hash:
+            value: "ade6d6ec81975cf514b0f9e2061614f2799cfe97"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:milessabin/macro-compat.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/milessabin/macro-compat.git"
+          revision: ""
+          path: ""
+      curations: []
+    dependency_graphs:
+      SBT:
+        packages:
+        - "Maven:ch.qos.logback:logback-classic:1.2.3"
+        - "Maven:ch.qos.logback:logback-core:1.2.3"
+        - "Maven:org.slf4j:slf4j-api:1.7.25"
+        - "Maven:com.typesafe:config:1.3.1"
+        - "Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"
+        - "Maven:com.typesafe:ssl-config-core_2.12:0.2.2"
+        - "Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"
+        - "Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0"
+        - "Maven:org.reactivestreams:reactive-streams:1.0.1"
+        - "Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2"
+        - "Maven:org.scala-lang:scala-reflect:2.12.2"
+        - "Maven:net.logstash.logback:logstash-logback-encoder:4.11"
+        - "Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9"
+        - "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
+        - "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
+        - "Maven:org.scala-lang:scala-library:2.12.3"
+        - "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
+        - "Maven:org.scalacheck:scalacheck_2.12:1.13.5"
+        - "Maven:org.scala-sbt:test-interface:1.0"
+        - "Maven:org.scalatest:scalatest_2.12:3.0.4"
+        - "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
+        - "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
+        - "Maven:org.scalactic:scalactic_2.12:3.0.4"
+        - "Maven:com.github.julien-truffaut:monocle-core_2.12:1.4.0"
+        - "Maven:org.scalaz:scalaz-core_2.12:7.2.8"
+        - "Maven:com.github.julien-truffaut:monocle-macro_2.12:1.4.0"
+        - "Maven:org.typelevel:macro-compat_2.12:1.1.1"
+        - "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
+        - "Maven:com.github.pureconfig:pureconfig_2.12:0.8.0"
+        - "Maven:com.chuusai:shapeless_2.12:2.3.2"
+        - "Maven:com.github.pureconfig:pureconfig-macros_2.12:0.8.0"
+        - "Maven:org.scala-lang:scala-compiler:2.12.3"
+        scopes:
+          com.pbassiner:common_2.12:0.1-SNAPSHOT:compile:
+          - root: 0
+          - root: 3
+          - root: 4
+          - root: 9
+          - root: 11
+          - root: 15
+          - root: 16
+          com.pbassiner:common_2.12:0.1-SNAPSHOT:test:
+          - root: 17
+          - root: 19
+          com.pbassiner:multi1_2.12:0.1-SNAPSHOT:compile:
+          - root: 0
+          - root: 23
+          - root: 25
+          - root: 3
+          - root: 4
+          - root: 9
+          - root: 11
+          - root: 15
+          - root: 16
+          - root: 27
+          com.pbassiner:multi1_2.12:0.1-SNAPSHOT:test:
+          - root: 17
+          - root: 19
+          com.pbassiner:multi2_2.12:0.1-SNAPSHOT:compile:
+          - root: 0
+          - root: 28
+          - root: 3
+          - root: 4
+          - root: 9
+          - root: 11
+          - root: 15
+          - root: 16
+          - root: 27
+          com.pbassiner:multi2_2.12:0.1-SNAPSHOT:test:
+          - root: 17
+          - root: 19
+          com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT:compile:
+          - root: 15
+        nodes:
+        - {}
+        - pkg: 1
+        - pkg: 2
+        - pkg: 3
+        - pkg: 4
+        - pkg: 5
+        - pkg: 6
+        - pkg: 7
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Test issue 1"
+            severity: "ERROR"
+        - pkg: 8
+        - pkg: 9
+        - pkg: 10
+        - pkg: 11
+        - pkg: 12
+        - pkg: 13
+        - pkg: 14
+        - pkg: 15
+        - pkg: 16
+        - pkg: 17
+        - pkg: 18
+        - pkg: 19
+        - pkg: 20
+        - pkg: 21
+        - pkg: 22
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Test issue 2"
+            severity: "ERROR"
+        - pkg: 23
+        - pkg: 24
+        - pkg: 25
+        - pkg: 26
+        - pkg: 27
+          linkage: "PROJECT_DYNAMIC"
+        - pkg: 28
+        - pkg: 29
+        - pkg: 30
+        - pkg: 31
+        edges:
+        - from: 0
+          to: 1
+        - from: 0
+          to: 2
+        - from: 6
+          to: 7
+        - from: 4
+          to: 5
+        - from: 4
+          to: 6
+        - from: 4
+          to: 8
+        - from: 9
+          to: 10
+        - from: 12
+          to: 13
+        - from: 12
+          to: 14
+        - from: 11
+          to: 12
+        - from: 17
+          to: 18
+        - from: 19
+          to: 20
+        - from: 19
+          to: 21
+        - from: 19
+          to: 22
+        - from: 23
+          to: 24
+        - from: 25
+          to: 26
+        - from: 30
+          to: 26
+        - from: 30
+          to: 31
+        - from: 28
+          to: 29
+        - from: 28
+          to: 30
+    has_issues: false
+scanner: null
+advisor: null
+evaluator: null

--- a/model/src/test/assets/result-with-issues-scopes.yml
+++ b/model/src/test/assets/result-with-issues-scopes.yml
@@ -1,0 +1,1371 @@
+---
+repository:
+  vcs:
+    type: "Git"
+    url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+    revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+    revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+    path: ""
+  config: {}
+analyzer:
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  environment:
+    ort_version: "HEAD"
+    java_version: "<REPLACE_JAVA>"
+    os: "<REPLACE_OS>"
+    processors: 4
+    max_memory: 4096
+    variables: {}
+    tool_versions: {}
+  config:
+    ignore_tool_versions: false
+    allow_dynamic_versions: false
+  result:
+    projects:
+      - id: "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
+        definition_file_path: "common/target-scala-2.12-common_2.12-0.1-SNAPSHOT.pom"
+        authors:
+          - "com.pbassiner"
+        declared_licenses: []
+        declared_licenses_processed: {}
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+          revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+          path: "common"
+        homepage_url: ""
+        scopes:
+          - name: "compile"
+            dependencies:
+              - id: "Maven:ch.qos.logback:logback-classic:1.2.3"
+                dependencies:
+                  - id: "Maven:ch.qos.logback:logback-core:1.2.3"
+                  - id: "Maven:org.slf4j:slf4j-api:1.7.25"
+              - id: "Maven:com.typesafe:config:1.3.1"
+              - id: "Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"
+                dependencies:
+                  - id: "Maven:com.typesafe:ssl-config-core_2.12:0.2.2"
+                  - id: "Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"
+                    dependencies:
+                      - id: "Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0"
+                        issues:
+                        - timestamp: "1970-01-01T00:00:00Z"
+                          source: "Gradle"
+                          message: "Test issue 1"
+                          severity: "ERROR"
+                  - id: "Maven:org.reactivestreams:reactive-streams:1.0.1"
+              - id: "Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2"
+                dependencies:
+                  - id: "Maven:org.scala-lang:scala-reflect:2.12.2"
+              - id: "Maven:net.logstash.logback:logstash-logback-encoder:4.11"
+                dependencies:
+                  - id: "Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9"
+                    dependencies:
+                      - id: "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
+                      - id: "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
+              - id: "Maven:org.scala-lang:scala-library:2.12.3"
+              - id: "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
+          - name: "test"
+            dependencies:
+              - id: "Maven:org.scalacheck:scalacheck_2.12:1.13.5"
+                dependencies:
+                  - id: "Maven:org.scala-sbt:test-interface:1.0"
+              - id: "Maven:org.scalatest:scalatest_2.12:3.0.4"
+                dependencies:
+                  - id: "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
+                  - id: "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
+                  - id: "Maven:org.scalactic:scalactic_2.12:3.0.4"
+                    issues:
+                    - timestamp: "1970-01-01T00:00:00Z"
+                      source: "Gradle"
+                      message: "Test issue 2"
+                      severity: "ERROR"
+      - id: "SBT:com.pbassiner:multi1_2.12:0.1-SNAPSHOT"
+        definition_file_path: "multi1/target-scala-2.12-multi1_2.12-0.1-SNAPSHOT.pom"
+        authors:
+          - "com.pbassiner"
+        declared_licenses: []
+        declared_licenses_processed: {}
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+          revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+          path: "multi1"
+        homepage_url: ""
+        scopes:
+          - name: "compile"
+            dependencies:
+              - id: "Maven:ch.qos.logback:logback-classic:1.2.3"
+                dependencies:
+                  - id: "Maven:ch.qos.logback:logback-core:1.2.3"
+                  - id: "Maven:org.slf4j:slf4j-api:1.7.25"
+              - id: "Maven:com.github.julien-truffaut:monocle-core_2.12:1.4.0"
+                dependencies:
+                  - id: "Maven:org.scalaz:scalaz-core_2.12:7.2.8"
+              - id: "Maven:com.github.julien-truffaut:monocle-macro_2.12:1.4.0"
+                dependencies:
+                  - id: "Maven:org.typelevel:macro-compat_2.12:1.1.1"
+              - id: "Maven:com.typesafe:config:1.3.1"
+              - id: "Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"
+                dependencies:
+                  - id: "Maven:com.typesafe:ssl-config-core_2.12:0.2.2"
+                  - id: "Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"
+                    dependencies:
+                      - id: "Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0"
+                  - id: "Maven:org.reactivestreams:reactive-streams:1.0.1"
+              - id: "Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2"
+                dependencies:
+                  - id: "Maven:org.scala-lang:scala-reflect:2.12.2"
+              - id: "Maven:net.logstash.logback:logstash-logback-encoder:4.11"
+                dependencies:
+                  - id: "Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9"
+                    dependencies:
+                      - id: "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
+                      - id: "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
+              - id: "Maven:org.scala-lang:scala-library:2.12.3"
+              - id: "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
+              - id: "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
+                linkage: "PROJECT_DYNAMIC"
+          - name: "test"
+            dependencies:
+              - id: "Maven:org.scalacheck:scalacheck_2.12:1.13.5"
+                dependencies:
+                  - id: "Maven:org.scala-sbt:test-interface:1.0"
+              - id: "Maven:org.scalatest:scalatest_2.12:3.0.4"
+                dependencies:
+                  - id: "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
+                  - id: "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
+                  - id: "Maven:org.scalactic:scalactic_2.12:3.0.4"
+      - id: "SBT:com.pbassiner:multi2_2.12:0.1-SNAPSHOT"
+        definition_file_path: "multi2/target-scala-2.12-multi2_2.12-0.1-SNAPSHOT.pom"
+        authors:
+          - "com.pbassiner"
+        declared_licenses: []
+        declared_licenses_processed: {}
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+          revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+          path: "multi2"
+        homepage_url: ""
+        scopes:
+          - name: "compile"
+            dependencies:
+              - id: "Maven:ch.qos.logback:logback-classic:1.2.3"
+                dependencies:
+                  - id: "Maven:ch.qos.logback:logback-core:1.2.3"
+                  - id: "Maven:org.slf4j:slf4j-api:1.7.25"
+              - id: "Maven:com.github.pureconfig:pureconfig_2.12:0.8.0"
+                dependencies:
+                  - id: "Maven:com.chuusai:shapeless_2.12:2.3.2"
+                  - id: "Maven:com.github.pureconfig:pureconfig-macros_2.12:0.8.0"
+                    dependencies:
+                      - id: "Maven:org.scala-lang:scala-compiler:2.12.3"
+                      - id: "Maven:org.typelevel:macro-compat_2.12:1.1.1"
+              - id: "Maven:com.typesafe:config:1.3.1"
+              - id: "Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"
+                dependencies:
+                  - id: "Maven:com.typesafe:ssl-config-core_2.12:0.2.2"
+                  - id: "Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"
+                    dependencies:
+                      - id: "Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0"
+                  - id: "Maven:org.reactivestreams:reactive-streams:1.0.1"
+              - id: "Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2"
+                dependencies:
+                  - id: "Maven:org.scala-lang:scala-reflect:2.12.2"
+              - id: "Maven:net.logstash.logback:logstash-logback-encoder:4.11"
+                dependencies:
+                  - id: "Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9"
+                    dependencies:
+                      - id: "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
+                      - id: "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
+              - id: "Maven:org.scala-lang:scala-library:2.12.3"
+              - id: "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
+              - id: "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
+                linkage: "PROJECT_DYNAMIC"
+          - name: "test"
+            dependencies:
+              - id: "Maven:org.scalacheck:scalacheck_2.12:1.13.5"
+                dependencies:
+                  - id: "Maven:org.scala-sbt:test-interface:1.0"
+              - id: "Maven:org.scalatest:scalatest_2.12:3.0.4"
+                dependencies:
+                  - id: "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
+                  - id: "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
+                  - id: "Maven:org.scalactic:scalactic_2.12:3.0.4"
+      - id: "SBT:com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT"
+        definition_file_path: "target-scala-2.12-sbt-multi-project-example_2.12-0.1-SNAPSHOT.pom"
+        authors:
+          - "com.pbassiner"
+        declared_licenses: []
+        declared_licenses_processed: {}
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+          revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+          path: ""
+        homepage_url: ""
+        scopes:
+          - name: "compile"
+            dependencies:
+              - id: "Maven:org.scala-lang:scala-library:2.12.3"
+    packages:
+      - package:
+          id: "Maven:ch.qos.logback:logback-classic:1.2.3"
+          purl: "pkg:maven/ch.qos.logback/logback-classic@1.2.3"
+          authors:
+            - "Ceki Gulcu"
+            - "Joern Huxhorn"
+            - "QOS.ch"
+          declared_licenses:
+            - "Eclipse Public License - v 1.0"
+            - "GNU Lesser General Public License"
+          declared_licenses_processed:
+            spdx_expression: "EPL-1.0 OR LGPL-2.1-or-later"
+            mapped:
+              Eclipse Public License - v 1.0: "EPL-1.0"
+              GNU Lesser General Public License: "LGPL-2.1-or-later"
+          description: "logback-classic module"
+          homepage_url: "http://logback.qos.ch/logback-classic"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar"
+            hash:
+              value: "7c4f3c474fb2c041d8028740440937705ebb473a"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3-sources.jar"
+            hash:
+              value: "cfd5385e0c5ed1c8a5dce57d86e79cf357153a64"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:ceki/logback.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/ceki/logback.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:ch.qos.logback:logback-core:1.2.3"
+          purl: "pkg:maven/ch.qos.logback/logback-core@1.2.3"
+          authors:
+            - "Ceki Gulcu"
+            - "Joern Huxhorn"
+            - "QOS.ch"
+          declared_licenses:
+            - "Eclipse Public License - v 1.0"
+            - "GNU Lesser General Public License"
+          declared_licenses_processed:
+            spdx_expression: "EPL-1.0 OR LGPL-2.1-or-later"
+            mapped:
+              Eclipse Public License - v 1.0: "EPL-1.0"
+              GNU Lesser General Public License: "LGPL-2.1-or-later"
+          description: "logback-core module"
+          homepage_url: "http://logback.qos.ch/logback-core"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar"
+            hash:
+              value: "864344400c3d4d92dfeb0a305dc87d953677c03c"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3-sources.jar"
+            hash:
+              value: "3ebabe69eba0196af9ad3a814f723fb720b9101e"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:ceki/logback.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/ceki/logback.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.chuusai:shapeless_2.12:2.3.2"
+          purl: "pkg:maven/com.chuusai/shapeless_2.12@2.3.2"
+          authors:
+            - "Miles Sabin"
+            - "com.chuusai"
+          declared_licenses:
+            - "Apache 2"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              Apache 2: "Apache-2.0"
+          description: "core"
+          homepage_url: "https://github.com/milessabin/shapeless"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2.jar"
+            hash:
+              value: "27e115ffed7917b456e54891de67173f4a68d5f1"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2-sources.jar"
+            hash:
+              value: "6d83fa4fa6d25b1e8d8cd9d9d551c05c745633b1"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:milessabin/shapeless.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/milessabin/shapeless.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
+          purl: "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.8.0"
+          authors:
+            - "Christopher Currie"
+            - "FasterXML"
+            - "Paul Brown"
+            - "Tatu Saloranta"
+          declared_licenses:
+            - "The Apache Software License, Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              The Apache Software License, Version 2.0: "Apache-2.0"
+          description: "Core annotations used for value types, used by Jackson data\
+          \ binding package."
+          homepage_url: "http://github.com/FasterXML/jackson"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.8.0/jackson-annotations-2.8.0.jar"
+            hash:
+              value: "45b426f7796b741035581a176744d91090e2e6fb"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.8.0/jackson-annotations-2.8.0-sources.jar"
+            hash:
+              value: "29a1a95363d497e856c0a7d682e4f7973e334068"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:FasterXML/jackson-annotations.git"
+            revision: "jackson-annotations-2.8.0"
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/FasterXML/jackson-annotations.git"
+            revision: "jackson-annotations-2.8.0"
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
+          purl: "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.8.9"
+          authors:
+            - "Christopher Currie"
+            - "FasterXML"
+            - "Paul Brown"
+            - "Tatu Saloranta"
+          declared_licenses:
+            - "The Apache Software License, Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              The Apache Software License, Version 2.0: "Apache-2.0"
+          description: "Core Jackson abstractions, basic JSON streaming API implementation"
+          homepage_url: "https://github.com/FasterXML/jackson-core"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.8.9/jackson-core-2.8.9.jar"
+            hash:
+              value: "569b1752705da98f49aabe2911cc956ff7d8ed9d"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.8.9/jackson-core-2.8.9-sources.jar"
+            hash:
+              value: "8cf3613202ddcd495137f8cb944e2da69964a641"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:FasterXML/jackson-core.git"
+            revision: "jackson-core-2.8.9"
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/FasterXML/jackson-core.git"
+            revision: "jackson-core-2.8.9"
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9"
+          purl: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.9"
+          authors:
+            - "Christopher Currie"
+            - "FasterXML"
+            - "Paul Brown"
+            - "Tatu Saloranta"
+          declared_licenses:
+            - "The Apache Software License, Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              The Apache Software License, Version 2.0: "Apache-2.0"
+          description: "General data-binding functionality for Jackson: works on core\
+          \ streaming API"
+          homepage_url: "http://github.com/FasterXML/jackson"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.8.9/jackson-databind-2.8.9.jar"
+            hash:
+              value: "4dfca3975be3c1a98eacb829e70f02e9a71bc159"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.8.9/jackson-databind-2.8.9-sources.jar"
+            hash:
+              value: "98e1b4171628d8f230f6a60b248de84ed04fab0d"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:FasterXML/jackson-databind.git"
+            revision: "jackson-databind-2.8.9"
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/FasterXML/jackson-databind.git"
+            revision: "jackson-databind-2.8.9"
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.github.julien-truffaut:monocle-core_2.12:1.4.0"
+          purl: "pkg:maven/com.github.julien-truffaut/monocle-core_2.12@1.4.0"
+          authors:
+            - "Ilan Godik"
+            - "Julien Truffaut"
+            - "Kenji Yoshida"
+            - "Naoki Aoyama"
+            - "com.github.julien-truffaut"
+          declared_licenses:
+            - "MIT"
+          declared_licenses_processed:
+            spdx_expression: "MIT"
+          description: "core"
+          homepage_url: "https://github.com/julien-truffaut/Monocle"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-core_2.12/1.4.0/monocle-core_2.12-1.4.0.jar"
+            hash:
+              value: "219da9cc75878a75c888e38ad883fe4d30a7651d"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-core_2.12/1.4.0/monocle-core_2.12-1.4.0-sources.jar"
+            hash:
+              value: "37d333798ca15a03f5dfbb02f133d5b6b8e57b8c"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:julien-truffaut/Monocle.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/julien-truffaut/Monocle.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.github.julien-truffaut:monocle-macro_2.12:1.4.0"
+          purl: "pkg:maven/com.github.julien-truffaut/monocle-macro_2.12@1.4.0"
+          authors:
+            - "Ilan Godik"
+            - "Julien Truffaut"
+            - "Kenji Yoshida"
+            - "Naoki Aoyama"
+            - "com.github.julien-truffaut"
+          declared_licenses:
+            - "MIT"
+          declared_licenses_processed:
+            spdx_expression: "MIT"
+          description: "macros"
+          homepage_url: "https://github.com/julien-truffaut/Monocle"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-macro_2.12/1.4.0/monocle-macro_2.12-1.4.0.jar"
+            hash:
+              value: "319242d130983fec319a2e2d4f8e7741b809b5a0"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-macro_2.12/1.4.0/monocle-macro_2.12-1.4.0-sources.jar"
+            hash:
+              value: "e7ce64d7973ad64f3fa872b931a31c8c25de59b3"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:julien-truffaut/Monocle.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/julien-truffaut/Monocle.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.github.pureconfig:pureconfig-macros_2.12:0.8.0"
+          purl: "pkg:maven/com.github.pureconfig/pureconfig-macros_2.12@0.8.0"
+          authors:
+            - "Rui Gonçalves"
+            - "com.github.pureconfig"
+          declared_licenses:
+            - "Mozilla Public License, version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "MPL-2.0"
+            mapped:
+              Mozilla Public License, version 2.0: "MPL-2.0"
+          description: "pureconfig-macros"
+          homepage_url: "https://github.com/pureconfig/pureconfig"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig-macros_2.12/0.8.0/pureconfig-macros_2.12-0.8.0.jar"
+            hash:
+              value: "eea0e86f18c08e7fd00c90626f4f17a9ee6ef088"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig-macros_2.12/0.8.0/pureconfig-macros_2.12-0.8.0-sources.jar"
+            hash:
+              value: "7411f96540756236648b48347827b6ba2622e5e0"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:pureconfig/pureconfig.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/pureconfig/pureconfig.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.github.pureconfig:pureconfig_2.12:0.8.0"
+          purl: "pkg:maven/com.github.pureconfig/pureconfig_2.12@0.8.0"
+          authors:
+            - "Derek Morr"
+            - "Joao Azevedo"
+            - "Leif Wickland"
+            - "Mario Pastorelli"
+            - "Rui Gonçalves"
+            - "com.github.pureconfig"
+          declared_licenses:
+            - "Mozilla Public License, version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "MPL-2.0"
+            mapped:
+              Mozilla Public License, version 2.0: "MPL-2.0"
+          description: "pureconfig"
+          homepage_url: "https://github.com/pureconfig/pureconfig"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig_2.12/0.8.0/pureconfig_2.12-0.8.0.jar"
+            hash:
+              value: "891fde63cda086f593bffddb0b47933abc75523f"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig_2.12/0.8.0/pureconfig_2.12-0.8.0-sources.jar"
+            hash:
+              value: "fa6de3ab2dd82543fb37288626687a9a6c1a67a2"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:pureconfig/pureconfig.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/pureconfig/pureconfig.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.typesafe:config:1.3.1"
+          purl: "pkg:maven/com.typesafe/config@1.3.1"
+          authors:
+            - "Havoc Pennington"
+            - "com.typesafe"
+          declared_licenses:
+            - "Apache License, Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              Apache License, Version 2.0: "Apache-2.0"
+          description: "config"
+          homepage_url: "https://github.com/typesafehub/config"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/config/1.3.1/config-1.3.1.jar"
+            hash:
+              value: "2cf7a6cc79732e3bdf1647d7404279900ca63eb0"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/config/1.3.1/config-1.3.1-sources.jar"
+            hash:
+              value: "a27878630ff503b63ed25ff2a25fa8ef888740b3"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/typesafehub/config.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/typesafehub/config.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.typesafe:ssl-config-core_2.12:0.2.2"
+          purl: "pkg:maven/com.typesafe/ssl-config-core_2.12@0.2.2"
+          authors:
+            - "Konrad Malawski"
+            - "Will Sargent"
+            - "com.typesafe"
+          declared_licenses:
+            - "Apache License, Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              Apache License, Version 2.0: "Apache-2.0"
+          description: "ssl-config-core"
+          homepage_url: "https://github.com/typesafehub/ssl-config"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/ssl-config-core_2.12/0.2.2/ssl-config-core_2.12-0.2.2.jar"
+            hash:
+              value: "8a357d491f7f94c5b4b1e0b27644e1306cc8742d"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/ssl-config-core_2.12/0.2.2/ssl-config-core_2.12-0.2.2-sources.jar"
+            hash:
+              value: "1baaec9149929d0970330aa80aca73e3f1f15624"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/typesafehub/ssl-config.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/typesafehub/ssl-config.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"
+          purl: "pkg:maven/com.typesafe.akka/akka-actor_2.12@2.5.6"
+          authors:
+            - "Akka Contributors"
+            - "Lightbend Inc."
+          declared_licenses:
+            - "Apache License, Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              Apache License, Version 2.0: "Apache-2.0"
+          description: "akka-actor"
+          homepage_url: "http://akka.io/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.6/akka-actor_2.12-2.5.6.jar"
+            hash:
+              value: "1e9f4c1829d3ce5640c17164b1756d1e98eb7af3"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.6/akka-actor_2.12-2.5.6-sources.jar"
+            hash:
+              value: "9642cf6f2a774d781e2f2a2e5de152971bfd714e"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:akka/akka.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/akka/akka.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"
+          purl: "pkg:maven/com.typesafe.akka/akka-stream_2.12@2.5.6"
+          authors:
+            - "Akka Contributors"
+            - "Lightbend Inc."
+          declared_licenses:
+            - "Apache License, Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              Apache License, Version 2.0: "Apache-2.0"
+          description: "akka-stream"
+          homepage_url: "http://akka.io/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-stream_2.12/2.5.6/akka-stream_2.12-2.5.6.jar"
+            hash:
+              value: "876aa1471ac773a3dd02f70c1e511a9a014b3491"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-stream_2.12/2.5.6/akka-stream_2.12-2.5.6-sources.jar"
+            hash:
+              value: "14459df7523aea2cfd04080fe88eccd20897bcc5"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:akka/akka.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/akka/akka.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2"
+          purl: "pkg:maven/com.typesafe.scala-logging/scala-logging_2.12@3.7.2"
+          authors:
+            - "Heiko Seeberger"
+            - "Mathias Bogaert"
+            - "com.typesafe.scala-logging"
+          declared_licenses:
+            - "Apache 2.0 License"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              Apache 2.0 License: "Apache-2.0"
+          description: "scala-logging"
+          homepage_url: "https://github.com/typesafehub/scala-logging"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.7.2/scala-logging_2.12-3.7.2.jar"
+            hash:
+              value: "a1dc97509765287faa4747f7cb411f0b85dc9a34"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.7.2/scala-logging_2.12-3.7.2-sources.jar"
+            hash:
+              value: "a5f760917b60283e37c84bf3db2aeaf976980ad3"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/typesafehub/scala-logging.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/typesafehub/scala-logging.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:net.logstash.logback:logstash-logback-encoder:4.11"
+          purl: "pkg:maven/net.logstash.logback/logstash-logback-encoder@4.11"
+          authors:
+            - "John E. Vincent"
+            - "Nokia"
+            - "Phil Clay"
+          declared_licenses:
+            - "Apache License, Version 2.0"
+            - "MIT License"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0 OR MIT"
+            mapped:
+              Apache License, Version 2.0: "Apache-2.0"
+              MIT License: "MIT"
+          description: "Logback encoder which will output events as Logstash-compatible\
+          \ JSON"
+          homepage_url: "https://github.com/logstash/logstash-logback-encoder"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/net/logstash/logback/logstash-logback-encoder/4.11/logstash-logback-encoder-4.11.jar"
+            hash:
+              value: "163b6b046de5414ac17c83cbd6cb619e541fc69a"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/net/logstash/logback/logstash-logback-encoder/4.11/logstash-logback-encoder-4.11-sources.jar"
+            hash:
+              value: "8b889d5eb55aabfa5d9aa9cad95529668f3edb2b"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:logstash/logstash-logback-encoder.git"
+            revision: "logstash-logback-encoder-4.11"
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/logstash/logstash-logback-encoder.git"
+            revision: "logstash-logback-encoder-4.11"
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.reactivestreams:reactive-streams:1.0.1"
+          purl: "pkg:maven/org.reactivestreams/reactive-streams@1.0.1"
+          authors:
+            - "Reactive Streams SIG"
+          declared_licenses:
+            - "CC0"
+          declared_licenses_processed:
+            spdx_expression: "CC0-1.0"
+            mapped:
+              CC0: "CC0-1.0"
+          description: "A Protocol for Asynchronous Non-Blocking Data Sequence"
+          homepage_url: "http://www.reactive-streams.org/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/reactivestreams/reactive-streams/1.0.1/reactive-streams-1.0.1.jar"
+            hash:
+              value: "1b1c911686eb40179219466e6a59b634b9d7a748"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/reactivestreams/reactive-streams/1.0.1/reactive-streams-1.0.1-sources.jar"
+            hash:
+              value: "af471e34e448bd4f1c183e9b26c85679be11035c"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:reactive-streams/reactive-streams.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/reactive-streams/reactive-streams.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scala-lang:scala-compiler:2.12.3"
+          purl: "pkg:maven/org.scala-lang/scala-compiler@2.12.3"
+          authors:
+            - "LAMP/EPFL"
+            - "Lightbend, Inc."
+          declared_licenses:
+            - "BSD 3-Clause"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD 3-Clause: "BSD-3-Clause"
+          description: "Compiler for the Scala Programming Language"
+          homepage_url: "http://www.scala-lang.org/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-compiler/2.12.3/scala-compiler-2.12.3.jar"
+            hash:
+              value: "b6b9ca202fc8405260d30e703b9790e91c75cd85"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-compiler/2.12.3/scala-compiler-2.12.3-sources.jar"
+            hash:
+              value: "b8fe133c260f72b7fe9889195e19efeeab1b8087"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/scala/scala.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/scala/scala.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scala-lang:scala-library:2.12.3"
+          purl: "pkg:maven/org.scala-lang/scala-library@2.12.3"
+          authors:
+            - "LAMP/EPFL"
+            - "Lightbend, Inc."
+          declared_licenses:
+            - "BSD 3-Clause"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD 3-Clause: "BSD-3-Clause"
+          description: "Standard library for the Scala Programming Language"
+          homepage_url: "http://www.scala-lang.org/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.12.3/scala-library-2.12.3.jar"
+            hash:
+              value: "f2e496f21af2d80b48e0a61773f84c3a76a0d06f"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.12.3/scala-library-2.12.3-sources.jar"
+            hash:
+              value: "499c91b0a64bc706eee174481a3b7dde81b3591d"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/scala/scala.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/scala/scala.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scala-lang:scala-reflect:2.12.2"
+          purl: "pkg:maven/org.scala-lang/scala-reflect@2.12.2"
+          authors:
+            - "LAMP/EPFL"
+            - "Lightbend, Inc."
+          declared_licenses:
+            - "BSD 3-Clause"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD 3-Clause: "BSD-3-Clause"
+          description: "Compiler for the Scala Programming Language"
+          homepage_url: "http://www.scala-lang.org/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-reflect/2.12.2/scala-reflect-2.12.2.jar"
+            hash:
+              value: "fa13c13351566738ff156ef8a56b869868f4b77e"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-reflect/2.12.2/scala-reflect-2.12.2-sources.jar"
+            hash:
+              value: "a8808be417014e233b25ee44439f725e1f5e92a4"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/scala/scala.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/scala/scala.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0"
+          purl: "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.12@0.8.0"
+          authors:
+            - "EPFL"
+            - "Typesafe, Inc."
+            - "org.scala-lang.modules"
+          declared_licenses:
+            - "BSD 3-clause"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD 3-clause: "BSD-3-Clause"
+          description: "scala-java8-compat"
+          homepage_url: "http://www.scala-lang.org/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0.jar"
+            hash:
+              value: "1e6f1e745bf6d3c34d1e2ab150653306069aaf34"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0-sources.jar"
+            hash:
+              value: "0a33ce48278b9e3bbea8aed726e3c0abad3afadd"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/scala/scala-java8-compat.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/scala/scala-java8-compat.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
+          purl: "pkg:maven/org.scala-lang.modules/scala-parser-combinators_2.12@1.0.4"
+          authors:
+            - "EPFL"
+            - "Typesafe, Inc."
+            - "org.scala-lang.modules"
+          declared_licenses:
+            - "BSD 3-clause"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD 3-clause: "BSD-3-Clause"
+          description: "scala-parser-combinators"
+          homepage_url: "http://www.scala-lang.org/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4.jar"
+            hash:
+              value: "7c5f25a2d40ea7651452f0f0d1d4c12dabffcb8b"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4-sources.jar"
+            hash:
+              value: "9ec2f46c07d355853654af38e8b06e15ccca8cd0"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/scala/scala-parser-combinators.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/scala/scala-parser-combinators.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
+          purl: "pkg:maven/org.scala-lang.modules/scala-xml_2.12@1.0.5"
+          authors:
+            - "EPFL"
+            - "Typesafe, Inc."
+            - "org.scala-lang.modules"
+          declared_licenses:
+            - "BSD 3-clause"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD 3-clause: "BSD-3-Clause"
+          description: "scala-xml"
+          homepage_url: "http://www.scala-lang.org/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.5/scala-xml_2.12-1.0.5.jar"
+            hash:
+              value: "a2b2afbeea86818a911b05851bb11d7d4840bb75"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.5/scala-xml_2.12-1.0.5-sources.jar"
+            hash:
+              value: "d12864d1a73aa540f7b624c8a92a5f48783c342c"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/scala/scala-xml.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/scala/scala-xml.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scala-sbt:test-interface:1.0"
+          purl: "pkg:maven/org.scala-sbt/test-interface@1.0"
+          authors:
+            - "Bill Venners"
+            - "Chua Chee Seng"
+            - "Josh Cough"
+            - "Mark Harrah"
+            - "org.scala-sbt"
+          declared_licenses:
+            - "BSD"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD: "BSD-3-Clause"
+          description: "Uniform test interface to Scala/Java test frameworks (specs,\
+          \ ScalaCheck, ScalaTest, JUnit and other)"
+          homepage_url: "http://www.scala-sbt.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"
+            hash:
+              value: "0a3f14d010c4cb32071f863d97291df31603b521"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar"
+            hash:
+              value: "d44b23e9e3419ad0e00b91bba764a48d43075000"
+              algorithm: "SHA-1"
+          vcs:
+            type: ""
+            url: ""
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/sbt/test-interface.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scalacheck:scalacheck_2.12:1.13.5"
+          purl: "pkg:maven/org.scalacheck/scalacheck_2.12@1.13.5"
+          authors:
+            - "Rickard Nilsson"
+            - "org.scalacheck"
+          declared_licenses:
+            - "BSD-style"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD-style: "BSD-3-Clause"
+          description: "scalacheck"
+          homepage_url: "http://www.scalacheck.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scalacheck/scalacheck_2.12/1.13.5/scalacheck_2.12-1.13.5.jar"
+            hash:
+              value: "fff972ccaa0d83ca53bfdbbd0763c1059281fb76"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scalacheck/scalacheck_2.12/1.13.5/scalacheck_2.12-1.13.5-sources.jar"
+            hash:
+              value: "d0e1376902de65c7fa327f455b61d5d71957d78e"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:rickynils/scalacheck.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/rickynils/scalacheck.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scalactic:scalactic_2.12:3.0.4"
+          purl: "pkg:maven/org.scalactic/scalactic_2.12@3.0.4"
+          authors:
+            - "Bill Venners"
+            - "Chua Chee Seng"
+            - "George Berger"
+            - "org.scalactic"
+          declared_licenses:
+            - "the Apache License, ASL Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              the Apache License, ASL Version 2.0: "Apache-2.0"
+          description: "scalactic"
+          homepage_url: "http://www.scalatest.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scalactic/scalactic_2.12/3.0.4/scalactic_2.12-3.0.4.jar"
+            hash:
+              value: "e75f0f9c77aa391e01797cfc42fb82fd7c7d59a5"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scalactic/scalactic_2.12/3.0.4/scalactic_2.12-3.0.4-sources.jar"
+            hash:
+              value: "9f7f02217c7d2f14c6b1982493c39243a20b749d"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:scalatest/scalatest.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/scalatest/scalatest.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scalatest:scalatest_2.12:3.0.4"
+          purl: "pkg:maven/org.scalatest/scalatest_2.12@3.0.4"
+          authors:
+            - "Bill Venners"
+            - "Chua Chee Seng"
+            - "George Berger"
+            - "org.scalatest"
+          declared_licenses:
+            - "the Apache License, ASL Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              the Apache License, ASL Version 2.0: "Apache-2.0"
+          description: "scalatest"
+          homepage_url: "http://www.scalatest.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scalatest/scalatest_2.12/3.0.4/scalatest_2.12-3.0.4.jar"
+            hash:
+              value: "87d68f3d06dbf698fd0084c0a8b8996864d15465"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scalatest/scalatest_2.12/3.0.4/scalatest_2.12-3.0.4-sources.jar"
+            hash:
+              value: "ba669c2c9b7092151e2a19e975b1bf2a2e7a5fda"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:scalatest/scalatest.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/scalatest/scalatest.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scalaz:scalaz-core_2.12:7.2.8"
+          purl: "pkg:maven/org.scalaz/scalaz-core_2.12@7.2.8"
+          authors:
+            - "Alexey Romanov"
+            - "Daniel Peebles"
+            - "Edward Kmett"
+            - "Jason Zaugg"
+            - "Kris Nuttycombe"
+            - "Lars Hupel"
+            - "Paul Chiusano"
+            - "Richard Wallace"
+            - "Runar Bjarnason"
+            - "Tony Morris"
+            - "org.scalaz"
+          declared_licenses:
+            - "BSD-style"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD-style: "BSD-3-Clause"
+          description: "scalaz-core"
+          homepage_url: "http://scalaz.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scalaz/scalaz-core_2.12/7.2.8/scalaz-core_2.12-7.2.8.jar"
+            hash:
+              value: "2922d47f6dc7aba452634fe674087b6221b90dbf"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scalaz/scalaz-core_2.12/7.2.8/scalaz-core_2.12-7.2.8-sources.jar"
+            hash:
+              value: "c94295a434f26b5650ec0fcbf93c9d2c7aada88e"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:scalaz/scalaz.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/scalaz/scalaz.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
+          purl: "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.25"
+          authors:
+            - "Ceki Gulcu"
+            - "QOS.ch"
+          declared_licenses:
+            - "MIT License"
+          declared_licenses_processed:
+            spdx_expression: "MIT"
+            mapped:
+              MIT License: "MIT"
+          description: "JCL 1.2 implemented over SLF4J"
+          homepage_url: "http://www.slf4j.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25.jar"
+            hash:
+              value: "f8c32b13ff142a513eeb5b6330b1588dcb2c0461"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25-sources.jar"
+            hash:
+              value: "ffd0827a7c67d5915b7dc611afbda56a1f247191"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:qos-ch/slf4j.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/qos-ch/slf4j.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.slf4j:slf4j-api:1.7.25"
+          purl: "pkg:maven/org.slf4j/slf4j-api@1.7.25"
+          authors:
+            - "Ceki Gulcu"
+            - "QOS.ch"
+          declared_licenses:
+            - "MIT License"
+          declared_licenses_processed:
+            spdx_expression: "MIT"
+            mapped:
+              MIT License: "MIT"
+          description: "The slf4j API"
+          homepage_url: "http://www.slf4j.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
+            hash:
+              value: "da76ca59f6a57ee3102f8f9bd9cee742973efa8a"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25-sources.jar"
+            hash:
+              value: "962153db4a9ea71b79d047dfd1b2a0d80d8f4739"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:qos-ch/slf4j.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/qos-ch/slf4j.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.typelevel:macro-compat_2.12:1.1.1"
+          purl: "pkg:maven/org.typelevel/macro-compat_2.12@1.1.1"
+          authors:
+            - "Miles Sabin"
+            - "org.typelevel"
+          declared_licenses:
+            - "Apache 2"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              Apache 2: "Apache-2.0"
+          description: "core"
+          homepage_url: "https://github.com/milessabin/macro-compat"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1.jar"
+            hash:
+              value: "ed809d26ef4237d7c079ae6cf7ebd0dfa7986adf"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1-sources.jar"
+            hash:
+              value: "ade6d6ec81975cf514b0f9e2061614f2799cfe97"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:milessabin/macro-compat.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/milessabin/macro-compat.git"
+            revision: ""
+            path: ""
+        curations: []
+    has_issues: false
+scanner: null
+advisor: null
+evaluator: null

--- a/model/src/test/assets/sbt-multi-project-example-graph-old.yml
+++ b/model/src/test/assets/sbt-multi-project-example-graph-old.yml
@@ -1,0 +1,1364 @@
+---
+repository:
+  vcs:
+    type: "Git"
+    url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+    revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+    revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+    path: ""
+  config: {}
+analyzer:
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  environment:
+    ort_version: "HEAD"
+    java_version: "<REPLACE_JAVA>"
+    os: "<REPLACE_OS>"
+    processors: "<REPLACE_PROCESSORS>"
+    max_memory: "<REPLACE_MAX_MEMORY>"
+    variables: {}
+    tool_versions: {}
+  config:
+    ignore_tool_versions: false
+    allow_dynamic_versions: false
+  result:
+    projects:
+    - id: "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
+      definition_file_path: "common/target-scala-2.12-common_2.12-0.1-SNAPSHOT.pom"
+      authors:
+      - "com.pbassiner"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        path: "common"
+      homepage_url: ""
+      scope_names:
+      - "compile"
+      - "test"
+    - id: "SBT:com.pbassiner:multi1_2.12:0.1-SNAPSHOT"
+      definition_file_path: "multi1/target-scala-2.12-multi1_2.12-0.1-SNAPSHOT.pom"
+      authors:
+      - "com.pbassiner"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        path: "multi1"
+      homepage_url: ""
+      scope_names:
+      - "compile"
+      - "test"
+    - id: "SBT:com.pbassiner:multi2_2.12:0.1-SNAPSHOT"
+      definition_file_path: "multi2/target-scala-2.12-multi2_2.12-0.1-SNAPSHOT.pom"
+      authors:
+      - "com.pbassiner"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        path: "multi2"
+      homepage_url: ""
+      scope_names:
+      - "compile"
+      - "test"
+    - id: "SBT:com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT"
+      definition_file_path: "target-scala-2.12-sbt-multi-project-example_2.12-0.1-SNAPSHOT.pom"
+      authors:
+      - "com.pbassiner"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        path: ""
+      homepage_url: ""
+      scope_names:
+      - "compile"
+    packages:
+    - package:
+        id: "Maven:ch.qos.logback:logback-classic:1.2.3"
+        purl: "pkg:maven/ch.qos.logback/logback-classic@1.2.3"
+        authors:
+        - "Ceki Gulcu"
+        - "Joern Huxhorn"
+        - "QOS.ch"
+        declared_licenses:
+        - "Eclipse Public License - v 1.0"
+        - "GNU Lesser General Public License"
+        declared_licenses_processed:
+          spdx_expression: "EPL-1.0 OR LGPL-2.1-or-later"
+          mapped:
+            Eclipse Public License - v 1.0: "EPL-1.0"
+            GNU Lesser General Public License: "LGPL-2.1-or-later"
+        description: "logback-classic module"
+        homepage_url: "http://logback.qos.ch/logback-classic"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar"
+          hash:
+            value: "7c4f3c474fb2c041d8028740440937705ebb473a"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3-sources.jar"
+          hash:
+            value: "cfd5385e0c5ed1c8a5dce57d86e79cf357153a64"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:ceki/logback.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/ceki/logback.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:ch.qos.logback:logback-core:1.2.3"
+        purl: "pkg:maven/ch.qos.logback/logback-core@1.2.3"
+        authors:
+        - "Ceki Gulcu"
+        - "Joern Huxhorn"
+        - "QOS.ch"
+        declared_licenses:
+        - "Eclipse Public License - v 1.0"
+        - "GNU Lesser General Public License"
+        declared_licenses_processed:
+          spdx_expression: "EPL-1.0 OR LGPL-2.1-or-later"
+          mapped:
+            Eclipse Public License - v 1.0: "EPL-1.0"
+            GNU Lesser General Public License: "LGPL-2.1-or-later"
+        description: "logback-core module"
+        homepage_url: "http://logback.qos.ch/logback-core"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar"
+          hash:
+            value: "864344400c3d4d92dfeb0a305dc87d953677c03c"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3-sources.jar"
+          hash:
+            value: "3ebabe69eba0196af9ad3a814f723fb720b9101e"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:ceki/logback.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/ceki/logback.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.chuusai:shapeless_2.12:2.3.2"
+        purl: "pkg:maven/com.chuusai/shapeless_2.12@2.3.2"
+        authors:
+        - "Miles Sabin"
+        - "com.chuusai"
+        declared_licenses:
+        - "Apache 2"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache 2: "Apache-2.0"
+        description: "core"
+        homepage_url: "https://github.com/milessabin/shapeless"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2.jar"
+          hash:
+            value: "27e115ffed7917b456e54891de67173f4a68d5f1"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2-sources.jar"
+          hash:
+            value: "6d83fa4fa6d25b1e8d8cd9d9d551c05c745633b1"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:milessabin/shapeless.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/milessabin/shapeless.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
+        purl: "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.8.0"
+        authors:
+        - "Christopher Currie"
+        - "FasterXML"
+        - "Paul Brown"
+        - "Tatu Saloranta"
+        declared_licenses:
+        - "The Apache Software License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
+        description: "Core annotations used for value types, used by Jackson data\
+          \ binding package."
+        homepage_url: "http://github.com/FasterXML/jackson"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.8.0/jackson-annotations-2.8.0.jar"
+          hash:
+            value: "45b426f7796b741035581a176744d91090e2e6fb"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.8.0/jackson-annotations-2.8.0-sources.jar"
+          hash:
+            value: "29a1a95363d497e856c0a7d682e4f7973e334068"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:FasterXML/jackson-annotations.git"
+          revision: "jackson-annotations-2.8.0"
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/FasterXML/jackson-annotations.git"
+          revision: "jackson-annotations-2.8.0"
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
+        purl: "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.8.9"
+        authors:
+        - "Christopher Currie"
+        - "FasterXML"
+        - "Paul Brown"
+        - "Tatu Saloranta"
+        declared_licenses:
+        - "The Apache Software License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
+        description: "Core Jackson abstractions, basic JSON streaming API implementation"
+        homepage_url: "https://github.com/FasterXML/jackson-core"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.8.9/jackson-core-2.8.9.jar"
+          hash:
+            value: "569b1752705da98f49aabe2911cc956ff7d8ed9d"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.8.9/jackson-core-2.8.9-sources.jar"
+          hash:
+            value: "8cf3613202ddcd495137f8cb944e2da69964a641"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:FasterXML/jackson-core.git"
+          revision: "jackson-core-2.8.9"
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/FasterXML/jackson-core.git"
+          revision: "jackson-core-2.8.9"
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9"
+        purl: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.9"
+        authors:
+        - "Christopher Currie"
+        - "FasterXML"
+        - "Paul Brown"
+        - "Tatu Saloranta"
+        declared_licenses:
+        - "The Apache Software License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            The Apache Software License, Version 2.0: "Apache-2.0"
+        description: "General data-binding functionality for Jackson: works on core\
+          \ streaming API"
+        homepage_url: "http://github.com/FasterXML/jackson"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.8.9/jackson-databind-2.8.9.jar"
+          hash:
+            value: "4dfca3975be3c1a98eacb829e70f02e9a71bc159"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.8.9/jackson-databind-2.8.9-sources.jar"
+          hash:
+            value: "98e1b4171628d8f230f6a60b248de84ed04fab0d"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:FasterXML/jackson-databind.git"
+          revision: "jackson-databind-2.8.9"
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/FasterXML/jackson-databind.git"
+          revision: "jackson-databind-2.8.9"
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.github.julien-truffaut:monocle-core_2.12:1.4.0"
+        purl: "pkg:maven/com.github.julien-truffaut/monocle-core_2.12@1.4.0"
+        authors:
+        - "Ilan Godik"
+        - "Julien Truffaut"
+        - "Kenji Yoshida"
+        - "Naoki Aoyama"
+        - "com.github.julien-truffaut"
+        declared_licenses:
+        - "MIT"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+        description: "core"
+        homepage_url: "https://github.com/julien-truffaut/Monocle"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-core_2.12/1.4.0/monocle-core_2.12-1.4.0.jar"
+          hash:
+            value: "219da9cc75878a75c888e38ad883fe4d30a7651d"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-core_2.12/1.4.0/monocle-core_2.12-1.4.0-sources.jar"
+          hash:
+            value: "37d333798ca15a03f5dfbb02f133d5b6b8e57b8c"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:julien-truffaut/Monocle.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/julien-truffaut/Monocle.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.github.julien-truffaut:monocle-macro_2.12:1.4.0"
+        purl: "pkg:maven/com.github.julien-truffaut/monocle-macro_2.12@1.4.0"
+        authors:
+        - "Ilan Godik"
+        - "Julien Truffaut"
+        - "Kenji Yoshida"
+        - "Naoki Aoyama"
+        - "com.github.julien-truffaut"
+        declared_licenses:
+        - "MIT"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+        description: "macros"
+        homepage_url: "https://github.com/julien-truffaut/Monocle"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-macro_2.12/1.4.0/monocle-macro_2.12-1.4.0.jar"
+          hash:
+            value: "319242d130983fec319a2e2d4f8e7741b809b5a0"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-macro_2.12/1.4.0/monocle-macro_2.12-1.4.0-sources.jar"
+          hash:
+            value: "e7ce64d7973ad64f3fa872b931a31c8c25de59b3"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:julien-truffaut/Monocle.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/julien-truffaut/Monocle.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.github.pureconfig:pureconfig-macros_2.12:0.8.0"
+        purl: "pkg:maven/com.github.pureconfig/pureconfig-macros_2.12@0.8.0"
+        authors:
+        - "Rui Gonçalves"
+        - "com.github.pureconfig"
+        declared_licenses:
+        - "Mozilla Public License, version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "MPL-2.0"
+          mapped:
+            Mozilla Public License, version 2.0: "MPL-2.0"
+        description: "pureconfig-macros"
+        homepage_url: "https://github.com/pureconfig/pureconfig"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig-macros_2.12/0.8.0/pureconfig-macros_2.12-0.8.0.jar"
+          hash:
+            value: "eea0e86f18c08e7fd00c90626f4f17a9ee6ef088"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig-macros_2.12/0.8.0/pureconfig-macros_2.12-0.8.0-sources.jar"
+          hash:
+            value: "7411f96540756236648b48347827b6ba2622e5e0"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:pureconfig/pureconfig.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/pureconfig/pureconfig.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.github.pureconfig:pureconfig_2.12:0.8.0"
+        purl: "pkg:maven/com.github.pureconfig/pureconfig_2.12@0.8.0"
+        authors:
+        - "Derek Morr"
+        - "Joao Azevedo"
+        - "Leif Wickland"
+        - "Mario Pastorelli"
+        - "Rui Gonçalves"
+        - "com.github.pureconfig"
+        declared_licenses:
+        - "Mozilla Public License, version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "MPL-2.0"
+          mapped:
+            Mozilla Public License, version 2.0: "MPL-2.0"
+        description: "pureconfig"
+        homepage_url: "https://github.com/pureconfig/pureconfig"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig_2.12/0.8.0/pureconfig_2.12-0.8.0.jar"
+          hash:
+            value: "891fde63cda086f593bffddb0b47933abc75523f"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig_2.12/0.8.0/pureconfig_2.12-0.8.0-sources.jar"
+          hash:
+            value: "fa6de3ab2dd82543fb37288626687a9a6c1a67a2"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:pureconfig/pureconfig.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/pureconfig/pureconfig.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.typesafe:config:1.3.1"
+        purl: "pkg:maven/com.typesafe/config@1.3.1"
+        authors:
+        - "Havoc Pennington"
+        - "com.typesafe"
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+        description: "config"
+        homepage_url: "https://github.com/typesafehub/config"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/config/1.3.1/config-1.3.1.jar"
+          hash:
+            value: "2cf7a6cc79732e3bdf1647d7404279900ca63eb0"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/config/1.3.1/config-1.3.1-sources.jar"
+          hash:
+            value: "a27878630ff503b63ed25ff2a25fa8ef888740b3"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/typesafehub/config.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/typesafehub/config.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.typesafe:ssl-config-core_2.12:0.2.2"
+        purl: "pkg:maven/com.typesafe/ssl-config-core_2.12@0.2.2"
+        authors:
+        - "Konrad Malawski"
+        - "Will Sargent"
+        - "com.typesafe"
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+        description: "ssl-config-core"
+        homepage_url: "https://github.com/typesafehub/ssl-config"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/ssl-config-core_2.12/0.2.2/ssl-config-core_2.12-0.2.2.jar"
+          hash:
+            value: "8a357d491f7f94c5b4b1e0b27644e1306cc8742d"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/ssl-config-core_2.12/0.2.2/ssl-config-core_2.12-0.2.2-sources.jar"
+          hash:
+            value: "1baaec9149929d0970330aa80aca73e3f1f15624"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/typesafehub/ssl-config.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/typesafehub/ssl-config.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"
+        purl: "pkg:maven/com.typesafe.akka/akka-actor_2.12@2.5.6"
+        authors:
+        - "Akka Contributors"
+        - "Lightbend Inc."
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+        description: "akka-actor"
+        homepage_url: "http://akka.io/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.6/akka-actor_2.12-2.5.6.jar"
+          hash:
+            value: "1e9f4c1829d3ce5640c17164b1756d1e98eb7af3"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.6/akka-actor_2.12-2.5.6-sources.jar"
+          hash:
+            value: "9642cf6f2a774d781e2f2a2e5de152971bfd714e"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:akka/akka.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/akka/akka.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"
+        purl: "pkg:maven/com.typesafe.akka/akka-stream_2.12@2.5.6"
+        authors:
+        - "Akka Contributors"
+        - "Lightbend Inc."
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+        description: "akka-stream"
+        homepage_url: "http://akka.io/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-stream_2.12/2.5.6/akka-stream_2.12-2.5.6.jar"
+          hash:
+            value: "876aa1471ac773a3dd02f70c1e511a9a014b3491"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-stream_2.12/2.5.6/akka-stream_2.12-2.5.6-sources.jar"
+          hash:
+            value: "14459df7523aea2cfd04080fe88eccd20897bcc5"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:akka/akka.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/akka/akka.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2"
+        purl: "pkg:maven/com.typesafe.scala-logging/scala-logging_2.12@3.7.2"
+        authors:
+        - "Heiko Seeberger"
+        - "Mathias Bogaert"
+        - "com.typesafe.scala-logging"
+        declared_licenses:
+        - "Apache 2.0 License"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache 2.0 License: "Apache-2.0"
+        description: "scala-logging"
+        homepage_url: "https://github.com/typesafehub/scala-logging"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.7.2/scala-logging_2.12-3.7.2.jar"
+          hash:
+            value: "a1dc97509765287faa4747f7cb411f0b85dc9a34"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.7.2/scala-logging_2.12-3.7.2-sources.jar"
+          hash:
+            value: "a5f760917b60283e37c84bf3db2aeaf976980ad3"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/typesafehub/scala-logging.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/typesafehub/scala-logging.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:net.logstash.logback:logstash-logback-encoder:4.11"
+        purl: "pkg:maven/net.logstash.logback/logstash-logback-encoder@4.11"
+        authors:
+        - "John E. Vincent"
+        - "Nokia"
+        - "Phil Clay"
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        - "MIT License"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0 OR MIT"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+            MIT License: "MIT"
+        description: "Logback encoder which will output events as Logstash-compatible\
+          \ JSON"
+        homepage_url: "https://github.com/logstash/logstash-logback-encoder"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/net/logstash/logback/logstash-logback-encoder/4.11/logstash-logback-encoder-4.11.jar"
+          hash:
+            value: "163b6b046de5414ac17c83cbd6cb619e541fc69a"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/net/logstash/logback/logstash-logback-encoder/4.11/logstash-logback-encoder-4.11-sources.jar"
+          hash:
+            value: "8b889d5eb55aabfa5d9aa9cad95529668f3edb2b"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:logstash/logstash-logback-encoder.git"
+          revision: "logstash-logback-encoder-4.11"
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/logstash/logstash-logback-encoder.git"
+          revision: "logstash-logback-encoder-4.11"
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.reactivestreams:reactive-streams:1.0.1"
+        purl: "pkg:maven/org.reactivestreams/reactive-streams@1.0.1"
+        authors:
+        - "Reactive Streams SIG"
+        declared_licenses:
+        - "CC0"
+        declared_licenses_processed:
+          spdx_expression: "CC0-1.0"
+          mapped:
+            CC0: "CC0-1.0"
+        description: "A Protocol for Asynchronous Non-Blocking Data Sequence"
+        homepage_url: "http://www.reactive-streams.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/reactivestreams/reactive-streams/1.0.1/reactive-streams-1.0.1.jar"
+          hash:
+            value: "1b1c911686eb40179219466e6a59b634b9d7a748"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/reactivestreams/reactive-streams/1.0.1/reactive-streams-1.0.1-sources.jar"
+          hash:
+            value: "af471e34e448bd4f1c183e9b26c85679be11035c"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:reactive-streams/reactive-streams.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/reactive-streams/reactive-streams.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang:scala-compiler:2.12.3"
+        purl: "pkg:maven/org.scala-lang/scala-compiler@2.12.3"
+        authors:
+        - "LAMP/EPFL"
+        - "Lightbend, Inc."
+        declared_licenses:
+        - "BSD 3-Clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-Clause: "BSD-3-Clause"
+        description: "Compiler for the Scala Programming Language"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-compiler/2.12.3/scala-compiler-2.12.3.jar"
+          hash:
+            value: "b6b9ca202fc8405260d30e703b9790e91c75cd85"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-compiler/2.12.3/scala-compiler-2.12.3-sources.jar"
+          hash:
+            value: "b8fe133c260f72b7fe9889195e19efeeab1b8087"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang:scala-library:2.12.3"
+        purl: "pkg:maven/org.scala-lang/scala-library@2.12.3"
+        authors:
+        - "LAMP/EPFL"
+        - "Lightbend, Inc."
+        declared_licenses:
+        - "BSD 3-Clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-Clause: "BSD-3-Clause"
+        description: "Standard library for the Scala Programming Language"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.12.3/scala-library-2.12.3.jar"
+          hash:
+            value: "f2e496f21af2d80b48e0a61773f84c3a76a0d06f"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.12.3/scala-library-2.12.3-sources.jar"
+          hash:
+            value: "499c91b0a64bc706eee174481a3b7dde81b3591d"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang:scala-reflect:2.12.2"
+        purl: "pkg:maven/org.scala-lang/scala-reflect@2.12.2"
+        authors:
+        - "LAMP/EPFL"
+        - "Lightbend, Inc."
+        declared_licenses:
+        - "BSD 3-Clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-Clause: "BSD-3-Clause"
+        description: "Compiler for the Scala Programming Language"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-reflect/2.12.2/scala-reflect-2.12.2.jar"
+          hash:
+            value: "fa13c13351566738ff156ef8a56b869868f4b77e"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-reflect/2.12.2/scala-reflect-2.12.2-sources.jar"
+          hash:
+            value: "a8808be417014e233b25ee44439f725e1f5e92a4"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0"
+        purl: "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.12@0.8.0"
+        authors:
+        - "EPFL"
+        - "Typesafe, Inc."
+        - "org.scala-lang.modules"
+        declared_licenses:
+        - "BSD 3-clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-clause: "BSD-3-Clause"
+        description: "scala-java8-compat"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0.jar"
+          hash:
+            value: "1e6f1e745bf6d3c34d1e2ab150653306069aaf34"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0-sources.jar"
+          hash:
+            value: "0a33ce48278b9e3bbea8aed726e3c0abad3afadd"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala-java8-compat.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala-java8-compat.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
+        purl: "pkg:maven/org.scala-lang.modules/scala-parser-combinators_2.12@1.0.4"
+        authors:
+        - "EPFL"
+        - "Typesafe, Inc."
+        - "org.scala-lang.modules"
+        declared_licenses:
+        - "BSD 3-clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-clause: "BSD-3-Clause"
+        description: "scala-parser-combinators"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4.jar"
+          hash:
+            value: "7c5f25a2d40ea7651452f0f0d1d4c12dabffcb8b"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4-sources.jar"
+          hash:
+            value: "9ec2f46c07d355853654af38e8b06e15ccca8cd0"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala-parser-combinators.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala-parser-combinators.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
+        purl: "pkg:maven/org.scala-lang.modules/scala-xml_2.12@1.0.5"
+        authors:
+        - "EPFL"
+        - "Typesafe, Inc."
+        - "org.scala-lang.modules"
+        declared_licenses:
+        - "BSD 3-clause"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD 3-clause: "BSD-3-Clause"
+        description: "scala-xml"
+        homepage_url: "http://www.scala-lang.org/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.5/scala-xml_2.12-1.0.5.jar"
+          hash:
+            value: "a2b2afbeea86818a911b05851bb11d7d4840bb75"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.5/scala-xml_2.12-1.0.5-sources.jar"
+          hash:
+            value: "d12864d1a73aa540f7b624c8a92a5f48783c342c"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git://github.com/scala/scala-xml.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/scala/scala-xml.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scala-sbt:test-interface:1.0"
+        purl: "pkg:maven/org.scala-sbt/test-interface@1.0"
+        authors:
+        - "Bill Venners"
+        - "Chua Chee Seng"
+        - "Josh Cough"
+        - "Mark Harrah"
+        - "org.scala-sbt"
+        declared_licenses:
+        - "BSD"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD: "BSD-3-Clause"
+        description: "Uniform test interface to Scala/Java test frameworks (specs,\
+          \ ScalaCheck, ScalaTest, JUnit and other)"
+        homepage_url: "http://www.scala-sbt.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"
+          hash:
+            value: "0a3f14d010c4cb32071f863d97291df31603b521"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar"
+          hash:
+            value: "d44b23e9e3419ad0e00b91bba764a48d43075000"
+            algorithm: "SHA-1"
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/sbt/test-interface.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scalacheck:scalacheck_2.12:1.13.5"
+        purl: "pkg:maven/org.scalacheck/scalacheck_2.12@1.13.5"
+        authors:
+        - "Rickard Nilsson"
+        - "org.scalacheck"
+        declared_licenses:
+        - "BSD-style"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD-style: "BSD-3-Clause"
+        description: "scalacheck"
+        homepage_url: "http://www.scalacheck.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalacheck/scalacheck_2.12/1.13.5/scalacheck_2.12-1.13.5.jar"
+          hash:
+            value: "fff972ccaa0d83ca53bfdbbd0763c1059281fb76"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalacheck/scalacheck_2.12/1.13.5/scalacheck_2.12-1.13.5-sources.jar"
+          hash:
+            value: "d0e1376902de65c7fa327f455b61d5d71957d78e"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:rickynils/scalacheck.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/rickynils/scalacheck.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scalactic:scalactic_2.12:3.0.4"
+        purl: "pkg:maven/org.scalactic/scalactic_2.12@3.0.4"
+        authors:
+        - "Bill Venners"
+        - "Chua Chee Seng"
+        - "George Berger"
+        - "org.scalactic"
+        declared_licenses:
+        - "the Apache License, ASL Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            the Apache License, ASL Version 2.0: "Apache-2.0"
+        description: "scalactic"
+        homepage_url: "http://www.scalatest.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalactic/scalactic_2.12/3.0.4/scalactic_2.12-3.0.4.jar"
+          hash:
+            value: "e75f0f9c77aa391e01797cfc42fb82fd7c7d59a5"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalactic/scalactic_2.12/3.0.4/scalactic_2.12-3.0.4-sources.jar"
+          hash:
+            value: "9f7f02217c7d2f14c6b1982493c39243a20b749d"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:scalatest/scalatest.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/scalatest/scalatest.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scalatest:scalatest_2.12:3.0.4"
+        purl: "pkg:maven/org.scalatest/scalatest_2.12@3.0.4"
+        authors:
+        - "Bill Venners"
+        - "Chua Chee Seng"
+        - "George Berger"
+        - "org.scalatest"
+        declared_licenses:
+        - "the Apache License, ASL Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            the Apache License, ASL Version 2.0: "Apache-2.0"
+        description: "scalatest"
+        homepage_url: "http://www.scalatest.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalatest/scalatest_2.12/3.0.4/scalatest_2.12-3.0.4.jar"
+          hash:
+            value: "87d68f3d06dbf698fd0084c0a8b8996864d15465"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalatest/scalatest_2.12/3.0.4/scalatest_2.12-3.0.4-sources.jar"
+          hash:
+            value: "ba669c2c9b7092151e2a19e975b1bf2a2e7a5fda"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:scalatest/scalatest.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/scalatest/scalatest.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.scalaz:scalaz-core_2.12:7.2.8"
+        purl: "pkg:maven/org.scalaz/scalaz-core_2.12@7.2.8"
+        authors:
+        - "Alexey Romanov"
+        - "Daniel Peebles"
+        - "Edward Kmett"
+        - "Jason Zaugg"
+        - "Kris Nuttycombe"
+        - "Lars Hupel"
+        - "Paul Chiusano"
+        - "Richard Wallace"
+        - "Runar Bjarnason"
+        - "Tony Morris"
+        - "org.scalaz"
+        declared_licenses:
+        - "BSD-style"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            BSD-style: "BSD-3-Clause"
+        description: "scalaz-core"
+        homepage_url: "http://scalaz.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalaz/scalaz-core_2.12/7.2.8/scalaz-core_2.12-7.2.8.jar"
+          hash:
+            value: "2922d47f6dc7aba452634fe674087b6221b90dbf"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/scalaz/scalaz-core_2.12/7.2.8/scalaz-core_2.12-7.2.8-sources.jar"
+          hash:
+            value: "c94295a434f26b5650ec0fcbf93c9d2c7aada88e"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:scalaz/scalaz.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/scalaz/scalaz.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
+        purl: "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.25"
+        authors:
+        - "Ceki Gulcu"
+        - "QOS.ch"
+        declared_licenses:
+        - "MIT License"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+          mapped:
+            MIT License: "MIT"
+        description: "JCL 1.2 implemented over SLF4J"
+        homepage_url: "http://www.slf4j.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25.jar"
+          hash:
+            value: "f8c32b13ff142a513eeb5b6330b1588dcb2c0461"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25-sources.jar"
+          hash:
+            value: "ffd0827a7c67d5915b7dc611afbda56a1f247191"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:qos-ch/slf4j.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/qos-ch/slf4j.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.slf4j:slf4j-api:1.7.25"
+        purl: "pkg:maven/org.slf4j/slf4j-api@1.7.25"
+        authors:
+        - "Ceki Gulcu"
+        - "QOS.ch"
+        declared_licenses:
+        - "MIT License"
+        declared_licenses_processed:
+          spdx_expression: "MIT"
+          mapped:
+            MIT License: "MIT"
+        description: "The slf4j API"
+        homepage_url: "http://www.slf4j.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
+          hash:
+            value: "da76ca59f6a57ee3102f8f9bd9cee742973efa8a"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25-sources.jar"
+          hash:
+            value: "962153db4a9ea71b79d047dfd1b2a0d80d8f4739"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:qos-ch/slf4j.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/qos-ch/slf4j.git"
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.typelevel:macro-compat_2.12:1.1.1"
+        purl: "pkg:maven/org.typelevel/macro-compat_2.12@1.1.1"
+        authors:
+        - "Miles Sabin"
+        - "org.typelevel"
+        declared_licenses:
+        - "Apache 2"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache 2: "Apache-2.0"
+        description: "core"
+        homepage_url: "https://github.com/milessabin/macro-compat"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1.jar"
+          hash:
+            value: "ed809d26ef4237d7c079ae6cf7ebd0dfa7986adf"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1-sources.jar"
+          hash:
+            value: "ade6d6ec81975cf514b0f9e2061614f2799cfe97"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "git@github.com:milessabin/macro-compat.git"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "ssh://git@github.com/milessabin/macro-compat.git"
+          revision: ""
+          path: ""
+      curations: []
+    dependency_graphs:
+      SBT:
+        packages:
+        - "Maven:ch.qos.logback:logback-classic:1.2.3"
+        - "Maven:ch.qos.logback:logback-core:1.2.3"
+        - "Maven:org.slf4j:slf4j-api:1.7.25"
+        - "Maven:com.typesafe:config:1.3.1"
+        - "Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"
+        - "Maven:com.typesafe:ssl-config-core_2.12:0.2.2"
+        - "Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"
+        - "Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0"
+        - "Maven:org.reactivestreams:reactive-streams:1.0.1"
+        - "Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2"
+        - "Maven:org.scala-lang:scala-reflect:2.12.2"
+        - "Maven:net.logstash.logback:logstash-logback-encoder:4.11"
+        - "Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9"
+        - "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
+        - "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
+        - "Maven:org.scala-lang:scala-library:2.12.3"
+        - "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
+        - "Maven:org.scalacheck:scalacheck_2.12:1.13.5"
+        - "Maven:org.scala-sbt:test-interface:1.0"
+        - "Maven:org.scalatest:scalatest_2.12:3.0.4"
+        - "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
+        - "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
+        - "Maven:org.scalactic:scalactic_2.12:3.0.4"
+        - "Maven:com.github.julien-truffaut:monocle-core_2.12:1.4.0"
+        - "Maven:org.scalaz:scalaz-core_2.12:7.2.8"
+        - "Maven:com.github.julien-truffaut:monocle-macro_2.12:1.4.0"
+        - "Maven:org.typelevel:macro-compat_2.12:1.1.1"
+        - "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
+        - "Maven:com.github.pureconfig:pureconfig_2.12:0.8.0"
+        - "Maven:com.chuusai:shapeless_2.12:2.3.2"
+        - "Maven:com.github.pureconfig:pureconfig-macros_2.12:0.8.0"
+        - "Maven:org.scala-lang:scala-compiler:2.12.3"
+        scope_roots:
+        - dependencies:
+          - pkg: 1
+          - pkg: 2
+        - pkg: 3
+        - pkg: 4
+          dependencies:
+          - pkg: 5
+          - pkg: 6
+            dependencies:
+            - pkg: 7
+          - pkg: 8
+        - pkg: 9
+          dependencies:
+          - pkg: 10
+        - pkg: 11
+          dependencies:
+          - pkg: 12
+            dependencies:
+            - pkg: 13
+            - pkg: 14
+        - pkg: 15
+        - pkg: 16
+        - pkg: 17
+          dependencies:
+          - pkg: 18
+        - pkg: 19
+          dependencies:
+          - pkg: 20
+          - pkg: 21
+          - pkg: 22
+        - pkg: 23
+          dependencies:
+          - pkg: 24
+        - pkg: 25
+          dependencies:
+          - pkg: 26
+        - pkg: 27
+          linkage: "PROJECT_DYNAMIC"
+        - pkg: 28
+          dependencies:
+          - pkg: 29
+          - pkg: 30
+            dependencies:
+            - pkg: 26
+            - pkg: 31
+        scopes:
+          com.pbassiner:common_2.12:0.1-SNAPSHOT:compile:
+          - root: 0
+          - root: 3
+          - root: 4
+          - root: 9
+          - root: 11
+          - root: 15
+          - root: 16
+          com.pbassiner:common_2.12:0.1-SNAPSHOT:test:
+          - root: 17
+          - root: 19
+          com.pbassiner:multi1_2.12:0.1-SNAPSHOT:compile:
+          - root: 0
+          - root: 23
+          - root: 25
+          - root: 3
+          - root: 4
+          - root: 9
+          - root: 11
+          - root: 15
+          - root: 16
+          - root: 27
+          com.pbassiner:multi1_2.12:0.1-SNAPSHOT:test:
+          - root: 17
+          - root: 19
+          com.pbassiner:multi2_2.12:0.1-SNAPSHOT:compile:
+          - root: 0
+          - root: 28
+          - root: 3
+          - root: 4
+          - root: 9
+          - root: 11
+          - root: 15
+          - root: 16
+          - root: 27
+          com.pbassiner:multi2_2.12:0.1-SNAPSHOT:test:
+          - root: 17
+          - root: 19
+          com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT:compile:
+          - root: 15
+scanner: null
+advisor: null
+evaluator: null

--- a/model/src/test/assets/sbt-multi-project-example-graph.yml
+++ b/model/src/test/assets/sbt-multi-project-example-graph.yml
@@ -1,0 +1,1394 @@
+---
+repository:
+  vcs:
+    type: "Git"
+    url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+    revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+    revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+    path: ""
+  config: {}
+analyzer:
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  environment:
+    ort_version: "HEAD"
+    java_version: "<REPLACE_JAVA>"
+    os: "<REPLACE_OS>"
+    processors: "<REPLACE_PROCESSORS>"
+    max_memory: "<REPLACE_MAX_MEMORY>"
+    variables: {}
+    tool_versions: {}
+  config:
+    ignore_tool_versions: false
+    allow_dynamic_versions: false
+  result:
+    projects:
+      - id: "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
+        definition_file_path: "common/target-scala-2.12-common_2.12-0.1-SNAPSHOT.pom"
+        authors:
+          - "com.pbassiner"
+        declared_licenses: []
+        declared_licenses_processed: {}
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+          revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+          path: "common"
+        homepage_url: ""
+        scope_names:
+          - "compile"
+          - "test"
+      - id: "SBT:com.pbassiner:multi1_2.12:0.1-SNAPSHOT"
+        definition_file_path: "multi1/target-scala-2.12-multi1_2.12-0.1-SNAPSHOT.pom"
+        authors:
+          - "com.pbassiner"
+        declared_licenses: []
+        declared_licenses_processed: {}
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+          revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+          path: "multi1"
+        homepage_url: ""
+        scope_names:
+          - "compile"
+          - "test"
+      - id: "SBT:com.pbassiner:multi2_2.12:0.1-SNAPSHOT"
+        definition_file_path: "multi2/target-scala-2.12-multi2_2.12-0.1-SNAPSHOT.pom"
+        authors:
+          - "com.pbassiner"
+        declared_licenses: []
+        declared_licenses_processed: {}
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+          revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+          path: "multi2"
+        homepage_url: ""
+        scope_names:
+          - "compile"
+          - "test"
+      - id: "SBT:com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT"
+        definition_file_path: "target-scala-2.12-sbt-multi-project-example_2.12-0.1-SNAPSHOT.pom"
+        authors:
+          - "com.pbassiner"
+        declared_licenses: []
+        declared_licenses_processed: {}
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/pbassiner/sbt-multi-project-example.git"
+          revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+          path: ""
+        homepage_url: ""
+        scope_names:
+          - "compile"
+    packages:
+      - package:
+          id: "Maven:ch.qos.logback:logback-classic:1.2.3"
+          purl: "pkg:maven/ch.qos.logback/logback-classic@1.2.3"
+          authors:
+            - "Ceki Gulcu"
+            - "Joern Huxhorn"
+            - "QOS.ch"
+          declared_licenses:
+            - "Eclipse Public License - v 1.0"
+            - "GNU Lesser General Public License"
+          declared_licenses_processed:
+            spdx_expression: "EPL-1.0 OR LGPL-2.1-or-later"
+            mapped:
+              Eclipse Public License - v 1.0: "EPL-1.0"
+              GNU Lesser General Public License: "LGPL-2.1-or-later"
+          description: "logback-classic module"
+          homepage_url: "http://logback.qos.ch/logback-classic"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar"
+            hash:
+              value: "7c4f3c474fb2c041d8028740440937705ebb473a"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3-sources.jar"
+            hash:
+              value: "cfd5385e0c5ed1c8a5dce57d86e79cf357153a64"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:ceki/logback.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/ceki/logback.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:ch.qos.logback:logback-core:1.2.3"
+          purl: "pkg:maven/ch.qos.logback/logback-core@1.2.3"
+          authors:
+            - "Ceki Gulcu"
+            - "Joern Huxhorn"
+            - "QOS.ch"
+          declared_licenses:
+            - "Eclipse Public License - v 1.0"
+            - "GNU Lesser General Public License"
+          declared_licenses_processed:
+            spdx_expression: "EPL-1.0 OR LGPL-2.1-or-later"
+            mapped:
+              Eclipse Public License - v 1.0: "EPL-1.0"
+              GNU Lesser General Public License: "LGPL-2.1-or-later"
+          description: "logback-core module"
+          homepage_url: "http://logback.qos.ch/logback-core"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar"
+            hash:
+              value: "864344400c3d4d92dfeb0a305dc87d953677c03c"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3-sources.jar"
+            hash:
+              value: "3ebabe69eba0196af9ad3a814f723fb720b9101e"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:ceki/logback.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/ceki/logback.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.chuusai:shapeless_2.12:2.3.2"
+          purl: "pkg:maven/com.chuusai/shapeless_2.12@2.3.2"
+          authors:
+            - "Miles Sabin"
+            - "com.chuusai"
+          declared_licenses:
+            - "Apache 2"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              Apache 2: "Apache-2.0"
+          description: "core"
+          homepage_url: "https://github.com/milessabin/shapeless"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2.jar"
+            hash:
+              value: "27e115ffed7917b456e54891de67173f4a68d5f1"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2-sources.jar"
+            hash:
+              value: "6d83fa4fa6d25b1e8d8cd9d9d551c05c745633b1"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:milessabin/shapeless.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/milessabin/shapeless.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
+          purl: "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.8.0"
+          authors:
+            - "Christopher Currie"
+            - "FasterXML"
+            - "Paul Brown"
+            - "Tatu Saloranta"
+          declared_licenses:
+            - "The Apache Software License, Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              The Apache Software License, Version 2.0: "Apache-2.0"
+          description: "Core annotations used for value types, used by Jackson data\
+          \ binding package."
+          homepage_url: "http://github.com/FasterXML/jackson"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.8.0/jackson-annotations-2.8.0.jar"
+            hash:
+              value: "45b426f7796b741035581a176744d91090e2e6fb"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.8.0/jackson-annotations-2.8.0-sources.jar"
+            hash:
+              value: "29a1a95363d497e856c0a7d682e4f7973e334068"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:FasterXML/jackson-annotations.git"
+            revision: "jackson-annotations-2.8.0"
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/FasterXML/jackson-annotations.git"
+            revision: "jackson-annotations-2.8.0"
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
+          purl: "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.8.9"
+          authors:
+            - "Christopher Currie"
+            - "FasterXML"
+            - "Paul Brown"
+            - "Tatu Saloranta"
+          declared_licenses:
+            - "The Apache Software License, Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              The Apache Software License, Version 2.0: "Apache-2.0"
+          description: "Core Jackson abstractions, basic JSON streaming API implementation"
+          homepage_url: "https://github.com/FasterXML/jackson-core"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.8.9/jackson-core-2.8.9.jar"
+            hash:
+              value: "569b1752705da98f49aabe2911cc956ff7d8ed9d"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.8.9/jackson-core-2.8.9-sources.jar"
+            hash:
+              value: "8cf3613202ddcd495137f8cb944e2da69964a641"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:FasterXML/jackson-core.git"
+            revision: "jackson-core-2.8.9"
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/FasterXML/jackson-core.git"
+            revision: "jackson-core-2.8.9"
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9"
+          purl: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.9"
+          authors:
+            - "Christopher Currie"
+            - "FasterXML"
+            - "Paul Brown"
+            - "Tatu Saloranta"
+          declared_licenses:
+            - "The Apache Software License, Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              The Apache Software License, Version 2.0: "Apache-2.0"
+          description: "General data-binding functionality for Jackson: works on core\
+          \ streaming API"
+          homepage_url: "http://github.com/FasterXML/jackson"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.8.9/jackson-databind-2.8.9.jar"
+            hash:
+              value: "4dfca3975be3c1a98eacb829e70f02e9a71bc159"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.8.9/jackson-databind-2.8.9-sources.jar"
+            hash:
+              value: "98e1b4171628d8f230f6a60b248de84ed04fab0d"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:FasterXML/jackson-databind.git"
+            revision: "jackson-databind-2.8.9"
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/FasterXML/jackson-databind.git"
+            revision: "jackson-databind-2.8.9"
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.github.julien-truffaut:monocle-core_2.12:1.4.0"
+          purl: "pkg:maven/com.github.julien-truffaut/monocle-core_2.12@1.4.0"
+          authors:
+            - "Ilan Godik"
+            - "Julien Truffaut"
+            - "Kenji Yoshida"
+            - "Naoki Aoyama"
+            - "com.github.julien-truffaut"
+          declared_licenses:
+            - "MIT"
+          declared_licenses_processed:
+            spdx_expression: "MIT"
+          description: "core"
+          homepage_url: "https://github.com/julien-truffaut/Monocle"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-core_2.12/1.4.0/monocle-core_2.12-1.4.0.jar"
+            hash:
+              value: "219da9cc75878a75c888e38ad883fe4d30a7651d"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-core_2.12/1.4.0/monocle-core_2.12-1.4.0-sources.jar"
+            hash:
+              value: "37d333798ca15a03f5dfbb02f133d5b6b8e57b8c"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:julien-truffaut/Monocle.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/julien-truffaut/Monocle.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.github.julien-truffaut:monocle-macro_2.12:1.4.0"
+          purl: "pkg:maven/com.github.julien-truffaut/monocle-macro_2.12@1.4.0"
+          authors:
+            - "Ilan Godik"
+            - "Julien Truffaut"
+            - "Kenji Yoshida"
+            - "Naoki Aoyama"
+            - "com.github.julien-truffaut"
+          declared_licenses:
+            - "MIT"
+          declared_licenses_processed:
+            spdx_expression: "MIT"
+          description: "macros"
+          homepage_url: "https://github.com/julien-truffaut/Monocle"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-macro_2.12/1.4.0/monocle-macro_2.12-1.4.0.jar"
+            hash:
+              value: "319242d130983fec319a2e2d4f8e7741b809b5a0"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/github/julien-truffaut/monocle-macro_2.12/1.4.0/monocle-macro_2.12-1.4.0-sources.jar"
+            hash:
+              value: "e7ce64d7973ad64f3fa872b931a31c8c25de59b3"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:julien-truffaut/Monocle.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/julien-truffaut/Monocle.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.github.pureconfig:pureconfig-macros_2.12:0.8.0"
+          purl: "pkg:maven/com.github.pureconfig/pureconfig-macros_2.12@0.8.0"
+          authors:
+            - "Rui Gonçalves"
+            - "com.github.pureconfig"
+          declared_licenses:
+            - "Mozilla Public License, version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "MPL-2.0"
+            mapped:
+              Mozilla Public License, version 2.0: "MPL-2.0"
+          description: "pureconfig-macros"
+          homepage_url: "https://github.com/pureconfig/pureconfig"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig-macros_2.12/0.8.0/pureconfig-macros_2.12-0.8.0.jar"
+            hash:
+              value: "eea0e86f18c08e7fd00c90626f4f17a9ee6ef088"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig-macros_2.12/0.8.0/pureconfig-macros_2.12-0.8.0-sources.jar"
+            hash:
+              value: "7411f96540756236648b48347827b6ba2622e5e0"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:pureconfig/pureconfig.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/pureconfig/pureconfig.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.github.pureconfig:pureconfig_2.12:0.8.0"
+          purl: "pkg:maven/com.github.pureconfig/pureconfig_2.12@0.8.0"
+          authors:
+            - "Derek Morr"
+            - "Joao Azevedo"
+            - "Leif Wickland"
+            - "Mario Pastorelli"
+            - "Rui Gonçalves"
+            - "com.github.pureconfig"
+          declared_licenses:
+            - "Mozilla Public License, version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "MPL-2.0"
+            mapped:
+              Mozilla Public License, version 2.0: "MPL-2.0"
+          description: "pureconfig"
+          homepage_url: "https://github.com/pureconfig/pureconfig"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig_2.12/0.8.0/pureconfig_2.12-0.8.0.jar"
+            hash:
+              value: "891fde63cda086f593bffddb0b47933abc75523f"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/github/pureconfig/pureconfig_2.12/0.8.0/pureconfig_2.12-0.8.0-sources.jar"
+            hash:
+              value: "fa6de3ab2dd82543fb37288626687a9a6c1a67a2"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:pureconfig/pureconfig.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/pureconfig/pureconfig.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.typesafe:config:1.3.1"
+          purl: "pkg:maven/com.typesafe/config@1.3.1"
+          authors:
+            - "Havoc Pennington"
+            - "com.typesafe"
+          declared_licenses:
+            - "Apache License, Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              Apache License, Version 2.0: "Apache-2.0"
+          description: "config"
+          homepage_url: "https://github.com/typesafehub/config"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/config/1.3.1/config-1.3.1.jar"
+            hash:
+              value: "2cf7a6cc79732e3bdf1647d7404279900ca63eb0"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/config/1.3.1/config-1.3.1-sources.jar"
+            hash:
+              value: "a27878630ff503b63ed25ff2a25fa8ef888740b3"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/typesafehub/config.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/typesafehub/config.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.typesafe:ssl-config-core_2.12:0.2.2"
+          purl: "pkg:maven/com.typesafe/ssl-config-core_2.12@0.2.2"
+          authors:
+            - "Konrad Malawski"
+            - "Will Sargent"
+            - "com.typesafe"
+          declared_licenses:
+            - "Apache License, Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              Apache License, Version 2.0: "Apache-2.0"
+          description: "ssl-config-core"
+          homepage_url: "https://github.com/typesafehub/ssl-config"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/ssl-config-core_2.12/0.2.2/ssl-config-core_2.12-0.2.2.jar"
+            hash:
+              value: "8a357d491f7f94c5b4b1e0b27644e1306cc8742d"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/ssl-config-core_2.12/0.2.2/ssl-config-core_2.12-0.2.2-sources.jar"
+            hash:
+              value: "1baaec9149929d0970330aa80aca73e3f1f15624"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/typesafehub/ssl-config.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/typesafehub/ssl-config.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"
+          purl: "pkg:maven/com.typesafe.akka/akka-actor_2.12@2.5.6"
+          authors:
+            - "Akka Contributors"
+            - "Lightbend Inc."
+          declared_licenses:
+            - "Apache License, Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              Apache License, Version 2.0: "Apache-2.0"
+          description: "akka-actor"
+          homepage_url: "http://akka.io/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.6/akka-actor_2.12-2.5.6.jar"
+            hash:
+              value: "1e9f4c1829d3ce5640c17164b1756d1e98eb7af3"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.6/akka-actor_2.12-2.5.6-sources.jar"
+            hash:
+              value: "9642cf6f2a774d781e2f2a2e5de152971bfd714e"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:akka/akka.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/akka/akka.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"
+          purl: "pkg:maven/com.typesafe.akka/akka-stream_2.12@2.5.6"
+          authors:
+            - "Akka Contributors"
+            - "Lightbend Inc."
+          declared_licenses:
+            - "Apache License, Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              Apache License, Version 2.0: "Apache-2.0"
+          description: "akka-stream"
+          homepage_url: "http://akka.io/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-stream_2.12/2.5.6/akka-stream_2.12-2.5.6.jar"
+            hash:
+              value: "876aa1471ac773a3dd02f70c1e511a9a014b3491"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-stream_2.12/2.5.6/akka-stream_2.12-2.5.6-sources.jar"
+            hash:
+              value: "14459df7523aea2cfd04080fe88eccd20897bcc5"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:akka/akka.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/akka/akka.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2"
+          purl: "pkg:maven/com.typesafe.scala-logging/scala-logging_2.12@3.7.2"
+          authors:
+            - "Heiko Seeberger"
+            - "Mathias Bogaert"
+            - "com.typesafe.scala-logging"
+          declared_licenses:
+            - "Apache 2.0 License"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              Apache 2.0 License: "Apache-2.0"
+          description: "scala-logging"
+          homepage_url: "https://github.com/typesafehub/scala-logging"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.7.2/scala-logging_2.12-3.7.2.jar"
+            hash:
+              value: "a1dc97509765287faa4747f7cb411f0b85dc9a34"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/typesafe/scala-logging/scala-logging_2.12/3.7.2/scala-logging_2.12-3.7.2-sources.jar"
+            hash:
+              value: "a5f760917b60283e37c84bf3db2aeaf976980ad3"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/typesafehub/scala-logging.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/typesafehub/scala-logging.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:net.logstash.logback:logstash-logback-encoder:4.11"
+          purl: "pkg:maven/net.logstash.logback/logstash-logback-encoder@4.11"
+          authors:
+            - "John E. Vincent"
+            - "Nokia"
+            - "Phil Clay"
+          declared_licenses:
+            - "Apache License, Version 2.0"
+            - "MIT License"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0 OR MIT"
+            mapped:
+              Apache License, Version 2.0: "Apache-2.0"
+              MIT License: "MIT"
+          description: "Logback encoder which will output events as Logstash-compatible\
+          \ JSON"
+          homepage_url: "https://github.com/logstash/logstash-logback-encoder"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/net/logstash/logback/logstash-logback-encoder/4.11/logstash-logback-encoder-4.11.jar"
+            hash:
+              value: "163b6b046de5414ac17c83cbd6cb619e541fc69a"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/net/logstash/logback/logstash-logback-encoder/4.11/logstash-logback-encoder-4.11-sources.jar"
+            hash:
+              value: "8b889d5eb55aabfa5d9aa9cad95529668f3edb2b"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:logstash/logstash-logback-encoder.git"
+            revision: "logstash-logback-encoder-4.11"
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/logstash/logstash-logback-encoder.git"
+            revision: "logstash-logback-encoder-4.11"
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.reactivestreams:reactive-streams:1.0.1"
+          purl: "pkg:maven/org.reactivestreams/reactive-streams@1.0.1"
+          authors:
+            - "Reactive Streams SIG"
+          declared_licenses:
+            - "CC0"
+          declared_licenses_processed:
+            spdx_expression: "CC0-1.0"
+            mapped:
+              CC0: "CC0-1.0"
+          description: "A Protocol for Asynchronous Non-Blocking Data Sequence"
+          homepage_url: "http://www.reactive-streams.org/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/reactivestreams/reactive-streams/1.0.1/reactive-streams-1.0.1.jar"
+            hash:
+              value: "1b1c911686eb40179219466e6a59b634b9d7a748"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/reactivestreams/reactive-streams/1.0.1/reactive-streams-1.0.1-sources.jar"
+            hash:
+              value: "af471e34e448bd4f1c183e9b26c85679be11035c"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:reactive-streams/reactive-streams.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/reactive-streams/reactive-streams.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scala-lang:scala-compiler:2.12.3"
+          purl: "pkg:maven/org.scala-lang/scala-compiler@2.12.3"
+          authors:
+            - "LAMP/EPFL"
+            - "Lightbend, Inc."
+          declared_licenses:
+            - "BSD 3-Clause"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD 3-Clause: "BSD-3-Clause"
+          description: "Compiler for the Scala Programming Language"
+          homepage_url: "http://www.scala-lang.org/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-compiler/2.12.3/scala-compiler-2.12.3.jar"
+            hash:
+              value: "b6b9ca202fc8405260d30e703b9790e91c75cd85"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-compiler/2.12.3/scala-compiler-2.12.3-sources.jar"
+            hash:
+              value: "b8fe133c260f72b7fe9889195e19efeeab1b8087"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/scala/scala.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/scala/scala.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scala-lang:scala-library:2.12.3"
+          purl: "pkg:maven/org.scala-lang/scala-library@2.12.3"
+          authors:
+            - "LAMP/EPFL"
+            - "Lightbend, Inc."
+          declared_licenses:
+            - "BSD 3-Clause"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD 3-Clause: "BSD-3-Clause"
+          description: "Standard library for the Scala Programming Language"
+          homepage_url: "http://www.scala-lang.org/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.12.3/scala-library-2.12.3.jar"
+            hash:
+              value: "f2e496f21af2d80b48e0a61773f84c3a76a0d06f"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.12.3/scala-library-2.12.3-sources.jar"
+            hash:
+              value: "499c91b0a64bc706eee174481a3b7dde81b3591d"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/scala/scala.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/scala/scala.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scala-lang:scala-reflect:2.12.2"
+          purl: "pkg:maven/org.scala-lang/scala-reflect@2.12.2"
+          authors:
+            - "LAMP/EPFL"
+            - "Lightbend, Inc."
+          declared_licenses:
+            - "BSD 3-Clause"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD 3-Clause: "BSD-3-Clause"
+          description: "Compiler for the Scala Programming Language"
+          homepage_url: "http://www.scala-lang.org/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-reflect/2.12.2/scala-reflect-2.12.2.jar"
+            hash:
+              value: "fa13c13351566738ff156ef8a56b869868f4b77e"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-reflect/2.12.2/scala-reflect-2.12.2-sources.jar"
+            hash:
+              value: "a8808be417014e233b25ee44439f725e1f5e92a4"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/scala/scala.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/scala/scala.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0"
+          purl: "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.12@0.8.0"
+          authors:
+            - "EPFL"
+            - "Typesafe, Inc."
+            - "org.scala-lang.modules"
+          declared_licenses:
+            - "BSD 3-clause"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD 3-clause: "BSD-3-Clause"
+          description: "scala-java8-compat"
+          homepage_url: "http://www.scala-lang.org/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0.jar"
+            hash:
+              value: "1e6f1e745bf6d3c34d1e2ab150653306069aaf34"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0-sources.jar"
+            hash:
+              value: "0a33ce48278b9e3bbea8aed726e3c0abad3afadd"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/scala/scala-java8-compat.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/scala/scala-java8-compat.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
+          purl: "pkg:maven/org.scala-lang.modules/scala-parser-combinators_2.12@1.0.4"
+          authors:
+            - "EPFL"
+            - "Typesafe, Inc."
+            - "org.scala-lang.modules"
+          declared_licenses:
+            - "BSD 3-clause"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD 3-clause: "BSD-3-Clause"
+          description: "scala-parser-combinators"
+          homepage_url: "http://www.scala-lang.org/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4.jar"
+            hash:
+              value: "7c5f25a2d40ea7651452f0f0d1d4c12dabffcb8b"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4-sources.jar"
+            hash:
+              value: "9ec2f46c07d355853654af38e8b06e15ccca8cd0"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/scala/scala-parser-combinators.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/scala/scala-parser-combinators.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
+          purl: "pkg:maven/org.scala-lang.modules/scala-xml_2.12@1.0.5"
+          authors:
+            - "EPFL"
+            - "Typesafe, Inc."
+            - "org.scala-lang.modules"
+          declared_licenses:
+            - "BSD 3-clause"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD 3-clause: "BSD-3-Clause"
+          description: "scala-xml"
+          homepage_url: "http://www.scala-lang.org/"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.5/scala-xml_2.12-1.0.5.jar"
+            hash:
+              value: "a2b2afbeea86818a911b05851bb11d7d4840bb75"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.5/scala-xml_2.12-1.0.5-sources.jar"
+            hash:
+              value: "d12864d1a73aa540f7b624c8a92a5f48783c342c"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git://github.com/scala/scala-xml.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/scala/scala-xml.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scala-sbt:test-interface:1.0"
+          purl: "pkg:maven/org.scala-sbt/test-interface@1.0"
+          authors:
+            - "Bill Venners"
+            - "Chua Chee Seng"
+            - "Josh Cough"
+            - "Mark Harrah"
+            - "org.scala-sbt"
+          declared_licenses:
+            - "BSD"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD: "BSD-3-Clause"
+          description: "Uniform test interface to Scala/Java test frameworks (specs,\
+          \ ScalaCheck, ScalaTest, JUnit and other)"
+          homepage_url: "http://www.scala-sbt.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"
+            hash:
+              value: "0a3f14d010c4cb32071f863d97291df31603b521"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar"
+            hash:
+              value: "d44b23e9e3419ad0e00b91bba764a48d43075000"
+              algorithm: "SHA-1"
+          vcs:
+            type: ""
+            url: ""
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "https://github.com/sbt/test-interface.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scalacheck:scalacheck_2.12:1.13.5"
+          purl: "pkg:maven/org.scalacheck/scalacheck_2.12@1.13.5"
+          authors:
+            - "Rickard Nilsson"
+            - "org.scalacheck"
+          declared_licenses:
+            - "BSD-style"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD-style: "BSD-3-Clause"
+          description: "scalacheck"
+          homepage_url: "http://www.scalacheck.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scalacheck/scalacheck_2.12/1.13.5/scalacheck_2.12-1.13.5.jar"
+            hash:
+              value: "fff972ccaa0d83ca53bfdbbd0763c1059281fb76"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scalacheck/scalacheck_2.12/1.13.5/scalacheck_2.12-1.13.5-sources.jar"
+            hash:
+              value: "d0e1376902de65c7fa327f455b61d5d71957d78e"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:rickynils/scalacheck.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/rickynils/scalacheck.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scalactic:scalactic_2.12:3.0.4"
+          purl: "pkg:maven/org.scalactic/scalactic_2.12@3.0.4"
+          authors:
+            - "Bill Venners"
+            - "Chua Chee Seng"
+            - "George Berger"
+            - "org.scalactic"
+          declared_licenses:
+            - "the Apache License, ASL Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              the Apache License, ASL Version 2.0: "Apache-2.0"
+          description: "scalactic"
+          homepage_url: "http://www.scalatest.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scalactic/scalactic_2.12/3.0.4/scalactic_2.12-3.0.4.jar"
+            hash:
+              value: "e75f0f9c77aa391e01797cfc42fb82fd7c7d59a5"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scalactic/scalactic_2.12/3.0.4/scalactic_2.12-3.0.4-sources.jar"
+            hash:
+              value: "9f7f02217c7d2f14c6b1982493c39243a20b749d"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:scalatest/scalatest.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/scalatest/scalatest.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scalatest:scalatest_2.12:3.0.4"
+          purl: "pkg:maven/org.scalatest/scalatest_2.12@3.0.4"
+          authors:
+            - "Bill Venners"
+            - "Chua Chee Seng"
+            - "George Berger"
+            - "org.scalatest"
+          declared_licenses:
+            - "the Apache License, ASL Version 2.0"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              the Apache License, ASL Version 2.0: "Apache-2.0"
+          description: "scalatest"
+          homepage_url: "http://www.scalatest.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scalatest/scalatest_2.12/3.0.4/scalatest_2.12-3.0.4.jar"
+            hash:
+              value: "87d68f3d06dbf698fd0084c0a8b8996864d15465"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scalatest/scalatest_2.12/3.0.4/scalatest_2.12-3.0.4-sources.jar"
+            hash:
+              value: "ba669c2c9b7092151e2a19e975b1bf2a2e7a5fda"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:scalatest/scalatest.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/scalatest/scalatest.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.scalaz:scalaz-core_2.12:7.2.8"
+          purl: "pkg:maven/org.scalaz/scalaz-core_2.12@7.2.8"
+          authors:
+            - "Alexey Romanov"
+            - "Daniel Peebles"
+            - "Edward Kmett"
+            - "Jason Zaugg"
+            - "Kris Nuttycombe"
+            - "Lars Hupel"
+            - "Paul Chiusano"
+            - "Richard Wallace"
+            - "Runar Bjarnason"
+            - "Tony Morris"
+            - "org.scalaz"
+          declared_licenses:
+            - "BSD-style"
+          declared_licenses_processed:
+            spdx_expression: "BSD-3-Clause"
+            mapped:
+              BSD-style: "BSD-3-Clause"
+          description: "scalaz-core"
+          homepage_url: "http://scalaz.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scalaz/scalaz-core_2.12/7.2.8/scalaz-core_2.12-7.2.8.jar"
+            hash:
+              value: "2922d47f6dc7aba452634fe674087b6221b90dbf"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/scalaz/scalaz-core_2.12/7.2.8/scalaz-core_2.12-7.2.8-sources.jar"
+            hash:
+              value: "c94295a434f26b5650ec0fcbf93c9d2c7aada88e"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:scalaz/scalaz.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/scalaz/scalaz.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
+          purl: "pkg:maven/org.slf4j/jcl-over-slf4j@1.7.25"
+          authors:
+            - "Ceki Gulcu"
+            - "QOS.ch"
+          declared_licenses:
+            - "MIT License"
+          declared_licenses_processed:
+            spdx_expression: "MIT"
+            mapped:
+              MIT License: "MIT"
+          description: "JCL 1.2 implemented over SLF4J"
+          homepage_url: "http://www.slf4j.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25.jar"
+            hash:
+              value: "f8c32b13ff142a513eeb5b6330b1588dcb2c0461"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25-sources.jar"
+            hash:
+              value: "ffd0827a7c67d5915b7dc611afbda56a1f247191"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:qos-ch/slf4j.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/qos-ch/slf4j.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.slf4j:slf4j-api:1.7.25"
+          purl: "pkg:maven/org.slf4j/slf4j-api@1.7.25"
+          authors:
+            - "Ceki Gulcu"
+            - "QOS.ch"
+          declared_licenses:
+            - "MIT License"
+          declared_licenses_processed:
+            spdx_expression: "MIT"
+            mapped:
+              MIT License: "MIT"
+          description: "The slf4j API"
+          homepage_url: "http://www.slf4j.org"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
+            hash:
+              value: "da76ca59f6a57ee3102f8f9bd9cee742973efa8a"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25-sources.jar"
+            hash:
+              value: "962153db4a9ea71b79d047dfd1b2a0d80d8f4739"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:qos-ch/slf4j.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/qos-ch/slf4j.git"
+            revision: ""
+            path: ""
+        curations: []
+      - package:
+          id: "Maven:org.typelevel:macro-compat_2.12:1.1.1"
+          purl: "pkg:maven/org.typelevel/macro-compat_2.12@1.1.1"
+          authors:
+            - "Miles Sabin"
+            - "org.typelevel"
+          declared_licenses:
+            - "Apache 2"
+          declared_licenses_processed:
+            spdx_expression: "Apache-2.0"
+            mapped:
+              Apache 2: "Apache-2.0"
+          description: "core"
+          homepage_url: "https://github.com/milessabin/macro-compat"
+          binary_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1.jar"
+            hash:
+              value: "ed809d26ef4237d7c079ae6cf7ebd0dfa7986adf"
+              algorithm: "SHA-1"
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1-sources.jar"
+            hash:
+              value: "ade6d6ec81975cf514b0f9e2061614f2799cfe97"
+              algorithm: "SHA-1"
+          vcs:
+            type: "Git"
+            url: "git@github.com:milessabin/macro-compat.git"
+            revision: ""
+            path: ""
+          vcs_processed:
+            type: "Git"
+            url: "ssh://git@github.com/milessabin/macro-compat.git"
+            revision: ""
+            path: ""
+        curations: []
+    dependency_graphs:
+      SBT:
+        packages:
+          - "Maven:ch.qos.logback:logback-classic:1.2.3"
+          - "Maven:ch.qos.logback:logback-core:1.2.3"
+          - "Maven:org.slf4j:slf4j-api:1.7.25"
+          - "Maven:com.typesafe:config:1.3.1"
+          - "Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"
+          - "Maven:com.typesafe:ssl-config-core_2.12:0.2.2"
+          - "Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"
+          - "Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0"
+          - "Maven:org.reactivestreams:reactive-streams:1.0.1"
+          - "Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2"
+          - "Maven:org.scala-lang:scala-reflect:2.12.2"
+          - "Maven:net.logstash.logback:logstash-logback-encoder:4.11"
+          - "Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9"
+          - "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
+          - "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
+          - "Maven:org.scala-lang:scala-library:2.12.3"
+          - "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
+          - "Maven:org.scalacheck:scalacheck_2.12:1.13.5"
+          - "Maven:org.scala-sbt:test-interface:1.0"
+          - "Maven:org.scalatest:scalatest_2.12:3.0.4"
+          - "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
+          - "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
+          - "Maven:org.scalactic:scalactic_2.12:3.0.4"
+          - "Maven:com.github.julien-truffaut:monocle-core_2.12:1.4.0"
+          - "Maven:org.scalaz:scalaz-core_2.12:7.2.8"
+          - "Maven:com.github.julien-truffaut:monocle-macro_2.12:1.4.0"
+          - "Maven:org.typelevel:macro-compat_2.12:1.1.1"
+          - "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
+          - "Maven:com.github.pureconfig:pureconfig_2.12:0.8.0"
+          - "Maven:com.chuusai:shapeless_2.12:2.3.2"
+          - "Maven:com.github.pureconfig:pureconfig-macros_2.12:0.8.0"
+          - "Maven:org.scala-lang:scala-compiler:2.12.3"
+        scopes:
+          com.pbassiner:common_2.12:0.1-SNAPSHOT:compile:
+            - root: 0
+            - root: 3
+            - root: 4
+            - root: 9
+            - root: 11
+            - root: 15
+            - root: 16
+          com.pbassiner:common_2.12:0.1-SNAPSHOT:test:
+            - root: 17
+            - root: 19
+          com.pbassiner:multi1_2.12:0.1-SNAPSHOT:compile:
+            - root: 0
+            - root: 23
+            - root: 25
+            - root: 3
+            - root: 4
+            - root: 9
+            - root: 11
+            - root: 15
+            - root: 16
+            - root: 27
+          com.pbassiner:multi1_2.12:0.1-SNAPSHOT:test:
+            - root: 17
+            - root: 19
+          com.pbassiner:multi2_2.12:0.1-SNAPSHOT:compile:
+            - root: 0
+            - root: 28
+            - root: 3
+            - root: 4
+            - root: 9
+            - root: 11
+            - root: 15
+            - root: 16
+            - root: 27
+          com.pbassiner:multi2_2.12:0.1-SNAPSHOT:test:
+            - root: 17
+            - root: 19
+          com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT:compile:
+            - root: 15
+        nodes:
+          - {}
+          - pkg: 1
+          - pkg: 2
+          - pkg: 3
+          - pkg: 4
+          - pkg: 5
+          - pkg: 6
+          - pkg: 7
+          - pkg: 8
+          - pkg: 9
+          - pkg: 10
+          - pkg: 11
+          - pkg: 12
+          - pkg: 13
+          - pkg: 14
+          - pkg: 15
+          - pkg: 16
+          - pkg: 17
+          - pkg: 18
+          - pkg: 19
+          - pkg: 20
+          - pkg: 21
+          - pkg: 22
+          - pkg: 23
+          - pkg: 24
+          - pkg: 25
+          - pkg: 26
+          - pkg: 27
+            linkage: "PROJECT_DYNAMIC"
+          - pkg: 28
+          - pkg: 29
+          - pkg: 30
+          - pkg: 31
+        edges:
+          - from: 0
+            to: 1
+          - from: 0
+            to: 2
+          - from: 6
+            to: 7
+          - from: 4
+            to: 5
+          - from: 4
+            to: 6
+          - from: 4
+            to: 8
+          - from: 9
+            to: 10
+          - from: 12
+            to: 13
+          - from: 12
+            to: 14
+          - from: 11
+            to: 12
+          - from: 17
+            to: 18
+          - from: 19
+            to: 20
+          - from: 19
+            to: 21
+          - from: 19
+            to: 22
+          - from: 23
+            to: 24
+          - from: 25
+            to: 26
+          - from: 30
+            to: 26
+          - from: 30
+            to: 31
+          - from: 28
+            to: 29
+          - from: 28
+            to: 30
+    has_issues: false
+scanner: null
+advisor: null
+evaluator: null

--- a/model/src/test/kotlin/AbstractDependencyNavigatorTest.kt
+++ b/model/src/test/kotlin/AbstractDependencyNavigatorTest.kt
@@ -1,0 +1,371 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.contain
+import io.kotest.matchers.collections.containAll
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.haveSize
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.sequences.beEmpty as beEmptySequence
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
+
+import java.io.File
+import java.time.Instant
+
+import org.ossreviewtoolkit.utils.test.containExactly as containExactlyPairs
+import org.ossreviewtoolkit.utils.test.readOrtResult
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
+
+/**
+ * A base class for tests of concrete [DependencyNavigator] implementations.
+ *
+ * The class is configured with an ORT result file that contains the expected results in a specific format. It then
+ * runs tests on the [DependencyNavigator] of this result and checks whether it returns the correct dependency
+ * information.
+ */
+abstract class AbstractDependencyNavigatorTest : WordSpec() {
+    /** The name of the result file to be used by all test cases. */
+    protected abstract val resultFileName: String
+
+    /**
+     * The name of the file with a result that contains issues. This is used by tests of the collectIssues() function.
+     */
+    protected abstract val resultWithIssuesFileName: String
+
+    private val testResult by lazy { readOrtResult(resultFileName) }
+
+    private val testProject by lazy { testResult.getProject(PROJECT_ID)!! }
+
+    protected val navigator by lazy { testResult.dependencyNavigator }
+
+    init {
+        "scopeNames" should {
+            "return the scope names of a project" {
+                navigator.scopeNames(testProject) should containExactlyInAnyOrder("compile", "test")
+            }
+        }
+
+        "directDependencies" should {
+            "return the direct dependencies of a project" {
+                navigator.directDependencies(testProject, "test").map { it.id }.toList() should containExactly(
+                    Identifier("Maven:org.scalacheck:scalacheck_2.12:1.13.5"),
+                    Identifier("Maven:org.scalatest:scalatest_2.12:3.0.4")
+                )
+            }
+
+            "return an empty sequence for an unknown scope" {
+                navigator.directDependencies(testProject, "unknownScope") should beEmptySequence()
+            }
+        }
+
+        "scopeDependencies" should {
+            "return a map with scopes and their dependencies for a project" {
+                val scopeDependencies = navigator.scopeDependencies(testProject)
+
+                scopeDependencies.keys should containExactlyInAnyOrder("compile", "test")
+
+                scopeDependencies["compile"] shouldNotBeNull {
+                    this should haveSize(17)
+                    this should containAll(
+                        Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"),
+                        Identifier("Maven:org.scala-lang:scala-reflect:2.12.2"),
+                        Identifier("Maven:org.scala-lang:scala-library:2.12.3")
+                    )
+                }
+
+                scopeDependencies["test"] shouldNotBeNull {
+                    this should haveSize(6)
+                    this should containAll(
+                        Identifier("Maven:org.scalacheck:scalacheck_2.12:1.13.5"),
+                        Identifier("Maven:org.scalactic:scalactic_2.12:3.0.4")
+                    )
+                }
+            }
+
+            "return a map with scopes and their direct dependencies by using maxDepth = 1" {
+                val scopeDependencies = navigator.scopeDependencies(testProject, maxDepth = 1)
+
+                scopeDependencies["compile"] shouldNotBeNull {
+                    this should haveSize(7)
+                    this shouldNot contain(Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"))
+                }
+            }
+
+            "return a map with scopes and their dependencies up to a given maxDepth" {
+                val scopeDependencies = navigator.scopeDependencies(testProject, maxDepth = 2)
+
+                scopeDependencies["compile"] shouldNotBeNull {
+                    this should haveSize(14)
+                    this shouldNot contain(
+                        Identifier("Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0")
+                    )
+                }
+            }
+
+            "return a map with scopes and their dependencies with filter criteria" {
+                val matchedIds = mutableSetOf<Identifier>()
+                val scopeDependencies = navigator.scopeDependencies(testProject) { node ->
+                    matchedIds += node.id
+                    node.id.namespace == "com.typesafe.akka"
+                }
+
+                scopeDependencies["compile"] shouldNotBeNull {
+                    this should containExactlyInAnyOrder(
+                        Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"),
+                        Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
+                    )
+                }
+
+                matchedIds should haveSize(23)
+            }
+        }
+
+        "dependenciesForScope" should {
+            "return an empty set for an unknown scope" {
+                navigator.dependenciesForScope(testProject, "unknownScope") should beEmpty()
+            }
+
+            "return the dependencies of a specific scope" {
+                val compileDependencies = navigator.dependenciesForScope(testProject, "compile")
+
+                compileDependencies should haveSize(17)
+                compileDependencies should containAll(
+                    Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"),
+                    Identifier("Maven:org.scala-lang:scala-reflect:2.12.2"),
+                    Identifier("Maven:org.scala-lang:scala-library:2.12.3")
+                )
+            }
+
+            "return the dependencies of a specific scope up to a given maxDepth" {
+                val compileDependencies = navigator.dependenciesForScope(testProject, "compile", maxDepth = 2)
+
+                compileDependencies should haveSize(14)
+                compileDependencies shouldNot contain(
+                    Identifier("Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0")
+                )
+            }
+
+            "return the dependencies of a specific scope with filter criteria" {
+                val akkaDependencies = navigator.dependenciesForScope(testProject, "compile") { node ->
+                    node.id.namespace.contains("akka")
+                }
+
+                akkaDependencies.shouldContainExactlyInAnyOrder(
+                    Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"),
+                    Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
+                )
+            }
+        }
+
+        "packageDependencies" should {
+            "return the dependencies of an existing package in a project" {
+                val pkgId = Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
+
+                val dependencies = navigator.packageDependencies(testProject, pkgId)
+
+                dependencies should containExactlyInAnyOrder(
+                    Identifier("Maven:com.typesafe:ssl-config-core_2.12:0.2.2"),
+                    Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"),
+                    Identifier("Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0"),
+                    Identifier("Maven:org.reactivestreams:reactive-streams:1.0.1")
+                )
+            }
+
+            "return an empty set for the dependencies of a non-existing package" {
+                val pkgId = Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.7")
+
+                val dependencies = navigator.packageDependencies(testProject, pkgId)
+
+                dependencies should beEmpty()
+            }
+
+            "support a maxDepth filter" {
+                val pkgId = Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
+
+                val dependencies = navigator.packageDependencies(testProject, pkgId, maxDepth = 1)
+
+                dependencies should containExactlyInAnyOrder(
+                    Identifier("Maven:com.typesafe:ssl-config-core_2.12:0.2.2"),
+                    Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"),
+                    Identifier("Maven:org.reactivestreams:reactive-streams:1.0.1")
+                )
+            }
+
+            "support a DependencyMatcher" {
+                val pkgId = Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
+
+                val dependencies = navigator.packageDependencies(testProject, pkgId) { node ->
+                    node.id.namespace.startsWith("com.typesafe")
+                }
+
+                dependencies should containExactlyInAnyOrder(
+                    Identifier("Maven:com.typesafe:ssl-config-core_2.12:0.2.2"),
+                    Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6")
+                )
+            }
+        }
+
+        "getShortestPaths" should {
+            "return the shortest paths for a project" {
+                val paths = navigator.getShortestPaths(testProject)
+
+                paths.keys should haveSize(2)
+
+                paths["compile"] shouldNotBeNull {
+                    this should containExactlyPairs(
+                        Identifier("Maven:ch.qos.logback:logback-classic:1.2.3") to emptyList(),
+                        Identifier("Maven:ch.qos.logback:logback-core:1.2.3") to listOf(
+                            Identifier("Maven:ch.qos.logback:logback-classic:1.2.3")
+                        ),
+                        Identifier("Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0") to listOf(
+                            Identifier("Maven:net.logstash.logback:logstash-logback-encoder:4.11"),
+                            Identifier("Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9")
+                        ),
+                        Identifier("Maven:com.fasterxml.jackson.core:jackson-core:2.8.9") to listOf(
+                            Identifier("Maven:net.logstash.logback:logstash-logback-encoder:4.11"),
+                            Identifier("Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9")
+                        ),
+                        Identifier("Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9") to listOf(
+                            Identifier("Maven:net.logstash.logback:logstash-logback-encoder:4.11")
+                        ),
+                        Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6") to listOf(
+                            Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
+                        ),
+                        Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6") to emptyList(),
+                        Identifier("Maven:com.typesafe:config:1.3.1") to emptyList(),
+                        Identifier("Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2") to emptyList(),
+                        Identifier("Maven:com.typesafe:ssl-config-core_2.12:0.2.2") to listOf(
+                            Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
+                        ),
+                        Identifier("Maven:net.logstash.logback:logstash-logback-encoder:4.11") to emptyList(),
+                        Identifier("Maven:org.scala-lang:scala-library:2.12.3") to emptyList(),
+                        Identifier("Maven:org.scala-lang:scala-reflect:2.12.2") to listOf(
+                            Identifier("Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2")
+                        ),
+                        Identifier("Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0") to listOf(
+                            Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"),
+                            Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6")
+                        ),
+                        Identifier("Maven:org.reactivestreams:reactive-streams:1.0.1") to listOf(
+                            Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
+                        ),
+                        Identifier("Maven:org.slf4j:jcl-over-slf4j:1.7.25") to emptyList(),
+                        Identifier("Maven:org.slf4j:slf4j-api:1.7.25") to listOf(
+                            Identifier("Maven:ch.qos.logback:logback-classic:1.2.3")
+                        ),
+                    )
+                }
+            }
+        }
+
+        "projectDependencies" should {
+            "return the dependencies of a project" {
+                val scopeDependencies = navigator.scopeDependencies(testProject)
+                val projectDependencies = navigator.projectDependencies(testProject)
+
+                scopeDependencies.keys should containExactlyInAnyOrder("compile", "test")
+                val expectedDependencies = scopeDependencies.getValue("compile") + scopeDependencies.getValue("test")
+                projectDependencies should containExactlyInAnyOrder(expectedDependencies)
+            }
+
+            "support filtering the dependencies of a project" {
+                val dependencies = navigator.projectDependencies(testProject, 1) {
+                    it.linkage != PackageLinkage.PROJECT_DYNAMIC
+                }
+
+                dependencies should containExactlyInAnyOrder(
+                    Identifier("Maven:ch.qos.logback:logback-classic:1.2.3"),
+                    Identifier("Maven:com.typesafe:config:1.3.1"),
+                    Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"),
+                    Identifier("Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2"),
+                    Identifier("Maven:net.logstash.logback:logstash-logback-encoder:4.11"),
+                    Identifier("Maven:org.scala-lang:scala-library:2.12.3"),
+                    Identifier("Maven:org.slf4j:jcl-over-slf4j:1.7.25"),
+                    Identifier("Maven:org.scalacheck:scalacheck_2.12:1.13.5"),
+                    Identifier("Maven:org.scalatest:scalatest_2.12:3.0.4")
+                )
+            }
+
+            "return no dependencies for a maxDepth of 0" {
+                val dependencies = navigator.projectDependencies(testProject, 0)
+
+                dependencies should beEmpty()
+            }
+        }
+
+        "collectSubProjects" should {
+            "find all the sub projects of a project" {
+                val projectId = Identifier("SBT:com.pbassiner:multi1_2.12:0.1-SNAPSHOT")
+                testResult.getProject(projectId) shouldNotBeNull {
+                    val subProjectIds = navigator.collectSubProjects(this)
+
+                    subProjectIds should containExactly(PROJECT_ID)
+                }
+            }
+        }
+
+        "dependencyTreeDepth" should {
+            "calculate the dependency tree depth for a project" {
+                navigator.dependencyTreeDepth(testProject, "compile") shouldBe 3
+                navigator.dependencyTreeDepth(testProject, "test") shouldBe 2
+            }
+
+            "return 0 if the scope cannot be resolved" {
+                navigator.dependencyTreeDepth(testProject, "unknownScope") shouldBe 0
+            }
+        }
+
+        "projectIssues" should {
+            "return the issues of a project" {
+                val ortResultWithIssues = File(resultWithIssuesFileName).readValue<OrtResult>()
+                val project = ortResultWithIssues.analyzer?.result?.projects.orEmpty().first()
+                val navigator = ortResultWithIssues.dependencyNavigator
+
+                val issues = navigator.projectIssues(project)
+
+                issues should org.ossreviewtoolkit.utils.test.containExactly(
+                    Identifier("Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0") to setOf(
+                        OrtIssue(
+                            Instant.EPOCH,
+                            "Gradle",
+                            "Test issue 1"
+                        )
+                    ),
+                    Identifier("Maven:org.scalactic:scalactic_2.12:3.0.4") to setOf(
+                        OrtIssue(
+                            Instant.EPOCH,
+                            "Gradle",
+                            "Test issue 2"
+                        )
+                    )
+                )
+            }
+        }
+    }
+}
+
+/** Identifier of the project used by the tests. */
+private val PROJECT_ID = Identifier("SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT")

--- a/model/src/test/kotlin/AbstractDependencyNavigatorTest.kt
+++ b/model/src/test/kotlin/AbstractDependencyNavigatorTest.kt
@@ -31,6 +31,7 @@ import io.kotest.matchers.sequences.beEmpty as beEmptySequence
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
+import io.kotest.matchers.shouldNotBe
 
 import java.io.File
 import java.time.Instant
@@ -57,7 +58,7 @@ abstract class AbstractDependencyNavigatorTest : WordSpec() {
 
     private val testResult by lazy { readOrtResult(resultFileName) }
 
-    private val testProject by lazy { testResult.getProject(PROJECT_ID)!! }
+    protected val testProject by lazy { testResult.getProject(PROJECT_ID)!! }
 
     protected val navigator by lazy { testResult.dependencyNavigator }
 
@@ -362,6 +363,38 @@ abstract class AbstractDependencyNavigatorTest : WordSpec() {
                         )
                     )
                 )
+            }
+        }
+
+        "DependencyNode.equals" should {
+            "be reflexive" {
+                val node = navigator.directDependencies(testProject, "compile").iterator().next()
+
+                node shouldBe node
+            }
+
+            "return false for a different node" {
+                val iterator = navigator.directDependencies(testProject, "compile").iterator()
+                val node1 = iterator.next().getStableReference()
+                val node2 = iterator.next()
+
+                node1 shouldNotBe node2
+            }
+
+            "return true the same node" {
+                val node1 = navigator.directDependencies(testProject, "compile").iterator().next()
+                    .getStableReference()
+                val node2 = navigator.directDependencies(testProject, "compile").iterator().next()
+                    .getStableReference()
+
+                node1 shouldBe node2
+                node1.hashCode() shouldBe node2.hashCode()
+            }
+
+            "return false for another object" {
+                val node = navigator.directDependencies(testProject, "compile").iterator().next()
+
+                node shouldNotBe this
             }
         }
     }

--- a/model/src/test/kotlin/DependencyGraphNavigatorLegacyTest.kt
+++ b/model/src/test/kotlin/DependencyGraphNavigatorLegacyTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+/**
+ * Test class for [DependencyGraphNavigator] that checks whether the navigator implementation can handle results
+ * containing a dependency graph in the legacy format.
+ */
+class DependencyGraphNavigatorLegacyTest : AbstractDependencyNavigatorTest() {
+    override val resultFileName = "src/test/assets/sbt-multi-project-example-graph-old.yml"
+
+    override val resultWithIssuesFileName = "src/test/assets/result-with-issues-graph-old.yml"
+}

--- a/model/src/test/kotlin/DependencyGraphNavigatorTest.kt
+++ b/model/src/test/kotlin/DependencyGraphNavigatorTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import io.kotest.assertions.throwables.shouldThrow
+
+import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
+import org.ossreviewtoolkit.utils.Environment
+
+class DependencyGraphNavigatorTest : AbstractDependencyNavigatorTest() {
+    override val resultFileName = "src/test/assets/sbt-multi-project-example-graph.yml"
+
+    override val resultWithIssuesFileName = "src/test/assets/result-with-issues-graph.yml"
+
+    init {
+        "init" should {
+            "fail if there is no analyzer result" {
+                shouldThrow<IllegalArgumentException> {
+                    DependencyGraphNavigator(OrtResult.EMPTY)
+                }
+            }
+
+            "fail if the map with dependency graphs is empty" {
+                val result = OrtResult.EMPTY.copy(
+                    analyzer = AnalyzerRun(
+                        result = AnalyzerResult.EMPTY,
+                        environment = Environment(),
+                        config = AnalyzerConfiguration()
+                    )
+                )
+
+                shouldThrow<IllegalArgumentException> {
+                    DependencyGraphNavigator(result)
+                }
+            }
+        }
+    }
+}

--- a/model/src/test/kotlin/DependencyGraphTest.kt
+++ b/model/src/test/kotlin/DependencyGraphTest.kt
@@ -131,6 +131,39 @@ class DependencyGraphTest : WordSpec({
             scopeDependencies(scopes, "s2") shouldBe "${ids[2]}<${ids[1]}<${ids[3]}>${ids[0]}>"
         }
 
+        "construct scopes from graph nodes and edges" {
+            val ids = listOf(
+                id("org.apache.commons", "commons-lang3", "3.11"),
+                id("org.apache.commons", "commons-collections4", "4.4"),
+                id("org.apache.commons", "commons-configuration2", "2.8"),
+                id("org.apache.commons", "commons-logging", "1.3")
+            )
+            val nodeLogging = DependencyGraphNode(3)
+            val nodeLang = DependencyGraphNode(0)
+            val nodeCollections1 = DependencyGraphNode(1)
+            val nodeCollections2 = DependencyGraphNode(1, fragment = 1)
+            val nodeConfig1 = DependencyGraphNode(2)
+            val nodeConfig2 = DependencyGraphNode(2, fragment = 1)
+            val nodes = listOf(nodeLogging, nodeLang, nodeCollections1, nodeCollections2, nodeConfig1, nodeConfig2)
+            val edges = listOf(
+                DependencyGraphEdge(3, 0),
+                DependencyGraphEdge(4, 1),
+                DependencyGraphEdge(4, 2),
+                DependencyGraphEdge(5, 1),
+                DependencyGraphEdge(5, 3)
+            )
+            val scopeMap = mapOf(
+                "s1" to listOf(RootDependencyIndex(2)),
+                "s2" to listOf(RootDependencyIndex(2, fragment = 1))
+            )
+
+            val graph = DependencyGraph(ids, sortedSetOf(), scopeMap, nodes, edges)
+            val scopes = graph.createScopes()
+
+            scopeDependencies(scopes, "s1") shouldBe "${ids[2]}<${ids[1]}${ids[0]}>"
+            scopeDependencies(scopes, "s2") shouldBe "${ids[2]}<${ids[1]}<${ids[3]}>${ids[0]}>"
+        }
+
         "deal with attributes of package references" {
             val ids = listOf(
                 id("org.apache.commons", "commons-lang3", "3.10"),

--- a/model/src/test/kotlin/DependencyTreeNavigatorTest.kt
+++ b/model/src/test/kotlin/DependencyTreeNavigatorTest.kt
@@ -19,250 +19,16 @@
 
 package org.ossreviewtoolkit.model
 
-import io.kotest.core.spec.style.WordSpec
-import io.kotest.matchers.collections.beEmpty
-import io.kotest.matchers.collections.contain
-import io.kotest.matchers.collections.containAll
-import io.kotest.matchers.collections.containExactly
-import io.kotest.matchers.collections.containExactlyInAnyOrder
-import io.kotest.matchers.collections.haveSize
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNot
-import io.kotest.matchers.types.beTheSameInstanceAs
 
-import java.io.File
-import java.time.Instant
+class DependencyTreeNavigatorTest : AbstractDependencyNavigatorTest() {
+    override val resultFileName: String = RESULT_FILE
 
-import org.ossreviewtoolkit.utils.test.readOrtResult
-
-class DependencyTreeNavigatorTest : WordSpec() {
-    private val testResult = readOrtResult(RESULT_FILE)
-
-    private val testProject = testResult.getProject(PROJECT_ID)!!
-
-    private val navigator = testResult.dependencyNavigator
+    override val resultWithIssuesFileName: String = RESULT_WITH_ISSUES_FILE
 
     init {
-        "scopeNames" should {
-            "return the scope names of a project" {
-                navigator.scopeNames(testProject) should containExactlyInAnyOrder("compile", "test")
-            }
-        }
-
-        "directDependencies" should {
-            "return the direct dependencies of a project" {
-                navigator.directDependencies(testProject, "test")
-                    .map { it.id }.toList() should containExactly(
-                    Identifier("Maven:org.scalacheck:scalacheck_2.12:1.13.5"),
-                    Identifier("Maven:org.scalatest:scalatest_2.12:3.0.4")
-                )
-            }
-
-            "return an empty sequence for an unknown scope" {
-                navigator.directDependencies(testProject, "unknownScope").toList() should beEmpty()
-            }
-        }
-
-        "scopeDependencies" should {
-            "return a map with scopes and their dependencies for a project" {
-                val scopeDependencies = navigator.scopeDependencies(testProject)
-
-                scopeDependencies.keys should containExactlyInAnyOrder("compile", "test")
-
-                val compileDependencies = scopeDependencies["compile"].orEmpty()
-                compileDependencies should haveSize(17)
-                compileDependencies should containAll(
-                    Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"),
-                    Identifier("Maven:org.scala-lang:scala-reflect:2.12.2"),
-                    Identifier("Maven:org.scala-lang:scala-library:2.12.3")
-                )
-
-                val testDependencies = scopeDependencies["test"].orEmpty()
-                testDependencies should haveSize(6)
-                testDependencies should containAll(
-                    Identifier("Maven:org.scalacheck:scalacheck_2.12:1.13.5"),
-                    Identifier("Maven:org.scalactic:scalactic_2.12:3.0.4")
-                )
-            }
-
-            "return a map with scopes and their direct dependencies by using maxDepth = 1" {
-                val scopeDependencies = navigator.scopeDependencies(testProject, maxDepth = 1)
-
-                val compileDependencies = scopeDependencies["compile"].orEmpty()
-                compileDependencies should haveSize(7)
-                compileDependencies shouldNot contain(Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"))
-            }
-
-            "return a map with scopes and their dependencies up to a given maxDepth" {
-                val scopeDependencies = navigator.scopeDependencies(testProject, maxDepth = 2)
-
-                val compileDependencies = scopeDependencies["compile"].orEmpty()
-                compileDependencies should haveSize(14)
-                compileDependencies shouldNot contain(
-                    Identifier("Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0")
-                )
-            }
-
-            "return a map with scopes and their dependencies with filter criteria" {
-                val id1 = Identifier("Maven:test:dependency1:1")
-                val id2 = Identifier("Maven:test:dependency2:2")
-                val ref1 = PackageReference(id1)
-                val ref2 = PackageReference(
-                    id2,
-                    linkage = PackageLinkage.PROJECT_STATIC,
-                    issues = listOf(OrtIssue(source = "test", message = "test message"))
-                )
-                val scope = Scope("test", sortedSetOf(ref1, ref2))
-                val project = Project.EMPTY.copy(scopeDependencies = sortedSetOf(scope))
-
-                val matchedIds = mutableSetOf<Identifier>()
-                val scopeDependencies = navigator.scopeDependencies(project) { node ->
-                    matchedIds += node.id
-                    node.linkage == PackageLinkage.PROJECT_STATIC && node.issues.isNotEmpty()
-                }
-
-                scopeDependencies["test"].orEmpty() should containExactly(id2)
-                matchedIds should containExactlyInAnyOrder(id1, id2)
-            }
-        }
-
-        "dependenciesForScope" should {
-            "return an empty set for an unknown scope" {
-                navigator.dependenciesForScope(testProject, "unknownScope") should beEmpty()
-            }
-
-            "return the dependencies of a specific scope" {
-                val compileDependencies = navigator.dependenciesForScope(testProject, "compile")
-
-                compileDependencies should haveSize(17)
-                compileDependencies should containAll(
-                    Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"),
-                    Identifier("Maven:org.scala-lang:scala-reflect:2.12.2"),
-                    Identifier("Maven:org.scala-lang:scala-library:2.12.3")
-                )
-            }
-
-            "return the dependencies of a specific scope up to a given maxDepth" {
-                val compileDependencies = navigator.dependenciesForScope(testProject, "compile", maxDepth = 2)
-
-                compileDependencies should haveSize(14)
-                compileDependencies shouldNot contain(
-                    Identifier("Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0")
-                )
-            }
-
-            "return the dependencies of a specific scope with filter criteria" {
-                val akkaDependencies = navigator.dependenciesForScope(testProject, "compile") { node ->
-                    node.id.namespace.contains("akka")
-                }
-
-                akkaDependencies.shouldContainExactlyInAnyOrder(
-                    Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"),
-                    Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
-                )
-            }
-        }
-
-        "packageDependencies" should {
-            "return the dependencies of an existing package in a project" {
-                val pkgId = Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
-
-                val dependencies = navigator.packageDependencies(testProject, pkgId)
-
-                dependencies should containExactlyInAnyOrder(
-                    Identifier("Maven:com.typesafe:ssl-config-core_2.12:0.2.2"),
-                    Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"),
-                    Identifier("Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0"),
-                    Identifier("Maven:org.reactivestreams:reactive-streams:1.0.1")
-                )
-            }
-
-            "return an empty set for the dependencies of a non-existing package" {
-                val pkgId = Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.7")
-
-                val dependencies = navigator.packageDependencies(testProject, pkgId)
-
-                dependencies should beEmpty()
-            }
-
-            "support a maxDepth filter" {
-                val pkgId = Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
-
-                val dependencies = navigator.packageDependencies(testProject, pkgId, maxDepth = 1)
-
-                dependencies should containExactlyInAnyOrder(
-                    Identifier("Maven:com.typesafe:ssl-config-core_2.12:0.2.2"),
-                    Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"),
-                    Identifier("Maven:org.reactivestreams:reactive-streams:1.0.1")
-                )
-            }
-
-            "support a DependencyMatcher" {
-                val pkgId = Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
-
-                val dependencies = navigator.packageDependencies(testProject, pkgId) { node ->
-                    node.id.namespace.startsWith("com.typesafe")
-                }
-
-                dependencies should containExactlyInAnyOrder(
-                    Identifier("Maven:com.typesafe:ssl-config-core_2.12:0.2.2"),
-                    Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6")
-                )
-            }
-        }
-
         "getShortestPaths" should {
-            "return the shortest paths for a project" {
-                val paths = navigator.getShortestPaths(testProject)
-
-                paths.keys should haveSize(2)
-
-                paths["compile"]!! should org.ossreviewtoolkit.utils.test.containExactly(
-                    Identifier("Maven:ch.qos.logback:logback-classic:1.2.3") to emptyList(),
-                    Identifier("Maven:ch.qos.logback:logback-core:1.2.3") to listOf(
-                        Identifier("Maven:ch.qos.logback:logback-classic:1.2.3")
-                    ),
-                    Identifier("Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0") to listOf(
-                        Identifier("Maven:net.logstash.logback:logstash-logback-encoder:4.11"),
-                        Identifier("Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9")
-                    ),
-                    Identifier("Maven:com.fasterxml.jackson.core:jackson-core:2.8.9") to listOf(
-                        Identifier("Maven:net.logstash.logback:logstash-logback-encoder:4.11"),
-                        Identifier("Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9")
-                    ),
-                    Identifier("Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9") to listOf(
-                        Identifier("Maven:net.logstash.logback:logstash-logback-encoder:4.11")
-                    ),
-                    Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6") to listOf(
-                        Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
-                    ),
-                    Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6") to emptyList(),
-                    Identifier("Maven:com.typesafe:config:1.3.1") to emptyList(),
-                    Identifier("Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2") to emptyList(),
-                    Identifier("Maven:com.typesafe:ssl-config-core_2.12:0.2.2") to listOf(
-                        Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
-                    ),
-                    Identifier("Maven:net.logstash.logback:logstash-logback-encoder:4.11") to emptyList(),
-                    Identifier("Maven:org.scala-lang:scala-library:2.12.3") to emptyList(),
-                    Identifier("Maven:org.scala-lang:scala-reflect:2.12.2") to listOf(
-                        Identifier("Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2")
-                    ),
-                    Identifier("Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0") to listOf(
-                        Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"),
-                        Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6")
-                    ),
-                    Identifier("Maven:org.reactivestreams:reactive-streams:1.0.1") to listOf(
-                        Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
-                    ),
-                    Identifier("Maven:org.slf4j:jcl-over-slf4j:1.7.25") to emptyList(),
-                    Identifier("Maven:org.slf4j:slf4j-api:1.7.25") to listOf(
-                        Identifier("Maven:ch.qos.logback:logback-classic:1.2.3")
-                    ),
-                )
-            }
-
             "find the shortest paths to each dependency in a scope" {
                 // This test case comes from ScopeTest initially. It uses a specific dependency tree to test
                 // various corner cases.
@@ -314,62 +80,7 @@ class DependencyTreeNavigatorTest : WordSpec() {
             }
         }
 
-        "projectDependencies" should {
-            "return the dependencies of a project" {
-                val scopeDependencies = navigator.scopeDependencies(testProject)
-                val projectDependencies = navigator.projectDependencies(testProject)
-
-                projectDependencies should containExactlyInAnyOrder(
-                    scopeDependencies.getValue("compile") + scopeDependencies.getValue("test")
-                )
-            }
-
-            "support filtering the dependencies of a project" {
-                val dependencies = navigator.projectDependencies(testProject, 1) {
-                    it.linkage != PackageLinkage.PROJECT_DYNAMIC
-                }
-
-                dependencies should containExactlyInAnyOrder(
-                    Identifier("Maven:ch.qos.logback:logback-classic:1.2.3"),
-                    Identifier("Maven:com.typesafe:config:1.3.1"),
-                    Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"),
-                    Identifier("Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2"),
-                    Identifier("Maven:net.logstash.logback:logstash-logback-encoder:4.11"),
-                    Identifier("Maven:org.scala-lang:scala-library:2.12.3"),
-                    Identifier("Maven:org.slf4j:jcl-over-slf4j:1.7.25"),
-                    Identifier("Maven:org.scalacheck:scalacheck_2.12:1.13.5"),
-                    Identifier("Maven:org.scalatest:scalatest_2.12:3.0.4")
-                )
-            }
-
-            "return no dependencies for a maxDepth of 0" {
-                val dependencies = navigator.projectDependencies(testProject, 0)
-
-                dependencies should beEmpty()
-            }
-        }
-
-        "collectSubProjects" should {
-            "find all the sub projects of a project" {
-                val projectId = Identifier("SBT:com.pbassiner:multi1_2.12:0.1-SNAPSHOT")
-                val project = testResult.getProject(projectId)!!
-
-                val subProjectIds = navigator.collectSubProjects(project)
-
-                subProjectIds should containExactly(PROJECT_ID)
-            }
-        }
-
         "dependencyTreeDepth" should {
-            "calculate the dependency tree depth for a project" {
-                navigator.dependencyTreeDepth(testProject, "compile") shouldBe 3
-                navigator.dependencyTreeDepth(testProject, "test") shouldBe 2
-            }
-
-            "return 0 if the scope cannot be resolved" {
-                navigator.dependencyTreeDepth(testProject, "unknownScope") shouldBe 0
-            }
-
             "return 0 if the scope does not contain any package" {
                 val scope = Scope(name = "test", dependencies = sortedSetOf())
                 val project = Project.EMPTY.copy(scopeDependencies = sortedSetOf(scope))
@@ -422,69 +133,6 @@ class DependencyTreeNavigatorTest : WordSpec() {
                 navigator.dependencyTreeDepth(project, scope.name) shouldBe 3
             }
         }
-
-        "collectIssues" should {
-            "return a map with all issues of the given dependencies" {
-                val project = projectWithIssues()
-                val dependencies = project.scopeDependencies.orEmpty().flatMap { it.dependencies }
-
-                val issues = DependencyNavigator.collectIssues(dependencies.asSequence())
-
-                issues should org.ossreviewtoolkit.utils.test.containExactly(
-                    Identifier("Unknown:org.apache.commons:commons-text:1.1") to setOf(
-                        OrtIssue(
-                            Instant.EPOCH,
-                            "Gradle",
-                            "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency " +
-                                    "org.apache.commons:commons-text:1.1 because no repositories are defined."
-                        )
-                    ),
-                    Identifier("Unknown:junit:junit:4.12") to setOf(
-                        OrtIssue(
-                            Instant.EPOCH,
-                            "Gradle",
-                            "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency " +
-                                    "junit:junit:4.12 because no repositories are defined."
-                        )
-                    )
-                )
-            }
-        }
-
-        "projectIssues" should {
-            "return the issues of a project" {
-                val project = projectWithIssues()
-
-                val issues = navigator.projectIssues(project)
-
-                issues should org.ossreviewtoolkit.utils.test.containExactly(
-                    Identifier("Unknown:org.apache.commons:commons-text:1.1") to setOf(
-                        OrtIssue(
-                            Instant.EPOCH,
-                            "Gradle",
-                            "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency " +
-                                    "org.apache.commons:commons-text:1.1 because no repositories are defined."
-                        )
-                    ),
-                    Identifier("Unknown:junit:junit:4.12") to setOf(
-                        OrtIssue(
-                            Instant.EPOCH,
-                            "Gradle",
-                            "Unresolved: ModuleVersionNotFoundException: Cannot resolve external dependency " +
-                                    "junit:junit:4.12 because no repositories are defined."
-                        )
-                    )
-                )
-            }
-        }
-
-        "dependency nodes" should {
-            "return themselves as stable reference" {
-                val dependencies = navigator.directDependencies(testProject, "compile")
-
-                dependencies.forEach { it.getStableReference() should beTheSameInstanceAs(it) }
-            }
-        }
     }
 }
 
@@ -492,8 +140,8 @@ class DependencyTreeNavigatorTest : WordSpec() {
 private const val RESULT_FILE =
     "../analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml"
 
-/** Identifier of the project used by the tests. */
-private val PROJECT_ID = Identifier("SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT")
+/** Name of the file with a result that contains some issues. */
+private const val RESULT_WITH_ISSUES_FILE = "src/test/assets/result-with-issues-scopes.yml"
 
 private class PackageRefBuilder(id: String) {
     private val id = Identifier(id)
@@ -508,11 +156,3 @@ private class PackageRefBuilder(id: String) {
 
 private fun pkg(id: String, block: PackageRefBuilder.() -> Unit = {}): PackageReference =
     PackageRefBuilder(id).apply { block() }.build()
-
-/**
- * Return a [Project] with dependencies that have some issues.
- */
-private fun projectWithIssues(): Project =
-    File("../analyzer/src/funTest/assets/projects/synthetic")
-        .resolve("gradle-expected-output-lib-without-repo.yml")
-        .readValue<ProjectAnalyzerResult>().project

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -27,6 +27,7 @@ import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldMatch
+import io.kotest.matchers.types.beInstanceOf
 
 import java.lang.IllegalArgumentException
 
@@ -150,6 +151,12 @@ class OrtResultTest : WordSpec({
             )
 
             ortResult.dependencyNavigator shouldBe DependencyTreeNavigator
+        }
+
+        "return a navigator for the dependency graph" {
+            val ortResult = readOrtResult("src/test/assets/sbt-multi-project-example-graph.yml")
+
+            ortResult.dependencyNavigator should beInstanceOf<DependencyGraphNavigator>()
         }
     }
 })

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -21,22 +21,18 @@ package org.ossreviewtoolkit.model
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.shouldMatch
 
-import java.io.File
 import java.lang.IllegalArgumentException
 
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.utils.Environment
 import org.ossreviewtoolkit.utils.test.readOrtResult
-import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class OrtResultTest : WordSpec({
     "collectDependencies" should {
@@ -144,19 +140,6 @@ class OrtResultTest : WordSpec({
             }
 
             e.message shouldMatch "The .* of project .* cannot be found in .*"
-        }
-    }
-
-    "projects" should {
-        "return projects with resolved scopes" {
-            val resultFile = File("src/test/assets/analyzer-result-with-dependency-graph.yml")
-            val result = resultFile.readValue<OrtResult>()
-
-            val project = result.getProject(Identifier("Maven:com.vdurmont:semver4j:3.1.0"))
-
-            project.shouldNotBeNull {
-                scopes shouldNot beEmpty()
-            }
         }
     }
 

--- a/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
+++ b/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.model.utils
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
@@ -36,6 +37,7 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.PackageReference
 import org.ossreviewtoolkit.model.Scope
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class DependencyGraphBuilderTest : WordSpec({
     "DependencyGraphBuilder" should {
@@ -53,7 +55,15 @@ class DependencyGraphBuilderTest : WordSpec({
                 .addDependency(scope2, dep1)
                 .build()
 
-            graph.scopeRoots shouldHaveSize 3
+            graph.scopeRoots should beEmpty()
+            graph.nodes shouldNotBeNull {
+                this shouldHaveSize 3
+            }
+
+            graph.edges shouldNotBeNull {
+                this should beEmpty()
+            }
+
             val scopes = graph.createScopes()
             scopes.map { it.name } should containExactlyInAnyOrder(scope1, scope2)
 
@@ -102,10 +112,12 @@ class DependencyGraphBuilderTest : WordSpec({
                 .addDependency(scope2, dep4)
                 .build()
 
-            graph.scopeRoots shouldHaveSize 2
-            graph.scopeRoots.all { it.fragment == 0 } shouldBe true
-            val scopes = graph.createScopes()
+            graph.nodes shouldNotBeNull {
+                this shouldHaveSize 5
+                all { it.fragment == 0 } shouldBe true
+            }
 
+            val scopes = graph.createScopes()
             val scopeDependencies1 = scopeDependencies(scopes, scope1)
             scopeDependencies1 should containExactly(dep5, dep3, dep1)
 

--- a/model/src/test/kotlin/utils/DependencyGraphConverterTest.kt
+++ b/model/src/test/kotlin/utils/DependencyGraphConverterTest.kt
@@ -34,7 +34,7 @@ import java.util.SortedSet
 
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.CuratedPackage
-import org.ossreviewtoolkit.model.DependencyReference
+import org.ossreviewtoolkit.model.DependencyGraphNode
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
@@ -115,12 +115,12 @@ class DependencyGraphConverterTest : WordSpec({
             val graph = convertedResult.dependencyGraphs["Maven"]!!
             val issues = mutableListOf<OrtIssue>()
 
-            fun collectIssues(ref: DependencyReference) {
-                issues += ref.issues
-                ref.dependencies.forEach(::collectIssues)
+            fun collectIssues(node: DependencyGraphNode) {
+                issues += node.issues
+                graph.dependencies[node]?.forEach(::collectIssues)
             }
 
-            graph.scopeRoots.forEach(::collectIssues)
+            graph.nodes?.forEach(::collectIssues)
             issues shouldNot beEmpty()
         }
 
@@ -137,7 +137,10 @@ class DependencyGraphConverterTest : WordSpec({
             val convertedResult = DependencyGraphConverter.convert(mixedResult)
 
             convertedResult.dependencyGraphs["Gradle"] shouldNotBeNull {
-                scopeRoots shouldNot beEmpty()
+                nodes shouldNotBeNull {
+                    this shouldNot beEmpty()
+                }
+
                 scopes.keys shouldNot beEmpty()
             }
         }


### PR DESCRIPTION
This is going to become the default implementation of the `DependencyNavigator` interface. It allows access to dependency information in ORT results that completely use the dependency graph format.

This PR also reworks the representation of dependency graphs in ORT result files again. The new format has the following advantages:
* It is more compact, especially for complex graphs referencing dependency sub trees multiple times. (To give you an impression: for a bigger JavaScript project, the size of the analyzer result could be reduced from 25 MB to ~900 KB.)
* No duplication of objects happens during serialization or deserialization.
* The serialized form may be easier to understand, as it is based on a typical graph representation with nodes and edges.

The code can handle the original dependency graph format as well; so existing result files can still be processed.

Note that on loading an ORT result, the single commands still do a conversion to the classic dependency tree format. There is one more PR to come that does the final integration.