### PR TITLE
NuGetSupport: Get more project properties from a nuspec, if present

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output-with-nuspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output-with-nuspec.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "DotNet::src/funTest/assets/projects/synthetic/dotnet/subProjectTestWithNuspec/test.csproj:"
+  id: "DotNet::MyPackage:0.8.15"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/dotnet/subProjectTestWithNuspec/test.csproj"
   authors:
   - "Author1"

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -319,8 +319,8 @@ private fun PackageManager.getProject(
         id = Identifier(
             type = managerName,
             namespace = "",
-            name = definitionFile.relativeTo(analysisRoot).invariantSeparatorsPath,
-            version = ""
+            name = spec?.metadata?.id ?: definitionFile.relativeTo(analysisRoot).invariantSeparatorsPath,
+            version = spec?.metadata?.version.orEmpty()
         ),
         definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
         authors = parseAuthors(spec),


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>