### PR TITLE
reporter: Align the default output names of CycloneDX and SPDX files

### DIFF
--- a/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
+++ b/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
@@ -61,7 +61,7 @@ import org.ossreviewtoolkit.utils.isFalse
  */
 class CycloneDxReporter : Reporter {
     companion object {
-        const val REPORT_BASE_FILENAME = "CycloneDX-BOM"
+        const val REPORT_BASE_FILENAME = "bom.cyclonedx"
 
         const val OPTION_SINGLE_BOM = "single.bom"
         const val OPTION_OUTPUT_FILE_FORMATS = "output.file.formats"

--- a/reporter/src/main/kotlin/reporters/SpdxDocumentReporter.kt
+++ b/reporter/src/main/kotlin/reporters/SpdxDocumentReporter.kt
@@ -42,6 +42,8 @@ import org.ossreviewtoolkit.spdx.model.SpdxDocument
  */
 class SpdxDocumentReporter : Reporter {
     companion object {
+        const val REPORT_BASE_FILENAME = "bom.spdx"
+
         const val OPTION_CREATION_INFO_COMMENT = "creationInfo.comment"
         const val OPTION_DOCUMENT_COMMENT = "document.comment"
         const val OPTION_DOCUMENT_NAME = "document.name"
@@ -78,7 +80,7 @@ class SpdxDocumentReporter : Reporter {
         return outputFileFormats.map { fileFormat ->
             val serializedDocument = fileFormat.mapper.writeValueAsString(spdxDocument)
 
-            outputDir.resolve("document.spdx.${fileFormat.fileExtension}").apply {
+            outputDir.resolve("$REPORT_BASE_FILENAME.${fileFormat.fileExtension}").apply {
                 bufferedWriter().use { it.write(serializedDocument) }
             }
         }


### PR DESCRIPTION
These days it's all about (S)BOMs, so align the names of these commonly
used BOM formats to appear next to each other when sorted
alphabetically, for a better overview.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>