### PR TITLE
reference.conf: Use hash-chars for comments in HOCON

### DIFF
--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -1,5 +1,5 @@
-// A reference configuration file containing all possible ORT configuration options. Some of those options are mutually
-// exclusive, so this file is only used to show all options and to validate the configuration.
+# A reference configuration file containing all possible ORT configuration options. Some of those options are mutually
+# exclusive, so this file is only used to show all options and to validate the configuration.
 ort {
   licenseFilePatterns {
     licenseFilenames = ["license*"]
@@ -38,7 +38,7 @@ ort {
   }
 
   downloader {
-    // Only used by the CLI tool when the '--license-classifications-file' option is specified.
+    # Only used by the CLI tool when the '--license-classifications-file' option is specified.
     includedLicenseCategories: [
       category-a,
       category-b
@@ -75,8 +75,8 @@ ort {
     createMissingArchives = false
 
     options {
-      // A map of maps from scanner class names to scanner-specific key-value pairs.
-      // At the example of applying custom options for ScanCode, this would look like:
+      # A map of maps from scanner class names to scanner-specific key-value pairs.
+      # At the example of applying custom options for ScanCode, this would look like:
       ScanCode {
         commandLine = --copyright --license --info --strip-root --timeout 300
         parseLicenseExpressions = true


### PR DESCRIPTION
This is to align a bit with YAML configuration files.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>