### PR TITLE
ConanFunTest: Replace the dependencies

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-py.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-py.yml
@@ -25,19 +25,17 @@ project:
     dependencies: []
   - name: "requires"
     dependencies:
-    - id: "Conan::OpenSSL:1.0.2o"
+    - id: "Conan::openssl:3.0.0"
       dependencies:
       - id: "Conan::zlib:1.2.11"
     - id: "Conan::zlib:1.2.11"
 packages:
-- id: "Conan::OpenSSL:1.0.2o"
-  purl: "pkg:conan/OpenSSL@1.0.2o"
-  authors:
-  - "Conan Community"
+- id: "Conan::openssl:3.0.0"
+  purl: "pkg:conan/openssl@3.0.0"
   declared_licenses:
-  - "OpenSSL"
+  - "Apache-2.0"
   declared_licenses_processed:
-    spdx_expression: "OpenSSL"
+    spdx_expression: "Apache-2.0"
   description: "A toolkit for the Transport Layer Security (TLS) and Secure Sockets\
     \ Layer (SSL) protocols"
   homepage_url: "https://github.com/openssl/openssl"
@@ -53,18 +51,16 @@ packages:
       algorithm: ""
   vcs:
     type: "Git"
-    url: "http://github.com/conan-community/conan-openssl"
+    url: "https://github.com/conan-io/conan-center-index"
     revision: ""
     path: ""
   vcs_processed:
     type: "Git"
-    url: "https://github.com/conan-community/conan-openssl.git"
+    url: "https://github.com/conan-io/conan-center-index.git"
     revision: ""
     path: ""
 - id: "Conan::zlib:1.2.11"
   purl: "pkg:conan/zlib@1.2.11"
-  authors:
-  - "Conan Community"
   declared_licenses:
   - "Zlib"
   declared_licenses_processed:
@@ -84,11 +80,11 @@ packages:
       algorithm: ""
   vcs:
     type: "Git"
-    url: "http://github.com/conan-community/conan-zlib"
+    url: "https://github.com/conan-io/conan-center-index"
     revision: ""
     path: ""
   vcs_processed:
     type: "Git"
-    url: "https://github.com/conan-community/conan-zlib.git"
+    url: "https://github.com/conan-io/conan-center-index.git"
     revision: ""
     path: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-txt.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-txt.yml
@@ -18,22 +18,27 @@ project:
   scopes:
   - name: "build_requires"
     dependencies:
-    - id: "Conan::protobuf:3.6.1"
-    - id: "Conan::protoc_installer:3.6.1"
+    - id: "Conan::libiconv:1.16"
+    - id: "Conan::libxml2:2.9.12"
+      dependencies:
+      - id: "Conan::zlib:1.2.11"
   - name: "requires"
     dependencies:
-    - id: "Conan::protobuf:3.6.1"
+    - id: "Conan::libcurl:7.79.1"
+      dependencies:
+      - id: "Conan::openssl:1.1.1l"
+      - id: "Conan::zlib:1.2.11"
+    - id: "Conan::openssl:1.1.1l"
+    - id: "Conan::zlib:1.2.11"
 packages:
-- id: "Conan::protobuf:3.6.1"
-  purl: "pkg:conan/protobuf@3.6.1"
-  authors:
-  - "Bincrafters"
+- id: "Conan::libcurl:7.79.1"
+  purl: "pkg:conan/libcurl@7.79.1"
   declared_licenses:
-  - "BSD-3-Clause"
+  - "MIT"
   declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-  description: "Protocol Buffers - Google's data interchange format"
-  homepage_url: "https://github.com/protocolbuffers/protobuf"
+    spdx_expression: "MIT"
+  description: "command line tool and library for transferring data with URLs"
+  homepage_url: "https://curl.haxx.se"
   binary_artifact:
     url: ""
     hash:
@@ -46,24 +51,24 @@ packages:
       algorithm: ""
   vcs:
     type: "Git"
-    url: "https://github.com/bincrafters/conan-protobuf"
+    url: "https://github.com/conan-io/conan-center-index"
     revision: ""
     path: ""
   vcs_processed:
     type: "Git"
-    url: "https://github.com/bincrafters/conan-protobuf.git"
+    url: "https://github.com/conan-io/conan-center-index.git"
     revision: ""
     path: ""
-- id: "Conan::protoc_installer:3.6.1"
-  purl: "pkg:conan/protoc_installer@3.6.1"
-  authors:
-  - "Bincrafters"
+- id: "Conan::libiconv:1.16"
+  purl: "pkg:conan/libiconv@1.16"
   declared_licenses:
