### PR TITLE
GitWorkingTreeFunTest: Fix a failing test case

### DIFF
--- a/downloader/src/funTest/kotlin/vcs/GitWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitWorkingTreeFunTest.kt
@@ -114,7 +114,8 @@ class GitWorkingTreeFunTest : StringSpec() {
                 "0.9.0",
                 "1.0.0",
                 "2.0.0",
-                "2.0.0b1"
+                "2.0.0b1",
+                "2.1.0"
             )
         }
 


### PR DESCRIPTION
There is obviously a new remote tag in a project used by the test.
Therefore, adapt the expectations accordingly.
