### PR TITLE
Experimental scanner: Add storage implementations

### DIFF
--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -290,7 +290,7 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
 
 private fun createDefaultStorage(): ScanStorage {
     val localFileStorage = XZCompressedLocalFileStorage(ortDataDirectory.resolve("$TOOL_NAME/results"))
-    return FileBasedStorage(localFileStorage)
+    return ProvenanceBasedFileStorage(localFileStorage)
 }
 
 private fun createStorage(config: ScanStorageConfiguration): ScanStorage =

--- a/model/src/main/kotlin/config/ScanStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/ScanStorageConfiguration.kt
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.utils.storage.FileStorage
 
 /**
@@ -59,7 +61,12 @@ data class FileBasedStorageConfiguration(
     /**
      * The configuration of the [FileStorage] used to store the files.
      */
-    val backend: FileStorageConfiguration
+    val backend: FileStorageConfiguration,
+
+    /**
+     * The way that scan results are stored, defaults to [StorageType.PACKAGE_BASED].
+     */
+    val type: StorageType = StorageType.PACKAGE_BASED
 ) : ScanStorageConfiguration()
 
 /**
@@ -109,7 +116,12 @@ data class PostgresStorageConfiguration(
      * The full path of the root certificate file.
      * See: https://jdbc.postgresql.org/documentation/head/connect.html
      */
-    val sslrootcert: String? = null
+    val sslrootcert: String? = null,
+
+    /**
+     * The way that scan results are stored, defaults to [StorageType.PACKAGE_BASED].
+     */
+    val type: StorageType = StorageType.PACKAGE_BASED
 
     /**
      * TODO: Make additional parameters configurable, see:
@@ -160,3 +172,18 @@ data class Sw360StorageConfiguration(
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     val token: String = ""
 ) : ScanStorageConfiguration()
+
+/**
+ * An enum to describe different types of storages.
+ */
+enum class StorageType {
+    /**
+     * A storage that stores scan results by [Package].
+     */
+    PACKAGE_BASED,
+
+    /**
+     * A storage that stores scan results by [Provenance].
+     */
+    PROVENANCE_BASED
+}

