### PR TITLE
SpdxDocumentFiles: Use `originator` as the author

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
@@ -2,6 +2,8 @@
 project:
   id: "SpdxDocumentFile::xyz:0.1.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml"
+  authors:
+  - "Thomas Steenbergen"
   declared_licenses:
   - "Apache-2.0 AND curl AND LicenseRef-Proprietary-ExampleInc"
   declared_licenses_processed:
@@ -29,6 +31,8 @@ project:
 packages:
 - id: "SpdxDocumentFile::curl:7.70.0"
   purl: "pkg:spdxdocumentfile/curl@7.70.0"
+  authors:
+  - "Daniel Stenberg (daniel@haxx.se)"
   declared_licenses:
   - "curl"
   declared_licenses_processed:
@@ -60,6 +64,9 @@ packages:
     path: ""
 - id: "SpdxDocumentFile::zlib:1.2.11"
   purl: "pkg:spdxdocumentfile/zlib@1.2.11"
+  authors:
+  - "Jean-loup Gailly"
+  - "Mark Adler"
   declared_licenses:
   - "Zlib"
   declared_licenses_processed:
@@ -88,6 +95,8 @@ packages:
     path: "analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/zlib"
 - id: "SpdxDocumentFile:OpenSSL Development Team:openssl:1.1.1g"
   purl: "pkg:a-name/openssl@1.1.1g"
+  authors:
+  - "OpenSSL Development Team"
   declared_licenses:
   - "Apache-2.0"
   declared_licenses_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
@@ -49,6 +49,7 @@ packages:
   packageFileName: "./libs/openssl"
   name: "openssl"
   versionInfo: "1.1.1g"
+  supplier: "Organization: OpenSSL Development Team"
   originator: "Organization: OpenSSL Development Team"
 - SPDXID: "SPDXRef-Package-Saxon"
   checksums:

--- a/analyzer/src/funTest/kotlin/managers/SpdxDocumentFileFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/SpdxDocumentFileFunTest.kt
@@ -71,6 +71,7 @@ class SpdxDocumentFileFunTest : WordSpec({
                 Project(
                     id = Identifier("SpdxDocumentFile::curl:7.70.0"),
                     definitionFilePath = packageFileCurl.relativeTo(vcsDir.getRootPath()).invariantSeparatorsPath,
+                    authors = sortedSetOf("Daniel Stenberg (daniel@haxx.se)"),
                     declaredLicenses = sortedSetOf("curl"),
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = VcsInfo(
@@ -90,6 +91,7 @@ class SpdxDocumentFileFunTest : WordSpec({
                 Project(
                     id = Identifier("SpdxDocumentFile::zlib:1.2.11"),
                     definitionFilePath = packageFileZlib.relativeTo(vcsDir.getRootPath()).invariantSeparatorsPath,
+                    authors = sortedSetOf("Jean-loup Gailly", "Mark Adler"),
                     declaredLicenses = sortedSetOf("Zlib"),
                     vcs = VcsInfo.EMPTY,
                     vcsProcessed = VcsInfo(

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -329,7 +329,8 @@ class SpdxDocumentFile(
     private fun SpdxPackage.toIdentifier() =
         Identifier(
             type = managerName,
-            namespace = originator?.withoutPrefix(SpdxConstants.ORGANIZATION).orEmpty(),
+            namespace = listOfNotNull(supplier, originator).firstOrNull()
+                ?.withoutPrefix(SpdxConstants.ORGANIZATION).orEmpty(),
             name = name,
             version = versionInfo
         )

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -252,15 +252,6 @@ private fun SpdxPackage.locateExternalReference(type: SpdxExternalReference.Type
     externalRefs.find { it.referenceType == type }?.referenceLocator
 
 /**
- * Return the organization from an "originator", "supplier", or "annotator" string, or null if no organization is
- * specified.
- */
-private fun String.extractOrganization(): String? =
-    lineSequence().mapNotNull { line ->
-        line.withoutPrefix(SpdxConstants.ORGANIZATION)
-    }.firstOrNull()
-
-/**
  * Return whether the string has the format of an [SpdxExternalDocumentReference], with or without an additional
  * package id.
  */
@@ -338,7 +329,7 @@ class SpdxDocumentFile(
     private fun SpdxPackage.toIdentifier() =
         Identifier(
             type = managerName,
-            namespace = originator?.extractOrganization().orEmpty(),
+            namespace = originator?.withoutPrefix(SpdxConstants.ORGANIZATION).orEmpty(),
             name = name,
             version = versionInfo
         )

--- a/spdx-utils/src/main/kotlin/SpdxConstants.kt
+++ b/spdx-utils/src/main/kotlin/SpdxConstants.kt
@@ -71,12 +71,12 @@ object SpdxConstants {
     const val LICENSE_LIST_URL = "https://spdx.org/licenses/"
 
     /**
-     * Return true if and only if the given value equals [NONE] or [NOASSERTION].
+     * Return true if and only if the given value is null or equals [NONE] or [NOASSERTION].
      */
-    fun isNotPresent(value: String) = value in setOf(NONE, NOASSERTION)
+    fun isNotPresent(value: String?) = value in setOf(null, NONE, NOASSERTION)
 
     /**
-     * Return true if and only if the given value does not equal [NONE] or [NOASSERTION].
+     * Return true if and only if the given value is not null and does not equal [NONE] or [NOASSERTION].
      */
-    fun isPresent(value: String) = !isNotPresent(value)
+    fun isPresent(value: String?) = !isNotPresent(value)
 }


### PR DESCRIPTION
Resolves #4058.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>