### PR TITLE
OssIndexService: Make a Vulnerability's `cvssVector` optional

### DIFF
--- a/advisor/src/main/kotlin/advisors/OssIndex.kt
+++ b/advisor/src/main/kotlin/advisors/OssIndex.kt
@@ -100,7 +100,7 @@ class OssIndex(name: String, serverUrl: String = OssIndexService.DEFAULT_BASE_UR
     private fun OssIndexService.Vulnerability.toVulnerability(): Vulnerability {
         val reference = VulnerabilityReference(
             url = URI(reference),
-            scoringSystem = cvssVector.substringBefore('/'),
+            scoringSystem = cvssVector?.substringBefore('/'),
             severity = cvssScore.toString()
         )
 

--- a/clients/oss-index/src/main/kotlin/OssIndexService.kt
+++ b/clients/oss-index/src/main/kotlin/OssIndexService.kt
@@ -122,7 +122,7 @@ interface OssIndexService {
         val cvssScore: Float,
 
         /** A CVSS vector string. */
-        val cvssVector: String,
+        val cvssVector: String? = null,
 
         /** A Common Vulnerabilities and Exposures value, if known. */
         val cve: String? = null,


### PR DESCRIPTION
Fixes #4601.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>