### PR TITLE
declared-license-mapping: Add an entry for OLDAP-2.8

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -408,6 +408,7 @@
 "The MIT License(MIT)": MIT
 "The MIT": MIT
 "The New BSD License": BSD-3-Clause
+"The OpenLDAP Public License, Version 2.8, 17 August 2003": OLDAP-2.8
 "The PostgreSQL License": PostgreSQL
 "The SAX License": SAX-PD
 "The W3C License": W3C


### PR DESCRIPTION
Found in [1].

[1] https://jcenter.bintray.com/io/objectbox/objectbox-android/2.8.1/objectbox-android-2.8.1.pom
