### PR TITLE
FossId: Fix the extraction of a repository name from a Git URL

### DIFF
--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -86,7 +86,7 @@ class FossId internal constructor(
 
     companion object {
         @JvmStatic
-        private val PROJECT_NAME_REGEX = Regex("""^.*\/([\w.\-]+)(?:\.git)?$""")
+        private val PROJECT_NAME_REGEX = Regex("""^.*\/([\w.\-]+?)(?:\.git)?$""")
 
         @JvmStatic
         private val GIT_FETCH_DONE_REGEX = Regex("-> FETCH_HEAD(?: Already up to date.)*$")

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -88,6 +88,7 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.scanOrtResult
+import org.ossreviewtoolkit.scanner.scanners.fossid.FossId.Companion.convertGitUrlToProjectName
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class FossIdTest : WordSpec({
@@ -100,6 +101,14 @@ class FossIdTest : WordSpec({
             val fossId = createFossId(createConfig())
 
             fossId.version shouldBe FOSSID_VERSION
+        }
+    }
+
+    "convertGitUrlToProjectName()" should {
+        "extract the repository name from the Git URL without the .git suffix" {
+            convertGitUrlToProjectName("https://github.com/jshttp/mime-types.git") shouldBe "mime-types"
+            convertGitUrlToProjectName("https://github.com/vdurmont/semver4j.git") shouldBe "semver4j"
+            convertGitUrlToProjectName("https://dev.azure.com/org/project/_git/repo") shouldBe "repo"
         }
     }
 
@@ -601,7 +610,7 @@ private const val USER = "fossIdTestUser"
 private const val API_KEY = "fossId-API-key"
 
 /** A test project name. */
-private const val PROJECT = "fossId-test-project.git"
+private const val PROJECT = "fossId-test-project"
 
 /** A test revision. */
 private const val REVISION = "test-revision"
@@ -717,7 +726,7 @@ private fun createVcsInfo(
     path: String = "",
     revision: String = REVISION
 ): VcsInfo =
-    VcsInfo(type = type, path = path, revision = revision, url = "https://github.com/test/$projectName")
+    VcsInfo(type = type, path = path, revision = revision, url = "https://github.com/test/$projectName.git")
 
 /**
  * Create a test [Identifier] with properties derived from the given [index].


### PR DESCRIPTION
This fixes the regex for the extraction of the repository name from
a Git URL, because the old regex could not omit the .git suffix from
the Git URL. Additionally, it adds a new test case for testing the
function convertGitUrlToProjectName with several Git URLs.