### PR TITLE
Azure: Do not build the reporter-web-app in analyzer tests

### DIFF
--- a/.azure-pipelines/LinuxAnalyzerTest.yml
+++ b/.azure-pipelines/LinuxAnalyzerTest.yml
@@ -117,7 +117,7 @@ jobs:
     inputs:
       gradleWrapperFile: gradlew
       # TODO: Only exclude ExpensiveTag on PR builds.
-      options: --no-daemon --stacktrace -Dkotest.tags.exclude=ExpensiveTag -Dkotest.assertions.multi-line-diff=simple -PbuildCacheRetentionDays=3
+      options: --no-daemon --stacktrace -x reporter-web-app:yarnBuild -Dkotest.tags.exclude=ExpensiveTag -Dkotest.assertions.multi-line-diff=simple -PbuildCacheRetentionDays=3
       tasks: analyzer:test analyzer:funTest jacocoReport
       publishJUnitResults: true
       testResultsFiles: '**/flattened/TEST-*.xml'

--- a/.azure-pipelines/WindowsAnalyzerTest.yml
+++ b/.azure-pipelines/WindowsAnalyzerTest.yml
@@ -108,7 +108,7 @@ jobs:
     inputs:
       gradleWrapperFile: gradlew.bat
       # TODO: Only exclude ExpensiveTag on PR builds.
-      options: --no-daemon --stacktrace -Dkotest.tags.exclude=ExpensiveTag -Dkotest.assertions.multi-line-diff=simple -PbuildCacheRetentionDays=3
+      options: --no-daemon --stacktrace -x reporter-web-app:yarnBuild -Dkotest.tags.exclude=ExpensiveTag -Dkotest.assertions.multi-line-diff=simple -PbuildCacheRetentionDays=3
       tasks: analyzer:test analyzer:funTest
       publishJUnitResults: true
       testResultsFiles: '**/flattened/TEST-*.xml'


### PR DESCRIPTION
For running the analyzer tests we do not need to build the
reporter-web-app, so explicitly exclude the task.