### PR TITLE
Dockerfile: Update Cargo to the available upstream version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ ENV \
     # Package manager versions.
     BOWER_VERSION=1.8.8 \
     BUNDLER_VERSION=1.16.1-1 \
-    CARGO_VERSION=0.47.0-1~exp1ubuntu1~18.04.1 \
+    CARGO_VERSION=0.52.0-0ubuntu1~18.04.1 \
     COMPOSER_VERSION=1.6.3-1 \
     CONAN_VERSION=1.18.0 \
     GO_DEP_VERSION=0.5.4 \


### PR DESCRIPTION
The old package has been removed and there is a new one: https://packages.ubuntu.com/search?keywords=cargo&searchon=names&suite=bionic&section=all