### PR TITLE
declared-license-mapping: Add mapping for "Eclipse Public License - Version 2.0"

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -177,6 +177,7 @@
 "Eclipse Public License (EPL)": EPL-1.0
 "Eclipse Public License (EPL), Version 1.0": EPL-1.0
 "Eclipse Public License - Version 1.0": EPL-1.0
+"Eclipse Public License - Version 2.0": EPL-2.0
 "Eclipse Public License - v 1.0": EPL-1.0
 "Eclipse Public License - v 2.0": EPL-2.0
 "Eclipse Public License 1.0 (EPL-1.0)": EPL-1.0


### PR DESCRIPTION
Found in [1].

[1]: https://github.com/eclipse/paho.mqtt.java/blob/v1.2.4/pom.xml#L50.
