### PR TITLE
Readme: Fix wrong uppercase in advisor documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ authentication is not required:
 ```hocon
 ort {
   advisor {
-    VulnerableCode {
+    vulnerableCode {
       serverUrl = "http://localhost:8000"
     }
   }


### PR DESCRIPTION
Resolves #4371.

