### PR TITLE
Extract a configuration for FossId

### DIFF
--- a/cli/src/main/resources/log4j2.xml
+++ b/cli/src/main/resources/log4j2.xml
@@ -20,5 +20,6 @@
     </Logger>
 
     <Logger name="org.ossreviewtoolkit.scanner.scanners.fossid.FossId" level="info"/>
+    <Logger name="org.ossreviewtoolkit.scanner.scanners.fossid.FossIdConfig" level="info"/>
   </Loggers>
 </Configuration>

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -61,7 +61,6 @@ import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.config.ScannerOptions
 import org.ossreviewtoolkit.scanner.AbstractScannerFactory
 import org.ossreviewtoolkit.scanner.RemoteScanner
-import org.ossreviewtoolkit.scanner.scanners.fossid.FossId.Companion.NAMING_CONVENTION_VARIABLE_PREFIX
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.showStackTrace
@@ -70,27 +69,8 @@ import org.ossreviewtoolkit.utils.toUri
 /**
  * A wrapper for [FossID](https://fossid.com/).
  *
- * This scanner can be configured in [ScannerConfiguration.options] using the key "FossId". It offers the following
- * configuration options:
- *
- * * **"serverUrl":** The URL of the FossID server.
- * * **"user":** The user to connect to the FossID server.
- * * **"apiKey":** The API key of the user which connects to the FossID server.
- * * **"packageNamespaceFilter":** If this optional filter is set, only packages having an identifier in given namespace
- * will be scanned.
- * * **"packageAuthorsFilter":** If this optional filter is set, only packages from a given author will be scanned.
- * * **"addAuthenticationToUrl":** When set, ORT will add credentials from its Authenticator to the URLs sent to FossID.
- * * **"waitForResult":** When set to false, ORT doesn't wait for repositories to be downloaded nor scans to be
- * completed. As a consequence, scan results won't be available in ORT result.
- * * **"deltaScans":** When set, ORT will create delta scans. When only changes in a repository need to be scanned,
- * delta scans reuse the identifications of latest scan on this repository to reduce the amount of findings. If
- * deltaScans is set and no scan exist yet, an initial scan called "origin" scan will be created.
- *
- * Naming conventions options. If they are not set, default naming convention are used.
- * * **"namingProjectPattern":** A pattern for project names when projects are created on the FossID instance. Contains
- * variables prefixed by "$" e.g. "$Var1_$Var2". Variables are also passed as options and are prefixed by
- * [NAMING_CONVENTION_VARIABLE_PREFIX] e.g. namingVariableVar1 = "foo".
- * * **"namingScanPattern":** A pattern for scan names when scans are created on the FossID instance.
+ * This scanner can be configured in [ScannerConfiguration.options]. For the options available and their documentation
+ * refer to [FossIdConfig].
  */
 class FossId internal constructor(
     name: String,
@@ -115,11 +95,6 @@ class FossId internal constructor(
 
         @JvmStatic
         private val WAIT_REPETITION = 360
-
-        /**
-         * The scanner options beginning with this prefix will be used to parametrize project and scan names.
-         */
-        private const val NAMING_CONVENTION_VARIABLE_PREFIX = "namingVariable"
 
         /**
          * Convert a Git repository URL to a valid project name, e.g.

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
@@ -29,7 +29,27 @@ import retrofit2.converter.jackson.JacksonConverterFactory
 
 /**
  * A data class that holds the configuration options supported by the [FossId] scanner. An instance of this class is
- * created from the options contained in a [ScannerConfiguration] object.
+ * created from the options contained in a [ScannerConfiguration] object under the key _FossId_. It offers the
+ * following configuration options:
+ *
+ * * **"serverUrl":** The URL of the FossID server.
+ * * **"user":** The user to connect to the FossID server.
+ * * **"apiKey":** The API key of the user which connects to the FossID server.
+ * * **"packageNamespaceFilter":** If this optional filter is set, only packages having an identifier in given namespace
+ * will be scanned.
+ * * **"packageAuthorsFilter":** If this optional filter is set, only packages from a given author will be scanned.
+ * * **"addAuthenticationToUrl":** When set, ORT will add credentials from its Authenticator to the URLs sent to FossID.
+ * * **"waitForResult":** When set to false, ORT doesn't wait for repositories to be downloaded nor scans to be
+ * completed. As a consequence, scan results won't be available in ORT result.
+ * * **"deltaScans":** When set, ORT will create delta scans. When only changes in a repository need to be scanned,
+ * delta scans reuse the identifications of latest scan on this repository to reduce the amount of findings. If
+ * deltaScans is set and no scan exist yet, an initial scan called "origin" scan will be created.
+ *
+ * Naming conventions options. If they are not set, default naming convention are used.
+ * * **"namingProjectPattern":** A pattern for project names when projects are created on the FossID instance. Contains
+ * variables prefixed by "$" e.g. "$Var1_$Var2". Variables are also passed as options and are prefixed by
+ * [NAMING_CONVENTION_VARIABLE_PREFIX] e.g. namingVariableVar1 = "foo".
+ * * **"namingScanPattern":** A pattern for scan names when scans are created on the FossID instance.
  */
 internal data class FossIdConfig(
     /** The URL where the FossID service is running. */

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
@@ -19,8 +19,13 @@
 
 package org.ossreviewtoolkit.scanner.scanners.fossid
 
+import org.ossreviewtoolkit.clients.fossid.FossIdRestService
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.utils.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.log
+
+import retrofit2.Retrofit
+import retrofit2.converter.jackson.JacksonConverterFactory
 
 /**
  * A data class that holds the configuration options supported by the [FossId] scanner. An instance of this class is
@@ -140,5 +145,21 @@ internal data class FossIdConfig(
             .mapKeys { it.key.substringAfter(NAMING_CONVENTION_VARIABLE_PREFIX) }
 
         return FossIdNamingProvider(namingProjectPattern, namingScanPattern, namingConventionVariables)
+    }
+
+    /**
+     * Create the [FossIdRestService] to interact with the FossID instance described by this configuration.
+     */
+    fun createService(): FossIdRestService {
+        val client = OkHttpClientHelper.buildClient()
+        log.info { "FossID server URL is $serverUrl." }
+
+        val retrofit = Retrofit.Builder()
+            .client(client)
+            .baseUrl(serverUrl)
+            .addConverterFactory(JacksonConverterFactory.create(FossIdRestService.JSON_MAPPER))
+            .build()
+
+        return retrofit.create(FossIdRestService::class.java)
     }
 }

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.fossid
+
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.utils.log
+
+/**
+ * A data class that holds the configuration options supported by the [FossId] scanner. An instance of this class is
+ * created from the options contained in a [ScannerConfiguration] object.
+ */
+internal data class FossIdConfig(
+    /** The URL where the FossID service is running. */
+    val serverUrl: String,
+
+    /** The API key to access the FossID server. */
+    val apiKey: String,
+
+    /** The user to authenticate against the server. */
+    val user: String,
+
+    /** Flag whether the scanner should wait for the completion of FossID scans. */
+    val waitForResult: Boolean,
+
+    /** Filter for package namespaces (empty string if undefined). */
+    val packageNamespaceFilter: String,
+
+    /** Filter for package authors (empty string if undefined). */
+    val packageAuthorsFilter: String,
+
+    /** Flag whether credentials should be passed to FossID in URLs. */
+    val addAuthenticationToUrl: Boolean,
+
+    /** Flag whether delta scans should be triggered. */
+    val deltaScans: Boolean,
+
+    /** Stores the map with FossID-specific configuration options. */
+    private val options: Map<String, String>
+) {
+    companion object {
+        /** Name of the configuration property for the server URL. */
+        private const val SERVER_URL_PROPERTY = "serverUrl"
+
+        /** Name of the configuration property for the API key. */
+        private const val API_KEY_PROPERTY = "apiKey"
+
+        /** Name of the configuration property for the user name. */
+        private const val USER_PROPERTY = "user"
+
+        /** Name of the configuration property for the packages namespace filter. */
+        private const val NAMESPACE_FILTER_PROPERTY = "packageNamespaceFilter"
+
+        /** Name of the configuration property for the packages authros filter. */
+        private const val AUTHORS_FILTER_PROPERTY = "packageAuthorsFilter"
+
+        /** Name of the configuration property controlling that credentials are added to URLs. */
+        private const val CREDENTIALS_IN_URL_PROPERTY = "addAuthenticationToUrl"
+
+        /** Name of the configuration property controlling whether ORT should wait for FossID results. */
+        private const val WAIT_FOR_RESULT_PROPERTY = "waitForResult"
+
+        /** Name of the configuration property controlling whether delta scans are to be created. */
+        private const val DELTA_SCAN_PROPERTY = "deltaScans"
+
+        fun create(scannerConfig: ScannerConfiguration): FossIdConfig {
+            val fossIdScannerOptions = scannerConfig.options?.get("FossId")
+
+            requireNotNull(fossIdScannerOptions) { "No FossId Scanner configuration found." }
+
+            val serverUrl = fossIdScannerOptions[SERVER_URL_PROPERTY]
+                ?: throw IllegalArgumentException("No FossId server URL configuration found.")
+            val apiKey = fossIdScannerOptions[API_KEY_PROPERTY]
+                ?: throw IllegalArgumentException("No FossId API Key configuration found.")
+            val user = fossIdScannerOptions[USER_PROPERTY]
+                ?: throw IllegalArgumentException("No FossId User configuration found.")
+            val packageNamespaceFilter = fossIdScannerOptions[NAMESPACE_FILTER_PROPERTY].orEmpty()
+            val packageAuthorsFilter = fossIdScannerOptions[AUTHORS_FILTER_PROPERTY].orEmpty()
+            val addAuthenticationToUrl = fossIdScannerOptions[CREDENTIALS_IN_URL_PROPERTY].toBoolean()
+            val waitForResult = fossIdScannerOptions[WAIT_FOR_RESULT_PROPERTY]?.toBooleanStrictOrNull() ?: true
+            val deltaScans = fossIdScannerOptions[DELTA_SCAN_PROPERTY].toBoolean()
+
+            log.info { "waitForResult parameter is set to '$waitForResult'" }
+
+            return FossIdConfig(
+                serverUrl,
+                apiKey,
+                user,
+                waitForResult,
+                packageNamespaceFilter,
+                packageAuthorsFilter,
+                addAuthenticationToUrl,
+                deltaScans,
+                fossIdScannerOptions
+            )
+        }
+    }
+}

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
@@ -76,8 +76,19 @@ internal data class FossIdConfig(
         /** Name of the configuration property controlling whether ORT should wait for FossID results. */
         private const val WAIT_FOR_RESULT_PROPERTY = "waitForResult"
 
+        /** Name of the configuration property defining the naming convention for projects. */
+        private const val NAMING_PROJECT_PATTERN_PROPERTY = "namingProjectPattern"
+
+        /** Name of the configuration property defining the naming convention for scans. */
+        private const val NAMING_SCAN_PATTERN_PROPERTY = "namingScanPattern"
+
         /** Name of the configuration property controlling whether delta scans are to be created. */
         private const val DELTA_SCAN_PROPERTY = "deltaScans"
+
+        /**
+         * The scanner options beginning with this prefix will be used to parametrize project and scan names.
+         */
+        private const val NAMING_CONVENTION_VARIABLE_PREFIX = "namingVariable"
 
         fun create(scannerConfig: ScannerConfiguration): FossIdConfig {
             val fossIdScannerOptions = scannerConfig.options?.get("FossId")
@@ -110,5 +121,24 @@ internal data class FossIdConfig(
                 fossIdScannerOptions
             )
         }
+    }
+
+    /**
+     * Create a [FossIdNamingProvider] helper object based on the configuration stored in this object.
+     */
+    fun createNamingProvider(): FossIdNamingProvider {
+        val namingProjectPattern = options[NAMING_PROJECT_PATTERN_PROPERTY]?.also {
+            log.info { "Naming pattern for projects is $it." }
+        }
+
+        val namingScanPattern = options[NAMING_SCAN_PATTERN_PROPERTY]?.also {
+            log.info { "Naming pattern for scans is $it." }
+        }
+
+        val namingConventionVariables = options
+            .filterKeys { it.startsWith(NAMING_CONVENTION_VARIABLE_PREFIX) }
+            .mapKeys { it.key.substringAfter(NAMING_CONVENTION_VARIABLE_PREFIX) }
+
+        return FossIdNamingProvider(namingProjectPattern, namingScanPattern, namingConventionVariables)
     }
 }

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
@@ -113,6 +113,44 @@ class FossIdConfigTest : WordSpec({
             shouldThrow<IllegalArgumentException> { FossIdConfig.create(scannerConfig) }
         }
     }
+
+    "createNamingProvider" should {
+        "create a naming provider with a correct project naming convention" {
+            val scannerConfig = mapOf(
+                "serverUrl" to SERVER_URL,
+                "apiKey" to API_KEY,
+                "user" to USER,
+                "namingProjectPattern" to "#projectName_\$Org_\$Unit",
+                "namingVariableOrg" to "TestOrganization",
+                "namingVariableUnit" to "TestUnit"
+            ).toScannerConfig()
+
+            val fossIdConfig = FossIdConfig.create(scannerConfig)
+            val namingProvider = fossIdConfig.createNamingProvider()
+
+            val projectName = namingProvider.createProjectCode("TestProject")
+
+            projectName shouldBe "TestProject_TestOrganization_TestUnit"
+        }
+
+        "create a naming provider with a correct scan naming convention" {
+            val scannerConfig = mapOf(
+                "serverUrl" to SERVER_URL,
+                "apiKey" to API_KEY,
+                "user" to USER,
+                "namingScanPattern" to "#projectName_\$Org_\$Unit_#deltaTag",
+                "namingVariableOrg" to "TestOrganization",
+                "namingVariableUnit" to "TestUnit"
+            ).toScannerConfig()
+
+            val fossIdConfig = FossIdConfig.create(scannerConfig)
+            val namingProvider = fossIdConfig.createNamingProvider()
+
+            val scanCode = namingProvider.createScanCode("TestProject", FossId.DeltaTag.DELTA)
+
+            scanCode shouldBe "TestProject_TestOrganization_TestUnit_delta"
+        }
+    }
 })
 
 private const val SERVER_URL = "https://www.example.org/fossid"

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.fossid
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import kotlin.IllegalArgumentException
+
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+
+class FossIdConfigTest : WordSpec({
+    "create" should {
+            "throw if no options for FossID are provided in the scanner configuration" {
+                val scannerConfig = ScannerConfiguration()
+
+                shouldThrow<IllegalArgumentException> { FossIdConfig.create(scannerConfig) }
+            }
+
+        "read all properties from the scanner configuration" {
+            val options = mapOf(
+                "serverUrl" to SERVER_URL,
+                "apiKey" to API_KEY,
+                "user" to USER,
+                "packageNamespaceFilter" to NAMESPACE_FILTER,
+                "packageAuthorsFilter" to AUTHOR_FILTER,
+                "waitForResult" to "false",
+                "deltaScans" to "true",
+                "addAuthenticationToUrl" to "false"
+            )
+            val scannerConfig = options.toScannerConfig()
+
+            val fossIdConfig = FossIdConfig.create(scannerConfig)
+
+            fossIdConfig shouldBe FossIdConfig(
+                serverUrl = SERVER_URL,
+                apiKey = API_KEY,
+                user = USER,
+                packageAuthorsFilter = AUTHOR_FILTER,
+                packageNamespaceFilter = NAMESPACE_FILTER,
+                waitForResult = false,
+                deltaScans = true,
+                addAuthenticationToUrl = false,
+                options = options
+            )
+        }
+
+        "set default values for optional properties" {
+            val options = mapOf(
+                "serverUrl" to SERVER_URL,
+                "apiKey" to API_KEY,
+                "user" to USER
+            )
+            val scannerConfig = options.toScannerConfig()
+
+            val fossIdConfig = FossIdConfig.create(scannerConfig)
+
+            fossIdConfig shouldBe FossIdConfig(
+                serverUrl = SERVER_URL,
+                apiKey = API_KEY,
+                user = USER,
+                packageAuthorsFilter = "",
+                packageNamespaceFilter = "",
+                waitForResult = true,
+                deltaScans = false,
+                addAuthenticationToUrl = false,
+                options = options
+            )
+        }
+
+        "throw if the server URL is missing" {
+            val scannerConfig = mapOf(
+                "apiKey" to API_KEY,
+                "user" to USER
+            ).toScannerConfig()
+
+            shouldThrow<IllegalArgumentException> { FossIdConfig.create(scannerConfig) }
+        }
+
+        "throw if the API key is missing" {
+            val scannerConfig = mapOf(
+                "serverUrl" to SERVER_URL,
+                "user" to USER
+            ).toScannerConfig()
+
+            shouldThrow<IllegalArgumentException> { FossIdConfig.create(scannerConfig) }
+        }
+
+        "throw if the user name is missing" {
+            val scannerConfig = mapOf(
+                "serverUrl" to SERVER_URL,
+                "apiKey" to API_KEY
+            ).toScannerConfig()
+
+            shouldThrow<IllegalArgumentException> { FossIdConfig.create(scannerConfig) }
+        }
+    }
+})
+
+private const val SERVER_URL = "https://www.example.org/fossid"
+private const val API_KEY = "test_api_key"
+private const val USER = "fossIdTestUser"
+private const val NAMESPACE_FILTER = "testFilterForNamespace"
+private const val AUTHOR_FILTER = "testFilterForAuthors"
+
+/**
+ * Return a [ScannerConfiguration] with this map as options for the FossID scanner.
+ */
+private fun Map<String, String>.toScannerConfig(): ScannerConfiguration {
+    val options = mapOf("FossId" to this)
+    return ScannerConfiguration(options = options)
+}


### PR DESCRIPTION
This PR is a minor refactoring of FossId with the aim to make this class easier to test. The idea is to extract the various parameters into a dedicated configuration class, which also supports the creation of helper objects. By passing a mock configuration, it is then possible to inject mocks for these helpers.