--- a/scanner/src/funTest/kotlin/experimental/AbstractProvenanceBasedStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/AbstractProvenanceBasedStorageFunTest.kt
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import com.vdurmont.semver4j.Semver
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.test.TestCase
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.should
+
+import java.time.Instant
+
+import org.ossreviewtoolkit.model.ArtifactProvenance
+import org.ossreviewtoolkit.model.Hash
+import org.ossreviewtoolkit.model.HashAlgorithm
+import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.ScannerDetails
+import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.model.UnknownProvenance
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.scanner.ScannerCriteria
+
+abstract class AbstractProvenanceBasedStorageFunTest : WordSpec() {
+    private lateinit var storage: ProvenanceBasedScanStorage
+
+    override fun beforeTest(testCase: TestCase) {
+        storage = createStorage()
+    }
+
+    protected abstract fun createStorage(): ProvenanceBasedScanStorage
+
+    init {
+        "Adding a scan result" should {
+            "succeed for a valid scan result" {
+                val scanResult = createScanResult()
+
+                storage.write(scanResult)
+                val readResult = storage.read(scanResult.provenance as KnownProvenance)
+
+                readResult should containExactly(scanResult)
+            }
+
+            "fail if provenance information is missing" {
+                val scanResult = createScanResult(provenance = UnknownProvenance)
+
+                shouldThrow<ScanStorageException> { storage.write(scanResult) }
+            }
+
+            "fail if a result for the same provenance and scanner is already stored" {
+                val scanResult = createScanResult()
+
+                storage.write(scanResult)
+                shouldThrow<ScanStorageException> { storage.write(scanResult) }
+            }
+
+            "fail if the provenance contains a VCS path" {
+                val scanResult = createScanResult(
+                    provenance = createRepositoryProvenance(
+                        vcsInfo = VcsInfo.valid().copy(path = "path")
+                    )
+                )
+
+                shouldThrow<ScanStorageException> { storage.write(scanResult) }
+            }
+
+            "ignore the VCS revision in favor of the resolved revision when adding a duplicate" {
+                val scanResult1 = createScanResult(provenance = createRepositoryProvenance())
+                val scanResult2 = createScanResult(
+                    provenance = createRepositoryProvenance(
+                        vcsInfo = VcsInfo.valid().copy(revision = "another")
+                    )
+                )
+
+                storage.write(scanResult1)
+                shouldThrow<ScanStorageException> { storage.write(scanResult2) }
+            }
+        }
+
+        "Reading a scan result" should {
+            "find all scan results for a provenance" {
+                val scanResult1 = createScanResult()
+                val scanResult2 = createScanResult(scannerDetails = createScannerDetails(name = "other"))
+
+                storage.write(scanResult1)
+                storage.write(scanResult2)
+
+                val readResult = storage.read(scanResult1.provenance as KnownProvenance)
+
+                readResult should containExactlyInAnyOrder(scanResult1, scanResult2)
+            }
+
+            "use only the resolved revision for matching and return the provided provenance" {
+                val provenance1 = createRepositoryProvenance()
+                val provenance2 = provenance1.copy(vcsInfo = provenance1.vcsInfo.copy(revision = "another"))
+
+                val scanResult = createScanResult(provenance = provenance1)
+
+                storage.write(scanResult)
+
+                val readResult = storage.read(provenance2)
+
+                readResult should containExactlyInAnyOrder(scanResult.copy(provenance = provenance2))
+            }
+
+            "fail if the provenance contains a VCS path" {
+                val provenance = createRepositoryProvenance(vcsInfo = VcsInfo.valid().copy(path = "path"))
+                val criteria = createScannerDetails().toCriteria()
+
+                shouldThrow<ScanStorageException> { storage.read(provenance) }
+                shouldThrow<ScanStorageException> { storage.read(provenance, criteria) }
+            }
+
+            "find scan result for a specific scanner" {
+                val scanResult1 = createScanResult()
+                val scanResult2 = createScanResult(scannerDetails = createScannerDetails(name = "other"))
+
+                storage.write(scanResult1)
+                storage.write(scanResult2)
+
+                val readResult =
+                    storage.read(scanResult1.provenance as KnownProvenance, scanResult1.scanner.toCriteria())
+
+                readResult should containExactlyInAnyOrder(scanResult1)
+            }
+
+            "find all scan results for scanners with names matching a pattern" {
+                val scanResult1 = createScanResult(scannerDetails = createScannerDetails(name = "name1"))
+                val scanResult2 = createScanResult(scannerDetails = createScannerDetails(name = "name2"))
+                val scanResult3 = createScanResult(scannerDetails = createScannerDetails(name = "other name"))
+                val criteria = scanResult1.scanner.toCriteria().copy(regScannerName = "name.+")
+
+                storage.write(scanResult1)
+                storage.write(scanResult2)
+                storage.write(scanResult3)
+
+                val readResult = storage.read(scanResult1.provenance as KnownProvenance, criteria)
+
+                readResult should containExactlyInAnyOrder(scanResult1, scanResult2)
+            }
+
+            "find all scan results for compatible scanners" {
+                val scanResult = createScanResult()
+                val scanResultCompatible1 = createScanResult(scannerDetails = createScannerDetails(version = "1.0.1"))
+                val scanResultCompatible2 =
+                    createScanResult(scannerDetails = createScannerDetails(version = "1.0.1-alpha.1"))
+                val scanResultIncompatible = createScanResult(scannerDetails = createScannerDetails(version = "2.0.0"))
+                val criteria = scanResult.scanner.toCriteria().let { it.copy(maxVersion = it.minVersion.nextMinor()) }
+
+                storage.write(scanResult)
+                storage.write(scanResultCompatible1)
+                storage.write(scanResultCompatible2)
+                storage.write(scanResultIncompatible)
+
+                val readResult = storage.read(scanResult.provenance as KnownProvenance, criteria)
+
+                readResult should containExactlyInAnyOrder(scanResult, scanResultCompatible1, scanResultCompatible2)
+            }
+        }
+    }
+}
+
+private fun ScannerDetails.toCriteria() =
+    ScannerCriteria(
+        regScannerName = name,
+        minVersion = Semver(version),
+        maxVersion = Semver(version).nextPatch(),
+        configMatcher = { true }
+    )
+
+private fun RemoteArtifact.Companion.valid() =
+    RemoteArtifact(
+        url = "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.14.1/log4j-api-2.14.1-sources.jar",
+        hash = Hash("b2327c47ca413c1ec183575b19598e281fcd74d8", HashAlgorithm.SHA1)
+    )
+
+private fun VcsInfo.Companion.valid() =
+    VcsInfo(
+        type = VcsType.GIT,
+        url = "https://github.com/oss-review-toolkit/ort.git",
+        revision = "f42e41a8fedc1e0acd78fab147e91fa047cb2853"
+    )
+
+private fun createKnownProvenance() = ArtifactProvenance(sourceArtifact = RemoteArtifact.valid())
+
+private fun createRepositoryProvenance(
+    vcsInfo: VcsInfo = VcsInfo.valid(),
+    resolvedRevision: String = VcsInfo.valid().revision
+) = RepositoryProvenance(vcsInfo, resolvedRevision)
+
+private fun createScannerDetails(
+    name: String = "name",
+    version: String = "1.0.0",
+    configuration: String = "configuration"
+) = ScannerDetails(name, version, configuration)
+
+private fun createScanSummary(licenseFindings: Set<LicenseFinding> = emptySet()) =
+    ScanSummary(Instant.EPOCH, Instant.EPOCH, "", licenseFindings.toSortedSet(), sortedSetOf())
+
+private fun createScanResult(
+    provenance: Provenance = createKnownProvenance(),
+    scannerDetails: ScannerDetails = createScannerDetails(),
+    license: String = "Apache-2.0"
+) =
+    ScanResult(
+        provenance,
+        scannerDetails,
+        createScanSummary(
+            licenseFindings = sortedSetOf(
+                LicenseFinding(license, TextLocation("file.txt", 1, 2))
+            )
+        )
+    )

