### PR TITLE
DependencyGraph: Rework test expectations to be in the dependency graph format

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -3,12 +3,12 @@ repository:
   vcs:
     type: "GitRepo"
     url: "https://github.com/oss-review-toolkit/ort-test-data-git-repo"
-    revision: "<REPLACE_REVISION>"
+    revision: "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
     path: "manifest.xml"
   vcs_processed:
     type: "GitRepo"
     url: "https://github.com/oss-review-toolkit/ort-test-data-git-repo.git"
-    revision: "<REPLACE_REVISION>"
+    revision: "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
     path: "manifest.xml"
   nested_repositories:
     spdx-tools:
@@ -75,7 +75,9 @@ analyzer:
         revision: "941c5c62471168b5d18153755c2a7b38d2560e58"
         path: ""
       homepage_url: ""
-      scopes: []
+      scope_names:
+      - "dependencies"
+      - "devDependencies"
     - id: "Maven:org.apache.commons:commons-text:1.6"
       definition_file_path: "pom.xml"
       authors:
@@ -102,23 +104,9 @@ analyzer:
         revision: "7643b12421100d29fd2b78053e77bcb04a251b2e"
         path: ""
       homepage_url: "http://commons.apache.org/proper/commons-text"
-      scopes:
-      - name: "compile"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.8.1"
-      - name: "test"
-        dependencies:
-        - id: "Maven:org.assertj:assertj-core:3.11.1"
-        - id: "Maven:org.junit.jupiter:junit-jupiter-engine:5.3.1"
-          dependencies:
-          - id: "Maven:org.apiguardian:apiguardian-api:1.0.0"
-          - id: "Maven:org.junit.jupiter:junit-jupiter-api:5.3.1"
-          - id: "Maven:org.junit.platform:junit-platform-engine:1.3.1"
-            dependencies:
-            - id: "Maven:org.junit.platform:junit-platform-commons:1.3.1"
-            - id: "Maven:org.opentest4j:opentest4j:1.1.1"
-        - id: "Maven:org.junit.jupiter:junit-jupiter-params:5.3.1"
-        - id: "Maven:org.junit.platform:junit-platform-launcher:1.3.1"
+      scope_names:
+      - "compile"
+      - "test"
     - id: "Maven:org.spdx:spdx-tools:2.1.15-SNAPSHOT"
       definition_file_path: "pom.xml"
       authors:
@@ -141,85 +129,9 @@ analyzer:
         revision: "e179fae47590eccedc46186ea0ce20cbade5fda7"
         path: ""
       homepage_url: "http://spdx.org/tools"
-      scopes:
-      - name: "compile"
-        dependencies:
-        - id: "Maven:com.github.cliftonlabs:json-simple:2.3.1"
-        - id: "Maven:com.github.spullara.mustache.java:compiler:0.7.9"
-        - id: "Maven:com.google.code.gson:gson:2.8.0"
-        - id: "Maven:com.google.guava:guava:16.0.1"
-        - id: "Maven:net.sf.opencsv:opencsv:2.3"
-        - id: "Maven:net.sf.saxon:saxon:8.7"
-        - id: "Maven:net.sf.saxon:saxon-dom:8.7"
-        - id: "Maven:nu.validator.htmlparser:htmlparser:1.4"
-        - id: "Maven:org.antlr:antlr:3.4"
-          dependencies:
-          - id: "Maven:org.antlr:ST4:4.0.4"
-          - id: "Maven:org.antlr:antlr-runtime:3.4"
-            dependencies:
-            - id: "Maven:antlr:antlr:2.7.7"
-            - id: "Maven:org.antlr:stringtemplate:3.2.1"
-        - id: "Maven:org.apache.commons:commons-lang3:3.1"
-        - id: "Maven:org.apache.jena:apache-jena-libs:3.9.0"
-          dependencies:
-          - id: "Maven:org.apache.jena:jena-rdfconnection:3.9.0"
-          - id: "Maven:org.apache.jena:jena-tdb:3.9.0"
-            dependencies:
-            - id: "Maven:org.apache.jena:jena-arq:3.9.0"
-              dependencies:
-              - id: "Maven:com.github.jsonld-java:jsonld-java:0.12.1"
-                dependencies:
-                - id: "Maven:com.fasterxml.jackson.core:jackson-core:2.9.6"
-                - id: "Maven:com.fasterxml.jackson.core:jackson-databind:2.9.6"
-                  dependencies:
-                  - id: "Maven:com.fasterxml.jackson.core:jackson-annotations:2.9.0"
-                - id: "Maven:commons-io:commons-io:2.6"
-              - id: "Maven:org.apache.httpcomponents:httpclient:4.5.5"
-                dependencies:
-                - id: "Maven:org.apache.httpcomponents:httpcore:4.4.9"
-              - id: "Maven:org.apache.httpcomponents:httpclient-cache:4.5.5"
-              - id: "Maven:org.apache.jena:jena-core:3.9.0"
-                dependencies:
-                - id: "Maven:commons-cli:commons-cli:1.4"
-                - id: "Maven:org.apache.jena:jena-base:3.9.0"
-                  dependencies:
-                  - id: "Maven:com.github.andrewoma.dexx:collection:0.7"
-                  - id: "Maven:org.apache.commons:commons-compress:1.17"
-                  - id: "Maven:org.apache.commons:commons-csv:1.5"
-              - id: "Maven:org.apache.jena:jena-shaded-guava:3.9.0"
-              - id: "Maven:org.apache.thrift:libthrift:0.10.0"
-              - id: "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
-          - id: "Maven:org.apache.jena:jena-tdb2:3.9.0"
-            dependencies:
-            - id: "Maven:org.apache.jena:jena-dboe-trans-data:3.9.0"
-              dependencies:
-              - id: "Maven:org.apache.jena:jena-dboe-index:3.9.0"
-              - id: "Maven:org.apache.jena:jena-dboe-transaction:3.9.0"
-                dependencies:
-                - id: "Maven:org.apache.jena:jena-dboe-base:3.9.0"
-          - id: "Maven:org.slf4j:slf4j-api:1.7.25"
-        - id: "Maven:org.apache.jena:jena-iri:3.9.0"
-        - id: "Maven:org.apache.logging.log4j:log4j-api:2.10.0"
-        - id: "Maven:org.apache.logging.log4j:log4j-core:2.10.0"
-        - id: "Maven:org.apache.logging.log4j:log4j-slf4j-impl:2.10.0"
-        - id: "Maven:org.apache.poi:poi:3.15"
-          dependencies:
-          - id: "Maven:commons-codec:commons-codec:1.10"
-          - id: "Maven:org.apache.commons:commons-collections4:4.1"
-        - id: "Maven:org.apache.poi:poi-ooxml:3.15"
-          dependencies:
-          - id: "Maven:com.github.virtuald:curvesapi:1.04"
-          - id: "Maven:org.apache.poi:poi-ooxml-schemas:3.15"
-            dependencies:
-            - id: "Maven:org.apache.xmlbeans:xmlbeans:2.6.0"
-              dependencies:
-              - id: "Maven:stax:stax-api:1.0.1"
-        - id: "Maven:org.jsoup:jsoup:1.7.2"
-      - name: "test"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+      scope_names:
+      - "compile"
+      - "test"
     - id: "NPM::isarray:2.0.5"
       definition_file_path: "package.json"
       authors:
@@ -239,26 +151,8 @@ analyzer:
         revision: "63ea4ca0a0d6b0574d6a470ebd26880c3026db4a"
         path: ""
       homepage_url: "https://github.com/juliangruber/isarray"
-      scopes:
-      - name: "devDependencies"
-        dependencies:
-        - id: "NPM::tape:2.13.4"
-          dependencies:
-          - id: "NPM::deep-equal:0.2.2"
-          - id: "NPM::defined:0.0.0"
-          - id: "NPM::glob:3.2.11"
-            dependencies:
-            - id: "NPM::inherits:2.0.3"
-            - id: "NPM::minimatch:0.3.0"
-              dependencies:
-              - id: "NPM::lru-cache:2.7.3"
-              - id: "NPM::sigmund:1.0.1"
-          - id: "NPM::inherits:2.0.3"
-          - id: "NPM::object-inspect:0.4.0"
-          - id: "NPM::resumer:0.0.0"
-            dependencies:
-            - id: "NPM::through:2.3.8"
-          - id: "NPM::through:2.3.8"
+      scope_names:
+      - "devDependencies"
     - id: "NPM::npm-test-project:1.0.0"
       definition_file_path: "package.json"
       declared_licenses:
@@ -276,92 +170,9 @@ analyzer:
         revision: "ad0367b7b9920144a47b8d30cc0c84cea102b821"
         path: ""
       homepage_url: ""
-      scopes:
-      - name: "dependencies"
-        dependencies:
-        - id: "NPM::cheerio:1.0.0-rc.1"
-          dependencies:
-          - id: "NPM::css-select:1.2.0"
-            dependencies:
-            - id: "NPM::boolbase:1.0.0"
-            - id: "NPM::css-what:2.1.3"
-            - id: "NPM::domutils:1.5.1"
-              dependencies:
-              - id: "NPM::dom-serializer:0.1.1"
-                dependencies:
-                - id: "NPM::domelementtype:1.3.1"
-                - id: "NPM::entities:1.1.2"
-              - id: "NPM::domelementtype:1.3.1"
-            - id: "NPM::nth-check:1.0.2"
-              dependencies:
-              - id: "NPM::boolbase:1.0.0"
-          - id: "NPM::dom-serializer:0.1.1"
-            dependencies:
-            - id: "NPM::domelementtype:1.3.1"
-            - id: "NPM::entities:1.1.2"
-          - id: "NPM::entities:1.1.2"
-          - id: "NPM::htmlparser2:3.10.1"
-            dependencies:
-            - id: "NPM::domelementtype:1.3.1"
-            - id: "NPM::domhandler:2.4.2"
-              dependencies:
-              - id: "NPM::domelementtype:1.3.1"
-            - id: "NPM::domutils:1.5.1"
-              dependencies:
-              - id: "NPM::dom-serializer:0.1.1"
-                dependencies:
-                - id: "NPM::domelementtype:1.3.1"
-                - id: "NPM::entities:1.1.2"
-              - id: "NPM::domelementtype:1.3.1"
-            - id: "NPM::entities:1.1.2"
-            - id: "NPM::inherits:2.0.3"
-            - id: "NPM::readable-stream:3.2.0"
-              dependencies:
-              - id: "NPM::inherits:2.0.3"
-              - id: "NPM::string_decoder:1.2.0"
-                dependencies:
-                - id: "NPM::safe-buffer:5.1.2"
-              - id: "NPM::util-deprecate:1.0.2"
-          - id: "NPM::lodash:4.17.11"
-          - id: "NPM::parse5:3.0.3"
-            dependencies:
-            - id: "NPM:@types:node:11.9.6"
-      - name: "devDependencies"
-        dependencies:
-        - id: "NPM::cson:4.1.0"
-          dependencies:
-          - id: "NPM::coffee-script:1.12.7"
-          - id: "NPM::cson-parser:1.3.5"
-            dependencies:
-            - id: "NPM::coffee-script:1.12.7"
-          - id: "NPM::extract-opts:3.3.1"
-            dependencies:
-            - id: "NPM::eachr:3.2.0"
-              dependencies:
-              - id: "NPM::editions:1.3.4"
-              - id: "NPM::typechecker:4.7.0"
-                dependencies:
-                - id: "NPM::editions:2.1.3"
-                  dependencies:
-                  - id: "NPM::errlop:1.1.1"
-                  - id: "NPM::semver:5.6.0"
-            - id: "NPM::editions:1.3.4"
-            - id: "NPM::typechecker:4.7.0"
-              dependencies:
-              - id: "NPM::editions:2.1.3"
-                dependencies:
-                - id: "NPM::errlop:1.1.1"
-                - id: "NPM::semver:5.6.0"
-          - id: "NPM::requirefresh:2.2.0"
-            dependencies:
-            - id: "NPM::editions:2.1.3"
-              dependencies:
-              - id: "NPM::errlop:1.1.1"
-              - id: "NPM::semver:5.6.0"
-          - id: "NPM::safefs:4.1.0"
-            dependencies:
-            - id: "NPM::editions:1.3.4"
-            - id: "NPM::graceful-fs:4.1.15"
+      scope_names:
+      - "dependencies"
+      - "devDependencies"
     - id: "NPM::submodules/test-data-npm/long.js/package.json:"
       definition_file_path: "package.json"
       declared_licenses: []
@@ -377,8 +188,8 @@ analyzer:
         revision: "941c5c62471168b5d18153755c2a7b38d2560e58"
         path: ""
       homepage_url: ""
-      scopes: []
-    - id: "Unmanaged:manifest.xml:manifest:<REPLACE_REVISION>"
+      scope_names: []
+    - id: "Unmanaged:manifest.xml:manifest:31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
       definition_file_path: ""
       declared_licenses: []
       declared_licenses_processed: {}
@@ -4320,6 +4131,466 @@ analyzer:
           \ This potentially results in unstable versions of dependencies. To allow\
           \ this, enable support for dynamic versions."
         severity: "ERROR"
+    dependency_graphs:
+      Maven:
+        packages:
+        - "Maven:antlr:antlr:2.7.7"
+        - "Maven:com.fasterxml.jackson.core:jackson-annotations:2.9.0"
+        - "Maven:com.fasterxml.jackson.core:jackson-core:2.9.6"
+        - "Maven:com.fasterxml.jackson.core:jackson-databind:2.9.6"
+        - "Maven:com.github.andrewoma.dexx:collection:0.7"
+        - "Maven:com.github.cliftonlabs:json-simple:2.3.1"
+        - "Maven:com.github.jsonld-java:jsonld-java:0.12.1"
+        - "Maven:com.github.spullara.mustache.java:compiler:0.7.9"
+        - "Maven:com.github.virtuald:curvesapi:1.04"
+        - "Maven:com.google.code.gson:gson:2.8.0"
+        - "Maven:com.google.guava:guava:16.0.1"
+        - "Maven:commons-cli:commons-cli:1.4"
+        - "Maven:commons-codec:commons-codec:1.10"
+        - "Maven:commons-io:commons-io:2.6"
+        - "Maven:junit:junit:4.12"
+        - "Maven:net.sf.opencsv:opencsv:2.3"
+        - "Maven:net.sf.saxon:saxon-dom:8.7"
+        - "Maven:net.sf.saxon:saxon:8.7"
+        - "Maven:nu.validator.htmlparser:htmlparser:1.4"
+        - "Maven:org.antlr:ST4:4.0.4"
+        - "Maven:org.antlr:antlr-runtime:3.4"
+        - "Maven:org.antlr:antlr:3.4"
+        - "Maven:org.antlr:stringtemplate:3.2.1"
+        - "Maven:org.apache.commons:commons-collections4:4.1"
+        - "Maven:org.apache.commons:commons-compress:1.17"
+        - "Maven:org.apache.commons:commons-csv:1.5"
+        - "Maven:org.apache.commons:commons-lang3:3.1"
+        - "Maven:org.apache.commons:commons-lang3:3.8.1"
+        - "Maven:org.apache.httpcomponents:httpclient-cache:4.5.5"
+        - "Maven:org.apache.httpcomponents:httpclient:4.5.5"
+        - "Maven:org.apache.httpcomponents:httpcore:4.4.9"
+        - "Maven:org.apache.jena:apache-jena-libs:3.9.0"
+        - "Maven:org.apache.jena:jena-arq:3.9.0"
+        - "Maven:org.apache.jena:jena-base:3.9.0"
+        - "Maven:org.apache.jena:jena-core:3.9.0"
+        - "Maven:org.apache.jena:jena-dboe-base:3.9.0"
+        - "Maven:org.apache.jena:jena-dboe-index:3.9.0"
+        - "Maven:org.apache.jena:jena-dboe-trans-data:3.9.0"
+        - "Maven:org.apache.jena:jena-dboe-transaction:3.9.0"
+        - "Maven:org.apache.jena:jena-iri:3.9.0"
+        - "Maven:org.apache.jena:jena-rdfconnection:3.9.0"
+        - "Maven:org.apache.jena:jena-shaded-guava:3.9.0"
+        - "Maven:org.apache.jena:jena-tdb2:3.9.0"
+        - "Maven:org.apache.jena:jena-tdb:3.9.0"
+        - "Maven:org.apache.logging.log4j:log4j-api:2.10.0"
+        - "Maven:org.apache.logging.log4j:log4j-core:2.10.0"
+        - "Maven:org.apache.logging.log4j:log4j-slf4j-impl:2.10.0"
+        - "Maven:org.apache.poi:poi-ooxml-schemas:3.15"
+        - "Maven:org.apache.poi:poi-ooxml:3.15"
+        - "Maven:org.apache.poi:poi:3.15"
+        - "Maven:org.apache.thrift:libthrift:0.10.0"
+        - "Maven:org.apache.xmlbeans:xmlbeans:2.6.0"
+        - "Maven:org.apiguardian:apiguardian-api:1.0.0"
+        - "Maven:org.assertj:assertj-core:3.11.1"
+        - "Maven:org.hamcrest:hamcrest-core:1.3"
+        - "Maven:org.jsoup:jsoup:1.7.2"
+        - "Maven:org.junit.jupiter:junit-jupiter-api:5.3.1"
+        - "Maven:org.junit.jupiter:junit-jupiter-engine:5.3.1"
+        - "Maven:org.junit.jupiter:junit-jupiter-params:5.3.1"
+        - "Maven:org.junit.platform:junit-platform-commons:1.3.1"
+        - "Maven:org.junit.platform:junit-platform-engine:1.3.1"
+        - "Maven:org.junit.platform:junit-platform-launcher:1.3.1"
+        - "Maven:org.opentest4j:opentest4j:1.1.1"
+        - "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
+        - "Maven:org.slf4j:slf4j-api:1.7.25"
+        - "Maven:stax:stax-api:1.0.1"
+        scopes:
+          org.apache.commons:commons-text:1.6:compile:
+          - root: 27
+          org.apache.commons:commons-text:1.6:test:
+          - root: 53
+          - root: 57
+          - root: 58
+          - root: 61
+          org.spdx:spdx-tools:2.1.15-SNAPSHOT:compile:
+          - root: 5
+          - root: 7
+          - root: 9
+          - root: 10
+          - root: 15
+          - root: 16
+          - root: 17
+          - root: 18
+          - root: 21
+          - root: 26
+          - root: 31
+          - root: 39
+          - root: 44
+          - root: 45
+          - root: 46
+          - root: 48
+          - root: 49
+          - root: 55
+          org.spdx:spdx-tools:2.1.15-SNAPSHOT:test:
+          - root: 14
+        nodes:
+        - pkg: 31
+        - pkg: 43
+        - pkg: 32
+        - pkg: 34
+        - pkg: 11
+        - pkg: 33
+        - pkg: 25
+        - pkg: 24
+        - pkg: 4
+        - pkg: 41
+        - pkg: 29
+        - pkg: 30
+        - pkg: 6
+        - pkg: 2
+        - pkg: 3
+        - pkg: 1
+        - pkg: 13
+        - pkg: 28
+        - pkg: 50
+        - pkg: 63
+        - pkg: 42
+        - pkg: 37
+        - pkg: 38
+        - pkg: 35
+        - pkg: 36
+        - pkg: 40
+        - pkg: 64
+        - pkg: 39
+        - pkg: 21
+        - pkg: 20
+        - pkg: 22
+        - {}
+        - pkg: 19
+        - pkg: 26
+        - pkg: 49
+        - pkg: 12
+        - pkg: 23
+        - pkg: 48
+        - pkg: 47
+        - pkg: 51
+        - pkg: 65
+        - pkg: 8
+        - pkg: 15
+        - pkg: 18
+        - pkg: 17
+        - pkg: 55
+        - pkg: 10
+        - pkg: 7
+        - pkg: 44
+        - pkg: 45
+        - pkg: 46
+        - pkg: 14
+        - pkg: 54
+        - pkg: 9
+        - pkg: 16
+        - pkg: 5
+        - pkg: 27
+        - pkg: 57
+        - pkg: 52
+        - pkg: 60
+        - pkg: 59
+        - pkg: 62
+        - pkg: 56
+        - pkg: 58
+        - pkg: 61
+        - pkg: 53
+        edges:
+        - from: 5
+          to: 6
+        - from: 5
+          to: 7
+        - from: 5
+          to: 8
+        - from: 3
+          to: 4
+        - from: 3
+          to: 5
+        - from: 10
+          to: 11
+        - from: 14
+          to: 15
+        - from: 12
+          to: 13
+        - from: 12
+          to: 14
+        - from: 12
+          to: 16
+        - from: 2
+          to: 3
+        - from: 2
+          to: 9
+        - from: 2
+          to: 10
+        - from: 2
+          to: 12
+        - from: 2
+          to: 17
+        - from: 2
+          to: 18
+        - from: 2
+          to: 19
+        - from: 1
+          to: 2
+        - from: 22
+          to: 23
+        - from: 21
+          to: 22
+        - from: 21
+          to: 24
+        - from: 20
+          to: 21
+        - from: 0
+          to: 1
+        - from: 0
+          to: 20
+        - from: 0
+          to: 25
+        - from: 0
+          to: 26
+        - from: 29
+          to: 30
+        - from: 29
+          to: 31
+        - from: 28
+          to: 29
+        - from: 28
+          to: 32
+        - from: 34
+          to: 35
+        - from: 34
+          to: 36
+        - from: 39
+          to: 40
+        - from: 38
+          to: 39
+        - from: 37
+          to: 38
+        - from: 37
+          to: 41
+        - from: 51
+          to: 52
+        - from: 59
+          to: 60
+        - from: 59
+          to: 61
+        - from: 57
+          to: 58
+        - from: 57
+          to: 59
+        - from: 57
+          to: 62
+      NPM:
+        packages:
+        - "NPM::boolbase:1.0.0"
+        - "NPM::cheerio:1.0.0-rc.1"
+        - "NPM::coffee-script:1.12.7"
+        - "NPM::cson-parser:1.3.5"
+        - "NPM::cson:4.1.0"
+        - "NPM::css-select:1.2.0"
+        - "NPM::css-what:2.1.3"
+        - "NPM::deep-equal:0.2.2"
+        - "NPM::defined:0.0.0"
+        - "NPM::dom-serializer:0.1.1"
+        - "NPM::domelementtype:1.3.1"
+        - "NPM::domhandler:2.4.2"
+        - "NPM::domutils:1.5.1"
+        - "NPM::eachr:3.2.0"
+        - "NPM::editions:1.3.4"
+        - "NPM::editions:2.1.3"
+        - "NPM::entities:1.1.2"
+        - "NPM::errlop:1.1.1"
+        - "NPM::extract-opts:3.3.1"
+        - "NPM::glob:3.2.11"
+        - "NPM::graceful-fs:4.1.15"
+        - "NPM::htmlparser2:3.10.1"
+        - "NPM::inherits:2.0.3"
+        - "NPM::lodash:4.17.11"
+        - "NPM::lru-cache:2.7.3"
+        - "NPM::minimatch:0.3.0"
+        - "NPM::nth-check:1.0.2"
+        - "NPM::object-inspect:0.4.0"
+        - "NPM::parse5:3.0.3"
+        - "NPM::readable-stream:3.2.0"
+        - "NPM::requirefresh:2.2.0"
+        - "NPM::resumer:0.0.0"
+        - "NPM::safe-buffer:5.1.2"
+        - "NPM::safefs:4.1.0"
+        - "NPM::semver:5.6.0"
+        - "NPM::sigmund:1.0.1"
+        - "NPM::string_decoder:1.2.0"
+        - "NPM::tape:2.13.4"
+        - "NPM::through:2.3.8"
+        - "NPM::typechecker:4.7.0"
+        - "NPM::util-deprecate:1.0.2"
+        - "NPM:@types:node:11.9.6"
+        scopes:
+          :isarray:2.0.5:devDependencies:
+          - root: 37
+          :npm-test-project:1.0.0:dependencies:
+          - root: 1
+          :npm-test-project:1.0.0:devDependencies:
+          - root: 4
+        nodes:
+        - pkg: 1
+        - pkg: 5
+        - pkg: 6
+        - pkg: 12
+        - pkg: 9
+        - pkg: 10
+        - pkg: 16
+        - {}
+        - pkg: 26
+        - pkg: 21
+        - pkg: 11
+        - pkg: 22
+        - pkg: 29
+        - pkg: 36
+        - pkg: 32
+        - pkg: 40
+        - pkg: 23
+        - pkg: 28
+        - pkg: 41
+        - pkg: 4
+        - pkg: 2
+        - pkg: 3
+        - pkg: 18
+        - pkg: 13
+        - pkg: 14
+        - pkg: 39
+        - pkg: 15
+        - pkg: 17
+        - pkg: 34
+        - pkg: 30
+        - pkg: 33
+        - pkg: 20
+        - pkg: 37
+        - pkg: 7
+        - pkg: 8
+        - pkg: 19
+        - pkg: 25
+        - pkg: 24
+        - pkg: 35
+        - pkg: 27
+        - pkg: 31
+        - pkg: 38
+        edges:
+        - from: 4
+          to: 5
+        - from: 4
+          to: 6
+        - from: 3
+          to: 4
+        - from: 3
+          to: 5
+        - from: 8
+          to: 7
+        - from: 1
+          to: 2
+        - from: 1
+          to: 3
+        - from: 1
+          to: 7
+        - from: 1
+          to: 8
+        - from: 10
+          to: 5
+        - from: 13
+          to: 14
+        - from: 12
+          to: 11
+        - from: 12
+          to: 13
+        - from: 12
+          to: 15
+        - from: 9
+          to: 3
+        - from: 9
+          to: 5
+        - from: 9
+          to: 6
+        - from: 9
+          to: 10
+        - from: 9
+          to: 11
+        - from: 9
+          to: 12
+        - from: 17
+          to: 18
+        - from: 0
+          to: 1
+        - from: 0
+          to: 4
+        - from: 0
+          to: 6
+        - from: 0
+          to: 9
+        - from: 0
+          to: 16
+        - from: 0
+          to: 17
+        - from: 21
+          to: 20
+        - from: 26
+          to: 27
+        - from: 26
+          to: 28
+        - from: 25
+          to: 26
+        - from: 23
+          to: 24
+        - from: 23
+          to: 25
+        - from: 22
+          to: 23
+        - from: 22
+          to: 24
+        - from: 22
+          to: 25
+        - from: 29
+          to: 26
+        - from: 30
+          to: 24
+        - from: 30
+          to: 31
+        - from: 19
+          to: 20
+        - from: 19
+          to: 21
+        - from: 19
+          to: 22
+        - from: 19
+          to: 29
+        - from: 19
+          to: 30
+        - from: 36
+          to: 37
+        - from: 36
+          to: 38
+        - from: 35
+          to: 11
+        - from: 35
+          to: 36
+        - from: 40
+          to: 41
+        - from: 32
+          to: 11
+        - from: 32
+          to: 33
+        - from: 32
+          to: 34
+        - from: 32
+          to: 35
+        - from: 32
+          to: 39
+        - from: 32
+          to: 40
+        - from: 32
+          to: 41
+      Bower:
+        nodes: []
+        edges: []
     has_issues: true
 scanner: null
 advisor: null

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-cli.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-cli.yml
@@ -1,6 +1,6 @@
 ---
