### PR TITLE
FilePackageCurationProvider: Fail if curations file cannot be read

### DIFF
--- a/analyzer/src/main/kotlin/curation/FilePackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/FilePackageCurationProvider.kt
@@ -48,12 +48,12 @@ class FilePackageCurationProvider(curationFiles: Collection<File>) : PackageCura
     }
 
     val packageCurations: Set<PackageCuration> = run {
-        val allCurations = curationFiles.mapNotNull { curationFile ->
+        val allCurations = curationFiles.map { curationFile ->
             runCatching {
                 curationFile.readValueOrDefault(emptyList<PackageCuration>())
             }.onFailure {
                 log.warn { "Failed parsing package curation from '${curationFile.absoluteFile}'." }
-            }.getOrNull()
+            }.getOrThrow()
         }.flatten()
 
         val duplicates = allCurations.getDuplicates()

--- a/analyzer/src/test/assets/package-curations-not-deserializable.yml
+++ b/analyzer/src/test/assets/package-curations-not-deserializable.yml
@@ -1,0 +1,1 @@
+not deserializable

--- a/analyzer/src/test/kotlin/curation/FilePackageCurationProviderTest.kt
+++ b/analyzer/src/test/kotlin/curation/FilePackageCurationProviderTest.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.analyzer.curation
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.haveSize
@@ -110,6 +111,22 @@ class FilePackageCurationProviderTest : StringSpec() {
             }
 
             curationsOutVersion should beEmpty()
+        }
+
+        "Provider throws an exception if the curations file is not de-serializable" {
+            val curationsFile = File("src/test/assets/package-curations-not-deserializable.yml")
+
+            shouldThrow<Exception> {
+                FilePackageCurationProvider(curationsFile)
+            }
+        }
+
+        "Provider throws an exception if the curations file does not exist" {
+            val curationsFile = File("src/test/assets/package-curations-not-existing.yml")
+
+            shouldThrow<Exception> {
+                FilePackageCurationProvider(curationsFile)
+            }
         }
     }
 }


### PR DESCRIPTION
Fail if any curation file does not exist or cannot be deserialized.
Previously, it could easily go unnoticed if curations have not been
applied, because the only hint was a warning in the logs.

