### PR TITLE
notifier: Exclude the conflicting log4j12 implementation for slf4j

### DIFF
--- a/notifier/build.gradle.kts
+++ b/notifier/build.gradle.kts
@@ -45,7 +45,9 @@ dependencies {
     implementation(project(":utils"))
 
     implementation("com.atlassian.jira:jira-rest-java-client-api:$jiraRestApiVersion")
-    implementation("com.atlassian.jira:jira-rest-java-client-app:$jiraRestApiVersion")
+    implementation("com.atlassian.jira:jira-rest-java-client-app:$jiraRestApiVersion") {
+        exclude("org.slf4j", "slf4j-log4j12")
+    }
     implementation("org.apache.commons:commons-email:$apacheCommonsEmailVersion")
 
     testImplementation("com.github.tomakehurst:wiremock:$wiremockVersion")


### PR DESCRIPTION
ORT uses Log4j 2 as the logger abstraction framework, which also
provides an implementation for the SLF4J logger abstraction framework.
As a result, the conflicting SLF4J implementation for Log4j 1 has to be
excluded to avoid the runtime warning that the "Class path contains
multiple SLF4J bindings".

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>