### PR TITLE
DependencyNavigator: Handle results with empty dependency graphs

### DIFF
--- a/model/src/main/kotlin/CompatibilityDependencyNavigator.kt
+++ b/model/src/main/kotlin/CompatibilityDependencyNavigator.kt
@@ -45,6 +45,10 @@ class CompatibilityDependencyNavigator internal constructor(
          * [CompatibilityDependencyNavigator].
          */
         fun create(ortResult: OrtResult): DependencyNavigator {
+            if (ortResult.analyzer?.result?.dependencyGraphs.orEmpty().isEmpty()) {
+                return DependencyTreeNavigator
+            }
+
             val (treeProjects, graphProjects) = ortResult.getProjects().partition(Project::usesTree)
 
             return when {

--- a/model/src/test/kotlin/CompatibilityDependencyNavigatorTest.kt
+++ b/model/src/test/kotlin/CompatibilityDependencyNavigatorTest.kt
@@ -78,6 +78,26 @@ class CompatibilityDependencyNavigatorTest : WordSpec() {
 
                 navigator shouldBe DependencyTreeNavigator
             }
+
+            "return a DependencyTreeNavigator for a result that does not contain any dependency graphs" {
+                val project = createProject("dummy", scopeNames = sortedSetOf())
+
+                val analyzerResult = AnalyzerResult(
+                    projects = sortedSetOf(project),
+                    packages = sortedSetOf(),
+                    dependencyGraphs = mapOf()
+                )
+                val analyzerRun = AnalyzerRun(
+                    result = analyzerResult,
+                    environment = Environment(),
+                    config = AnalyzerConfiguration()
+                )
+                val result = OrtResult.EMPTY.copy(analyzer = analyzerRun)
+
+                val navigator = CompatibilityDependencyNavigator.create(result)
+
+                navigator shouldBe DependencyTreeNavigator
+            }
         }
 
         "scopeNames" should {


### PR DESCRIPTION
CompatibilityDependencyNavigator.create() could fail with an exception
for an OrtResult that contains projects with an empty set of scope
names, but no dependency graph. This is a corner case that could
appear if a package manager had issues when constructing projects. To
prevent this exception, check first whether the result contains a
dependency graph, and if not, return the DependencyTreeNavigator.
