### PR TITLE
Pip: Do not fail hard on non-short-string / multi-string licenses

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -670,7 +670,23 @@ class Pip(
         }
 
         val declaredLicenses = sortedSetOf<String>()
-        getLicenseFromLicenseField(map["License"]?.single())?.let { declaredLicenses += it }
+
+        map["License"]?.let { licenseShortString ->
+            getLicenseFromLicenseField(licenseShortString.firstOrNull())?.let { declaredLicenses += it }
+
+            val moreLines = licenseShortString.drop(1)
+            if (moreLines.isNotEmpty()) {
+                log.warn {
+                    "The 'License' field is supposed to be a short string but contained the following additional " +
+                            "lines which will be ignored:"
+                }
+
+                moreLines.forEach { line ->
+                    log.warn { line }
+                }
+            }
+        }
+
         map["Classifiers"]?.mapNotNullTo(declaredLicenses) { getLicenseFromClassifier(it) }
 
         val authors = parseAuthorString(map["Author"]?.singleOrNull())


### PR DESCRIPTION
There are Pip packages that use the full license text here instead of a
short string. Only use the first line in that case, and warn about the
rest. Also see [1].

[1]: https://github.com/scanny/python-pptx/issues/748

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>