### PR TITLE
Apply VCS curation to `vcsProcessed` instead of to `vcs`

### DIFF
--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -103,7 +103,8 @@ data class Package(
     val vcs: VcsInfo,
 
     /**
-     * Processed VCS-related information about the [Package] that has e.g. common mistakes corrected.
+     * Processed VCS-related information about the [Package] in normalized form. The information is either derived from
+     * [vcs], guessed from additional data as a fallback, or empty.
      */
     val vcsProcessed: VcsInfo = vcs.normalize(),
 

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -104,7 +104,8 @@ data class Package(
 
     /**
      * Processed VCS-related information about the [Package] in normalized form. The information is either derived from
-     * [vcs], guessed from additional data as a fallback, or empty.
+     * [vcs], guessed from additional data as a fallback, or empty. On top of that [PackageCuration]s may have been
+     * applied.
      */
     val vcsProcessed: VcsInfo = vcs.normalize(),
 
@@ -164,7 +165,7 @@ data class Package(
             homepageUrl = homepageUrl.takeIf { it != other.homepageUrl },
             binaryArtifact = binaryArtifact.takeIf { it != other.binaryArtifact },
             sourceArtifact = sourceArtifact.takeIf { it != other.sourceArtifact },
-            vcs = vcs.takeIf { it != other.vcs }?.toCuration(),
+            vcs = vcsProcessed.takeIf { it != other.vcsProcessed }?.toCuration(),
             isMetaDataOnly = isMetaDataOnly.takeIf { it != other.isMetaDataOnly }
         )
     }

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -105,15 +105,15 @@ data class PackageCurationData(
 private fun applyCurationToPackage(targetPackage: CuratedPackage, curation: PackageCurationData): CuratedPackage {
     val base = targetPackage.pkg
 
-    val vcs = curation.vcs?.let {
+    val vcsProcessed = curation.vcs?.let {
         // Curation data for VCS information is handled specially so we can curate only individual properties.
         VcsInfo(
-            type = it.type ?: base.vcs.type,
-            url = it.url ?: base.vcs.url,
-            revision = it.revision ?: base.vcs.revision,
-            path = it.path ?: base.vcs.path
-        )
-    } ?: base.vcs
+            type = it.type ?: base.vcsProcessed.type,
+            url = it.url ?: base.vcsProcessed.url,
+            revision = it.revision ?: base.vcsProcessed.revision,
+            path = it.path ?: base.vcsProcessed.path
+        ).normalize()
+    } ?: base.vcsProcessed
 
     val authors = curation.authors ?: base.authors
     val declaredLicenseMapping = targetPackage.getDeclaredLicenseMapping() + curation.declaredLicenseMapping
@@ -129,7 +129,8 @@ private fun applyCurationToPackage(targetPackage: CuratedPackage, curation: Pack
         homepageUrl = curation.homepageUrl ?: base.homepageUrl,
         binaryArtifact = curation.binaryArtifact ?: base.binaryArtifact,
         sourceArtifact = curation.sourceArtifact ?: base.sourceArtifact,
-        vcs = vcs,
+        vcs = base.vcs,
+        vcsProcessed = vcsProcessed,
         isMetaDataOnly = curation.isMetaDataOnly ?: base.isMetaDataOnly,
         isModified = curation.isModified ?: base.isModified
     )

--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -90,7 +90,8 @@ class PackageCurationTest : WordSpec({
                 homepageUrl shouldBe curation.data.homepageUrl
                 binaryArtifact shouldBe curation.data.binaryArtifact
                 sourceArtifact shouldBe curation.data.sourceArtifact
-                vcs.toCuration() shouldBe curation.data.vcs
+                vcs shouldBe pkg.vcs
+                vcsProcessed.toCuration() shouldBe curation.data.vcs
                 isMetaDataOnly shouldBe true
                 isModified shouldBe true
             }
@@ -197,7 +198,7 @@ class PackageCurationTest : WordSpec({
             val curatedPkg = curation.apply(pkg.toCuratedPackage())
 
             curatedPkg.curations.size shouldBe 1
-            curatedPkg.pkg.vcs shouldBe VcsInfo.EMPTY
+            curatedPkg.pkg.vcsProcessed shouldBe VcsInfo.EMPTY
         }
 
         "fail if identifiers do not match" {

--- a/model/src/test/kotlin/PackageTest.kt
+++ b/model/src/test/kotlin/PackageTest.kt
@@ -77,7 +77,7 @@ class PackageTest : StringSpec({
         diff.authors shouldBe pkg.authors
         diff.homepageUrl shouldBe pkg.homepageUrl
         diff.sourceArtifact shouldBe pkg.sourceArtifact
-        diff.vcs shouldBe pkg.vcs.toCuration()
+        diff.vcs shouldBe pkg.vcsProcessed.toCuration()
         diff.isMetaDataOnly shouldBe pkg.isMetaDataOnly
     }
 


### PR DESCRIPTION
When a package lacks VCS meta-data several of ORT's package manager
integrations use fallback URLs to guess the VCS location. The result of
that guess ends up in `Package.vcsProcess` but not in `Package.vcs`.

Applying a VCS package curation works by patching `Package.vcs` and
setting `Package.vcsProcessed` to `Package.vcs.normalize()`. So, the
result of the above mentioned guess based on the fallback URLs gets
discarded.

For example, applying a VCS path curation to a package with empty `vcs`
but non-empty `vcsProcessed` yields a package wich has empty VCS info
(besides the path) for both, `vcs` and `vcsProcessed`.

Avoid loosing the guessed VCS by applying the curation to `vcsProcessed`
instead of to `vcs`. Note that only the former is considered by the
downloader or scanner respectively.

Apply the normalization on top of the curation to make this change
non-breaking, even though it might make sense to drop the normalization
later on.

Fixes #4618.