### PR TITLE
OrtResult: Add the function hasLabel()

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -484,4 +484,9 @@ data class OrtResult(
      */
     fun getLabelValues(key: String): Set<String> =
         labels[key]?.split(',').orEmpty().mapTo(mutableSetOf()) { it.trim() }
+
+    /**
+     * Return true if and only if this [OrtResult] contains a label with the given [key].
+     */
+    fun hasLabel(key: String): Boolean = key in labels
 }


### PR DESCRIPTION
This can be useful to call from the policy rules. It's a tad nicer to
than `key in ortResult.labels` and it encapsulates the labels
representatioon so that e.g. the policy rules won't break if the labels
representation in the OrtResult changes.
