### PR TITLE
fossid-webapp: Remove the dependency on the "utils" project

### DIFF
--- a/clients/fossid-webapp/build.gradle.kts
+++ b/clients/fossid-webapp/build.gradle.kts
@@ -30,8 +30,6 @@ plugins {
 dependencies {
     api("com.squareup.retrofit2:retrofit:$retrofitVersion")
 
-    implementation(project(":utils"))
-
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     implementation("com.squareup.retrofit2:converter-jackson:$retrofitVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")


### PR DESCRIPTION
The main code of clients should be independent of ORT. Indeed, the
fossid-webapp does not depend on "utils", but only on "test-utils" for
the test implementation, and that dependency is globally added for all
library projects via the root "build.gradle.kts" file.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>