### PR TITLE
Allow curating the package URL

### DIFF
--- a/docs/config-file-curations-yml.md
+++ b/docs/config-file-curations-yml.md
@@ -52,6 +52,7 @@ The structure of the curations file consist of one or more `id` entries:
 - id: "Maven:com.example.app:example:0.0.1"
   curations:
     comment: "An explanation why the curation is needed or the reasoning for a license conclusion"
+    purl: "pkg:Maven/com.example.app/example@0.0.1?arch=arm64-v8a#src/main"
     concluded_license: "Valid SPDX license expression to override the license findings."
     declared_license_mapping:
       "license a": "Apache-2.0"

--- a/docs/config-file-curations-yml.md
+++ b/docs/config-file-curations-yml.md
@@ -49,12 +49,12 @@ location of source artifacts.
 The structure of the curations file consist of one or more `id` entries:
 
 ```yaml
-- id: "package identifier."
+- id: "Maven:com.example.app:example:0.0.1"
   curations:
     comment: "An explanation why the curation is needed or the reasoning for a license conclusion"
     concluded_license: "Valid SPDX license expression to override the license findings."
     declared_license_mapping:
-      "license a": "SPDX license identifier."
+      "license a": "Apache-2.0"
     description: "Curated description."
     homepage_url: "http://example.com"
     binary_artifact:

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -42,6 +42,11 @@ data class PackageCurationData(
     val comment: String? = null,
 
     /**
+     * An additional identifier in [package URL syntax](https://github.com/package-url/purl-spec).
+     */
+    val purl: String? = null,
+
+    /**
      * The list of authors of this package.
      */
     val authors: SortedSet<String>? = null,
@@ -121,6 +126,7 @@ private fun applyCurationToPackage(targetPackage: CuratedPackage, curation: Pack
 
     val pkg = Package(
         id = base.id,
+        purl = curation.purl ?: base.purl,
         authors = authors,
         declaredLicenses = base.declaredLicenses,
         declaredLicensesProcessed = declaredLicensesProcessed,

--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -53,6 +53,7 @@ class PackageCurationTest : WordSpec({
             val curation = PackageCuration(
                 id = pkg.id,
                 data = PackageCurationData(
+                    purl = "pkg:maven/org.hamcrest/hamcrest-core@1.3#subpath=src/main/java/org/hamcrest/core",
                     authors = sortedSetOf("author 1", "author 2"),
                     declaredLicenseMapping = mapOf("license a" to "Apache-2.0".toSpdx()),
                     concludedLicense = "license1 OR license2".toSpdx(),
@@ -81,6 +82,7 @@ class PackageCurationTest : WordSpec({
 
             with(curatedPkg.pkg) {
                 id.toCoordinates() shouldBe pkg.id.toCoordinates()
+                purl shouldBe curation.data.purl
                 authors shouldBe curation.data.authors
                 declaredLicenses shouldBe pkg.declaredLicenses
                 declaredLicensesProcessed.spdxExpression shouldBe "Apache-2.0".toSpdx()
@@ -138,6 +140,7 @@ class PackageCurationTest : WordSpec({
 
             with(curatedPkg.pkg) {
                 id.toCoordinates() shouldBe pkg.id.toCoordinates()
+                purl shouldBe pkg.purl
                 authors shouldBe pkg.authors
                 declaredLicenses shouldBe pkg.declaredLicenses
                 concludedLicense shouldBe pkg.concludedLicense


### PR DESCRIPTION
For some packages the default value for the package URL generated by
ORT is invalid. That generated default value also does not cover some
of the parameters e.g. qualifiers or subpaths, see [1].

Allow curating the package URLs to enable fixing invalid or improving
valid default values.

[1] https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst

Fixes #4565.