### PR TITLE
License: Use the HTTPS link to the Apache 2.0 license in the template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/src/test/kotlin/HashAlgorithmTest.kt
+++ b/model/src/test/kotlin/HashAlgorithmTest.kt
@@ -31,12 +31,12 @@ class HashAlgorithmTest : StringSpec({
 
     "Calculating the SHA1 on a file should yield the correct result" {
         // The expected hash was calculated with "sha1sum".
-        HashAlgorithm.SHA1.calculate(file) shouldBe "92170cdc034b2ff819323ff670d3b7266c8bffcd"
+        HashAlgorithm.SHA1.calculate(file) shouldBe "c00ef43045659b53da5d71d49b8cd7e528c9d55b"
     }
 
     "Calculating the SHA1-GIT on a file should yield the correct result" {
         // The expected hash was calculated with "git ls-tree HEAD".
-        HashAlgorithm.SHA1_GIT.calculate(file) shouldBe "8dada3edaf50dbc082c9a125058f25def75e625a"
+        HashAlgorithm.SHA1_GIT.calculate(file) shouldBe "3f4d322ebd76de0f1bbb9c867e1f818f5202efd3"
     }
 
     "Calculating the SHA1-GIT on a resource should yield the correct result" {

--- a/model/src/test/kotlin/HashTest.kt
+++ b/model/src/test/kotlin/HashTest.kt
@@ -87,8 +87,8 @@ class HashTest : WordSpec({
         "be insensitive to the hash's case" {
             val licenseFile = File("../LICENSE")
 
-            Hash.create("92170cdc034b2ff819323ff670d3b7266c8bffcd").verify(licenseFile) shouldBe true
-            Hash.create("92170CDC034B2FF819323FF670D3B7266C8BFFCD").verify(licenseFile) shouldBe true
+            Hash.create("c00ef43045659b53da5d71d49b8cd7e528c9d55b").verify(licenseFile) shouldBe true
+            Hash.create("C00EF43045659B53DA5D71D49B8CD7E528C9D55B").verify(licenseFile) shouldBe true
         }
     }
 })

--- a/scanner/src/test/assets/oss-review-toolkit-license-and-readme_scancode-2.9.2.json
+++ b/scanner/src/test/assets/oss-review-toolkit-license-and-readme_scancode-2.9.2.json
@@ -20,7 +20,7 @@
       "extension": "",
       "size": 11357,
       "date": "2018-06-04",
-      "sha1": "92170cdc034b2ff819323ff670d3b7266c8bffcd",
+      "sha1": "c00ef43045659b53da5d71d49b8cd7e528c9d55b",
       "md5": "e3fc50a88d0a364313df4b21ef20c29e",
       "mime_type": "text/plain",
       "file_type": "ASCII text",


### PR DESCRIPTION
As it is done in the source files.