-project:
-  id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:cli:1.0"
+projects:
+- id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:cli:1.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/external/multi-kotlin-project/cli/build.gradle.kts"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -15,416 +15,338 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/external/multi-kotlin-project/cli"
   homepage_url: ""
-  scopes:
-  - name: "apiDependenciesMetadata"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "compile"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "default"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "implementationDependenciesMetadata"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "kotlinCompilerClasspath"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-          dependencies:
-          - id: "Maven:org.jetbrains:annotations:13.0"
-          - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "kotlinCompilerPluginClasspath"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
-  - name: "runtime"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testApiDependenciesMetadata"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testCompile"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testImplementationDependenciesMetadata"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testRuntime"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+  scope_names:
+  - "apiDependenciesMetadata"
+  - "compile"
+  - "compileClasspath"
+  - "default"
+  - "implementationDependenciesMetadata"
+  - "kotlinCompilerClasspath"
+  - "kotlinCompilerPluginClasspath"
+  - "runtime"
+  - "runtimeClasspath"
+  - "testApiDependenciesMetadata"
+  - "testCompile"
+  - "testCompileClasspath"
+  - "testImplementationDependenciesMetadata"
+  - "testRuntime"
+  - "testRuntimeClasspath"
 packages:
-- id: "Maven:org.jetbrains:annotations:13.0"
-  purl: "pkg:maven/org.jetbrains/annotations@13.0"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache Software License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache Software License, Version 2.0: "Apache-2.0"
-  description: "A set of annotations used for code inspection support and code documentation."
-  homepage_url: "http://www.jetbrains.org"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar"
-    hash:
-      value: "919f0dfe192fb4e063e7dacadee7f8bb9a2672a9"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0-sources.jar"
-    hash:
-      value: "5991ca87ef1fb5544943d9abc5a9a37583fabe03"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/intellij-community.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/intellij-community.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
-  purl: "pkg:maven/org.jetbrains.kotlin/kotlin-compiler-embeddable@1.3.11"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache License, Version 2.0: "Apache-2.0"
-  description: "Kotlin Compiler (embeddable)"
-  homepage_url: "https://kotlinlang.org/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/1.3.11/kotlin-compiler-embeddable-1.3.11.jar"
-    hash:
-      value: "a8db6c14f8b8ed74aa11b8379f961587b639c571"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/1.3.11/kotlin-compiler-embeddable-1.3.11-sources.jar"
-    hash:
-      value: "86e3750eb7fc889a61af127ef5b2b843d141ba09"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
-  purl: "pkg:maven/org.jetbrains.kotlin/kotlin-reflect@1.3.11"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache License, Version 2.0: "Apache-2.0"
-  description: "Kotlin Full Reflection Library"
-  homepage_url: "https://kotlinlang.org/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.3.11/kotlin-reflect-1.3.11.jar"
-    hash:
-      value: "aae7b33412715e9ed441934c4ffaad1bb80e9d36"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.3.11/kotlin-reflect-1.3.11-sources.jar"
-    hash:
-      value: "92835479c406bf6b1d55c41b0013f238a5ed5bd8"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
-  purl: "pkg:maven/org.jetbrains.kotlin/kotlin-script-runtime@1.3.11"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache License, Version 2.0: "Apache-2.0"
-  description: "Kotlin Script Runtime"
-  homepage_url: "https://kotlinlang.org/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/1.3.11/kotlin-script-runtime-1.3.11.jar"
-    hash:
-      value: "1ef3a816aeacb9cd051b3ed37e2abf88910f1503"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/1.3.11/kotlin-script-runtime-1.3.11-sources.jar"
-    hash:
-      value: "819822a4658989d09761f8e3e9d31b4743897b22"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
-  purl: "pkg:maven/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable@1.3.11"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache License, Version 2.0: "Apache-2.0"
-  description: "Kotlin Scripting Compiler Plugin for embeddable compiler"
-  homepage_url: "https://kotlinlang.org/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.3.11/kotlin-scripting-compiler-embeddable-1.3.11.jar"
-    hash:
-      value: "d7d145f70c063e3bb2edb41b766971e359155b99"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.3.11/kotlin-scripting-compiler-embeddable-1.3.11-sources.jar"
-    hash:
-      value: "9ed059e6df49c3e812b4a8d9431287a629a0e5bb"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-  purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@1.3.11"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache License, Version 2.0: "Apache-2.0"
-  description: "Kotlin Standard Library for JVM"
-  homepage_url: "https://kotlinlang.org/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11.jar"
-    hash:
-      value: "4cbc5922a54376018307a731162ccaf3ef851a39"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11-sources.jar"
-    hash:
-      value: "d46e00faac79f8ec6bb956154ecde4282871a6bf"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib-common@1.3.11"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache License, Version 2.0: "Apache-2.0"
-  description: "Kotlin Common Standard Library"
-  homepage_url: "https://kotlinlang.org/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11.jar"
-    hash:
-      value: "d8b8e746e279f1c4f5e08bc14a96b82e6bb1de02"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11-sources.jar"
-    hash:
-      value: "e49742d3259938ea3539346c8ca3babb54a5140f"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
+- package:
+    id: "Maven:org.jetbrains:annotations:13.0"
+    purl: "pkg:maven/org.jetbrains/annotations@13.0"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache Software License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
+    description: "A set of annotations used for code inspection support and code documentation."
+    homepage_url: "http://www.jetbrains.org"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar"
+      hash:
+        value: "919f0dfe192fb4e063e7dacadee7f8bb9a2672a9"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0-sources.jar"
+      hash:
+        value: "5991ca87ef1fb5544943d9abc5a9a37583fabe03"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/intellij-community.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/intellij-community.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
+    purl: "pkg:maven/org.jetbrains.kotlin/kotlin-compiler-embeddable@1.3.11"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
+    description: "Kotlin Compiler (embeddable)"
+    homepage_url: "https://kotlinlang.org/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/1.3.11/kotlin-compiler-embeddable-1.3.11.jar"
+      hash:
+        value: "a8db6c14f8b8ed74aa11b8379f961587b639c571"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/1.3.11/kotlin-compiler-embeddable-1.3.11-sources.jar"
+      hash:
+        value: "86e3750eb7fc889a61af127ef5b2b843d141ba09"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
+    purl: "pkg:maven/org.jetbrains.kotlin/kotlin-reflect@1.3.11"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
+    description: "Kotlin Full Reflection Library"
+    homepage_url: "https://kotlinlang.org/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.3.11/kotlin-reflect-1.3.11.jar"
+      hash:
+        value: "aae7b33412715e9ed441934c4ffaad1bb80e9d36"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.3.11/kotlin-reflect-1.3.11-sources.jar"
+      hash:
+        value: "92835479c406bf6b1d55c41b0013f238a5ed5bd8"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
+    purl: "pkg:maven/org.jetbrains.kotlin/kotlin-script-runtime@1.3.11"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
+    description: "Kotlin Script Runtime"
+    homepage_url: "https://kotlinlang.org/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/1.3.11/kotlin-script-runtime-1.3.11.jar"
+      hash:
+        value: "1ef3a816aeacb9cd051b3ed37e2abf88910f1503"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/1.3.11/kotlin-script-runtime-1.3.11-sources.jar"
+      hash:
+        value: "819822a4658989d09761f8e3e9d31b4743897b22"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
+    purl: "pkg:maven/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable@1.3.11"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
+    description: "Kotlin Scripting Compiler Plugin for embeddable compiler"
+    homepage_url: "https://kotlinlang.org/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.3.11/kotlin-scripting-compiler-embeddable-1.3.11.jar"
+      hash:
+        value: "d7d145f70c063e3bb2edb41b766971e359155b99"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.3.11/kotlin-scripting-compiler-embeddable-1.3.11-sources.jar"
+      hash:
+        value: "9ed059e6df49c3e812b4a8d9431287a629a0e5bb"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+    purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@1.3.11"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
+    description: "Kotlin Standard Library for JVM"
+    homepage_url: "https://kotlinlang.org/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11.jar"
+      hash:
+        value: "4cbc5922a54376018307a731162ccaf3ef851a39"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11-sources.jar"
+      hash:
+        value: "d46e00faac79f8ec6bb956154ecde4282871a6bf"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+    purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib-common@1.3.11"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
+    description: "Kotlin Common Standard Library"
+    homepage_url: "https://kotlinlang.org/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11.jar"
+      hash:
+        value: "d8b8e746e279f1c4f5e08bc14a96b82e6bb1de02"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11-sources.jar"
+      hash:
+        value: "e49742d3259938ea3539346c8ca3babb54a5140f"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+  curations: []
+dependency_graphs:
+  Gradle:
+    packages:
+    - "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+    - "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+    - "Maven:org.jetbrains:annotations:13.0"
+    scopes:
+      org.gradle.kotlin.dsl.samples.multiproject:cli:1.0:apiDependenciesMetadata:
+      - root: 0
+      - root: 6
+      org.gradle.kotlin.dsl.samples.multiproject:cli:1.0:compile:
+      - root: 0
+      - root: 6
+      org.gradle.kotlin.dsl.samples.multiproject:cli:1.0:compileClasspath:
+      - root: 0
+      - root: 6
+      org.gradle.kotlin.dsl.samples.multiproject:cli:1.0:default:
+      - root: 0
+      - root: 6
+      org.gradle.kotlin.dsl.samples.multiproject:cli:1.0:implementationDependenciesMetadata:
+      - root: 0
+      - root: 6
+      org.gradle.kotlin.dsl.samples.multiproject:cli:1.0:kotlinCompilerClasspath:
+      - root: 1
+      org.gradle.kotlin.dsl.samples.multiproject:cli:1.0:kotlinCompilerPluginClasspath:
+      - root: 4
+      org.gradle.kotlin.dsl.samples.multiproject:cli:1.0:runtime:
+      - root: 0
+      - root: 6
+      org.gradle.kotlin.dsl.samples.multiproject:cli:1.0:runtimeClasspath:
+      - root: 0
+      - root: 6
+      org.gradle.kotlin.dsl.samples.multiproject:cli:1.0:testApiDependenciesMetadata:
+      - root: 0
+      - root: 6
+      org.gradle.kotlin.dsl.samples.multiproject:cli:1.0:testCompile:
+      - root: 0
+      - root: 6
+      org.gradle.kotlin.dsl.samples.multiproject:cli:1.0:testCompileClasspath:
+      - root: 0
+      - root: 6
+      org.gradle.kotlin.dsl.samples.multiproject:cli:1.0:testImplementationDependenciesMetadata:
+      - root: 0
+      - root: 6
+      org.gradle.kotlin.dsl.samples.multiproject:cli:1.0:testRuntime:
+      - root: 0
+      - root: 6
+      org.gradle.kotlin.dsl.samples.multiproject:cli:1.0:testRuntimeClasspath:
+      - root: 0
+      - root: 6
+    nodes:
+    - linkage: "PROJECT_DYNAMIC"
+    - pkg: 6
+    - pkg: 5
+    - pkg: 7
+    - pkg: 1
+    - pkg: 3
+    - pkg: 2
+    - pkg: 4
+    edges:
+    - from: 1
+      to: 2
+    - from: 1
+      to: 3
+    - from: 0
+      to: 1
+    - from: 6
+      to: 1
+    - from: 4
+      to: 1
+    - from: 4
+      to: 5
+    - from: 4
+      to: 6
+has_issues: false

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-core.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-core.yml
@@ -1,6 +1,6 @@
 ---
-project:
-  id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+projects:
+- id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/external/multi-kotlin-project/core/build.gradle.kts"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -15,325 +15,321 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/external/multi-kotlin-project/core"
   homepage_url: ""
-  scopes:
-  - name: "apiDependenciesMetadata"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "compile"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "default"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "implementationDependenciesMetadata"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "kotlinCompilerClasspath"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-          dependencies:
-          - id: "Maven:org.jetbrains:annotations:13.0"
-          - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "kotlinCompilerPluginClasspath"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
-  - name: "runtime"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testApiDependenciesMetadata"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testCompile"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testImplementationDependenciesMetadata"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testRuntime"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-      dependencies:
-      - id: "Maven:org.jetbrains:annotations:13.0"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+  scope_names:
+  - "apiDependenciesMetadata"
+  - "compile"
+  - "compileClasspath"
+  - "default"
+  - "implementationDependenciesMetadata"
+  - "kotlinCompilerClasspath"
+  - "kotlinCompilerPluginClasspath"
+  - "runtime"
+  - "runtimeClasspath"
+  - "testApiDependenciesMetadata"
+  - "testCompile"
+  - "testCompileClasspath"
+  - "testImplementationDependenciesMetadata"
+  - "testRuntime"
+  - "testRuntimeClasspath"
 packages:
-- id: "Maven:org.jetbrains:annotations:13.0"
-  purl: "pkg:maven/org.jetbrains/annotations@13.0"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache Software License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache Software License, Version 2.0: "Apache-2.0"
-  description: "A set of annotations used for code inspection support and code documentation."
-  homepage_url: "http://www.jetbrains.org"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar"
-    hash:
-      value: "919f0dfe192fb4e063e7dacadee7f8bb9a2672a9"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0-sources.jar"
-    hash:
-      value: "5991ca87ef1fb5544943d9abc5a9a37583fabe03"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/intellij-community.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/intellij-community.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
-  purl: "pkg:maven/org.jetbrains.kotlin/kotlin-compiler-embeddable@1.3.11"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache License, Version 2.0: "Apache-2.0"
-  description: "Kotlin Compiler (embeddable)"
-  homepage_url: "https://kotlinlang.org/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/1.3.11/kotlin-compiler-embeddable-1.3.11.jar"
-    hash:
-      value: "a8db6c14f8b8ed74aa11b8379f961587b639c571"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/1.3.11/kotlin-compiler-embeddable-1.3.11-sources.jar"
-    hash:
-      value: "86e3750eb7fc889a61af127ef5b2b843d141ba09"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
-  purl: "pkg:maven/org.jetbrains.kotlin/kotlin-reflect@1.3.11"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache License, Version 2.0: "Apache-2.0"
-  description: "Kotlin Full Reflection Library"
-  homepage_url: "https://kotlinlang.org/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.3.11/kotlin-reflect-1.3.11.jar"
-    hash:
-      value: "aae7b33412715e9ed441934c4ffaad1bb80e9d36"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.3.11/kotlin-reflect-1.3.11-sources.jar"
-    hash:
-      value: "92835479c406bf6b1d55c41b0013f238a5ed5bd8"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
-  purl: "pkg:maven/org.jetbrains.kotlin/kotlin-script-runtime@1.3.11"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache License, Version 2.0: "Apache-2.0"
-  description: "Kotlin Script Runtime"
-  homepage_url: "https://kotlinlang.org/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/1.3.11/kotlin-script-runtime-1.3.11.jar"
-    hash:
-      value: "1ef3a816aeacb9cd051b3ed37e2abf88910f1503"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/1.3.11/kotlin-script-runtime-1.3.11-sources.jar"
-    hash:
-      value: "819822a4658989d09761f8e3e9d31b4743897b22"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
-  purl: "pkg:maven/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable@1.3.11"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache License, Version 2.0: "Apache-2.0"
-  description: "Kotlin Scripting Compiler Plugin for embeddable compiler"
-  homepage_url: "https://kotlinlang.org/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.3.11/kotlin-scripting-compiler-embeddable-1.3.11.jar"
-    hash:
-      value: "d7d145f70c063e3bb2edb41b766971e359155b99"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.3.11/kotlin-scripting-compiler-embeddable-1.3.11-sources.jar"
-    hash:
-      value: "9ed059e6df49c3e812b4a8d9431287a629a0e5bb"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-  purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@1.3.11"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache License, Version 2.0: "Apache-2.0"
-  description: "Kotlin Standard Library for JVM"
-  homepage_url: "https://kotlinlang.org/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11.jar"
-    hash:
-      value: "4cbc5922a54376018307a731162ccaf3ef851a39"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11-sources.jar"
-    hash:
-      value: "d46e00faac79f8ec6bb956154ecde4282871a6bf"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib-common@1.3.11"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache License, Version 2.0: "Apache-2.0"
-  description: "Kotlin Common Standard Library"
-  homepage_url: "https://kotlinlang.org/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11.jar"
-    hash:
-      value: "d8b8e746e279f1c4f5e08bc14a96b82e6bb1de02"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11-sources.jar"
-    hash:
-      value: "e49742d3259938ea3539346c8ca3babb54a5140f"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
+- package:
+    id: "Maven:org.jetbrains:annotations:13.0"
+    purl: "pkg:maven/org.jetbrains/annotations@13.0"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache Software License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
+    description: "A set of annotations used for code inspection support and code documentation."
+    homepage_url: "http://www.jetbrains.org"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar"
+      hash:
+        value: "919f0dfe192fb4e063e7dacadee7f8bb9a2672a9"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0-sources.jar"
+      hash:
+        value: "5991ca87ef1fb5544943d9abc5a9a37583fabe03"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/intellij-community.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/intellij-community.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
+    purl: "pkg:maven/org.jetbrains.kotlin/kotlin-compiler-embeddable@1.3.11"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
+    description: "Kotlin Compiler (embeddable)"
+    homepage_url: "https://kotlinlang.org/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/1.3.11/kotlin-compiler-embeddable-1.3.11.jar"
+      hash:
+        value: "a8db6c14f8b8ed74aa11b8379f961587b639c571"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/1.3.11/kotlin-compiler-embeddable-1.3.11-sources.jar"
+      hash:
+        value: "86e3750eb7fc889a61af127ef5b2b843d141ba09"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
+    purl: "pkg:maven/org.jetbrains.kotlin/kotlin-reflect@1.3.11"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
+    description: "Kotlin Full Reflection Library"
+    homepage_url: "https://kotlinlang.org/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.3.11/kotlin-reflect-1.3.11.jar"
+      hash:
+        value: "aae7b33412715e9ed441934c4ffaad1bb80e9d36"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.3.11/kotlin-reflect-1.3.11-sources.jar"
+      hash:
+        value: "92835479c406bf6b1d55c41b0013f238a5ed5bd8"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
+    purl: "pkg:maven/org.jetbrains.kotlin/kotlin-script-runtime@1.3.11"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
+    description: "Kotlin Script Runtime"
+    homepage_url: "https://kotlinlang.org/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/1.3.11/kotlin-script-runtime-1.3.11.jar"
+      hash:
+        value: "1ef3a816aeacb9cd051b3ed37e2abf88910f1503"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/1.3.11/kotlin-script-runtime-1.3.11-sources.jar"
+      hash:
+        value: "819822a4658989d09761f8e3e9d31b4743897b22"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
+    purl: "pkg:maven/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable@1.3.11"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
+    description: "Kotlin Scripting Compiler Plugin for embeddable compiler"
+    homepage_url: "https://kotlinlang.org/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.3.11/kotlin-scripting-compiler-embeddable-1.3.11.jar"
+      hash:
+        value: "d7d145f70c063e3bb2edb41b766971e359155b99"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.3.11/kotlin-scripting-compiler-embeddable-1.3.11-sources.jar"
+      hash:
+        value: "9ed059e6df49c3e812b4a8d9431287a629a0e5bb"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+    purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@1.3.11"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
+    description: "Kotlin Standard Library for JVM"
+    homepage_url: "https://kotlinlang.org/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11.jar"
+      hash:
+        value: "4cbc5922a54376018307a731162ccaf3ef851a39"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11-sources.jar"
+      hash:
+        value: "d46e00faac79f8ec6bb956154ecde4282871a6bf"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+    purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib-common@1.3.11"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
+    description: "Kotlin Common Standard Library"
+    homepage_url: "https://kotlinlang.org/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11.jar"
+      hash:
+        value: "d8b8e746e279f1c4f5e08bc14a96b82e6bb1de02"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11-sources.jar"
+      hash:
+        value: "e49742d3259938ea3539346c8ca3babb54a5140f"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+  curations: []
+dependency_graphs:
+  Gradle:
+    packages:
+    - "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-reflect:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-script-runtime:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+    - "Maven:org.jetbrains:annotations:13.0"
+    scopes:
+      org.gradle.kotlin.dsl.samples.multiproject:core:1.0:apiDependenciesMetadata:
+      - root: 5
+      org.gradle.kotlin.dsl.samples.multiproject:core:1.0:compile:
+      - root: 5
+      org.gradle.kotlin.dsl.samples.multiproject:core:1.0:compileClasspath:
+      - root: 5
+      org.gradle.kotlin.dsl.samples.multiproject:core:1.0:default:
+      - root: 5
+      org.gradle.kotlin.dsl.samples.multiproject:core:1.0:implementationDependenciesMetadata:
+      - root: 5
+      org.gradle.kotlin.dsl.samples.multiproject:core:1.0:kotlinCompilerClasspath:
+      - root: 0
+      org.gradle.kotlin.dsl.samples.multiproject:core:1.0:kotlinCompilerPluginClasspath:
+      - root: 3
+      org.gradle.kotlin.dsl.samples.multiproject:core:1.0:runtime:
+      - root: 5
+      org.gradle.kotlin.dsl.samples.multiproject:core:1.0:runtimeClasspath:
+      - root: 5
+      org.gradle.kotlin.dsl.samples.multiproject:core:1.0:testApiDependenciesMetadata:
+      - root: 5
+      org.gradle.kotlin.dsl.samples.multiproject:core:1.0:testCompile:
+      - root: 5
+      org.gradle.kotlin.dsl.samples.multiproject:core:1.0:testCompileClasspath:
+      - root: 5
+      org.gradle.kotlin.dsl.samples.multiproject:core:1.0:testImplementationDependenciesMetadata:
+      - root: 5
+      org.gradle.kotlin.dsl.samples.multiproject:core:1.0:testRuntime:
+      - root: 5
+      org.gradle.kotlin.dsl.samples.multiproject:core:1.0:testRuntimeClasspath:
+      - root: 5
+    nodes:
+    - {}
+    - pkg: 5
+    - pkg: 4
+    - pkg: 6
+    - pkg: 2
+    - pkg: 1
+    - pkg: 3
+    edges:
+    - from: 1
+      to: 2
+    - from: 1
+      to: 3
+    - from: 5
+      to: 1
+    - from: 0
+      to: 1
+    - from: 0
+      to: 4
+    - from: 0
+      to: 5
+has_issues: false

--- a/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/external/multi-kotlin-project-expected-output-root.yml
@@ -1,6 +1,6 @@
 ---
-project:
-  id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:multi-kotlin-project:1.0"
+projects:
+- id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:multi-kotlin-project:1.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/external/multi-kotlin-project/build.gradle.kts"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -15,124 +15,139 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/external/multi-kotlin-project"
   homepage_url: ""
-  scopes:
-  - name: "archives"
-    dependencies:
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:cli:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-        linkage: "PROJECT_DYNAMIC"
-        dependencies:
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-          dependencies:
-          - id: "Maven:org.jetbrains:annotations:13.0"
-          - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-    - id: "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-        dependencies:
-        - id: "Maven:org.jetbrains:annotations:13.0"
-        - id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+  scope_names:
+  - "archives"
 packages:
-- id: "Maven:org.jetbrains:annotations:13.0"
-  purl: "pkg:maven/org.jetbrains/annotations@13.0"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache Software License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache Software License, Version 2.0: "Apache-2.0"
-  description: "A set of annotations used for code inspection support and code documentation."
-  homepage_url: "http://www.jetbrains.org"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar"
-    hash:
-      value: "919f0dfe192fb4e063e7dacadee7f8bb9a2672a9"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0-sources.jar"
-    hash:
-      value: "5991ca87ef1fb5544943d9abc5a9a37583fabe03"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/intellij-community.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/intellij-community.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
-  purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@1.3.11"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache License, Version 2.0: "Apache-2.0"
-  description: "Kotlin Standard Library for JVM"
-  homepage_url: "https://kotlinlang.org/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11.jar"
-    hash:
-      value: "4cbc5922a54376018307a731162ccaf3ef851a39"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11-sources.jar"
-    hash:
-      value: "d46e00faac79f8ec6bb956154ecde4282871a6bf"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
-  purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib-common@1.3.11"
-  authors:
-  - "JetBrains"
-  declared_licenses:
-  - "The Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache License, Version 2.0: "Apache-2.0"
-  description: "Kotlin Common Standard Library"
-  homepage_url: "https://kotlinlang.org/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11.jar"
-    hash:
-      value: "d8b8e746e279f1c4f5e08bc14a96b82e6bb1de02"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11-sources.jar"
-    hash:
-      value: "e49742d3259938ea3539346c8ca3babb54a5140f"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/JetBrains/kotlin.git"
-    revision: ""
-    path: ""
+- package:
+    id: "Maven:org.jetbrains:annotations:13.0"
+    purl: "pkg:maven/org.jetbrains/annotations@13.0"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache Software License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
+    description: "A set of annotations used for code inspection support and code documentation."
+    homepage_url: "http://www.jetbrains.org"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar"
+      hash:
+        value: "919f0dfe192fb4e063e7dacadee7f8bb9a2672a9"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/13.0/annotations-13.0-sources.jar"
+      hash:
+        value: "5991ca87ef1fb5544943d9abc5a9a37583fabe03"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/intellij-community.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/intellij-community.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+    purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@1.3.11"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
+    description: "Kotlin Standard Library for JVM"
+    homepage_url: "https://kotlinlang.org/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11.jar"
+      hash:
+        value: "4cbc5922a54376018307a731162ccaf3ef851a39"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.3.11/kotlin-stdlib-1.3.11-sources.jar"
+      hash:
+        value: "d46e00faac79f8ec6bb956154ecde4282871a6bf"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+    purl: "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib-common@1.3.11"
+    authors:
+    - "JetBrains"
+    declared_licenses:
+    - "The Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
+    description: "Kotlin Common Standard Library"
+    homepage_url: "https://kotlinlang.org/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11.jar"
+      hash:
+        value: "d8b8e746e279f1c4f5e08bc14a96b82e6bb1de02"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.11/kotlin-stdlib-common-1.3.11-sources.jar"
+      hash:
+        value: "e49742d3259938ea3539346c8ca3babb54a5140f"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/JetBrains/kotlin.git"
+      revision: ""
+      path: ""
+  curations: []
+dependency_graphs:
+  Gradle:
+    packages:
+    - "Gradle:org.gradle.kotlin.dsl.samples.multiproject:cli:1.0"
+    - "Gradle:org.gradle.kotlin.dsl.samples.multiproject:core:1.0"
+    - "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11"
+    - "Maven:org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
+    - "Maven:org.jetbrains:annotations:13.0"
+    scopes:
+      org.gradle.kotlin.dsl.samples.multiproject:multi-kotlin-project:1.0:archives:
+      - root: 0
+      - root: 1
+    nodes:
+    - linkage: "PROJECT_DYNAMIC"
+    - pkg: 1
+      linkage: "PROJECT_DYNAMIC"
+    - pkg: 3
+    - pkg: 2
+    - pkg: 4
+    edges:
+    - from: 2
+      to: 3
+    - from: 2
+      to: 4
+    - from: 1
+      to: 2
+    - from: 0
+      to: 1
+    - from: 0
+      to: 2
+has_issues: false

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -66,7 +66,7 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
       homepage_url: ""
-      scopes: []
+      scope_names: []
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:app:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
       declared_licenses: []
@@ -82,88 +82,16 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
       homepage_url: ""
-      scopes:
-      - name: "compile"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "compileClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "default"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtime"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtimeClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompile"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompileClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testRuntime"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testRuntimeClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      scope_names:
+      - "compile"
+      - "compileClasspath"
+      - "default"
+      - "runtime"
+      - "runtimeClasspath"
+      - "testCompile"
+      - "testCompileClasspath"
+      - "testRuntime"
+      - "testRuntimeClasspath"
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
       declared_licenses: []
@@ -179,73 +107,16 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
       homepage_url: ""
-      scopes:
-      - name: "compile"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "compileClasspath"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "default"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtime"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtimeClasspath"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompile"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompileClasspath"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testRuntime"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testRuntimeClasspath"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      scope_names:
+      - "compile"
+      - "compileClasspath"
+      - "default"
+      - "runtime"
+      - "runtimeClasspath"
+      - "testCompile"
+      - "testCompileClasspath"
+      - "testRuntime"
+      - "testRuntimeClasspath"
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo/build.gradle"
       declared_licenses: []
@@ -261,125 +132,16 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
       homepage_url: ""
-      scopes:
-      - name: "compile"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "compileClasspath"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "default"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "runtime"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "runtimeClasspath"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testCompile"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testCompileClasspath"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testRuntime"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testRuntimeClasspath"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
+      scope_names:
+      - "compile"
+      - "compileClasspath"
+      - "default"
+      - "runtime"
+      - "runtimeClasspath"
+      - "testCompile"
+      - "testCompileClasspath"
+      - "testRuntime"
+      - "testRuntimeClasspath"
     packages:
     - package:
         id: "Maven:junit:junit:4.12"
@@ -629,6 +391,120 @@ analyzer:
         curation:
           comment: "Fix description."
           description: "Curated description."
+    dependency_graphs:
+      Gradle:
+        packages:
+        - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+        - "Maven:junit:junit:4.12"
+        - "Maven:org.apache.commons:commons-lang3:3.5"
+        - "Maven:org.apache.commons:commons-text:1.1"
+        - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+        - "Maven:org.hamcrest:hamcrest-core:1.3"
+        - "Unknown:junit:junit:4.12"
+        - "Unknown:org.apache.commons:commons-text:1.1"
+        scopes:
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:compile:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:compileClasspath:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:default:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:runtime:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:runtimeClasspath:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:testCompile:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:testCompileClasspath:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:testRuntime:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:testRuntimeClasspath:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:compile:
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:compileClasspath:
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:default:
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:runtime:
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:runtimeClasspath:
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:testCompile:
+          - root: 6
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:testCompileClasspath:
+          - root: 6
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:testRuntime:
+          - root: 6
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:testRuntimeClasspath:
+          - root: 6
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:compile:
+          - root: 3
+          - root: 4
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:compileClasspath:
+          - root: 3
+          - root: 4
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:default:
+          - root: 3
+          - root: 4
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:runtime:
+          - root: 3
+          - root: 4
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:runtimeClasspath:
+          - root: 3
+          - root: 4
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:testCompile:
+          - root: 1
+          - root: 3
+          - root: 4
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:testCompileClasspath:
+          - root: 1
+          - root: 3
+          - root: 4
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:testRuntime:
+          - root: 1
+          - root: 3
+          - root: 4
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:testRuntimeClasspath:
+          - root: 1
+          - root: 3
+          - root: 4
+        nodes:
+        - pkg: 7
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
+        - pkg: 6
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency junit:junit:4.12 because no repositories are defined."
+            severity: "ERROR"
+        - linkage: "PROJECT_DYNAMIC"
+        - pkg: 3
+        - pkg: 2
+        - pkg: 4
+        - pkg: 1
+        - pkg: 5
+        edges:
+        - from: 3
+          to: 4
+        - from: 2
+          to: 3
+        - from: 2
+          to: 5
+        - from: 6
+          to: 7
     has_issues: true
 scanner: null
 advisor: null

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -66,7 +66,7 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
       homepage_url: ""
-      scopes: []
+      scope_names: []
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:app:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
       declared_licenses: []
@@ -82,88 +82,16 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
       homepage_url: ""
-      scopes:
-      - name: "compile"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "compileClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "default"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtime"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtimeClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompile"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompileClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testRuntime"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testRuntimeClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      scope_names:
+      - "compile"
+      - "compileClasspath"
+      - "default"
+      - "runtime"
+      - "runtimeClasspath"
+      - "testCompile"
+      - "testCompileClasspath"
+      - "testRuntime"
+      - "testRuntimeClasspath"
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
       declared_licenses: []
@@ -179,73 +107,16 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
       homepage_url: ""
-      scopes:
-      - name: "compile"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "compileClasspath"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "default"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtime"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtimeClasspath"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompile"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompileClasspath"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testRuntime"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testRuntimeClasspath"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+      scope_names:
+      - "compile"
+      - "compileClasspath"
+      - "default"
+      - "runtime"
+      - "runtimeClasspath"
+      - "testCompile"
+      - "testCompileClasspath"
+      - "testRuntime"
+      - "testRuntimeClasspath"
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0"
       definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo/build.gradle"
       declared_licenses: []
@@ -261,125 +132,16 @@ analyzer:
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
       homepage_url: ""
-      scopes:
-      - name: "compile"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "compileClasspath"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "default"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "runtime"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "runtimeClasspath"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testCompile"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testCompileClasspath"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testRuntime"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testRuntimeClasspath"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
+      scope_names:
+      - "compile"
+      - "compileClasspath"
+      - "default"
+      - "runtime"
+      - "runtimeClasspath"
+      - "testCompile"
+      - "testCompileClasspath"
+      - "testRuntime"
+      - "testRuntimeClasspath"
     packages:
     - package:
         id: "Maven:junit:junit:4.12"
@@ -619,6 +381,120 @@ analyzer:
           revision: ""
           path: ""
       curations: []
+    dependency_graphs:
+      Gradle:
+        packages:
+        - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+        - "Maven:junit:junit:4.12"
+        - "Maven:org.apache.commons:commons-lang3:3.5"
+        - "Maven:org.apache.commons:commons-text:1.1"
+        - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+        - "Maven:org.hamcrest:hamcrest-core:1.3"
+        - "Unknown:junit:junit:4.12"
+        - "Unknown:org.apache.commons:commons-text:1.1"
+        scopes:
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:compile:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:compileClasspath:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:default:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:runtime:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:runtimeClasspath:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:testCompile:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:testCompileClasspath:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:testRuntime:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:app:1.0.0:testRuntimeClasspath:
+          - root: 0
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:compile:
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:compileClasspath:
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:default:
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:runtime:
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:runtimeClasspath:
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:testCompile:
+          - root: 6
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:testCompileClasspath:
+          - root: 6
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:testRuntime:
+          - root: 6
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:testRuntimeClasspath:
+          - root: 6
+          - root: 7
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:compile:
+          - root: 3
+          - root: 4
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:compileClasspath:
+          - root: 3
+          - root: 4
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:default:
+          - root: 3
+          - root: 4
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:runtime:
+          - root: 3
+          - root: 4
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:runtimeClasspath:
+          - root: 3
+          - root: 4
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:testCompile:
+          - root: 1
+          - root: 3
+          - root: 4
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:testCompileClasspath:
+          - root: 1
+          - root: 3
+          - root: 4
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:testRuntime:
+          - root: 1
+          - root: 3
+          - root: 4
+          org.ossreviewtoolkit.gradle.example:lib:1.0.0:testRuntimeClasspath:
+          - root: 1
+          - root: 3
+          - root: 4
+        nodes:
+        - linkage: "PROJECT_DYNAMIC"
+        - pkg: 3
+        - pkg: 2
+        - pkg: 4
+        - pkg: 1
+        - pkg: 5
+        - pkg: 7
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+              \ are defined."
+            severity: "ERROR"
+        - pkg: 6
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Gradle"
+            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+              \ dependency junit:junit:4.12 because no repositories are defined."
+            severity: "ERROR"
+        edges:
+        - from: 1
+          to: 2
+        - from: 0
+          to: 1
+        - from: 0
+          to: 3
+        - from: 4
+          to: 5
     has_issues: true
 scanner: null
 advisor: null

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
@@ -1,6 +1,6 @@
 ---
