### PR TITLE
Stop dynamically creating issues for unmapped licenses

### DIFF
--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -90,13 +90,6 @@ data class AnalyzerResult(
             }
         }
 
-        packages.forEach { curatedPackage ->
-            val issues = curatedPackage.collectIssues()
-            if (issues.isNotEmpty()) {
-                collectedIssues.getOrPut(curatedPackage.pkg.id) { mutableSetOf() } += issues
-            }
-        }
-
         dependencyGraphs.values.forEach { graph ->
             graph.collectIssues().forEach { (id, issues) ->
                 collectedIssues.getOrPut(id) { mutableSetOf() } += issues

--- a/model/src/main/kotlin/CuratedPackage.kt
+++ b/model/src/main/kotlin/CuratedPackage.kt
@@ -47,21 +47,6 @@ data class CuratedPackage(
     override fun compareTo(other: CuratedPackage) = pkg.id.compareTo(other.pkg.id)
 
     /**
-     * Check if this package contains any erroneous data.
-     */
-    fun collectIssues(): List<OrtIssue> {
-        val severity = pkg.concludedLicense?.let { Severity.HINT } ?: Severity.WARNING
-        return pkg.declaredLicensesProcessed.unmapped.map { unmappedLicense ->
-            OrtIssue(
-                severity = severity,
-                source = pkg.id.toCoordinates(),
-                message = "The declared license '$unmappedLicense' could not be mapped to a valid license or " +
-                        "parsed as an SPDX expression."
-            )
-        }
-    }
-
-    /**
      * Return a [Package] representing the same package as this one but which does not have any curations applied.
      */
     fun toUncuratedPackage() =

--- a/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
@@ -326,10 +326,6 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             result += addIssues(analyzerIssues, EvaluatedOrtIssueType.ANALYZER, pkg, null, null)
         }
 
-        input.ortResult.getPackage(id)?.let {
-            result += addIssues(it.collectIssues(), EvaluatedOrtIssueType.ANALYZER, pkg, null, null)
-        }
-
         return result
     }
 

--- a/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
@@ -113,7 +113,6 @@ class ReportTableModelMapper(
         val summaryRows = mutableMapOf<Identifier, SummaryRow>()
 
         val analyzerResult = ortResult.analyzer?.result
-        val analyzerIssuesForPackages = ortResult.getPackages().associateBy({ it.pkg.id }, { it.collectIssues() })
         val scanRecord = ortResult.scanner?.results
         val excludes = ortResult.getExcludes()
 
@@ -136,8 +135,7 @@ class ReportTableModelMapper(
                 val detectedLicenses = resolvedLicenseInfo.filter { LicenseSource.DETECTED in it.sources }
                     .sortedBy { it.license.toString() }
 
-                val analyzerIssues = projectIssues[id].orEmpty() + analyzerResult.issues[id].orEmpty() +
-                        analyzerIssuesForPackages[id].orEmpty()
+                val analyzerIssues = projectIssues[id].orEmpty() + analyzerResult.issues[id].orEmpty()
 
                 val scanIssues = scanResult?.flatMapTo(mutableSetOf()) {
                     it.summary.issues


### PR DESCRIPTION
Treating unmapped licenses as issues has caused confusion in the past as
these issues are not serialized into the ORT result despite "has_issues"
being "true" in that case. Moreover, unmapped licenses are not a
technical problem, but a metadata problem, which in many workflows will be
handled by different people than technical issues.

So do not dynamically create issues for unmapped licenses anymore;
instead the recommendation is to use the example code from [1] to report
unmapped licenses as policy violations.

Resolves #3324.

[1] https://github.com/oss-review-toolkit/ort/blob/2e8f08e/examples/rules.kts#L123-L135

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>