### PR TITLE
Add a new JiraNotifier

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -93,6 +93,15 @@ repositories {
             includeGroup("com.github.everit-org.json-schema")
         }
     }
+    exclusiveContent {
+        forRepository {
+            maven("https://packages.atlassian.com/maven-external")
+        }
+
+        filter {
+            includeGroupByRegex("com\\.atlassian\\..*")
+        }
+    }
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,6 +45,7 @@ hikariVersion = 5.0.0
 hopliteVersion = 1.4.0
 jacksonVersion = 2.12.3
 jgitVersion = 5.12.0.202106070339-r
+jiraRestApiVersion = 5.2.2
 jSchAgentProxyVersion = 0.0.7
 jsltVersion = 0.1.11
 kotestVersion = 4.6.1

--- a/model/src/main/kotlin/config/JiraConfiguration.kt
+++ b/model/src/main/kotlin/config/JiraConfiguration.kt
@@ -19,7 +19,19 @@
 
 package org.ossreviewtoolkit.model.config
 
-data class NotifierConfiguration(
-    val mail: SendMailConfiguration? = null,
-    val jira: JiraConfiguration? = null
+data class JiraConfiguration(
+    /**
+     * The host for the Jira instance.
+     */
+    val host: String,
+
+    /**
+     * The username used for the authentication.
+     */
+    val username: String,
+
+    /**
+     * The password used for the authentication.
+     */
+    val password: String
 )

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -170,5 +170,11 @@ ort {
       useSsl = true
       fromAddress = "no-reply@oss-review-toolkit.org"
     }
+
+    jira {
+        host = "localhost"
+        username = "user"
+        password = "secret"
+    }
   }
 }

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -148,6 +148,14 @@ class OrtConfigurationTest : WordSpec({
                 }
             }
 
