### PR TITLE
Project-specific package curations

### DIFF
--- a/analyzer/src/main/kotlin/curation/SimplePackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/SimplePackageCurationProvider.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.curation
+
+import org.ossreviewtoolkit.analyzer.PackageCurationProvider
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.PackageCuration
+
+/**
+ * A [PackageCurationProvider] that provides the specified [packageCurations].
+ */
+class SimplePackageCurationProvider(private val packageCurations: Collection<PackageCuration>) :
+    PackageCurationProvider {
+    override fun getCurationsFor(pkgId: Identifier) = packageCurations.filter { it.isApplicable(pkgId) }
+}

--- a/docs/config-file-ort-yml.md
+++ b/docs/config-file-ort-yml.md
@@ -1,6 +1,8 @@
 # The `.ort.yml` file
 
 The items below can be configured by adding an `.ort.yml` file to the root of the source code repository.
+All configurations in this file apply only to this Project's context. Usually the global context is preferred for an
+increased degree of automation and local configurations should only be done if there are good reasons.
 
 * [excludes](#excludes) - Mark [files, directories](#excluding-paths) or [package manager scopes](#excluding-scopes) as
   not included in released artifacts.
@@ -125,7 +127,7 @@ scopes defined in the examples below match the scopes in your project.
 
 ### When to Use Curations
 
-Project-specific curations should be used when you want to correct the licenses detected in the source code of the
+Curations should be used when you want to correct the licenses detected in the source code of the
 project. If you need to correct the license findings for a third-party dependency then add a curation to
 [curations.yml](config-file-curations-yml.md) or [package configuration](config-file-package-configuration-yml.md).
 
@@ -160,7 +162,7 @@ The list of available options for `reason` are defined in
 
 ### When to Use Resolutions
 
-Project-specific resolutions should be used if you are unable to solve an issue by other means.
+Resolutions should be used if you are unable to solve an issue by other means.
 
 If a resolution is not project-specific than add it to [resolutions.yml](./config-file-resolutions-yml.md) so that it is
 applied to each scan.

--- a/docs/config-file-ort-yml.md
+++ b/docs/config-file-ort-yml.md
@@ -6,7 +6,7 @@ increased degree of automation and local configurations should only be done if t
 
 * [excludes](#excludes) - Mark [files, directories](#excluding-paths) or [package manager scopes](#excluding-scopes) as
   not included in released artifacts.
-* [license finding curations](#curations) - Overwrite scan results to correct identified licenses.
+* [curations](#curations) - Overwrite package metadata, set a concluded license or correct license findings.
 * [resolutions](#resolutions) - Resolve any issues or policy rule violations.
 * [license choices](#License-Choices) - Select a license for packages which offer a license choice.
 
@@ -127,11 +127,11 @@ scopes defined in the examples below match the scopes in your project.
 
 ### When to Use Curations
 
-Curations should be used when you want to correct the licenses detected in the source code of the
-project. If you need to correct the license findings for a third-party dependency then add a curation to
-[curations.yml](config-file-curations-yml.md) or [package configuration](config-file-package-configuration-yml.md).
+License finding curations should be used when you want to correct the licenses detected in the source code of the
+project. To define path excludes on a global level for third-party packages, please use the
+[package configurations](config-file-package-configuration-yml.md).
 
-### Curating License Findings
+### Curating Project License Findings
 
 An `ort scan` result represents the detected licenses as a collection of license findings. A single `LicenseFinding` is
 represented as a tuple: `(license id, file path, start line, end line)`. Applying a `LicenseFindingCuration` changes the
@@ -157,6 +157,25 @@ For details of the specification, see
 [LicenseFindingCuration.kt](../model/src/main/kotlin/config/LicenseFindingCuration.kt).
 The list of available options for `reason` are defined in
 [LicenseFindingCurationReason.kt](../model/src/main/kotlin/config/LicenseFindingCurationReason.kt).
+
+### Curating Metadata
+
+Package curations can be added if you want to correct metadata of third-party dependencies.
+
+The following example corrects the source-artifact URL of the package with the id `Maven:com.example:dummy:0.0.1`.
+
+e.g.:
+```yaml
+curations:
+  package_curations:
+  - id: "Maven:com.example:dummy:0.0.1"
+    comment: "An explanation why the curation is needed."
+    source_artifact:
+      url: "https://example.com/sources.zip"
+```
+
+For more information about package curations see
+[the documentation for the curations.yml file](config-file-curations-yml.md).
 
 ## Resolutions
 

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -812,7 +812,7 @@ internal fun RepositoryConfiguration.merge(
             scopes = excludes.scopes.mergeScopeExcludes(other.excludes.scopes)
         ),
         curations = Curations(
-            curations.licenseFindings.mergeLicenseFindingCurations(other.curations.licenseFindings)
+            licenseFindings = curations.licenseFindings.mergeLicenseFindingCurations(other.curations.licenseFindings)
         ),
         resolutions = Resolutions(
             issues = resolutions.issues.mergeIssueResolutions(other.resolutions.issues),

--- a/model/src/main/kotlin/config/Curations.kt
+++ b/model/src/main/kotlin/config/Curations.kt
@@ -21,10 +21,18 @@ package org.ossreviewtoolkit.model.config
 
 import com.fasterxml.jackson.annotation.JsonInclude
 
+import org.ossreviewtoolkit.model.PackageCuration
+
 /**
  * Curations for artifacts in a repository.
  */
 data class Curations(
+    /**
+     * Curations for third-party packages.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val packages: List<PackageCuration> = emptyList(),
+
     /**
      * Curations for license findings.
      */

--- a/model/src/main/kotlin/config/RepositoryConfiguration.kt
+++ b/model/src/main/kotlin/config/RepositoryConfiguration.kt
@@ -63,10 +63,10 @@ private class ExcludesFilter {
 @Suppress("EqualsOrHashCode", "EqualsWithHashCodeExist") // The class is not supposed to be used with hashing.
 private class ResolutionsFilter {
     override fun equals(other: Any?): Boolean =
-        other is Resolutions
-                && other.issues.isEmpty()
-                && other.ruleViolations.isEmpty()
-                && other.vulnerabilities.isEmpty()
+        other is Resolutions &&
+                other.issues.isEmpty() &&
+                other.ruleViolations.isEmpty() &&
+                other.vulnerabilities.isEmpty()
 }
 
 @Suppress("EqualsOrHashCode", "EqualsWithHashCodeExist") // The class is not supposed to be used with hashing.

--- a/model/src/main/kotlin/config/RepositoryConfiguration.kt
+++ b/model/src/main/kotlin/config/RepositoryConfiguration.kt
@@ -72,7 +72,7 @@ private class ResolutionsFilter {
 @Suppress("EqualsOrHashCode", "EqualsWithHashCodeExist") // The class is not supposed to be used with hashing.
 private class CurationsFilter {
     override fun equals(other: Any?): Boolean =
-        if (other is Curations) other.licenseFindings.isEmpty() else false
+        other is Curations && other.licenseFindings.isEmpty() && other.packages.isEmpty()
 }
 
 @Suppress("EqualsOrHashCode", "EqualsWithHashCodeExist") // The class is not supposed to be used with hashing.


### PR DESCRIPTION
Enable package curations from the project's repository configuration file in order to enable project-specific curations.