### PR TITLE
SpdxDocumentFile: Use packageFilename before downloadLocation for VcsInfo

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
@@ -109,11 +109,11 @@ packages:
       algorithm: ""
   vcs:
     type: "Git"
-    url: "ssh://github.com/openssl/openssl.git"
-    revision: "e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
-    path: ""
+    url: "<REPLACE_URL>"
+    revision: "<REPLACE_REVISION>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/spdx/project/libs/openssl"
   vcs_processed:
     type: "Git"
-    url: "ssh://git@github.com/openssl/openssl.git"
-    revision: "e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
-    path: ""
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/spdx/project/libs/openssl"

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -317,12 +317,10 @@ class SpdxDocumentFile(
     private fun SpdxPackage.toPackage(workingDir: File): Package {
         val packageDescription = description.takeUnless { it.isEmpty() } ?: summary
 
-        // If the VCS information cannot be determined from the download location, fall back to try getting it from the
-        // VCS working tree itself.
-        val vcs = getVcsInfo() ?: run {
-            val packageDir = workingDir.resolve(packageFilename)
-            VersionControlSystem.forDirectory(packageDir)?.getInfo()
-        }.orEmpty()
+        // If the VCS information cannot be determined from the VCS working tree itself, fall back to try getting it
+        // from the download location.
+        val packageDir = workingDir.resolve(packageFilename)
+        val vcs = VersionControlSystem.forDirectory(packageDir)?.getInfo() ?: getVcsInfo().orEmpty()
 
         val id = toIdentifier()
 


### PR DESCRIPTION
If the `packageFilename` is defined, the code is already present, thus, need
not be downloaded again. Additionally, this ensures that the code is scanned
that is actually used by the project, which could include minor changes.

Resolves #4276.

This was discussed in [this thread](https://ort-talk.slack.com/archives/C9NNJ54B1/p1625841198374400) in Slack. 
