### PR TITLE
Upgrade the ScanCode version (and install it from binary release)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -81,4 +81,4 @@ buildCacheRetentionDays = 7
 
 kotlin.code.style = official
 
-scancodeVersion = 3.2.1-rc2
+scancodeVersion = 21.8.4


### PR DESCRIPTION
Binary releases are slightly more featureful and better supported by upstream
We also make sure we properly run the configure script (instead of running it implicitly)
and run it inside its own directory which is what it is expecting.

and additional scancode-pip binary is linked so that you can install custom plugins
(which is what we have at Renault)

superseeds #4324 