+            with(ortConfig.notifier) {
+                jira shouldNotBeNull {
+                    host shouldBe "localhost"
+                    username shouldBe "user"
+                    password shouldBe "secret"
+                }
+            }
+
             with(ortConfig.licenseFilePatterns) {
                 licenseFilenames shouldContainExactly listOf("license*")
                 patentFilenames shouldContainExactly listOf("patents")

--- a/notifier/build.gradle.kts
+++ b/notifier/build.gradle.kts
@@ -18,10 +18,25 @@
  */
 
 val apacheCommonsEmailVersion: String by project
+val jiraRestApiVersion: String by project
+val mockkVersion: String by project
+val wiremockVersion: String by project
 
 plugins {
     // Apply core plugins.
     `java-library`
+}
+
+repositories {
+    exclusiveContent {
+        forRepository {
+            maven("https://packages.atlassian.com/maven-external")
+        }
+
+        filter {
+            includeGroupByRegex("com\\.atlassian\\..*")
+        }
+    }
 }
 
 dependencies {
@@ -29,5 +44,10 @@ dependencies {
 
     implementation(project(":utils"))
 
+    implementation("com.atlassian.jira:jira-rest-java-client-api:$jiraRestApiVersion")
+    implementation("com.atlassian.jira:jira-rest-java-client-app:$jiraRestApiVersion")
     implementation("org.apache.commons:commons-email:$apacheCommonsEmailVersion")
+
+    testImplementation("com.github.tomakehurst:wiremock:$wiremockVersion")
+    testImplementation("io.mockk:mockk:$mockkVersion")
 }

--- a/notifier/src/main/kotlin/Notifier.kt
+++ b/notifier/src/main/kotlin/Notifier.kt
@@ -24,6 +24,7 @@ import java.time.Instant
 import org.ossreviewtoolkit.model.NotifierRun
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.NotifierConfiguration
+import org.ossreviewtoolkit.notifier.modules.JiraNotifier
 import org.ossreviewtoolkit.notifier.modules.MailNotifier
 import org.ossreviewtoolkit.utils.ScriptRunner
 
@@ -45,6 +46,7 @@ class Notifier(ortResult: OrtResult = OrtResult.EMPTY, config: NotifierConfigura
         engine.put("ortResult", ortResult)
 
         config.mail?.let { engine.put("mailClient", MailNotifier(it)) }
+        config.jira?.let { engine.put("jiraClient", JiraNotifier(it)) }
     }
 
     override fun run(script: String): NotifierRun {

--- a/notifier/src/main/kotlin/modules/JiraNotifier.kt
+++ b/notifier/src/main/kotlin/modules/JiraNotifier.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.notifier.modules
+
+import com.atlassian.jira.rest.client.api.JiraRestClient
+import com.atlassian.jira.rest.client.api.RestClientException
+import com.atlassian.jira.rest.client.api.domain.BasicIssue
+import com.atlassian.jira.rest.client.api.domain.Comment
+import com.atlassian.jira.rest.client.api.domain.input.IssueInputBuilder
+import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory
+
+import java.net.URI
+
+import org.ossreviewtoolkit.model.Failure
+import org.ossreviewtoolkit.model.Result
+import org.ossreviewtoolkit.model.Success
+import org.ossreviewtoolkit.model.config.JiraConfiguration
+import org.ossreviewtoolkit.utils.collectMessagesAsString
+import org.ossreviewtoolkit.utils.log
+
+class JiraNotifier(
+    val config: JiraConfiguration,
+    private val restClient: JiraRestClient = AsynchronousJiraRestClientFactory()
+        .createWithBasicHttpAuthentication(URI(config.host), config.username, config.password)
+) {
+    /**
+     * Returns a [ProjectIssueBuilder] object, which can be used to do operations for the given [projectKey].
+     */
+    fun projectIssueBuilder(projectKey: String): ProjectIssueBuilder =
+        ProjectIssueBuilder(projectKey, restClient)
+
+    class ProjectIssueBuilder(
+        private val projectKey: String,
+        private val restClient: JiraRestClient
+        ) {
+        private val issueTypes = restClient.projectClient.getProject(projectKey).claim()
+            .issueTypes.associateBy { it.name }
+
+        /**
+         * Create an issue for the project with the usage of [summary], [description] and [issueType]. If an [assignee]
+         * is given, the assignee for the issue is also set. The [avoidDuplicates] flag decides whether duplicate issues
+         * will be created or not. If the flag is set to true (default), it will not create a new issue if there is
+         * already exactly one issue with the same [summary], but it will add a comment to the issue with the given
+         * [description]. If false, it will always create a new issue even if there are issues with the same [summary].
+         * Return a [Result] that encapsulates the created issue on success, or the caught exception on failure.
+         */
+        fun createIssue(
+            summary: String,
+            description: String,
+            issueType: String,
+            assignee: String? = null,
+            avoidDuplicates: Boolean = true
+        ): Result<BasicIssue> {
+            if (issueType !in issueTypes) {
+                return Failure("The issue type '$issueType' is not valid. Use a valid issue type, specified in " +
+                        "your project '$projectKey'")
+            }
+
+            val issueInputBuilder = IssueInputBuilder()
+                .setProjectKey(projectKey)
+                .setSummary(summary)
+                .setDescription(description)
+                .setIssueType(issueTypes[issueType])
+            assignee?.let { issueInputBuilder.setAssigneeName(assignee) }
+            val issueInput = issueInputBuilder.build()
+
+            if (avoidDuplicates) {
+                val searchResult = restClient.searchClient.searchJql(
+                    "project = \"$projectKey\" AND summary ~ \"$summary\""
+                ).claim()
+
+                // TODO: Currently, only a comment is added to an issue if there is exactly one duplicate of it. If the
+                //       search returns several issues, a failure is returned.
+                //       An improvement has to be added here so that it can handle the case that the search returns more
+                //       than one issue.
+                if (searchResult.total == 1) {
+                    val issue = searchResult.issues.iterator().next()
+
+                    return try {
+                        restClient.issueClient.addComment(
+                            issue.commentsUri,
+                            Comment.valueOf("Duplicate of: $summary \n $description")
+                        ).claim()
+
+                        Success(issue)
+                    } catch (e: RestClientException) {
+                        log.error { "The comment for the issue '${issue.key} could not be added: " +
+                                "${e.collectMessagesAsString()}" }
+
+                        Failure(e.collectMessagesAsString())
+                    }
+                } else if (searchResult.total > 1) {
+                    log.debug { "There are more then 1 duplicate issues of '$summary', which is supported yet." }
+
+                    return Failure("There are more then 1 duplicate issues of '$summary', which is supported yet.")
+                }
+            }
+
+            return try {
+                val resultIssue = restClient.issueClient.createIssue(issueInput).claim()
+
+                log.info { "Issue ${resultIssue.key} created." }
+
+                Success(resultIssue)
+            } catch (e: RestClientException) {
+                log.error { "The issue for the project '$projectKey' could not be created: " +
+                        "${e.collectMessagesAsString()}" }
+
+                Failure(e.collectMessagesAsString())
+            }
+        }
+    }
+}

--- a/notifier/src/test/assets/__files/response_create_issue.json
+++ b/notifier/src/test/assets/__files/response_create_issue.json
@@ -1,0 +1,5 @@
+{
+  "id": "2457237",
+  "key": "PROJECT-1",
+  "self": "https://jira.oss-review-toolkit.org/rest/api/2/issue/2457237"
+}

--- a/notifier/src/test/assets/__files/response_get_project.json
+++ b/notifier/src/test/assets/__files/response_get_project.json
@@ -1,0 +1,66 @@
+{
+  "expand": "description,lead,url,projectKeys",
+  "self": "https://jira.oss-review-toolkit.org/rest/api/latest/project/14252",
+  "id": "14252",
+  "key": "TEST",
+  "description": "",
+  "lead": {
+    "self": "https://jira.oss-review-toolkit.org/rest/api/latest/user?username=TESTUSER",
+    "key": "432145",
+    "name": "TESTUSER",
+    "avatarUrls": { },
+    "displayName": "Test User",
+    "active": true
+  },
+  "components": [ ],
+  "issueTypes": [
+    {
+      "self": "https://jira.oss-review-toolkit.org/rest/api/2/issuetype/1",
+      "id": "1",
+      "description": "A problem which impairs or prevents the functions of the product.",
+      "iconUrl": "https://jira.oss-review-toolkit.org/secure/viewavatar?size=xsmall&avatarId=14563&avatarType=issuetype",
+      "name": "Bug",
+      "subtask": false,
+      "avatarId": 14563
+    },
+    {
+      "self": "https://jira.oss-review-toolkit.org/rest/api/2/issuetype/2",
+      "id": "2",
+      "description": "A new feature of the product, which has yet to be developed.",
+      "iconUrl": "https://jira.oss-review-toolkit.org/secure/viewavatar?size=xsmall&avatarId=14571&avatarType=issuetype",
+      "name": "New Feature",
+      "subtask": false,
+      "avatarId": 14571
+    },    {
+      "self": "https://jira.oss-review-toolkit.org/rest/api/2/issuetype/3",
+      "id": "3",
+      "description": "A task that needs to be done.",
+      "iconUrl": "https://jira.oss-review-toolkit.org/secure/viewavatar?size=xsmall&avatarId=14578&avatarType=issuetype",
+      "name": "Task",
+      "subtask": false,
+      "avatarId": 14578
+    },
+    {
+      "self": "https://jira.oss-review-toolkit.org/rest/api/2/issuetype/4",
+      "id": "4",
+      "description": "An improvement or enhancement to an existing feature or task.",
+      "iconUrl": "https://jira.oss-review-toolkit.org/secure/viewavatar?size=xsmall&avatarId=14570&avatarType=issuetype",
+      "name": "Improvement",
+      "subtask": false,
+      "avatarId": 14570
+    }
+  ],
+  "assigneeType": "UNASSIGNED",
+  "versions": [ ],
+  "name": "Test Project",
+  "roles": { },
+  "avatarUrls": { },
+  "projectCategory": {
+    "self": "https://jira.oss-review-toolkit.org/rest/api/latest/projectCategory/10332",
+    "id": "10332",
+    "name": "Test category",
+    "description": "Test project category description"
+  },
+  "projectTypeKey": "software",
+  "archived": false
+}

--- a/notifier/src/test/assets/__files/response_search_jql.json
+++ b/notifier/src/test/assets/__files/response_search_jql.json
@@ -1,0 +1,218 @@
+{
+  "expand": "names,schema",
+  "startAt": 0,
+  "maxResults": 50,
+  "total": 2,
+  "issues": [
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "2457255",
+      "self": "https://jira.oss-review-toolkit.org/rest/api/latest/issue/2457255",
+      "key": "TEST-505",
+      "fields": {
+        "lastViewed": "2021-07-19T15:33:12.108+0200",
+        "issuelinks": [],
+        "assignee": {
+          "self": "https://jira.oss-review-toolkit.org/rest/api/2/user?username=TESTUSER",
+          "name": "TESTUSER",
+          "key": "TESTUSER",
+          "emailAddress": "test.user@example.org",
+          "avatarUrls": {
+            "48x48": "https://jira.oss-review-toolkit.org/secure/useravatar?ownerId=sco1be&avatarId=31314",
+            "24x24": "https://jira.oss-review-toolkit.org/secure/useravatar?size=small&ownerId=sco1be&avatarId=31314",
+            "16x16": "https://jira.oss-review-toolkit.org/secure/useravatar?size=xsmall&ownerId=sco1be&avatarId=31314",
+            "32x32": "https://jira.oss-review-toolkit.org/secure/useravatar?size=medium&ownerId=sco1be&avatarId=31314"
+          },
+          "displayName": "Test User",
+          "active": true,
+          "timeZone": "Europe/Berlin"
+        },
+        "subtasks": [],
+        "status": {
+          "self": "https://jira.oss-review-toolkit.org/rest/api/2/status/10159",
+          "description": "This status is managed internally by JIRA Software",
+          "iconUrl": "https://jira.oss-review-toolkit.org/images/icons/subtask.gif",
+          "name": "To Do",
+          "id": "10159",
+          "statusCategory": {
+            "self": "https://jira.oss-review-toolkit.org/rest/api/2/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+          }
+        },
+        "issuetype": {
+          "self": "https://jira.oss-review-toolkit.org/rest/api/2/issuetype/1",
+          "id": "1",
+          "description": "A problem which impairs or prevents the functions of the product.",
+          "iconUrl": "https://jira.oss-review-toolkit.org/secure/viewavatar?size=xsmall&avatarId=14563&avatarType=issuetype",
+          "name": "Bug",
+          "subtask": false,
+          "avatarId": 14563
+        },
+        "environment": null,
+        "duedate": null,
+        "timespent": null,
+        "labels": [],
+        "components": [],
+        "reporter": {
+          "self": "https://jira.oss-review-toolkit.org/rest/api/2/user?username=TESTUSER2",
+          "name": "TESTUSER2",
+          "key": "TESTUSER2",
+          "emailAddress": "test.user2@example.org",
+          "avatarUrls": {
+            "48x48": "https://jira.oss-review-toolkit.org/secure/useravatar?avatarId=10122",
+            "24x24": "https://jira.oss-review-toolkit.org/secure/useravatar?size=small&avatarId=10122",
+            "16x16": "https://jira.oss-review-toolkit.org/secure/useravatar?size=xsmall&avatarId=10122",
+            "32x32": "https://jira.oss-review-toolkit.org/secure/useravatar?size=medium&avatarId=10122"
+          },
+          "displayName": "Test User 2",
+          "active": true,
+          "timeZone": "Europe/Berlin"
+        },
+        "progress": {
+          "progress": 0,
+          "total": 0
+        },
+        "project": {
+          "self": "https://jira.oss-review-toolkit.org/rest/api/2/project/47211",
+          "id": "47211",
+          "key": "TEST",
+          "name": "Test Project for testing purposes",
+          "projectTypeKey": "software",
+          "avatarUrls": {
+            "48x48": "https://jira.oss-review-toolkit.org/secure/projectavatar?pid=47211&avatarId=33505",
+            "24x24": "https://jira.oss-review-toolkit.org/secure/projectavatar?size=small&pid=47211&avatarId=33505",
+            "16x16": "https://jira.oss-review-toolkit.org/secure/projectavatar?size=xsmall&pid=47211&avatarId=33505",
+            "32x32": "https://jira.oss-review-toolkit.org/secure/projectavatar?size=medium&pid=47211&avatarId=33505"
+          },
+          "projectCategory": {
+            "self": "https://jira.oss-review-toolkit.org/rest/api/2/projectCategory/17280",
+            "id": "17280",
+            "description": "a category",
+            "name": "CAT"
+          }
+        },
+        "updated": "2021-07-19T15:27:15.000+0200",
+        "description": "Test description",
+        "summary": "Test Issue",
+        "fixVersions": [],
+        "priority": {
+          "self": "https://jira.oss-review-toolkit.org/rest/api/2/priority/4",
+          "iconUrl": "https://jira.oss-review-toolkit.org/images/icons/priorities/minor.svg",
+          "name": "Minor",
+          "id": "4"
+        },
+        "versions": [],
+        "created": "2021-07-19T15:27:15.000+0200"
+      }
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "2457256",
+      "self": "https://jira.oss-review-toolkit.org/rest/api/latest/issue/2457256",
+      "key": "TEST-506",
+      "fields": {
+        "lastViewed": "2021-07-19T15:33:12.108+0200",
+        "issuelinks": [],
+        "assignee": {
+          "self": "https://jira.oss-review-toolkit.org/rest/api/2/user?username=TESTUSER",
+          "name": "TESTUSER",
+          "key": "TESTUSER",
+          "emailAddress": "test.user@example.org",
+          "avatarUrls": {
+            "48x48": "https://jira.oss-review-toolkit.org/secure/useravatar?ownerId=sco1be&avatarId=31314",
+            "24x24": "https://jira.oss-review-toolkit.org/secure/useravatar?size=small&ownerId=sco1be&avatarId=31314",
+            "16x16": "https://jira.oss-review-toolkit.org/secure/useravatar?size=xsmall&ownerId=sco1be&avatarId=31314",
+            "32x32": "https://jira.oss-review-toolkit.org/secure/useravatar?size=medium&ownerId=sco1be&avatarId=31314"
+          },
+          "displayName": "Test User",
+          "active": true,
+          "timeZone": "Europe/Berlin"
+        },
+        "subtasks": [],
+        "status": {
+          "self": "https://jira.oss-review-toolkit.org/rest/api/2/status/10159",
+          "description": "This status is managed internally by JIRA Software",
+          "iconUrl": "https://jira.oss-review-toolkit.org/images/icons/subtask.gif",
+          "name": "To Do",
+          "id": "10159",
+          "statusCategory": {
+            "self": "https://jira.oss-review-toolkit.org/rest/api/2/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+          }
+        },
+        "issuetype": {
+          "self": "https://jira.oss-review-toolkit.org/rest/api/2/issuetype/1",
+          "id": "1",
+          "description": "A problem which impairs or prevents the functions of the product.",
+          "iconUrl": "https://jira.oss-review-toolkit.org/secure/viewavatar?size=xsmall&avatarId=14563&avatarType=issuetype",
+          "name": "Bug",
+          "subtask": false,
+          "avatarId": 14563
+        },
+        "environment": null,
+        "duedate": null,
+        "timespent": null,
+        "labels": [],
+        "components": [],
+        "reporter": {
+          "self": "https://jira.oss-review-toolkit.org/rest/api/2/user?username=TESTUSER2",
+          "name": "TESTUSER2",
+          "key": "TESTUSER2",
+          "emailAddress": "test.user@example.org",
+          "avatarUrls": {
+            "48x48": "https://jira.oss-review-toolkit.org/secure/useravatar?avatarId=10122",
+            "24x24": "https://jira.oss-review-toolkit.org/secure/useravatar?size=small&avatarId=10122",
+            "16x16": "https://jira.oss-review-toolkit.org/secure/useravatar?size=xsmall&avatarId=10122",
+            "32x32": "https://jira.oss-review-toolkit.org/secure/useravatar?size=medium&avatarId=10122"
+          },
+          "displayName": "Test User 2",
+          "active": true,
+          "timeZone": "Europe/Berlin"
+        },
+        "progress": {
+          "progress": 0,
+          "total": 0
+        },
+        "project": {
+          "self": "https://jira.oss-review-toolkit.org/rest/api/2/project/47211",
+          "id": "47211",
+          "key": "TEST",
+          "name": "Test Project for testing purposes",
+          "projectTypeKey": "software",
+          "avatarUrls": {
+            "48x48": "https://jira.oss-review-toolkit.org/secure/projectavatar?pid=47211&avatarId=33505",
+            "24x24": "https://jira.oss-review-toolkit.org/secure/projectavatar?size=small&pid=47211&avatarId=33505",
+            "16x16": "https://jira.oss-review-toolkit.org/secure/projectavatar?size=xsmall&pid=47211&avatarId=33505",
+            "32x32": "https://jira.oss-review-toolkit.org/secure/projectavatar?size=medium&pid=47211&avatarId=33505"
+          },
+          "projectCategory": {
+            "self": "https://jira.oss-review-toolkit.org/rest/api/2/projectCategory/17280",
+            "id": "17280",
+            "description": "a category",
+            "name": "CAT"
+          }
+        },
+        "updated": "2021-07-19T15:27:15.000+0200",
+        "description": "Test description 2",
+        "summary": "Test Issue 2",
+        "fixVersions": [],
+        "priority": {
+          "self": "https://jira.oss-review-toolkit.org/rest/api/2/priority/4",
+          "iconUrl": "https://jira.oss-review-toolkit.org/images/icons/priorities/minor.svg",
+          "name": "Minor",
+          "id": "4"
+        },
+        "versions": [],
+        "created": "2021-07-19T15:27:15.000+0200"
+      }
+    }
+  ],
+  "names": { },
+  "schema": { }
+}

--- a/notifier/src/test/kotlin/modules/JiraNotifierTest.kt
+++ b/notifier/src/test/kotlin/modules/JiraNotifierTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.notifier.modules
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.configureFor
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.matching
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.beOfType
+
+import java.net.URI
+
+import org.ossreviewtoolkit.model.Failure
+import org.ossreviewtoolkit.model.Success
+import org.ossreviewtoolkit.model.config.JiraConfiguration
+
+class JiraNotifierTest : WordSpec({
+    val wiremock = WireMockServer(
+        WireMockConfiguration.options()
+            .dynamicPort()
+            .usingFilesUnderDirectory(TEST_FILES_ROOT)
+    )
+
+    beforeSpec {
+        wiremock.start()
+        configureFor(wiremock.port())
+    }
+
+    afterSpec {
+        wiremock.stop()
+    }
+
+    beforeTest {
+        wiremock.resetAll()
+    }
+
+    "JiraNotifier" should {
+        "create a Jira ticket" {
+            val projectKey = "TEST"
+            val notifier = JiraNotifier(
+                JiraConfiguration("http://localhost:${wiremock.port()}", "testuser", "testpassword")
+            )
+
+            stubFor(
+                get(urlPathEqualTo("/rest/api/latest/project/$projectKey"))
+                    .willReturn(
+                        aResponse().withStatus(200)
+                            .withBodyFile("response_get_project.json")
+                    )
+            )
+            stubFor(
+                post(urlPathEqualTo("/rest/api/latest/issue"))
+                    .withHeader("Content-Type", equalTo("application/json"))
+                    .willReturn(
+                        aResponse().withStatus(201)
+                            .withBodyFile("response_create_issue.json")
+                    )
+            )
+
+            val projectIssueBuilder = notifier.projectIssueBuilder(projectKey)
+            val resultIssue = projectIssueBuilder.createIssue(
+                "Ticket summary",
+                "The description of the ticket.",
+                "Bug",
+                null,
+                false
+            )
+
+            resultIssue should beOfType(Success::class)
+            (resultIssue as Success).result.let { issue ->
+                issue.id shouldBe 2457237
+                issue.key shouldBe "PROJECT-1"
+                issue.self shouldBe URI("https://jira.oss-review-toolkit.org/rest/api/2/issue/2457237")
+            }
+        }
+
+        "not create an issue when there are more then one duplicate" {
+            val projectKey = "TEST"
+            val notifier = JiraNotifier(
+                JiraConfiguration("http://localhost:${wiremock.port()}", "testuser", "testpassword")
+            )
+
+            stubFor(
+                get(urlPathEqualTo("/rest/api/latest/project/$projectKey"))
+                    .willReturn(
+                        aResponse().withStatus(200)
+                            .withBodyFile("response_get_project.json")
+                    )
+            )
+            stubFor(
+                get(urlPathEqualTo("/rest/api/latest/search"))
+                    .withQueryParam("jql", matching("project.*summary.*"))
+                    .willReturn(
+                        aResponse().withStatus(201)
+                            .withBodyFile("response_search_jql.json")
+                    )
+            )
+
+            val projectIssueBuilder = notifier.projectIssueBuilder(projectKey)
+            val resultIssue = projectIssueBuilder.createIssue(
+                "Ticket summary",
+                "The description of the ticket.",
+                "Bug"
+            )
+
+            resultIssue should beOfType(Failure::class)
+            (resultIssue as Failure).error shouldContain("more then 1 duplicate issues")
+        }
+
+        "return a Failure if issue type is invalid" {
+            val projectKey = "TEST"
+            val issueType = "unknownType"
+            val notifier = JiraNotifier(
+                JiraConfiguration("http://localhost:${wiremock.port()}", "testuser", "testpassword")
+            )
+
+            stubFor(
+                get(urlPathEqualTo("/rest/api/latest/project/$projectKey"))
+                    .willReturn(
+                        aResponse().withStatus(200)
+                                .withBodyFile("response_get_project.json")
+                    )
+            )
+
+            val projectIssueBuilder = notifier.projectIssueBuilder(projectKey)
+            val result = projectIssueBuilder.createIssue(
+                "Ticket summary",
+                "The description of the ticket.",
+                issueType,
+                null,
+                false
+            )
+
+            result should beOfType(Failure::class)
+            (result as Failure).error shouldContain("'$issueType' is not valid")
+        }
+    }
+})
+
+private const val TEST_FILES_ROOT = "src/test/assets/"


### PR DESCRIPTION
This introduces the Jira notifier, which uses the Java REST client of
Jira in order to make the CRUD operations. Currently, the JiraNotifier
only provides a wrapper function to create new issues in Jira.