### PR TITLE
docs: Fix a typo

### DIFF
--- a/docs/dir-custom-license-texts.md
+++ b/docs/dir-custom-license-texts.md
@@ -5,7 +5,7 @@ from [ScanCode](https://github.com/nexB/scancode-toolkit/tree/develop/src/licens
 texts will be used when generating open source notices using the [NoticeTemplateReporter](./notice-templates.md).
 
 If you need a license text that is not provided by ORT you can put it in the custom license texts directory. By default
-it is located at `$ORT_CONFIG_DIR/custom-liense-texts`. Alternatively, you can pass a different location to the
+it is located at `$ORT_CONFIG_DIR/custom-license-texts`. Alternatively, you can pass a different location to the
 `--custom-license-texts-dir` option of the _reporter_:
 
 ```bash


### PR DESCRIPTION
Fix a small typo in documentation for custom license text directory.
