### PR TITLE
Scanner: Increase the visibility of scanPackages

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -186,7 +186,7 @@ abstract class Scanner(
      * [Package]. The map may contain multiple results for the same [Package] if the storage contains more than one
      * result for the specification of this scanner.
      */
-    internal abstract suspend fun scanPackages(
+    abstract suspend fun scanPackages(
         packages: Set<Package>,
         outputDirectory: File
     ): Map<Package, List<ScanResult>>


### PR DESCRIPTION
If one wants to implement a scanner working on binary artifacts, LocalScanner cannot be inherited because it operates exclusively on source artifacts.
The solution is then to inherit directly Scanner but, for that, the function must be public to be able to do the implementation in a plugin.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>

