### PR TITLE
Dockerfile: Stop using the outdated Java 11 binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -174,6 +174,10 @@ RUN tar xf /opt/ort.tar -C /opt/ort --strip-components 1 && \
     rm /opt/ort.tar && \
     /opt/ort/bin/ort requirements
 
+# Use the most recent version of Java 11 under '/usr/bin/java'. Note that '/opt/java/openjdk/bin' is outdated and leads
+# to issues with analyzing some SBT projects, see https://github.com/oss-review-toolkit/ort/issues/4543.
+RUN export PATH=$(echo PATH | sed 's/\/opt\/java\/openjdk\/bin/\/usr\/bin\/java/g')
+
 COPY --from=build /usr/local/src/ort/helper-cli/build/scripts/orth /opt/ort/bin/
 COPY --from=build /usr/local/src/ort/helper-cli/build/libs/helper-cli-*.jar /opt/ort/lib/
 


### PR DESCRIPTION
The docker image has two `java` binaries installed. Version
`11.0.8 2020-07-14` is located in `/opt/java/openjdk/bin` and version
`11.0.11 2021-04-20` in `/usr/lib/jvm/java-11-openjdk-amd64/bin`.

The analysis of some SBT projects fails with a null pointer exception
with the more outdated version while it succeeds with the more recent
one for unkown reason. Fix that issue by patching up the PATH variable
to use the more recent Java binary.

Note: ORT's docker image is currently based on the deprecated
AdoptOpenJDK image which needs to be fixed. Migrating the docker image
to a (more recent) non-deprecated base image will likely eliminate the
need for this work-around anyway. Therefore it should be ok to go for
this rather ugly hack temporarily.
