### PR TITLE
reporter: Fix license file handling

### DIFF
--- a/reporter/src/main/resources/templates/asciidoc/disclosure_document.ftl
+++ b/reporter/src/main/resources/templates/asciidoc/disclosure_document.ftl
@@ -107,14 +107,9 @@ ignores declared and detected licenses if a license conclusion for the package w
 for a concluded license those statements are kept.
 --]
 [#assign
-resolvedLicenses =
-    LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED
-      .filter(
-          package.licensesNotInLicenseFiles(
-            LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED
-                .filter(package.license, package.licenseChoices).licenses
-          )
-      )
+resolvedLicenses = package.licensesNotInLicenseFiles(
+    LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED.filter(package.license, package.licenseChoices).licenses
+)
 ]
 [#if resolvedLicenses?has_content]
 

--- a/reporter/src/main/resources/templates/notice/default.ftl
+++ b/reporter/src/main/resources/templates/notice/default.ftl
@@ -98,8 +98,9 @@ ${copyrights?join("\n", "")}
         are configured not to be included in notice files, and filter all licenses that are contained in the license
         files already printed above.
     --]
+    [#assign licensesFilteredBySource = LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED.filter(package.license.licenses)]
     [#assign resolvedLicenses = helper.filterForCategory(
-        LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED.filter(package.licensesNotInLicenseFiles()),
+        package.licensesNotInLicenseFiles(licensesFilteredBySource),
         noticeCategoryName
     )]
     [#assign isFirst = true]


### PR DESCRIPTION
Improve the handling of license files in the Freemarker templates, see the commit messages for details.
