### PR TITLE
fossid-webapp: Introduce pattern options for naming projects and scans

### DIFF
--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -81,6 +81,22 @@ ort {
         commandLine = --copyright --license --info --strip-root --timeout 300
         parseLicenseExpressions = true
       }
+
+      FossId {
+        serverUrl = "https://fossid.example.com/instance/"
+        user = "user"
+        apiKey = "XYZ"
+
+        namingProjectPattern = "$Var1_$Var2"
+        namingScanPattern = "$Var1_#projectBaseCode_$Var3"
+        namingVariableVar1 = "myOrg"
+        namingVariableVar2 = "myTeam"
+        namingVariableVar3 = "myUnit"
+
+        waitForResult = "false"
+        packageNamespaceFilter = "myorg.myunit"
+        addAuthenticationToUrl = "false"
+      }
     }
 
     storages {

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -320,7 +320,10 @@ class FossId(
                 checkNotNull(scans)
 
                 val existingScan = scans.sortedByDescending { it.id }.find { scan ->
-                    scan.gitBranch == revision && scan.gitRepoUrl == url
+                    // The scans in the server contain the url with the credentials so we have to remove it for the
+                    // comparison. If we don't, the scans won't be matched if the password changes!
+                    val urlWithoutCredentials = scan.gitRepoUrl?.replaceCredentialsInUri()
+                    scan.gitBranch == revision && urlWithoutCredentials == url
                 }
 
                 val scanCode = if (existingScan == null) {

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -23,8 +23,6 @@ import java.io.File
 import java.io.IOException
 import java.net.Authenticator
 import java.time.Instant
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 import kotlin.time.measureTimedValue
 
@@ -85,6 +83,12 @@ import retrofit2.converter.jackson.JacksonConverterFactory
  * * **"addAuthenticationToUrl":** When set, ORT will add credentials from its Authenticator to the URLs sent to FossID.
  * * **"waitForResult":** When set to false, ORT doesn't wait for repositories to be downloaded nor scans to be
  * completed. As a consequence, scan results won't be available in ORT result.
+ *
+ * Naming conventions options. If they are not set, default naming convention are used.
+ * * **"namingProjectPattern":** A pattern for project names when projects are created on the FossID instance. Contains
+ * variables prefixed by "$" e.g. "$Var1_$Var2". Variables are also passed as options and are prefixed by
+ * [NAMING_CONVENTION_VARIABLE_PREFIX] e.g. namingVariableVar1 = "foo".
+ * * **"namingScanPattern":** A pattern for scan names when scans are created on the FossID instance.
  */
 class FossId(
     name: String,
@@ -108,6 +112,11 @@ class FossId(
 
         @JvmStatic
         private val WAIT_REPETITION = 50
+
+        /**
+         * The scanner options beginning with this prefix will be used to parametrize project and scan names.
+         */
+        private const val NAMING_CONVENTION_VARIABLE_PREFIX = "namingVariable"
 
         /**
          * Convert a Git repository URL to a valid project name, e.g.
@@ -158,6 +167,7 @@ class FossId(
     private val user: String
     private val waitForResult: Boolean
     private val secretKeys = listOf("serverUrl", "apiKey", "user")
+    private val namingProvider: FossIdNamingProvider
 
     private val service: FossIdRestService
     private val packageNamespaceFilter: String
@@ -185,6 +195,19 @@ class FossId(
         waitForResult = fossIdScannerOptions["waitForResult"]?.toBooleanStrictOrNull() ?: true
 
         log.info { "waitForResult parameter is set to '$waitForResult'" }
+
+        val namingProjectPattern = fossIdScannerOptions["namingProjectPattern"]?.apply {
+            FossId.log.info { "Naming pattern for projects is $this." }
+        }
+        val namingScanPattern = fossIdScannerOptions["namingScanPattern"]?.apply {
+            FossId.log.info { "Naming pattern for scans is $this." }
+        }
+
+        val namingConventionVariables = fossIdScannerOptions
+            .filterKeys { it.startsWith(NAMING_CONVENTION_VARIABLE_PREFIX) }
+            .mapKeys { it.key.substringAfter(NAMING_CONVENTION_VARIABLE_PREFIX) }
+
+        namingProvider = FossIdNamingProvider(namingProjectPattern, namingScanPattern, namingConventionVariables)
 
         val client = OkHttpClientHelper.buildClient()
 
@@ -282,7 +305,8 @@ class FossId(
 
                 val url = pkg.vcsProcessed.url
                 val revision = pkg.vcsProcessed.revision.ifEmpty { "HEAD" }
-                val projectCode = convertGitUrlToProjectName(url)
+                val projectName = convertGitUrlToProjectName(url)
+                val projectCode = namingProvider.createProjectCode(projectName)
 
                 if (getProject(projectCode) == null) {
                     log.info { "Creating project '$projectCode' ..." }
@@ -304,13 +328,13 @@ class FossId(
 
                     val newUrl = if (addAuthenticationToUrl) queryAuthenticator(url) else url
 
-                    val scanCode = createScan(projectCode, newUrl, revision)
+                    val scanCode = createScan(projectCode, projectName, newUrl, revision)
                     log.info { "Initiating data download ..." }
                     service.downloadFromGit(user, apiKey, scanCode)
                         .checkResponse("download data from Git", false)
                     scanCode
                 } else {
-                    log.info { "Scan found for $url and revision $revision." }
+                    log.info { "Scan ${existingScan.code} found for $url and revision $revision." }
 
                     requireNotNull(existingScan.code) {
                         "FossId returned a null scancode for an existing scan"
@@ -360,9 +384,12 @@ class FossId(
     /**
      * Create a new scan in the FossID server and return the scan code.
      */
-    private suspend fun createScan(projectCode: String, url: String, revision: String): String {
-        val formatter = DateTimeFormatter.ofPattern("'$projectCode'_yyyyMMdd_HHmmss")
-        val scanCode = formatter.format(LocalDateTime.now())
+    private suspend fun createScan(
+        projectCode: String, projectName: String, url: String, revision: String
+    ): String {
+        val scanCode = namingProvider.createScanCode(projectName)
+
+        log.info { "Creating scan $scanCode ..." }
 
         val response = service.createScan(user, apiKey, projectCode, scanCode, url, revision)
             .checkResponse("create scan")

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdNamingProvider.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdNamingProvider.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.fossid
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+import org.ossreviewtoolkit.utils.log
+
+/**
+ * This class provides names for projects and scans when the FossID scanner creates them, following a given pattern.
+ * If one or both patterns is null, a default naming convention is used.
+ *
+ * [namingScanPattern] and [namingProjectPattern] are patterns describing the name using variables, e.g. "$var1_$var2".
+ * Variable values are given in the map [namingConventionVariables].
+ *
+ * There also are builtin variables. Builtin variables are are prefixed in the pattern with "#" e.g. "$var1_#builtin".
+ * Available builtin variables:
+ * * **projectName**: The name of the project (i.e. the part of the URL before .git).
+ * * **currentTimestamp**: The current time.
+ */
+class FossIdNamingProvider(
+    private val namingProjectPattern: String?,
+    private val namingScanPattern: String?,
+    private val namingConventionVariables: Map<String, String>
+) {
+    companion object {
+        @JvmStatic
+        val FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")
+    }
+
+    fun createProjectCode(projectName: String): String = namingProjectPattern?.let {
+        replaceNamingConventionVariables(namingProjectPattern, projectName, namingConventionVariables)
+    } ?: projectName
+
+    fun createScanCode(projectName: String): String {
+        val pattern = namingScanPattern ?: "${projectName}_#currentTimestamp"
+        return replaceNamingConventionVariables(pattern, projectName, namingConventionVariables)
+    }
+
+    /**
+     * Replace the naming convention variables with their values. Used for projects and scans.
+     */
+    private fun replaceNamingConventionVariables(
+        namingConventionPattern: String, projectName: String,
+        namingConventionVariables: Map<String, String>
+    ): String {
+        log.info { "Parametrizing the name with naming=$namingConventionPattern, projectName=$projectName" }
+        val currentTimestamp = FORMATTER.format(LocalDateTime.now())
+        val builtins = mapOf("#projectName" to projectName, "#currentTimestamp" to currentTimestamp)
+
+        val allVariables = namingConventionVariables.mapKeys { "\$${it.key}" } + builtins
+
+        return allVariables.entries.fold(namingConventionPattern) { acc, entry ->
+            acc.replace(entry.key, entry.value)
+        }
+    }
+}


### PR DESCRIPTION
These patterns allow to control the name when a scan or project is created.
When a pattern is omitted, a default naming convention is used.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>