### PR TITLE
Add an experimental provenance based scanner implementation

### DIFF
--- a/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
+++ b/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
@@ -1,0 +1,402 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import java.time.Instant
+
+import kotlin.time.measureTimedValue
+
+import org.ossreviewtoolkit.downloader.DownloadException
+import org.ossreviewtoolkit.model.AccessStatistics
+import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.ScanRecord
+import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.ScannerRun
+import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.utils.Environment
+import org.ossreviewtoolkit.utils.collectMessagesAsString
+import org.ossreviewtoolkit.utils.createOrtTempDir
+import org.ossreviewtoolkit.utils.log
+
+class ExperimentalScanner(
+    val scannerConfig: ScannerConfiguration,
+    val downloaderConfig: DownloaderConfiguration,
+    val provenanceDownloader: ProvenanceDownloader,
+    val storageReaders: List<ScanStorageReader>,
+    val storageWriters: List<ScanStorageWriter>,
+    val packageProvenanceResolver: PackageProvenanceResolver,
+    val nestedProvenanceResolver: NestedProvenanceResolver,
+    val scannerWrappers: List<ScannerWrapper>
+) {
+    init {
+        require(scannerWrappers.isNotEmpty()) {
+            "At least one ScannerWrapper must be provided."
+        }
+    }
+
+    suspend fun scan(ortResult: OrtResult): OrtResult {
+        val startTime = Instant.now()
+
+        val result = scan(
+            (ortResult.getProjects().map { it.toPackage() } + ortResult.getPackages().map { it.pkg }).toSet()
+        )
+
+        val endTime = Instant.now()
+
+        val scanResults = result.entries.associateTo(sortedMapOf()) { it.key.id to it.value.merge() }
+
+        val scanRecord = ScanRecord(
+            scanResults = scanResults,
+            storageStats = AccessStatistics() // TODO: Record access statistics.
+        )
+
+        // TODO: Filter scanner options to obfuscate credentials, see Scanner.filterOptionsForResult().
+        val scannerRun = ScannerRun(startTime, endTime, Environment(), scannerConfig, scanRecord)
+
+        return ortResult.copy(scanner = scannerRun)
+    }
+
+    suspend fun scan(packages: Set<Package>): Map<Package, NestedProvenanceScanResult> {
+        log.info { "Resolving provenance for ${packages.size} packages." }
+        // TODO: Handle issues for packages where provenance cannot be resolved.
+        val (packageProvenances, packageProvenanceDuration) = measureTimedValue { getPackageProvenances(packages) }
+        log.info {
+            "Resolved provenance for ${packages.size} packages in ${packageProvenanceDuration.inWholeMilliseconds}ms."
+        }
+
+        log.info { "Resolving source trees for ${packages.size} packages." }
+        val (nestedProvenances, nestedProvenanceDuration) =
+            measureTimedValue { getNestedProvenances(packageProvenances) }
+        log.info {
+            "Resolved source trees for ${packages.size} packages in ${nestedProvenanceDuration.inWholeMilliseconds}ms."
+        }
+
+        val allKnownProvenances = (
+                packageProvenances.values.filterIsInstance<KnownProvenance>() +
+                        nestedProvenances.values.flatMap { nestedProvenance ->
+                            nestedProvenance.subRepositories.values
+                        }
+                ).toSet()
+
+        val scanResults = mutableMapOf<ScannerWrapper, MutableMap<KnownProvenance, List<ScanResult>>>()
+
+        // Get stored scan results for each ScannerWrapper by provenance.
+        log.info {
+            "Reading stored scan results for ${packageProvenances.size} packages with ${allKnownProvenances.size} " +
+                    "provenances."
+        }
+        val (storedResults, readDuration) = measureTimedValue {
+            getStoredResults(allKnownProvenances, packageProvenances)
+        }
+
+        log.info {
+            "Read stored scan results in ${readDuration}ms:"
+        }
+        scanResults.entries.forEach { (scanner, results) ->
+            log.info { "\t${scanner.name}: Results for ${results.size} of ${allKnownProvenances.size} provenances." }
+        }
+
+        scanResults += storedResults
+
+        // Check which packages have incomplete scan results.
+        val packagesWithIncompleteScanResult =
+            getPackagesWithIncompleteResults(packages, packageProvenances, nestedProvenances, scanResults)
+
+        log.info { "${packagesWithIncompleteScanResult.size} packages have incomplete scan results." }
+
+        log.info { "Starting scan of missing packages if any package based scanners are configured." }
+
+        // Scan packages with incomplete scan results.
+        packagesWithIncompleteScanResult.forEach { (pkg, scanners) ->
+            // TODO: Move to function.
+            // TODO: Verify that there are still missing scan results for the package, previous scan of another package
+            //       from the same repository could have fixed that already.
+            scanners.filterIsInstance<PackageBasedRemoteScannerWrapper>().forEach { scanner ->
+                log.info { "Scanning ${pkg.id.toCoordinates()} with package based remote scanner ${scanner.name}." }
+
+                // Scan whole package with remote scanner.
+                // TODO: Use coroutines to execute scanners in parallel.
+                val scanResult = scanner.scanPackage(pkg)
+
+                log.info {
+                    "Scan of ${pkg.id.toCoordinates()} with package based remote scanner ${scanner.name} finished."
+                }
+
+                // Split scan results by provenance and add them to the map of scan results.
+                val nestedProvenanceScanResult =
+                    scanResult.toNestedProvenanceScanResult(nestedProvenances.getValue(pkg))
+                nestedProvenanceScanResult.scanResults.forEach { (provenance, scanResultsForProvenance) ->
+                    val scanResultsForScanner = scanResults.getOrPut(scanner) { mutableMapOf() }
+                    scanResultsForScanner[provenance] =
+                        scanResultsForScanner[provenance].orEmpty() + scanResultsForProvenance
+
+                    storageWriters.filterIsInstance<ProvenanceBasedScanStorageWriter>().forEach { writer ->
+                        scanResultsForProvenance.forEach { scanResult ->
+                            // TODO: Only store new scan results, for nested provenance some of them could have a stored
+                            //       result already.
+                            writer.write(scanResult)
+                        }
+                    }
+                }
+            }
+        }
+
+        // Check which provenances have incomplete scan results.
+        val provenancesWithIncompleteScanResults =
+            getProvenancesWithIncompleteScanResults(allKnownProvenances, scanResults)
+
+        log.info { "${provenancesWithIncompleteScanResults.size} provenances have incomplete scan results." }
+
+        log.info { "Starting scan of missing provenances if any provenance based scanners are configured." }
+
+        provenancesWithIncompleteScanResults.forEach { (provenance, scanners) ->
+            // Scan provenances with remote scanners.
+            // TODO: Move to function.
+            scanners.filterIsInstance<ProvenanceBasedRemoteScannerWrapper>().forEach { scanner ->
+                log.info { "Scanning $provenance with provenance based remote scanner ${scanner.name}." }
+
+                // TODO: Use coroutines to execute scanners in parallel.
+                val scanResult = scanner.scanProvenance(provenance)
+
+                log.info {
+                    "Scan of $provenance with provenance based remote scanner ${scanner.name} finished."
+                }
+
+                val scanResultsForScanner = scanResults.getOrPut(scanner) { mutableMapOf() }
+                scanResultsForScanner[provenance] = scanResultsForScanner[provenance].orEmpty() + scanResult
+
+                storageWriters.filterIsInstance<ProvenanceBasedScanStorageWriter>().forEach { writer ->
+                    writer.write(scanResult)
+                }
+            }
+
+            // Scan provenances with local scanners.
+            val localScanners = scanners.filterIsInstance<LocalScannerWrapper>()
+            if (localScanners.isNotEmpty()) {
+                val localScanResults = scanLocal(provenance, localScanners)
+
+                localScanResults.forEach { (scanner, scanResult) ->
+                    val scanResultsForScanner = scanResults.getOrPut(scanner) { mutableMapOf() }
+                    scanResultsForScanner[provenance] = scanResultsForScanner[provenance].orEmpty() + scanResult
+
+                    storageWriters.filterIsInstance<ProvenanceBasedScanStorageWriter>().forEach { writer ->
+                        writer.write(scanResult)
+                    }
+                }
+            }
+        }
+
+        val nestedProvenanceScanResults = createNestedProvenanceScanResults(packages, nestedProvenances, scanResults)
+
+        packagesWithIncompleteScanResult.forEach { (pkg, _) ->
+            storageWriters.filterIsInstance<PackageBasedScanStorageWriter>().forEach { writer ->
+                nestedProvenanceScanResults[pkg]?.let { nestedProvenanceScanResult ->
+                    // TODO: Save only results for scanners which did not have a stored result.
+                    writer.write(pkg, nestedProvenanceScanResult)
+                }
+            }
+        }
+
+        return nestedProvenanceScanResults
+    }
+
+    private fun getPackageProvenances(packages: Set<Package>): Map<Package, Provenance> =
+        packages.associateWith { pkg ->
+            packageProvenanceResolver.resolveProvenance(pkg, downloaderConfig.sourceCodeOrigins)
+        }
+
+    private fun getNestedProvenances(packageProvenances: Map<Package, Provenance>): Map<Package, NestedProvenance> =
+        packageProvenances.mapNotNull { (pkg, provenance) ->
+            (provenance as? KnownProvenance)?.let { knownProvenance ->
+                pkg to nestedProvenanceResolver.resolveNestedProvenance(knownProvenance)
+            }
+        }.toMap()
+
+    private fun getStoredResults(
+        provenances: Set<KnownProvenance>,
+        packageProvenances: Map<Package, Provenance>
+    ): Map<ScannerWrapper, MutableMap<KnownProvenance, List<ScanResult>>> {
+        return scannerWrappers.associateWith { scanner ->
+            val scannerCriteria = scanner.criteria
+            val result = mutableMapOf<KnownProvenance, List<ScanResult>>()
+
+            provenances.forEach { provenance ->
+                if (result[provenance] != null) return@forEach
+
+                storageReaders.forEach { reader ->
+                    when (reader) {
+                        is PackageBasedScanStorageReader -> {
+                            packageProvenances.entries.find { it.value == provenance }?.key?.let { pkg ->
+                                reader.read(pkg, scannerCriteria).forEach { scanResult2 ->
+                                    // TODO: Do not overwrite entries from other storages in result.
+                                    // TODO: Map scan result to known source tree for package.
+                                    result += scanResult2.scanResults
+                                }
+                            }
+                        }
+
+                        is ProvenanceBasedScanStorageReader -> {
+                            // TODO: Do not overwrite entries from other storages in result.
+                            result[provenance] = reader.read(provenance, scannerCriteria)
+                        }
+                    }
+                }
+            }
+
+            result
+        }
+    }
+
+    private fun getPackagesWithIncompleteResults(
+        packages: Set<Package>,
+        packageProvenances: Map<Package, Provenance>,
+        nestedProvenances: Map<Package, NestedProvenance>,
+        scanResults: Map<ScannerWrapper, Map<KnownProvenance, List<ScanResult>>>,
+    ): Map<Package, List<ScannerWrapper>> =
+        packages.associateWith { pkg ->
+            scannerWrappers.filter { scanner ->
+                val hasPackageProvenanceResult = scanResults.hasResult(scanner, packageProvenances.getValue(pkg))
+                val hasAllNestedProvenanceResults = nestedProvenances[pkg]?.let { nestedProvenance ->
+                    scanResults.hasResult(scanner, nestedProvenance.root) &&
+                            nestedProvenance.subRepositories.all { (_, provenance) ->
+                                scanResults.hasResult(scanner, provenance)
+                            }
+                } != false
+
+                !hasPackageProvenanceResult || !hasAllNestedProvenanceResults
+            }
+        }.filterValues { it.isNotEmpty() }
+
+    private fun getProvenancesWithIncompleteScanResults(
+        provenances: Set<KnownProvenance>,
+        scanResults: Map<ScannerWrapper, Map<KnownProvenance, List<ScanResult>>>
+    ): Map<KnownProvenance, List<ScannerWrapper>> =
+        provenances.associateWith { provenance ->
+            scannerWrappers.filter { scanner -> !scanResults.hasResult(scanner, provenance) }
+        }.filterValues { it.isNotEmpty() }
+
+    private fun createNestedProvenanceScanResults(
+        packages: Set<Package>,
+        nestedProvenances: Map<Package, NestedProvenance>,
+        scanResults: Map<ScannerWrapper, Map<KnownProvenance, List<ScanResult>>>
+    ): Map<Package, NestedProvenanceScanResult> =
+        packages.associateWith { pkg ->
+            val nestedProvenance = nestedProvenances.getValue(pkg)
+            val provenances = nestedProvenance.getProvenances()
+            val scanResultsByProvenance = provenances.associateWith { provenance ->
+                scanResults.values.flatMap { it[provenance].orEmpty() }
+            }
+            NestedProvenanceScanResult(nestedProvenance, scanResultsByProvenance)
+        }
+
+    private fun scanLocal(
+        provenance: KnownProvenance,
+        scanners: List<LocalScannerWrapper>
+    ): Map<LocalScannerWrapper, ScanResult> {
+        val downloadDir = createOrtTempDir() // TODO: Use provided download dir instead.
+
+        try {
+            provenanceDownloader.download(provenance, downloadDir)
+        } catch (e: DownloadException) {
+            val message = "Could not download provenance $provenance: ${e.collectMessagesAsString()}"
+            log.error { message }
+
+            val summary = ScanSummary(
+                startTime = Instant.now(),
+                endTime = Instant.now(),
+                packageVerificationCode = "",
+                licenseFindings = sortedSetOf(),
+                copyrightFindings = sortedSetOf(),
+                issues = listOf(
+                    OrtIssue(
+                        source = "Downloader",
+                        message = message,
+                        severity = Severity.ERROR
+                    )
+                )
+            )
+
+            return scanners.associateWith { scanner ->
+                ScanResult(
+                    provenance = provenance,
+                    scanner = scanner.details,
+                    summary = summary
+                )
+            }
+        }
+
+        return scanners.associateWith { scanner ->
+            log.info { "Scanning $provenance with local scanner ${scanner.name}." }
+
+            val summary = scanner.scanPath(downloadDir)
+            log.info { "Scan of $provenance with provenance based remote scanner ${scanner.name} finished." }
+
+            ScanResult(provenance, scanner.details, summary)
+        }
+    }
+}
+
+/**
+ * Split this [ScanResult] into separate results for each [KnownProvenance] contained in the [nestedProvenance] by
+ * matching the paths of findings with the paths in the source tree.
+ */
+fun ScanResult.toNestedProvenanceScanResult(nestedProvenance: NestedProvenance): NestedProvenanceScanResult {
+    val provenanceByPath = listOf(
+        "" to nestedProvenance.root,
+        *nestedProvenance.subRepositories.toList().toTypedArray()
+    ).sortedByDescending { it.first.length }
+
+    val copyrightFindingsByProvenance = summary.copyrightFindings.groupBy { copyrightFinding ->
+        provenanceByPath.first { copyrightFinding.location.path.startsWith(it.first) }.second
+    }
+
+    val licenseFindingsByProvenance = summary.licenseFindings.groupBy { licenseFinding ->
+        provenanceByPath.first { licenseFinding.location.path.startsWith(it.first) }.second
+    }
+
+    val provenances = nestedProvenance.getProvenances()
+    val scanResultsByProvenance = provenances.associateWith { provenance ->
+        // TODO: Find a solution for the incorrect fileCount and packageVerificationCode and for how to associate issues
+        //       to the correct scan result.
+        listOf(
+            copy(
+                summary = summary.copy(
+                    licenseFindings = licenseFindingsByProvenance[provenance].orEmpty().toSortedSet(),
+                    copyrightFindings = copyrightFindingsByProvenance[provenance].orEmpty().toSortedSet()
+                )
+            )
+        )
+    }
+
+    return NestedProvenanceScanResult(nestedProvenance, scanResultsByProvenance)
+}
+
+private fun Map<ScannerWrapper, Map<KnownProvenance, List<ScanResult>>>.hasResult(
+    scanner: ScannerWrapper,
+    provenance: Provenance
+) = getValue(scanner)[provenance].let { it != null && it.isNotEmpty() }

