### PR TITLE
evaluator: Add the new rule type `OrtResultRule`

### DIFF
--- a/evaluator/src/main/kotlin/OrtResultRule.kt
+++ b/evaluator/src/main/kotlin/OrtResultRule.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.evaluator
+
+import org.ossreviewtoolkit.model.OrtResult
+
+/**
+ * A [Rule] to check an [OrtResult].
+ */
+open class OrtResultRule(
+    ruleSet: RuleSet,
+    name: String,
+
+    /**
+     * The [OrtResult] to check.
+     */
+    val ortResult: OrtResult,
+) : Rule(ruleSet, name) {
+    override val description = "Evaluating ORT result rule '$name'."
+
+    override fun issueSource() = "$name - ORT result"
+
+    fun error(message: String, howToFix: String): Unit =
+        error(
+            pkgId = null,
+            license = null,
+            licenseSource = null,
+            message = message,
+            howToFix = howToFix
+        )
+}

--- a/evaluator/src/main/kotlin/Rule.kt
+++ b/evaluator/src/main/kotlin/Rule.kt
@@ -143,7 +143,7 @@ abstract class Rule(
      */
     fun issue(
         severity: Severity,
-        pkgId: Identifier,
+        pkgId: Identifier?,
         license: SpdxSingleLicenseExpression?,
         licenseSource: LicenseSource?,
         message: String,
@@ -164,7 +164,7 @@ abstract class Rule(
      * Add a [hint][Severity.HINT] to the list of [violations].
      */
     fun hint(
-        pkgId: Identifier,
+        pkgId: Identifier?,
         license: SpdxSingleLicenseExpression?,
         licenseSource: LicenseSource?,
         message: String,
@@ -176,7 +176,7 @@ abstract class Rule(
      * Add a [warning][Severity.WARNING] to the list of [violations].
      */
     fun warning(
-        pkgId: Identifier,
+        pkgId: Identifier?,
         license: SpdxSingleLicenseExpression?,
         licenseSource: LicenseSource?,
         message: String,
@@ -188,7 +188,7 @@ abstract class Rule(
      * Add an [error][Severity.ERROR] to the list of [violations].
      */
     fun error(
-        pkgId: Identifier,
+        pkgId: Identifier?,
         license: SpdxSingleLicenseExpression?,
         licenseSource: LicenseSource?,
         message: String,

--- a/evaluator/src/main/kotlin/RuleSet.kt
+++ b/evaluator/src/main/kotlin/RuleSet.kt
@@ -41,6 +41,16 @@ class RuleSet(
     val violations = mutableSetOf<RuleViolation>()
 
     /**
+     * A DSL function to configure an [OrtResultRule]. The rule is applied once to [ortResult].
+     */
+    fun ortResultRule(name: String, configure: OrtResultRule.() -> Unit) {
+        OrtResultRule(this, name, ortResult).apply {
+            configure()
+            evaluate()
+        }
+    }
+
+    /**
      * A DSL function to configure a [PackageRule]. The rule is applied to each [Package] and [Project] contained in
      * [ortResult].
      */

--- a/model/src/main/kotlin/RuleViolation.kt
+++ b/model/src/main/kotlin/RuleViolation.kt
@@ -30,7 +30,7 @@ data class RuleViolation(
     /**
      * The identifier of the package that caused this rule violation.
      */
-    val pkg: Identifier,
+    val pkg: Identifier?,
 
     /**
      * The name of the license that caused this rule violation. Can be null if the rule does not work on licenses.

--- a/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedModelMapper.kt
@@ -360,7 +360,10 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
 
     private fun addRuleViolation(ruleViolation: RuleViolation) {
         val resolutions = addResolutions(ruleViolation)
-        val pkg = packages[ruleViolation.pkg] ?: createEmptyPackage(ruleViolation.pkg)
+        val pkg = ruleViolation.pkg?.let { id ->
+            packages[id] ?: createEmptyPackage(id)
+        }
+
         val license = ruleViolation.license?.let { licenses.addIfRequired(LicenseId(it.toString())) }
 
         val evaluatedViolation = EvaluatedRuleViolation(

--- a/reporter/src/main/kotlin/model/EvaluatedRuleViolation.kt
+++ b/reporter/src/main/kotlin/model/EvaluatedRuleViolation.kt
@@ -32,7 +32,7 @@ import org.ossreviewtoolkit.model.config.RuleViolationResolution
 data class EvaluatedRuleViolation(
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val rule: String,
-    val pkg: EvaluatedPackage,
+    val pkg: EvaluatedPackage?,
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val license: LicenseId?,
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -295,7 +295,7 @@ class StaticHtmlReporter : Reporter {
                 }
             }
             td { +ruleViolation.violation.rule }
-            td { +ruleViolation.violation.pkg.toCoordinates() }
+            td { +(ruleViolation.violation.pkg?.toCoordinates() ?: "-") }
             td {
                 +if (ruleViolation.violation.license != null) {
                     "${ruleViolation.violation.licenseSource}: ${ruleViolation.violation.license}"


### PR DESCRIPTION
Having a generic rule which is executed once per ORT result helps with use
cases for which the more specific rules aren't a good fit. As a pre-requisite the field
`RuleViolation.pkgId` is made nullable, which eliminates the assumption that a rule violation always corresponds to a package.

NOTE: The PR has to be amended to properly handle the now nullable attribute in the `web-app`.
