### PR TITLE
Pub: Override the getVersion command

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -581,6 +581,12 @@ class Pub(
         return yamlMapper.readTree(definitionFile)
     }
 
+    override fun getVersion(workingDir: File?): String {
+        val result = ProcessCapture(workingDir, command(workingDir), getVersionArguments()).requireSuccess()
+
+        return transformVersion(result.stderr)
+    }
+
     override fun command(workingDir: File?): String =
         if (flutterAbsolutePath.isDirectory) "$flutterAbsolutePath${File.separator}$dartCommand" else dartCommand
 


### PR DESCRIPTION
The default implementation uses the `run` method. In Pub's case this
uses `dart pub`, which does not offer the `--version` flag. Therefore,
using the `dart`'s version information.
