### PR TITLE
Pip: Update the pipdeptree dependency to version 2.2.0

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -58,7 +58,9 @@ import org.ossreviewtoolkit.utils.resolveWindowsExecutable
 import org.ossreviewtoolkit.utils.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.textValueOrEmpty
 
-private const val PIP_VERSION = "21.3"
+// The lowest version that supports "--prefer-binary" and PEP 508 URL requirements to be used as dependencies.
+private const val PIP_VERSION = "18.1"
+
 private const val PIPDEPTREE_VERSION = "2.2.0"
 
 private val PHONY_DEPENDENCIES = mapOf(


### PR DESCRIPTION
This supports running with Pip 21.3, see [1].

[1]: https://github.com/naiquevin/pipdeptree/blob/master/CHANGES.md#220

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>