### PR TITLE
DependencyGraph: Fix a crash and a couple of subsequent issues

### DIFF
--- a/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
@@ -370,19 +370,19 @@ class DependencyGraphBuilder<D>(
 private fun Collection<DependencyReference>.toGraph(): Pair<List<DependencyGraphNode>, List<DependencyGraphEdge>> {
     val nodes = mutableSetOf<DependencyGraphNode>()
     val edges = mutableListOf<DependencyGraphEdge>()
-    val nodeIndexMapping = mutableMapOf<DependencyReference, Int>()
+    val nodeIndexMapping = mutableMapOf<NodeKey, Int>()
 
     fun constructGraph(dependencies: Collection<DependencyReference>) {
         dependencies.forEach { ref ->
             val node = DependencyGraphNode(ref.pkg, ref.fragment, ref.linkage, ref.issues)
             if (node !in nodes) {
-                val fromIndex = nodes.size.also { nodeIndexMapping[ref] = it }
+                val fromIndex = nodes.size.also { nodeIndexMapping[ref.key] = it }
                 nodes += node
 
                 constructGraph(ref.dependencies)
 
                 ref.dependencies.forEach { dep ->
-                    edges += DependencyGraphEdge(fromIndex, nodeIndexMapping.getValue(dep))
+                    edges += DependencyGraphEdge(fromIndex, nodeIndexMapping.getValue(dep.key))
                 }
             }
         }
@@ -391,3 +391,11 @@ private fun Collection<DependencyReference>.toGraph(): Pair<List<DependencyGraph
     constructGraph(this)
     return nodes.toList() to edges
 }
+
+private data class NodeKey(
+    val pkg: Int,
+    val fragment: Int
+)
+
+private val DependencyReference.key: NodeKey
+    get() = NodeKey(pkg, fragment)

--- a/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
@@ -370,19 +370,19 @@ class DependencyGraphBuilder<D>(
 private fun Collection<DependencyReference>.toGraph(): Pair<List<DependencyGraphNode>, List<DependencyGraphEdge>> {
     val nodes = mutableSetOf<DependencyGraphNode>()
     val edges = mutableListOf<DependencyGraphEdge>()
-    val nodeIndexMapping = mutableMapOf<NodeKey, Int>()
+    val nodeIndices = mutableMapOf<NodeKey, Int>()
 
     fun constructGraph(dependencies: Collection<DependencyReference>) {
         dependencies.forEach { ref ->
             val node = DependencyGraphNode(ref.pkg, ref.fragment, ref.linkage, ref.issues)
             if (node !in nodes) {
-                val fromIndex = nodes.size.also { nodeIndexMapping[ref.key] = it }
+                val fromIndex = nodes.size.also { nodeIndices[ref.key] = it }
                 nodes += node
 
                 constructGraph(ref.dependencies)
 
                 ref.dependencies.forEach { dep ->
-                    edges += DependencyGraphEdge(fromIndex, nodeIndexMapping.getValue(dep.key))
+                    edges += DependencyGraphEdge(fromIndex, nodeIndices.getValue(dep.key))
                 }
             }
         }

--- a/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
@@ -387,14 +387,14 @@ private fun Collection<DependencyReference>.toGraph(): Pair<List<DependencyGraph
     val edges = mutableListOf<DependencyGraphEdge>()
     val nodeIndices = mutableMapOf<NodeKey, Int>()
 
-    visitEach { ref ->
-        val node = DependencyGraphNode(ref.pkg, ref.fragment, ref.linkage, ref.issues)
+    visitEach { fromRef ->
+        val node = DependencyGraphNode(fromRef.pkg, fromRef.fragment, fromRef.linkage, fromRef.issues)
         if (node !in nodes) {
-            val fromIndex = nodes.size.also { nodeIndices[ref.key] = it }
+            val fromIndex = nodes.size.also { nodeIndices[fromRef.key] = it }
             nodes += node
 
-            ref.dependencies.forEach { dep ->
-                edges += DependencyGraphEdge(fromIndex, nodeIndices.getValue(dep))
+            fromRef.dependencies.forEach { toRef ->
+                edges += DependencyGraphEdge(fromIndex, nodeIndices.getValue(toRef.key))
             }
         }
     }

--- a/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
@@ -161,14 +161,18 @@ class DependencyGraphBuilder<D>(
      * the conditions do not hold then.
      */
     fun build(checkReferences: Boolean = true): DependencyGraph {
-        require(!checkReferences || resolvedPackages.keys.containsAll(validPackageDependencies)) {
-            "The following references do not actually refer to packages: " +
-                    "${validPackageDependencies - resolvedPackages.keys}."
-        }
+        if (checkReferences) checkReferences()
 
         val (nodes, edges) = directDependencies.toGraph()
 
         return DependencyGraph(dependencyIds, sortedSetOf(), scopeMapping, nodes, edges)
+    }
+
+    private fun checkReferences() {
+        require(resolvedPackages.keys.containsAll(validPackageDependencies)) {
+            "The following references do not actually refer to packages: " +
+                    "${validPackageDependencies - resolvedPackages.keys}."
+        }
     }
 
     /**

--- a/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
@@ -173,6 +173,15 @@ class DependencyGraphBuilder<D>(
             "The following references do not actually refer to packages: " +
                     "${validPackageDependencies - resolvedPackages.keys}."
         }
+
+        val packageReferencesKeysWithMultipleDistinctPackageReferences = directDependencies.groupBy { it.key }.filter {
+            it.value.distinct().size > 1
+        }.keys
+
+        require(packageReferencesKeysWithMultipleDistinctPackageReferences.isEmpty()) {
+            "Found multiple distinct package references for each of the following package / fragment index tuples " +
+                "${packageReferencesKeysWithMultipleDistinctPackageReferences.joinToString()}."
+        }
     }
 
     /**

--- a/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
@@ -30,6 +30,7 @@ import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.RootDependencyIndex
+import org.ossreviewtoolkit.utils.log
 
 /**
  * Internal class to represent the result of a search in the dependency graph. The outcome of the search
@@ -167,7 +168,19 @@ class DependencyGraphBuilder<D>(
 
         val (nodes, edges) = directDependencies.toGraph()
 
-        return DependencyGraph(dependencyIds, sortedSetOf(), scopeMapping, nodes, edges)
+        return DependencyGraph(dependencyIds, sortedSetOf(), scopeMapping, nodes, edges.removeCycles())
+    }
+
+    private fun Collection<DependencyGraphEdge>.removeCycles(): List<DependencyGraphEdge> {
+        val edges = mapTo(mutableSetOf()) { it.from to it.to }
+        val edgesToKeep = breakCycles(edges)
+        val edgesToRemove = edges - edgesToKeep
+
+        edgesToRemove.forEach {
+            this@DependencyGraphBuilder.log.warn { "Removing edge '${it.first} -> ${it.second}' to break a cycle." }
+        }
+
+        return filter { it.from to it.to in edgesToKeep }
     }
 
     private fun checkReferences() {
@@ -427,3 +440,46 @@ private data class NodeKey(
 
 private val DependencyReference.key: NodeKey
     get() = NodeKey(pkg, fragment)
+
+private enum class NodeColor { WHITE, GRAY, BLACK }
+
+/**
+ * A depth-first-search (DFS)-based implementation which breaks all cycles in O(V + E).
+ * Finding a minimal solution is NP-complete.
+ */
+internal fun breakCycles(edges: Collection<Pair<Int, Int>>): Set<Pair<Int, Int>> {
+    val outgoingEdgesForNodes = edges.groupBy({ it.first }, { it.second }).mapValues { it.value.toMutableSet() }
+    val color = outgoingEdgesForNodes.keys.associateWithTo(mutableMapOf()) { NodeColor.WHITE }
+
+    fun visit(u: Int) {
+        color[u] = NodeColor.GRAY
+
+        val nodesClosingCircle = mutableSetOf<Int>()
+
+        outgoingEdgesForNodes[u].orEmpty().forEach { v ->
+            if (color[v] == NodeColor.WHITE) {
+                visit(v)
+            } else if (color[v] == NodeColor.GRAY) {
+                nodesClosingCircle += v
+            }
+        }
+
+        outgoingEdgesForNodes[u]?.removeAll(nodesClosingCircle)
+
+        color[u] = NodeColor.BLACK
+    }
+
+    val queue = LinkedList(outgoingEdgesForNodes.keys)
+
+    while (queue.isNotEmpty()) {
+        val v = queue.removeFirst()
+
+        if (color.getValue(v) != NodeColor.WHITE) continue
+
+        visit(v)
+    }
+
+    return outgoingEdgesForNodes.flatMapTo(mutableSetOf()) { (fromNode, toNodes) ->
+        toNodes.map { toNode -> fromNode to toNode }
+    }
+}

--- a/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
+++ b/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
@@ -24,6 +24,7 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -247,6 +248,38 @@ class DependencyGraphBuilderTest : WordSpec({
                 .addDependency("s", depLang)
                 .addDependency("s", depLog)
                 .build(checkReferences = false)
+        }
+    }
+
+    "breakCycles()" should {
+        "not break undirected cycles" {
+            val edges = listOf(
+                1 to 2,
+                2 to 3,
+                3 to 4,
+                1 to 4
+            )
+
+            breakCycles(edges) shouldContainExactlyInAnyOrder edges
+        }
+
+        "break a directed cycle with a single node" {
+            val edges = listOf(1 to 1)
+
+            breakCycles(edges) should beEmpty()
+        }
+
+        "break directed cycles involving multiple nodes" {
+            val edges = listOf(
+                1 to 2,
+                2 to 3,
+                3 to 4,
+                4 to 1
+            )
+
+            val result = breakCycles(edges)
+
+            result.intersect(edges) shouldHaveSize 3
         }
     }
 })


### PR DESCRIPTION
When `DependencyGraphBuilder.toGraph()` looks-up the node index of the "to node" of an edge, the look-up may fail since it happens that the map entry hasn't been created before. Fix that issue (crash) by making sure that the map entry is properly created.

The false logic which exhibited that bug also skipped edges which may mean actually eliminating circles. 
In fact when fixing the logic, ORT runs into a subsequent issue because several consumers of the graph assume the absence of any cycle. 

While in the long run it makes sense to allow cycle in the graph, implement a temporary solution to just break all cycle. 
Allowing circles is a bigger topic and needs proper planning and involvement of all relevant people. The goal of this PR is to fix the crash in the short term.

Fixes #4405.