### PR TITLE
Un-deprecate a path exclude reason

### DIFF
--- a/cli/src/funTest/assets/semver4j-analyzer-result.yml
+++ b/cli/src/funTest/assets/semver4j-analyzer-result.yml
@@ -12,8 +12,8 @@ repository:
     path: ""
   config:
     excludes:
-      paths:
-      - pattern: "src/test"
+      scopes:
+      - pattern: "testClasspath"
         reason: "TEST_TOOL_OF"
 analyzer:
   start_time: "2020-10-26T20:00:07.677878Z"

--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -152,7 +152,7 @@ class ExamplesFunTest : StringSpec() {
                 "COPYLEFT_LIMITED_IN_SOURCE",
                 "VULNERABILITY_IN_PACKAGE",
                 "HIGH_SEVERITY_VULNERABILITY_IN_PACKAGE",
-                "DEPRECATED_PATH_EXCLUDE_REASON_IN_ORT_YML"
+                "DEPRECATED_SCOPE_EXCLUDE_REASON_IN_ORT_YML"
             )
         }
 

--- a/examples/rules.kts
+++ b/examples/rules.kts
@@ -248,16 +248,16 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver) {
         }
     }
 
-    ortResultRule("DEPRECATED_PATH_EXCLUDE_REASON_IN_ORT_YML") {
-        val reasons = ortResult.repository.config.excludes.paths.mapTo(mutableSetOf()) { it.reason }
-        val deprecatedReasons = setOf(PathExcludeReason.TEST_TOOL_OF)
+    ortResultRule("DEPRECATED_SCOPE_EXCLUDE_REASON_IN_ORT_YML") {
+        val reasons = ortResult.repository.config.excludes.scopes.mapTo(mutableSetOf()) { it.reason }
+        val deprecatedReasons = setOf(ScopeExcludeReason.TEST_TOOL_OF)
 
         reasons.intersect(deprecatedReasons).forEach { offendingReason ->
             warning(
-                "The repository configuration is using the deprecated path exclude reason '$offendingReason'.",
-                "Please use only non-deprecated path exclude reasons, see " +
+                "The repository configuration is using the deprecated scope exclude reason '$offendingReason'.",
+                "Please use only non-deprecated scope exclude reasons, see " +
                         "https://github.com/oss-review-toolkit/ort/blob/master/model/src/main/" +
-                        "kotlin/config/PathExcludeReason.kt."
+                        "kotlin/config/ScopeExcludeReason.kt."
             )
         }
     }

--- a/examples/rules.kts
+++ b/examples/rules.kts
@@ -249,10 +249,10 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver) {
     }
 
     ortResultRule("DEPRECATED_PATH_EXCLUDE_REASON_IN_ORT_YML") {
-        val pathExcludeReasons = ortResult.repository.config.excludes.paths.mapTo(mutableSetOf()) { it.reason }
-        val deprecatedPathExcludeReasons = setOf(PathExcludeReason.TEST_TOOL_OF)
+        val reasons = ortResult.repository.config.excludes.paths.mapTo(mutableSetOf()) { it.reason }
+        val deprecatedReasons = setOf(PathExcludeReason.TEST_TOOL_OF)
 
-        pathExcludeReasons.intersect(deprecatedPathExcludeReasons).forEach { offendingReason ->
+        reasons.intersect(deprecatedReasons).forEach { offendingReason ->
             warning(
                 "The repository configuration is using the deprecated path exclude reason '$offendingReason'.",
                 "Please use only non-deprecated path exclude reasons, see " +

--- a/model/src/main/kotlin/config/PathExcludeReason.kt
+++ b/model/src/main/kotlin/config/PathExcludeReason.kt
@@ -72,12 +72,5 @@ enum class PathExcludeReason {
      * The path only contains tools used for testing source code which are not included in distributed build
      * artifacts.
      */
-    @Deprecated(
-        message = "Use SPDX-2.2-style enum value instead.",
-        replaceWith = ReplaceWith(
-            expression = "PathExcludeReason.TEST_OF",
-            imports = ["org.ossreviewtoolkit.model.config.PathExcludeReason"]
-        )
-    )
     TEST_TOOL_OF
 }


### PR DESCRIPTION
Undo a deprecation which should not have been done in the first place according to [1] and refactor an example policy rule accordingly.

[1] https://github.com/spdx/spdx-spec/blob/development/v2.2.2/chapters/relationships-between-SPDX-elements.md