### PR TITLE
PackageManager: Skip pathologic cases of empty definition files

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -113,7 +113,7 @@ abstract class PackageManager(
                         return FileVisitResult.SKIP_SUBTREE
                     }
 
-                    val filesInDir = dirAsFile.walk().maxDepth(1).filter { it.isFile }.toList()
+                    val filesInDir = dirAsFile.walk().maxDepth(1).filter { it.isFile && it.length() > 0 }.toList()
 
                     packageManagers.forEach { manager ->
                         // Create a list of lists of matching files per glob.


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>