### PR TITLE
Dockerfile: Do not hard-code $HOME to /root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY . /usr/local/src/ort
 WORKDIR /usr/local/src/ort
 
 # Gradle build.
-RUN --mount=type=cache,target=/root/.gradle/ \
+RUN --mount=type=cache,target=$HOME/.gradle/ \
     scripts/import_proxy_certs.sh && \
     scripts/set_gradle_proxy.sh && \
     sed -i -r 's,(^distributionUrl=)(.+)-all\.zip$,\1\2-bin.zip,' gradle/wrapper/gradle-wrapper.properties && \


### PR DESCRIPTION
This is to allow running as a non-root user.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>