### PR TITLE
scanner: Add a parser for SCANOSS results

### DIFF
--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOssResultParser.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOssResultParser.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2020-2021 SCANOSS TECNOLOGIAS SL
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.scanoss
+
+import com.fasterxml.jackson.databind.JsonNode
+
+import java.io.File
+import java.time.Instant
+
+import org.ossreviewtoolkit.model.CopyrightFinding
+import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.utils.spdx.SpdxConstants
+import org.ossreviewtoolkit.utils.spdx.SpdxExpression
+import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
+
+/**
+ * Generate a summary from the given raw SCANOSS [result], using [startTime] and [endTime] metadata. From the [scanPath]
+ * the package verification code is generated.
+ */
+internal fun generateSummary(startTime: Instant, endTime: Instant, scanPath: File, result: JsonNode) =
+    generateSummary(
+        startTime,
+        endTime,
+        calculatePackageVerificationCode(scanPath),
+        result
+    )
+
+/**
+ * Generate a summary from the given raw SCANOSS [result], using [startTime], [endTime], and [verificationCode]
+ * metadata. This variant can be used if the result is not read from a local file.
+ */
+internal fun generateSummary(
+    startTime: Instant,
+    endTime: Instant,
+    verificationCode: String,
+    result: JsonNode
+): ScanSummary {
+    val licenseFindings = mutableListOf<LicenseFinding>()
+    val copyrightFindings = mutableListOf<CopyrightFinding>()
+
+    result.fields().asSequence().forEach { (filename, matches) ->
+        matches.asSequence().forEach { match ->
+            licenseFindings += getLicenseFindings(match, filename)
+            copyrightFindings += getCopyrightFindings(match, filename)
+        }
+    }
+
+    return ScanSummary(
+        startTime = startTime,
+        endTime = endTime,
+        packageVerificationCode = verificationCode,
+        licenseFindings = licenseFindings.toSortedSet(),
+        copyrightFindings = copyrightFindings.toSortedSet(),
+        issues = emptyList()
+    )
+}
+
+/**
+ * Get the license findings from the given [match]. Use [filename] as a fallback if no file is given in the match.
+ */
+private fun getLicenseFindings(match: JsonNode, filename: String): Sequence<LicenseFinding> =
+    match["licenses"]?.asSequence().orEmpty().map {
+        val licenseName = it["name"].asText()
+        val licenseExpression = runCatching { SpdxExpression.parse(licenseName) }.getOrNull()
+
+        val license = when {
+            licenseExpression == null -> SpdxConstants.NOASSERTION
+            licenseExpression.isValid() -> licenseName
+            else -> "${SpdxConstants.LICENSE_REF_PREFIX}scanoss-$licenseName"
+        }
+
+        LicenseFinding(
+            license = license,
+            location = TextLocation(
+                path = match["file"].textValue() ?: filename,
+                startLine = TextLocation.UNKNOWN_LINE,
+                endLine = TextLocation.UNKNOWN_LINE
+            )
+        )
+    }
+
+/**
+ * Get the copyright findings from the given [match]. Use [filename] as a fallback if no file is given in the match.
+ */
+private fun getCopyrightFindings(match: JsonNode, filename: String): Sequence<CopyrightFinding> =
+    match["copyrights"]?.asSequence().orEmpty().map {
+        val copyrightName = it["name"].asText()
+
+        CopyrightFinding(
+            statement = copyrightName,
+            location = TextLocation(
+                path = match["file"].textValue() ?: filename,
+                startLine = TextLocation.UNKNOWN_LINE,
+                endLine = TextLocation.UNKNOWN_LINE
+            )
+        )
+    }

--- a/scanner/src/test/assets/pigz-c-scanoss.json
+++ b/scanner/src/test/assets/pigz-c-scanoss.json
@@ -1,0 +1,30 @@
+{
+  "pigz.c": [
+    {
+      "id": "file",
+      "lines": "all",
+      "oss_lines": "all",
+      "matched": "100%",
+      "vendor": "madler",
+      "component": "pigz",
+      "version": "v2.4",
+      "latest": "v2.4",
+      "url": "https://github.com/madler/pigz/archive/v2.4.tar.gz",
+      "file": "pigz-2.4/pigz.c",
+      "dependencies": [],
+      "licenses": [
+        {
+          "name": "Zlib",
+          "source": "file_header"
+        }
+      ],
+      "copyrights": [
+        {
+          "name": "Copyright (C) 2007-2017 Mark Adler",
+          "source": "file_header"
+        }
+      ],
+      "elapsed": "0.000907s"
+    }
+  ]
+}

--- a/scanner/src/test/kotlin/scanners/scanoss/ScanOssResultParserTest.kt
+++ b/scanner/src/test/kotlin/scanners/scanoss/ScanOssResultParserTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020-2021 SCANOSS TECNOLOGIAS SL
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.scanoss
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.should
+
+import java.io.File
+import java.time.Instant
+
+import org.ossreviewtoolkit.model.CopyrightFinding
+import org.ossreviewtoolkit.model.LicenseFinding
+import org.ossreviewtoolkit.model.TextLocation
+import org.ossreviewtoolkit.model.readJsonFile
+import org.ossreviewtoolkit.utils.spdx.SpdxConstants
+
+class ScanOssResultParserTest : WordSpec({
+    "generateSummary()" should {
+        "properly summarize pigz.c findings" {
+            val resultFile = File("src/test/assets/pigz-c-scanoss.json")
+            val result = readJsonFile(resultFile)
+
+            val summary = generateSummary(Instant.now(), Instant.now(), SpdxConstants.NONE, result)
+
+            summary.licenseFindings should containExactlyInAnyOrder(
+                    LicenseFinding(
+                            license = "Zlib",
+                            location = TextLocation(
+                                path = "pigz-2.4/pigz.c",
+                                startLine = TextLocation.UNKNOWN_LINE,
+                                endLine = TextLocation.UNKNOWN_LINE
+                            )
+                    )
+            )
+            summary.copyrightFindings should containExactlyInAnyOrder(
+                    CopyrightFinding(
+                            statement = "Copyright (C) 2007-2017 Mark Adler",
+                            location = TextLocation(
+                                path = "pigz-2.4/pigz.c",
+                                startLine = TextLocation.UNKNOWN_LINE,
+                                endLine = TextLocation.UNKNOWN_LINE
+                            )
+                    )
+            )
+        }
+    }
+})


### PR DESCRIPTION

SCANNOSS [1] is a snippet scanner whose engine [2], mining tool [3] and
some other parts are Open Source. It also provides a public database of
"fingerprints" for Open Source packages [4]. As such it is a good fit
for being added to ORT as a supported scanner. This commit prepares for
that by adding a parser for SCANOSS results. More changes that trigger
the actualy scans and extensions to the ORT data model to capture
snippet findings [5] will follow later.

The license name is an SPDX ID, or "NOASSERTION" when there is an
exceptional situation.

[1]: https://scanoss.com/
[2]: https://github.com/scanoss/engine
[3]: https://github.com/scanoss/minr
[4]: https://osskb.org/
[5]: https://github.com/oss-review-toolkit/ort/issues/3265

Signed-off-by: Juan M Salamanca <juan.m.salamanca@scanoss.com>
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>