### PR TITLE
config-file-ort-yml: Fix wrong documentation about project-local package-configurations

### DIFF
--- a/docs/config-file-ort-yml.md
+++ b/docs/config-file-ort-yml.md
@@ -155,18 +155,17 @@ curations:
 
 For findings in third-party dependencies package-configurations can be used to replace findings:
 ```yaml
-configurations:
-  package_configurations:
-  - id: 'Maven:com.example:package:1.2.3'
-    source_artifact_url: "https://repo.maven.apache.org/maven2/com/example/package/1.2.3/package-1.2.3-sources.jar"
-    license_finding_curations:
-    - path: "path/to/problematic/file.java"
-      start_lines: 22
-      line_count: 1
-      detected_license: "GPL-2.0-only"
-      reason: "CODE"
-      comment: "The scanner matches a variable named `gpl`."
-      concluded_license: "Apache-2.0"
+package_configurations:
+- id: 'Maven:com.example:package:1.2.3'
+  source_artifact_url: "https://repo.maven.apache.org/maven2/com/example/package/1.2.3/package-1.2.3-sources.jar"
+  license_finding_curations:
+  - path: "path/to/problematic/file.java"
+    start_lines: 22
+    line_count: 1
+    detected_license: "GPL-2.0-only"
+    reason: "CODE"
+    comment: "The scanner matches a variable named `gpl`."
+    concluded_license: "Apache-2.0"
 ```
 
 For details of the specification, see 


### PR DESCRIPTION
This is a fixup for e2b6a34e0a029308f63daf75dda4e1b42a846cb0.
