### PR TITLE
LicenseInfoResolver: Fix resolving original expressions for detected licenses

### DIFF
--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -127,13 +127,16 @@ class LicenseInfoResolver(
 
         val unmatchedCopyrights = mutableMapOf<Provenance, MutableSet<CopyrightFinding>>()
         val resolvedLocations = resolveLocations(filteredDetectedLicenseInfo, unmatchedCopyrights)
+        val detectedLicenses = licenseInfo.detectedLicenseInfo.findings.flatMapTo(mutableSetOf()) { findings ->
+            findings.licenses.map { it.license }
+        }
 
         resolvedLocations.keys.forEach { license ->
             license.builder().apply {
                 resolvedLocations[license]?.let { locations.addAll(it) }
 
-                licenseInfo.detectedLicenseInfo.findings.forEach { findings ->
-                    originalExpressions[LicenseSource.DETECTED] = findings.licenses.mapTo(mutableSetOf()) { it.license }
+                originalExpressions[LicenseSource.DETECTED] = detectedLicenses.filterTo(mutableSetOf()) {
+                    license in it.decompose()
                 }
             }
         }

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -27,6 +27,7 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.haveSize
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -66,6 +67,7 @@ import org.ossreviewtoolkit.spdx.toSpdx
 import org.ossreviewtoolkit.utils.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.storage.LocalFileStorage
 import org.ossreviewtoolkit.utils.test.createDefault
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class LicenseInfoResolverTest : WordSpec() {
     init {
@@ -171,6 +173,13 @@ class LicenseInfoResolverTest : WordSpec() {
                     provenance = provenance,
                     location = TextLocation("LICENSE", 41)
                 )
+
+                result.licenses.find { it.license == "Apache-2.0 WITH LLVM-exception".toSpdx() } shouldNotBeNull {
+                    originalExpressions[LicenseSource.DETECTED] shouldContainExactlyInAnyOrder listOf(
+                        "Apache-2.0 WITH LLVM-exception",
+                        "MIT" // FIXME: The originalExpression must contain only license related to `it.license`.
+                    ).map { it.toSpdx() }
+                }
             }
 
             "resolve concluded licenses" {

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -176,8 +176,7 @@ class LicenseInfoResolverTest : WordSpec() {
 
                 result.licenses.find { it.license == "Apache-2.0 WITH LLVM-exception".toSpdx() } shouldNotBeNull {
                     originalExpressions[LicenseSource.DETECTED] shouldContainExactlyInAnyOrder listOf(
-                        "Apache-2.0 WITH LLVM-exception",
-                        "MIT" // FIXME: The originalExpression must contain only license related to `it.license`.
+                        "Apache-2.0 WITH LLVM-exception"
                     ).map { it.toSpdx() }
                 }
             }


### PR DESCRIPTION
The resolver accidentally associates all detected licenses to each "resolved license" instance, which is fixed by this PR.
