### PR TITLE
Dockerfile: Set `GRADLE_USER_HOME` instead of using a symlink to the default location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ WORKDIR /usr/local/src/ort
 
 # Gradle build.
 RUN --mount=type=cache,target=/tmp/.gradle/ \
-    ln -s /tmp/.gradle/ $HOME/.gradle && \
+    GRADLE_USER_HOME=/tmp/.gradle/ && \
     scripts/import_proxy_certs.sh && \
     scripts/set_gradle_proxy.sh && \
     sed -i -r 's,(^distributionUrl=)(.+)-all\.zip$,\1\2-bin.zip,' gradle/wrapper/gradle-wrapper.properties && \


### PR DESCRIPTION
In some environments using a symlink to `$HOME/.gradle` won't work.
Instead, change the location by setting `GRADLE_HOME`.

For our Azure environment gradle is not able to create a lock file when symlinking the `.gradle` directory:
```
#15 [build 5/5] RUN --mount=type=cache,target=/tmp/.gradle/     ln -s /tmp/....
#15 1.381 Skipping the import of certificates as no HTTPS proxy is set.
#15 1.790 Exception in thread "main" java.lang.RuntimeException: Could not create parent directory for lock file /root/.gradle/wrapper/dists/gradle-7.2-bin/2dnblmf4td7x66yl1d74lt32g/gradle-7.2-bin.zip.lck
#15 1.791   at org.gradle.wrapper.ExclusiveFileAccessManager.access(ExclusiveFileAccessManager.java:43)
#15 1.792   at org.gradle.wrapper.Install.createDist(Install.java:48)
#15 1.792   at org.gradle.wrapper.WrapperExecutor.execute(WrapperExecutor.java:107)
#15 1.792   at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:63)
#15 ERROR: executor failed running [/bin/sh -c ln -s /tmp/.gradle/ $HOME/.gradle &&     scripts/import_proxy_certs.sh &&     scripts/set_gradle_proxy.sh &&     sed -i -r 's,(^distributionUrl=)(.+)-all\.zip$,\1\2-bin.zip,' gradle/wrapper/gradle-wrapper.properties &&     ./gradlew --no-daemon --stacktrace -Pversion=$ORT_VERSION :cli:distTar :helper-cli:startScripts]: runc did not terminate sucessfully
```