### PR TITLE
FossIdConfig: Align parsing of booleans for clarity and case-insensitivity

### DIFF
--- a/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
@@ -135,9 +135,9 @@ internal data class FossIdConfig(
                 ?: throw IllegalArgumentException("No FossId User configuration found.")
             val packageNamespaceFilter = fossIdScannerOptions[NAMESPACE_FILTER_PROPERTY].orEmpty()
             val packageAuthorsFilter = fossIdScannerOptions[AUTHORS_FILTER_PROPERTY].orEmpty()
-            val addAuthenticationToUrl = fossIdScannerOptions[CREDENTIALS_IN_URL_PROPERTY].toBoolean()
-            val waitForResult = fossIdScannerOptions[WAIT_FOR_RESULT_PROPERTY]?.toBooleanStrictOrNull() ?: true
-            val deltaScans = fossIdScannerOptions[DELTA_SCAN_PROPERTY].toBoolean()
+            val addAuthenticationToUrl = fossIdScannerOptions[CREDENTIALS_IN_URL_PROPERTY]?.toBoolean() ?: false
+            val waitForResult = fossIdScannerOptions[WAIT_FOR_RESULT_PROPERTY]?.toBoolean() ?: true
+            val deltaScans = fossIdScannerOptions[DELTA_SCAN_PROPERTY]?.toBoolean() ?: false
 
             val deltaScanLimit = fossIdScannerOptions[DELTA_SCAN_LIMIT_PROPERTY]?.toInt() ?: Int.MAX_VALUE
             require(deltaScanLimit > 0) {


### PR DESCRIPTION
toBooleanStrictOrNull() parses case-sensitively while toBoolean() is
case-insensitive. Align on the latter for more lenient parsing.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>