### PR TITLE
scanner: Add a NestedProvenanceResolver

### DIFF
--- a/scanner/src/funTest/kotlin/experimental/DefaultNestedProvenanceResolverFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/DefaultNestedProvenanceResolverFunTest.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import java.io.IOException
+
+import org.ossreviewtoolkit.model.ArtifactProvenance
+import org.ossreviewtoolkit.model.Hash
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.utils.Os
+import org.ossreviewtoolkit.utils.test.containExactly
+
+class DefaultNestedProvenanceResolverFunTest : WordSpec() {
+    private val resolver = DefaultNestedProvenanceResolver()
+
+    init {
+        "Resolving an artifact provenance" should {
+            "Return only the artifact provenance" {
+                val provenance = ArtifactProvenance(
+                    sourceArtifact = RemoteArtifact(
+                        url = "",
+                        hash = Hash.NONE
+                    )
+                )
+
+                resolver.resolveNestedProvenance(provenance) shouldBe
+                        NestedProvenance(root = provenance, subRepositories = emptyMap())
+            }
+        }
+
+        "Resolving a repository provenance" should {
+            "Return the correct root provenance" {
+                val provenance = RepositoryProvenance(
+                    vcsInfo = VcsInfo(
+                        type = VcsType.GIT,
+                        url = "https://github.com/oss-review-toolkit/ort-governance.git",
+                        revision = "1440358978888bfc4b6fbf356e4e6be005c9a25e"
+                    ),
+                    resolvedRevision = "1440358978888bfc4b6fbf356e4e6be005c9a25e"
+                )
+
+                resolver.resolveNestedProvenance(provenance) shouldBe
+                        NestedProvenance(root = provenance, subRepositories = emptyMap())
+            }
+
+            "Find recursive Git submodules" {
+                val provenance = RepositoryProvenance(
+                    vcsInfo = VcsInfo(
+                        type = VcsType.GIT,
+                        url = "https://github.com/oss-review-toolkit/ort-test-data-git-submodules.git",
+                        revision = "fcea94bab5835172e826afddb9f6427274c983b9"
+                    ),
+                    resolvedRevision = "fcea94bab5835172e826afddb9f6427274c983b9"
+                )
+
+                val nestedProvenance = resolver.resolveNestedProvenance(provenance)
+
+                nestedProvenance.root shouldBe provenance
+                nestedProvenance.subRepositories should containExactly(
+                    "commons-text" to RepositoryProvenance(
+                        vcsInfo = VcsInfo(
+                            type = VcsType.GIT,
+                            url = "https://github.com/apache/commons-text.git",
+                            revision = "7643b12421100d29fd2b78053e77bcb04a251b2e"
+                        ),
+                        resolvedRevision = "7643b12421100d29fd2b78053e77bcb04a251b2e"
+                    ),
+                    "test-data-npm" to RepositoryProvenance(
+                        vcsInfo = VcsInfo(
+                            type = VcsType.GIT,
+                            url = "https://github.com/oss-review-toolkit/ort-test-data-npm.git",
+                            revision = "ad0367b7b9920144a47b8d30cc0c84cea102b821"
+                        ),
+                        resolvedRevision = "ad0367b7b9920144a47b8d30cc0c84cea102b821"
+                    ),
+                    "test-data-npm/isarray" to RepositoryProvenance(
+                        vcsInfo = VcsInfo(
+                            type = VcsType.GIT,
+                            url = "https://github.com/juliangruber/isarray.git",
+                            revision = "63ea4ca0a0d6b0574d6a470ebd26880c3026db4a"
+                        ),
+                        resolvedRevision = "63ea4ca0a0d6b0574d6a470ebd26880c3026db4a"
+                    ),
+                    "test-data-npm/long.js" to RepositoryProvenance(
+                        vcsInfo = VcsInfo(
+                            type = VcsType.GIT, url = "https://github.com/dcodeIO/long.js.git",
+                            revision = "941c5c62471168b5d18153755c2a7b38d2560e58"
+                        ),
+                        resolvedRevision = "941c5c62471168b5d18153755c2a7b38d2560e58"
+                    )
+                )
+            }
+
+            "Find Git-Repo projects with recursive Git submodules".config(enabled = !Os.isWindows) {
+                val provenance = RepositoryProvenance(
+                    vcsInfo = VcsInfo(
+                        type = VcsType.GIT_REPO,
+                        url = "https://github.com/oss-review-toolkit/ort-test-data-git-repo.git",
+                        revision = "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa",
+                        path = "manifest.xml"
+                    ),
+                    resolvedRevision = "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
+                )
+
+                val nestedProvenance = resolver.resolveNestedProvenance(provenance)
+
+                nestedProvenance.root shouldBe provenance
+                nestedProvenance.subRepositories should containExactly(
+                    "spdx-tools" to RepositoryProvenance(
+                        vcsInfo = VcsInfo(
+                            type = VcsType.GIT,
+                            url = "https://github.com/spdx/tools",
+                            revision = "e179fae47590eccedc46186ea0ce20cbade5fda7"
+                        ),
+                        resolvedRevision = "e179fae47590eccedc46186ea0ce20cbade5fda7"
+                    ),
+                    "submodules" to RepositoryProvenance(
+                        vcsInfo = VcsInfo(
+                            type = VcsType.GIT,
+                            url = "https://github.com/oss-review-toolkit/ort-test-data-git-submodules",
+                            revision = "fcea94bab5835172e826afddb9f6427274c983b9"
+                        ),
+                        resolvedRevision = "fcea94bab5835172e826afddb9f6427274c983b9"
+                    ),
+                    "submodules/commons-text" to RepositoryProvenance(
+                        vcsInfo = VcsInfo(
+                            type = VcsType.GIT,
+                            url = "https://github.com/apache/commons-text.git",
+                            revision = "7643b12421100d29fd2b78053e77bcb04a251b2e"
+                        ),
+                        resolvedRevision = "7643b12421100d29fd2b78053e77bcb04a251b2e"
+                    ),
+                    "submodules/test-data-npm" to RepositoryProvenance(
+                        vcsInfo = VcsInfo(
+                            type = VcsType.GIT,
+                            url = "https://github.com/oss-review-toolkit/ort-test-data-npm.git",
+                            revision = "ad0367b7b9920144a47b8d30cc0c84cea102b821"
+                        ),
+                        resolvedRevision = "ad0367b7b9920144a47b8d30cc0c84cea102b821"
+                    ),
+                    "submodules/test-data-npm/isarray" to RepositoryProvenance(
+                        vcsInfo = VcsInfo(
+                            type = VcsType.GIT,
+                            url = "https://github.com/juliangruber/isarray.git",
+                            revision = "63ea4ca0a0d6b0574d6a470ebd26880c3026db4a"
+                        ),
+                        resolvedRevision = "63ea4ca0a0d6b0574d6a470ebd26880c3026db4a"
+                    ),
+                    "submodules/test-data-npm/long.js" to RepositoryProvenance(
+                        vcsInfo = VcsInfo(
+                            type = VcsType.GIT,
+                            url = "https://github.com/dcodeIO/long.js.git",
+                            revision = "941c5c62471168b5d18153755c2a7b38d2560e58"
+                        ),
+                        resolvedRevision = "941c5c62471168b5d18153755c2a7b38d2560e58"
+                    )
+                )
+            }
+
+            "Throw an exception if the resolved revision does not exist" {
+                val provenance = RepositoryProvenance(
+                    vcsInfo = VcsInfo(
+                        type = VcsType.GIT,
+                        url = "https://github.com/oss-review-toolkit/ort-governance.git",
+                        revision = "fcea94bab5835172e826afddb9f6427274c983b9"
+                    ),
+                    resolvedRevision = "0000000000000000000000000000000000000000"
+                )
+
+                shouldThrow<IOException> {
+                    resolver.resolveNestedProvenance(provenance) shouldBe
+                            NestedProvenance(root = provenance, subRepositories = emptyMap())
+                }
+            }
+        }
+    }
+}

