### PR TITLE
ScanSummary: Ignore the file_count property on deserialization

### DIFF
--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
@@ -34,6 +35,7 @@ import org.ossreviewtoolkit.utils.FileMatcher
 /**
  * A short summary of the scan results.
  */
+@JsonIgnoreProperties("file_count")
 data class ScanSummary(
     /**
      * The time when the scan started.


### PR DESCRIPTION
The `fileCount` property was removed in 3cfda8c. Ignore it during
deserialization to allow deserialization of old scan summaries.
