### PR TITLE
PackageManager: Fix a broken assumption

### DIFF
--- a/model/src/test/kotlin/CompatibilityDependencyNavigatorTest.kt
+++ b/model/src/test/kotlin/CompatibilityDependencyNavigatorTest.kt
@@ -217,10 +217,18 @@ class CompatibilityDependencyNavigatorTest : WordSpec() {
  */
 private fun createOrtResult(vararg projects: Project): OrtResult {
     val graph = DependencyGraph(packages = emptyList(), scopeRoots = sortedSetOf(), scopes = emptyMap())
-    val analyzerResult =
-        AnalyzerResult(sortedSetOf(*projects), sortedSetOf(), dependencyGraphs = mapOf("test" to graph))
-    val analyzerRun =
-        AnalyzerRun(result = analyzerResult, environment = Environment(), config = AnalyzerConfiguration())
+
+    val analyzerResult = AnalyzerResult(
+        projects = sortedSetOf(*projects),
+        packages = sortedSetOf(),
+        dependencyGraphs = mapOf("test" to graph)
+    )
+
+    val analyzerRun = AnalyzerRun(
+        result = analyzerResult,
+        environment = Environment(),
+        config = AnalyzerConfiguration()
+    )
 
     return OrtResult.EMPTY.copy(analyzer = analyzerRun)
 }


### PR DESCRIPTION
PackageMangaer: Fix a broken assumption
    
The evaluator calls `CompatibilityDependencyNavigator.create()` in order
to construct a dependency navigator. That function creates an instance
 of DependencyGraphNavigator if `Project.scopeNames` is not null [2].
The constructor of DependencyGraphNavigator in turn requires a
dependency graph to exist [3].
    
That requires check [3] fails if the project has an empty set as
`scopeNames` and at the same time there is no dependency graph available
for the type of the project. This happens e.g. if a source tree with
only one definition file is analyzed, whereas `resolvedDependencies()`
fails with an exception, see [4]. The failed requires check results in
a crash of the evaluator.
    
Guarantee that in case `project.usesTree() == false` a dependency graph
for the corresponding project type exists, to fix that problem.
    
[1] https://github.com/oss-review-toolkit/ort/blob/42845fa5eb5fbb1a9bc617aa778c2979ca0da26d/model/src/main/kotlin/CompatibilityDependencyNavigator.kt#L47-L60
[2] https://github.com/oss-review-toolkit/ort/blob/463a6ebb57cd3e9613b954a2094a509947c85dc3/model/src/main/kotlin/CompatibilityDependencyNavigator.kt#L96
[3] https://github.com/oss-review-toolkit/ort/blob/463a6ebb57cd3e9613b954a2094a509947c85dc3/model/src/main/kotlin/DependencyGraphNavigator.kt#L29-L31
[4] https://github.com/oss-review-toolkit/ort/blob/463a6ebb57cd3e9613b954a2094a509947c85dc3/analyzer/src/main/kotlin/PackageManager.kt#L255
   
Fixes #4441 .