### PR TITLE
Environment: Add `PATH` to the relevant variables

### DIFF
--- a/utils/src/main/kotlin/Environment.kt
+++ b/utils/src/main/kotlin/Environment.kt
@@ -86,6 +86,7 @@ data class Environment(
             "http_proxy",
             "https_proxy",
             "JAVA_HOME",
+            "PATH",
             "ANDROID_HOME",
             "GOPATH"
         )


### PR DESCRIPTION
Show the value of the `PATH` variable as part of the version header of
the cli, see also `getVersionHeader()` in `OrtMain.kt`. This can be
useful for debugging.

