### PR TITLE
Dockerfile: Upgrade Node to version 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ ENV \
     GO_DEP_VERSION=0.5.4 \
     GO_VERSION=1.16.5 \
     HASKELL_STACK_VERSION=2.1.3 \
-    NPM_VERSION=6.14.2 \
+    NPM_VERSION=7.20.6 \
     PYTHON_PIPENV_VERSION=2018.11.26 \
     PYTHON_VIRTUALENV_VERSION=15.1.0 \
     SBT_VERSION=1.3.8 \
@@ -76,7 +76,7 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
     apt-get install -y --no-install-recommends gnupg software-properties-common && \
     echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
     curl -ksS "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key adv --import - && \
-    curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
     add-apt-repository -y ppa:git-core/ppa && \
     apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -337,7 +337,7 @@ open class Npm(
 
     override fun command(workingDir: File?) = if (Os.isWindows) "npm.cmd" else "npm"
 
-    override fun getVersionRequirement(): Requirement = Requirement.buildNPM("5.7.* - 6.14.*")
+    override fun getVersionRequirement(): Requirement = Requirement.buildNPM("5.7.* - 7.20.*")
 
     override fun mapDefinitionFiles(definitionFiles: List<File>) = mapDefinitionFilesForNpm(definitionFiles).toList()
 


### PR DESCRIPTION
Upgrading Node from version 12 to version 16 also leads to an upgrade of
Npm. So, pin the Npm version accordingly to the latest release. See also
[1] and [2].

This change fixes [3] for unknown reason.

[1] https://github.com/nodejs/node/blob/7ca38f05a023666274569343f128c5aed81599f3/doc/changelogs/CHANGELOG_V16.md
[2] https://github.com/npm/cli/blob/59b9851d1649b8f78203cae187b1337f2441219d/CHANGELOG.md#v7206-2021-08-12
[3] https://stackoverflow.com/questions/68021121/fsevents-not-accessible-from-jest-haste-map.