--- a/scanner/src/main/kotlin/experimental/NestedProvenance.kt
+++ b/scanner/src/main/kotlin/experimental/NestedProvenance.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import org.ossreviewtoolkit.model.ArtifactProvenance
+import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.RepositoryProvenance
+
+/**
+ * This class contains information about a [root] provenance and all nested [subRepositories].
+ */
+data class NestedProvenance(
+    /**
+     * The root provenance that contains the [nested provenances][subRepositories].
+     */
+    val root: KnownProvenance,
+
+    /**
+     * If [root] is a [RepositoryProvenance] this map contains all paths which contain nested repositories associated
+     * with the [RepositoryProvenance] of the nested repository. If [root] is an [ArtifactProvenance] this map is always
+     * empty.
+     */
+    val subRepositories: Map<String, RepositoryProvenance>
+)

--- a/scanner/src/main/kotlin/experimental/NestedProvenanceResolver.kt
+++ b/scanner/src/main/kotlin/experimental/NestedProvenanceResolver.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import java.io.IOException
+
+import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.model.ArtifactProvenance
+import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.utils.createOrtTempDir
+
+/**
+ * The [NestedProvenanceResolver] provides a function to resolve nested provenances.
+ */
+interface NestedProvenanceResolver {
+    /**
+     * Resolve nested [Provenance]s of the provided [provenance]. For an [ArtifactProvenance] the returned
+     * [NestedProvenance] always contains only the provided [ArtifactProvenance]. For a [RepositoryProvenance] the
+     * resolver looks for nested repositories, for example Git submodules or Mercurial subrepositories.
+     */
+    fun resolveNestedProvenance(provenance: KnownProvenance): NestedProvenance
+}
+
+/**
+ * The default implementation of [NestedProvenanceResolver].
+ */
+class DefaultNestedProvenanceResolver : NestedProvenanceResolver {
+    override fun resolveNestedProvenance(provenance: KnownProvenance): NestedProvenance {
+        return when (provenance) {
+            is ArtifactProvenance -> NestedProvenance(root = provenance, subRepositories = emptyMap())
+            is RepositoryProvenance -> resolveNestedRepository(provenance)
+        }
+    }
+
+    private fun resolveNestedRepository(provenance: RepositoryProvenance): NestedProvenance {
+        val vcs = VersionControlSystem.forType(provenance.vcsInfo.type)
+            ?: VersionControlSystem.forUrl(provenance.vcsInfo.url)
+            ?: throw IOException("Could not determine VCS type for ${provenance.vcsInfo}.")
+
+        val targetDir = createOrtTempDir()
+        val vcsInfo = provenance.vcsInfo.copy(revision = provenance.resolvedRevision)
+        val workingTree = vcs.initWorkingTree(targetDir, vcsInfo)
+
+        vcs.updateWorkingTree(workingTree, vcsInfo.revision, path = vcsInfo.path, recursive = true)
+            .onFailure { throw it }
+
+        val subRepositories = workingTree.getNested().mapValues { (_, nestedVcs) ->
+            // TODO: Verify that the revision is always a resolved revision.
+            RepositoryProvenance(nestedVcs, nestedVcs.revision)
+        }
+
+        return NestedProvenance(root = provenance, subRepositories = subRepositories)
+    }
+}


### PR DESCRIPTION
The `ProvenanceTreeResolver` is used to resolve nested repositories in a
`RepositoryProvenance`. It will be used by a new experimental scanner
implementation in a later commit, therefore it is also located in the
"experimental" package for now.