### PR TITLE
Move `allowMovingRevisions` to the `DownloaderConfiguration`

### DIFF
--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -29,7 +29,6 @@ import com.github.ajalt.clikt.parameters.groups.required
 import com.github.ajalt.clikt.parameters.groups.single
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.options.split
@@ -130,12 +129,6 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
         .convert { it.absoluteFile.normalize() }
         .required()
         .outputGroup()
-
-    private val allowMovingRevisions by option(
-        "--allow-moving-revisions",
-        help = "Allow the download of moving revisions (like e.g. HEAD or master in Git). By default these revisions " +
-                "are forbidden because they are not pointing to a fixed revision of the source code."
-    ).flag()
 
     private val globalOptionsForSubcommands by requireObject<GlobalOptions>()
 
@@ -246,7 +239,7 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
 
                 packageDownloadDirs.forEach { (pkg, dir) ->
                     try {
-                        Downloader(config.downloader).download(pkg, dir, allowMovingRevisions)
+                        Downloader(config.downloader).download(pkg, dir)
 
                         if (archiveMode == ArchiveMode.ENTITY) {
                             val zipFile = outputDir.resolve("${pkg.id.toPath("-")}.zip")
@@ -320,7 +313,7 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
                     // Always allow moving revisions when directly downloading a single project only. This is for
                     // convenience as often the latest revision (referred to by some VCS-specific symbolic name) of a
                     // project needs to be downloaded.
-                    Downloader(config.downloader).download(dummyPackage, outputDir, allowMovingRevisions = true)
+                    Downloader(config.downloader.copy(allowMovingRevisions = true)).download(dummyPackage, outputDir)
                 } catch (e: DownloadException) {
                     e.showStackTrace()
 

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -197,8 +197,8 @@ abstract class VersionControlSystem {
 
     /**
      * Download the source code as specified by the [pkg] information to [targetDir]. [allowMovingRevisions] toggles
-     * whether symbolic names, for which the revision they point to might change, are accepted or not. If [recursive] is
-     * `true`, any nested repositories (like Git submodules or Mercurial subrepositories) are downloaded, too.
+     * whether to allow downloads using symbolic names that point to moving revisions, like Git branches. If [recursive]
+     * is `true`, any nested repositories (like Git submodules or Mercurial subrepositories) are downloaded, too.
      *
      * @return An object describing the downloaded working tree.
      *
@@ -253,8 +253,8 @@ abstract class VersionControlSystem {
      * The provided [workingTree] must have been created from the [processed VCS information][Package.vcsProcessed] of
      * the [package][pkg] for the function to return correct results.
      *
-     * [allowMovingRevisions] toggles whether symbolic names, for which the revision they point to might change, are
-     * accepted or not.
+     * [allowMovingRevisions] toggles whether candidates with symbolic names that point to moving revisions, like Git
+     * branches, are accepted or not.
      *
      * Revision candidates are created from the [processed VCS information[Package.vcsProcessed] of the [package][pkg]
      * and from [guessing revisions][WorkingTree.guessRevisionName] based on the name and version of the [package][pkg].

--- a/model/src/main/kotlin/config/DownloaderConfiguration.kt
+++ b/model/src/main/kotlin/config/DownloaderConfiguration.kt
@@ -25,6 +25,11 @@ import org.ossreviewtoolkit.spdx.getDuplicates
 
 data class DownloaderConfiguration(
     /**
+     * Toggle whether to allow downloads using symbolic names that point to moving revisions, like Git branches.
+     */
+    val allowMovingRevisions: Boolean = false,
+
+    /**
      * The [categories][LicenseCategory] licenses of packages need to be part of in order to get included into the
      * download, or an empty list to include all packages.
      */

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -38,6 +38,8 @@ ort {
   }
 
   downloader {
+    allowMovingRevisions = true
+
     # Only used by the CLI tool when the '--license-classifications-file' option is specified.
     includedLicenseCategories: [
       category-a,

--- a/scanner/src/main/kotlin/experimental/ProvenanceDownloader.kt
+++ b/scanner/src/main/kotlin/experimental/ProvenanceDownloader.kt
@@ -60,7 +60,7 @@ class DefaultProvenanceDownloader(config: DownloaderConfiguration) : ProvenanceD
                 val pkg = Package.EMPTY.copy(
                     vcsProcessed = provenance.vcsInfo.copy(revision = provenance.resolvedRevision)
                 )
-                downloader.downloadFromVcs(pkg, downloadDir, allowMovingRevisions = false, recursive = false)
+                downloader.downloadFromVcs(pkg, downloadDir, recursive = false)
             }
         }
     }


### PR DESCRIPTION
This way the option can not only be configured when running the
`DownloaderCommand` directly, but takes also effect when the downloader
is invoked by the scanner.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>