--- a/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
+++ b/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
@@ -366,10 +366,9 @@ class ExperimentalScanner(
  * matching the paths of findings with the paths in the source tree.
  */
 fun ScanResult.toNestedProvenanceScanResult(nestedProvenance: NestedProvenance): NestedProvenanceScanResult {
-    val provenanceByPath = listOf(
-        "" to nestedProvenance.root,
-        *nestedProvenance.subRepositories.toList().toTypedArray()
-    ).sortedByDescending { it.first.length }
+    val provenanceByPath = nestedProvenance.subRepositories.toList().toMutableList<Pair<String, KnownProvenance>>()
+        .also { it += ("" to nestedProvenance.root) }
+        .sortedByDescending { it.first.length }
 
     val copyrightFindingsByProvenance = summary.copyrightFindings.groupBy { copyrightFinding ->
         provenanceByPath.first { copyrightFinding.location.path.startsWith(it.first) }.second

--- a/scanner/src/main/kotlin/experimental/NestedProvenance.kt
+++ b/scanner/src/main/kotlin/experimental/NestedProvenance.kt
@@ -38,4 +38,10 @@ data class NestedProvenance(
      * empty.
      */
     val subRepositories: Map<String, RepositoryProvenance>
-)
+) {
+    /**
+     * Return a set of all contained [KnownProvenance]s.
+     */
+    fun getProvenances(): Set<KnownProvenance> =
+        subRepositories.values.toMutableSet<KnownProvenance>().also { it += root }
+}

--- a/scanner/src/main/kotlin/experimental/NestedProvenanceScanResult.kt
+++ b/scanner/src/main/kotlin/experimental/NestedProvenanceScanResult.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.ScanResult
+
+/**
+ * A class that contains all [ScanResult]s for a [NestedProvenance].
+ */
+data class NestedProvenanceScanResult(
+    /**
+     * The [NestedProvenance] which the [scanResults] belong to.
+     */
+    val nestedProvenance: NestedProvenance,
+
+    /**
+     * A map of [KnownProvenance]s from [nestedProvenance] associated with lists of [ScanResult]s.
+     */
+    val scanResults: Map<KnownProvenance, List<ScanResult>>,
+) {
+    /**
+     * Return a set of all [KnownProvenance]s contained in [nestedProvenance].
+     */
+    fun getProvenances(): Set<KnownProvenance> = nestedProvenance.getProvenances()
+
+    /**
+     * Return true if [scanResults] contains at least one scan result for each of the [KnownProvenance]s contained in
+     * [nestedProvenance].
+     */
+    fun isComplete(): Boolean = getProvenances().all { scanResults[it]?.isNotEmpty() == true }
+}

--- a/scanner/src/main/kotlin/experimental/ProvenanceDownloader.kt
+++ b/scanner/src/main/kotlin/experimental/ProvenanceDownloader.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import java.io.File
+
+import org.ossreviewtoolkit.downloader.DownloadException
+import org.ossreviewtoolkit.downloader.Downloader
+import org.ossreviewtoolkit.model.ArtifactProvenance
+import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
+
+/**
+ * An interface that provides functionality to download source code.
+ */
+interface ProvenanceDownloader {
+    /**
+     * Download the source code specified by the provided [provenance] to the [downloadDir]. Throws a
+     * [DownloadException] if the download fails.
+     */
+    fun download(provenance: KnownProvenance, downloadDir: File)
+}
+
+/**
+ * An implementation of [ProvenanceDownloader] which uses the download functions from the [Downloader] class. As these
+ * functions require a [Package] to be provided, this implementation creates empty fake packages.
+ */
+class DefaultProvenanceDownloader(config: DownloaderConfiguration) : ProvenanceDownloader {
+    private val downloader = Downloader(config)
+
+    override fun download(provenance: KnownProvenance, downloadDir: File) {
+        when (provenance) {
+            // TODO: Add dedicated download functions for VcsInfo and RemoteArtifact to the Downloader.
+            is ArtifactProvenance -> {
+                val pkg = Package.EMPTY.copy(sourceArtifact = provenance.sourceArtifact)
+                downloader.downloadSourceArtifact(pkg, downloadDir)
+            }
+
+            is RepositoryProvenance -> {
+                val pkg = Package.EMPTY.copy(
+                    vcsProcessed = provenance.vcsInfo.copy(revision = provenance.resolvedRevision)
+                )
+                downloader.downloadFromVcs(pkg, downloadDir, allowMovingRevisions = false, recursive = false)
+            }
+        }
+    }
+}

--- a/scanner/src/main/kotlin/experimental/ScanStorage.kt
+++ b/scanner/src/main/kotlin/experimental/ScanStorage.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.scanner.ScannerCriteria
+
+/**
+ * A reader that reads [ScanResult]s from a storage.
+ */
+sealed interface ScanStorageReader
+
+/**
+ * A [ScanStorageReader]s that reads [ScanResult]s from a storage that stores results associated to [Package]s.
+ */
+interface PackageBasedScanStorageReader : ScanStorageReader {
+    fun read(pkg: Package): List<NestedProvenanceScanResult>
+    fun read(pkg: Package, scannerCriteria: ScannerCriteria): List<NestedProvenanceScanResult>
+}
+
+/**
+ * A [ScanStorageReader] that reads [ScanResult]s from a storage that stores results associated to [Provenance]s.
+ */
+interface ProvenanceBasedScanStorageReader : ScanStorageReader {
+    fun read(provenance: KnownProvenance): List<ScanResult>
+    fun read(provenance: KnownProvenance, scannerCriteria: ScannerCriteria): List<ScanResult>
+}
+
+/**
+ * A writer that writes [ScanResult]s to a storage.
+ */
+sealed interface ScanStorageWriter
+
+/**
+ * A [ScanStorageWriter] that writes [ScanResult]s to a storage that stores results associated to [Package]s.
+ */
+interface PackageBasedScanStorageWriter : ScanStorageWriter {
+    fun write(pkg: Package, nestedProvenanceScanResult: NestedProvenanceScanResult)
+}
+
+/**
+ * A [ScanStorageWriter] that writer [ScanResult]s to a storage that stores results by their [Provenance].
+ */
+interface ProvenanceBasedScanStorageWriter : ScanStorageWriter {
+    fun write(scanResult: ScanResult)
+}

--- a/scanner/src/main/kotlin/experimental/ScannerWrapper.kt
+++ b/scanner/src/main/kotlin/experimental/ScannerWrapper.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import java.io.File
+
+import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.ScannerDetails
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.scanner.ScannerCriteria
+
+/**
+ * The base interface for all types of scanners.
+ */
+sealed interface ScannerWrapper {
+    /**
+     * The name of the scanner.
+     */
+    val name: String
+
+    /**
+     * The details of the scanner.
+     */
+    val details: ScannerDetails
+
+    /**
+     * The [ScannerCriteria] object to be used when looking up existing scan results from a scan storage. By default,
+     * the properties of this object are initialized by the scanner implementation. These defaults can be overridden
+     * with the [ScannerConfiguration.options] property: Use properties of the form _scannerName.criteria.property_,
+     * where _scannerName_ is the name of the scanner and _property_ is the name of a property of the [ScannerCriteria]
+     * class. For instance, to specify that a specific minimum version of ScanCode is allowed, set this property:
+     * `options.ScanCode.criteria.minScannerVersion=3.0.2`.
+     */
+    val criteria: ScannerCriteria
+}
+
+/**
+ * A wrapper interface for remote scanners. A remote scanner is a scanner that is not executed locally but is running on
+ * a different machine and can be accessed via a remote interface.
+ */
+sealed interface RemoteScannerWrapper : ScannerWrapper
+
+/**
+ * A wrapper interface for remote scanners that operate on [Package]s.
+ */
+interface PackageBasedRemoteScannerWrapper : RemoteScannerWrapper {
+    fun scanPackage(pkg: Package): ScanResult
+}
+
+/**
+ * A wrapper interface for remote scanners that operate on [Provenance]s.
+ */
+interface ProvenanceBasedRemoteScannerWrapper : RemoteScannerWrapper {
+    fun scanProvenance(provenance: KnownProvenance): ScanResult
+}
+
+/**
+ * A wrapper interface for local scanners. A local scanner is a scanner that is running on the same machine and scanning
+ * files on the local filesystem.
+ */
+interface LocalScannerWrapper : ScannerWrapper {
+    fun scanPath(path: File): ScanSummary
+}

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,11 +41,13 @@ import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.scanner.AbstractScannerFactory
 import org.ossreviewtoolkit.scanner.LocalScanner
 import org.ossreviewtoolkit.scanner.ScanException
+import org.ossreviewtoolkit.scanner.experimental.LocalScannerWrapper
 import org.ossreviewtoolkit.spdx.calculatePackageVerificationCode
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.Os
 import org.ossreviewtoolkit.utils.ProcessCapture
+import org.ossreviewtoolkit.utils.createOrtTempFile
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.unpackZip
 
@@ -52,12 +55,14 @@ class Askalono(
     name: String,
     scannerConfig: ScannerConfiguration,
     downloaderConfig: DownloaderConfiguration
-) : LocalScanner(name, scannerConfig, downloaderConfig) {
+) : LocalScanner(name, scannerConfig, downloaderConfig), LocalScannerWrapper {
     class Factory : AbstractScannerFactory<Askalono>("Askalono") {
         override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
             Askalono(scannerName, scannerConfig, downloaderConfig)
     }
 
+    override val name = "Askalono"
+    override val criteria by lazy { getScannerCriteria() }
     override val expectedVersion = "0.4.3"
     override val configuration = ""
     override val resultFileExt = "txt"
@@ -167,4 +172,6 @@ class Askalono(
             issues = mutableListOf()
         )
     }
+
+    override fun scanPath(path: File): ScanSummary = scanPathInternal(path, createOrtTempFile(name))
 }

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,11 +40,13 @@ import org.ossreviewtoolkit.model.readJsonFile
 import org.ossreviewtoolkit.scanner.AbstractScannerFactory
 import org.ossreviewtoolkit.scanner.LocalScanner
 import org.ossreviewtoolkit.scanner.ScanException
+import org.ossreviewtoolkit.scanner.experimental.LocalScannerWrapper
 import org.ossreviewtoolkit.spdx.calculatePackageVerificationCode
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.Os
 import org.ossreviewtoolkit.utils.ProcessCapture
+import org.ossreviewtoolkit.utils.createOrtTempFile
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.unpackZip
 
@@ -51,7 +54,7 @@ class BoyterLc(
     name: String,
     scannerConfig: ScannerConfiguration,
     downloaderConfig: DownloaderConfiguration
-) : LocalScanner(name, scannerConfig, downloaderConfig) {
+) : LocalScanner(name, scannerConfig, downloaderConfig), LocalScannerWrapper {
     class Factory : AbstractScannerFactory<BoyterLc>("BoyterLc") {
         override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
             BoyterLc(scannerName, scannerConfig, downloaderConfig)
@@ -64,6 +67,8 @@ class BoyterLc(
         )
     }
 
+    override val name = "BoyterLc"
+    override val criteria by lazy { getScannerCriteria() }
     override val expectedVersion = "1.3.1"
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
     override val resultFileExt = "json"
@@ -166,4 +171,6 @@ class BoyterLc(
             issues = mutableListOf()
         )
     }
+
+    override fun scanPath(path: File): ScanSummary = scanPathInternal(path, createOrtTempFile(name))
 }

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,16 +34,18 @@ import org.ossreviewtoolkit.model.readJsonFile
 import org.ossreviewtoolkit.scanner.AbstractScannerFactory
 import org.ossreviewtoolkit.scanner.LocalScanner
 import org.ossreviewtoolkit.scanner.ScanException
