### PR TITLE
RemoveEntriesCommand: Don't crash when accessing scopes

### DIFF
--- a/helper-cli/src/main/kotlin/commands/repoconfig/RemoveEntriesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/repoconfig/RemoveEntriesCommand.kt
@@ -95,7 +95,7 @@ internal class RemoveEntriesCommand : CliktCommand(
 
         val scopeExcludes = ortResult
             .getProjects()
-            .flatMap(ortResult.dependencyNavigator::scopeNames)
+            .flatMap { project -> project.scopes.map { scope -> scope.name } }
             .let { projectScopes -> ortResult.getExcludes().scopes.minimize(projectScopes) }
 
         val licenseFindings = ortResult.getProjectLicenseFindings()


### PR DESCRIPTION
The previous way of accessing scopes always lead to a runtime exception
thrown from [1]. Fix that by accessing the scopes for any project via
the property`Project.scopes`. This works fine because the ORT result is
obtained via `readOrtResult()` which ensures that scopes are resolved.

[1] https://github.com/oss-review-toolkit/ort/blob/6a7e2855129c4c35d1b058aaeff5f4e2fece2c79/model/src/main/kotlin/DependencyGraphNavigator.kt#L29-L31