### PR TITLE
scanner: Fix creating the result files in Askalono and Licensee

### DIFF
--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -46,7 +46,7 @@ import org.ossreviewtoolkit.utils.core.ORT_NAME
 import org.ossreviewtoolkit.utils.core.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.core.Os
 import org.ossreviewtoolkit.utils.core.ProcessCapture
-import org.ossreviewtoolkit.utils.core.createOrtTempFile
+import org.ossreviewtoolkit.utils.core.createOrtTempDir
 import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.core.unpackZip
 import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
@@ -173,5 +173,6 @@ class Askalono(
         )
     }
 
-    override fun scanPath(path: File): ScanSummary = scanPathInternal(path, createOrtTempFile(name))
+    override fun scanPath(path: File): ScanSummary =
+        scanPathInternal(path, createOrtTempDir(name).resolve("result.$resultFileExt"))
 }

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -45,7 +45,7 @@ import org.ossreviewtoolkit.utils.core.ORT_NAME
 import org.ossreviewtoolkit.utils.core.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.core.Os
 import org.ossreviewtoolkit.utils.core.ProcessCapture
-import org.ossreviewtoolkit.utils.core.createOrtTempFile
+import org.ossreviewtoolkit.utils.core.createOrtTempDir
 import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.core.unpackZip
 import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
@@ -172,5 +172,6 @@ class BoyterLc(
         )
     }
 
-    override fun scanPath(path: File): ScanSummary = scanPathInternal(path, createOrtTempFile(name))
+    override fun scanPath(path: File): ScanSummary =
+        scanPathInternal(path, createOrtTempDir(name).resolve("result.$resultFileExt"))
 }

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -37,7 +37,7 @@ import org.ossreviewtoolkit.scanner.ScanException
 import org.ossreviewtoolkit.scanner.experimental.LocalScannerWrapper
 import org.ossreviewtoolkit.utils.core.Os
 import org.ossreviewtoolkit.utils.core.ProcessCapture
-import org.ossreviewtoolkit.utils.core.createOrtTempFile
+import org.ossreviewtoolkit.utils.core.createOrtTempDir
 import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 
@@ -139,5 +139,6 @@ class Licensee(
         )
     }
 
-    override fun scanPath(path: File): ScanSummary = scanPathInternal(path, createOrtTempFile(name))
+    override fun scanPath(path: File): ScanSummary =
+        scanPathInternal(path, createOrtTempDir(name).resolve("result.$resultFileExt"))
 }

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -49,7 +49,7 @@ import org.ossreviewtoolkit.utils.core.ORT_NAME
 import org.ossreviewtoolkit.utils.core.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.core.Os
 import org.ossreviewtoolkit.utils.core.ProcessCapture
-import org.ossreviewtoolkit.utils.core.createOrtTempFile
+import org.ossreviewtoolkit.utils.core.createOrtTempDir
 import org.ossreviewtoolkit.utils.core.isTrue
 import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.core.unpack
@@ -244,5 +244,6 @@ class ScanCode(
 
     override fun getRawResult(resultsFile: File) = readJsonFile(resultsFile)
 
-    override fun scanPath(path: File): ScanSummary = scanPathInternal(path, createOrtTempFile(name))
+    override fun scanPath(path: File): ScanSummary =
+        scanPathInternal(path, createOrtTempDir(name).resolve("result.$resultFileExt"))
 }


### PR DESCRIPTION
If `scanInternal()` is called from `scanPath()`, the result file was
already created by `createOrtTempFile()`. Therefore the `overwrite` flag
must be set to `true` when copying the file.