+import org.ossreviewtoolkit.scanner.experimental.LocalScannerWrapper
 import org.ossreviewtoolkit.spdx.calculatePackageVerificationCode
 import org.ossreviewtoolkit.utils.Os
 import org.ossreviewtoolkit.utils.ProcessCapture
+import org.ossreviewtoolkit.utils.createOrtTempFile
 import org.ossreviewtoolkit.utils.log
 
 class Licensee(
     name: String,
     scannerConfig: ScannerConfiguration,
     downloaderConfig: DownloaderConfiguration
-) : LocalScanner(name, scannerConfig, downloaderConfig) {
+) : LocalScanner(name, scannerConfig, downloaderConfig), LocalScannerWrapper {
     class Factory : AbstractScannerFactory<Licensee>("Licensee") {
         override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
             Licensee(scannerName, scannerConfig, downloaderConfig)
@@ -52,6 +55,8 @@ class Licensee(
         val CONFIGURATION_OPTIONS = listOf("--json")
     }
 
+    override val name = "Licensee"
+    override val criteria by lazy { getScannerCriteria() }
     override val expectedVersion = "9.13.0"
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
     override val resultFileExt = "json"
@@ -133,4 +138,6 @@ class Licensee(
             issues = mutableListOf()
         )
     }
+
+    override fun scanPath(path: File): ScanSummary = scanPathInternal(path, createOrtTempFile(name))
 }

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,10 +44,12 @@ import org.ossreviewtoolkit.scanner.BuildConfig
 import org.ossreviewtoolkit.scanner.LocalScanner
 import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
