### PR TITLE
README: Group supported package managers by primary programming language

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,39 +316,58 @@ JSON, see `-f`) format to a file named `analyzer-result.yml` in the specified ou
 exactly documents the status quo of all package-related metadata. It can be further processed or manually edited before
 passing it to one of the other tools.
 
-Currently, the following package managers are supported:
+Currently, the following package managers (grouped by the programming language they are most commonly used with) are
+supported:
 
-* [Bower](http://bower.io/) (JavaScript)
-* [Bundler](http://bundler.io/) (Ruby)
-* [Cargo](https://doc.rust-lang.org/cargo/) (Rust)
-* [Carthage](https://github.com/Carthage/Carthage) (iOS / Cocoa)
-* [CocoaPods](https://github.com/CocoaPods/CocoaPods) (iOS / Cocoa, with currently some
-  [limitations](https://github.com/oss-review-toolkit/ort/issues/4188))  
-* [Composer](https://getcomposer.org/) (PHP)
-* [Conan](https://conan.io/) (C / C++, *experimental* as the VCS locations often times do not contain the actual source
-  code, see [issue #2037](https://github.com/oss-review-toolkit/ort/issues/2037))
-* [dep](https://golang.github.io/dep/) (Go)
-* [DotNet](https://docs.microsoft.com/en-us/dotnet/core/tools/) (.NET, with currently some
-  [limitations](https://github.com/oss-review-toolkit/ort/pull/1303#issue-253860146))
-* [Glide](https://github.com/Masterminds/glide) (Go)
-* [Godep](https://github.com/tools/godep) (Go)
-* [GoMod](https://github.com/golang/go/wiki/Modules) (Go)
-* [Gradle](https://gradle.org/) (Java)
-* [Maven](http://maven.apache.org/) (Java)
-* [NPM](https://www.npmjs.com/) (Node.js)
-* [NuGet](https://www.nuget.org/) (.NET, with currently some
-  [limitations](https://github.com/oss-review-toolkit/ort/pull/1303#issue-253860146))
-* [PIP](https://pip.pypa.io/) (Python, currently [limited](https://github.com/oss-review-toolkit/ort/issues/3671) to
-  projects that are compatible with Python 2.7 or Python 3.6)
-* [Pipenv](https://pipenv.readthedocs.io/) (Python, currently [limited](https://github.com/oss-review-toolkit/ort/issues/3671)
-  to projects that are compatible with Python 2.7 or Python 3.6)
-* [Pub](https://pub.dev/) (Dart / Flutter)
-* [SBT](http://www.scala-sbt.org/) (Scala)
-* [SPDX](https://spdx.dev/specifications/) (SPDX documents used to describe
-  [projects](./analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml) or
-  [packages](./analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl/package.spdx.yml))
-* [Stack](http://haskellstack.org/) (Haskell)
-* [Yarn](https://yarnpkg.com/) (Node.js)
+* C / C++
+  * [Conan](https://conan.io/) (limitations:
+  [receipe vs. source repository](https://github.com/oss-review-toolkit/ort/issues/2037))
+  * Also see: [SPDX documents](#analyzer-for-spdx-documents)
+* Dart / Flutter
+  * [Pub](https://pub.dev/)
+* Go
+  * [dep](https://golang.github.io/dep/)
+  * [Glide](https://github.com/Masterminds/glide)
+  * [Godep](https://github.com/tools/godep)
+  * [GoMod](https://github.com/golang/go/wiki/Modules)
+* Haskell
+  * [Stack](http://haskellstack.org/)
+* Java
+  * [Gradle](https://gradle.org/)
+  * [Maven](http://maven.apache.org/)
+* JavaScript / Node.js
+  * [Bower](http://bower.io/)
+  * [NPM](https://www.npmjs.com/)
+  * [Yarn](https://yarnpkg.com/)
+* .NET
+  * [DotNet](https://docs.microsoft.com/en-us/dotnet/core/tools/) (limitations:
+  [no floating versions / ranges](https://github.com/oss-review-toolkit/ort/pull/1303#issue-253860146))
+  * [NuGet](https://www.nuget.org/) (limitations:
+  [no floating versions / ranges](https://github.com/oss-review-toolkit/ort/pull/1303#issue-253860146))
+* Objective-C / Swift
+  * [Carthage](https://github.com/Carthage/Carthage)
+  * [CocoaPods](https://github.com/CocoaPods/CocoaPods) (limitations:
+  [no custom source repositories](https://github.com/oss-review-toolkit/ort/issues/4188))
+* PHP
+  * [Composer](https://getcomposer.org/)
+* Python
+  * [PIP](https://pip.pypa.io/) (limitations:
+  [Python 2.7 or 3.6 only](https://github.com/oss-review-toolkit/ort/issues/3671))
+  * [Pipenv](https://pipenv.readthedocs.io/) (limitations:
+  [Python 2.7 or 3.6 only](https://github.com/oss-review-toolkit/ort/issues/3671))
+* Ruby
+  * [Bundler](http://bundler.io/)
+* Rust
+  * [Cargo](https://doc.rust-lang.org/cargo/)
+* Scala
+  * [SBT](http://www.scala-sbt.org/)
+
+<a name="analyzer-for-spdx-documents"></a>
+
+If another package manager that is not part of the list above is used (or no package manager at all), the generic
+fallback to [SPDX documents](https://spdx.dev/specifications/) can be leveraged to describe
+[projects](./analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml) or
+[packages](./analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl/package.spdx.yml).
 
 <a name="downloader">&nbsp;</a>
 

--- a/README.md
+++ b/README.md
@@ -329,23 +329,30 @@ supported:
   * [dep](https://golang.github.io/dep/)
   * [Glide](https://github.com/Masterminds/glide)
   * [Godep](https://github.com/tools/godep)
-  * [GoMod](https://github.com/golang/go/wiki/Modules)
+  * [GoMod](https://github.com/golang/go/wiki/Modules) (limitations:
+  [no `replace` directive](https://github.com/oss-review-toolkit/ort/issues/4445))
 * Haskell
   * [Stack](http://haskellstack.org/)
 * Java
   * [Gradle](https://gradle.org/)
-  * [Maven](http://maven.apache.org/)
+  * [Maven](http://maven.apache.org/) (limitations:
+  [default profile only](https://github.com/oss-review-toolkit/ort/issues/1774))
 * JavaScript / Node.js
   * [Bower](http://bower.io/)
-  * [NPM](https://www.npmjs.com/)
+  * [NPM](https://www.npmjs.com/) (limitations:
+  [no scope-specific registries](https://github.com/oss-review-toolkit/ort/issues/3741),
+  [no peer dependencies](https://github.com/oss-review-toolkit/ort/issues/95))
   * [Yarn](https://yarnpkg.com/)
 * .NET
   * [DotNet](https://docs.microsoft.com/en-us/dotnet/core/tools/) (limitations:
-  [no floating versions / ranges](https://github.com/oss-review-toolkit/ort/pull/1303#issue-253860146))
+  [no floating versions / ranges](https://github.com/oss-review-toolkit/ort/pull/1303#issue-253860146),
+  [no target framework](https://github.com/oss-review-toolkit/ort/issues/4083))
   * [NuGet](https://www.nuget.org/) (limitations:
-  [no floating versions / ranges](https://github.com/oss-review-toolkit/ort/pull/1303#issue-253860146))
+  [no floating versions / ranges](https://github.com/oss-review-toolkit/ort/pull/1303#issue-253860146),
+  [no target framework](https://github.com/oss-review-toolkit/ort/issues/4083))
 * Objective-C / Swift
-  * [Carthage](https://github.com/Carthage/Carthage)
+  * [Carthage](https://github.com/Carthage/Carthage) (limitation:
+  [no `cartfile.private`](https://github.com/oss-review-toolkit/ort/issues/3774))
   * [CocoaPods](https://github.com/CocoaPods/CocoaPods) (limitations:
   [no custom source repositories](https://github.com/oss-review-toolkit/ort/issues/4188))
 * PHP
@@ -356,7 +363,8 @@ supported:
   * [Pipenv](https://pipenv.readthedocs.io/) (limitations:
   [Python 2.7 or 3.6 only](https://github.com/oss-review-toolkit/ort/issues/3671))
 * Ruby
-  * [Bundler](http://bundler.io/)
+  * [Bundler](http://bundler.io/) (limitations:
+  [restricted to the version available on the host](https://github.com/oss-review-toolkit/ort/issues/1308))
 * Rust
   * [Cargo](https://doc.rust-lang.org/cargo/)
 * Scala


### PR DESCRIPTION
This is for a better overview for development teams that work with a
specific programming language. This also allows to document any
limitation more prominently with a short summary.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>