### PR TITLE
DependencyGraphConverter: filter out empty projects

### DIFF
--- a/model/src/main/kotlin/utils/DependencyGraphConverter.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphConverter.kt
@@ -86,7 +86,8 @@ object DependencyGraphConverter {
      * Determine the projects in this [AnalyzerResult] that require a conversion. These are the projects that manage
      * their dependencies in a scope structure.
      */
-    private fun AnalyzerResult.projectsWithScopes(): List<Project> = projects.filter { it.scopeNames == null }
+    private fun AnalyzerResult.projectsWithScopes(): List<Project> =
+        projects.filter { it.scopeDependencies?.isNotEmpty() ?: false }
 
     /**
      * Convert the dependency representation used by this [Project] to the dependency graph format, i.e. a set of

--- a/model/src/test/kotlin/utils/DependencyGraphConverterTest.kt
+++ b/model/src/test/kotlin/utils/DependencyGraphConverterTest.kt
@@ -123,6 +123,24 @@ class DependencyGraphConverterTest : WordSpec({
             graph.scopeRoots.forEach(::collectIssues)
             issues shouldNot beEmpty()
         }
+
+        "not override a dependency graph for an empty project" {
+            val gradleProject = createProject("Gradle", index = 1)
+            val gradleEmptyProject = createProject("Gradle", index = 2).copy(scopeDependencies = sortedSetOf())
+
+            val orgResult = createAnalyzerResult(gradleProject.createResult())
+            val resultWithGraph = DependencyGraphConverter.convert(orgResult)
+            val mixedResult = resultWithGraph.copy(
+                projects = sortedSetOf(gradleEmptyProject).apply { addAll(resultWithGraph.projects) }
+            )
+
+            val convertedResult = DependencyGraphConverter.convert(mixedResult)
+
+            convertedResult.dependencyGraphs["Gradle"] shouldNotBeNull {
+                scopeRoots shouldNot beEmpty()
+                scopes.keys shouldNot beEmpty()
+            }
+        }
     }
 })
 


### PR DESCRIPTION
Such projects are created as fall-back by PackageManager if resolving
of dependencies fails. They can cause problems if there is already a
dependency graph for their package manager type; then this graph is
overridden by an empty one.