--- a/scanner/src/funTest/kotlin/experimental/ProvenanceBasedFileStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/ProvenanceBasedFileStorageFunTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import org.ossreviewtoolkit.utils.storage.LocalFileStorage
+import org.ossreviewtoolkit.utils.test.createTestTempDir
+
+class ProvenanceBasedFileStorageFunTest : AbstractProvenanceBasedStorageFunTest() {
+    override fun createStorage() = ProvenanceBasedFileStorage(LocalFileStorage(createTestTempDir()))
+}

--- a/scanner/src/funTest/kotlin/experimental/ProvenanceBasedPostgresStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/ProvenanceBasedPostgresStorageFunTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import com.opentable.db.postgres.embedded.EmbeddedPostgres
+
+import io.kotest.core.spec.Spec
+import io.kotest.core.test.TestCase
+
+import java.time.Duration
+
+private val PG_STARTUP_WAIT = Duration.ofSeconds(20)
+
+class ProvenanceBasedPostgresStorageFunTest : AbstractProvenanceBasedStorageFunTest() {
+    private lateinit var postgres: EmbeddedPostgres
+
+    override fun beforeSpec(spec: Spec) {
+        postgres = EmbeddedPostgres.builder().setPGStartupWait(PG_STARTUP_WAIT).start()
+    }
+
+    override fun beforeTest(testCase: TestCase) {
+        postgres.postgresDatabase.connection.use { c ->
+            val s = c.createStatement()
+            s.execute("DROP SCHEMA public CASCADE")
+            s.execute("CREATE SCHEMA public")
+        }
+
+        super.beforeTest(testCase)
+    }
+
+    override fun afterSpec(spec: Spec) {
+        postgres.close()
+    }
+
+    override fun createStorage() = ProvenanceBasedPostgresStorage(postgres.postgresDatabase)
+}

