### PR TITLE
Vulnerability: Allow instances without references

### DIFF
--- a/model/src/main/kotlin/Vulnerability.kt
+++ b/model/src/main/kotlin/Vulnerability.kt
@@ -45,13 +45,7 @@ data class Vulnerability(
      * A list with detailed information for this vulnerability obtained from different sources.
      */
     val references: List<VulnerabilityReference>
-) {
-    init {
-        require(references.isNotEmpty()) {
-            "A Vulnerability must have at least one reference."
-        }
-    }
-}
+)
 
 /**
  * A custom deserializer to support the deserialization of [Vulnerability] instances using an older format, in which

--- a/model/src/test/kotlin/VulnerabilityTest.kt
+++ b/model/src/test/kotlin/VulnerabilityTest.kt
@@ -19,13 +19,10 @@
 
 package org.ossreviewtoolkit.model
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-
-import java.lang.IllegalArgumentException
 
 import org.ossreviewtoolkit.model.VulnerabilityReference.Cvss2Rating
 import org.ossreviewtoolkit.model.VulnerabilityReference.Cvss3Rating
@@ -64,11 +61,5 @@ class VulnerabilityTest : StringSpec({
         Cvss3Rating.fromScore(10.0f) shouldBe Cvss3Rating.CRITICAL
 
         Cvss3Rating.fromScore(10.1f) should beNull()
-    }
-
-    "A vulnerability must have at least one reference" {
-        shouldThrow<IllegalArgumentException> {
-            Vulnerability("CVE-2021-1234", emptyList())
-        }
     }
 })


### PR DESCRIPTION
When using the VulnerableCode advisor implementation, results have
been encountered that actually contain only an ID, but no references.
Therefore, to represent such results in ORT's vulnerability model,
remove the check for an empty list of references from the
Vulnerability class. (It is probably safer to store such results -
even if they contain limited information - than to drop them.)
