### PR TITLE
Configuration for project-local package-configurations and curations

### DIFF
--- a/docs/config-file-ort-yml.md
+++ b/docs/config-file-ort-yml.md
@@ -153,7 +153,9 @@ curations:
     concluded_license: "Apache-2.0"
  ```
 
-For findings in third-party dependencies package-configurations can be used to replace findings:
+To correct identified licenses in a dependency you can use a package configuration to overwrite scanner findings.
+Note that this feature requires `enableRepositoryPackageConfigurations` to be enabled in the `ort.conf` see
+[reference.conf](../model/src/main/resources/reference.conf).
 ```yaml
 package_configurations:
 - id: 'Maven:com.example:package:1.2.3'

--- a/docs/config-file-ort-yml.md
+++ b/docs/config-file-ort-yml.md
@@ -178,6 +178,8 @@ The list of available options for `reason` are defined in
 Package curations can be added if you want to correct metadata of third-party dependencies.
 
 The following example corrects the source-artifact URL of the package with the id `Maven:com.example:dummy:0.0.1`.
+Note that this feature requires `enableRepositoryPackageCurations` to be enabled in the `ort.conf`, see
+[reference.conf](../model/src/main/resources/reference.conf).
 
 e.g.:
 ```yaml

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -66,6 +66,13 @@ data class OrtConfiguration(
     val enableRepositoryPackageCurations: Boolean = false,
 
     /**
+     * Enable the usage of project-local package configurations from the [RepositoryConfiguration]. If set to true,
+     * apply package configurations from a local .ort.yml file before applying those specified via the command line i.e.
+     * configurations from the .ort.yml take precedence.
+     */
+    val enableRepositoryPackageConfigurations: Boolean = false,
+
+    /**
      * The configuration of the analyzer.
      */
     val analyzer: AnalyzerConfiguration = AnalyzerConfiguration(),

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -59,6 +59,13 @@ data class OrtConfiguration(
     val severeRuleViolationThreshold: Severity = Severity.WARNING,
 
     /**
+     * Enable the usage of project-local package curations from the [RepositoryConfiguration]. If set to true, apply
+     * package curations from a local .ort.yml file before applying those specified via the command line i.e. curations
+     * from the.ort.yml take precedence.
+     */
+    val enableRepositoryPackageCurations: Boolean = false,
+
+    /**
      * The configuration of the analyzer.
      */
     val analyzer: AnalyzerConfiguration = AnalyzerConfiguration(),

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -10,6 +10,8 @@ ort {
   severeIssueThreshold = ERROR
   severeRuleViolationThreshold = ERROR
 
+  enableRepositoryPackageCurations = true
+
   analyzer {
     ignoreToolVersions = true
     allowDynamicVersions = true

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -11,6 +11,7 @@ ort {
   severeRuleViolationThreshold = ERROR
 
   enableRepositoryPackageCurations = true
+  enableRepositoryPackageConfigurations = true
 
   analyzer {
     ignoreToolVersions = true

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -179,6 +179,7 @@ class OrtConfigurationTest : WordSpec({
             }
 
             ortConfig.enableRepositoryPackageCurations shouldBe true
+            ortConfig.enableRepositoryPackageConfigurations shouldBe true
         }
 
         "correctly prioritize the sources" {

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -177,6 +177,8 @@ class OrtConfigurationTest : WordSpec({
                 patentFilenames shouldContainExactly listOf("patents")
                 rootLicenseFilenames shouldContainExactly listOf("readme*")
             }
+
+            ortConfig.enableRepositoryPackageCurations shouldBe true
         }
 
         "correctly prioritize the sources" {

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -162,9 +162,7 @@ class OrtConfigurationTest : WordSpec({
                     useSsl shouldBe true
                     fromAddress shouldBe "no-reply@oss-review-toolkit.org"
                 }
-            }
 
-            with(ortConfig.notifier) {
                 jira shouldNotBeNull {
                     host shouldBe "localhost"
                     username shouldBe "user"


### PR DESCRIPTION
This disables the project-local package-configuration and curations by default, as it was discussed in the [developer meeting](https://github.com/oss-review-toolkit/ort/wiki/Developer-Meeting#2021-09-02).