### PR TITLE
DependencyGraph: Fix a deserialization problem with empty graphs

### DIFF
--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -175,6 +175,25 @@ class AnalyzerResultBuilderTest : WordSpec() {
 
                 resultTree["has_issues"].asBoolean() shouldBe true
             }
+
+            "be serialized and deserialized correctly with an empty dependency graph" {
+                val emptyGraph = DependencyGraph(packages = emptyList(), scopes = emptyMap())
+                val p1 = project1.copy(scopeDependencies = null, scopeNames = sortedSetOf("scope1"))
+                val p2 = project2.copy(scopeDependencies = null, scopeNames = sortedSetOf("scope3"))
+                val result = AnalyzerResult(
+                    projects = sortedSetOf(p1, p2, project3),
+                    packages = sortedSetOf(),
+                    dependencyGraphs = sortedMapOf(
+                        project1.id.type to graph1,
+                        project2.id.type to emptyGraph
+                    )
+                )
+
+                val serializedResult = yamlMapper.writeValueAsString(result)
+                val deserializedResult = yamlMapper.readValue<AnalyzerResult>(serializedResult)
+
+                deserializedResult.withScopesResolved() shouldBe result.withScopesResolved()
+            }
         }
 
         "collectIssues" should {

--- a/model/src/main/kotlin/DependencyGraph.kt
+++ b/model/src/main/kotlin/DependencyGraph.kt
@@ -74,7 +74,7 @@ data class DependencyGraph(
      * A list with the identifiers of the packages that appear in the dependency graph. This list is used to resolve
      * the numeric indices contained in the [DependencyGraphNode] objects.
      */
-    val packages: List<Identifier>,
+    val packages: List<Identifier> = emptyList(),
 
     /**
      * Stores the dependency graph as a list of root nodes for the direct dependencies referenced by scopes. Starting
@@ -88,7 +88,7 @@ data class DependencyGraph(
      * A mapping from scope names to the direct dependencies of the scopes. Based on this information, the set of
      * [Scope]s of a project can be constructed from the serialized form.
      */
-    val scopes: Map<String, List<RootDependencyIndex>>,
+    val scopes: Map<String, List<RootDependencyIndex>> = emptyMap(),
 
     /**
      * A list with the nodes of this dependency graph. Nodes correspond to packages, but in contrast to the [packages]


### PR DESCRIPTION
acd4aa8 added the @JsonInclude(JsonInclude.Include.NON_DEFAULT)
annotation to DependencyGraph. This caused a rather aggressive
optimization when serializing an empty DependencyGraph object: the
fields for packages and scopes were dropped completely. Such an
instance could then no longer be deserialized, because these fields
are not nullable and do not define a default value.

(Note: This problem was actually encountered in practice with a DotNet
project, which produced a dependency graph for NuGet and an empty one
for DotNet.)

Fix this by assigning empty default values to the problematic fields.
This is in-line with the other fields in this class, which have a
default value, too.
