### PR TITLE
Conan: Take local configuration (like remotes) into account

### DIFF
--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -108,8 +108,15 @@ class Conan(
         // [2]: https://docs.conan.io/en/latest/configuration/download_cache.html#download-cache
         val conanStoragePath = conanHome.resolve("data")
 
-        stashDirectories(conanStoragePath).use {
-            val workingDir = definitionFile.parentFile
+        val workingDir = definitionFile.parentFile
+        val conanConfig = listOf(workingDir, analysisRoot).map { it.resolve("conan_config") }
+            .find { it.isDirectory }
+        val directoryToStash = conanConfig?.let { conanHome } ?: conanStoragePath
+
+        stashDirectories(directoryToStash).use {
+            conanConfig?.also {
+                run("config", "install", it.absolutePath)
+            }
 
             installDependencies(workingDir)
 


### PR DESCRIPTION
This applies configuration stored to a conventional "conan_config"
directory before the dependency resolution. This is needed in order to
support custom remotes besides the default ConanCenter.

Resolves #4312.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>