### PR TITLE
workflows: Enable Java dependency caching

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -21,6 +21,7 @@ jobs:
       with:
         distribution: 'adopt'
         java-version: 11
+        cache: 'gradle'
     - name: Check for Detekt Issues
       uses: burrunan/gradle-cache-action@v1
       with:


### PR DESCRIPTION
See https://github.blog/changelog/2021-08-30-github-actions-setup-java-now-supports-dependency-caching/.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>