### PR TITLE
SpdxDocumentFile: Fix a crash of the scanner

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
@@ -10,14 +10,14 @@ project:
     spdx_expression: "Apache-2.0 AND curl AND LicenseRef-Proprietary-ExampleInc"
   vcs:
     type: "Git"
-    url: "ssh://gitlab.example.com:3389/products/xyz.git"
-    revision: "b2c358080011af6a366d2512a25a379fbe7b1f78"
-    path: ""
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/spdx/project"
   vcs_processed:
     type: "Git"
-    url: "ssh://gitlab.example.com:3389/products/xyz.git"
-    revision: "b2c358080011af6a366d2512a25a379fbe7b1f78"
-    path: ""
+    url: "<REPLACE_URL_PROCESSED>"
+    revision: "<REPLACE_REVISION>"
+    path: "analyzer/src/funTest/assets/projects/synthetic/spdx/project"
   homepage_url: "https://example.com/products/xyz"
   scopes:
   - name: "default"

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -565,14 +565,13 @@ class SpdxDocumentFile(
             dependencies = getDependencies(projectPackage, spdxDocument, definitionFile, packages)
         )
 
-        val homepage = projectPackage.homepage.mapNotPresentToEmpty()
         val project = Project(
             id = projectPackage.toIdentifier(),
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
             authors = projectPackage.originator.wrapPresentInSortedSet(),
             declaredLicenses = sortedSetOf(projectPackage.licenseDeclared),
-            vcs = projectPackage.getVcsInfo() ?: processProjectVcs(definitionFile.parentFile, VcsInfo.EMPTY, homepage),
-            homepageUrl = homepage,
+            vcs = processProjectVcs(definitionFile.parentFile, VcsInfo.EMPTY),
+            homepageUrl = projectPackage.homepage.mapNotPresentToEmpty(),
             scopeDependencies = scopes
         )
 


### PR DESCRIPTION
The `OrtResult` requires for all projects that their respective `vcsProcessed`
is contained in `OrtResult.repository` [1]. So, neither the VCS nor the
homepage URL specified in the SPDX package can be used to derive the
projects `vcs` / `vcsProcessed`. The homepage URL has been used for a
while to derive the `vcs` which was already problematic even though no
crashes have been observed there. As of [2] which also did not adhere to
[1] the crash has been observed frequently.

Fix the crash by only using VCSes contained in `OrtResult.repository`,
which partially reverts [2].

Fixes #4563.

[1] https://github.com/oss-review-toolkit/ort/blob/48d13129bcbd34b5b6f9e70fda67c7880fe91db2/model/src/main/kotlin/OrtResult.kt#L279-L281
[2] d0478ebd2c2d5a80a7495a51e6aee897d296f9b9

