### PR TITLE
Disable dependabot for reporter-web-app

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,3 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
-- package-ecosystem: "npm"
-  directory: "/reporter-web-app"
-  schedule:
-    interval: "daily"
-  labels:
-  - "reporter"


### PR DESCRIPTION
As there are no tests for the reporter-web-app dependency updates need
to be verified manually. Therefore updating dependencies individually
would be too much effort and dependencies are updated manually in bulk
instead.