### PR TITLE
LicenseInfoResolver: Make original expression curated instead of raw

### DIFF
--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -128,7 +128,11 @@ class LicenseInfoResolver(
         val unmatchedCopyrights = mutableMapOf<Provenance, MutableSet<CopyrightFinding>>()
         val resolvedLocations = resolveLocations(filteredDetectedLicenseInfo, unmatchedCopyrights)
         val detectedLicenses = licenseInfo.detectedLicenseInfo.findings.flatMapTo(mutableSetOf()) { findings ->
-            findings.licenses.map { it.license }
+            FindingCurationMatcher().applyAll(
+                findings.licenses,
+                findings.licenseFindingCurations,
+                findings.relativeFindingsPath
+            ).mapNotNull { it.curatedFinding?.license }
         }
 
         resolvedLocations.keys.forEach { license ->

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -459,6 +459,9 @@ class LicenseInfoResolverTest : WordSpec() {
                         )
                     )
                 )
+                result.licenses.flatMap {
+                    it.originalExpressions[LicenseSource.DETECTED].orEmpty()
+                } shouldContainExactlyInAnyOrder listOf() // FIXME: Curation should be applied, so should contain 'MIT'.
             }
 
             "contain a list of the original license expressions" {

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -461,7 +461,7 @@ class LicenseInfoResolverTest : WordSpec() {
                 )
                 result.licenses.flatMap {
                     it.originalExpressions[LicenseSource.DETECTED].orEmpty()
-                } shouldContainExactlyInAnyOrder listOf() // FIXME: Curation should be applied, so should contain 'MIT'.
+                } shouldContainExactlyInAnyOrder listOf("MIT".toSpdx())
             }
 
             "contain a list of the original license expressions" {


### PR DESCRIPTION
The previous implementation was using raw licenses for original expressions and curated licenses for resolved locations which is inconsistent. As original expressions are the basis for applying license choices these have to be curated.

The PR illustrates and fixes a bug where the resolved license info lacks original expressions. 