### PR TITLE
SpdxDocumentFile: Use package.spdx.yml if no project file is provided.

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/spdx-packages-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx-packages-expected-output.yml
@@ -1,0 +1,45 @@
+---
+- project:
+    id: "SpdxDocumentFile::curl:7.70.0"
+    definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl/package.spdx.yml"
+    declared_licenses:
+    - "curl"
+    declared_licenses_processed:
+      spdx_expression: "curl"
+    vcs:
+      type: ""
+      url: ""
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "<REPLACE_URL_PROCESSED>"
+      revision: "<REPLACE_REVISION>"
+      path: "analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl"
+    homepage_url: "https://curl.haxx.se/"
+    scopes:
+    - name: "default"
+      dependencies: []
+  packages: []
+- project:
+    id: "SpdxDocumentFile::zlib:1.2.11"
+    definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/zlib/package.spdx.yml"
+    declared_licenses:
+    - "Zlib"
+    declared_licenses_processed:
+      spdx_expression: "Zlib"
+    vcs:
+      type: ""
+      url: ""
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "<REPLACE_URL_PROCESSED>"
+      revision: "<REPLACE_REVISION>"
+      path: "analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/zlib"
+    homepage_url: "http://zlib.net"
+    scopes:
+    - name: "default"
+      dependencies: []
+  packages: []

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -472,6 +472,9 @@ class SpdxDocumentFile(
             // or a package-style SPDX document that describes a single (dependency-)package.
             spdxDocument.isProject()
         }.keys.toList().also { remainingFiles ->
+            if (remainingFiles.isEmpty()) {
+                return definitionFiles
+            }
             val discardedFiles = definitionFiles - remainingFiles
             if (discardedFiles.isNotEmpty()) {
                 log.info {
@@ -486,9 +489,15 @@ class SpdxDocumentFile(
         // For direct callers of this function mapDefinitionFiles() did not populate the map before, so add a fallback.
         val spdxDocument = spdxDocumentForFile.getOrPut(definitionFile) { SpdxModelMapper.read(definitionFile) }
 
-        // Guard against direct callers passing SPDX documents that do not describe a project.
-        val projectPackage = requireNotNull(spdxDocument.projectPackage()) {
-            "The SPDX document file at '$definitionFile' does not describe a project."
+        val packages = mutableSetOf<Package>()
+        val scopes = sortedSetOf<Scope>()
+
+        val projectPackage = if (!spdxDocument.isProject()) {
+            spdxDocument.packages[0]
+        } else {
+            requireNotNull(spdxDocument.projectPackage()) {
+                "The SPDX document file at '$definitionFile' does not describe a project."
+            }
         }
 
         log.info {
@@ -496,9 +505,7 @@ class SpdxDocumentFile(
                     "'${projectPackage.name}'."
         }
 
-        val packages = mutableSetOf<Package>()
-
-        val scopes = SPDX_SCOPE_RELATIONSHIPS.mapNotNullTo(sortedSetOf()) { type ->
+        scopes += SPDX_SCOPE_RELATIONSHIPS.mapNotNullTo(sortedSetOf()) { type ->
             createScope(spdxDocument, projectPackage, type, workingDir, packages)
         }
 

--- a/spdx-utils/src/main/kotlin/model/SpdxDocument.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxDocument.kt
@@ -138,6 +138,8 @@ data class SpdxDocument(
 
         require(dataLicense.isNotBlank()) { "The data license must not be blank." }
 
+        require(packages.isNotEmpty()) { "At least one package must be listed in packages" }
+
         val duplicateExternalDocumentRefs = externalDocumentRefs.getDuplicates { it.externalDocumentId }
         require(duplicateExternalDocumentRefs.isEmpty()) {
             "The document must not contain duplicate external document references but has " +


### PR DESCRIPTION
Resolves #4251. 

Previously, `package.spdx.yml` were discarded in favor of `project.spdx.yml`s. This was a breaking change.
In order to avoid duplicate packages, the `package.spdx.yml` is only used when no `project.spdx.yml` is amongst the definition files of the `SpdxDocumentFile` manager. 