### PR TITLE
MavenSupport: Lower the log level for a missing SCM prefix to "info"

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -241,7 +241,7 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
                     } else if (connection.startsWith("git://") || connection.endsWith(".git")) {
                         // It is a common mistake to omit the "scm:[provider]:" prefix. Add fall-backs for nevertheless
                         // clear cases.
-                        log.warn { "Maven SCM connection URL '$connection' lacks the required 'scm' prefix." }
+                        log.info { "Maven SCM connection URL '$connection' lacks the required 'scm' prefix." }
 
                         VcsInfo(type = VcsType.GIT, url = connection, revision = tag)
                     } else {


### PR DESCRIPTION
This happens quite often, and most of the time the user is not in the
position to fix it. Also ORT can transparently handle this metadata
problem, so lower the log level to "info" to not clutter the log by
default. That is also more in line with the log statement a few lines
below.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>