### PR TITLE
getting-started: Raise Java requirement to 11

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ ORT:
 ORT is tested to run on Linux, macOS, and Windows. This tutorial assumes that you are running on Linux, but it should be
 easy to adapt the commands to macOS or Windows.
 
-In addition to Java (version >= 8), for some of the supported package managers and Version Control Systems additional
+In addition to Java (version >= 11), for some of the supported package managers and Version Control Systems additional
 tools need to be installed. In the context of this tutorial the following tools are required:
 
 * Git (any recent version will do)


### PR DESCRIPTION
As of 48f2b96fbffbd2f6038e3d1dba4904302dac06ab Java 11 is required to
build ORT.

