### PR TITLE
fossid-webapp: Fix logging in FossId scanner

### DIFF
--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -375,7 +375,7 @@ class FossId internal constructor(
                 ScanStatus.STARTED, ScanStatus.STARTING, ScanStatus.RUNNING, ScanStatus.SCANNING, ScanStatus.AUTO_ID,
 
                 ScanStatus.QUEUED -> {
-                    log.warn {
+                    FossId.log.warn {
                         "Found a previous scan which is still running. Will ignore the 'waitForResult' option and " +
                                 "wait..."
                     }


### PR DESCRIPTION
This prevent an exception "Logging is only allowed on ORT classes, but
'java.util.Arrays.ArrayList' is used."

```
Exception in thread "main" java.lang.IllegalArgumentException: Logging is only allowed on ORT classes, but 'java.util.Arrays.ArrayList' is used.
	at org.ossreviewtoolkit.scanner.scanners.fossid.FossId.findLatestPendingOrFinishedScan(FossId.kt:1092)
	at org.ossreviewtoolkit.scanner.scanners.fossid.FossId.access$findLatestPendingOrFinishedScan(FossId.kt:76)
	at org.ossreviewtoolkit.scanner.scanners.fossid.FossId$findLatestPendingOrFinishedScan$1.invokeSuspend(FossId.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
```