### PR TITLE
analyzer: Replace jcenter with mavenCentral in test projects

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android/build.gradle
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -15,6 +15,6 @@ allprojects {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library/app/build.gradle
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library/app/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library/lib/build.gradle
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library/lib/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
Replace `jcenter()` with `mavenCentral()` in all synthetic test
projects, because JCenter is goin to be shutdown [1]. The external test
project will be addressed separately.

[1] https://blog.gradle.org/jcenter-shutdown