### PR TITLE
Add JSON schema for .ort.yml configuration

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -60,6 +60,10 @@ Files: clients/github-graphql/src/main/assets/*
 Copyright: 2021 Bosch.IO GmbH <osm@bosch.com>
 License: Apache-2.0
 
+Files: integrations/schemas/*
+Copyright: 2021 Bosch.IO GmbH <osm@bosch.com>
+License: Apache-2.0
+
 # Third-party files.
 
 Files: gradlew*

--- a/examples/curations.ort.yml
+++ b/examples/curations.ort.yml
@@ -1,0 +1,25 @@
+curations:
+  license_findings:
+  - path: "src/**.cpp"
+    start_lines: "3,8"
+    line_count: 1
+    detected_license: "GPL-2.0-only"
+    reason: "CODE"
+    comment: "The scanner matches a variable named `gpl`."
+    concluded_license: "Apache-2.0"
+  packages:
+  - id: "Maven:com.example:dummy:0.0.1"
+    curations:
+      comment: "An explanation why the curation is needed."
+      homepage_url: "https://example.com"
+      is_modified: false
+      vcs:
+        type: "Git"
+        url: "https://example.com/package.git"
+        revision: "main"
+      authors:
+      - "Name of the author"
+      is_meta_data_only: false
+      concluded_license: "BSD-2-Clause"
+      declared_license_mapping:
+        The BSD License: "BSD-2-Clause"

--- a/examples/package-configurations.ort.yml
+++ b/examples/package-configurations.ort.yml
@@ -1,0 +1,11 @@
+package_configurations:
+- id: 'Maven:com.example:package:1.2.3'
+  source_artifact_url: "https://repo.maven.apache.org/maven2/com/example/package/1.2.3/package-1.2.3-sources.jar"
+  license_finding_curations:
+  - path: "path/to/problematic/file.java"
+    start_lines: 22
+    line_count: 1
+    detected_license: "GPL-2.0-only"
+    reason: "CODE"
+    comment: "The scanner matches a variable named `gpl`."
+    concluded_license: "Apache-2.0"

--- a/examples/resolutions.ort.yml
+++ b/examples/resolutions.ort.yml
@@ -1,0 +1,9 @@
+resolutions:
+  issues:
+  - message: "Could not download 'Maven:com.example:library:.*"
+    reason: "CANT_FIX_ISSUE"
+    comment: "An example for an issue resolution."
+  rule_violations:
+  - message: "Example rule violation*."
+    reason: "DYNAMIC_LINKAGE_EXCEPTION"
+    comment: "An example for rule a rule violation resolution."

--- a/gradle.properties
+++ b/gradle.properties
@@ -52,6 +52,7 @@ jiraRestApiVersion = 5.2.2
 jschAgentProxyVersion = 0.0.7
 jrubyVersion = 9.2.17.0
 jsltVersion = 0.1.11
+jsonSchemaValidatorVersion = 1.0.63
 kotestVersion = 4.6.3
 kotlinxCoroutinesVersion = 1.5.2
 kotlinxHtmlVersion = 0.7.3

--- a/integrations/schemas/repository-configuration-schema.json
+++ b/integrations/schemas/repository-configuration-schema.json
@@ -1,0 +1,433 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "https://oss-review-toolkit.org/.ort.yml",
+  "title": "ORT repository configuration",
+  "description": "The OSS-Review-Toolkit (ORT) provides a possibility to configure exclusions, resolutions and more in a file called `.ort.yml`. A full list of all available options can be found at https://github.com/oss-review-toolkit/ort/blob/master/docs/config-file-ort-yml.md.",
+  "type": "object",
+  "properties": {
+    "excludes": {
+      "type": "object",
+      "description": "Defines which parts of a repository should be excluded.",
+      "properties": {
+        "paths": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pattern": {
+                "description": "A glob to match the path of the project definition file, relative to the root of the repository.",
+                "type": "string"
+              },
+              "reason": {
+                "$ref": "#/definitions/pathExcludeReason"
+              },
+              "comment": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "pattern",
+              "reason"
+            ]
+          }
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pattern": {
+                "type": "string"
+              },
+              "reason": {
+                "$ref": "#/definitions/scopeExcludeReason"
+              },
+              "comment": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "pattern",
+              "reason"
+            ]
+          }
+        }
+      }
+    },
+    "resolutions": {
+      "type": "object",
+      "description": "Resolutions for issues and rule violations.",
+      "properties": {
+        "issues": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "reason": {
+                "$ref": "#/definitions/issueResolutionReason"
+              },
+              "comment": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message",
+              "reason"
+            ]
+          }
+        },
+        "rule_violations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "reason": {
+                "$ref": "#/definitions/ruleViolationResolutionReason"
+              },
+              "comment": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message",
+              "reason"
+            ]
+          }
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "issues"
+          ]
+        },
+        {
+          "required": [
+            "rule_violations"
+          ]
+        }
+      ]
+    },
+    "curations": {
+      "type": "object",
+      "description": "Curations for artifacts in a repository.",
+      "properties": {
+        "license_findings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/licenseFindingCurations"
+          }
+        },
+        "packages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "curations": {
+                "type": "object",
+                "properties": {
+                  "comment": {
+                    "type": "string"
+                  },
+                  "authors": {
+                    "type": "array",
+                    "items": [
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "concluded_license": {
+                    "type": "string"
+                  },
+                  "declared_license_mapping": {
+                    "type": "object"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "homepage_url": {
+                    "type": "string"
+                  },
+                  "binary_artifact": {
+                    "type": "object",
+                    "properties": {
+                      "url": {
+                        "type": "string"
+                      },
+                      "hash": {
+                        "type": "string"
+                      },
+                      "hash_algorithm": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "url",
+                      "hash",
+                      "hash_algorithm"
+                    ]
+                  },
+                  "source_artifact": {
+                    "type": "object",
+                    "properties": {
+                      "url": {
+                        "type": "string"
+                      },
+                      "hash": {
+                        "type": "string"
+                      },
+                      "hash_algorithm": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "url",
+                      "hash",
+                      "hash_algorithm"
+                    ]
+                  },
+                  "vcs": {
+                    "$ref": "#/definitions/vcsMatcher"
+                  },
+                  "is_meta_data_only": {
+                    "type": "boolean"
+                  },
+                  "is_modified": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "required": [
+              "id",
+              "curations"
+            ]
+          }
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "license_findings"
+          ]
+        },
+        {
+          "required": [
+            "packages"
+          ]
+        }
+      ]
+    },
+    "package_configurations": {
+      "type": "array",
+      "description": "A configuration for a specific package and provenance.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "source_artifact_url": {
+            "type": "string"
+          },
+          "vcs": {
+            "$ref": "#/definitions/vcsMatcher"
+          },
+          "license_finding_curations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/licenseFindingCurations"
+            }
+          },
+          "path_excludes": {
+            "type": "object",
+            "properties": {
+              "pattern": {
+                "type": "string"
+              },
+              "reason": {
+                "$ref": "#/definitions/pathExcludeReason"
+              },
+              "comment": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "pattern",
+              "reason"
+            ]
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
+    },
+    "license_choices": {
+      "type": "object",
+      "description": "A configuration to select a license from a multi-licensed package.",
+      "properties": {
+        "package_license_choices": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "package_id": {
+                "type": "string"
+              },
+              "license_choices": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "given": {
+                      "type": "string"
+                    },
+                    "choice": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "choice"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "package_id",
+              "license_choices"
+            ]
+          }
+        },
+        "repository_license_choices": {
+          "type": "array",
+          "items": {
+            "given": {
+              "type": "string"
+            },
+            "choice": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "vcsMatcher": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "revision": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url",
+        "revision"
+      ]
+    },
+    "licenseFindingCurations": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "start_lines": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "line_count": {
+          "type": "integer"
+        },
+        "detected_license": {
+          "type": "string"
+        },
+        "concluded_license": {
+          "type": "string"
+        },
+        "reason": {
+          "$ref": "#/definitions/licenseFindingCurationReason"
+        },
+        "comment": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "concluded_license",
+        "reason"
+      ]
+    },
+    "pathExcludeReason": {
+      "enum": [
+        "BUILD_TOOL_OF",
+        "DATA_FILE_OF",
+        "DOCUMENTATION_OF",
+        "EXAMPLE_OF",
+        "OPTIONAL_COMPONENT_OF",
+        "OTHER",
+        "PROVIDED_BY",
+        "TEST_OF",
+        "TEST_TOOL_OF"
+      ]
+    },
+    "scopeExcludeReason": {
+      "enum": [
+        "BUILD_DEPENDENCY_OF",
+        "DEV_DEPENDENCY_OF",
+        "PROVIDED_DEPENDENCY_OF",
+        "TEST_DEPENDENCY_OF",
+        "RUNTIME_DEPENDENCY_OF"
+      ]
+    },
+    "issueResolutionReason": {
+      "enum": [
+        "BUILD_TOOL_ISSUE",
+        "CANT_FIX_ISSUE",
+        "SCANNER_ISSUE"
+      ]
+    },
+    "ruleViolationResolutionReason": {
+      "enum": [
+        "CANT_FIX_EXCEPTION",
+        "DYNAMIC_LINKAGE_EXCEPTION",
+        "EXAMPLE_OF_EXCEPTION",
+        "LICENSE_ACQUIRED_EXCEPTION",
+        "NOT_MODIFIED_EXCEPTION",
+        "PATENT_GRANT_EXCEPTION"
+      ]
+    },
+    "licenseFindingCurationReason": {
+      "enum": [
+        "CODE",
+        "DATA_OF",
+        "DOCUMENTATION_OF",
+        "INCORRECT",
+        "NOT_DETECTED",
+        "REFERENCE"
+      ]
+    }
+  }
+}

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -22,6 +22,7 @@ val exposedVersion: String by project
 val hikariVersion: String by project
 val hopliteVersion: String by project
 val jacksonVersion: String by project
+val jsonSchemaValidatorVersion: String by project
 val postgresEmbeddedVersion: String by project
 val postgresVersion: String by project
 val mockkVersion: String by project
@@ -54,6 +55,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.postgresql:postgresql:$postgresVersion")
 
+    testImplementation("com.networknt:json-schema-validator:$jsonSchemaValidatorVersion")
     testImplementation("com.opentable.components:otj-pg-embedded:$postgresEmbeddedVersion")
     testImplementation("io.mockk:mockk:$mockkVersion")
 }

--- a/model/src/test/kotlin/JsonSchemaTest.kt
+++ b/model/src/test/kotlin/JsonSchemaTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import com.networknt.schema.JsonSchemaFactory
+import com.networknt.schema.SpecVersion
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.haveSize
+import io.kotest.matchers.should
+
+import java.io.File
+
+class JsonSchemaTest : StringSpec() {
+    private val mapper = FileFormat.YAML.mapper
+
+    private val schema = JsonSchemaFactory
+        .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4))
+        .objectMapper(mapper)
+        .build()
+        .getSchema(File("../integrations/schemas/repository-configuration-schema.json").toURI())
+
+    init {
+        ".ort.yml validates successfully" {
+            val repositoryConfiguration = File("../.ort.yml").toJsonNode()
+
+            val errors = schema.validate(repositoryConfiguration)
+
+            errors should haveSize(0)
+        }
+
+        ".ort.yml examples validates successfully" {
+            val examplesDir = File("../examples")
+            val exampleFiles =
+                examplesDir.walk().filterTo(mutableListOf()) { it.isFile && it.name.endsWith(".ort.yml") }
+
+            exampleFiles.forAll {
+                val repositoryConfiguration = it.toJsonNode()
+
+                val errors = schema.validate(repositoryConfiguration)
+
+                errors should haveSize(0)
+            }
+        }
+    }
+
+    private fun File.toJsonNode() = mapper.readTree(inputStream())
+}


### PR DESCRIPTION
A JSON schema [1] is a description of a JSON document, which can also be
used for YAML files. This schema can be used to enable auto-completion
in multiple editors for the .ort.yml file [2]. E.g. IntelliJ IDEA has build-in support
for it [3]:
![Screenshot 2021-10-29 at 11 21 44](https://user-images.githubusercontent.com/4022103/139412824-1cf09a55-eb4a-40a1-8c38-bd5a00250948.png)

As a next step, the URL to this schema can be contributed to https://github.com/schemastore/schemastore/ and many editors will then have autocompletion for .ort.yml out of the box.

It would be nice to autogenerate this file, however I didn't find a convenient way to do this.
Adding the test coverage to avoid regressions in the schema should be good enough for now.

Missing as of now is the documentation from the model classes. It would be nice to also get this documentation during auto completion.

I opted to use the JSON format instead of a YAML format, to ensure better compatibility. I was e.g. not able to use a YAML schema with VS Code.

[1]: https://json-schema.org
[2]: https://www.schemastore.org/json
[3]: https://www.jetbrains.com/help/ruby/yaml.html#remote_json