### PR TITLE
hints-for-use-with-docker: Fix `-c` to be passed as a root option

### DIFF
--- a/docs/hints-for-use-with-docker.md
+++ b/docs/hints-for-use-with-docker.md
@@ -6,10 +6,10 @@
 
 ```shell
 docker run \
-  -v $PWD/:/project  \ # Mount current working directory into /project to use as input.
-  ort --info analyze \
+  -v $PWD/:/project \ # Mount current working directory into /project to use as input.
+  ort --info \
   -c /project/ort/config.hocon \ # Use file from "<workingdirectory>/ort" as config.
-  analyze (...) # Insert further arguments for the command.
+  analyze [...] # Insert further arguments for the command.
 ```
 
 **Note:** The single forward slash `/` between the environment variable `$PWD` and the `:` is required for PowerShell compatibility, as PowerShell otherwise interprets `:` as part of the environment variable. 


### PR DESCRIPTION
The "analyze" sub-command was actually given twice. Fixes #4633.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>