### PR TITLE
config-file-ort-yml: Fix example for project-local curations

### DIFF
--- a/docs/config-file-ort-yml.md
+++ b/docs/config-file-ort-yml.md
@@ -167,7 +167,7 @@ The following example corrects the source-artifact URL of the package with the i
 e.g.:
 ```yaml
 curations:
-  package_curations:
+  packages:
   - id: "Maven:com.example:dummy:0.0.1"
     comment: "An explanation why the curation is needed."
     source_artifact:


### PR DESCRIPTION
This is a fixup for f4a0ea166372635fe0bf0651dabc6928611118e4.
