### PR TITLE
Rule: Ignore invisible characters in the matching of the resolution

### DIFF
--- a/model/src/main/kotlin/config/IssueResolution.kt
+++ b/model/src/main/kotlin/config/IssueResolution.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.model.config
 import com.fasterxml.jackson.annotation.JsonIgnore
 
 import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.utils.sanitizeMessage
 
 /**
  * Defines the resolution of an [OrtIssue]. This can be used to silence false positives, or issues that have been
@@ -45,10 +46,10 @@ data class IssueResolution(
     val comment: String
 ) {
     @JsonIgnore
-    private val regex = Regex(message, RegexOption.DOT_MATCHES_ALL)
+    private val regex = Regex(message.sanitizeMessage(), RegexOption.DOT_MATCHES_ALL)
 
     /**
      * True if [message] matches the message of [issue].
      */
-    fun matches(issue: OrtIssue) = regex.matches(issue.message)
+    fun matches(issue: OrtIssue) = regex.matches(issue.message.sanitizeMessage())
 }

--- a/model/src/main/kotlin/config/RuleViolationResolution.kt
+++ b/model/src/main/kotlin/config/RuleViolationResolution.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.model.config
 import com.fasterxml.jackson.annotation.JsonIgnore
 
 import org.ossreviewtoolkit.model.RuleViolation
+import org.ossreviewtoolkit.model.utils.sanitizeMessage
 
 /**
  * Defines the resolution of a rule violation. This can be used to silence rule violations that have been identified
@@ -46,10 +47,10 @@ data class RuleViolationResolution(
     val comment: String
 ) {
     @JsonIgnore
-    private val regex = Regex(message, RegexOption.DOT_MATCHES_ALL)
+    private val regex = Regex(message.sanitizeMessage(), RegexOption.DOT_MATCHES_ALL)
 
     /**
      * True if [message] matches the message of [error].
      */
-    fun matches(violation: RuleViolation) = regex.matches(violation.message)
+    fun matches(violation: RuleViolation) = regex.matches(violation.message.sanitizeMessage())
 }

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -208,3 +208,9 @@ fun List<ScanResult>.filterByProject(project: Project): List<ScanResult> {
         }
     }
 }
+
+/**
+ * Messages are not rendered using additional white spaces and newlines in the reports. However, resolutions are based
+ * on the messages. Therefore, characters that are not shown in the reports need to be replaced in the comparison.
+ */
+fun String.sanitizeMessage() = replace(Regex("\\s+"), " ").trim()

--- a/model/src/test/kotlin/config/RuleViolationResolutionTest.kt
+++ b/model/src/test/kotlin/config/RuleViolationResolutionTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.config
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.model.RuleViolation
+import org.ossreviewtoolkit.model.Severity
+
+class RuleViolationResolutionTest : WordSpec({
+    "matches" should {
+        "ignore white spaces" {
+            val result = ruleViolationResolution("Message with additional spaces. Another line.").matches(
+                ruleViolation(
+                    """
+                        Message with  additional spaces. 
+                        Another line.
+                    """
+                )
+            )
+
+            result shouldBe true
+        }
+
+        "ignore new lines" {
+            val result = ruleViolationResolution("Message with newline.").matches(
+                ruleViolation("Message with\nnewline.")
+            )
+
+            result shouldBe true
+        }
+    }
+})
+
+private fun ruleViolationResolution(message: String) = RuleViolationResolution(
+    message = message,
+    reason = RuleViolationResolutionReason.EXAMPLE_OF_EXCEPTION,
+    comment = ""
+)
+
+private fun ruleViolation(message: String): RuleViolation {
+    return RuleViolation(
+        rule = "",
+        pkg = null,
+        license = null,
+        licenseSource = null,
+        severity = Severity.ERROR,
+        message = message,
+        howToFix = ""
+    )
+}

--- a/model/src/test/kotlin/utils/ExtensionsTest.kt
+++ b/model/src/test/kotlin/utils/ExtensionsTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.utils
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+class ExtensionsTest : WordSpec({
+    "sanitizeMessage()" should {
+        "remove additional white spaces" {
+            "String with additional   white spaces. ".sanitizeMessage() shouldBe "String with additional white spaces."
+        }
+
+        "remove newlines" {
+            "String\nwith\n\nnewlines.".sanitizeMessage() shouldBe "String with newlines."
+        }
+
+        "remove indentations" {
+            """
+                String with indentation.
+            """.sanitizeMessage() shouldBe "String with indentation."
+        }
+    }
+})


### PR DESCRIPTION
In the StaticHtml and WebApp reports the message is being rendered
without any additional whitespaces and new lines. However, when writing
resolutions for these messages the user needs to know that the message
contains these characters, otherwise the Regex will not work.

