### PR TITLE
 workflows/static-analysis.yml: Downgrade the `python-debian` package 

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -54,4 +54,5 @@ jobs:
     - name: Check REUSE Compliance
       run: |
         pip install --user reuse
+        pip install --user --force-reinstall python-debian==0.1.40 # See https://github.com/fsfe/reuse-tool/issues/427.
         ~/.local/bin/reuse lint


### PR DESCRIPTION
This is a workaround for [1], see also [2].

[1] AttributeError: 'TypeVar' object attribute '__doc__' is read-only
    Error: Process completed with exit code 1.
[2] https://github.com/fsfe/reuse-tool/issues/427
