### PR TITLE
 docs: Drop the "experimental" state from package configurations

### DIFF
--- a/docs/config-file-package-configuration-yml.md
+++ b/docs/config-file-package-configuration-yml.md
@@ -1,4 +1,4 @@
-# The Package Configuration File (Experimental)
+# The Package Configuration File
 
 A package configuration file allows you to define path excludes and license finding curations for a specific package
 (dependency) and provenance. Conceptually, the file is similar to


### PR DESCRIPTION
Package configurations have been around for about 1.5 years already,
are actively being used and the implementation has remained stable. So,
they are not experimental anymore.