-project:
-  id: "Gradle:org.ossreviewtoolkit.gradle.example:app:1.0.0"
+projects:
+- id: "Gradle:org.ossreviewtoolkit.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/app/build.gradle"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -15,679 +15,548 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/app"
   homepage_url: ""
-  scopes:
-  - name: "amazonDemoDebugAndroidTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoDebugAndroidTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoDebugCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoDebugRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoDebugUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonDemoDebugUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonDemoReleaseCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoReleaseRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonDemoReleaseUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonDemoReleaseUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonFullDebugAndroidTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullDebugAndroidTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullDebugCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullDebugRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullDebugUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonFullDebugUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonFullReleaseCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullReleaseRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-  - name: "amazonFullReleaseUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "amazonFullReleaseUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-      dependencies:
-      - id: "Maven:com.squareup.okio:okio:1.14.0"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleDemoDebugAndroidTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleDemoDebugAndroidTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleDemoDebugCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleDemoDebugRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleDemoDebugUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleDemoDebugUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleDemoReleaseCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleDemoReleaseRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleDemoReleaseUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleDemoReleaseUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.2"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleFullDebugAndroidTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleFullDebugAndroidTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleFullDebugCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleFullDebugRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleFullDebugUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleFullDebugUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleFullReleaseCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-  - name: "googleFullReleaseRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "googleFullReleaseUnitTestCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  - name: "googleFullReleaseUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-compress:1.17"
-      - id: "Maven:org.apache.commons:commons-text:1.3"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.7"
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  scope_names:
+  - "amazonDemoDebugAndroidTestCompileClasspath"
+  - "amazonDemoDebugAndroidTestRuntimeClasspath"
+  - "amazonDemoDebugCompileClasspath"
+  - "amazonDemoDebugRuntimeClasspath"
+  - "amazonDemoDebugUnitTestCompileClasspath"
+  - "amazonDemoDebugUnitTestRuntimeClasspath"
+  - "amazonDemoReleaseCompileClasspath"
+  - "amazonDemoReleaseRuntimeClasspath"
+  - "amazonDemoReleaseUnitTestCompileClasspath"
+  - "amazonDemoReleaseUnitTestRuntimeClasspath"
+  - "amazonFullDebugAndroidTestCompileClasspath"
+  - "amazonFullDebugAndroidTestRuntimeClasspath"
+  - "amazonFullDebugCompileClasspath"
+  - "amazonFullDebugRuntimeClasspath"
+  - "amazonFullDebugUnitTestCompileClasspath"
+  - "amazonFullDebugUnitTestRuntimeClasspath"
+  - "amazonFullReleaseCompileClasspath"
+  - "amazonFullReleaseRuntimeClasspath"
+  - "amazonFullReleaseUnitTestCompileClasspath"
+  - "amazonFullReleaseUnitTestRuntimeClasspath"
+  - "googleDemoDebugAndroidTestCompileClasspath"
+  - "googleDemoDebugAndroidTestRuntimeClasspath"
+  - "googleDemoDebugCompileClasspath"
+  - "googleDemoDebugRuntimeClasspath"
+  - "googleDemoDebugUnitTestCompileClasspath"
+  - "googleDemoDebugUnitTestRuntimeClasspath"
+  - "googleDemoReleaseCompileClasspath"
+  - "googleDemoReleaseRuntimeClasspath"
+  - "googleDemoReleaseUnitTestCompileClasspath"
+  - "googleDemoReleaseUnitTestRuntimeClasspath"
+  - "googleFullDebugAndroidTestCompileClasspath"
+  - "googleFullDebugAndroidTestRuntimeClasspath"
+  - "googleFullDebugCompileClasspath"
+  - "googleFullDebugRuntimeClasspath"
+  - "googleFullDebugUnitTestCompileClasspath"
+  - "googleFullDebugUnitTestRuntimeClasspath"
+  - "googleFullReleaseCompileClasspath"
+  - "googleFullReleaseRuntimeClasspath"
+  - "googleFullReleaseUnitTestCompileClasspath"
+  - "googleFullReleaseUnitTestRuntimeClasspath"
 packages:
-- id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
-  purl: "pkg:maven/com.squareup.okhttp3/okhttp@3.10.0"
-  declared_licenses:
-  - "Apache 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache 2.0: "Apache-2.0"
-  description: "An HTTP+HTTP/2 client for Android and Java applications"
-  homepage_url: "https://github.com/square/okhttp/okhttp"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/com/squareup/okhttp3/okhttp/3.10.0/okhttp-3.10.0-sources.jar"
-    hash:
-      value: "0e99b7b608968f16b07104b93e62cb90701174d0"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/square/okhttp.git"
-    revision: "parent-3.10.0"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/square/okhttp.git"
-    revision: "parent-3.10.0"
-    path: ""
-- id: "Maven:com.squareup.okio:okio:1.14.0"
-  purl: "pkg:maven/com.squareup.okio/okio@1.14.0"
-  declared_licenses:
-  - "Apache 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache 2.0: "Apache-2.0"
-  description: "A modern I/O API for Java"
-  homepage_url: "https://github.com/square/okio/okio"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/com/squareup/okio/okio/1.14.0/okio-1.14.0-sources.jar"
-    hash:
-      value: "e7c96b4fe5651490d8f3c022042940d743a3bdd9"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/square/okio.git"
-    revision: "okio-parent-1.14.0"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/square/okio.git"
-    revision: "okio-parent-1.14.0"
-    path: ""
-- id: "Maven:junit:junit:4.12"
-  purl: "pkg:maven/junit/junit@4.12"
-  authors:
-  - "David Saff"
-  - "JUnit"
-  - "Kevin Cooney"
-  - "Marc Philipp"
-  - "Stefan Birkner"
-  declared_licenses:
-  - "Eclipse Public License 1.0"
-  declared_licenses_processed:
-    spdx_expression: "EPL-1.0"
-    mapped:
-      Eclipse Public License 1.0: "EPL-1.0"
-  description: "JUnit is a unit testing framework for Java, created by Erich Gamma\
-    \ and Kent Beck."
-  homepage_url: "http://junit.org"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-    hash:
-      value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/junit-team/junit.git"
-    revision: "r4.12"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/junit-team/junit.git"
-    revision: "r4.12"
-    path: ""
-- id: "Maven:org.apache.commons:commons-compress:1.17"
-  purl: "pkg:maven/org.apache.commons/commons-compress@1.17"
-  authors:
-  - "Christian Grobmeier"
-  - "Damjan Jovanovic"
-  - "Emmanuel Bourg"
-  - "Gary Gregory"
-  - "Julius Davies"
-  - "Rob Tompkins"
-  - "Sebastian Bazley"
-  - "Stefan Bodewig"
-  - "The Apache Software Foundation"
-  - "Torsten Curdt"
-  declared_licenses:
-  - "Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache License, Version 2.0: "Apache-2.0"
-  description: "Apache Commons Compress software defines an API for working with\n\
-    compression and archive formats.  These include: bzip2, gzip, pack200,\nlzma,\
-    \ xz, Snappy, traditional Unix Compress, DEFLATE, DEFLATE64, LZ4,\nBrotli, Zstandard\
-    \ and ar, cpio, jar, tar, zip, dump, 7z, arj."
-  homepage_url: "https://commons.apache.org/proper/commons-compress/"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.17/commons-compress-1.17-sources.jar"
-    hash:
-      value: "9d064d7d42ee1d04ae07ad23025b4f9616652eed"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://git-wip-us.apache.org/repos/asf/commons-compress.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://git-wip-us.apache.org/repos/asf/commons-compress.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.apache.commons:commons-lang3:3.7"
-  purl: "pkg:maven/org.apache.commons/commons-lang3@3.7"
-  authors:
-  - "Benedikt Ritter"
-  - "Carman Consulting, Inc."
-  - "CollabNet, Inc."
-  - "Duncan Jones"
-  - "Fredrik Westermarck"
-  - "Gary D. Gregory"
-  - "Henri Yandell"
-  - "Joerg Schaible"
-  - "Loic Guibert"
-  - "Matt Benson"
-  - "Niall Pemberton"
-  - "Oliver Heger"
-  - "Paul Benedict"
-  - "Rob Tompkins"
-  - "Robert Burrell Donkin"
-  - "SITA ATS Ltd"
-  - "Steven Caswell"
-  - "The Apache Software Foundation"
-  declared_licenses:
-  - "Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache License, Version 2.0: "Apache-2.0"
-  description: "Apache Commons Lang, a package of Java utility classes for the\n \
-    \ classes that are in java.lang's hierarchy, or are considered to be so\n  standard\
-    \ as to justify existence in java.lang."
-  homepage_url: "http://commons.apache.org/proper/commons-lang/"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.7/commons-lang3-3.7-sources.jar"
-    hash:
-      value: "e7e36219edde1c66c93495a75490d8f526c377cb"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
-    revision: "LANG_3_6"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
-    revision: "LANG_3_6"
-    path: ""
-- id: "Maven:org.apache.commons:commons-text:1.2"
-  purl: "pkg:maven/org.apache.commons/commons-text@1.2"
-  authors:
-  - "Benedikt Ritter"
-  - "Bruno P. Kinoshita"
-  - "Duncan Jones"
-  - "Gary Gregory"
-  - "Rob Tompkins"
-  - "The Apache Software Foundation"
-  declared_licenses:
-  - "Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache License, Version 2.0: "Apache-2.0"
-  description: "Apache Commons Text is a library focused on algorithms working on\
-    \ strings."
-  homepage_url: "http://commons.apache.org/proper/commons-text/"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.2/commons-text-1.2-sources.jar"
-    hash:
-      value: "679282ee0f6f2b236f58a7a1dc8395861ad9fd97"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.apache.commons:commons-text:1.3"
-  purl: "pkg:maven/org.apache.commons/commons-text@1.3"
-  authors:
-  - "Benedikt Ritter"
-  - "Bruno P. Kinoshita"
-  - "Duncan Jones"
-  - "Gary Gregory"
-  - "Rob Tompkins"
-  - "The Apache Software Foundation"
-  declared_licenses:
-  - "Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache License, Version 2.0: "Apache-2.0"
-  description: "Apache Commons Text is a library focused on algorithms working on\
-    \ strings."
-  homepage_url: "http://commons.apache.org/proper/commons-text/"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.3/commons-text-1.3-sources.jar"
-    hash:
-      value: "9c51853f855aca4ea31785f30385e980a58eaf4b"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
-  authors:
-  - "Joe Walnes"
-  - "Nat Pryce"
-  - "Neil Dunn"
-  - "Steve Freeman"
-  - "Tom Denley"
-  declared_licenses:
-  - "New BSD License"
-  declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      New BSD License: "BSD-3-Clause"
-  description: "This is the core API of hamcrest matcher framework to be used by third-party\
-    \ framework providers. This includes the a foundation set of matcher implementations\
-    \ for common operations."
-  homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-    hash:
-      value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git@github.com:hamcrest/JavaHamcrest.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
-    revision: ""
-    path: ""
+- package:
+    id: "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+    purl: "pkg:maven/com.squareup.okhttp3/okhttp@3.10.0"
+    declared_licenses:
+    - "Apache 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache 2.0: "Apache-2.0"
+    description: "An HTTP+HTTP/2 client for Android and Java applications"
+    homepage_url: "https://github.com/square/okhttp/okhttp"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/com/squareup/okhttp3/okhttp/3.10.0/okhttp-3.10.0-sources.jar"
+      hash:
+        value: "0e99b7b608968f16b07104b93e62cb90701174d0"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/square/okhttp.git"
+      revision: "parent-3.10.0"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/square/okhttp.git"
+      revision: "parent-3.10.0"
+      path: ""
+  curations: []
+- package:
+    id: "Maven:com.squareup.okio:okio:1.14.0"
+    purl: "pkg:maven/com.squareup.okio/okio@1.14.0"
+    declared_licenses:
+    - "Apache 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache 2.0: "Apache-2.0"
+    description: "A modern I/O API for Java"
+    homepage_url: "https://github.com/square/okio/okio"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/com/squareup/okio/okio/1.14.0/okio-1.14.0-sources.jar"
+      hash:
+        value: "e7c96b4fe5651490d8f3c022042940d743a3bdd9"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/square/okio.git"
+      revision: "okio-parent-1.14.0"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/square/okio.git"
+      revision: "okio-parent-1.14.0"
+      path: ""
+  curations: []
+- package:
+    id: "Maven:junit:junit:4.12"
+    purl: "pkg:maven/junit/junit@4.12"
+    authors:
+    - "David Saff"
+    - "JUnit"
+    - "Kevin Cooney"
+    - "Marc Philipp"
+    - "Stefan Birkner"
+    declared_licenses:
+    - "Eclipse Public License 1.0"
+    declared_licenses_processed:
+      spdx_expression: "EPL-1.0"
+      mapped:
+        Eclipse Public License 1.0: "EPL-1.0"
+    description: "JUnit is a unit testing framework for Java, created by Erich Gamma\
+      \ and Kent Beck."
+    homepage_url: "http://junit.org"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+      hash:
+        value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git://github.com/junit-team/junit.git"
+      revision: "r4.12"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/junit-team/junit.git"
+      revision: "r4.12"
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.commons:commons-compress:1.17"
+    purl: "pkg:maven/org.apache.commons/commons-compress@1.17"
+    authors:
+    - "Christian Grobmeier"
+    - "Damjan Jovanovic"
+    - "Emmanuel Bourg"
+    - "Gary Gregory"
+    - "Julius Davies"
+    - "Rob Tompkins"
+    - "Sebastian Bazley"
+    - "Stefan Bodewig"
+    - "The Apache Software Foundation"
+    - "Torsten Curdt"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
+    description: "Apache Commons Compress software defines an API for working with\n\
+      compression and archive formats.  These include: bzip2, gzip, pack200,\nlzma,\
+      \ xz, Snappy, traditional Unix Compress, DEFLATE, DEFLATE64, LZ4,\nBrotli, Zstandard\
+      \ and ar, cpio, jar, tar, zip, dump, 7z, arj."
+    homepage_url: "https://commons.apache.org/proper/commons-compress/"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.17/commons-compress-1.17-sources.jar"
+      hash:
+        value: "9d064d7d42ee1d04ae07ad23025b4f9616652eed"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://git-wip-us.apache.org/repos/asf/commons-compress.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://git-wip-us.apache.org/repos/asf/commons-compress.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.commons:commons-lang3:3.7"
+    purl: "pkg:maven/org.apache.commons/commons-lang3@3.7"
+    authors:
+    - "Benedikt Ritter"
+    - "Carman Consulting, Inc."
+    - "CollabNet, Inc."
+    - "Duncan Jones"
+    - "Fredrik Westermarck"
+    - "Gary D. Gregory"
+    - "Henri Yandell"
+    - "Joerg Schaible"
+    - "Loic Guibert"
+    - "Matt Benson"
+    - "Niall Pemberton"
+    - "Oliver Heger"
+    - "Paul Benedict"
+    - "Rob Tompkins"
+    - "Robert Burrell Donkin"
+    - "SITA ATS Ltd"
+    - "Steven Caswell"
+    - "The Apache Software Foundation"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
+    description: "Apache Commons Lang, a package of Java utility classes for the\n\
+      \  classes that are in java.lang's hierarchy, or are considered to be so\n \
+      \ standard as to justify existence in java.lang."
+    homepage_url: "http://commons.apache.org/proper/commons-lang/"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.7/commons-lang3-3.7-sources.jar"
+      hash:
+        value: "e7e36219edde1c66c93495a75490d8f526c377cb"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+      revision: "LANG_3_6"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+      revision: "LANG_3_6"
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.commons:commons-text:1.2"
+    purl: "pkg:maven/org.apache.commons/commons-text@1.2"
+    authors:
+    - "Benedikt Ritter"
+    - "Bruno P. Kinoshita"
+    - "Duncan Jones"
+    - "Gary Gregory"
+    - "Rob Tompkins"
+    - "The Apache Software Foundation"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
+    description: "Apache Commons Text is a library focused on algorithms working on\
+      \ strings."
+    homepage_url: "http://commons.apache.org/proper/commons-text/"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.2/commons-text-1.2-sources.jar"
+      hash:
+        value: "679282ee0f6f2b236f58a7a1dc8395861ad9fd97"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.commons:commons-text:1.3"
+    purl: "pkg:maven/org.apache.commons/commons-text@1.3"
+    authors:
+    - "Benedikt Ritter"
+    - "Bruno P. Kinoshita"
+    - "Duncan Jones"
+    - "Gary Gregory"
+    - "Rob Tompkins"
+    - "The Apache Software Foundation"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
+    description: "Apache Commons Text is a library focused on algorithms working on\
+      \ strings."
+    homepage_url: "http://commons.apache.org/proper/commons-text/"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.3/commons-text-1.3-sources.jar"
+      hash:
+        value: "9c51853f855aca4ea31785f30385e980a58eaf4b"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.hamcrest:hamcrest-core:1.3"
+    purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
+    authors:
+    - "Joe Walnes"
+    - "Nat Pryce"
+    - "Neil Dunn"
+    - "Steve Freeman"
+    - "Tom Denley"
+    declared_licenses:
+    - "New BSD License"
+    declared_licenses_processed:
+      spdx_expression: "BSD-3-Clause"
+      mapped:
+        New BSD License: "BSD-3-Clause"
+    description: "This is the core API of hamcrest matcher framework to be used by\
+      \ third-party framework providers. This includes the a foundation set of matcher\
+      \ implementations for common operations."
+    homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+      hash:
+        value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git@github.com:hamcrest/JavaHamcrest.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
+      revision: ""
+      path: ""
+  curations: []
+dependency_graphs:
+  Gradle:
+    packages:
+    - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+    - "Maven:com.squareup.okhttp3:okhttp:3.10.0"
+    - "Maven:com.squareup.okio:okio:1.14.0"
+    - "Maven:junit:junit:4.12"
+    - "Maven:org.apache.commons:commons-compress:1.17"
+    - "Maven:org.apache.commons:commons-lang3:3.7"
+    - "Maven:org.apache.commons:commons-text:1.2"
+    - "Maven:org.apache.commons:commons-text:1.3"
+    - "Maven:org.hamcrest:hamcrest-core:1.3"
+    scopes:
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonDemoDebugAndroidTestCompileClasspath:
+      - root: 0
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonDemoDebugAndroidTestRuntimeClasspath:
+      - root: 0
+        fragment: 1
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonDemoDebugCompileClasspath:
+      - root: 0
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonDemoDebugRuntimeClasspath:
+      - root: 0
+        fragment: 1
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonDemoDebugUnitTestCompileClasspath:
+      - root: 0
+      - root: 1
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonDemoDebugUnitTestRuntimeClasspath:
+      - root: 0
+        fragment: 1
+      - root: 1
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonDemoReleaseCompileClasspath:
+      - root: 0
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonDemoReleaseRuntimeClasspath:
+      - root: 0
+        fragment: 1
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonDemoReleaseUnitTestCompileClasspath:
+      - root: 0
+      - root: 1
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonDemoReleaseUnitTestRuntimeClasspath:
+      - root: 0
+        fragment: 1
+      - root: 1
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonFullDebugAndroidTestCompileClasspath:
+      - root: 0
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonFullDebugAndroidTestRuntimeClasspath:
+      - root: 0
+        fragment: 2
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonFullDebugCompileClasspath:
+      - root: 0
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonFullDebugRuntimeClasspath:
+      - root: 0
+        fragment: 2
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonFullDebugUnitTestCompileClasspath:
+      - root: 0
+      - root: 1
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonFullDebugUnitTestRuntimeClasspath:
+      - root: 0
+        fragment: 2
+      - root: 1
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonFullReleaseCompileClasspath:
+      - root: 0
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonFullReleaseRuntimeClasspath:
+      - root: 0
+        fragment: 2
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonFullReleaseUnitTestCompileClasspath:
+      - root: 0
+      - root: 1
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:amazonFullReleaseUnitTestRuntimeClasspath:
+      - root: 0
+        fragment: 2
+      - root: 1
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleDemoDebugAndroidTestCompileClasspath:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleDemoDebugAndroidTestRuntimeClasspath:
+      - root: 0
+        fragment: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleDemoDebugCompileClasspath:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleDemoDebugRuntimeClasspath:
+      - root: 0
+        fragment: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleDemoDebugUnitTestCompileClasspath:
+      - root: 0
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleDemoDebugUnitTestRuntimeClasspath:
+      - root: 0
+        fragment: 1
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleDemoReleaseCompileClasspath:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleDemoReleaseRuntimeClasspath:
+      - root: 0
+        fragment: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleDemoReleaseUnitTestCompileClasspath:
+      - root: 0
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleDemoReleaseUnitTestRuntimeClasspath:
+      - root: 0
+        fragment: 1
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleFullDebugAndroidTestCompileClasspath:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleFullDebugAndroidTestRuntimeClasspath:
+      - root: 0
+        fragment: 2
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleFullDebugCompileClasspath:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleFullDebugRuntimeClasspath:
+      - root: 0
+        fragment: 2
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleFullDebugUnitTestCompileClasspath:
+      - root: 0
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleFullDebugUnitTestRuntimeClasspath:
+      - root: 0
+        fragment: 2
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleFullReleaseCompileClasspath:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleFullReleaseRuntimeClasspath:
+      - root: 0
+        fragment: 2
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleFullReleaseUnitTestCompileClasspath:
+      - root: 0
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:googleFullReleaseUnitTestRuntimeClasspath:
+      - root: 0
+        fragment: 2
+      - root: 3
+    nodes:
+    - linkage: "PROJECT_DYNAMIC"
+    - fragment: 1
+      linkage: "PROJECT_DYNAMIC"
+    - pkg: 4
+    - pkg: 6
+    - pkg: 5
+    - fragment: 2
+      linkage: "PROJECT_DYNAMIC"
+    - pkg: 7
+    - pkg: 1
+    - pkg: 2
+    - pkg: 3
+    - pkg: 8
+    edges:
+    - from: 3
+      to: 4
+    - from: 1
+      to: 2
+    - from: 1
+      to: 3
+    - from: 6
+      to: 4
+    - from: 5
+      to: 2
+    - from: 5
+      to: 6
+    - from: 7
+      to: 8
+    - from: 9
+      to: 10
+has_issues: false

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
@@ -1,6 +1,6 @@
 ---