-  - "BSD-3-Clause"
+  - "LGPL-2.1"
   declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-  description: "Protocol Buffers - Google's data interchange format"
-  homepage_url: "https://github.com/protocolbuffers/protobuf"
+    spdx_expression: "LGPL-2.1-only"
+    mapped:
+      LGPL-2.1: "LGPL-2.1-only"
+  description: "Convert text to and from Unicode"
+  homepage_url: "https://www.gnu.org/software/libiconv/"
   binary_artifact:
     url: ""
     hash:
@@ -76,11 +81,97 @@ packages:
       algorithm: ""
   vcs:
     type: "Git"
-    url: "https://github.com/bincrafters/conan-protobuf"
+    url: "https://github.com/conan-io/conan-center-index"
     revision: ""
     path: ""
   vcs_processed:
     type: "Git"
-    url: "https://github.com/bincrafters/conan-protobuf.git"
+    url: "https://github.com/conan-io/conan-center-index.git"
+    revision: ""
+    path: ""
+- id: "Conan::libxml2:2.9.12"
+  purl: "pkg:conan/libxml2@2.9.12"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "libxml2 is a software library for parsing XML documents"
+  homepage_url: "https://xmlsoft.org"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: "Git"
+    url: "https://github.com/conan-io/conan-center-index"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/conan-io/conan-center-index.git"
+    revision: ""
+    path: ""
+- id: "Conan::openssl:1.1.1l"
+  purl: "pkg:conan/openssl@1.1.1l"
+  declared_licenses:
+  - "OpenSSL"
+  declared_licenses_processed:
+    spdx_expression: "OpenSSL"
+  description: "A toolkit for the Transport Layer Security (TLS) and Secure Sockets\
+    \ Layer (SSL) protocols"
+  homepage_url: "https://github.com/openssl/openssl"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: "Git"
+    url: "https://github.com/conan-io/conan-center-index"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/conan-io/conan-center-index.git"
+    revision: ""
+    path: ""
+- id: "Conan::zlib:1.2.11"
+  purl: "pkg:conan/zlib@1.2.11"
+  declared_licenses:
+  - "Zlib"
+  declared_licenses_processed:
+    spdx_expression: "Zlib"
+  description: "A Massively Spiffy Yet Delicately Unobtrusive Compression Library\
+    \ (Also Free, Not to Mention Unencumbered by Patents)"
+  homepage_url: "https://zlib.net"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: "Git"
+    url: "https://github.com/conan-io/conan-center-index"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/conan-io/conan-center-index.git"
     revision: ""
     path: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/conan-py/conanfile.py
+++ b/analyzer/src/funTest/assets/projects/synthetic/conan-py/conanfile.py
@@ -96,7 +96,7 @@ cxx_14=False
 
     def requirements(self):
         if self.options.enable_netssl or self.options.enable_netssl_win or self.options.enable_crypto or self.options.force_openssl:
-            self.requires.add("OpenSSL/1.0.2o@conan/stable", private=False)
+            self.requires.add("openssl/3.0.0", private=False)
 
         if self.options.enable_data_mysql:
             # self.requires.add("MySQLClient/6.1.6@hklabbers/stable")

--- a/analyzer/src/funTest/assets/projects/synthetic/conan-txt/.gitignore
+++ b/analyzer/src/funTest/assets/projects/synthetic/conan-txt/.gitignore
@@ -1,5 +1,6 @@
 /conan.lock
 /conanbuildinfo.cmake
+/conanbuildinfo.props
 /conanbuildinfo.txt
 /conaninfo.txt
 /graph_info.json

--- a/analyzer/src/funTest/assets/projects/synthetic/conan-txt/conanfile.txt
+++ b/analyzer/src/funTest/assets/projects/synthetic/conan-txt/conanfile.txt
@@ -1,8 +1,8 @@
 [build_requires]
-protoc_installer/3.6.1@bincrafters/stable
+libxml2/2.9.12
 
 [requires]
-protobuf/3.6.1@bincrafters/stable
+libcurl/7.79.1
 
 [generators]
 cmake


### PR DESCRIPTION
The previously used dependencies were not available on Conan Center
anymore, probably because the Bintray default repository was removed in
Conan 1.40.0 [1].

While at it, use dependencies which have transitive dependencies, to
show how these are handled.

[1] https://docs.conan.io/en/1.40/changelog.html#id12