+import org.ossreviewtoolkit.scanner.experimental.LocalScannerWrapper
 import org.ossreviewtoolkit.utils.ORT_NAME
 import org.ossreviewtoolkit.utils.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.Os
 import org.ossreviewtoolkit.utils.ProcessCapture
+import org.ossreviewtoolkit.utils.createOrtTempFile
 import org.ossreviewtoolkit.utils.isTrue
 import org.ossreviewtoolkit.utils.log
 import org.ossreviewtoolkit.utils.unpack
@@ -69,7 +72,7 @@ class ScanCode(
     name: String,
     scannerConfig: ScannerConfiguration,
     downloaderConfig: DownloaderConfiguration
-) : LocalScanner(name, scannerConfig, downloaderConfig) {
+) : LocalScanner(name, scannerConfig, downloaderConfig), LocalScannerWrapper {
     class Factory : AbstractScannerFactory<ScanCode>(SCANNER_NAME) {
         override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
             ScanCode(scannerName, scannerConfig, downloaderConfig)
@@ -107,6 +110,8 @@ class ScanCode(
         }
     }
 
+    override val name = SCANNER_NAME
+    override val criteria by lazy { getScannerCriteria() }
     override val expectedVersion = BuildConfig.SCANCODE_VERSION
 
     override val configuration by lazy {
@@ -238,4 +243,6 @@ class ScanCode(
         }
 
     override fun getRawResult(resultsFile: File) = readJsonFile(resultsFile)
+
+    override fun scanPath(path: File): ScanSummary = scanPathInternal(path, createOrtTempFile(name))
 }

--- a/scanner/src/main/resources/META-INF/services/org.ossreviewtoolkit.scanner.ScannerWrapperFactory
+++ b/scanner/src/main/resources/META-INF/services/org.ossreviewtoolkit.scanner.ScannerWrapperFactory
@@ -1,0 +1,4 @@
+org.ossreviewtoolkit.scanner.scanners.Askalono$AskalonoFactory
+org.ossreviewtoolkit.scanner.scanners.BoyterLc$BoyterLcFactory
+org.ossreviewtoolkit.scanner.scanners.Licensee$LicenseeFactory
+org.ossreviewtoolkit.scanner.scanners.scancode.ScanCode$ScanCodeFactory

--- a/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
+++ b/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
@@ -1,0 +1,798 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import com.vdurmont.semver4j.Semver
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.should
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+
+import java.io.File
+import java.time.Instant
+
+import org.ossreviewtoolkit.model.ArtifactProvenance
+import org.ossreviewtoolkit.model.Hash
+import org.ossreviewtoolkit.model.HashAlgorithm
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.ScannerDetails
+import org.ossreviewtoolkit.model.SourceCodeOrigin
+import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.model.UnknownProvenance
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.yamlMapper
+import org.ossreviewtoolkit.scanner.ScannerCriteria
+import org.ossreviewtoolkit.utils.test.containExactly
+
+class ExperimentalScannerTest : WordSpec({
+    "Creating the experimental scanner" should {
+        "throw an exception if no scanner wrappers are provided" {
+            shouldThrow<IllegalArgumentException> {
+                createScanner()
+            }
+        }
+    }
+
+    "Scanning with a package based remote scanner" should {
+        "return a scan result for each package" {
+            val pkgWithArtifact = Package.new(id = "artifact").withValidSourceArtifact()
+            val pkgWithVcs = Package.new(id = "repository").withValidVcs()
+            val scannerWrapper = spyk(FakePackageBasedRemoteScannerWrapper())
+            val scanner = createScanner(scannerWrappers = listOf(scannerWrapper))
+
+            every { scannerWrapper.scanPackage(pkgWithArtifact) } returns
+                    createRemoteScanResult(pkgWithArtifact.artifactProvenance(), scannerWrapper.details)
+            every { scannerWrapper.scanPackage(pkgWithVcs) } returns
+                    createRemoteScanResult(pkgWithVcs.repositoryProvenance(), scannerWrapper.details)
+
+            val result = scanner.scan(setOf(pkgWithArtifact, pkgWithVcs))
+
+            result should containExactly(
+                pkgWithArtifact to createRemoteNestedScanResult(
+                    provenance = pkgWithArtifact.artifactProvenance(),
+                    scannerDetails = scannerWrapper.details
+                ),
+                pkgWithVcs to createRemoteNestedScanResult(
+                    provenance = pkgWithVcs.repositoryProvenance(),
+                    scannerDetails = scannerWrapper.details
+                )
+            )
+
+            verify(exactly = 1) {
+                scannerWrapper.scanPackage(pkgWithArtifact)
+                scannerWrapper.scanPackage(pkgWithVcs)
+            }
+        }
+
+        "not try to download the source code" {
+            val pkgWithArtifact = Package.new(id = "artifact").withValidSourceArtifact()
+            val pkgWithVcs = Package.new(id = "repository").withValidVcs()
+            val provenanceDownloader = mockk<ProvenanceDownloader>()
+            val scannerWrapper = FakePackageBasedRemoteScannerWrapper()
+            val scanner = createScanner(
+                provenanceDownloader = provenanceDownloader,
+                scannerWrappers = listOf(scannerWrapper)
+            )
+
+            scanner.scan(setOf(pkgWithArtifact, pkgWithVcs))
+
+            verify(exactly = 0) { provenanceDownloader.download(any(), any()) }
+        }
+    }
+
+    "Scanning with a provenance based remote scanner" should {
+        "return a scan result for each provenance" {
+            val pkgWithArtifact = Package.new(id = "artifact").withValidSourceArtifact()
+            val pkgWithVcs = Package.new(id = "repository").withValidVcs()
+            val scannerWrapper = spyk(FakeProvenanceBasedRemoteScannerWrapper())
+            val scanner = createScanner(scannerWrappers = listOf(scannerWrapper))
+
+            val result = scanner.scan(setOf(pkgWithArtifact, pkgWithVcs))
+
+            result should containExactly(
+                pkgWithArtifact to createRemoteNestedScanResult(
+                    provenance = pkgWithArtifact.artifactProvenance(),
+                    scannerDetails = scannerWrapper.details
+                ),
+                pkgWithVcs to createRemoteNestedScanResult(
+                    provenance = pkgWithVcs.repositoryProvenance(),
+                    scannerDetails = scannerWrapper.details
+                )
+            )
+
+            verify(exactly = 1) {
+                scannerWrapper.scanProvenance(pkgWithArtifact.artifactProvenance())
+                scannerWrapper.scanProvenance(pkgWithVcs.repositoryProvenance())
+            }
+        }
+
+        "not try to download the source code" {
+            val pkgWithArtifact = Package.new(id = "artifact").withValidSourceArtifact()
+            val pkgWithVcs = Package.new(id = "repository").withValidVcs()
+            val provenanceDownloader = mockk<ProvenanceDownloader>()
+            val scannerWrapper = FakeProvenanceBasedRemoteScannerWrapper()
+            val scanner = createScanner(
+                provenanceDownloader = provenanceDownloader,
+                scannerWrappers = listOf(scannerWrapper)
+            )
+
+            scanner.scan(setOf(pkgWithArtifact, pkgWithVcs))
+
+            verify(exactly = 0) { provenanceDownloader.download(any(), any()) }
+        }
+    }
+
+    "scanning with a local scanner" should {
+        "return a scan result for each provenance" {
+            val pkgWithArtifact = Package.new(id = "artifact").withValidSourceArtifact()
+            val pkgWithVcs = Package.new(id = "repository").withValidVcs()
+            val scannerWrapper = spyk(FakeLocalScannerWrapper())
+            val scanner = createScanner(scannerWrappers = listOf(scannerWrapper))
+
+            val result = scanner.scan(setOf(pkgWithArtifact, pkgWithVcs))
+
+            result should containExactly(
+                pkgWithArtifact to createLocalNestedScanResult(
+                    provenance = pkgWithArtifact.artifactProvenance(),
+                    scannerDetails = scannerWrapper.details
+                ),
+                pkgWithVcs to createLocalNestedScanResult(
+                    provenance = pkgWithVcs.repositoryProvenance(),
+                    scannerDetails = scannerWrapper.details
+                )
+            )
+
+            verify(exactly = 2) {
+                scannerWrapper.scanPath(any())
+            }
+        }
+
+        "try to download the source code" {
+            val pkgWithArtifact = Package.new(id = "artifact").withValidSourceArtifact()
+            val pkgWithVcs = Package.new(id = "repository").withValidVcs()
+            val provenanceDownloader = spyk(FakeProvenanceDownloader())
+            val scannerWrapper = FakeLocalScannerWrapper()
+            val scanner = createScanner(
+                provenanceDownloader = provenanceDownloader,
+                scannerWrappers = listOf(scannerWrapper)
+            )
+
+            scanner.scan(setOf(pkgWithArtifact, pkgWithVcs))
+
+            verify(exactly = 1) {
+                provenanceDownloader.download(pkgWithArtifact.artifactProvenance(), any())
+                provenanceDownloader.download(pkgWithVcs.repositoryProvenance(), any())
+            }
+        }
+    }
+
+    "scanning with a package based storage reader" should {
+        "prefer a stored result over a new scan" {
+            val pkgWithArtifact = Package.new(id = "artifact").withValidSourceArtifact()
+            val scannerWrapper = spyk(FakePackageBasedRemoteScannerWrapper())
+            val reader = spyk(FakePackageBasedStorageReader(scannerWrapper.details))
+
+            every { reader.read(pkgWithArtifact) } returns listOf(
+                createStoredNestedScanResult(pkgWithArtifact.artifactProvenance(), scannerWrapper.details)
+            )
+
+            val scanner = createScanner(
+                storageReaders = listOf(reader),
+                scannerWrappers = listOf(scannerWrapper)
+            )
+
+            val result = scanner.scan(setOf(pkgWithArtifact))
+
+            result should containExactly(
+                pkgWithArtifact to createStoredNestedScanResult(
+                    provenance = pkgWithArtifact.artifactProvenance(),
+                    scannerDetails = scannerWrapper.details
+                )
+            )
+
+            verify(exactly = 0) {
+                scannerWrapper.scanPackage(pkgWithArtifact)
+            }
+        }
+
+        "start a scan if no stored result is available" {
+            val pkgWithArtifact = Package.new(id = "artifact").withValidSourceArtifact()
+            val scannerWrapper = spyk(FakePackageBasedRemoteScannerWrapper())
+            val reader = spyk(FakePackageBasedStorageReader(scannerWrapper.details))
+
+            every { reader.read(any()) } returns emptyList()
+
+            val scanner = createScanner(
+                storageReaders = listOf(reader),
+                scannerWrappers = listOf(scannerWrapper)
+            )
+
+            val result = scanner.scan(setOf(pkgWithArtifact))
+
+            result should containExactly(
+                pkgWithArtifact to createRemoteNestedScanResult(
+                    provenance = pkgWithArtifact.artifactProvenance(),
+                    scannerDetails = scannerWrapper.details
+                )
+            )
+
+            verify(exactly = 1) {
+                reader.read(pkgWithArtifact)
+                scannerWrapper.scanPackage(pkgWithArtifact)
+            }
+        }
+
+        "scan only the parts of a nested provenance for which no stored result is available" {
+            val pkgCompletelyScanned = Package.new(id = "completely").withValidVcs().withVcsRevision("revision1")
+            val pkgPartlyScanned = Package.new(id = "partly").withValidVcs().withVcsRevision("revision2")
+
+            val scannerWrapper = spyk(FakeProvenanceBasedRemoteScannerWrapper())
+
+            val scannedSubRepository = RepositoryProvenance(
+                VcsInfo(VcsType.GIT, "https://example.com/scanned", "revision"),
+                "resolvedRevision"
+            )
+            val unscannedSubRepository = RepositoryProvenance(
+                VcsInfo(VcsType.GIT, "https://example.com/unscanned", "revision"),
+                "resolvedRevision"
+            )
+
+            val nestedProvenanceCompletelyScanned = NestedProvenance(
+                root = pkgCompletelyScanned.repositoryProvenance(),
+                subRepositories = mapOf("path" to scannedSubRepository)
+            )
+            val nestedProvenancePartlyScanned = NestedProvenance(
+                root = pkgPartlyScanned.repositoryProvenance(),
+                subRepositories = mapOf("path1" to scannedSubRepository, "path2" to unscannedSubRepository)
+            )
+
+            val nestedScanResultCompletelyScanned = createRemoteNestedScanResult(
+                provenance = nestedProvenanceCompletelyScanned.root,
+                scannerDetails = scannerWrapper.details,
+                subRepositories = nestedProvenanceCompletelyScanned.subRepositories
+            )
+            val nestedScanResultPartlyScanned = createRemoteNestedScanResult(
+                provenance = nestedProvenancePartlyScanned.root,
+                scannerDetails = scannerWrapper.details,
+                subRepositories = nestedProvenancePartlyScanned.subRepositories
+            )
+
+            val nestedProvenanceResolver = spyk(FakeNestedProvenanceResolver())
+
+            every {
+                nestedProvenanceResolver.resolveNestedProvenance(pkgCompletelyScanned.repositoryProvenance())
+            } returns nestedProvenanceCompletelyScanned
+            every {
+                nestedProvenanceResolver.resolveNestedProvenance(pkgPartlyScanned.repositoryProvenance())
+            } returns nestedProvenancePartlyScanned
+
+            val reader = spyk(FakePackageBasedStorageReader(scannerWrapper.details))
+
+            every { reader.read(pkgCompletelyScanned) } returns listOf(nestedScanResultCompletelyScanned)
+
+            val scanner = createScanner(
+                storageReaders = listOf(reader),
+                nestedProvenanceResolver = nestedProvenanceResolver,
+                scannerWrappers = listOf(scannerWrapper)
+            )
+
+            val result = scanner.scan(setOf(pkgCompletelyScanned, pkgPartlyScanned))
+
+            result should containExactly(
+                pkgCompletelyScanned to nestedScanResultCompletelyScanned,
+                pkgPartlyScanned to nestedScanResultPartlyScanned
+            )
+
+            verify(exactly = 0) {
+                scannerWrapper.scanProvenance(scannedSubRepository)
+            }
+
+            verify(exactly = 1) {
+                scannerWrapper.scanProvenance(unscannedSubRepository)
+            }
+        }
+    }
+
+    "scanning with a provenance based storage reader" should {
+        "prefer a stored result over a new scan" {
+            val pkgWithArtifact = Package.new(id = "artifact").withValidSourceArtifact()
+            val scannerWrapper = spyk(FakeProvenanceBasedRemoteScannerWrapper())
+            val reader = spyk(FakeProvenanceBasedStorageReader(scannerWrapper.details))
+
+            every { reader.read(pkgWithArtifact.artifactProvenance()) } returns listOf(
+                createStoredScanResult(pkgWithArtifact.artifactProvenance(), scannerWrapper.details)
+            )
+
+            val scanner = createScanner(
+                storageReaders = listOf(reader),
+                scannerWrappers = listOf(scannerWrapper)
+            )
+
+            val result = scanner.scan(setOf(pkgWithArtifact))
+
+            result should containExactly(
+                pkgWithArtifact to createStoredNestedScanResult(
+                    pkgWithArtifact.artifactProvenance(),
+                    scannerWrapper.details
+                )
+            )
+
+            verify(exactly = 0) {
+                scannerWrapper.scanProvenance(pkgWithArtifact.artifactProvenance())
+            }
+        }
+
+        "start a scan if no stored result is available" {
+            val pkgWithArtifact = Package.new(id = "artifact").withValidSourceArtifact()
+            val scannerWrapper = spyk(FakeProvenanceBasedRemoteScannerWrapper())
+            val reader = spyk(FakeProvenanceBasedStorageReader(scannerWrapper.details))
+
+            every { reader.read(any()) } returns emptyList()
+
+            val scanner = createScanner(
+                storageReaders = listOf(reader),
+                scannerWrappers = listOf(scannerWrapper)
+            )
+
+            val result = scanner.scan(setOf(pkgWithArtifact))
+
+            result should containExactly(
+                pkgWithArtifact to createRemoteNestedScanResult(
+                    pkgWithArtifact.artifactProvenance(),
+                    scannerWrapper.details
+                )
+            )
+
+            verify(exactly = 1) {
+                reader.read(pkgWithArtifact.artifactProvenance())
+                scannerWrapper.scanProvenance(pkgWithArtifact.artifactProvenance())
+            }
+        }
+
+        "scan only the parts of a nested provenance for which no stored result is available" {
+            val pkgCompletelyScanned = Package.new(id = "completely").withValidVcs().withVcsRevision("revision1")
+            val pkgPartlyScanned = Package.new(id = "partly").withValidVcs().withVcsRevision("revision2")
+
+            val scannerWrapper = spyk(FakeProvenanceBasedRemoteScannerWrapper())
+
+            val scannedSubRepository = RepositoryProvenance(
+                VcsInfo(VcsType.GIT, "https://example.com/scanned", "revision"),
+                "resolvedRevision"
+            )
+            val unscannedSubRepository = RepositoryProvenance(
+                VcsInfo(VcsType.GIT, "https://example.com/unscanned", "revision"),
+                "resolvedRevision"
+            )
+
+            val nestedProvenanceCompletelyScanned = NestedProvenance(
+                root = pkgCompletelyScanned.repositoryProvenance(),
+                subRepositories = mapOf("path" to scannedSubRepository)
+            )
+            val nestedProvenancePartlyScanned = NestedProvenance(
+                root = pkgPartlyScanned.repositoryProvenance(),
+                subRepositories = mapOf("path1" to scannedSubRepository, "path2" to unscannedSubRepository)
+            )
+
+            val nestedScanResultCompletelyScanned = createStoredNestedScanResult(
+                provenance = nestedProvenanceCompletelyScanned.root,
+                scannerDetails = scannerWrapper.details,
+                subRepositories = nestedProvenanceCompletelyScanned.subRepositories
+            )
+
+            val nestedScanResultPartlyScanned = NestedProvenanceScanResult(
+                nestedProvenance = nestedProvenancePartlyScanned,
+                scanResults = mapOf(
+                    pkgPartlyScanned.repositoryProvenance() to listOf(
+                        createStoredScanResult(pkgPartlyScanned.repositoryProvenance(), scannerWrapper.details)
+                    ),
+                    scannedSubRepository to listOf(
+                        createStoredScanResult(scannedSubRepository, scannerWrapper.details)
+                    ),
+                    unscannedSubRepository to listOf(
+                        createRemoteScanResult(unscannedSubRepository, scannerWrapper.details)
+                    )
+                )
+            )
+
+            val nestedProvenanceResolver = spyk(FakeNestedProvenanceResolver())
+
+            every {
+                nestedProvenanceResolver.resolveNestedProvenance(pkgCompletelyScanned.repositoryProvenance())
+            } returns nestedProvenanceCompletelyScanned
+            every {
+                nestedProvenanceResolver.resolveNestedProvenance(pkgPartlyScanned.repositoryProvenance())
+            } returns nestedProvenancePartlyScanned
+
+            val reader = spyk(FakeProvenanceBasedStorageReader(scannerWrapper.details))
+
+            every { reader.read(unscannedSubRepository) } returns emptyList()
+
+            val scanner = createScanner(
+                storageReaders = listOf(reader),
+                nestedProvenanceResolver = nestedProvenanceResolver,
+                scannerWrappers = listOf(scannerWrapper)
+            )
+
+            val result = scanner.scan(setOf(pkgCompletelyScanned, pkgPartlyScanned))
+
+            result should containExactly(
+                pkgCompletelyScanned to nestedScanResultCompletelyScanned,
+                pkgPartlyScanned to nestedScanResultPartlyScanned
+            )
+
+            verify(exactly = 0) {
+                scannerWrapper.scanProvenance(scannedSubRepository)
+            }
+
+            verify(exactly = 1) {
+                scannerWrapper.scanProvenance(unscannedSubRepository)
+            }
+        }
+    }
+
+    "scanning with a package based storage writer" should {
+        "store the scan result" {
+            val pkgWithArtifact = Package.new(id = "artifact").withValidSourceArtifact()
+            val scannerWrapper = FakePackageBasedRemoteScannerWrapper()
+            val writer = spyk(FakePackageBasedStorageWriter())
+
+            val scanner = createScanner(
+                storageWriters = listOf(writer),
+                scannerWrappers = listOf(scannerWrapper)
+            )
+
+            scanner.scan(setOf(pkgWithArtifact))
+
+            verify(exactly = 1) {
+                writer.write(
+                    pkgWithArtifact,
+                    createRemoteNestedScanResult(pkgWithArtifact.artifactProvenance(), scannerWrapper.details)
+                )
+            }
+        }
+
+        "not try to store the scan result if it was retrieved from a storage" {
+            val pkgWithArtifact = Package.new(id = "artifact").withValidSourceArtifact()
+            val scannerWrapper = FakePackageBasedRemoteScannerWrapper()
+            val reader = FakePackageBasedStorageReader(scannerWrapper.details)
+            val writer = spyk(FakePackageBasedStorageWriter())
+
+            val scanner = createScanner(
+                storageReaders = listOf(reader),
+                storageWriters = listOf(writer),
+                scannerWrappers = listOf(scannerWrapper)
+            )
+
+            scanner.scan(setOf(pkgWithArtifact))
+
+            verify(exactly = 0) {
+                writer.write(any(), any())
+            }
+        }
+    }
+
+    "scanning with a provenance based storage writer" should {
+        "store the scan result" {
+            val pkgWithArtifact = Package.new(id = "artifact").withValidSourceArtifact()
+            val scannerWrapper = FakePackageBasedRemoteScannerWrapper()
+            val writer = spyk(FakeProvenanceBasedStorageWriter())
+
+            val scanner = createScanner(
+                storageWriters = listOf(writer),
+                scannerWrappers = listOf(scannerWrapper)
+            )
+
+            scanner.scan(setOf(pkgWithArtifact))
+
+            verify(exactly = 1) {
+                writer.write(createRemoteScanResult(pkgWithArtifact.artifactProvenance(), scannerWrapper.details))
+            }
+        }
+
+        "not try to store the scan result if it was retrieved from a storage" {
+            val pkgWithArtifact = Package.new(id = "artifact").withValidSourceArtifact()
+            val scannerWrapper = FakePackageBasedRemoteScannerWrapper()
+            val reader = FakePackageBasedStorageReader(scannerWrapper.details)
+            val writer = spyk(FakeProvenanceBasedStorageWriter())
+
+            val scanner = createScanner(
+                storageReaders = listOf(reader),
+                storageWriters = listOf(writer),
+                scannerWrappers = listOf(scannerWrapper)
+            )
+
+            scanner.scan(setOf(pkgWithArtifact))
+
+            verify(exactly = 0) {
+                writer.write(any())
+            }
+        }
+    }
+
+    // TODO: Add tests for combinations of different types of storage readers and writers.
+    // TODO: Add tests for using multiple types of scanner wrappers at once.
+    // TODO: Add tests for a complex example with multiple types of scanner wrappers and storages.
+    // TODO: Add tests to verify that scanner details are correctly matched.
+    // TODO: Add tests to verify that repository provenance paths are correctly handled.
+    // TODO: Add tests for error handling, for example missing provenance, download errors, or scanner errors.
+    // TODO: Add tests to verify that scanner criteria are correctly handled.
+})
+
+/**
+ * An implementation of [PackageBasedRemoteScannerWrapper] that creates empty scan results.
+ */
+private class FakePackageBasedRemoteScannerWrapper(
+    val packageProvenanceResolver: PackageProvenanceResolver = FakePackageProvenanceResolver(),
+    val sourceCodeOriginPriority: List<SourceCodeOrigin> = listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT)
+) : PackageBasedRemoteScannerWrapper {
+    override val details: ScannerDetails = ScannerDetails("fake", "1.0.0", "config")
+    override val name: String = details.name
+    override val criteria: ScannerCriteria = details.toCriteria()
+
+    override fun scanPackage(pkg: Package): ScanResult =
+        createRemoteScanResult(packageProvenanceResolver.resolveProvenance(pkg, sourceCodeOriginPriority), details)
+}
+
+/**
+ * An implementation of [ProvenanceBasedRemoteScannerWrapper] that creates empty scan results.
+ */
+private class FakeProvenanceBasedRemoteScannerWrapper : ProvenanceBasedRemoteScannerWrapper {
+    override val details: ScannerDetails = ScannerDetails("fake", "1.0.0", "config")
+    override val name: String = details.name
+    override val criteria: ScannerCriteria = details.toCriteria()
+
+    override fun scanProvenance(provenance: KnownProvenance): ScanResult =
+        createRemoteScanResult(provenance, details)
+}
+
+/**
+ * An implementation of [LocalScannerWrapper] that creates scan results with one license finding for each file.
+ */
+private class FakeLocalScannerWrapper : LocalScannerWrapper {
+    override val details: ScannerDetails = ScannerDetails("fake", "1.0.0", "config")
+    override val name: String = details.name
+    override val criteria: ScannerCriteria = details.toCriteria()
+
+    override fun scanPath(path: File): ScanSummary {
+        val licenseFindings = path.walk().filter { it.isFile }.map { file ->
+            LicenseFinding("Apache-2.0", TextLocation(file.relativeTo(path).path, 1, 2))
+        }.toSortedSet()
+
+        return createScanSummary(licenseFindings = licenseFindings)
+    }
+}
+
+/**
+ * An implementation of [ProvenanceDownloader] that creates a file called "provenance.txt" containing the serialized
+ * provenance, instead of actually downloading the source code.
+ */
+private class FakeProvenanceDownloader : ProvenanceDownloader {
+    override fun download(provenance: KnownProvenance, downloadDir: File) {
+        // TODO: Should downloadDir be created if it does not exist?
+        val file = downloadDir.resolve("provenance.txt")
+        file.writeText(yamlMapper.writeValueAsString(provenance))
+    }
+}
+
+/**
+ * An implementation of [PackageProvenanceResolver] that returns the values from the package without performing any
+ * validation.
+ */
+private class FakePackageProvenanceResolver : PackageProvenanceResolver {
+    override fun resolveProvenance(pkg: Package, sourceCodeOriginPriority: List<SourceCodeOrigin>): Provenance {
+        sourceCodeOriginPriority.forEach { sourceCodeOrigin ->
+            when (sourceCodeOrigin) {
+                SourceCodeOrigin.ARTIFACT -> {
+                    if (pkg.sourceArtifact != RemoteArtifact.EMPTY) {
+                        return ArtifactProvenance(pkg.sourceArtifact)
+                    }
+                }
+
+                SourceCodeOrigin.VCS -> {
+                    if (pkg.vcsProcessed != VcsInfo.EMPTY) {
+                        return RepositoryProvenance(pkg.vcsProcessed, "resolvedRevision")
+                    }
+                }
+            }
+        }
+
+        return UnknownProvenance
+    }
+}
+
+/**
+ * An implementation of [NestedProvenanceResolver] that always returns a non-nested provenance.
+ */
+private class FakeNestedProvenanceResolver : NestedProvenanceResolver {
+    override fun resolveNestedProvenance(provenance: KnownProvenance): NestedProvenance =
+        NestedProvenance(root = provenance, subRepositories = emptyMap())
+}
+
+/**
+ * An implementation of [PackageBasedScanStorageReader] and [PackageBasedScanStorageWriter] that returns scan results
+ * with a single license finding for the provided [scannerDetails].
+ */
+private class FakePackageBasedStorageReader(val scannerDetails: ScannerDetails) : PackageBasedScanStorageReader {
+    override fun read(pkg: Package): List<NestedProvenanceScanResult> {
+        val provenance = if (pkg.sourceArtifact != RemoteArtifact.EMPTY) {
+            ArtifactProvenance(pkg.sourceArtifact)
+        } else {
+            RepositoryProvenance(pkg.vcsProcessed, pkg.vcsProcessed.revision)
+        }
+
+        return listOf(createStoredNestedScanResult(provenance, scannerDetails))
+    }
+
+    override fun read(pkg: Package, scannerCriteria: ScannerCriteria): List<NestedProvenanceScanResult> = read(pkg)
+}
+
+private class FakeProvenanceBasedStorageReader(val scannerDetails: ScannerDetails) : ProvenanceBasedScanStorageReader {
+    override fun read(provenance: KnownProvenance): List<ScanResult> =
+        listOf(createStoredScanResult(provenance, scannerDetails))
+
+    override fun read(provenance: KnownProvenance, scannerCriteria: ScannerCriteria): List<ScanResult> =
+        read(provenance)
+}
+
+private class FakePackageBasedStorageWriter : PackageBasedScanStorageWriter {
+    override fun write(pkg: Package, nestedProvenanceScanResult: NestedProvenanceScanResult) = Unit
+}
+
+private class FakeProvenanceBasedStorageWriter : ProvenanceBasedScanStorageWriter {
+    override fun write(scanResult: ScanResult) = Unit
+}
+
+@Suppress("LongParameterList")
+private fun createScanner(
+    scannerConfig: ScannerConfiguration = ScannerConfiguration(),
+    downloaderConfig: DownloaderConfiguration = DownloaderConfiguration(),
+    provenanceDownloader: ProvenanceDownloader = FakeProvenanceDownloader(),
+    storageReaders: List<ScanStorageReader> = emptyList(),
+    storageWriters: List<ScanStorageWriter> = emptyList(),
+    packageProvenanceResolver: PackageProvenanceResolver = FakePackageProvenanceResolver(),
+    nestedProvenanceResolver: NestedProvenanceResolver = FakeNestedProvenanceResolver(),
+    scannerWrappers: List<ScannerWrapper> = emptyList()
+) =
+    ExperimentalScanner(
+        scannerConfig,
+        downloaderConfig,
+        provenanceDownloader,
+        storageReaders,
+        storageWriters,
+        packageProvenanceResolver,
+        nestedProvenanceResolver,
+        scannerWrappers
+    )
+
+private fun ScannerDetails.toCriteria() =
+    ScannerCriteria(
+        regScannerName = name,
+        minVersion = Semver(version),
+        maxVersion = Semver(version),
+        configMatcher = { true }
+    )
+
+private fun Package.Companion.new(type: String = "", group: String = "", id: String = "", version: String = "") =
+    EMPTY.copy(id = Identifier(type, group, id, version))
+
+private fun Package.artifactProvenance() = ArtifactProvenance(sourceArtifact)
+private fun Package.repositoryProvenance() = RepositoryProvenance(vcsProcessed, "resolvedRevision")
+
+private fun Package.withValidSourceArtifact() = copy(sourceArtifact = RemoteArtifact.valid())
+private fun Package.withValidVcs() = copy(vcsProcessed = VcsInfo.valid())
+private fun Package.withVcsRevision(revision: String) = copy(vcsProcessed = vcsProcessed.copy(revision = revision))
+
+private fun RemoteArtifact.Companion.valid() =
+    RemoteArtifact(
+        url = "https://jitpack.io/com/github/oss-review-toolkit/ort/cli/f42e41a8fe/cli-f42e41a8fe-sources.jar",
+        hash = Hash("7d41355bbe5315daa1414683b301838c", HashAlgorithm.MD5)
+    )
+
+private fun VcsInfo.Companion.valid() =
+    VcsInfo(
+        type = VcsType.GIT,
+        url = "https://github.com/oss-review-toolkit/ort.git",
+        revision = "f42e41a8fedc1e0acd78fab147e91fa047cb2853"
+    )
+
+private fun createScanSummary(licenseFindings: Set<LicenseFinding> = emptySet()) =
+    ScanSummary(Instant.EPOCH, Instant.EPOCH, "", licenseFindings.toSortedSet(), sortedSetOf())
+
+private fun createRemoteScanResult(provenance: Provenance, scannerDetails: ScannerDetails) =
+    ScanResult(
+        provenance,
+        scannerDetails,
+        createScanSummary(
+            licenseFindings = sortedSetOf(
+                LicenseFinding("Apache-2.0", TextLocation("remote.txt", 1, 2))
+            )
+        )
+    )
+
+private fun createRemoteNestedScanResult(
+    provenance: KnownProvenance,
+    scannerDetails: ScannerDetails,
+    subRepositories: Map<String, RepositoryProvenance> = emptyMap()
+) =
+    NestedProvenanceScanResult(
+        NestedProvenance(root = provenance, subRepositories = subRepositories),
+        scanResults = mapOf(
+            provenance to listOf(createRemoteScanResult(provenance, scannerDetails))
+        ) + subRepositories.values.associateWith { listOf(createRemoteScanResult(it, scannerDetails)) }
+    )
+
+private fun createLocalScanResult(provenance: Provenance, scannerDetails: ScannerDetails) =
+    ScanResult(
+        provenance,
+        scannerDetails,
+        createScanSummary(
+            licenseFindings = setOf(
+                LicenseFinding("Apache-2.0", TextLocation("provenance.txt", 1, 2))
+            )
+        )
+    )
+
+private fun createLocalNestedScanResult(provenance: KnownProvenance, scannerDetails: ScannerDetails) =
+    NestedProvenanceScanResult(
+        NestedProvenance(root = provenance, subRepositories = emptyMap()),
+        scanResults = mapOf(
+            provenance to listOf(createLocalScanResult(provenance, scannerDetails))
+        )
+    )
+
+private fun createStoredScanResult(provenance: Provenance, scannerDetails: ScannerDetails) =
+    ScanResult(
+        provenance,
+        scannerDetails,
+        createScanSummary(
+            licenseFindings = sortedSetOf(
+                LicenseFinding("Apache-2.0", TextLocation("storage.txt", 1, 2))
+            )
+        )
+    )
+
+private fun createStoredNestedScanResult(
+    provenance: KnownProvenance,
+    scannerDetails: ScannerDetails,
+    subRepositories: Map<String, RepositoryProvenance> = emptyMap()
+) =
+    NestedProvenanceScanResult(
+        NestedProvenance(root = provenance, subRepositories = subRepositories),
+        scanResults = mapOf(
+            provenance to listOf(createStoredScanResult(provenance, scannerDetails))
+        ) + subRepositories.values.associateWith { listOf(createStoredScanResult(it, scannerDetails)) }
+    )


### PR DESCRIPTION
Add a new experimental scanner implementation that aims to scan each provenance (meaning source code repository or source artifact) only once. This provides better performance and uses less storage for scan results. The new implementation can be tried by providing the `--experimental` switch to the `scan` command.

Simplified, the algorithm of the new scanner is:
* Resolve the provenance of all packages, including sub-repositories, to determine if there are any overlaps.
* Check if any stored scan results are available for the provenances.
* Scan the remaining provenances.
* Associate the scan results back to the packages.

The implementation is not yet feature complete, missing functionality will be added in later PRs. Please see the commit messages for details.