-project:
-  id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+projects:
+- id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/lib/build.gradle"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -15,296 +15,283 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/lib"
   homepage_url: ""
-  scopes:
-  - name: "demoDebugAndroidTestCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoDebugAndroidTestRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoDebugCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoDebugRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoDebugUnitTestCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoDebugUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoReleaseCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoReleaseRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoReleaseUnitTestCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "demoReleaseUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.2"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullDebugAndroidTestCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullDebugAndroidTestRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullDebugCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullDebugRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullDebugUnitTestCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullDebugUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullReleaseCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullReleaseRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullReleaseUnitTestCompileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
-  - name: "fullReleaseUnitTestRuntimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-compress:1.17"
-    - id: "Maven:org.apache.commons:commons-text:1.3"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.7"
+  scope_names:
+  - "demoDebugAndroidTestCompileClasspath"
+  - "demoDebugAndroidTestRuntimeClasspath"
+  - "demoDebugCompileClasspath"
+  - "demoDebugRuntimeClasspath"
+  - "demoDebugUnitTestCompileClasspath"
+  - "demoDebugUnitTestRuntimeClasspath"
+  - "demoReleaseCompileClasspath"
+  - "demoReleaseRuntimeClasspath"
+  - "demoReleaseUnitTestCompileClasspath"
+  - "demoReleaseUnitTestRuntimeClasspath"
+  - "fullDebugAndroidTestCompileClasspath"
+  - "fullDebugAndroidTestRuntimeClasspath"
+  - "fullDebugCompileClasspath"
+  - "fullDebugRuntimeClasspath"
+  - "fullDebugUnitTestCompileClasspath"
+  - "fullDebugUnitTestRuntimeClasspath"
+  - "fullReleaseCompileClasspath"
+  - "fullReleaseRuntimeClasspath"
+  - "fullReleaseUnitTestCompileClasspath"
+  - "fullReleaseUnitTestRuntimeClasspath"
 packages:
-- id: "Maven:org.apache.commons:commons-compress:1.17"
-  purl: "pkg:maven/org.apache.commons/commons-compress@1.17"
-  authors:
-  - "Christian Grobmeier"
-  - "Damjan Jovanovic"
-  - "Emmanuel Bourg"
-  - "Gary Gregory"
-  - "Julius Davies"
-  - "Rob Tompkins"
-  - "Sebastian Bazley"
-  - "Stefan Bodewig"
-  - "The Apache Software Foundation"
-  - "Torsten Curdt"
-  declared_licenses:
-  - "Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache License, Version 2.0: "Apache-2.0"
-  description: "Apache Commons Compress software defines an API for working with\n\
-    compression and archive formats.  These include: bzip2, gzip, pack200,\nlzma,\
-    \ xz, Snappy, traditional Unix Compress, DEFLATE, DEFLATE64, LZ4,\nBrotli, Zstandard\
-    \ and ar, cpio, jar, tar, zip, dump, 7z, arj."
-  homepage_url: "https://commons.apache.org/proper/commons-compress/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.17/commons-compress-1.17.jar"
-    hash:
-      value: "474c20609032e7f815ef534cd8174d2e400d9a8d"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.17/commons-compress-1.17-sources.jar"
-    hash:
-      value: "9d064d7d42ee1d04ae07ad23025b4f9616652eed"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://git-wip-us.apache.org/repos/asf/commons-compress.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://git-wip-us.apache.org/repos/asf/commons-compress.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.apache.commons:commons-lang3:3.7"
-  purl: "pkg:maven/org.apache.commons/commons-lang3@3.7"
-  authors:
-  - "Benedikt Ritter"
-  - "Carman Consulting, Inc."
-  - "CollabNet, Inc."
-  - "Duncan Jones"
-  - "Fredrik Westermarck"
-  - "Gary D. Gregory"
-  - "Henri Yandell"
-  - "Joerg Schaible"
-  - "Loic Guibert"
-  - "Matt Benson"
-  - "Niall Pemberton"
-  - "Oliver Heger"
-  - "Paul Benedict"
-  - "Rob Tompkins"
-  - "Robert Burrell Donkin"
-  - "SITA ATS Ltd"
-  - "Steven Caswell"
-  - "The Apache Software Foundation"
-  declared_licenses:
-  - "Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache License, Version 2.0: "Apache-2.0"
-  description: "Apache Commons Lang, a package of Java utility classes for the\n \
-    \ classes that are in java.lang's hierarchy, or are considered to be so\n  standard\
-    \ as to justify existence in java.lang."
-  homepage_url: "http://commons.apache.org/proper/commons-lang/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.7/commons-lang3-3.7.jar"
-    hash:
-      value: "557edd918fd41f9260963583ebf5a61a43a6b423"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.7/commons-lang3-3.7-sources.jar"
-    hash:
-      value: "e7e36219edde1c66c93495a75490d8f526c377cb"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
-    revision: "LANG_3_6"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
-    revision: "LANG_3_6"
-    path: ""
-- id: "Maven:org.apache.commons:commons-text:1.2"
-  purl: "pkg:maven/org.apache.commons/commons-text@1.2"
-  authors:
-  - "Benedikt Ritter"
-  - "Bruno P. Kinoshita"
-  - "Duncan Jones"
-  - "Gary Gregory"
-  - "Rob Tompkins"
-  - "The Apache Software Foundation"
-  declared_licenses:
-  - "Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache License, Version 2.0: "Apache-2.0"
-  description: "Apache Commons Text is a library focused on algorithms working on\
-    \ strings."
-  homepage_url: "http://commons.apache.org/proper/commons-text/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.2/commons-text-1.2.jar"
-    hash:
-      value: "74acdec7237f576c4803fff0c1008ab8a3808b2b"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.2/commons-text-1.2-sources.jar"
-    hash:
-      value: "679282ee0f6f2b236f58a7a1dc8395861ad9fd97"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.apache.commons:commons-text:1.3"
-  purl: "pkg:maven/org.apache.commons/commons-text@1.3"
-  authors:
-  - "Benedikt Ritter"
-  - "Bruno P. Kinoshita"
-  - "Duncan Jones"
-  - "Gary Gregory"
-  - "Rob Tompkins"
-  - "The Apache Software Foundation"
-  declared_licenses:
-  - "Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache License, Version 2.0: "Apache-2.0"
-  description: "Apache Commons Text is a library focused on algorithms working on\
-    \ strings."
-  homepage_url: "http://commons.apache.org/proper/commons-text/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.3/commons-text-1.3.jar"
-    hash:
-      value: "9abf61708a66ab5e55f6169a200dbfc584b546d9"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.3/commons-text-1.3-sources.jar"
-    hash:
-      value: "9c51853f855aca4ea31785f30385e980a58eaf4b"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
-    revision: ""
-    path: ""
+- package:
+    id: "Maven:org.apache.commons:commons-compress:1.17"
+    purl: "pkg:maven/org.apache.commons/commons-compress@1.17"
+    authors:
+    - "Christian Grobmeier"
+    - "Damjan Jovanovic"
+    - "Emmanuel Bourg"
+    - "Gary Gregory"
+    - "Julius Davies"
+    - "Rob Tompkins"
+    - "Sebastian Bazley"
+    - "Stefan Bodewig"
+    - "The Apache Software Foundation"
+    - "Torsten Curdt"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
+    description: "Apache Commons Compress software defines an API for working with\n\
+      compression and archive formats.  These include: bzip2, gzip, pack200,\nlzma,\
+      \ xz, Snappy, traditional Unix Compress, DEFLATE, DEFLATE64, LZ4,\nBrotli, Zstandard\
+      \ and ar, cpio, jar, tar, zip, dump, 7z, arj."
+    homepage_url: "https://commons.apache.org/proper/commons-compress/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.17/commons-compress-1.17.jar"
+      hash:
+        value: "474c20609032e7f815ef534cd8174d2e400d9a8d"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.17/commons-compress-1.17-sources.jar"
+      hash:
+        value: "9d064d7d42ee1d04ae07ad23025b4f9616652eed"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://git-wip-us.apache.org/repos/asf/commons-compress.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://git-wip-us.apache.org/repos/asf/commons-compress.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.commons:commons-lang3:3.7"
+    purl: "pkg:maven/org.apache.commons/commons-lang3@3.7"
+    authors:
+    - "Benedikt Ritter"
+    - "Carman Consulting, Inc."
+    - "CollabNet, Inc."
+    - "Duncan Jones"
+    - "Fredrik Westermarck"
+    - "Gary D. Gregory"
+    - "Henri Yandell"
+    - "Joerg Schaible"
+    - "Loic Guibert"
+    - "Matt Benson"
+    - "Niall Pemberton"
+    - "Oliver Heger"
+    - "Paul Benedict"
+    - "Rob Tompkins"
+    - "Robert Burrell Donkin"
+    - "SITA ATS Ltd"
+    - "Steven Caswell"
+    - "The Apache Software Foundation"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
+    description: "Apache Commons Lang, a package of Java utility classes for the\n\
+      \  classes that are in java.lang's hierarchy, or are considered to be so\n \
+      \ standard as to justify existence in java.lang."
+    homepage_url: "http://commons.apache.org/proper/commons-lang/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.7/commons-lang3-3.7.jar"
+      hash:
+        value: "557edd918fd41f9260963583ebf5a61a43a6b423"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.7/commons-lang3-3.7-sources.jar"
+      hash:
+        value: "e7e36219edde1c66c93495a75490d8f526c377cb"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+      revision: "LANG_3_6"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+      revision: "LANG_3_6"
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.commons:commons-text:1.2"
+    purl: "pkg:maven/org.apache.commons/commons-text@1.2"
+    authors:
+    - "Benedikt Ritter"
+    - "Bruno P. Kinoshita"
+    - "Duncan Jones"
+    - "Gary Gregory"
+    - "Rob Tompkins"
+    - "The Apache Software Foundation"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
+    description: "Apache Commons Text is a library focused on algorithms working on\
+      \ strings."
+    homepage_url: "http://commons.apache.org/proper/commons-text/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.2/commons-text-1.2.jar"
+      hash:
+        value: "74acdec7237f576c4803fff0c1008ab8a3808b2b"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.2/commons-text-1.2-sources.jar"
+      hash:
+        value: "679282ee0f6f2b236f58a7a1dc8395861ad9fd97"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.commons:commons-text:1.3"
+    purl: "pkg:maven/org.apache.commons/commons-text@1.3"
+    authors:
+    - "Benedikt Ritter"
+    - "Bruno P. Kinoshita"
+    - "Duncan Jones"
+    - "Gary Gregory"
+    - "Rob Tompkins"
+    - "The Apache Software Foundation"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
+    description: "Apache Commons Text is a library focused on algorithms working on\
+      \ strings."
+    homepage_url: "http://commons.apache.org/proper/commons-text/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.3/commons-text-1.3.jar"
+      hash:
+        value: "9abf61708a66ab5e55f6169a200dbfc584b546d9"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.3/commons-text-1.3-sources.jar"
+      hash:
+        value: "9c51853f855aca4ea31785f30385e980a58eaf4b"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+  curations: []
+dependency_graphs:
+  Gradle:
+    packages:
+    - "Maven:org.apache.commons:commons-compress:1.17"
+    - "Maven:org.apache.commons:commons-lang3:3.7"
+    - "Maven:org.apache.commons:commons-text:1.2"
+    - "Maven:org.apache.commons:commons-text:1.3"
+    scopes:
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:demoDebugAndroidTestCompileClasspath:
+      - root: 0
+      - root: 2
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:demoDebugAndroidTestRuntimeClasspath:
+      - root: 0
+      - root: 2
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:demoDebugCompileClasspath:
+      - root: 0
+      - root: 2
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:demoDebugRuntimeClasspath:
+      - root: 0
+      - root: 2
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:demoDebugUnitTestCompileClasspath:
+      - root: 0
+      - root: 2
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:demoDebugUnitTestRuntimeClasspath:
+      - root: 0
+      - root: 2
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:demoReleaseCompileClasspath:
+      - root: 0
+      - root: 2
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:demoReleaseRuntimeClasspath:
+      - root: 0
+      - root: 2
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:demoReleaseUnitTestCompileClasspath:
+      - root: 0
+      - root: 2
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:demoReleaseUnitTestRuntimeClasspath:
+      - root: 0
+      - root: 2
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:fullDebugAndroidTestCompileClasspath:
+      - root: 0
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:fullDebugAndroidTestRuntimeClasspath:
+      - root: 0
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:fullDebugCompileClasspath:
+      - root: 0
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:fullDebugRuntimeClasspath:
+      - root: 0
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:fullDebugUnitTestCompileClasspath:
+      - root: 0
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:fullDebugUnitTestRuntimeClasspath:
+      - root: 0
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:fullReleaseCompileClasspath:
+      - root: 0
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:fullReleaseRuntimeClasspath:
+      - root: 0
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:fullReleaseUnitTestCompileClasspath:
+      - root: 0
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:fullReleaseUnitTestRuntimeClasspath:
+      - root: 0
+      - root: 3
+    nodes:
+    - {}
+    - pkg: 2
+    - pkg: 1
+    - pkg: 3
+    edges:
+    - from: 1
+      to: 2
+    - from: 3
+      to: 2
+has_issues: false

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
@@ -1,6 +1,6 @@
 ---
-project:
-  id: "Gradle:org.ossreviewtoolkit.gradle.example:Gradle-Android-Example:1.0.0"
+projects:
+- id: "Gradle:org.ossreviewtoolkit.gradle.example:Gradle-Android-Example:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android/build.gradle"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -15,5 +15,10 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-android"
   homepage_url: ""
-  scopes: []
+  scope_names: []
 packages: []
+dependency_graphs:
+  Gradle:
+    nodes: []
+    edges: []
+has_issues: false

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-bom-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-bom-expected-output.yml
@@ -1,6 +1,6 @@
 ---
-project:
-  id: "Gradle:org.ossreviewtoolkit.gradle.example:Gradle-BOM-Example:1.0.0"
+projects:
+- id: "Gradle:org.ossreviewtoolkit.gradle.example:Gradle-BOM-Example:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-bom/build.gradle"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -15,130 +15,147 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-bom"
   homepage_url: ""
-  scopes:
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Maven:com.fasterxml.jackson.core:jackson-core:2.12.2"
-  - name: "default"
-    dependencies:
-    - id: "Maven:com.fasterxml.jackson.core:jackson-core:2.12.2"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Maven:com.fasterxml.jackson.core:jackson-core:2.12.2"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Maven:com.fasterxml.jackson.core:jackson-core:2.12.2"
-    - id: "Maven:org.junit.platform:junit-platform-commons:1.7.2"
-      dependencies:
-      - id: "Maven:org.apiguardian:apiguardian-api:1.1.0"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Maven:com.fasterxml.jackson.core:jackson-core:2.12.2"
-    - id: "Maven:org.junit.platform:junit-platform-commons:1.7.2"
-      dependencies:
-      - id: "Maven:org.apiguardian:apiguardian-api:1.1.0"
+  scope_names:
+  - "compileClasspath"
+  - "default"
+  - "runtimeClasspath"
+  - "testCompileClasspath"
+  - "testRuntimeClasspath"
 packages:
