### PR TITLE
Pip: Raise PIP_VERSION to 18.1 to support PEP 508 URL requirements

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -25,7 +25,7 @@ project:
         - id: "PyPI::importlib-metadata:4.8.1"
           dependencies:
           - id: "PyPI::typing-extensions:3.10.0.2"
-          - id: "PyPI::zipp:3.5.1"
+          - id: "PyPI::zipp:3.6.0"
       - id: "PyPI::itsdangerous:2.0.1"
       - id: "PyPI::jinja2:2.8.1"
         dependencies:
@@ -371,8 +371,8 @@ packages:
     url: ""
     revision: ""
     path: ""
-- id: "PyPI::zipp:3.5.1"
-  purl: "pkg:pypi/zipp@3.5.1"
+- id: "PyPI::zipp:3.6.0"
+  purl: "pkg:pypi/zipp@3.6.0"
   authors:
   - "Jason R. Coombs"
   declared_licenses:
@@ -384,14 +384,14 @@ packages:
   description: "Backport of pathlib-compatible object wrapper for zip files"
   homepage_url: "https://github.com/jaraco/zipp"
   binary_artifact:
-    url: "https://files.pythonhosted.org/packages/6c/b3/0f6b1fef97055a75cebbcd5d4719145963f09cf9d62793201a769b1e3aaa/zipp-3.5.1-py3-none-any.whl"
+    url: "https://files.pythonhosted.org/packages/bd/df/d4a4974a3e3957fd1c1fa3082366d7fff6e428ddb55f074bf64876f8e8ad/zipp-3.6.0-py3-none-any.whl"
     hash:
-      value: "b2f6ffc0d2055cf2eac6f3c35101a26e"
+      value: "655d8bb10a010accc0158d23b11f2009"
       algorithm: "MD5"
   source_artifact:
-    url: "https://files.pythonhosted.org/packages/76/e4/b0f1010d29a61e3527667b214498da73299f747dd25ad0fd135705170716/zipp-3.5.1.tar.gz"
+    url: "https://files.pythonhosted.org/packages/02/bf/0d03dbdedb83afec081fefe86cae3a2447250ef1a81ac601a9a56e785401/zipp-3.6.0.tar.gz"
     hash:
-      value: "31ba90daf8af0808d93748dfb64e8d09"
+      value: "8d5cf6eb3270384ae13a6440797ea564"
       algorithm: "MD5"
   vcs:
     type: ""

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -59,8 +59,8 @@ import org.ossreviewtoolkit.utils.resolveWindowsExecutable
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.textValueOrEmpty
 
-// The lowest version that supports "--prefer-binary".
-private const val PIP_VERSION = "18.0"
+// The lowest version that supports "--prefer-binary" and PEP 508 URL requirements to be used as dependencies.
+private const val PIP_VERSION = "18.1"
 
 private const val PIPDEPTREE_VERSION = "0.13.2"
 


### PR DESCRIPTION
See [1] and [2] for some background information.

[1] https://pip.pypa.io/en/stable/news/#v18-1
[2] https://github.com/pypa/pipenv/issues/3058

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>