### PR TITLE
CocoaPods: Enable running this package manager as root user

### DIFF
--- a/analyzer/src/main/kotlin/managers/CocoaPods.kt
+++ b/analyzer/src/main/kotlin/managers/CocoaPods.kt
@@ -111,7 +111,7 @@ class CocoaPods(
         // [3] https://blog.cocoapods.org/CocoaPods-1.7.2/
 
         return stashDirectories(File("~/.cocoapods/repos")).use {
-            run("repo", "add-cdn", "trunk", "https://cdn.cocoapods.org")
+            run("repo", "add-cdn", "trunk", "https://cdn.cocoapods.org", "--allow-root")
 
             try {
                 resolveDependenciesInternal(definitionFile)


### PR DESCRIPTION
There a two code locations running the `pod` executable. One of these
two locations accidentally lacks passing the `--allow-root` argument.
As result this package manager integration can be run only as non-root
users.

Remove that limitation by adding that missing argument.
