### PR TITLE
MailNotifier: Provide the possibility to send HTML emails

### DIFF
--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -197,7 +197,9 @@ class ExamplesFunTest : StringSpec() {
             greenMail.waitForIncomingEmail(1000, 1) shouldBe true
             val actualBody = GreenMailUtil.getBody(greenMail.receivedMessages[0])
 
-            actualBody shouldBe "Number of issues found: ${ortResult.collectIssues().size}"
+            actualBody shouldContain "Content-Type: text/html; charset=UTF-8"
+            actualBody shouldContain "Content-Type: text/plain; charset=UTF-8" // Fallback
+            actualBody shouldContain "Number of issues found: ${ortResult.collectIssues().size}"
 
             greenMail.stop()
         }

--- a/examples/notifications.kts
+++ b/examples/notifications.kts
@@ -23,6 +23,6 @@ if (issues.isNotEmpty()) {
     mailClient.sendMail(
         subject = "Issues found",
         message = "Number of issues found: ${issues.size}",
-        receivers = arrayOf("example1@ossreviewtoolkit.org", "example2@ossreviewtoolkit.org")
+        receivers = arrayOf("example1@oss-review-toolkit.org", "example2@oss-review-toolkit.org")
     )
 }

--- a/examples/notifications.kts
+++ b/examples/notifications.kts
@@ -23,6 +23,8 @@ if (issues.isNotEmpty()) {
     mailClient.sendMail(
         subject = "Issues found",
         message = "Number of issues found: ${issues.size}",
+        htmlEmail = true,
+        charset = Charsets.UTF_8,
         receivers = arrayOf("example1@oss-review-toolkit.org", "example2@oss-review-toolkit.org")
     )
 }

--- a/notifier/src/main/kotlin/modules/MailNotifier.kt
+++ b/notifier/src/main/kotlin/modules/MailNotifier.kt
@@ -19,9 +19,10 @@
 
 package org.ossreviewtoolkit.notifier.modules
 
+import java.nio.charset.Charset
+
 import org.apache.commons.mail.DefaultAuthenticator
-import org.apache.commons.mail.Email
-import org.apache.commons.mail.SimpleEmail
+import org.apache.commons.mail.HtmlEmail
 
 import org.ossreviewtoolkit.model.config.SendMailConfiguration
 
@@ -29,23 +30,30 @@ import org.ossreviewtoolkit.model.config.SendMailConfiguration
  * Notification module that provides a configured email client.
  */
 class MailNotifier(config: SendMailConfiguration) {
-    private val client: Email
+    private val client: HtmlEmail = HtmlEmail()
 
     init {
-        client = SimpleEmail()
-
-        client.setHostName(config.hostName)
+        client.hostName = config.hostName
         client.setSmtpPort(config.port)
         client.setAuthenticator(DefaultAuthenticator(config.username, config.password))
-        client.setSSLOnConnect(config.useSsl)
+        client.isSSLOnConnect = config.useSsl
         client.setFrom(config.fromAddress)
     }
 
     @Suppress("UNUSED") // This is intended to be used by notification script implementations.
-    fun sendMail(subject: String, message: String, vararg receivers: String) {
+    fun sendMail(
+        subject: String,
+        message: String,
+        htmlEmail: Boolean = false,
+        charset: Charset = Charsets.UTF_8,
+        vararg receivers: String
+    ) {
         client.subject = subject
         client.setMsg(message)
+        client.setCharset(charset.name())
         client.addTo(*receivers)
+
+        if (htmlEmail) client.setHtmlMsg(message) else client.setTextMsg(message)
 
         client.send()
     }


### PR DESCRIPTION
Enable the mail notifier to be able to send HTML mails.