### PR TITLE
GoMod: Remove an unnecessary capturing group in a regex

### DIFF
--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -322,7 +322,7 @@ private class Graph(private val nodeMap: MutableMap<Identifier, Set<Identifier>>
 }
 
 // See https://golang.org/ref/mod#pseudo-versions.
-private val PSEUDO_VERSION_REGEX = "^v0.0.0-(?:[\\d]{14}-(?<sha1>[0-9a-f]+)$)".toRegex()
+private val PSEUDO_VERSION_REGEX = "^v0.0.0-[\\d]{14}-(?<sha1>[0-9a-f]+)$".toRegex()
 
 /** Separator string indicating that data of a new package follows in the output of the go mod why command. */
 private const val PACKAGE_SEPARATOR = "# "


### PR DESCRIPTION
Only the named "sha1" group is used. This fixes an inspection hint.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>