### PR TITLE
ClearlyDefinedPackageCurationProvider: Handle all exceptions

### DIFF
--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -28,6 +28,7 @@ val mockkVersion: String by project
 val semverVersion: String by project
 val sw360ClientVersion: String by project
 val toml4jVersion: String by project
+val wiremockVersion: String by project
 
 plugins {
     // Apply core plugins.
@@ -82,5 +83,6 @@ dependencies {
     implementation("org.gradle:gradle-tooling-api:${gradle.gradleVersion}")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
 
+    testImplementation("com.github.tomakehurst:wiremock:$wiremockVersion")
     testImplementation("io.mockk:mockk:$mockkVersion")
 }

--- a/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
@@ -96,29 +96,41 @@ class ClearlyDefinedPackageCurationProvider(
         val (type, provider) = pkgId.toClearlyDefinedTypeAndProvider() ?: return emptyList()
         val namespace = pkgId.namespace.takeUnless { it.isEmpty() } ?: "-"
 
-        val curation = try {
+        val curation = runCatching {
             // TODO: Maybe make PackageCurationProvider.getCurationsFor() a suspend function; then all derived
             //       classes could deal with coroutines more easily.
             runBlocking(Dispatchers.IO) { service.getCuration(type, provider, namespace, pkgId.name, pkgId.version) }
-        } catch (e: HttpException) {
-            // A "HTTP_NOT_FOUND" is expected for non-existing curations, so only handle other codes as a failure.
-            if (e.code() != HttpURLConnection.HTTP_NOT_FOUND) {
-                e.showStackTrace()
+        }.onFailure { e ->
+            when (e) {
+                is HttpException -> {
+                    // A "HTTP_NOT_FOUND" is expected for non-existing curations, so only handle other codes as a
+                    // failure.
+                    if (e.code() != HttpURLConnection.HTTP_NOT_FOUND) {
+                        e.showStackTrace()
 
-                log.warn {
-                    val message = e.response()?.errorBody()?.string() ?: e.collectMessagesAsString()
-                    "Getting curations for '${pkgId.toCoordinates()}' failed with code ${e.code()}: $message"
+                        log.warn {
+                            val message = e.response()?.errorBody()?.string() ?: e.collectMessagesAsString()
+                            "Getting curations for '${pkgId.toCoordinates()}' failed with code ${e.code()}: $message"
+                        }
+                    }
+                }
+
+                is JsonMappingException -> {
+                    e.showStackTrace()
+
+                    log.warn { "Deserializing the ClearlyDefined curation for '${pkgId.toCoordinates()}' failed." }
+                }
+
+                else -> {
+                    e.showStackTrace()
+
+                    log.warn {
+                        "Querying ClearlyDefined curation for '${pkgId.toCoordinates()}' failed: " +
+                                e.collectMessagesAsString()
+                    }
                 }
             }
-
-            return emptyList()
-        } catch (e: JsonMappingException) {
-            e.showStackTrace()
-
-            log.warn { "Deserializing the ClearlyDefined curation for '${pkgId.toCoordinates()}' failed." }
-
-            return emptyList()
-        }
+        }.getOrNull() ?: return emptyList()
 
         val declaredLicenseParsed = curation.licensed?.declared?.let { declaredLicense ->
             // Only take curations of good quality (i.e. those not using deprecated identifiers) and in particular none

--- a/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
@@ -26,6 +26,8 @@ import java.net.HttpURLConnection
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 
+import okhttp3.OkHttpClient
+
 import org.ossreviewtoolkit.analyzer.PackageCurationProvider
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
@@ -82,8 +84,13 @@ fun SourceLocation?.toArtifactOrVcs(): Any? =
 /**
  * A provider for curated package meta-data from the [ClearlyDefined](https://clearlydefined.io/) service.
  */
-class ClearlyDefinedPackageCurationProvider(server: Server = Server.PRODUCTION) : PackageCurationProvider {
-    private val service by lazy { ClearlyDefinedService.create(server, OkHttpClientHelper.buildClient()) }
+class ClearlyDefinedPackageCurationProvider(
+    serverUrl: String,
+    client: OkHttpClient? = null
+) : PackageCurationProvider {
+    constructor(server: Server = Server.PRODUCTION) : this(server.url)
+
+    private val service by lazy { ClearlyDefinedService.create(serverUrl, client ?: OkHttpClientHelper.buildClient()) }
 
     override fun getCurationsFor(pkgId: Identifier): List<PackageCuration> {
         val (type, provider) = pkgId.toClearlyDefinedTypeAndProvider() ?: return emptyList()

--- a/analyzer/src/test/kotlin/curation/ClearlyDefinedPackageCurationProviderMockTest.kt
+++ b/analyzer/src/test/kotlin/curation/ClearlyDefinedPackageCurationProviderMockTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.curation
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.should
+
+import java.time.Duration
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.utils.OkHttpClientHelper
+
+/**
+ * A test for [ClearlyDefinedPackageCurationProvider], which uses a mock server. This allows testing some specific
+ * error conditions.
+ */
+class ClearlyDefinedPackageCurationProviderMockTest : WordSpec({
+    val wiremock = WireMockServer(
+        WireMockConfiguration.options()
+            .dynamicPort()
+            .usingFilesUnderDirectory("src/test/assets/")
+    )
+
+    beforeSpec {
+        wiremock.start()
+        WireMock.configureFor(wiremock.port())
+    }
+
+    afterSpec {
+        wiremock.stop()
+    }
+
+    beforeTest {
+        wiremock.resetAll()
+    }
+
+    "ClearlyDefinedPackageCurationProvider" should {
+        "handle a SocketTimeoutException" {
+            wiremock.stubFor(get(anyUrl())
+                .willReturn(aResponse().withFixedDelay(2000)))
+            val client = OkHttpClientHelper.buildClient {
+                readTimeout(Duration.ofSeconds(1))
+            }
+
+            val provider = ClearlyDefinedPackageCurationProvider("http://localhost:${wiremock.port()}", client)
+
+            provider.getCurationsFor(Identifier("Maven:some-ns:some-component:1.2.3")) should beEmpty()
+        }
+    }
+})


### PR DESCRIPTION
In a concrete scenario, ClearlyDefined did not send a response within
the configured timeout, causing a SocketTimeoutException to be thrown.
This exception was not handled and eventually caused the analyzer to
crash. To avoid this, add a catch block for all exceptions.

Add a test case using a mock server to verify that timeout exceptions
are now handled properly.