-- id: "Maven:com.fasterxml.jackson.core:jackson-core:2.12.2"
-  purl: "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.12.2"
-  authors:
-  - "FasterXML"
-  - "Tatu Saloranta"
-  declared_licenses:
-  - "The Apache Software License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache Software License, Version 2.0: "Apache-2.0"
-  description: "Core Jackson processing abstractions (aka Streaming API), implementation\
-    \ for JSON"
-  homepage_url: "https://github.com/FasterXML/jackson-core"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.12.2/jackson-core-2.12.2.jar"
-    hash:
-      value: "8df50138521d05561a308ec2799cc8dda20c06df"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.12.2/jackson-core-2.12.2-sources.jar"
-    hash:
-      value: "882b7c5f3b71f22f181e0b4c88d5a1f818de04a6"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git@github.com:FasterXML/jackson-core.git"
-    revision: "jackson-core-2.12.2"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "ssh://git@github.com/FasterXML/jackson-core.git"
-    revision: "jackson-core-2.12.2"
-    path: ""
-- id: "Maven:org.apiguardian:apiguardian-api:1.1.0"
-  purl: "pkg:maven/org.apiguardian/apiguardian-api@1.1.0"
-  authors:
-  - "@API Guardian Team"
-  declared_licenses:
-  - "The Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache License, Version 2.0: "Apache-2.0"
-  description: "@API Guardian"
-  homepage_url: "https://github.com/apiguardian-team/apiguardian"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0.jar"
-    hash:
-      value: "fc9dff4bb36d627bdc553de77e1f17efd790876c"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0-sources.jar"
-    hash:
-      value: "f3c15fe970af864390c8d0634c9f16aca1b064a8"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/apiguardian-team/apiguardian.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/apiguardian-team/apiguardian.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.junit.platform:junit-platform-commons:1.7.2"
-  purl: "pkg:maven/org.junit.platform/junit-platform-commons@1.7.2"
-  authors:
-  - "Christian Stein"
-  - "Johannes Link"
-  - "Juliette de Rancourt"
-  - "Marc Philipp"
-  - "Matthias Merdes"
-  - "Sam Brannen"
-  - "Stefan Bechtold"
-  declared_licenses:
-  - "Eclipse Public License v2.0"
-  declared_licenses_processed:
-    spdx_expression: "EPL-2.0"
-    mapped:
-      Eclipse Public License v2.0: "EPL-2.0"
-  description: "Module \"junit-platform-commons\" of JUnit 5."
-  homepage_url: "https://junit.org/junit5/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.7.2/junit-platform-commons-1.7.2.jar"
-    hash:
-      value: "34adfea6c13fc4a996cf38cdad80800ce850d198"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.7.2/junit-platform-commons-1.7.2-sources.jar"
-    hash:
-      value: "1ff6be63f8bb2ef0d8c20b771a1d9160b6077a81"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/junit-team/junit5.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/junit-team/junit5.git"
-    revision: ""
-    path: ""
+- package:
+    id: "Maven:com.fasterxml.jackson.core:jackson-core:2.12.2"
+    purl: "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.12.2"
+    authors:
+    - "FasterXML"
+    - "Tatu Saloranta"
+    declared_licenses:
+    - "The Apache Software License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
+    description: "Core Jackson processing abstractions (aka Streaming API), implementation\
+      \ for JSON"
+    homepage_url: "https://github.com/FasterXML/jackson-core"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.12.2/jackson-core-2.12.2.jar"
+      hash:
+        value: "8df50138521d05561a308ec2799cc8dda20c06df"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.12.2/jackson-core-2.12.2-sources.jar"
+      hash:
+        value: "882b7c5f3b71f22f181e0b4c88d5a1f818de04a6"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git@github.com:FasterXML/jackson-core.git"
+      revision: "jackson-core-2.12.2"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "ssh://git@github.com/FasterXML/jackson-core.git"
+      revision: "jackson-core-2.12.2"
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apiguardian:apiguardian-api:1.1.0"
+    purl: "pkg:maven/org.apiguardian/apiguardian-api@1.1.0"
+    authors:
+    - "@API Guardian Team"
+    declared_licenses:
+    - "The Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache License, Version 2.0: "Apache-2.0"
+    description: "@API Guardian"
+    homepage_url: "https://github.com/apiguardian-team/apiguardian"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0.jar"
+      hash:
+        value: "fc9dff4bb36d627bdc553de77e1f17efd790876c"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0-sources.jar"
+      hash:
+        value: "f3c15fe970af864390c8d0634c9f16aca1b064a8"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git://github.com/apiguardian-team/apiguardian.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/apiguardian-team/apiguardian.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.junit.platform:junit-platform-commons:1.7.2"
+    purl: "pkg:maven/org.junit.platform/junit-platform-commons@1.7.2"
+    authors:
+    - "Christian Stein"
+    - "Johannes Link"
+    - "Juliette de Rancourt"
+    - "Marc Philipp"
+    - "Matthias Merdes"
+    - "Sam Brannen"
+    - "Stefan Bechtold"
+    declared_licenses:
+    - "Eclipse Public License v2.0"
+    declared_licenses_processed:
+      spdx_expression: "EPL-2.0"
+      mapped:
+        Eclipse Public License v2.0: "EPL-2.0"
+    description: "Module \"junit-platform-commons\" of JUnit 5."
+    homepage_url: "https://junit.org/junit5/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.7.2/junit-platform-commons-1.7.2.jar"
+      hash:
+        value: "34adfea6c13fc4a996cf38cdad80800ce850d198"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.7.2/junit-platform-commons-1.7.2-sources.jar"
+      hash:
+        value: "1ff6be63f8bb2ef0d8c20b771a1d9160b6077a81"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git://github.com/junit-team/junit5.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/junit-team/junit5.git"
+      revision: ""
+      path: ""
+  curations: []
+dependency_graphs:
+  Gradle:
+    packages:
+    - "Maven:com.fasterxml.jackson.core:jackson-core:2.12.2"
+    - "Maven:org.apiguardian:apiguardian-api:1.1.0"
+    - "Maven:org.junit.platform:junit-platform-commons:1.7.2"
+    scopes:
+      org.ossreviewtoolkit.gradle.example:Gradle-BOM-Example:1.0.0:compileClasspath:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:Gradle-BOM-Example:1.0.0:default:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:Gradle-BOM-Example:1.0.0:runtimeClasspath:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:Gradle-BOM-Example:1.0.0:testCompileClasspath:
+      - root: 0
+      - root: 2
+      org.ossreviewtoolkit.gradle.example:Gradle-BOM-Example:1.0.0:testRuntimeClasspath:
+      - root: 0
+      - root: 2
+    nodes:
+    - {}
+    - pkg: 2
+    - pkg: 1
+    edges:
+    - from: 1
+      to: 2
+has_issues: false

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -1,6 +1,6 @@
 ---
-project:
-  id: "Gradle:org.ossreviewtoolkit.gradle.example:app:1.0.0"
+projects:
+- id: "Gradle:org.ossreviewtoolkit.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app/build.gradle"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -15,239 +15,212 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
   homepage_url: ""
-  scopes:
-  - name: "compile"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "default"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompile"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testRuntime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  scope_names:
+  - "compile"
+  - "compileClasspath"
+  - "default"
+  - "runtime"
+  - "runtimeClasspath"
+  - "testCompile"
+  - "testCompileClasspath"
+  - "testRuntime"
+  - "testRuntimeClasspath"
 packages:
-- id: "Maven:org.apache.commons:commons-lang3:3.5"
-  purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
-  authors:
-  - "Benedikt Ritter"
-  - "Carman Consulting, Inc."
-  - "CollabNet, Inc."
-  - "Duncan Jones"
-  - "Fredrik Westermarck"
-  - "Gary D. Gregory"
-  - "Henri Yandell"
-  - "Joerg Schaible"
-  - "Loic Guibert"
-  - "Matt Benson"
-  - "Niall Pemberton"
-  - "Oliver Heger"
-  - "Paul Benedict"
-  - "Rob Tompkins"
-  - "Robert Burrell Donkin"
-  - "SITA ATS Ltd"
-  - "Steven Caswell"
-  - "The Apache Software Foundation"
-  declared_licenses:
-  - "Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache License, Version 2.0: "Apache-2.0"
-  description: "Apache Commons Lang, a package of Java utility classes for the\n \
-    \ classes that are in java.lang's hierarchy, or are considered to be so\n  standard\
-    \ as to justify existence in java.lang."
-  homepage_url: "http://commons.apache.org/proper/commons-lang/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
-    hash:
-      value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-    hash:
-      value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
-    revision: "LANG_3_5"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
-    revision: "LANG_3_5"
-    path: ""
-- id: "Maven:org.apache.commons:commons-text:1.1"
-  purl: "pkg:maven/org.apache.commons/commons-text@1.1"
-  authors:
-  - "Benedikt Ritter"
-  - "Bruno P. Kinoshita"
-  - "Gary Gregory"
-  - "Rob Tompkins"
-  - "The Apache Software Foundation"
-  declared_licenses:
-  - "Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache License, Version 2.0: "Apache-2.0"
-  description: "Apache Commons Text is a library focused on algorithms working on\
-    \ strings."
-  homepage_url: "http://commons.apache.org/proper/commons-text/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
-    hash:
-      value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-    hash:
-      value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
-  authors:
-  - "Aleksandr Mashchenko"
-  - "Alexandru Popescu"
-  - "Apache Software Foundation"
-  - "Bob Lee"
-  - "Bruce A. Phillips"
-  - "Cedric Dumoulin"
-  - "Christian Grobmeier"
-  - "Christoph Nenning"
-  - "Dave Newton"
-  - "David H. DeWolf"
-  - "Don Brown"
-  - "Greg Huber"
-  - "James Holmes"
-  - "James Mitchell"
-  - "Jeromy Evans"
-  - "Johannes Geppert"
-  - "John Lindal"
-  - "Laurie Harper"
-  - "Lukasz Lenart"
-  - "Martin Cooper"
-  - "Mathias Bogaert"
-  - "Matt Raible"
-  - "Maurizio Cucchiara"
-  - "Michael Jouravlev"
-  - "Niall Pemberton"
-  - "Nils-Helge Garli Hegvik"
-  - "Paul Benedict"
-  - "Rainer Hermanns"
-  - "Rene Gielen"
-  - "Ted Husted"
-  - "Toby Jee"
-  - "Wendy Smoak"
-  - "Wes Wannemacher"
-  declared_licenses:
-  - "The Apache Software License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache Software License, Version 2.0: "Apache-2.0"
-  description: "Apache Struts 2"
-  homepage_url: "http://struts.apache.org/struts2-assembly/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
-    hash:
-      value: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  vcs:
-    type: "Git"
-    url: "https://gitbox.apache.org/repos/asf/struts.git"
-    revision: "STRUTS_2_5_14_1"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://gitbox.apache.org/repos/asf/struts.git"
-    revision: "STRUTS_2_5_14_1"
-    path: ""
-  is_meta_data_only: true
+- package:
+    id: "Maven:org.apache.commons:commons-lang3:3.5"
+    purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
+    authors:
+    - "Benedikt Ritter"
+    - "Carman Consulting, Inc."
+    - "CollabNet, Inc."
+    - "Duncan Jones"
+    - "Fredrik Westermarck"
+    - "Gary D. Gregory"
+    - "Henri Yandell"
+    - "Joerg Schaible"
+    - "Loic Guibert"
+    - "Matt Benson"
+    - "Niall Pemberton"
+    - "Oliver Heger"
+    - "Paul Benedict"
+    - "Rob Tompkins"
+    - "Robert Burrell Donkin"
+    - "SITA ATS Ltd"
+    - "Steven Caswell"
+    - "The Apache Software Foundation"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
+    description: "Apache Commons Lang, a package of Java utility classes for the\n\
+      \  classes that are in java.lang's hierarchy, or are considered to be so\n \
+      \ standard as to justify existence in java.lang."
+    homepage_url: "http://commons.apache.org/proper/commons-lang/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
+      hash:
+        value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+      hash:
+        value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+      revision: "LANG_3_5"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+      revision: "LANG_3_5"
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.commons:commons-text:1.1"
+    purl: "pkg:maven/org.apache.commons/commons-text@1.1"
+    authors:
+    - "Benedikt Ritter"
+    - "Bruno P. Kinoshita"
+    - "Gary Gregory"
+    - "Rob Tompkins"
+    - "The Apache Software Foundation"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
+    description: "Apache Commons Text is a library focused on algorithms working on\
+      \ strings."
+    homepage_url: "http://commons.apache.org/proper/commons-text/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
+      hash:
+        value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+      hash:
+        value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
+    authors:
+    - "Aleksandr Mashchenko"
+    - "Alexandru Popescu"
+    - "Apache Software Foundation"
+    - "Bob Lee"
+    - "Bruce A. Phillips"
+    - "Cedric Dumoulin"
+    - "Christian Grobmeier"
+    - "Christoph Nenning"
+    - "Dave Newton"
+    - "David H. DeWolf"
+    - "Don Brown"
+    - "Greg Huber"
+    - "James Holmes"
+    - "James Mitchell"
+    - "Jeromy Evans"
+    - "Johannes Geppert"
+    - "John Lindal"
+    - "Laurie Harper"
+    - "Lukasz Lenart"
+    - "Martin Cooper"
+    - "Mathias Bogaert"
+    - "Matt Raible"
+    - "Maurizio Cucchiara"
+    - "Michael Jouravlev"
+    - "Niall Pemberton"
+    - "Nils-Helge Garli Hegvik"
+    - "Paul Benedict"
+    - "Rainer Hermanns"
+    - "Rene Gielen"
+    - "Ted Husted"
+    - "Toby Jee"
+    - "Wendy Smoak"
+    - "Wes Wannemacher"
+    declared_licenses:
+    - "The Apache Software License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
+    description: "Apache Struts 2"
+    homepage_url: "http://struts.apache.org/struts2-assembly/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
+      hash:
+        value: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    vcs:
+      type: "Git"
+      url: "https://gitbox.apache.org/repos/asf/struts.git"
+      revision: "STRUTS_2_5_14_1"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://gitbox.apache.org/repos/asf/struts.git"
+      revision: "STRUTS_2_5_14_1"
+      path: ""
+    is_meta_data_only: true
+  curations: []
+dependency_graphs:
+  Gradle:
+    packages:
+    - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+    - "Maven:org.apache.commons:commons-lang3:3.5"
+    - "Maven:org.apache.commons:commons-text:1.1"
+    - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    scopes:
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:compile:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:compileClasspath:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:default:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:runtime:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:runtimeClasspath:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:testCompile:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:testCompileClasspath:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:testRuntime:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:testRuntimeClasspath:
+      - root: 0
+    nodes:
+    - linkage: "PROJECT_DYNAMIC"
+    - pkg: 2
+    - pkg: 1
+    - pkg: 3
+    edges:
+    - from: 1
+      to: 2
+    - from: 0
+      to: 1
+    - from: 0
+      to: 3
+has_issues: false

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -1,6 +1,6 @@
 ---
-project:
-  id: "Gradle:org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0"
+projects:
+- id: "Gradle:org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo/build.gradle"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -15,123 +15,59 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
   homepage_url: ""
-  scopes:
-  - name: "compile"
-    dependencies:
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "default"
-    dependencies:
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "runtime"
-    dependencies:
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "testCompile"
-    dependencies:
-    - id: "Unknown:junit:junit:4.12"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency junit:junit:4.12 because no repositories are defined."
-        severity: "ERROR"
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Unknown:junit:junit:4.12"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency junit:junit:4.12 because no repositories are defined."
-        severity: "ERROR"
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "testRuntime"
-    dependencies:
-    - id: "Unknown:junit:junit:4.12"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency junit:junit:4.12 because no repositories are defined."
-        severity: "ERROR"
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Unknown:junit:junit:4.12"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency junit:junit:4.12 because no repositories are defined."
-        severity: "ERROR"
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
+  scope_names:
+  - "compile"
+  - "compileClasspath"
+  - "default"
+  - "runtime"
+  - "runtimeClasspath"
+  - "testCompile"
+  - "testCompileClasspath"
+  - "testRuntime"
+  - "testRuntimeClasspath"
 packages: []
+dependency_graphs:
+  Gradle:
+    packages:
+    - "Unknown:junit:junit:4.12"
+    - "Unknown:org.apache.commons:commons-text:1.1"
+    scopes:
+      org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:compile:
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:compileClasspath:
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:default:
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:runtime:
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:runtimeClasspath:
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:testCompile:
+      - root: 0
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:testCompileClasspath:
+      - root: 0
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:testRuntime:
+      - root: 0
+      - root: 1
+      org.ossreviewtoolkit.gradle.example:lib-without-repo:1.0.0:testRuntimeClasspath:
+      - root: 0
+      - root: 1
+    nodes:
+    - pkg: 1
+      issues:
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "Gradle"
+        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
+          \ are defined."
+        severity: "ERROR"
+    - issues:
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "Gradle"
+        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
+          \ dependency junit:junit:4.12 because no repositories are defined."
+        severity: "ERROR"
+    edges: []
+has_issues: true

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -1,6 +1,6 @@
 ---
-project:
-  id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+projects:
+- id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -15,299 +15,304 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
   homepage_url: ""
-  scopes:
-  - name: "compile"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "default"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtime"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompile"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testRuntime"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  scope_names:
+  - "compile"
+  - "compileClasspath"
+  - "default"
+  - "runtime"
+  - "runtimeClasspath"
+  - "testCompile"
+  - "testCompileClasspath"
+  - "testRuntime"
+  - "testRuntimeClasspath"
 packages:
-- id: "Maven:junit:junit:4.12"
-  purl: "pkg:maven/junit/junit@4.12"
-  authors:
-  - "David Saff"
-  - "JUnit"
-  - "Kevin Cooney"
-  - "Marc Philipp"
-  - "Stefan Birkner"
-  declared_licenses:
-  - "Eclipse Public License 1.0"
-  declared_licenses_processed:
-    spdx_expression: "EPL-1.0"
-    mapped:
-      Eclipse Public License 1.0: "EPL-1.0"
-  description: "JUnit is a unit testing framework for Java, created by Erich Gamma\
-    \ and Kent Beck."
-  homepage_url: "http://junit.org"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
-    hash:
-      value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-    hash:
-      value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/junit-team/junit.git"
-    revision: "r4.12"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/junit-team/junit.git"
-    revision: "r4.12"
-    path: ""
-- id: "Maven:org.apache.commons:commons-lang3:3.5"
-  purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
-  authors:
-  - "Benedikt Ritter"
-  - "Carman Consulting, Inc."
-  - "CollabNet, Inc."
-  - "Duncan Jones"
-  - "Fredrik Westermarck"
-  - "Gary D. Gregory"
-  - "Henri Yandell"
-  - "Joerg Schaible"
-  - "Loic Guibert"
-  - "Matt Benson"
-  - "Niall Pemberton"
-  - "Oliver Heger"
-  - "Paul Benedict"
-  - "Rob Tompkins"
-  - "Robert Burrell Donkin"
-  - "SITA ATS Ltd"
-  - "Steven Caswell"
-  - "The Apache Software Foundation"
-  declared_licenses:
-  - "Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache License, Version 2.0: "Apache-2.0"
-  description: "Apache Commons Lang, a package of Java utility classes for the\n \
-    \ classes that are in java.lang's hierarchy, or are considered to be so\n  standard\
-    \ as to justify existence in java.lang."
-  homepage_url: "http://commons.apache.org/proper/commons-lang/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
-    hash:
-      value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-    hash:
-      value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
-    revision: "LANG_3_5"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
-    revision: "LANG_3_5"
-    path: ""
-- id: "Maven:org.apache.commons:commons-text:1.1"
-  purl: "pkg:maven/org.apache.commons/commons-text@1.1"
-  authors:
-  - "Benedikt Ritter"
-  - "Bruno P. Kinoshita"
-  - "Gary Gregory"
-  - "Rob Tompkins"
-  - "The Apache Software Foundation"
-  declared_licenses:
-  - "Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache License, Version 2.0: "Apache-2.0"
-  description: "Apache Commons Text is a library focused on algorithms working on\
-    \ strings."
-  homepage_url: "http://commons.apache.org/proper/commons-text/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
-    hash:
-      value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-    hash:
-      value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
-  authors:
-  - "Aleksandr Mashchenko"
-  - "Alexandru Popescu"
-  - "Apache Software Foundation"
-  - "Bob Lee"
-  - "Bruce A. Phillips"
-  - "Cedric Dumoulin"
-  - "Christian Grobmeier"
-  - "Christoph Nenning"
-  - "Dave Newton"
-  - "David H. DeWolf"
-  - "Don Brown"
-  - "Greg Huber"
-  - "James Holmes"
-  - "James Mitchell"
-  - "Jeromy Evans"
-  - "Johannes Geppert"
-  - "John Lindal"
-  - "Laurie Harper"
-  - "Lukasz Lenart"
-  - "Martin Cooper"
-  - "Mathias Bogaert"
-  - "Matt Raible"
-  - "Maurizio Cucchiara"
-  - "Michael Jouravlev"
-  - "Niall Pemberton"
-  - "Nils-Helge Garli Hegvik"
-  - "Paul Benedict"
-  - "Rainer Hermanns"
-  - "Rene Gielen"
-  - "Ted Husted"
-  - "Toby Jee"
-  - "Wendy Smoak"
-  - "Wes Wannemacher"
-  declared_licenses:
-  - "The Apache Software License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache Software License, Version 2.0: "Apache-2.0"
-  description: "Apache Struts 2"
-  homepage_url: "http://struts.apache.org/struts2-assembly/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
-    hash:
-      value: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  vcs:
-    type: "Git"
-    url: "https://gitbox.apache.org/repos/asf/struts.git"
-    revision: "STRUTS_2_5_14_1"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://gitbox.apache.org/repos/asf/struts.git"
-    revision: "STRUTS_2_5_14_1"
-    path: ""
-  is_meta_data_only: true
-- id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
-  authors:
-  - "Joe Walnes"
-  - "Nat Pryce"
-  - "Neil Dunn"
-  - "Steve Freeman"
-  - "Tom Denley"
-  declared_licenses:
-  - "New BSD License"
-  declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      New BSD License: "BSD-3-Clause"
-  description: "This is the core API of hamcrest matcher framework to be used by third-party\
-    \ framework providers. This includes the a foundation set of matcher implementations\
-    \ for common operations."
-  homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
-    hash:
-      value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-    hash:
-      value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git@github.com:hamcrest/JavaHamcrest.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
-    revision: ""
-    path: ""
+- package:
+    id: "Maven:junit:junit:4.12"
+    purl: "pkg:maven/junit/junit@4.12"
+    authors:
+    - "David Saff"
+    - "JUnit"
+    - "Kevin Cooney"
+    - "Marc Philipp"
+    - "Stefan Birkner"
+    declared_licenses:
+    - "Eclipse Public License 1.0"
+    declared_licenses_processed:
+      spdx_expression: "EPL-1.0"
+      mapped:
+        Eclipse Public License 1.0: "EPL-1.0"
+    description: "JUnit is a unit testing framework for Java, created by Erich Gamma\
+      \ and Kent Beck."
+    homepage_url: "http://junit.org"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
+      hash:
+        value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+      hash:
+        value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git://github.com/junit-team/junit.git"
+      revision: "r4.12"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/junit-team/junit.git"
+      revision: "r4.12"
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.commons:commons-lang3:3.5"
+    purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
+    authors:
+    - "Benedikt Ritter"
+    - "Carman Consulting, Inc."
+    - "CollabNet, Inc."
+    - "Duncan Jones"
+    - "Fredrik Westermarck"
+    - "Gary D. Gregory"
+    - "Henri Yandell"
+    - "Joerg Schaible"
+    - "Loic Guibert"
+    - "Matt Benson"
+    - "Niall Pemberton"
+    - "Oliver Heger"
+    - "Paul Benedict"
+    - "Rob Tompkins"
+    - "Robert Burrell Donkin"
+    - "SITA ATS Ltd"
+    - "Steven Caswell"
+    - "The Apache Software Foundation"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
+    description: "Apache Commons Lang, a package of Java utility classes for the\n\
+      \  classes that are in java.lang's hierarchy, or are considered to be so\n \
+      \ standard as to justify existence in java.lang."
+    homepage_url: "http://commons.apache.org/proper/commons-lang/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
+      hash:
+        value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+      hash:
+        value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+      revision: "LANG_3_5"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+      revision: "LANG_3_5"
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.commons:commons-text:1.1"
+    purl: "pkg:maven/org.apache.commons/commons-text@1.1"
+    authors:
+    - "Benedikt Ritter"
+    - "Bruno P. Kinoshita"
+    - "Gary Gregory"
+    - "Rob Tompkins"
+    - "The Apache Software Foundation"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
+    description: "Apache Commons Text is a library focused on algorithms working on\
+      \ strings."
+    homepage_url: "http://commons.apache.org/proper/commons-text/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
+      hash:
+        value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+      hash:
+        value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
+    authors:
+    - "Aleksandr Mashchenko"
+    - "Alexandru Popescu"
+    - "Apache Software Foundation"
+    - "Bob Lee"
+    - "Bruce A. Phillips"
+    - "Cedric Dumoulin"
+    - "Christian Grobmeier"
+    - "Christoph Nenning"
+    - "Dave Newton"
+    - "David H. DeWolf"
+    - "Don Brown"
+    - "Greg Huber"
+    - "James Holmes"
+    - "James Mitchell"
+    - "Jeromy Evans"
+    - "Johannes Geppert"
+    - "John Lindal"
+    - "Laurie Harper"
+    - "Lukasz Lenart"
+    - "Martin Cooper"
+    - "Mathias Bogaert"
+    - "Matt Raible"
+    - "Maurizio Cucchiara"
+    - "Michael Jouravlev"
+    - "Niall Pemberton"
+    - "Nils-Helge Garli Hegvik"
+    - "Paul Benedict"
+    - "Rainer Hermanns"
+    - "Rene Gielen"
+    - "Ted Husted"
+    - "Toby Jee"
+    - "Wendy Smoak"
+    - "Wes Wannemacher"
+    declared_licenses:
+    - "The Apache Software License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
+    description: "Apache Struts 2"
+    homepage_url: "http://struts.apache.org/struts2-assembly/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
+      hash:
+        value: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    vcs:
+      type: "Git"
+      url: "https://gitbox.apache.org/repos/asf/struts.git"
+      revision: "STRUTS_2_5_14_1"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://gitbox.apache.org/repos/asf/struts.git"
+      revision: "STRUTS_2_5_14_1"
+      path: ""
+    is_meta_data_only: true
+  curations: []
+- package:
+    id: "Maven:org.hamcrest:hamcrest-core:1.3"
+    purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
+    authors:
+    - "Joe Walnes"
+    - "Nat Pryce"
+    - "Neil Dunn"
+    - "Steve Freeman"
+    - "Tom Denley"
+    declared_licenses:
+    - "New BSD License"
+    declared_licenses_processed:
+      spdx_expression: "BSD-3-Clause"
+      mapped:
+        New BSD License: "BSD-3-Clause"
+    description: "This is the core API of hamcrest matcher framework to be used by\
+      \ third-party framework providers. This includes the a foundation set of matcher\
+      \ implementations for common operations."
+    homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
+      hash:
+        value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+      hash:
+        value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git@github.com:hamcrest/JavaHamcrest.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
+      revision: ""
+      path: ""
+  curations: []
+dependency_graphs:
+  Gradle:
+    packages:
+    - "Maven:junit:junit:4.12"
+    - "Maven:org.apache.commons:commons-lang3:3.5"
+    - "Maven:org.apache.commons:commons-text:1.1"
+    - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    - "Maven:org.hamcrest:hamcrest-core:1.3"
+    scopes:
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:compile:
+      - root: 2
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:compileClasspath:
+      - root: 2
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:default:
+      - root: 2
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:runtime:
+      - root: 2
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:runtimeClasspath:
+      - root: 2
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:testCompile:
+      - root: 0
+      - root: 2
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:testCompileClasspath:
+      - root: 0
+      - root: 2
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:testRuntime:
+      - root: 0
+      - root: 2
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:testRuntimeClasspath:
+      - root: 0
+      - root: 2
+      - root: 3
+    nodes:
+    - pkg: 2
+    - pkg: 1
+    - pkg: 3
+    - {}
+    - pkg: 4
+    edges:
+    - from: 0
+      to: 1
+    - from: 3
+      to: 4
+has_issues: false

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
@@ -1,6 +1,6 @@
 ---
