### PR TITLE
Notifier: Rename emailClient to mailClient

### DIFF
--- a/examples/notifications.kts
+++ b/examples/notifications.kts
@@ -20,7 +20,7 @@
 val issues: Map<Identifier, Set<OrtIssue>> = ortResult.collectIssues()
 
 if (issues.isNotEmpty()) {
-    emailClient.sendEmail(
+    mailClient.sendMail(
         subject = "Issues found",
         message = "Number of issues found: ${issues.size}",
         receivers = arrayOf("example1@ossreviewtoolkit.org", "example2@ossreviewtoolkit.org")

--- a/notifier/src/main/kotlin/Notifier.kt
+++ b/notifier/src/main/kotlin/Notifier.kt
@@ -24,7 +24,7 @@ import java.time.Instant
 import org.ossreviewtoolkit.model.NotifierRun
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.NotifierConfiguration
-import org.ossreviewtoolkit.notifier.modules.EmailNotifier
+import org.ossreviewtoolkit.notifier.modules.MailNotifier
 import org.ossreviewtoolkit.utils.ScriptRunner
 
 class Notifier(ortResult: OrtResult = OrtResult.EMPTY, config: NotifierConfiguration = NotifierConfiguration()) :
@@ -44,7 +44,7 @@ class Notifier(ortResult: OrtResult = OrtResult.EMPTY, config: NotifierConfigura
     init {
         engine.put("ortResult", ortResult)
 
-        config.mail?.let { engine.put("emailClient", EmailNotifier(it)) }
+        config.mail?.let { engine.put("mailClient", MailNotifier(it)) }
     }
 
     override fun run(script: String): NotifierRun {

--- a/notifier/src/main/kotlin/modules/MailNotifier.kt
+++ b/notifier/src/main/kotlin/modules/MailNotifier.kt
@@ -28,7 +28,7 @@ import org.ossreviewtoolkit.model.config.SendMailConfiguration
 /**
  * Notification module that provides a configured email client.
  */
-class EmailNotifier(config: SendMailConfiguration) {
+class MailNotifier(config: SendMailConfiguration) {
     private val client: Email
 
     init {
@@ -42,7 +42,7 @@ class EmailNotifier(config: SendMailConfiguration) {
     }
 
     @Suppress("UNUSED") // This is intended to be used by notification script implementations.
-    fun sendEmail(subject: String, message: String, vararg receivers: String) {
+    fun sendMail(subject: String, message: String, vararg receivers: String) {
         client.subject = subject
         client.setMsg(message)
         client.addTo(*receivers)


### PR DESCRIPTION
This is a fixup for cbb5c9641accdec4b679059d9947d3fec71bd6c2 to use the
same naming scheme as the corresponding `SendMailConfiguration`.
