### PR TITLE
Sort service loader factories by name if not sorted otherwise

### DIFF
--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -48,7 +48,7 @@ class Advisor(
         /**
          * The list of all available [VulnerabilityProvider]s in the classpath.
          */
-        val ALL by lazy { LOADER.iterator().asSequence().toList() }
+        val ALL by lazy { LOADER.iterator().asSequence().toList().sortedBy { it.providerName } }
     }
 
     fun retrieveVulnerabilityInformation(ortResult: OrtResult, skipExcluded: Boolean = false): OrtResult {

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -69,7 +69,7 @@ abstract class PackageManager(
         /**
          * The list of all available package managers in the classpath.
          */
-        val ALL by lazy { LOADER.iterator().asSequence().toList() }
+        val ALL by lazy { LOADER.iterator().asSequence().toList().sortedBy { it.managerName } }
 
         private val PACKAGE_MANAGER_DIRECTORIES = listOf(
             // Ignore intermediate build system directories.

--- a/reporter/src/main/kotlin/Reporter.kt
+++ b/reporter/src/main/kotlin/Reporter.kt
@@ -40,7 +40,7 @@ interface Reporter {
         /**
          * The list of all available reporters in the classpath.
          */
-        val ALL by lazy { LOADER.iterator().asSequence().toList() }
+        val ALL by lazy { LOADER.iterator().asSequence().toList().sortedBy { it.reporterName } }
     }
 
     /**

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -178,7 +178,7 @@ abstract class Scanner(
         /**
          * The list of all available scanners in the classpath.
          */
-        val ALL by lazy { LOADER.iterator().asSequence().toList() }
+        val ALL by lazy { LOADER.iterator().asSequence().toList().sortedBy { it.scannerName } }
     }
 
     /**


### PR DESCRIPTION
This way also e.g. package managers added via external plugins show up
sorted in the CLI output for activated package managers.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>