### PR TITLE
fossid-webapp: Refine the "reuse identification" behavior

### DIFF
--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -454,7 +454,7 @@ class FossId(
             log.info { "No scan found for $url and revision $revision. Creating origin scan ..." }
             namingProvider.createScanCode(projectName, DeltaTag.ORIGIN)
         } else {
-            log.info { "No scan found for $url and revision $revision. Creating delta scan ..." }
+            log.info { "Scan found for $url and revision $revision. Creating delta scan ..." }
             namingProvider.createScanCode(projectName, DeltaTag.DELTA)
         }
 


### PR DESCRIPTION
Tweak the logic when reusing existing scans: If the scan is not finished, wait for it to complete.