### PR TITLE
Consistently spell it like "metadata" throughout the code base

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It does so by orchestrating a _highly customizable_ pipeline of tools that _abst
 These tools are implemented as libraries (for programmatic use) and exposed via a command line interface (for scripted
 use):
 
-* [_Analyzer_](#analyzer) - determines the dependencies of projects and their meta-data, abstracting which package
+* [_Analyzer_](#analyzer) - determines the dependencies of projects and their metadata, abstracting which package
   managers or build systems are actually being used.
 * [_Downloader_](#downloader) - fetches all source code of the projects and their dependencies, abstracting which
   Version Control System (VCS) or other means are used to retrieve the source code.
@@ -313,7 +313,7 @@ to your existing project source code, like applying build system plugins, are ne
 transitive dependencies per project is written out as part of an
 [OrtResult](https://github.com/oss-review-toolkit/ort/blob/master/model/src/main/kotlin/OrtResult.kt) in YAML (or
 JSON, see `-f`) format to a file named `analyzer-result.yml` in the specified output directory (`-o`). The output file
-exactly documents the status quo of all package-related meta-data. It can be further processed or manually edited before
+exactly documents the status quo of all package-related metadata. It can be further processed or manually edited before
 passing it to one of the other tools.
 
 Currently, the following package managers are supported:

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -163,7 +163,7 @@ abstract class PackageManager(
                 // Enrich (not overwrite) the normalized VCS information from the package...
                 val mergedVcs = normalizedVcsFromPackage.merge(fallbackVcs)
                 if (mergedVcs != normalizedVcsFromPackage) {
-                    // ... but if indeed meta data was enriched, overwrite the URL with the one from the fallback VCS
+                    // ... but if indeed metadata was enriched, overwrite the URL with the one from the fallback VCS
                     // information to ensure we get the correct base URL if additional VCS information (like a revision
                     // or path) has been split from the original URL.
                     return mergedVcs.copy(url = fallbackVcs.url)
@@ -175,7 +175,7 @@ abstract class PackageManager(
 
         /**
          * Enrich VCS information determined from the [project's directory][projectDir] with VCS information determined
-         * from the [project's meta data][vcsFromProject], if any, and from a [list of fallback URLs][fallbackUrls] (the
+         * from the [project's metadata][vcsFromProject], if any, and from a [list of fallback URLs][fallbackUrls] (the
          * first element that is recognized as a VCS URL is used).
          */
         fun processProjectVcs(

--- a/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
@@ -82,7 +82,7 @@ fun SourceLocation?.toArtifactOrVcs(): Any? =
     }
 
 /**
- * A provider for curated package meta-data from the [ClearlyDefined](https://clearlydefined.io/) service.
+ * A provider for curated package metadata from the [ClearlyDefined](https://clearlydefined.io/) service.
  */
 class ClearlyDefinedPackageCurationProvider(
     serverUrl: String,

--- a/analyzer/src/main/kotlin/curation/Sw360PackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/Sw360PackageCurationProvider.kt
@@ -46,7 +46,7 @@ import org.ossreviewtoolkit.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
 
 /**
- * A [PackageCurationProvider] for curated package meta-data from the configured SW360 instance using the REST API.
+ * A [PackageCurationProvider] for curated package metadata from the configured SW360 instance using the REST API.
  */
 class Sw360PackageCurationProvider(sw360Configuration: Sw360StorageConfiguration) : PackageCurationProvider {
     private val sw360Connection = createSw360Connection(

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -253,7 +253,7 @@ class Bundler(
             GemSpec.createFromJson(it)
         }.onFailure {
             val error = (it as? HttpDownloadError) ?: run {
-                log.warn { "Unable to retrieve meta-data for gem '$name' from RubyGems: ${it.message}" }
+                log.warn { "Unable to retrieve metadata for gem '$name' from RubyGems: ${it.message}" }
                 return null
             }
 
@@ -262,7 +262,7 @@ class Bundler(
 
                 OkHttpClientHelper.HTTP_TOO_MANY_REQUESTS -> {
                     throw IOException(
-                        "RubyGems reported too many requests when requesting meta-data for gem '$name', see " +
+                        "RubyGems reported too many requests when requesting metadata for gem '$name', see " +
                                 "https://guides.rubygems.org/rubygems-org-api/#rate-limits."
                     )
                 }
@@ -275,13 +275,13 @@ class Bundler(
                     }
 
                     throw IOException(
-                        "RubyGems reported too many bad gateway errors when requesting meta-data for gem '$name'."
+                        "RubyGems reported too many bad gateway errors when requesting metadata for gem '$name'."
                     )
                 }
 
                 else -> {
                     throw IOException(
-                        "RubyGems reported unhandled HTTP code ${error.code} when requesting meta-data for gem '$name'."
+                        "RubyGems reported unhandled HTTP code ${error.code} when requesting metadata for gem '$name'."
                     )
                 }
             }

--- a/analyzer/src/main/kotlin/managers/CocoaPods.kt
+++ b/analyzer/src/main/kotlin/managers/CocoaPods.kt
@@ -66,7 +66,7 @@ import org.ossreviewtoolkit.utils.textValueOrEmpty
  * on any platform. Note that obtaining the dependency tree from the 'pod' command without a lock file has Xcode
  * dependencies and is not supported by this class.
  *
- * The only interactions with the 'pod' command happen in order to obtain meta-data for dependencies. Therefore
+ * The only interactions with the 'pod' command happen in order to obtain metadata for dependencies. Therefore
  * 'pod spec which' gets executed, which works also under Linux.
  *
  * Note: This class depends on https://github.com/CocoaPods/CocoaPods/pull/10609 which is not yet released.
@@ -98,7 +98,7 @@ class CocoaPods(
     override fun beforeResolution(definitionFiles: List<File>) = checkVersion(analyzerConfig.ignoreToolVersions)
 
     override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
-        // CocoaPods originally used and may still use the Specs repository on GitHub [1] as package meta-data database.
+        // CocoaPods originally used and may still use the Specs repository on GitHub [1] as package metadata database.
         // Using [1] requires an initial clone which is slow to do and consumes already more than 5 GB on disk, see
         // also [2]. (Final) CDN support has been added in version 1.7.2 [3] to speed things up.
         //

--- a/analyzer/src/main/kotlin/managers/Composer.kt
+++ b/analyzer/src/main/kotlin/managers/Composer.kt
@@ -183,7 +183,7 @@ class Composer(
         dependencies.filterNot { packageName ->
             packageName in EXCLUDED_PACKAGES
                     || packageName.startsWith("ext-") // Exclude extensions to PHP itself.
-                    || packageName in virtualPackages // Exclude virtual packages as they have no meta-data.
+                    || packageName in virtualPackages // Exclude virtual packages as they have no metadata.
         }.forEach { packageName ->
             val packageInfo = packages[packageName]
                 ?: throw IOException("Could not find package info for $packageName")

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -358,7 +358,7 @@ open class Npm(
         val workingDir = definitionFile.parentFile
 
         stashDirectories(workingDir.resolve("node_modules")).use {
-            // Actually installing the dependencies is the easiest way to get the meta-data of all transitive
+            // Actually installing the dependencies is the easiest way to get the metadata of all transitive
             // dependencies (i.e. their respective "package.json" files). As NPM uses a global cache, the same
             // dependency is only ever downloaded once.
             installDependencies(workingDir)

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -219,9 +219,9 @@ class Pip(
     override fun resolveDependencies(definitionFile: File): List<ProjectAnalyzerResult> {
         // For an overview, dependency resolution involves the following steps:
         // 1. Install dependencies via pip (inside a virtualenv, for isolation from globally installed packages).
-        // 2. Get meta-data about the local project via pydep (only for setup.py-based projects).
+        // 2. Get metadata about the local project via pydep (only for setup.py-based projects).
         // 3. Get the hierarchy of dependencies via pipdeptree.
-        // 4. Get additional remote package meta-data via PyPIJSON.
+        // 4. Get additional remote package metadata via PyPIJSON.
 
         val workingDir = definitionFile.parentFile
         val virtualEnvDir = setupVirtualEnv(workingDir, definitionFile)
@@ -229,7 +229,7 @@ class Pip(
         // List all packages installed locally in the virtualenv.
         val pipdeptree = runInVirtualEnv(virtualEnvDir, workingDir, "pipdeptree", "-l", "--json-tree")
 
-        // Get the locally available meta data for all installed packages as a fallback.
+        // Get the locally available metadata for all installed packages as a fallback.
         val installedPackages = getInstalledPackagesWithLocalMetaData(virtualEnvDir, workingDir).associateBy { it.id }
 
         // Install pydep after running any other command but before looking at the dependencies because it
@@ -251,7 +251,7 @@ class Pip(
         var authors: SortedSet<String> = sortedSetOf()
         var declaredLicenses: SortedSet<String> = sortedSetOf()
 
-        // First try to get meta-data from "setup.py" in any case, even for "requirements.txt" projects.
+        // First try to get metadata from "setup.py" in any case, even for "requirements.txt" projects.
         val (setupName, setupVersion, setupHomepage) = if (workingDir.resolve("setup.py").isFile) {
             val pydep = if (Os.isWindows) {
                 // On Windows, the script itself is not executable, so we need to wrap the call by "python".
@@ -289,7 +289,7 @@ class Pip(
                 }
             }
 
-            // In case of "requirements*.txt" there is no meta-data at all available, so use the parent directory name
+            // In case of "requirements*.txt" there is no metadata at all available, so use the parent directory name
             // plus what "*" expands to as the project name and the VCS revision, if any, as the project version.
             val suffix = definitionFile.name.removePrefix("requirements").removeSuffix(".txt")
             val name = definitionFile.parentFile.name + suffix
@@ -307,7 +307,7 @@ class Pip(
 
         val projectName = when {
             hasSetupName && !hasRequirementsName -> setupName
-            // In case of only a requirements file without further meta-data, use the relative path to the analyzer
+            // In case of only a requirements file without further metadata, use the relative path to the analyzer
             // root as a unique project name.
             !hasSetupName && hasRequirementsName -> definitionFile.relativeTo(analysisRoot).invariantSeparatorsPath
             hasSetupName && hasRequirementsName -> "$setupName-requirements$requirementsSuffix"
@@ -341,9 +341,9 @@ class Pip(
             val packageTemplates = sortedSetOf<Package>()
             parseDependencies(projectDependencies, packageTemplates, installDependencies)
 
-            // Enrich the package templates with additional meta-data from PyPI.
+            // Enrich the package templates with additional metadata from PyPI.
             packageTemplates.mapTo(packages) { pkg ->
-                // TODO: Retrieve meta data of package not hosted on PyPI by querying the respective repository.
+                // TODO: Retrieve metadata of package not hosted on PyPI by querying the respective repository.
                 pkg.enrichWith(getPackageFromPyPi(pkg.id))
                     .enrichWith(installedPackages[pkg.id])
             }
@@ -609,7 +609,7 @@ class Pip(
                 vcsProcessed = processPackageVcs(VcsInfo.EMPTY, homepageUrl)
             )
         }.onFailure {
-            log.warn { "Unable to retrieve PyPI meta-data for package '${id.toCoordinates()}'." }
+            log.warn { "Unable to retrieve PyPI metadata for package '${id.toCoordinates()}'." }
         }.getOrDefault(Package.EMPTY.copy(id = id))
     }
 

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -190,7 +190,7 @@ class Stack(
 
                 val pkg = allPackages.getOrPut(pkgId) {
                     if (pkgId.type == "Hackage") {
-                        // Enrich the package with additional meta-data from Hackage.
+                        // Enrich the package with additional metadata from Hackage.
                         downloadCabalFile(pkgId)?.let {
                             parseCabalFile(it)
                         } ?: pkgFallback
@@ -214,7 +214,7 @@ class Stack(
         val url = "${getPackageUrl(pkgId.name, pkgId.version)}/src/${pkgId.name}.cabal"
 
         return OkHttpClientHelper.downloadText(url).onFailure {
-            log.warn { "Unable to retrieve Hackage meta-data for package '${pkgId.toCoordinates()}'." }
+            log.warn { "Unable to retrieve Hackage metadata for package '${pkgId.toCoordinates()}'." }
         }.getOrNull()
     }
 

--- a/clients/clearly-defined/src/main/kotlin/Enums.kt
+++ b/clients/clearly-defined/src/main/kotlin/Enums.kt
@@ -114,7 +114,7 @@ enum class ContributionType {
 }
 
 /**
- * The status of meta-data harvesting of the various tools.
+ * The status of metadata harvesting of the various tools.
  */
 enum class HarvestStatus {
     NOT_HARVESTED,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,7 +60,7 @@ git checkout 2.1.18
 ## 4. Run the analyzer on `mime-types`
 
 The next step is to run the _analyzer_. It will create a JSON or YAML output file containing the full dependency tree of
-`mime-types` including the meta-data of `mime-types` and its dependencies.
+`mime-types` including the metadata of `mime-types` and its dependencies.
 
 ```bash
 # Command line help specific to the analyzer.

--- a/docs/sw360-integration.md
+++ b/docs/sw360-integration.md
@@ -52,7 +52,7 @@ cli/build/install/ort/bin/ort upload-result-to-sw360
   -i [analyzer-output-dir]/analyzer-result.yml
 ```
 
-## Use SW360 Package Meta-data Curations in ORT
+## Use SW360 Package Metadata Curations in ORT
 
 ### When to use
 

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -274,7 +274,7 @@ abstract class VersionControlSystem {
                 if (it.isNotBlank() && (allowMovingRevisions || isFixedRevision(workingTree, it))) {
                     if (revisionCandidates.add(it)) {
                         log.info {
-                            "Adding $type revision '$it' (taken from package meta-data) as a candidate."
+                            "Adding $type revision '$it' (taken from package metadata) as a candidate."
                         }
                     }
                 }
@@ -283,7 +283,7 @@ abstract class VersionControlSystem {
             it.showStackTrace()
 
             log.info {
-                "Meta-data has invalid $type revision '${pkg.vcsProcessed.revision}': ${it.collectMessagesAsString()}"
+                "Metadata has invalid $type revision '${pkg.vcsProcessed.revision}': ${it.collectMessagesAsString()}"
             }
 
             emptyRevisionCandidatesException.addSuppressed(it)

--- a/evaluator/src/main/kotlin/PackageRule.kt
+++ b/evaluator/src/main/kotlin/PackageRule.kt
@@ -136,7 +136,7 @@ open class PackageRule(
         }
 
     /**
-     * A [RuleMatcher] that checks whether the [package][pkg] is meta data only.
+     * A [RuleMatcher] that checks whether the [package][pkg] is metadata only.
      */
     fun isMetaDataOnly() =
         object : RuleMatcher {

--- a/evaluator/src/test/kotlin/PackageRuleTest.kt
+++ b/evaluator/src/test/kotlin/PackageRuleTest.kt
@@ -106,14 +106,14 @@ class PackageRuleTest : WordSpec() {
         }
 
         "isMetaDataOnly()" should {
-            "return true for a package that has only meta data" {
+            "return true for a package that has only metadata" {
                 val rule = createPackageRule(packageMetaDataOnly)
                 val matcher = rule.isMetaDataOnly()
 
                 matcher.matches() shouldBe true
             }
 
-            "return false for a package that has not only meta data" {
+            "return false for a package that has not only metadata" {
                 val rule = createPackageRule(packageWithoutLicense)
                 val matcher = rule.isMetaDataOnly()
 

--- a/evaluator/src/test/kotlin/TestData.kt
+++ b/evaluator/src/test/kotlin/TestData.kt
@@ -111,7 +111,7 @@ val packageWithVulnerabilities = Package.EMPTY.copy(
 )
 
 val packageMetaDataOnly = Package.EMPTY.copy(
-    id = Identifier("Maven:org.ossreviewtoolkit:package-meta-data-only:1.0"),
+    id = Identifier("Maven:org.ossreviewtoolkit:package-metadata-only:1.0"),
     isMetaDataOnly = true
 )
 

--- a/examples/curations.yml
+++ b/examples/curations.yml
@@ -22,7 +22,7 @@
 #      url: "http://example.com/repo.git"
 #      revision: "1234abc"
 #      path: "subdirectory"
-#    is_meta_data_only: true # Whether the package is meta data only.
+#    is_meta_data_only: true # Whether the package is metadata only.
 #    is_modified: true # Whether the package is modified compared to the original source.
 
 - id: "Maven:asm:asm" # No version means the curation will be applied to all versions of the package.

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -30,7 +30,7 @@ import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.ProcessedDeclaredLicense
 
 /**
- * A generic descriptor for a software package. It contains all relevant meta-data about a package like the name,
+ * A generic descriptor for a software package. It contains all relevant metadata about a package like the name,
  * version, and how to retrieve the package and its source code. It does not contain information about the package's
  * dependencies, however. This is because at this stage we would only be able to get the declared dependencies, whereas
  * we are interested in the resolved dependencies. Resolved dependencies might differ from declared dependencies due to
@@ -101,7 +101,7 @@ data class Package(
     val sourceArtifact: RemoteArtifact,
 
     /**
-     * Original VCS-related information as defined in the [Package]'s meta-data.
+     * Original VCS-related information as defined in the [Package]'s metadata.
      */
     val vcs: VcsInfo,
 
@@ -111,7 +111,7 @@ data class Package(
     val vcsProcessed: VcsInfo = vcs.normalize(),
 
     /**
-     * Indicates whether this [Package] is just meta data, like e.g. Maven BOM artifacts which only define constraints
+     * Indicates whether this [Package] is just metadata, like e.g. Maven BOM artifacts which only define constraints
      * for dependency versions.
      */
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -28,8 +28,8 @@ import org.ossreviewtoolkit.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
 
 /**
- * This class contains curation data for a package. It is used to amend the automatically detected meta data for a
- * package with corrections. This is required because the meta data provided by a package can be wrong (e.g. outdated
+ * This class contains curation data for a package. It is used to amend the automatically detected metadata for a
+ * package with corrections. This is required because the metadata provided by a package can be wrong (e.g. outdated
  * VCS data) or incomplete.
  */
 @JsonIgnoreProperties(value = [/* Backwards-compatibility: */ "declared_licenses"])
@@ -79,7 +79,7 @@ data class PackageCurationData(
     val vcs: VcsInfoCurationData? = null,
 
     /**
-     * Whether the package is meta data only.
+     * Whether the package is metadata only.
      */
     val isMetaDataOnly: Boolean? = null,
 

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.ProcessedDeclaredLicense
 
 /**
  * A class describing a software project. A [Project] is very similar to a [Package] but contains some additional
- * meta-data like e.g. the [homepageUrl]. Most importantly, it defines the dependency scopes that refer to the actual
+ * metadata like e.g. the [homepageUrl]. Most importantly, it defines the dependency scopes that refer to the actual
  * packages.
  */
 @JsonIgnoreProperties(value = ["aliases", "purl"])
@@ -72,7 +72,7 @@ data class Project(
     val declaredLicensesProcessed: ProcessedDeclaredLicense = DeclaredLicenseProcessor.process(declaredLicenses),
 
     /**
-     * Original VCS-related information as defined in the [Project]'s meta-data.
+     * Original VCS-related information as defined in the [Project]'s metadata.
      */
     val vcs: VcsInfo,
 

--- a/model/src/main/kotlin/licenses/LicenseCategorization.kt
+++ b/model/src/main/kotlin/licenses/LicenseCategorization.kt
@@ -24,9 +24,9 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 
 /**
- * A class for configuring meta data for a specific license referred to by a SPDX license identifier.
+ * A class for configuring metadata for a specific license referred to by a SPDX license identifier.
  *
- * The meta data consists of assignments to generic categories whose exact meaning is customer specific.
+ * The metadata consists of assignments to generic categories whose exact meaning is customer specific.
  * The categories a license belong to can be evaluated by other components, such as rules or templates,
  * which can decide - based on this information - how to handle a specific license.
  */

--- a/model/src/main/kotlin/licenses/LicenseClassifications.kt
+++ b/model/src/main/kotlin/licenses/LicenseClassifications.kt
@@ -29,21 +29,21 @@ import org.ossreviewtoolkit.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.spdx.getDuplicates
 
 /**
- * Classifications for licenses which allow to assign meta data to licenses. This allows defining rather generic
+ * Classifications for licenses which allow to assign metadata to licenses. This allows defining rather generic
  * categories and assigning licenses to these. That way flexible classifications can be created based on
  * customizable categories. The available license categories need to be declared explicitly; when creating an
  * instance, it is checked that all the references from the [categorizations] point to existing [categories].
  */
 data class LicenseClassifications(
     /**
-     * Defines meta data for the license categories.
+     * Defines metadata for the license categories.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonAlias("license_sets")
     val categories: List<LicenseCategory> = emptyList(),
 
     /**
-     * Defines meta data for licenses.
+     * Defines metadata for licenses.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonAlias("licenses")

--- a/reporter-web-app/public/index.html
+++ b/reporter-web-app/public/index.html
@@ -8967,7 +8967,7 @@
                   "vcs" : {
                     "path" : "acorn"
                   },
-                  "comment" : "Package in 'acorn' path of the acorn repo, but this path is missing in meta-data."
+                  "comment" : "Package in 'acorn' path of the acorn repo, but this path is missing in metadata."
                 }
               } ],
               "paths" : [ 1 ],

--- a/reporter/src/main/kotlin/model/MetaData.kt
+++ b/reporter/src/main/kotlin/model/MetaData.kt
@@ -23,7 +23,7 @@ package org.ossreviewtoolkit.reporter.model
 import java.time.Instant
 
 /**
- * Meta data about the ORT run itself.
+ * Metadata about the ORT run itself.
  */
 data class MetaData(
     /**

--- a/reporter/src/main/kotlin/reporters/SpdxDocumentReporter.kt
+++ b/reporter/src/main/kotlin/reporters/SpdxDocumentReporter.kt
@@ -35,8 +35,8 @@ import org.ossreviewtoolkit.spdx.model.SpdxDocument
  * as a future extension of this [SpdxDocumentReporter] or as a separate [Reporter].
  *
  * This reporter supports the following options:
- * - *creationInfo.comment*: Add the corresponding value as meta-data to the [SpdxDocument].
- * - *document.comment*: Add the corresponding value as meta-data to the [SpdxDocument].
+ * - *creationInfo.comment*: Add the corresponding value as metadata to the [SpdxDocument].
+ * - *document.comment*: Add the corresponding value as metadata to the [SpdxDocument].
  * - *document.name*: The name of the generated [SpdxDocument], defaults to "Unnamed document".
  * - *output.file.formats*: The list of [FileFormat]s to generate, defaults to [FileFormat.YAML].
  */

--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -209,7 +209,7 @@ abstract class LocalScanner(
 
         val remainingPackages = packages.filterTo(mutableListOf()) { pkg ->
             !pkg.isMetaDataOnly.also {
-                if (it) LocalScanner.log.info { "Skipping '${pkg.id.toCoordinates()}' as it is meta data only." }
+                if (it) LocalScanner.log.info { "Skipping '${pkg.id.toCoordinates()}' as it is metadata only." }
             }
         }
 

--- a/spdx-utils/src/main/kotlin/model/SpdxCreationInfo.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxCreationInfo.kt
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import java.time.Instant
 
 /**
- * Meta data corresponding to a [SpdxDocument].
+ * Metadata corresponding to a [SpdxDocument].
  */
 data class SpdxCreationInfo(
     /**

--- a/spdx-utils/src/main/kotlin/model/SpdxFile.kt
+++ b/spdx-utils/src/main/kotlin/model/SpdxFile.kt
@@ -28,7 +28,7 @@ import org.ossreviewtoolkit.spdx.SpdxConstants.REF_PREFIX
 import org.ossreviewtoolkit.spdx.isSpdxExpressionOrNotPresent
 
 /**
- * Provides important meta-data about a particular file of a software package.
+ * Provides important metadata about a particular file of a software package.
  */
 @JsonIgnoreProperties("ranges") // TODO: Implement ranges which is broken in the specification examples.
 data class SpdxFile(


### PR DESCRIPTION
The "metadata" spelling seems to be way more common than "meta data" or
"meta-data".

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>