### PR TITLE
Analyzer: add JvmOverloads annotation to analyze method

### DIFF
--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -43,6 +43,7 @@ import org.ossreviewtoolkit.utils.log
  * The class to run the analysis. The signatures of public functions in this class define the library API.
  */
 class Analyzer(private val config: AnalyzerConfiguration) {
+    @JvmOverloads
     fun analyze(
         absoluteProjectPath: File,
         packageManagers: List<PackageManagerFactory> = PackageManager.ALL,


### PR DESCRIPTION
The JvmOverloads annotation tells the Kotlin compiler to generate overloaded methods. These methods can be then used by other JVM languages that do not support default parameters for methods.

Signed-off-by: LeelaChacha <me@hukumraj-singh-deora.party>

Issue: #4486