### PR TITLE
AsciiDocTemplateReporter: Remove not required deleting of files

### DIFF
--- a/reporter/src/main/kotlin/reporters/AsciiDocTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/AsciiDocTemplateReporter.kt
@@ -146,7 +146,6 @@ class AsciiDocTemplateReporter : Reporter {
                 val outputFile = outputDir.resolve("${file.nameWithoutExtension}.$backend")
 
                 asciidoctor.convertFile(file, optionsBuilder.toFile(outputFile).build())
-                file.delete()
 
                 outputFiles += outputFile
             }


### PR DESCRIPTION
It's not required to delete each Asciidoc file individually in the loop,
because the parent temp directory will be deleted afterwards. Additionally,
the Asciidoc files can depend on each other, which requires them to exist
within the loop.
