### PR TITLE
azure-pipelines: Temporarily disable building the reporter-web-app

### DIFF
--- a/.azure-pipelines/LinuxTest.yml
+++ b/.azure-pipelines/LinuxTest.yml
@@ -75,7 +75,7 @@ jobs:
     inputs:
       gradleWrapperFile: gradlew
       # TODO: Only exclude ExpensiveTag on PR builds.
-      options: --no-daemon --stacktrace -Dkotest.tags.exclude=ExpensiveTag -Dkotest.assertions.multi-line-diff=simple -x analyzer:test -x analyzer:funTest -PbuildCacheRetentionDays=3
+      options: --no-daemon --stacktrace -Dkotest.tags.exclude=ExpensiveTag -Dkotest.assertions.multi-line-diff=simple -x analyzer:test -x analyzer:funTest -x :reporter-web-app:yarnBuild -PbuildCacheRetentionDays=3
       tasks: test funTest jacocoReport
       publishJUnitResults: true
       testResultsFiles: '**/flattened/TEST-*.xml'


### PR DESCRIPTION
For unknown reasons this currently causes a MODULE_NOT_FOUND error on
Azure [1].

[1]: https://dev.azure.com/oss-review-toolkit/ort/_build/results?buildId=5386&view=logs&j=73971eb3-8d1e-575d-2f23-aa690e8d7d5f&t=22252e19-f5e4-50c3-b539-7e131bc11d8a&l=120

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>