### PR TITLE
VersionControlSystem: Fix an intended `break` which is `continue`

### DIFF
--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -219,10 +219,10 @@ abstract class VersionControlSystem {
         val revisionCandidates = getRevisionCandidates(workingTree, pkg, allowMovingRevisions)
         val results = mutableListOf<Result<String>>()
 
-        revisionCandidates.forEachIndexed { index, revision ->
+        for ((index, revision) in revisionCandidates.withIndex()) {
             log.info { "Trying revision candidate '$revision' (${index + 1} of ${revisionCandidates.size})..." }
             results += updateWorkingTree(workingTree, revision, pkg.vcsProcessed.path, recursive)
-            if (results.last().isSuccess) return@forEachIndexed
+            if (results.last().isSuccess) break
         }
 
         val workingTreeRevision = results.last().getOrElse {


### PR DESCRIPTION
Previously, the loop always iterated over all revision candidates, no
matter whether they are successful or not and it seems that this was
by accident. If a package specifies a fixed revision in its meta-data,
that revision should take precendence over any revision guessed from
the package version or Git tags. So, always use the first successful
revision candidate.

Note that ORT's downloader in fact preferred the guessed revisions over
the provided fixed revision for projects (ORT speak), which always have
a correct fixed revision in their meta-data (disregarding the case of a
history re-write happening after the analysis but before the downloader
or scanner run repsectively). That issue is now fixed.