### PR TITLE
scanner: Operate on (deduplicated) sets of packages

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -200,7 +200,7 @@ abstract class LocalScanner(
     }
 
     override suspend fun scanPackages(
-        packages: Collection<Package>,
+        packages: Set<Package>,
         outputDirectory: File
     ): Map<Package, List<ScanResult>> {
         val scannerCriteria = getScannerCriteria()

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -87,7 +87,7 @@ fun scanOrtResult(
         .filter { it.pkg.id !in projectPackageIds }
         .map { it.pkg }
 
-    fun removeConcludedPackages(packages: Collection<Package>, scanner: Scanner): Collection<Package> =
+    fun removeConcludedPackages(packages: Set<Package>, scanner: Scanner): Set<Package> =
         packages.takeUnless { scanner.scannerConfig.skipConcluded }
             // Remove all packages that have a concluded license and authors set.
             ?: packages.partition { it.concludedLicense != null && it.authors.isNotEmpty() }.let { (skip, keep) ->
@@ -95,11 +95,11 @@ fun scanOrtResult(
                     scanner.log.debug { "Not scanning the following packages with concluded licenses: $skip" }
                 }
 
-                keep
+                keep.toSet()
             }
 
     val filteredProjectPackages = removeConcludedPackages(projectPackages, projectScanner)
-    val filteredPackages = removeConcludedPackages(packages, scanner)
+    val filteredPackages = removeConcludedPackages(packages.toSet(), scanner)
 
     val scanResults = runBlocking {
         // Scan the projects from the ORT result.
@@ -187,7 +187,7 @@ abstract class Scanner(
      * result for the specification of this scanner.
      */
     internal abstract suspend fun scanPackages(
-        packages: Collection<Package>,
+        packages: Set<Package>,
         outputDirectory: File
     ): Map<Package, List<ScanResult>>
 

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -208,7 +208,7 @@ class FossId internal constructor(
         }
 
     override suspend fun scanPackages(
-        packages: Collection<Package>,
+        packages: Set<Package>,
         outputDirectory: File
     ): Map<Package, List<ScanResult>> {
         val (results, duration) = measureTimedValue {

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -379,7 +379,7 @@ class FossIdTest : WordSpec({
 
             shouldThrow<TimeoutCancellationException> {
                 withTimeout(1000) {
-                    fossId.scanPackages(listOf(createPackage(createIdentifier(index = 1), vcsInfo)), File("output"))
+                    fossId.scanPackages(setOf(createPackage(createIdentifier(index = 1), vcsInfo)), File("output"))
                 }
             }
 


### PR DESCRIPTION
Packages should be distinct for performance reasons, so ensure that
already via the function signatures.

This is, in a sense, a follow-up to 3fca5af.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>