### PR TITLE
Allow to use a different scanner for projects than for packages

### DIFF
--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -135,7 +135,7 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
                     it.isFile && it.name == transformedScanResultsFileName
                 }.count()
 
-                println("Local file storage has $fileCount scan results files.")
+                println("Local file storage has $fileCount scan results file(s).")
             }
         }
 

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -44,7 +44,7 @@ const val TOOL_NAME = "scanner"
 
 /**
  * Use the [scanner] to scan the [Project]s and [Package]s specified in the [ortResult]. Scan results are stored in the
- * [outputDirectory].  If [skipExcluded] is true, packages for which excludes are defined are not scanned. Return scan
+ * [outputDirectory]. If [skipExcluded] is true, packages for which excludes are defined are not scanned. Return scan
  * results as an [OrtResult].
  */
 fun scanOrtResult(

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -64,7 +64,7 @@ fun scanOrtResult(
         return ortResult
     }
 
-    // Add the projects as packages to scan.
+    // Determine the projects to scan as packages.
     val consolidatedProjects = consolidateProjectPackagesByVcs(ortResult.getProjects(skipExcluded))
     val projectPackages = consolidatedProjects.keys
 


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.