### PR TITLE
Scanner: Pass the labels to the `scanPackages` function

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -201,7 +201,8 @@ abstract class LocalScanner(
 
     override suspend fun scanPackages(
         packages: Set<Package>,
-        outputDirectory: File
+        outputDirectory: File,
+        labels: Map<String, String>
     ): Map<Package, List<ScanResult>> {
         val scannerCriteria = getScannerCriteria()
 

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -105,7 +105,8 @@ fun scanOrtResult(
         // Scan the projects from the ORT result.
         val deferredProjectScan = async {
             if (filteredProjectPackages.isNotEmpty()) {
-                projectScanner.scanPackages(filteredProjectPackages, outputDirectory).mapKeys { it.key.id }
+                projectScanner.scanPackages(filteredProjectPackages, outputDirectory, ortResult.labels)
+                    .mapKeys { it.key.id }
             } else {
                 projectScanner.log.info { "No projects to scan." }
                 emptyMap()
@@ -115,7 +116,7 @@ fun scanOrtResult(
         // Scan the packages from the ORT result.
         val deferredPackageScan = async {
             if (filteredPackages.isNotEmpty()) {
-                scanner.scanPackages(filteredPackages, outputDirectory).mapKeys { it.key.id }
+                scanner.scanPackages(filteredPackages, outputDirectory, ortResult.labels).mapKeys { it.key.id }
             } else {
                 scanner.log.info { "No packages to scan." }
                 emptyMap()
@@ -185,10 +186,13 @@ abstract class Scanner(
      * Scan the [packages] and store the scan results in [outputDirectory]. [ScanResult]s are returned associated by
      * [Package]. The map may contain multiple results for the same [Package] if the storage contains more than one
      * result for the specification of this scanner.
+     * [labels] are the labels present in [OrtResult.labels], created by previous invocations of ORT tools. They can be
+     * used by scanner implementations to decide if and how packages are scanned.
      */
     abstract suspend fun scanPackages(
         packages: Set<Package>,
-        outputDirectory: File
+        outputDirectory: File,
+        labels: Map<String, String>
     ): Map<Package, List<ScanResult>>
 
     /**

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -209,7 +209,8 @@ class FossId internal constructor(
 
     override suspend fun scanPackages(
         packages: Set<Package>,
-        outputDirectory: File
+        outputDirectory: File,
+        labels: Map<String, String>
     ): Map<Package, List<ScanResult>> {
         val (results, duration) = measureTimedValue {
             val results = mutableMapOf<Package, MutableList<ScanResult>>()

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -388,7 +388,9 @@ class FossIdTest : WordSpec({
 
             shouldThrow<TimeoutCancellationException> {
                 withTimeout(1000) {
-                    fossId.scanPackages(setOf(createPackage(createIdentifier(index = 1), vcsInfo)), File("output"))
+                    fossId.scanPackages(
+                        setOf(createPackage(createIdentifier(index = 1), vcsInfo)), File("output"), emptyMap()
+                    )
                 }
             }
 


### PR DESCRIPTION
This allows implementing a scanning logic depending on the labels
created by previous ORT tools invocations. This is useful, for instance,
for custom scanner plugin.

This commit follows the related discussion on the Slack channel.

Please note that only the `Scanner` abstract class has been updated. The labels are currently no propagated to `LocalScanner` implementations. This could be done when needed, to avoid a YAGNI effect.
 
**@oss-review-toolkit/kotlin-devs**: Should this have `breaking-change` ? Is anyone else writing scanner plugin ?

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>

