### PR TITLE
Add support for defects to ORT's data model

### DIFF
--- a/advisor/src/main/kotlin/AdviceProvider.kt
+++ b/advisor/src/main/kotlin/AdviceProvider.kt
@@ -31,22 +31,22 @@ import org.ossreviewtoolkit.utils.collectMessagesAsString
 import org.ossreviewtoolkit.utils.showStackTrace
 
 /**
- * An abstract class that represents a service that can retrieve vulnerability information
- * for a list of given [Package]s.
+ * An abstract class that represents a service that can retrieve any kind of advice information
+ * for a list of given [Package]s. Examples of such information can be security vulnerabilities, known defects,
+ * or code analysis results.
  */
-abstract class VulnerabilityProvider(val providerName: String) {
+abstract class AdviceProvider(val providerName: String) {
     /**
-     * For a given list of [Package]s, retrieve vulnerability information and return a map
-     * that associates each package with a list of [AdvisorResult]s. Needs to be implemented
-     * by child classes.
+     * For a given list of [Package]s, retrieve  findings and return a map that associates each package with a list
+     * of [AdvisorResult]s. Needs to be implemented by child classes.
      */
-    abstract suspend fun retrievePackageVulnerabilities(
+    abstract suspend fun retrievePackageFindings(
         packages: List<Package>
     ): Map<Package, List<AdvisorResult>>
 
     /**
      * A generic method that creates a failed [AdvisorResult] for [Package]s if there was an issue
-     * during the retrieval of vulnerability information.
+     * constructing the provider-specific information.
      */
     protected fun createFailedResults(
         startTime: Instant,
@@ -67,7 +67,7 @@ abstract class VulnerabilityProvider(val providerName: String) {
                     issues = listOf(
                         createAndLogIssue(
                             source = providerName,
-                            message = "Failed to retrieve security vulnerabilities from $providerName: " +
+                            message = "Failed to retrieve findings from $providerName: " +
                                     t.collectMessagesAsString()
                         )
                     )

--- a/advisor/src/main/kotlin/AdviceProviderFactory.kt
+++ b/advisor/src/main/kotlin/AdviceProviderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Bosch.IO GmbH
+ * Copyright (C) 2020-2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,27 +26,27 @@ import org.ossreviewtoolkit.utils.ORT_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ortConfigDirectory
 
 /**
- * A common interface for use with [ServiceLoader] that all [AbstractVulnerabilityProviderFactory] classes need to
+ * A common interface for use with [ServiceLoader] that all [AbstractAdviceProviderFactory] classes need to
  * implement.
  */
-interface VulnerabilityProviderFactory {
+interface AdviceProviderFactory {
     /**
      * The name to use to refer to the provider.
      */
     val providerName: String
 
     /**
-     * Create a [VulnerabilityProvider] using the specified [config].
+     * Create an [AdviceProvider] using the specified [config].
      */
-    fun create(config: AdvisorConfiguration): VulnerabilityProvider
+    fun create(config: AdvisorConfiguration): AdviceProvider
 }
 
 /**
- * A generic factory class for a [VulnerabilityProvider].
+ * A generic factory class for an [AdviceProvider].
  */
-abstract class AbstractVulnerabilityProviderFactory<out T : VulnerabilityProvider>(
+abstract class AbstractAdviceProviderFactory<out T : AdviceProvider>(
     override val providerName: String
-) : VulnerabilityProviderFactory {
+) : AdviceProviderFactory {
     abstract override fun create(config: AdvisorConfiguration): T
 
     protected fun <T : Any> AdvisorConfiguration.forProvider(select: AdvisorConfiguration.() -> T?): T =

--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -36,22 +36,23 @@ import org.ossreviewtoolkit.utils.Environment
 import org.ossreviewtoolkit.utils.log
 
 /**
- * The class to manage [VulnerabilityProvider]s that retrieve security advisories.
+ * The class to manage [AdviceProvider]s. It invokes the configured providers and adds their findings to the current
+ * [OrtResult].
  */
 class Advisor(
-    private val providerFactories: List<VulnerabilityProviderFactory>,
+    private val providerFactories: List<AdviceProviderFactory>,
     private val config: AdvisorConfiguration
 ) {
     companion object {
-        private val LOADER = ServiceLoader.load(VulnerabilityProviderFactory::class.java)!!
+        private val LOADER = ServiceLoader.load(AdviceProviderFactory::class.java)!!
 
         /**
-         * The list of all available [VulnerabilityProvider]s in the classpath.
+         * The list of all available [AdviceProvider]s in the classpath.
          */
         val ALL by lazy { LOADER.iterator().asSequence().toList().sortedBy { it.providerName } }
     }
 
-    fun retrieveVulnerabilityInformation(ortResult: OrtResult, skipExcluded: Boolean = false): OrtResult {
+    fun retrieveFindings(ortResult: OrtResult, skipExcluded: Boolean = false): OrtResult {
         val startTime = Instant.now()
 
         if (ortResult.analyzer == null) {
@@ -72,7 +73,7 @@ class Advisor(
         runBlocking {
             providers.map { provider ->
                 async {
-                    provider.retrievePackageVulnerabilities(packages)
+                    provider.retrievePackageFindings(packages)
                 }
             }.forEach { providerResults ->
                 providerResults.await().forEach { (pkg, advisorResults) ->

--- a/advisor/src/main/kotlin/advisors/NexusIq.kt
+++ b/advisor/src/main/kotlin/advisors/NexusIq.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Bosch.IO GmbH
+ * Copyright (C) 2020-2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,9 +97,9 @@ class NexusIq(name: String, private val nexusIqConfig: NexusIqConfiguration) : V
                 componentDetails[pkg.id.toPurl()]?.let { details ->
                     pkg to listOf(
                         AdvisorResult(
-                            details.securityData.securityIssues.map { it.toVulnerability() },
                             AdvisorDetails(providerName),
-                            AdvisorSummary(startTime, endTime)
+                            AdvisorSummary(startTime, endTime),
+                            vulnerabilities = details.securityData.securityIssues.map { it.toVulnerability() }
                         )
                     )
                 }

--- a/advisor/src/main/kotlin/advisors/NexusIq.kt
+++ b/advisor/src/main/kotlin/advisors/NexusIq.kt
@@ -23,8 +23,8 @@ import java.io.IOException
 import java.net.URI
 import java.time.Instant
 
-import org.ossreviewtoolkit.advisor.AbstractVulnerabilityProviderFactory
-import org.ossreviewtoolkit.advisor.VulnerabilityProvider
+import org.ossreviewtoolkit.advisor.AbstractAdviceProviderFactory
+import org.ossreviewtoolkit.advisor.AdviceProvider
 import org.ossreviewtoolkit.clients.nexusiq.NexusIqService
 import org.ossreviewtoolkit.model.AdvisorDetails
 import org.ossreviewtoolkit.model.AdvisorResult
@@ -50,8 +50,8 @@ private const val REQUEST_CHUNK_SIZE = 128
 /**
  * A wrapper for [Nexus IQ Server](https://help.sonatype.com/iqserver) security vulnerability data.
  */
-class NexusIq(name: String, private val nexusIqConfig: NexusIqConfiguration) : VulnerabilityProvider(name) {
-    class Factory : AbstractVulnerabilityProviderFactory<NexusIq>("NexusIQ") {
+class NexusIq(name: String, private val nexusIqConfig: NexusIqConfiguration) : AdviceProvider(name) {
+    class Factory : AbstractAdviceProviderFactory<NexusIq>("NexusIQ") {
         override fun create(config: AdvisorConfiguration) = NexusIq(providerName, config.forProvider { nexusIq })
     }
 
@@ -64,7 +64,7 @@ class NexusIq(name: String, private val nexusIqConfig: NexusIqConfiguration) : V
         )
     }
 
-    override suspend fun retrievePackageVulnerabilities(packages: List<Package>): Map<Package, List<AdvisorResult>> {
+    override suspend fun retrievePackageFindings(packages: List<Package>): Map<Package, List<AdvisorResult>> {
         val startTime = Instant.now()
 
         val components = packages.map { pkg ->

--- a/advisor/src/main/kotlin/advisors/OssIndex.kt
+++ b/advisor/src/main/kotlin/advisors/OssIndex.kt
@@ -23,8 +23,8 @@ import java.io.IOException
 import java.net.URI
 import java.time.Instant
 
-import org.ossreviewtoolkit.advisor.AbstractVulnerabilityProviderFactory
-import org.ossreviewtoolkit.advisor.VulnerabilityProvider
+import org.ossreviewtoolkit.advisor.AbstractAdviceProviderFactory
+import org.ossreviewtoolkit.advisor.AdviceProvider
 import org.ossreviewtoolkit.clients.ossindex.OssIndexService
 import org.ossreviewtoolkit.model.AdvisorDetails
 import org.ossreviewtoolkit.model.AdvisorResult
@@ -47,8 +47,8 @@ private const val REQUEST_CHUNK_SIZE = 128
 /**
  * A wrapper for [Sonatype OSS Index](https://ossindex.sonatype.org/) security vulnerability data.
  */
-class OssIndex(name: String) : VulnerabilityProvider(name) {
-    class Factory : AbstractVulnerabilityProviderFactory<OssIndex>("OssIndex") {
+class OssIndex(name: String) : AdviceProvider(name) {
+    class Factory : AbstractAdviceProviderFactory<OssIndex>("OssIndex") {
         override fun create(config: AdvisorConfiguration) = OssIndex(providerName)
     }
 
@@ -59,7 +59,7 @@ class OssIndex(name: String) : VulnerabilityProvider(name) {
         )
     }
 
-    override suspend fun retrievePackageVulnerabilities(packages: List<Package>): Map<Package, List<AdvisorResult>> {
+    override suspend fun retrievePackageFindings(packages: List<Package>): Map<Package, List<AdvisorResult>> {
         val startTime = Instant.now()
 
         val components = packages.map { it.purl }

--- a/advisor/src/main/kotlin/advisors/OssIndex.kt
+++ b/advisor/src/main/kotlin/advisors/OssIndex.kt
@@ -81,9 +81,9 @@ class OssIndex(name: String) : VulnerabilityProvider(name) {
                 componentReports[pkg.id.toPurl()]?.let { report ->
                     pkg to listOf(
                         AdvisorResult(
-                            report.vulnerabilities.mapNotNull { it.toVulnerability() },
                             AdvisorDetails(providerName),
-                            AdvisorSummary(startTime, endTime)
+                            AdvisorSummary(startTime, endTime),
+                            vulnerabilities = report.vulnerabilities.mapNotNull { it.toVulnerability() }
                         )
                     )
                 }

--- a/advisor/src/main/kotlin/advisors/VulnerableCode.kt
+++ b/advisor/src/main/kotlin/advisors/VulnerableCode.kt
@@ -22,8 +22,8 @@ package org.ossreviewtoolkit.advisor.advisors
 import java.net.URI
 import java.time.Instant
 
-import org.ossreviewtoolkit.advisor.AbstractVulnerabilityProviderFactory
-import org.ossreviewtoolkit.advisor.VulnerabilityProvider
+import org.ossreviewtoolkit.advisor.AbstractAdviceProviderFactory
+import org.ossreviewtoolkit.advisor.AdviceProvider
 import org.ossreviewtoolkit.clients.vulnerablecode.VulnerableCodeService
 import org.ossreviewtoolkit.clients.vulnerablecode.VulnerableCodeService.PackagesWrapper
 import org.ossreviewtoolkit.model.AdvisorDetails
@@ -37,14 +37,14 @@ import org.ossreviewtoolkit.model.config.VulnerableCodeConfiguration
 import org.ossreviewtoolkit.utils.OkHttpClientHelper
 
 /**
- * A [VulnerabilityProvider] implementation that obtains security vulnerability information from a
+ * An [AdviceProvider] implementation that obtains security vulnerability information from a
  * [VulnerableCode][https://github.com/nexB/vulnerablecode] instance.
  */
 class VulnerableCode(
     name: String,
     private val vulnerableCodeConfiguration: VulnerableCodeConfiguration
-) : VulnerabilityProvider(name) {
-    class Factory : AbstractVulnerabilityProviderFactory<VulnerableCode>("VulnerableCode") {
+) : AdviceProvider(name) {
+    class Factory : AbstractAdviceProviderFactory<VulnerableCode>("VulnerableCode") {
         override fun create(config: AdvisorConfiguration) =
             VulnerableCode(providerName, config.forProvider { vulnerableCode })
     }
@@ -67,7 +67,7 @@ class VulnerableCode(
         VulnerableCodeService.create(vulnerableCodeConfiguration.serverUrl, OkHttpClientHelper.buildClient())
     }
 
-    override suspend fun retrievePackageVulnerabilities(packages: List<Package>): Map<Package, List<AdvisorResult>> {
+    override suspend fun retrievePackageFindings(packages: List<Package>): Map<Package, List<AdvisorResult>> {
         val startTime = Instant.now()
 
         @Suppress("TooGenericExceptionCaught")

--- a/advisor/src/main/kotlin/advisors/VulnerableCode.kt
+++ b/advisor/src/main/kotlin/advisors/VulnerableCode.kt
@@ -97,7 +97,7 @@ class VulnerableCode(
             packageMap[pv.purl]?.let { pkg ->
                 val vulnerabilities = pv.unresolvedVulnerabilities.map { it.toModel() }
                 val summary = AdvisorSummary(startTime, Instant.now())
-                pkg to listOf(AdvisorResult(vulnerabilities, details, summary))
+                pkg to listOf(AdvisorResult(details, summary, vulnerabilities = vulnerabilities))
             }
         }.toMap()
     }

--- a/advisor/src/test/kotlin/advisors/VulnerableCodeTest.kt
+++ b/advisor/src/test/kotlin/advisors/VulnerableCodeTest.kt
@@ -81,7 +81,7 @@ class VulnerableCodeTest : WordSpec({
             val vulnerableCode = createVulnerableCode(wiremock)
             val packagesToAdvise = inputPackages()
 
-            val result = vulnerableCode.retrievePackageVulnerabilities(packagesToAdvise).mapKeys { it.key.id }
+            val result = vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             result.shouldNotBeEmpty()
             result.keys should containExactlyInAnyOrder(idLang, idStruts)
@@ -161,7 +161,7 @@ class VulnerableCodeTest : WordSpec({
             val vulnerableCode = createVulnerableCode(wiremock)
             val packagesToAdvise = inputPackages()
 
-            val result = vulnerableCode.retrievePackageVulnerabilities(packagesToAdvise).mapKeys { it.key.id }
+            val result = vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             result.keys should containExactly(idStruts)
         }
@@ -171,7 +171,7 @@ class VulnerableCodeTest : WordSpec({
             val vulnerableCode = createVulnerableCode(wiremock)
             val packagesToAdvise = inputPackages()
 
-            val result = vulnerableCode.retrievePackageVulnerabilities(packagesToAdvise).mapKeys { it.key.id }
+            val result = vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             result.keys should containExactlyInAnyOrder(idLang, idStruts)
         }
@@ -228,7 +228,7 @@ private fun expectErrorResult(wiremock: WireMockServer) {
     val packagesToAdvise = inputPackages()
 
     val result = runBlocking {
-        vulnerableCode.retrievePackageVulnerabilities(packagesToAdvise).mapKeys { it.key.id }
+        vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
     }
 
     result shouldNotBeNull {

--- a/cli/src/main/kotlin/commands/AdvisorCommand.kt
+++ b/cli/src/main/kotlin/commands/AdvisorCommand.kt
@@ -114,7 +114,7 @@ class AdvisorCommand : CliktCommand(name = "advise", help = "Check dependencies 
         val advisor = Advisor(distinctProviders, config.advisor)
 
         val ortResultInput = readOrtResult(ortFile)
-        val ortResultOutput = advisor.retrieveVulnerabilityInformation(ortResultInput, skipExcluded).mergeLabels(labels)
+        val ortResultOutput = advisor.retrieveFindings(ortResultInput, skipExcluded).mergeLabels(labels)
 
         outputDir.safeMkdirs()
         writeOrtResult(ortResultOutput, outputFiles, "advisor")

--- a/evaluator/src/test/kotlin/TestData.kt
+++ b/evaluator/src/test/kotlin/TestData.kt
@@ -223,6 +223,8 @@ val ortResult = OrtResult(
             advisorResults = sortedMapOf(
                 packageWithVulnerabilities.id to listOf(
                     AdvisorResult(
+                        advisor = AdvisorDetails.EMPTY,
+                        summary = AdvisorSummary(startTime = Instant.EPOCH, endTime = Instant.EPOCH),
                         vulnerabilities = listOf(
                             Vulnerability(
                                 id = "CVE-2021-critical",
@@ -244,9 +246,7 @@ val ortResult = OrtResult(
                                     )
                                 )
                             )
-                        ),
-                        advisor = AdvisorDetails.EMPTY,
-                        summary = AdvisorSummary(startTime = Instant.EPOCH, endTime = Instant.EPOCH)
+                        )
                     )
                 )
             )

--- a/model/src/main/kotlin/AdvisorRecord.kt
+++ b/model/src/main/kotlin/AdvisorRecord.kt
@@ -67,7 +67,21 @@ data class AdvisorRecord(
      * from different advisors are merged if necessary.
      */
     fun getVulnerabilities(pkgId: Identifier): List<Vulnerability> =
-        advisorResults[pkgId].orEmpty().flatMap { it.vulnerabilities }.mergeVulnerabilities()
+        getFindings(pkgId) { it.vulnerabilities }.mergeVulnerabilities()
+
+    /**
+     * Return a list with all [Defect] objects that have been found for the given [package][pkgId]. If there are
+     * results from different advisors, a union list is constructed. No merging is done, as it is expected that the
+     * results from different advisors cannot be combined.
+     */
+    fun getDefects(pkgId: Identifier): List<Defect> = getFindings(pkgId) { it.defects }
+
+    /**
+     * Helper function to obtain the findings of type [T] for the given [package][pkgId] using a [selector] function
+     * to extract the desired field.
+     */
+    private fun <T> getFindings(pkgId: Identifier, selector: (AdvisorResult) -> List<T>): List<T> =
+        advisorResults[pkgId].orEmpty().flatMap(selector)
 }
 
 /**

--- a/model/src/main/kotlin/AdvisorResult.kt
+++ b/model/src/main/kotlin/AdvisorResult.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Bosch.IO GmbH
+ * Copyright (C) 2020-2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,14 +20,12 @@
 package org.ossreviewtoolkit.model
 
 /**
- * The result of a single vulnerability check of a single package.
+ * The result of a specific advisor execution for a single package.
+ *
+ * Different advisor implementations may produce findings of different types. To reflect this, this class has multiple
+ * fields for findings of these types. It is up to a concrete advisor, which of these fields it populates.
  */
 data class AdvisorResult(
-    /**
-     * The found vulnerabilities.
-     */
-    val vulnerabilities: List<Vulnerability>,
-
     /**
      * Details about the used advisor.
      */
@@ -36,5 +34,15 @@ data class AdvisorResult(
     /**
      * A summary of the advisor results.
      */
-    val summary: AdvisorSummary
+    val summary: AdvisorSummary,
+
+    /**
+     * The defects.
+     */
+    val defects: List<Defect> = emptyList(),
+
+    /**
+     * The vulnerabilities.
+     */
+    val vulnerabilities: List<Vulnerability> = emptyList()
 )

--- a/model/src/main/kotlin/Defect.kt
+++ b/model/src/main/kotlin/Defect.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+import java.net.URI
+import java.time.Instant
+
+/**
+ * A data model for software defects.
+ *
+ * Instances of this class are created by advisor implementations that retrieve information about known defects in
+ * packages.
+ */
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+data class Defect(
+    /**
+     * The (external) ID of this defect. This is a string used by a concrete issue tracker system to reference this
+     * defect, such as a bug ID or ticket number.
+     */
+    val id: String,
+
+    /**
+     * The URL pointing to the source of this defect. This is typically a reference into the issue tracker system that
+     * contains this defect.
+     */
+    val url: URI,
+
+    /**
+     * A title for this defect if available. This is a short summary describing the problem at hand.
+     */
+    val title: String? = null,
+
+    /**
+     * A state of the associated defect if available. The concrete meaning of this string depends on the source from
+     * where it was obtained, as different issue tracker systems use their specific terminology. Possible values could
+     * be *OPEN*, *IN PROGRESS*, *BLOCKED*, etc.
+     */
+    val state: String? = null,
+
+    /**
+     * The severity assigned to the defect if available. The meaning of this string depends on the source system.
+     */
+    val severity: String? = null,
+
+    /**
+     * An optional description of this defect. It can contain more detailed information about the defect and its
+     * impact. The field may be undefined if the [url] of this defect already points to a website with all this
+     * information.
+     */
+    val description: String? = null,
+
+    /**
+     * The creation time of this defect if available.
+     */
+    val creationTime: Instant? = null,
+
+    /**
+     * Contains a time when this defect has been modified the last time in the tracker system it has been obtained
+     * from. This information can be useful for instance to find out how up-to-date this defect report might be.
+     */
+    val modificationTime: Instant? = null,
+
+    /**
+     * A map with labels assigned to this defect. Labels provide a means frequently used by issue tracker systems to
+     * classify defects based on defined criteria. The exact meaning of these labels is depending on the source system.
+     */
+    val labels: Map<String, String> = emptyMap()
+) {
+    init {
+        require(id.isNotBlank()) { "Defect ID must not be blank." }
+    }
+}

--- a/model/src/test/kotlin/AdvisorRecordTest.kt
+++ b/model/src/test/kotlin/AdvisorRecordTest.kt
@@ -236,6 +236,33 @@ class AdvisorRecordTest : WordSpec({
             record.getVulnerabilities(queryId) should containExactly(mergedVulnerability)
         }
     }
+
+    "getDefects" should {
+        "return an empty list for an unknown package" {
+            val record = AdvisorRecord(sortedMapOf())
+
+            record.getDefects(langId) should beEmpty()
+        }
+
+        "return the combined defects detected for a specific package" {
+            val defect1 = createDefect("d1")
+            val defect2 = createDefect("d2")
+            val defect3 = createDefect("d3")
+            val defect4 = createDefect("d4")
+            val defect5 = createDefect("d5")
+
+            val record = AdvisorRecord(
+                sortedMapOf(
+                    queryId to listOf(
+                        createResult(1, defects = listOf(defect1, defect2)),
+                        createResult(2, defects = listOf(defect3, defect4, defect5))
+                    )
+                )
+            )
+
+            record.getDefects(queryId) should containExactlyInAnyOrder(defect1, defect2, defect3, defect4, defect5)
+        }
+    }
 })
 
 /** The prefix for URIs pointing to the source of vulnerabilities. */
@@ -269,13 +296,20 @@ private fun createVulnerability(
     )
 
 /**
- * Create an [AdvisorResult] for an advisor with the given [advisorIndex] with the passed in [issues] and
- * [vulnerabilities].
+ * Construct a [Defect] based on the given [id].
+ */
+private fun createDefect(id: String): Defect =
+    Defect(id, URI("https://defects.example.org/$id"), "Defect $id")
+
+/**
+ * Create an [AdvisorResult] for an advisor with the given [advisorIndex] with the passed in [issues],
+ * [vulnerabilities], and [defects].
  */
 private fun createResult(
     advisorIndex: Int,
     issues: List<OrtIssue> = emptyList(),
-    vulnerabilities: List<Vulnerability> = emptyList()
+    vulnerabilities: List<Vulnerability> = emptyList(),
+    defects: List<Defect> = emptyList()
 ): AdvisorResult {
     val details = AdvisorDetails("advisor$advisorIndex")
     val summary = AdvisorSummary(
@@ -284,5 +318,5 @@ private fun createResult(
         issues = issues
     )
 
-    return AdvisorResult(vulnerabilities, details, summary)
+    return AdvisorResult(details, summary, defects, vulnerabilities)
 }

--- a/model/src/test/kotlin/AdvisorResultContainerTest.kt
+++ b/model/src/test/kotlin/AdvisorResultContainerTest.kt
@@ -55,6 +55,22 @@ class AdvisorResultContainerTest : WordSpec() {
     private val vulnerabilities1 = listOf(vulnerability11, vulnerability12)
     private val vulnerabilities2 = listOf(vulnerability21, vulnerability22)
 
+    private val defects = listOf(
+        Defect(
+            "defect1",
+            URI("https://defects.example.org/d1"),
+            "Some bug",
+            creationTime = Instant.parse("2021-09-23T11:28:33.123Z")
+        ),
+        Defect(
+            "defect2",
+            URI("https://defects.example.org/d2"),
+            "Another bug",
+            severity = "ugly",
+            labels = mapOf("backend" to "true", "expensive" to "true")
+        )
+    )
+
     private val advisorDetails1 = AdvisorDetails("name 1")
     private val advisorDetails2 = AdvisorDetails("name 2")
 
@@ -80,8 +96,8 @@ class AdvisorResultContainerTest : WordSpec() {
         mutableListOf(issue21, issue22)
     )
 
-    private val advisorResult1 = AdvisorResult(vulnerabilities1, advisorDetails1, advisorSummary1)
-    private val advisorResult2 = AdvisorResult(vulnerabilities2, advisorDetails2, advisorSummary2)
+    private val advisorResult1 = AdvisorResult(advisorDetails1, advisorSummary1, vulnerabilities = vulnerabilities1)
+    private val advisorResult2 = AdvisorResult(advisorDetails2, advisorSummary2, defects, vulnerabilities2)
 
     private val advisorResults = AdvisorResultContainer(id, listOf(advisorResult1, advisorResult2))
 

--- a/model/src/test/kotlin/DefectTest.kt
+++ b/model/src/test/kotlin/DefectTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+
+import java.net.URI
+
+class DefectTest : StringSpec({
+    "Creating a Defect with an empty ID should fail" {
+        shouldThrow<IllegalArgumentException> {
+            Defect("", URI("https://defect.example.org"))
+        }
+    }
+})


### PR DESCRIPTION
This PR adds a `Defect` class to the data model that can be used in a similar way as the existing `Vulnerability` class. The goal is to support advisor implementations that can retrieve information about known defects for the packages involved. To make this possible, the result classes used by advisors have been extended to store defects as well.

To reflect this broader scope advisors can now have, some classes have been renamed to no longer refer to *vulnerabilities* exclusively.