### PR TITLE
OssIndexService: Make a ComponentReport's description optional

### DIFF
--- a/clients/oss-index/src/main/kotlin/OssIndexService.kt
+++ b/clients/oss-index/src/main/kotlin/OssIndexService.kt
@@ -94,7 +94,7 @@ interface OssIndexService {
         val coordinates: String,
 
         /** The description of the component. */
-        val description: String,
+        val description: String? = null,
 
         /** The reference URL of the component on OSS Index itself. */
         val reference: String,


### PR DESCRIPTION
Fixes #4557.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>