-project:
-  id: "Gradle::Gradle-Example:"
+projects:
+- id: "Gradle::Gradle-Example:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/build.gradle"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -15,5 +15,10 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle"
   homepage_url: ""
-  scopes: []
+  scope_names: []
 packages: []
+dependency_graphs:
+  Gradle:
+    nodes: []
+    edges: []
+has_issues: false

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
@@ -1,6 +1,6 @@
 ---
-project:
-  id: "Gradle:org.ossreviewtoolkit.gradle.example:app:1.0.0"
+projects:
+- id: "Gradle:org.ossreviewtoolkit.gradle.example:app:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/app/build.gradle"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -15,237 +15,218 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/app"
   homepage_url: ""
-  scopes:
-  - name: "compile"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-  - name: "default"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompile"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-  - name: "testRuntime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  scope_names:
+  - "compile"
+  - "compileClasspath"
+  - "default"
+  - "runtime"
+  - "runtimeClasspath"
+  - "testCompile"
+  - "testCompileClasspath"
+  - "testRuntime"
+  - "testRuntimeClasspath"
 packages:
-- id: "Maven:org.apache.commons:commons-lang3:3.5"
-  purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
-  authors:
-  - "Benedikt Ritter"
-  - "Carman Consulting, Inc."
-  - "CollabNet, Inc."
-  - "Duncan Jones"
-  - "Fredrik Westermarck"
-  - "Gary D. Gregory"
-  - "Henri Yandell"
-  - "Joerg Schaible"
-  - "Loic Guibert"
-  - "Matt Benson"
-  - "Niall Pemberton"
-  - "Oliver Heger"
-  - "Paul Benedict"
-  - "Rob Tompkins"
-  - "Robert Burrell Donkin"
-  - "SITA ATS Ltd"
-  - "Steven Caswell"
-  - "The Apache Software Foundation"
-  declared_licenses:
-  - "Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache License, Version 2.0: "Apache-2.0"
-  description: "Apache Commons Lang, a package of Java utility classes for the\n \
-    \ classes that are in java.lang's hierarchy, or are considered to be so\n  standard\
-    \ as to justify existence in java.lang."
-  homepage_url: "http://commons.apache.org/proper/commons-lang/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
-    hash:
-      value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-    hash:
-      value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
-    revision: "LANG_3_5"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
-    revision: "LANG_3_5"
-    path: ""
-- id: "Maven:org.apache.commons:commons-text:1.1"
-  purl: "pkg:maven/org.apache.commons/commons-text@1.1"
-  authors:
-  - "Benedikt Ritter"
-  - "Bruno P. Kinoshita"
-  - "Gary Gregory"
-  - "Rob Tompkins"
-  - "The Apache Software Foundation"
-  declared_licenses:
-  - "Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache License, Version 2.0: "Apache-2.0"
-  description: "Apache Commons Text is a library focused on algorithms working on\
-    \ strings."
-  homepage_url: "http://commons.apache.org/proper/commons-text/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
-    hash:
-      value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-    hash:
-      value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
-  authors:
-  - "Aleksandr Mashchenko"
-  - "Alexandru Popescu"
-  - "Apache Software Foundation"
-  - "Bob Lee"
-  - "Bruce A. Phillips"
-  - "Cedric Dumoulin"
-  - "Christian Grobmeier"
-  - "Christoph Nenning"
-  - "Dave Newton"
-  - "David H. DeWolf"
-  - "Don Brown"
-  - "Greg Huber"
-  - "James Holmes"
-  - "James Mitchell"
-  - "Jeromy Evans"
-  - "Johannes Geppert"
-  - "John Lindal"
-  - "Laurie Harper"
-  - "Lukasz Lenart"
-  - "Martin Cooper"
-  - "Mathias Bogaert"
-  - "Matt Raible"
-  - "Maurizio Cucchiara"
-  - "Michael Jouravlev"
-  - "Niall Pemberton"
-  - "Nils-Helge Garli Hegvik"
-  - "Paul Benedict"
-  - "Rainer Hermanns"
-  - "Rene Gielen"
-  - "Ted Husted"
-  - "Toby Jee"
-  - "Wendy Smoak"
-  - "Wes Wannemacher"
-  declared_licenses:
-  - "The Apache Software License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache Software License, Version 2.0: "Apache-2.0"
-  description: "Apache Struts 2"
-  homepage_url: "http://struts.apache.org/struts2-assembly/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
-    hash:
-      value: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  vcs:
-    type: "Git"
-    url: "https://gitbox.apache.org/repos/asf/struts.git"
-    revision: "STRUTS_2_5_14_1"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://gitbox.apache.org/repos/asf/struts.git"
-    revision: "STRUTS_2_5_14_1"
-    path: ""
-  is_meta_data_only: true
+- package:
+    id: "Maven:org.apache.commons:commons-lang3:3.5"
+    purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
+    authors:
+    - "Benedikt Ritter"
+    - "Carman Consulting, Inc."
+    - "CollabNet, Inc."
+    - "Duncan Jones"
+    - "Fredrik Westermarck"
+    - "Gary D. Gregory"
+    - "Henri Yandell"
+    - "Joerg Schaible"
+    - "Loic Guibert"
+    - "Matt Benson"
+    - "Niall Pemberton"
+    - "Oliver Heger"
+    - "Paul Benedict"
+    - "Rob Tompkins"
+    - "Robert Burrell Donkin"
+    - "SITA ATS Ltd"
+    - "Steven Caswell"
+    - "The Apache Software Foundation"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
+    description: "Apache Commons Lang, a package of Java utility classes for the\n\
+      \  classes that are in java.lang's hierarchy, or are considered to be so\n \
+      \ standard as to justify existence in java.lang."
+    homepage_url: "http://commons.apache.org/proper/commons-lang/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
+      hash:
+        value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+      hash:
+        value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+      revision: "LANG_3_5"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+      revision: "LANG_3_5"
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.commons:commons-text:1.1"
+    purl: "pkg:maven/org.apache.commons/commons-text@1.1"
+    authors:
+    - "Benedikt Ritter"
+    - "Bruno P. Kinoshita"
+    - "Gary Gregory"
+    - "Rob Tompkins"
+    - "The Apache Software Foundation"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
+    description: "Apache Commons Text is a library focused on algorithms working on\
+      \ strings."
+    homepage_url: "http://commons.apache.org/proper/commons-text/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
+      hash:
+        value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+      hash:
+        value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
+    authors:
+    - "Aleksandr Mashchenko"
+    - "Alexandru Popescu"
+    - "Apache Software Foundation"
+    - "Bob Lee"
+    - "Bruce A. Phillips"
+    - "Cedric Dumoulin"
+    - "Christian Grobmeier"
+    - "Christoph Nenning"
+    - "Dave Newton"
+    - "David H. DeWolf"
+    - "Don Brown"
+    - "Greg Huber"
+    - "James Holmes"
+    - "James Mitchell"
+    - "Jeromy Evans"
+    - "Johannes Geppert"
+    - "John Lindal"
+    - "Laurie Harper"
+    - "Lukasz Lenart"
+    - "Martin Cooper"
+    - "Mathias Bogaert"
+    - "Matt Raible"
+    - "Maurizio Cucchiara"
+    - "Michael Jouravlev"
+    - "Niall Pemberton"
+    - "Nils-Helge Garli Hegvik"
+    - "Paul Benedict"
+    - "Rainer Hermanns"
+    - "Rene Gielen"
+    - "Ted Husted"
+    - "Toby Jee"
+    - "Wendy Smoak"
+    - "Wes Wannemacher"
+    declared_licenses:
+    - "The Apache Software License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
+    description: "Apache Struts 2"
+    homepage_url: "http://struts.apache.org/struts2-assembly/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
+      hash:
+        value: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    vcs:
+      type: "Git"
+      url: "https://gitbox.apache.org/repos/asf/struts.git"
+      revision: "STRUTS_2_5_14_1"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://gitbox.apache.org/repos/asf/struts.git"
+      revision: "STRUTS_2_5_14_1"
+      path: ""
+    is_meta_data_only: true
+  curations: []
+dependency_graphs:
+  Gradle:
+    packages:
+    - "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+    - "Maven:org.apache.commons:commons-lang3:3.5"
+    - "Maven:org.apache.commons:commons-text:1.1"
+    - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    scopes:
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:compile:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:compileClasspath:
+      - root: 0
+        fragment: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:default:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:runtime:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:runtimeClasspath:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:testCompile:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:testCompileClasspath:
+      - root: 0
+        fragment: 1
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:testRuntime:
+      - root: 0
+      org.ossreviewtoolkit.gradle.example:app:1.0.0:testRuntimeClasspath:
+      - root: 0
+    nodes:
+    - linkage: "PROJECT_DYNAMIC"
+    - pkg: 2
+    - pkg: 1
+    - pkg: 3
+    - fragment: 1
+      linkage: "PROJECT_DYNAMIC"
+    edges:
+    - from: 1
+      to: 2
+    - from: 0
+      to: 1
+    - from: 0
+      to: 3
+    - from: 4
+      to: 1
+has_issues: false

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
@@ -1,6 +1,6 @@
 ---
-project:
-  id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+projects:
+- id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/lib/build.gradle"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -15,269 +15,286 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/lib"
   homepage_url: ""
-  scopes:
-  - name: "compileClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "default"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtimeClasspath"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompileClasspath"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testRuntimeClasspath"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+  scope_names:
+  - "compileClasspath"
+  - "default"
+  - "runtimeClasspath"
+  - "testCompileClasspath"
+  - "testRuntimeClasspath"
 packages:
-- id: "Maven:junit:junit:4.12"
-  purl: "pkg:maven/junit/junit@4.12"
-  authors:
-  - "David Saff"
-  - "JUnit"
-  - "Kevin Cooney"
-  - "Marc Philipp"
-  - "Stefan Birkner"
-  declared_licenses:
-  - "Eclipse Public License 1.0"
-  declared_licenses_processed:
-    spdx_expression: "EPL-1.0"
-    mapped:
-      Eclipse Public License 1.0: "EPL-1.0"
-  description: "JUnit is a unit testing framework for Java, created by Erich Gamma\
-    \ and Kent Beck."
-  homepage_url: "http://junit.org"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
-    hash:
-      value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
-    hash:
-      value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/junit-team/junit.git"
-    revision: "r4.12"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/junit-team/junit.git"
-    revision: "r4.12"
-    path: ""
-- id: "Maven:org.apache.commons:commons-lang3:3.5"
-  purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
-  authors:
-  - "Benedikt Ritter"
-  - "Carman Consulting, Inc."
-  - "CollabNet, Inc."
-  - "Duncan Jones"
-  - "Fredrik Westermarck"
-  - "Gary D. Gregory"
-  - "Henri Yandell"
-  - "Joerg Schaible"
-  - "Loic Guibert"
-  - "Matt Benson"
-  - "Niall Pemberton"
-  - "Oliver Heger"
-  - "Paul Benedict"
-  - "Rob Tompkins"
-  - "Robert Burrell Donkin"
-  - "SITA ATS Ltd"
-  - "Steven Caswell"
-  - "The Apache Software Foundation"
-  declared_licenses:
-  - "Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache License, Version 2.0: "Apache-2.0"
-  description: "Apache Commons Lang, a package of Java utility classes for the\n \
-    \ classes that are in java.lang's hierarchy, or are considered to be so\n  standard\
-    \ as to justify existence in java.lang."
-  homepage_url: "http://commons.apache.org/proper/commons-lang/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
-    hash:
-      value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
-    hash:
-      value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
-    revision: "LANG_3_5"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
-    revision: "LANG_3_5"
-    path: ""
-- id: "Maven:org.apache.commons:commons-text:1.1"
-  purl: "pkg:maven/org.apache.commons/commons-text@1.1"
-  authors:
-  - "Benedikt Ritter"
-  - "Bruno P. Kinoshita"
-  - "Gary Gregory"
-  - "Rob Tompkins"
-  - "The Apache Software Foundation"
-  declared_licenses:
-  - "Apache License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      Apache License, Version 2.0: "Apache-2.0"
-  description: "Apache Commons Text is a library focused on algorithms working on\
-    \ strings."
-  homepage_url: "http://commons.apache.org/proper/commons-text/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
-    hash:
-      value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
-    hash:
-      value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
-    revision: ""
-    path: ""
-- id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
-  authors:
-  - "Aleksandr Mashchenko"
-  - "Alexandru Popescu"
-  - "Apache Software Foundation"
-  - "Bob Lee"
-  - "Bruce A. Phillips"
-  - "Cedric Dumoulin"
-  - "Christian Grobmeier"
-  - "Christoph Nenning"
-  - "Dave Newton"
-  - "David H. DeWolf"
-  - "Don Brown"
-  - "Greg Huber"
-  - "James Holmes"
-  - "James Mitchell"
-  - "Jeromy Evans"
-  - "Johannes Geppert"
-  - "John Lindal"
-  - "Laurie Harper"
-  - "Lukasz Lenart"
-  - "Martin Cooper"
-  - "Mathias Bogaert"
-  - "Matt Raible"
-  - "Maurizio Cucchiara"
-  - "Michael Jouravlev"
-  - "Niall Pemberton"
-  - "Nils-Helge Garli Hegvik"
-  - "Paul Benedict"
-  - "Rainer Hermanns"
-  - "Rene Gielen"
-  - "Ted Husted"
-  - "Toby Jee"
-  - "Wendy Smoak"
-  - "Wes Wannemacher"
-  declared_licenses:
-  - "The Apache Software License, Version 2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-    mapped:
-      The Apache Software License, Version 2.0: "Apache-2.0"
-  description: "Apache Struts 2"
-  homepage_url: "http://struts.apache.org/struts2-assembly/"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
-    hash:
-      value: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  vcs:
-    type: "Git"
-    url: "https://gitbox.apache.org/repos/asf/struts.git"
-    revision: "STRUTS_2_5_14_1"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://gitbox.apache.org/repos/asf/struts.git"
-    revision: "STRUTS_2_5_14_1"
-    path: ""
-  is_meta_data_only: true
-- id: "Maven:org.hamcrest:hamcrest-core:1.3"
-  purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
-  authors:
-  - "Joe Walnes"
-  - "Nat Pryce"
-  - "Neil Dunn"
-  - "Steve Freeman"
-  - "Tom Denley"
-  declared_licenses:
-  - "New BSD License"
-  declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      New BSD License: "BSD-3-Clause"
-  description: "This is the core API of hamcrest matcher framework to be used by third-party\
-    \ framework providers. This includes the a foundation set of matcher implementations\
-    \ for common operations."
-  homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
-  binary_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
-    hash:
-      value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
-      algorithm: "SHA-1"
-  source_artifact:
-    url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-    hash:
-      value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git@github.com:hamcrest/JavaHamcrest.git"
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
-    revision: ""
-    path: ""
+- package:
+    id: "Maven:junit:junit:4.12"
+    purl: "pkg:maven/junit/junit@4.12"
+    authors:
+    - "David Saff"
+    - "JUnit"
+    - "Kevin Cooney"
+    - "Marc Philipp"
+    - "Stefan Birkner"
+    declared_licenses:
+    - "Eclipse Public License 1.0"
+    declared_licenses_processed:
+      spdx_expression: "EPL-1.0"
+      mapped:
+        Eclipse Public License 1.0: "EPL-1.0"
+    description: "JUnit is a unit testing framework for Java, created by Erich Gamma\
+      \ and Kent Beck."
+    homepage_url: "http://junit.org"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
+      hash:
+        value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+      hash:
+        value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git://github.com/junit-team/junit.git"
+      revision: "r4.12"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/junit-team/junit.git"
+      revision: "r4.12"
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.commons:commons-lang3:3.5"
+    purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
+    authors:
+    - "Benedikt Ritter"
+    - "Carman Consulting, Inc."
+    - "CollabNet, Inc."
+    - "Duncan Jones"
+    - "Fredrik Westermarck"
+    - "Gary D. Gregory"
+    - "Henri Yandell"
+    - "Joerg Schaible"
+    - "Loic Guibert"
+    - "Matt Benson"
+    - "Niall Pemberton"
+    - "Oliver Heger"
+    - "Paul Benedict"
+    - "Rob Tompkins"
+    - "Robert Burrell Donkin"
+    - "SITA ATS Ltd"
+    - "Steven Caswell"
+    - "The Apache Software Foundation"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
+    description: "Apache Commons Lang, a package of Java utility classes for the\n\
+      \  classes that are in java.lang's hierarchy, or are considered to be so\n \
+      \ standard as to justify existence in java.lang."
+    homepage_url: "http://commons.apache.org/proper/commons-lang/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
+      hash:
+        value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+      hash:
+        value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+      revision: "LANG_3_5"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-lang.git"
+      revision: "LANG_3_5"
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.commons:commons-text:1.1"
+    purl: "pkg:maven/org.apache.commons/commons-text@1.1"
+    authors:
+    - "Benedikt Ritter"
+    - "Bruno P. Kinoshita"
+    - "Gary Gregory"
+    - "Rob Tompkins"
+    - "The Apache Software Foundation"
+    declared_licenses:
+    - "Apache License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        Apache License, Version 2.0: "Apache-2.0"
+    description: "Apache Commons Text is a library focused on algorithms working on\
+      \ strings."
+    homepage_url: "http://commons.apache.org/proper/commons-text/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
+      hash:
+        value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+      hash:
+        value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "http://git-wip-us.apache.org/repos/asf/commons-text.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    purl: "pkg:maven/org.apache.struts/struts2-assembly@2.5.14.1"
+    authors:
+    - "Aleksandr Mashchenko"
+    - "Alexandru Popescu"
+    - "Apache Software Foundation"
+    - "Bob Lee"
+    - "Bruce A. Phillips"
+    - "Cedric Dumoulin"
+    - "Christian Grobmeier"
+    - "Christoph Nenning"
+    - "Dave Newton"
+    - "David H. DeWolf"
+    - "Don Brown"
+    - "Greg Huber"
+    - "James Holmes"
+    - "James Mitchell"
+    - "Jeromy Evans"
+    - "Johannes Geppert"
+    - "John Lindal"
+    - "Laurie Harper"
+    - "Lukasz Lenart"
+    - "Martin Cooper"
+    - "Mathias Bogaert"
+    - "Matt Raible"
+    - "Maurizio Cucchiara"
+    - "Michael Jouravlev"
+    - "Niall Pemberton"
+    - "Nils-Helge Garli Hegvik"
+    - "Paul Benedict"
+    - "Rainer Hermanns"
+    - "Rene Gielen"
+    - "Ted Husted"
+    - "Toby Jee"
+    - "Wendy Smoak"
+    - "Wes Wannemacher"
+    declared_licenses:
+    - "The Apache Software License, Version 2.0"
+    declared_licenses_processed:
+      spdx_expression: "Apache-2.0"
+      mapped:
+        The Apache Software License, Version 2.0: "Apache-2.0"
+    description: "Apache Struts 2"
+    homepage_url: "http://struts.apache.org/struts2-assembly/"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/struts/struts2-assembly/2.5.14.1/struts2-assembly-2.5.14.1-min-lib.zip"
+      hash:
+        value: "8e75a38e3b8ceb01e007c5899d8d29e7a075cb7d"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    vcs:
+      type: "Git"
+      url: "https://gitbox.apache.org/repos/asf/struts.git"
+      revision: "STRUTS_2_5_14_1"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://gitbox.apache.org/repos/asf/struts.git"
+      revision: "STRUTS_2_5_14_1"
+      path: ""
+    is_meta_data_only: true
+  curations: []
+- package:
+    id: "Maven:org.hamcrest:hamcrest-core:1.3"
+    purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
+    authors:
+    - "Joe Walnes"
+    - "Nat Pryce"
+    - "Neil Dunn"
+    - "Steve Freeman"
+    - "Tom Denley"
+    declared_licenses:
+    - "New BSD License"
+    declared_licenses_processed:
+      spdx_expression: "BSD-3-Clause"
+      mapped:
+        New BSD License: "BSD-3-Clause"
+    description: "This is the core API of hamcrest matcher framework to be used by\
+      \ third-party framework providers. This includes the a foundation set of matcher\
+      \ implementations for common operations."
+    homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
+    binary_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
+      hash:
+        value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+        algorithm: "SHA-1"
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+      hash:
+        value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git@github.com:hamcrest/JavaHamcrest.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "ssh://git@github.com/hamcrest/JavaHamcrest.git"
+      revision: ""
+      path: ""
+  curations: []
+dependency_graphs:
+  Gradle:
+    packages:
+    - "Maven:junit:junit:4.12"
+    - "Maven:org.apache.commons:commons-lang3:3.5"
+    - "Maven:org.apache.commons:commons-text:1.1"
+    - "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
+    - "Maven:org.hamcrest:hamcrest-core:1.3"
+    scopes:
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:compileClasspath:
+      - root: 2
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:default:
+      - root: 2
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:runtimeClasspath:
+      - root: 2
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:testCompileClasspath:
+      - root: 0
+      - root: 2
+      - root: 3
+      org.ossreviewtoolkit.gradle.example:lib:1.0.0:testRuntimeClasspath:
+      - root: 0
+      - root: 2
+      - root: 3
+    nodes:
+    - pkg: 2
+    - pkg: 1
+    - pkg: 3
+    - {}
+    - pkg: 4
+    edges:
+    - from: 0
+      to: 1
+    - from: 3
+      to: 4
+has_issues: false

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-root.yml
@@ -1,6 +1,6 @@
 ---