--- a/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
+++ b/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
@@ -111,7 +111,7 @@ class ExperimentalScanner(
                     "provenances."
         }
         val (storedResults, readDuration) = measureTimedValue {
-            getStoredResults(allKnownProvenances, packageProvenances)
+            getStoredResults(allKnownProvenances, nestedProvenances, packageProvenances)
         }
 
         log.info {
@@ -239,6 +239,7 @@ class ExperimentalScanner(
 
     private fun getStoredResults(
         provenances: Set<KnownProvenance>,
+        nestedProvenances: Map<Package, NestedProvenance>,
         packageProvenances: Map<Package, Provenance>
     ): Map<ScannerWrapper, MutableMap<KnownProvenance, List<ScanResult>>> {
         return scannerWrappers.associateWith { scanner ->
@@ -252,7 +253,8 @@ class ExperimentalScanner(
                     when (reader) {
                         is PackageBasedScanStorageReader -> {
                             packageProvenances.entries.find { it.value == provenance }?.key?.let { pkg ->
-                                reader.read(pkg, scannerCriteria).forEach { scanResult2 ->
+                                val nestedProvenance = nestedProvenances.getValue(pkg)
+                                reader.read(pkg, nestedProvenance, scannerCriteria).forEach { scanResult2 ->
                                     // TODO: Do not overwrite entries from other storages in result.
                                     // TODO: Map scan result to known source tree for package.
                                     result += scanResult2.scanResults

--- a/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
+++ b/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
@@ -117,7 +117,7 @@ class ExperimentalScanner(
         log.info {
             "Read stored scan results in ${readDuration}ms:"
         }
-        scanResults.entries.forEach { (scanner, results) ->
+        storedResults.entries.forEach { (scanner, results) ->
             log.info { "\t${scanner.name}: Results for ${results.size} of ${allKnownProvenances.size} provenances." }
         }
 

--- a/scanner/src/main/kotlin/experimental/ProvenanceBasedFileStorage.kt
+++ b/scanner/src/main/kotlin/experimental/ProvenanceBasedFileStorage.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import com.fasterxml.jackson.module.kotlin.readValue
+
+import java.io.ByteArrayInputStream
+import java.io.FileNotFoundException
+import java.io.IOException
+
+import org.ossreviewtoolkit.model.ArtifactProvenance
+import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.yamlMapper
+import org.ossreviewtoolkit.utils.collectMessagesAsString
+import org.ossreviewtoolkit.utils.fileSystemEncode
+import org.ossreviewtoolkit.utils.log
+import org.ossreviewtoolkit.utils.showStackTrace
+import org.ossreviewtoolkit.utils.storage.FileStorage
+
+class ProvenanceBasedFileStorage(private val backend: FileStorage) : ProvenanceBasedScanStorage {
+    override fun read(provenance: KnownProvenance): List<ScanResult> {
+        requireEmptyVcsPath(provenance)
+
+        val path = storagePath(provenance)
+
+        return runCatching {
+            backend.read(path).use { input ->
+                yamlMapper.readValue<List<ScanResult>>(input).map {
+                    // Use the provided provenance for the result instead of building it from the stored values, because
+                    // in the case of a RepositoryRevision only the resolved revision matters.
+                    it.copy(provenance = provenance)
+                }
+            }
+        }.getOrElse {
+            when (it) {
+                is FileNotFoundException -> {
+                    // If the file cannot be found it means no scan results have been stored, yet.
+                    emptyList()
+                }
+                else -> {
+                    val message = "Could not read scan results for '$provenance' from path '$path': " +
+                            it.collectMessagesAsString()
+
+                    log.info { message }
+
+                    // TODO: Propagate error.
+                    emptyList()
+                }
+            }
+        }
+    }
+
+    override fun write(scanResult: ScanResult) {
+        val provenance = scanResult.provenance
+
+        requireEmptyVcsPath(provenance)
+
+        if (provenance !is KnownProvenance) {
+            throw ScanStorageException("Scan result must have a known provenance, but it is $provenance.")
+        }
+
+        val existingScanResults = read(provenance)
+
+        if (existingScanResults.any { it.matches(scanResult) }) {
+            throw ScanStorageException(
+                "Storage already contains a result for ${scanResult.provenance} and ${scanResult.scanner}."
+            )
+        }
+
+        val scanResults = existingScanResults + scanResult
+
+        val path = storagePath(provenance)
+        val yamlBytes = yamlMapper.writeValueAsBytes(scanResults)
+        val input = ByteArrayInputStream(yamlBytes)
+
+        runCatching {
+            backend.write(path, input)
+            log.debug { "Stored scan result for '$provenance' at path '$path'." }
+        }.onFailure {
+            when (it) {
+                is IllegalArgumentException, is IOException -> {
+                    it.showStackTrace()
+
+                    val message = "Could not store scan result for '$provenance' at path '$path': " +
+                            it.collectMessagesAsString()
+                    log.warn { message }
+                }
+                else -> throw it
+            }
+        }
+    }
+}
+
+private const val SCAN_RESULTS_FILE_NAME = "scan-results.yml"
+
+private fun storagePath(provenance: KnownProvenance) =
+    when (provenance) {
+        is ArtifactProvenance -> "artifact/${provenance.sourceArtifact.url.fileSystemEncode()}/$SCAN_RESULTS_FILE_NAME"
+        is RepositoryProvenance -> {
+            "repository/${provenance.vcsInfo.type.toString().fileSystemEncode()}" +
+                    "/${provenance.vcsInfo.url.fileSystemEncode()}" +
+                    "/${provenance.resolvedRevision.fileSystemEncode()}" +
+                    "/$SCAN_RESULTS_FILE_NAME"
+        }
+    }
+
+private fun ScanResult.matches(other: ScanResult): Boolean {
+    val thisProvenance = provenance
+    val otherProvenance = other.provenance
+
+    return scanner == other.scanner && when {
+        thisProvenance is RepositoryProvenance && otherProvenance is RepositoryProvenance -> {
+            thisProvenance.vcsInfo.type == otherProvenance.vcsInfo.type &&
+                    thisProvenance.vcsInfo.url == otherProvenance.vcsInfo.url &&
+                    thisProvenance.resolvedRevision == otherProvenance.resolvedRevision
+        }
+
+        else -> provenance == otherProvenance
+    }
+}

--- a/scanner/src/main/kotlin/experimental/ProvenanceBasedPostgresStorage.kt
+++ b/scanner/src/main/kotlin/experimental/ProvenanceBasedPostgresStorage.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import java.sql.SQLException
+
+import javax.sql.DataSource
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.SchemaUtils.withDataBaseLock
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.andWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+
+import org.ossreviewtoolkit.model.ArtifactProvenance
+import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.ScannerDetails
+import org.ossreviewtoolkit.model.utils.DatabaseUtils.checkDatabaseEncoding
+import org.ossreviewtoolkit.model.utils.DatabaseUtils.tableExists
+import org.ossreviewtoolkit.model.utils.DatabaseUtils.transaction
+import org.ossreviewtoolkit.scanner.storages.utils.jsonb
+import org.ossreviewtoolkit.utils.collectMessagesAsString
+import org.ossreviewtoolkit.utils.log
+import org.ossreviewtoolkit.utils.showStackTrace
+
+class ProvenanceBasedPostgresStorage(
+    /**
+     * The JDBC data source to obtain database connections.
+     */
+    private val dataSource: DataSource,
+
+    /**
+     * The name of the table used for storing scan results.
+     */
+    private val tableName: String = "provenance_scan_results"
+) : ProvenanceBasedScanStorage {
+    private val table = ProvenanceScanResults(tableName)
+
+    /** The [Database] instance on which all operations are executed. */
+    private val database = setupDatabase()
+
+    private fun setupDatabase(): Database =
+        Database.connect(dataSource).apply {
+            transaction {
+                withDataBaseLock {
+                    if (!tableExists(tableName)) {
+                        checkDatabaseEncoding()
+                        SchemaUtils.createMissingTablesAndColumns(table)
+                    }
+                }
+            }
+        }
+
+    override fun read(provenance: KnownProvenance): List<ScanResult> {
+        requireEmptyVcsPath(provenance)
+
+        try {
+            return database.transaction {
+                val query = table.selectAll()
+
+                when (provenance) {
+                    is ArtifactProvenance -> {
+                        query.andWhere {
+                            table.artifactUrl eq provenance.sourceArtifact.url and
+                                    (table.artifactHash eq provenance.sourceArtifact.hash.value)
+                        }
+                    }
+
+                    is RepositoryProvenance -> {
+                        query.andWhere {
+                            table.vcsType eq provenance.vcsInfo.type.toString() and
+                                    (table.vcsUrl eq provenance.vcsInfo.url) and
+                                    (table.vcsRevision eq provenance.resolvedRevision)
+                        }
+                    }
+                }
+
+                // Use the provided provenance for the result instead of building it from the stored values, because in
+                // the case of a RepositoryRevision only the resolved revision matters, therefore the VcsInfo.revision
+                // is not stored in the database.
+                query.map {
+                    ScanResult(
+                        provenance = provenance,
+                        scanner = ScannerDetails(
+                            name = it[table.scannerName],
+                            version = it[table.scannerVersion],
+                            configuration = it[table.scannerConfiguration]
+                        ),
+                        summary = it[table.scanSummary]
+                    )
+                }
+            }
+        } catch (e: SQLException) {
+            e.showStackTrace()
+
+            log.error { "Could not read scan results: ${e.collectMessagesAsString()}" }
+
+            throw ScanStorageException(e)
+        }
+    }
+
+    // TODO: Override read(provenance, scannerCriteria) to make it more efficient by matching the scanner details in the
+    //       query.
+
+    override fun write(scanResult: ScanResult) {
+        val provenance = scanResult.provenance
+
+        requireEmptyVcsPath(provenance)
+
+        if (provenance !is KnownProvenance) {
+            throw ScanStorageException("Scan result must have a known provenance, but it is $provenance.")
+        }
+
+        try {
+            database.transaction {
+                table.insert {
+                    when (provenance) {
+                        is ArtifactProvenance -> {
+                            it[artifactUrl] = provenance.sourceArtifact.url
+                            it[artifactHash] = provenance.sourceArtifact.hash.value
+                        }
+
+                        is RepositoryProvenance -> {
+                            it[vcsType] = provenance.vcsInfo.type.toString()
+                            it[vcsUrl] = provenance.vcsInfo.url
+                            it[vcsRevision] = provenance.resolvedRevision
+                        }
+                    }
+
+                    it[scannerName] = scanResult.scanner.name
+                    it[scannerVersion] = scanResult.scanner.version
+                    it[scannerConfiguration] = scanResult.scanner.configuration
+                    it[scanSummary] = scanResult.summary
+                }
+            }
+        } catch (e: SQLException) {
+            e.showStackTrace()
+
+            log.error { "Could not write scan result: ${e.collectMessagesAsString()}" }
+
+            throw ScanStorageException(e)
+        }
+    }
+}
+
+private class ProvenanceScanResults(tableName: String) : IntIdTable(tableName) {
+    val artifactUrl = text("artifact_url").nullable()
+    val artifactHash = text("artifact_hash").nullable()
+    val vcsType = text("vcs_type").nullable()
+    val vcsUrl = text("vcs_url").nullable()
+    val vcsRevision = text("vcs_revision").nullable()
+    val scannerName = text("scanner_name")
+    val scannerVersion = text("scanner_version")
+    val scannerConfiguration = text("scanner_configuration")
+    val scanSummary = jsonb("scan_summary", ScanSummary::class)
+
+    init {
+        // Indices to prevent duplicate entries.
+        uniqueIndex(artifactUrl, artifactHash, scannerName, scannerVersion, scannerConfiguration)
+        uniqueIndex(vcsType, vcsUrl, vcsRevision, scannerName, scannerVersion, scannerConfiguration)
+
+        // Indices to improve lookup performance.
+        index(isUnique = false, artifactUrl, artifactHash)
+        index(isUnique = false, vcsType, vcsUrl, vcsRevision)
+    }
+}

--- a/scanner/src/main/kotlin/experimental/ScanStorage.kt
+++ b/scanner/src/main/kotlin/experimental/ScanStorage.kt
@@ -119,15 +119,21 @@ interface ProvenanceBasedScanStorageWriter : ScanStorageWriter {
 }
 
 /**
+ * A combination of the [ScanStorageReader] and [ScanStorageWriter]. This is a markup interface used when it is not
+ * known or relevant which actual implementation a storage class provides.
+ */
+interface ScanStorage : ScanStorageReader, ScanStorageWriter
+
+/**
  * A combination of the [PackageBasedScanStorageReader] and [PackageBasedScanStorageWriter]. This interface is usually
  * implemented by actual storage implementations, because it is often convenient to implement both interfaces in a
  * single class.
  */
-interface PackageBasedScanStorage : PackageBasedScanStorageReader, PackageBasedScanStorageWriter
+interface PackageBasedScanStorage : ScanStorage, PackageBasedScanStorageReader, PackageBasedScanStorageWriter
 
 /**
  * A combination of the [ProvenanceBasedScanStorageReader] and [ProvenanceBasedScanStorageWriter]. This interface is
  * usually implemented by actual storage implementations, because it is often convenient to implement both interfaces in
  * a single class.
  */
-interface ProvenanceBasedScanStorage : ProvenanceBasedScanStorageReader, ProvenanceBasedScanStorageWriter
+interface ProvenanceBasedScanStorage : ScanStorage, ProvenanceBasedScanStorageReader, ProvenanceBasedScanStorageWriter

--- a/scanner/src/main/kotlin/experimental/ScanStorage.kt
+++ b/scanner/src/main/kotlin/experimental/ScanStorage.kt
@@ -113,3 +113,17 @@ interface ProvenanceBasedScanStorageWriter : ScanStorageWriter {
      */
     fun write(scanResult: ScanResult)
 }
+
+/**
+ * A combination of the [PackageBasedScanStorageReader] and [PackageBasedScanStorageWriter]. This interface is usually
+ * implemented by actual storage implementations, because it is often convenient to implement both interfaces in a
+ * single class.
+ */
+interface PackageBasedScanStorage : PackageBasedScanStorageReader, PackageBasedScanStorageWriter
+
+/**
+ * A combination of the [ProvenanceBasedScanStorageReader] and [ProvenanceBasedScanStorageWriter]. This interface is
+ * usually implemented by actual storage implementations, because it is often convenient to implement both interfaces in
+ * a single class.
+ */
+interface ProvenanceBasedScanStorage : ProvenanceBasedScanStorageReader, ProvenanceBasedScanStorageWriter

--- a/scanner/src/main/kotlin/experimental/ScanStorage.kt
+++ b/scanner/src/main/kotlin/experimental/ScanStorage.kt
@@ -40,17 +40,21 @@ sealed interface ScanStorageReader
 interface PackageBasedScanStorageReader : ScanStorageReader {
     /**
      * Read all [ScanResult]s for the provided [package][pkg]. This includes all stored scan results matching the
-     * [package id][Package.id] and [provenance][KnownProvenance.matches].
+     * [package id][Package.id] and [provenance][KnownProvenance.matches], and the provided [nestedProvenance].
      *
      * A [ScanStorageException] is thrown if:
      * * An error occurs while reading from the storage.
      */
-    fun read(pkg: Package): List<NestedProvenanceScanResult>
+    fun read(pkg: Package, nestedProvenance: NestedProvenance): List<NestedProvenanceScanResult>
 
     /**
      * Like [read], but also filters by the provided [scannerCriteria].
      */
-    fun read(pkg: Package, scannerCriteria: ScannerCriteria): List<NestedProvenanceScanResult>
+    fun read(
+        pkg: Package,
+        nestedProvenance: NestedProvenance,
+        scannerCriteria: ScannerCriteria
+    ): List<NestedProvenanceScanResult>
 }
 
 /**

--- a/scanner/src/main/kotlin/experimental/ScanStorageException.kt
+++ b/scanner/src/main/kotlin/experimental/ScanStorageException.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+class ScanStorageException : Exception {
+    constructor(message: String?, cause: Throwable?) : super(message, cause)
+    constructor(message: String?) : super(message)
+    constructor(cause: Throwable?) : super(cause)
+}

--- a/scanner/src/main/kotlin/experimental/Utils.kt
+++ b/scanner/src/main/kotlin/experimental/Utils.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.RepositoryProvenance
+
+/**
+ * Throw a [ScanStorageException] if [provenance] is a [RepositoryProvenance] with a non-empty VCS path.
+ */
+internal fun requireEmptyVcsPath(provenance: Provenance) {
+    if (provenance is RepositoryProvenance && provenance.vcsInfo.path.isNotEmpty()) {
+        throw ScanStorageException("Repository provenances with a non-empty VCS path are not supported.")
+    }
+}

--- a/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
+++ b/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
@@ -206,7 +206,7 @@ class ExperimentalScannerTest : WordSpec({
             val scannerWrapper = spyk(FakePackageBasedRemoteScannerWrapper())
             val reader = spyk(FakePackageBasedStorageReader(scannerWrapper.details))
 
-            every { reader.read(pkgWithArtifact) } returns listOf(
+            every { reader.read(pkgWithArtifact, any()) } returns listOf(
                 createStoredNestedScanResult(pkgWithArtifact.artifactProvenance(), scannerWrapper.details)
             )
 
@@ -234,7 +234,7 @@ class ExperimentalScannerTest : WordSpec({
             val scannerWrapper = spyk(FakePackageBasedRemoteScannerWrapper())
             val reader = spyk(FakePackageBasedStorageReader(scannerWrapper.details))
 
-            every { reader.read(any()) } returns emptyList()
+            every { reader.read(any(), any()) } returns emptyList()
 
             val scanner = createScanner(
                 storageReaders = listOf(reader),
@@ -251,7 +251,7 @@ class ExperimentalScannerTest : WordSpec({
             )
 
             verify(exactly = 1) {
-                reader.read(pkgWithArtifact)
+                reader.read(pkgWithArtifact, any())
                 scannerWrapper.scanPackage(pkgWithArtifact)
             }
         }
@@ -302,7 +302,7 @@ class ExperimentalScannerTest : WordSpec({
 
             val reader = spyk(FakePackageBasedStorageReader(scannerWrapper.details))
 
-            every { reader.read(pkgCompletelyScanned) } returns listOf(nestedScanResultCompletelyScanned)
+            every { reader.read(pkgCompletelyScanned, any()) } returns listOf(nestedScanResultCompletelyScanned)
 
             val scanner = createScanner(
                 storageReaders = listOf(reader),
@@ -647,7 +647,7 @@ private class FakeNestedProvenanceResolver : NestedProvenanceResolver {
  * with a single license finding for the provided [scannerDetails].
  */
 private class FakePackageBasedStorageReader(val scannerDetails: ScannerDetails) : PackageBasedScanStorageReader {
-    override fun read(pkg: Package): List<NestedProvenanceScanResult> {
+    override fun read(pkg: Package, nestedProvenance: NestedProvenance): List<NestedProvenanceScanResult> {
         val provenance = if (pkg.sourceArtifact != RemoteArtifact.EMPTY) {
             ArtifactProvenance(pkg.sourceArtifact)
         } else {
@@ -657,7 +657,11 @@ private class FakePackageBasedStorageReader(val scannerDetails: ScannerDetails) 
         return listOf(createStoredNestedScanResult(provenance, scannerDetails))
     }
 
-    override fun read(pkg: Package, scannerCriteria: ScannerCriteria): List<NestedProvenanceScanResult> = read(pkg)
+    override fun read(
+        pkg: Package,
+        nestedProvenance: NestedProvenance,
+        scannerCriteria: ScannerCriteria
+    ): List<NestedProvenanceScanResult> = read(pkg, nestedProvenance)
 }
 
 private class FakeProvenanceBasedStorageReader(val scannerDetails: ScannerDetails) : ProvenanceBasedScanStorageReader {


### PR DESCRIPTION
Adapt the existing storages for the experimental scanner and add new provenance based storages. For details see the commit messages.