### PR TITLE
declared-license-mapping: Add BSD 3-clause License w/nuclear disclaimer

### DIFF
--- a/spdx-utils/src/main/resources/declared-license-mapping.yml
+++ b/spdx-utils/src/main/resources/declared-license-mapping.yml
@@ -73,6 +73,7 @@
 "BSD 3-Clause License": BSD-3-Clause
 "BSD 3-Clause \"New\" or \"Revised\" License (BSD-3-Clause)": BSD-3-Clause
 "BSD 3-Clause": BSD-3-Clause
+"BSD 3-clause License w/nuclear disclaimer": BSD-3-Clause-No-Nuclear-Warranty
 "BSD 3-clause New License": BSD-3-Clause
 "BSD 4 Clause": BSD-4-Clause
 "BSD Four Clause License": BSD-4-Clause


### PR DESCRIPTION
As seen in [1].

[1]: https://repo.maven.apache.org/maven2/com/github/jai-imageio/jai-imageio-core/1.4.0/jai-imageio-core-1.4.0.pom

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>