-project:
-  id: "Gradle::Gradle-Example:"
+projects:
+- id: "Gradle::Gradle-Example:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/build.gradle"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -15,5 +15,10 @@ project:
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library"
   homepage_url: ""
-  scopes: []
+  scope_names: []
 packages: []
+dependency_graphs:
+  Gradle:
+    nodes: []
+    edges: []
+has_issues: false

--- a/analyzer/src/funTest/kotlin/GitRepoFunTest.kt
+++ b/analyzer/src/funTest/kotlin/GitRepoFunTest.kt
@@ -37,7 +37,6 @@ import org.ossreviewtoolkit.utils.Ci
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
-import org.ossreviewtoolkit.utils.test.convertToDependencyGraph
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
@@ -67,13 +66,11 @@ class GitRepoFunTest : StringSpec() {
         // Disabled on Azure Windows because it fails for unknown reasons.
         "Analyzer correctly reports VcsInfo for git-repo projects".config(enabled = !Ci.isAzureWindows) {
             val ortResult = Analyzer(DEFAULT_ANALYZER_CONFIGURATION).analyze(outputDir)
-            val actualResult = ortResult.withResolvedScopes().toYaml()
-            val expectedResult = convertToDependencyGraph(
-                patchExpectedResult(
-                    File("src/funTest/assets/projects/external/git-repo-expected-output.yml"),
-                    revision = REPO_REV,
-                    path = outputDir.invariantSeparatorsPath
-                )
+            val actualResult = ortResult.toYaml()
+            val expectedResult = patchExpectedResult(
+                File("src/funTest/assets/projects/external/git-repo-expected-output.yml"),
+                revision = REPO_REV,
+                path = outputDir.invariantSeparatorsPath
             )
 
             patchActualResult(actualResult, patchStartAndEndTime = true) shouldBe expectedResult

--- a/analyzer/src/funTest/kotlin/managers/GradleAndroidFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleAndroidFunTest.kt
@@ -47,7 +47,7 @@ class GradleAndroidFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
+            val result = createGradle().resultForProject(packageFile)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -60,7 +60,7 @@ class GradleAndroidFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
+            val result = createGradle().resultForProject(packageFile)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -73,7 +73,7 @@ class GradleAndroidFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
+            val result = createGradle().resultForProject(packageFile)
 
             result.toYaml() shouldBe expectedResult
         }

--- a/analyzer/src/funTest/kotlin/managers/GradleBomFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleBomFunTest.kt
@@ -46,7 +46,7 @@ class GradleBomFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
+            val result = createGradle().resultForProject(packageFile)
 
             result.toYaml() shouldBe expectedResult
         }

--- a/analyzer/src/funTest/kotlin/managers/GradleFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleFunTest.kt
@@ -63,7 +63,7 @@ class GradleFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
+            val result = createGradle().resultForProject(packageFile)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -76,7 +76,7 @@ class GradleFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
+            val result = createGradle().resultForProject(packageFile)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -89,7 +89,7 @@ class GradleFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
+            val result = createGradle().resultForProject(packageFile)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -102,7 +102,7 @@ class GradleFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
+            val result = createGradle().resultForProject(packageFile)
 
             patchActualResult(result.toYaml()) shouldBe expectedResult
         }

--- a/analyzer/src/funTest/kotlin/managers/GradleKotlinScriptFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleKotlinScriptFunTest.kt
@@ -46,7 +46,7 @@ class GradleKotlinScriptFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
+            val result = createGradle().resultForProject(packageFile)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -59,7 +59,7 @@ class GradleKotlinScriptFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
+            val result = createGradle().resultForProject(packageFile)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -72,7 +72,7 @@ class GradleKotlinScriptFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
+            val result = createGradle().resultForProject(packageFile)
 
             result.toYaml() shouldBe expectedResult
         }

--- a/analyzer/src/funTest/kotlin/managers/GradleLibraryFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleLibraryFunTest.kt
@@ -46,7 +46,7 @@ class GradleLibraryFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
+            val result = createGradle().resultForProject(packageFile)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -59,7 +59,7 @@ class GradleLibraryFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
+            val result = createGradle().resultForProject(packageFile)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -72,7 +72,7 @@ class GradleLibraryFunTest : StringSpec() {
                 revision = vcsRevision
             )
 
-            val result = createGradle().resolveSingleProject(packageFile, resolveScopes = true)
+            val result = createGradle().resultForProject(packageFile)
 
             result.toYaml() shouldBe expectedResult
         }

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -257,7 +257,7 @@ class Gradle(
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = processProjectVcs(definitionFile.parentFile),
                     homepageUrl = "",
-                    scopeNames = dependencyTreeModel.configurations.map { it.name }.toSortedSet()
+                    scopeNames = graphBuilder.scopesFor(projectId)
                 )
 
                 val issues = mutableListOf<OrtIssue>()

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -145,7 +145,7 @@ class Maven(
             vcs = vcsFromPackage,
             vcsProcessed = processProjectVcs(projectDir, vcsFromPackage, *vcsFallbackUrls),
             homepageUrl = homepageUrl.orEmpty(),
-            scopeNames = projectBuildingResult.dependencies.mapTo(sortedSetOf()) { it.dependency.scope }
+            scopeNames = graphBuilder.scopesFor(projectId)
         )
 
         val packages = graphBuilder.packages().toSortedSet()

--- a/cli/src/funTest/kotlin/OrtMainFunTest.kt
+++ b/cli/src/funTest/kotlin/OrtMainFunTest.kt
@@ -34,7 +34,6 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.utils.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.redirectStdout
-import org.ossreviewtoolkit.utils.test.convertToDependencyGraph
 import org.ossreviewtoolkit.utils.test.createTestTempDir
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
@@ -108,13 +107,11 @@ class OrtMainFunTest : StringSpec() {
 
         "Analyzer creates correct output" {
             val analyzerOutputDir = outputDir.resolve("merged-results")
-            val expectedResult = convertToDependencyGraph(
-                patchExpectedResult(
-                    projectDir.resolve("gradle-all-dependencies-expected-result.yml"),
-                    url = vcsUrl,
-                    revision = vcsRevision,
-                    urlProcessed = normalizeVcsUrl(vcsUrl)
-                )
+            val expectedResult = patchExpectedResult(
+                projectDir.resolve("gradle-all-dependencies-expected-result.yml"),
+                url = vcsUrl,
+                revision = vcsRevision,
+                urlProcessed = normalizeVcsUrl(vcsUrl)
             )
 
             runMain(
@@ -125,21 +122,19 @@ class OrtMainFunTest : StringSpec() {
             )
 
             val analyzerResult = analyzerOutputDir.resolve("analyzer-result.yml").readValue<OrtResult>()
-            val resolvedResult = analyzerResult.withResolvedScopes()
 
-            patchActualResult(resolvedResult, patchStartAndEndTime = true) shouldBe expectedResult
+            patchActualResult(analyzerResult, patchStartAndEndTime = true) shouldBe expectedResult
         }
 
         "Package curation data file is applied correctly" {
             val analyzerOutputDir = outputDir.resolve("curations")
-            val expectedResult = convertToDependencyGraph(
+            val expectedResult =
                 patchExpectedResult(
                     projectDir.resolve("gradle-all-dependencies-expected-result-with-curations.yml"),
                     url = vcsUrl,
                     revision = vcsRevision,
                     urlProcessed = normalizeVcsUrl(vcsUrl)
                 )
-            )
 
             runMain(
                 "analyze",
@@ -150,9 +145,8 @@ class OrtMainFunTest : StringSpec() {
             )
 
             val analyzerResult = analyzerOutputDir.resolve("analyzer-result.yml").readValue<OrtResult>()
-            val resolvedResult = analyzerResult.withResolvedScopes()
 
-            patchActualResult(resolvedResult, patchStartAndEndTime = true) shouldBe expectedResult
+            patchActualResult(analyzerResult, patchStartAndEndTime = true) shouldBe expectedResult
         }
 
         "Passing mutually exclusive evaluator options fails" {

--- a/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.model.utils
 
 import java.util.LinkedList
+import java.util.SortedSet
 
 import org.ossreviewtoolkit.model.DependencyGraph
 import org.ossreviewtoolkit.model.DependencyGraphEdge
@@ -210,6 +211,26 @@ class DependencyGraphBuilder<D>(
      * Return a set with all the packages that have been encountered for the current project.
      */
     fun packages(): Set<Package> = resolvedPackages.values.toSet()
+
+    /**
+     * Return a set of all the scope names known to this builder that start with the given [prefix]. If [unqualify] is
+     * *true*, remove this prefix from the returned scope names.
+     */
+    fun scopesFor(prefix: String, unqualify: Boolean = true): SortedSet<String> {
+        val qualifiedScopes = scopeMapping.keys.filter { it.startsWith(prefix) }
+
+        return (qualifiedScopes.takeUnless { unqualify }
+            ?: qualifiedScopes.map { it.substring(prefix.length) }).toSortedSet()
+    }
+
+    /**
+     * Return a set of all the scope names known to this builder that are qualified with the given [projectId]. If
+     * [unqualify] is *true*, remove the project qualifier from the returned scope names. As dependency graphs are
+     * shared between multiple projects, scope names are given a project-specific prefix to make them unique. Using
+     * this function, the scope names of a specific project can be retrieved.
+     */
+    fun scopesFor(projectId: Identifier, unqualify: Boolean = true): SortedSet<String> =
+        scopesFor(DependencyGraph.qualifyScope(projectId, ""), unqualify)
 
     /**
      * Update the dependency graph by adding the given [dependency], which may be [transitive], for the scope with name

--- a/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
+++ b/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
@@ -32,6 +32,7 @@ import io.kotest.matchers.string.shouldContain
 
 import java.util.SortedSet
 
+import org.ossreviewtoolkit.model.DependencyGraph
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.Package
@@ -272,6 +273,34 @@ class DependencyGraphBuilderTest : WordSpec({
                 .addDependency("s", depLang)
                 .addDependency("s", depLog)
                 .build(checkReferences = false)
+        }
+
+        "collect information about scopes of projects" {
+            val projectId = Identifier("test", "test", "project1", "1.0")
+            val scope1 = DependencyGraph.qualifyScope(projectId, "test")
+            val scope2 = DependencyGraph.qualifyScope(projectId, "compile")
+            val builder = createGraphBuilder()
+
+            builder.addDependency(scope1, createDependency("org.apache.commons", "commons-lang3", "3.11"))
+                .addDependency(scope2, createDependency("org.apache.commons", "commons-collections4", "4.4"))
+                .addDependency(scope1, createDependency("g1", "a1", "1"))
+                .addDependency("anotherScope", createDependency("g2", "a2", "2"))
+
+            builder.scopesFor(projectId) should containExactly("compile", "test")
+        }
+
+        "collect information about qualified scopes of projects" {
+            val projectId = Identifier("test", "test", "project1", "1.0")
+            val scope1 = DependencyGraph.qualifyScope(projectId, "test")
+            val scope2 = DependencyGraph.qualifyScope(projectId, "compile")
+            val builder = createGraphBuilder()
+
+            builder.addDependency(scope1, createDependency("org.apache.commons", "commons-lang3", "3.11"))
+                .addDependency(scope2, createDependency("org.apache.commons", "commons-collections4", "4.4"))
+                .addDependency(scope1, createDependency("g1", "a1", "1"))
+                .addDependency("anotherScope", createDependency("g2", "a2", "2"))
+
+            builder.scopesFor(projectId, unqualify = false) should containExactly(scope2, scope1)
         }
     }
 

--- a/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
+++ b/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
@@ -37,6 +37,7 @@ import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.PackageReference
+import org.ossreviewtoolkit.model.RootDependencyIndex
 import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
@@ -73,6 +74,29 @@ class DependencyGraphBuilderTest : WordSpec({
 
             val scope2Dependencies = scopeDependencies(scopes, scope2)
             scope2Dependencies should containExactlyInAnyOrder(dep2, dep1)
+        }
+
+        "order the scopes, their dependencies, and packages" {
+            val scope1 = "compile"
+            val scope2 = "test"
+            val dep1 = createDependency("org.apache.commons", "commons-lang3", "3.11")
+            val dep2 = createDependency("org.apache.commons", "commons-collections4", "4.4")
+            val dep3 = createDependency("my-project", "my-module", "1.0")
+
+            val graph = createGraphBuilder()
+                .addDependency(scope2, dep1)
+                .addDependency(scope2, dep2)
+                .addDependency(scope1, dep3)
+                .addDependency(scope1, dep1)
+                .build()
+
+            graph.scopes.keys should containExactly("compile", "test")
+            graph.scopes.getValue("compile") should containExactly(
+                RootDependencyIndex(0),
+                RootDependencyIndex(2)
+            )
+
+            graph.packages should containExactly(dep3.id, dep2.id, dep1.id)
         }
 
         "collect information about packages" {

--- a/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
@@ -37,7 +37,6 @@ import org.ossreviewtoolkit.scanner.LocalScanner
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.scanner.scanOrtResult
 import org.ossreviewtoolkit.spdx.calculatePackageVerificationCode
-import org.ossreviewtoolkit.utils.test.convertToDependencyGraph
 import org.ossreviewtoolkit.utils.test.createTestTempDir
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
@@ -52,10 +51,8 @@ class ScannerIntegrationFunTest : StringSpec() {
             outputDir = createTestTempDir()
 
             val analyzerResultFile = assetsDir.resolve("analyzer-result.yml")
-            val expectedResult = convertToDependencyGraph(
-                patchExpectedResult(
-                    assetsDir.resolve("dummy-expected-output-for-analyzer-result.yml")
-                )
+            val expectedResult = patchExpectedResult(
+                assetsDir.resolve("dummy-expected-output-for-analyzer-result.yml")
             )
 
             val scanner = DummyScanner("Dummy", ScannerConfiguration(), DownloaderConfiguration())

--- a/test-utils/src/main/kotlin/Utils.kt
+++ b/test-utils/src/main/kotlin/Utils.kt
@@ -99,14 +99,3 @@ fun patchActualResultObject(result: OrtResult, patchStartAndEndTime: Boolean = f
 fun readOrtResult(file: String) = readOrtResult(File(file))
 
 fun readOrtResult(file: File) = file.mapper().readValue<OrtResult>(patchExpectedResult(file))
-
-/**
- * Deserialize an [OrtResult] from the given [string representation][result] and then serialize it again. As for some
- * of the components in the result custom serializers or deserializers are registered, this can cause some
- * modifications and conversions on the original result. This function is also used to convert expected test results
- * stored in the assets to the most recent serialization format.
- */
-fun convertToDependencyGraph(result: String): String {
-    val ortResult = yamlMapper.readValue<OrtResult>(result)
-    return yamlMapper.writeValueAsString(ortResult)
-}


### PR DESCRIPTION
This PR is a final cleanup for the transition to the dependency graph format and to close #4069. 

Currently the functional tests for concrete `PackageManager` implementations store their expectations in the dependency tree format. So there is always some conversion required before results can be compared. This PR, among some other things, converts these expectations to the dependency graph format, so that tests can be simplified. Unfortunately, this causes a big diff.