### PR TITLE
fossid-webapp: Delta scans

### DIFF
--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -329,9 +329,9 @@ class FossId(
                 val scanCode = if (existingScan == null) {
                     log.info { "No scan found for $url and revision $revision. Creating scan ..." }
 
+                    val scanCode = namingProvider.createScanCode(projectName)
                     val newUrl = if (addAuthenticationToUrl) queryAuthenticator(url) else url
-
-                    val scanCode = createScan(projectCode, projectName, newUrl, revision)
+                    createScan(projectCode, scanCode, newUrl, revision)
                     log.info { "Initiating data download ..." }
                     service.downloadFromGit(user, apiKey, scanCode)
                         .checkResponse("download data from Git", false)
@@ -386,11 +386,7 @@ class FossId(
     /**
      * Create a new scan in the FossID server and return the scan code.
      */
-    private suspend fun createScan(
-        projectCode: String, projectName: String, url: String, revision: String
-    ): String {
-        val scanCode = namingProvider.createScanCode(projectName)
-
+    private suspend fun createScan(projectCode: String, scanCode: String, url: String, revision: String): String {
         log.info { "Creating scan $scanCode ..." }
 
         val response = service.createScan(user, apiKey, projectCode, scanCode, url, revision)

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdNamingProvider.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdNamingProvider.kt
@@ -51,7 +51,7 @@ class FossIdNamingProvider(
     } ?: projectName
 
     fun createScanCode(projectName: String): String {
-        val pattern = namingScanPattern ?: "${projectName}_#currentTimestamp"
+        val pattern = namingScanPattern ?: "#projectName_#currentTimestamp"
         return replaceNamingConventionVariables(pattern, projectName, namingConventionVariables)
     }
 


### PR DESCRIPTION
When set, ORT will create delta scans. When only changes in a repository
need to be scanned, delta scans reuse the identifications of latest scan
on the same repository to reduce the amount of findings.
If deltaScans is set and no scan exist yet, an initial scan called
"origin" scan will be created.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>
