### PR TITLE
Move the code to detect Maven Central URLs to a utility function

### DIFF
--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -57,6 +57,7 @@ import org.ossreviewtoolkit.reporter.containsUnresolved
 import org.ossreviewtoolkit.reporter.description
 import org.ossreviewtoolkit.utils.core.Environment
 import org.ossreviewtoolkit.utils.core.ORT_FULL_NAME
+import org.ossreviewtoolkit.utils.core.isMavenCentralUrl
 import org.ossreviewtoolkit.utils.core.isValidUri
 import org.ossreviewtoolkit.utils.core.normalizeLineBreaks
 import org.ossreviewtoolkit.utils.spdx.SpdxCompoundExpression
@@ -714,8 +715,7 @@ private fun ResolvedLicenseLocation.permalink(id: Identifier): String? {
 
     (provenance as? ArtifactProvenance)?.let {
         if (it.sourceArtifact != RemoteArtifact.EMPTY) {
-            val mavenCentralPattern = Regex("https?://repo[^/]+maven[^/]+org/.*")
-            if (it.sourceArtifact.url.matches(mavenCentralPattern)) {
+            if (isMavenCentralUrl(it.sourceArtifact.url)) {
                 // At least for source artifacts on Maven Central, use the "proxy" from Sonatype which has the
                 // Archive Browser plugin installed to link to the files with findings.
                 return with(id) {

--- a/utils/core/src/main/kotlin/Utils.kt
+++ b/utils/core/src/main/kotlin/Utils.kt
@@ -27,6 +27,8 @@ import kotlin.reflect.full.memberProperties
 
 import org.ossreviewtoolkit.utils.spdx.VCS_DIRECTORIES
 
+private val mavenCentralUrlPattern = Regex("^https?://repo1?\\.maven(\\.apache)?\\.org(/.*)?$")
+
 /**
  * The directory to store ORT (read-only) configuration in.
  */
@@ -222,6 +224,11 @@ fun installAuthenticatorAndProxySelector(): OrtProxySelector {
     OrtAuthenticator.install()
     return OrtProxySelector.install()
 }
+
+/**
+ * Return whether the given [url] points to Maven Central or not.
+ */
+fun isMavenCentralUrl(url: String) = url.matches(mavenCentralUrlPattern)
 
 /**
  * Return the concatenated [strings] separated by [separator] whereas blank strings are omitted.

--- a/utils/core/src/test/kotlin/UtilsTest.kt
+++ b/utils/core/src/test/kotlin/UtilsTest.kt
@@ -255,6 +255,30 @@ class UtilsTest : WordSpec({
         }
     }
 
+    "isMavenCentralUrl()" should {
+        "return true for URLs that point to Maven Central" {
+            listOf(
+                "https://repo.maven.apache.org/maven2",
+                "https://repo.maven.apache.org",
+                "http://repo.maven.apache.org",
+                "https://repo1.maven.org/maven2",
+                "https://repo1.maven.org",
+                "http://repo1.maven.org"
+            ).forAll {
+                isMavenCentralUrl(it) shouldBe true
+            }
+        }
+
+        "return false for URLs that do not point to Maven Central" {
+            listOf(
+                "https://repo2.maven.org",
+                "https://github.com"
+            ).forAll {
+                isMavenCentralUrl(it) shouldBe false
+            }
+        }
+    }
+
     "normalizeVcsUrl" should {
         "do nothing for empty URLs" {
             normalizeVcsUrl("") shouldBe ""


### PR DESCRIPTION
This is to prepare for upcoming reuse.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>