### PR TITLE
StaticHtmlReport: Respect the path excludes for the effective license

### DIFF
--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -639,7 +639,7 @@ Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
               <dl>
                 <dd>
                   <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a> AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:197ec4de65a2e5414b290fb46dee75f55e1b69e8">CC-BY-NC-3.0</a> AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:f288702d2fa16d3cdf0035b15a9fcbc552cd88e7">GPL-3.0-only</a> WITH <a href="https://archive.softwareheritage.org/browse/content/sha1_git:e86f7fb58a4656330ebdfab5e75d72f86f5e9af9">GCC-exception-3.1</a> AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a>
+                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a> AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:197ec4de65a2e5414b290fb46dee75f55e1b69e8">CC-BY-NC-3.0</a> AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:f288702d2fa16d3cdf0035b15a9fcbc552cd88e7">GPL-3.0-only</a> WITH <a href="https://archive.softwareheritage.org/browse/content/sha1_git:e86f7fb58a4656330ebdfab5e75d72f86f5e9af9">GCC-exception-3.1</a>
                   </div>
                 </dd>
               </dl>

--- a/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/utils/ReportTableModelMapper.kt
@@ -154,7 +154,7 @@ class ReportTableModelMapper(
                     concludedLicense = concludedLicense,
                     declaredLicenses = declaredLicenses,
                     detectedLicenses = detectedLicenses,
-                    effectiveLicense = resolvedLicenseInfo.effectiveLicense(
+                    effectiveLicense = resolvedLicenseInfo.filterExcluded().effectiveLicense(
                         LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED,
                         ortResult.getPackageLicenseChoices(id),
                         ortResult.getRepositoryLicenseChoices()


### PR DESCRIPTION
The HTML report shows an effective license which does not adhere to path
excludes for detected licenses. So, if there is no concluded license the
effective license always includes all detected licenses. Fix that by
using filterExcluded().