### PR TITLE
reporter: Add a reporter for the CtrlX Automation framework

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -78,6 +78,10 @@ Files: clients/github-graphql/src/main/assets/schema.docs.graphql
 Copyright: 2017 Gregor Martynus
 License: MIT
 
+Files: reporter/src/funTest/assets/sample.fossinfo.json
+Copyright: 2020-2021 Bosch Rexroth AG
+License: MIT
+
 Files: utils/spdx/src/main/resources/exceptions/*
 Copyright: 2010-2020 Linux Foundation and its Contributors
 License: CC0-1.0

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -74,6 +74,10 @@ Files: gradle/*
 Copyright: 2007-2020 The original author or authors <info@gradle.com>
 License: Apache-2.0
 
+Files: clients/github-graphql/src/main/assets/schema.docs.graphql
+Copyright: 2017 Gregor Martynus
+License: MIT
+
 Files: utils/spdx/src/main/resources/exceptions/*
 Copyright: 2010-2020 Linux Foundation and its Contributors
 License: CC0-1.0
@@ -89,7 +93,3 @@ License: CC0-1.0
 Files: utils/spdx/src/test/resources/spdx-spec-examples/*
 Copyright: 2010-2020 Linux Foundation and its Contributors
 License: CC-BY-3.0
-
-Files: clients/github-graphql/src/main/assets/schema.docs.graphql
-Copyright: 2017 Gregor Martynus
-License: MIT

--- a/README.md
+++ b/README.md
@@ -666,6 +666,7 @@ following formats are supported (reporter names are case-insensitive):
     * Man page (`-f ManPageTemplate`)
     * AsciiDoc (`-f AdocTemplate`): Does not convert the created AsciiDoc files but writes the generated files as
       reports.
+* [ctrlX AUTOMATION](https://ctrlx-automation.com/) [FOSS information](https://github.com/boschrexroth/json-schema/tree/master/ctrlx-automation/ctrlx-core/apps/fossinfo)
 * [CycloneDX](https://cyclonedx.org/) BOM (`-f CycloneDx`)
 * [Excel](https://products.office.com/excel) sheet (`-f Excel`)
 * [GitLabLicenseModel](https://docs.gitlab.com/ee/ci/pipelines/job_artifacts.html#artifactsreportslicense_scanning-ultimate) (`-f GitLabLicenseModel`)

--- a/reporter/src/funTest/assets/sample.fossinfo.json
+++ b/reporter/src/funTest/assets/sample.fossinfo.json
@@ -1,0 +1,168 @@
+{
+    "$schema": "https://github.com/boschrexroth/json-schema/blob/a84eab6/ctrlx-automation/ctrlx-core/apps/fossinfo/fossinfo.v1.schema.json",
+    "components": [
+        {
+            "name": "Apache Portable Runtime Utilities (APR-util)",
+            "version": "1.5.3",
+            "homepage": "http://apr.apache.org/docs/apr-util/1.2/index.html",
+            "usage": "Modified",
+            "integrationMechanism": "LinkedDynamically",
+            "copyright": {
+                "text": "Apache Portable Runtime Utility Library Copyright (c) 2011 The Apache Software Foundation",
+                "notice": "\nApache Portable Runtime Utility Library\nCopyright (c) 2011 The Apache Software Foundation.\n\nThis product includes software developed by\nThe Apache Software Foundation (http://www.apache.org/).\n\nPortions of this software were developed at the National Center\nfor Supercomputing Applications (NCSA) at the University of\nIllinois at Urbana-Champaign.\n\nThis software contains code derived from the RSA Data Security\nInc. MD5 Message-Digest Algorithm, including various\nmodifications by Spyglass Inc., Carnegie Mellon University, and\nBell Communications Research, Inc (Bellcore).\n"
+            },
+            "licenses": [
+                {
+                    "name": "Apache License 2.0",
+                    "version": "2.0",
+                    "spdx": "Apache-2.0",
+                    "text": "\n                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   This software\n * is provided ``as is\u0027\u0027 without express or implied warranty.\n */\n"
+                },
+                {
+                    "name": "RSA Data Security",
+                    "text": "Copyright (C) 1991-2, RSA Data Security, Inc. Created 1991. All rights reserved.\r\n"
+                },
+                {
+                    "name": "Massachusetts Institute of Technology",
+                    "text": "Copyright 1991 by the Massachusetts Institute of Technology\r\n"
+                },
+                {
+                    "name": "MIT License",
+                    "spdx": "MIT",
+                    "text": "Copyright (c) 1998, 1999, 2000 Thai Open Source Software Center Ltd and Clark Cooper\r\n"
+                }
+            ]
+        },
+        {
+            "name": "Apache Subversion",
+            "version": "1.8.8",
+            "homepage": "http://subversion.apache.org/",
+            "usage": "Modified",
+            "integrationMechanism": "LinkedStatically",
+            "copyright": {
+                "text": "Apache Subversion Copyright 2013 The Apache Software Foundation",
+                "notice": "\n        Apache Subversion\n        Copyright 2013 The Apache Software Foundation\n\n                ## vim:fileencoding=utf8\n"
+            },
+            "licenses": [
+                {
+                    "name": "Apache License 2.0",
+                    "version": "2.0",
+                    "spdx": "Apache-2.0",
+                    "text": "\n\n                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n"
+                }
+            ]
+        },
+        {
+            "name": "Apache-APR",
+            "version": "1.5.0",
+            "homepage": "http://apr.apache.org/",
+            "usage": "Modified",
+            "integrationMechanism": "LinkedStatically",
+            "copyright": {
+                "text": "Apache Portable Runtime Copyright (c) 2011 The Apache Software Foundation.",
+                "notice": "\n        Apache Portable Runtime\n        Copyright (c) 2011 The Apache Software Foundation.\n\n        This product includes software developed by\n        The Apache Software Foundation (http://www.apache.org/).\n\n        Portions of this software were developed at the National Center\n        for Supercomputing Applications (NCSA) at the University of\n        Illinois at Urbana-Champaign.\n\n        This software contains code derived from the RSA Data Security\n        Inc. MD5 Message-Digest Algorithm.\n\n        This software contains code derived from UNIX V7, Copyright(C)\n        Caldera International Inc.\n"
+            },
+            "licenses": [
+                {
+                    "name": "Apache License 2.0",
+                    "version": "2.0",
+                    "spdx": "Apache-2.0",
+                    "text": "\n                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n"
+                },
+                {
+                    "name": "Regents of University of California Berkeley License",
+                    "text": "Copyright (c) 1987, 1993, 1994 The Regents of the University of California. All rights reserved.\r\n\r\n\n\r\n"
+                },
+                {
+                    "name": "Caldera License",
+                    "spdx": "Caldera",
+                    "text": "Copyright(C) Caldera International Inc. 2001-2002. All rights reserved.\r\n\r\n\n\r\n"
+                }
+            ]
+        },
+        {
+            "name": "OpenSSL",
+            "version": "1.0.1f",
+            "homepage": "https://www.openssl.org/",
+            "usage": "Modified",
+            "integrationMechanism": "LinkedStatically",
+            "copyright": {
+                "text": "Copyright (c) 1998-2011 The OpenSSL Project. All rights reserved. Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com). All rights reserved."
+            },
+            "licenses": [
+                {
+                    "name": "OpenSSL Combined License",
+                    "spdx": "OpenSSL",
+                    "text": "\n  LICENSE ISSUES\n  ==============\n\n  The OpenSSL toolkit stays under a dual license, i.e. both the conditions of\n  the OpenSSL License and the original SSLeay license apply to the toolkit.\n  See below for the actual license texts. Actually both licenses are BSD-style\n  Open Source licenses. In case of any license issues related to OpenSSL\n  please contact openssl-core@openssl.org.\n\n  OpenSSL License\n  ---------------\n"
+                }
+            ]
+        },
+        {
+            "name": "serf",
+            "version": "1.3.4",
+            "homepage": "https://code.google.com/archive/p/serf/",
+            "usage": "Modified",
+            "integrationMechanism": "LinkedStatically",
+            "copyright": {
+                "text": "Copyright © 2017 The Apache Software Foundation",
+                "notice": "\n        This product includes software developed by\n        The Apache Software Foundation (http://www.apache.org/).\n"
+            },
+            "licenses": [
+                {
+                    "name": "Apache License 2.0",
+                    "version": "2.0",
+                    "spdx": "Apache-2.0",
+                    "text": "\n                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n"
+                }
+            ]
+        },
+        {
+            "name": "SQLite",
+            "version": "3.7.17",
+            "homepage": "http://www.sqlite.org/",
+            "usage": "Modified",
+            "integrationMechanism": "LinkedStatically",
+            "licenses": [
+                {
+                    "name": "Public Domain",
+                    "text": "\nCommercial use of SQLite is explicitly allowed, see https://www.sqlite.org/copyright.html.\n\nInternal reference: https://connect.bosch.com/wikis/home?lang=de-de#!/wiki/We02f74c5aa95_4f46_afbc_00d511e4a6d3/page/SQLite\n"
+                }
+            ]
+        },
+        {
+            "name": "The SharpSVN Project",
+            "version": "1.8",
+            "homepage": "http://sharpsvn.open.collab.net/",
+            "usage": "Modified",
+            "integrationMechanism": "LinkedDynamically",
+            "copyright": {
+                "text": "Copyright (c) 2007-2012 The SharpSvn Project"
+            },
+            "licenses": [
+                {
+                    "name": "Apache License 2.0",
+                    "version": "2.0",
+                    "spdx": "Apache-2.0",
+                    "text": "\n   Copyright (c) 2007-2012 The SharpSvn Project\n\n   Licensed under the Apache License, Version 2.0 (the \"License\");\n   you may not use this file except in compliance with the License.\n   You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n   Unless required by applicable law or agreed to in writing, software\n   distributed under the License is distributed on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n   See the License for the specific language governing permissions and\n   limitations under the License.\n\n\n----------------------------------------------------------------------------\n\n                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n"
+                }
+            ]
+        },
+        {
+            "name": "zlib",
+            "version": "1.2.8",
+            "homepage": "http://www.zlib.net/",
+            "usage": "Modified",
+            "integrationMechanism": "LinkedStatically",
+            "copyright": {
+                "text": "(C) 1995-2013 Jean-loup Gailly and Mark Adler"
+            },
+            "licenses": [
+                {
+                    "name": "zlib License",
+                    "spdx": "Zlib",
+                    "text": "\nCopyright notice:\n\n (C) 1995-2013 Jean-loup Gailly and Mark Adler\n\n  This software is provided \u0027as-is\u0027, without any express or implied\n  warranty.  In no event will the authors be held liable for any damages\n  arising from the use of this software.\n\n  Permission is granted to anyone to use this software for any purpose,\n  including commercial applications, and to alter it and redistribute it\n  freely, subject to the following restrictions:\n\n  1. The origin of this software must not be misrepresented; you must not\n     claim that you wrote the original software. If you use this software\n     in a product, an acknowledgment in the product documentation would be\n     appreciated but is not required.\n  2. Altered source versions must be plainly marked as such, and must not be\n     misrepresented as being the original software.\n  3. This notice may not be removed or altered from any source distribution.\n\n  Jean-loup Gailly        Mark Adler\n  jloup@gzip.org          madler@alumni.caltech.edu\n"
+                }
+            ]
+        }
+    ]
+}

--- a/reporter/src/funTest/kotlin/reporters/ctrlx/CtrlXAutomationReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/ctrlx/CtrlXAutomationReporterFunTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.reporter.reporters.ctrlx
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.haveSize
+import io.kotest.matchers.should
+
+import java.io.File
+
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.reporter.ORT_RESULT
+import org.ossreviewtoolkit.reporter.ReporterInput
+import org.ossreviewtoolkit.reporter.reporters.ctrlx.CtrlXAutomationReporter.Companion.REPORT_FILENAME
+import org.ossreviewtoolkit.utils.test.createTestTempDir
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
+
+class CtrlXAutomationReporterFunTest : StringSpec({
+    "The official sample file can be deserialized" {
+        val fossInfoFile = File("src/funTest/assets/sample.fossinfo.json")
+        val fossInfo = fossInfoFile.readValue<FossInfo>()
+
+        fossInfo.components shouldNotBeNull {
+            this should haveSize(8)
+        }
+    }
+
+    "Generating a report works" {
+        val outputDir = createTestTempDir()
+        val reportFiles = CtrlXAutomationReporter().generateReport(ReporterInput(ORT_RESULT), outputDir)
+
+        reportFiles.map { it.name } should containExactly(REPORT_FILENAME)
+    }
+})

--- a/reporter/src/main/kotlin/reporters/ctrlx/CtrlXAutomationModel.kt
+++ b/reporter/src/main/kotlin/reporters/ctrlx/CtrlXAutomationModel.kt
@@ -1,0 +1,213 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.reporter.reporters.ctrlx
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+import org.ossreviewtoolkit.utils.spdx.SpdxExpression
+
+/**
+ * The root element of "fossinfo.json" files, see https://github.com/boschrexroth/json-schema.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class FossInfo(
+    /**
+     * The reference to the JSON schema in use.
+     */
+    @JsonProperty("\$schema")
+    val schema: String? = "https://github.com/boschrexroth/json-schema/blob/a84eab6/ctrlx-automation/ctrlx-core/apps/" +
+            "fossinfo/fossinfo.v1.schema.json",
+
+    /**
+     * An inlined OSS component, in case of a single component.
+     */
+    val component: Component? = null,
+
+    /**
+     * A list of OSS components, in case of multiple components.
+     */
+    val components: List<Component>? = null
+) {
+    init {
+        require(component == null || components == null) {
+            "Not both a single 'component' and a list of 'components' may be specified."
+        }
+    }
+}
+
+/**
+ * An OSS component.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class Component(
+    /**
+     * The OSS component name.
+     */
+    val name: String,
+
+    /**
+     * The OSS component version. If a version is not available, use the date of the download.
+     */
+    val version: String? = null,
+
+    /**
+     * The OSS component homepage.
+     */
+    val homepage: String? = null,
+
+    /**
+     * The OSS component copyright information.
+     */
+    val copyright: CopyrightInformation? = null,
+
+    /**
+     * The OSS component licenses. At least one license is required.
+     */
+    val licenses: List<License>,
+
+    /**
+     * A list of multiple usage forms. The key in the map indicates whether the entry is a "usage" or an
+     * "integrationMechanism".
+     */
+    val usages: List<Map<String, String>>? = null,
+
+    /**
+     * A single OSS component usage.
+     */
+    val usage: Usage? = null,
+
+    /**
+     * A single OSS component integration.
+     */
+    @JsonProperty("integrationMechanism")
+    val integrationMechanism: IntegrationMechanism? = null
+) {
+    init {
+        require(name.trim() == name) {
+            "The '$name' value of the 'name' field must not contain any leading or trailing whitespaces."
+        }
+
+        require(version?.trim() == version) {
+            "The '$version' value of the 'version' field must not contain any leading or trailing whitespaces."
+        }
+
+        require(homepage?.trim() == homepage) {
+            "The '$homepage' value of the 'homepage' field must not contain any leading or trailing whitespaces."
+        }
+
+        require(licenses.isNotEmpty()) {
+            "The 'licenses' must contain at least one license."
+        }
+    }
+}
+
+/**
+ * An OSS component's copyright information.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class CopyrightInformation(
+    /**
+     * The copyright text.
+     */
+    val text: String,
+
+    /**
+     * The copyright notice, e.g. NOTICE file contents of Apache-2.0 licensed components. Use "\n" as line separator.
+     */
+    val notice: String? = null
+)
+
+/**
+ * An OSS component's license.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class License(
+    /**
+     * The license name.
+     */
+    val name: String,
+
+    /**
+     * The official identifier of the license, also see https://spdx.org/licenses.
+     */
+    val spdx: SpdxExpression? = null,
+
+    /**
+     * OSS component license text. Use "\n" as line separator.
+     */
+    val text: String,
+
+    /**
+     * The version or date of the license. Hint: Must not contain leading and trailing whitespaces.
+     */
+    val version: String? = null
+) {
+    init {
+        require(name.trim() == name) {
+            "The '$name' value of the 'name' field must not contain any leading or trailing whitespaces."
+        }
+
+        require(spdx?.isValid() != false) {
+            "The '$spdx' value of the 'spdx' field must be a valid SPDX identifier."
+        }
+
+        require(version?.trim() == version) {
+            "The '$version' value of the 'version' field must not contain any leading or trailing whitespaces."
+        }
+    }
+}
+
+/**
+ * The OSS component usage which may affect the required obligations.
+ */
+enum class Usage {
+    /** The OSS component is used without modifications. */
+    AsIs,
+
+    /** The OSS component has been modified. */
+    Modified
+}
+
+/**
+ * The OSS component integration which may affect the required obligations.
+ */
+enum class IntegrationMechanism {
+    /** DLL, Assembly. */
+    LinkedDynamically,
+
+    /** OSS library integrated in an executable. */
+    LinkedStatically,
+
+    /** Parts of the OSS sources in proprietary sources. */
+    Snippet,
+
+    /** Use system calls to OSS kernel component. */
+    CallOfLinuxKernelServiceViaSystemCall,
+
+    /** Delivery of OSS component. */
+    SeparateComponent,
+
+    /** Integrated as npm package. */
+    Npm,
+
+    /** Integrated as golang module. */
+    Go
+}

--- a/reporter/src/main/kotlin/reporters/ctrlx/CtrlXAutomationReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ctrlx/CtrlXAutomationReporter.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.reporter.reporters.ctrlx
+
+import java.io.File
+
+import org.ossreviewtoolkit.model.licenses.LicenseView
+import org.ossreviewtoolkit.model.writeValue
+import org.ossreviewtoolkit.reporter.Reporter
+import org.ossreviewtoolkit.reporter.ReporterInput
+
+class CtrlXAutomationReporter : Reporter {
+    companion object {
+        const val REPORT_FILENAME = "fossinfo.json"
+    }
+
+    override val reporterName = "CtrlXAutomation"
+
+    override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
+        val reportFile = outputDir.resolve(REPORT_FILENAME)
+
+        val packages = input.ortResult.getPackages(omitExcluded = true)
+        val components = packages.mapTo(mutableListOf()) { (pkg, _) ->
+            val qualifiedName = when (pkg.id.type) {
+                // At least for NPM packages, CtrlX requires the component name to be prefixed with the scope name,
+                // separated with a slash. Other package managers might require similar handling, but there seems to be
+                // no documentation about the expected separator character.
+                "NPM" -> with(pkg.id) {
+                    listOfNotNull(namespace.takeIf { it.isNotEmpty() }, name).joinToString("/")
+                }
+
+                else -> pkg.id.name
+            }
+
+            val resolvedLicenseInfo = input.licenseInfoResolver.resolveLicenseInfo(pkg.id).filterExcluded()
+            val copyrights = resolvedLicenseInfo.getCopyrights().joinToString("\n").takeUnless { it.isEmpty() }
+            val effectiveLicense = resolvedLicenseInfo.effectiveLicense(
+                LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED,
+                input.ortResult.getPackageLicenseChoices(pkg.id),
+                input.ortResult.getRepositoryLicenseChoices()
+            )
+            val licenses = effectiveLicense?.decompose()?.map {
+                val id = it.toString()
+                val text = input.licenseTextProvider.getLicenseText(id)
+                License(name = id, spdx = it, text = text.orEmpty())
+            }
+
+            Component(
+                name = qualifiedName,
+                version = pkg.id.version,
+                homepage = pkg.homepageUrl.takeUnless { it.isEmpty() },
+                copyright = copyrights?.let { CopyrightInformation(it) },
+                licenses = licenses.orEmpty(),
+                usage = if (pkg.isModified) Usage.Modified else Usage.AsIs
+                // TODO: Map the PackageLinkage to an IntegrationMechanism.
+            )
+        }
+
+        val info = FossInfo(components = components)
+        reportFile.writeValue(info)
+
+        return listOf(reportFile)
+    }
+}

--- a/reporter/src/main/resources/META-INF/services/org.ossreviewtoolkit.reporter.Reporter
+++ b/reporter/src/main/resources/META-INF/services/org.ossreviewtoolkit.reporter.Reporter
@@ -3,6 +3,7 @@ org.ossreviewtoolkit.reporter.reporters.ExcelReporter
 org.ossreviewtoolkit.reporter.reporters.OpossumReporter
 org.ossreviewtoolkit.reporter.reporters.StaticHtmlReporter
 org.ossreviewtoolkit.reporter.reporters.WebAppReporter
+org.ossreviewtoolkit.reporter.reporters.ctrlx.CtrlXAutomationReporter
 org.ossreviewtoolkit.reporter.reporters.evaluatedmodel.EvaluatedModelReporter
 org.ossreviewtoolkit.reporter.reporters.freemarker.NoticeTemplateReporter
 org.ossreviewtoolkit.reporter.reporters.freemarker.asciidoc.AdocTemplateReporter


### PR DESCRIPTION
"ctrlX AUTOMATION" is a suite of tools developed by Bosch Rexroth to
automate various processes in engineering. The "ctrlX CORE" tool defines
a JSON schema to document FOSS information [2]. This new reporter
exports to that format.

[1] https://ctrlx-automation.com/
[2] https://github.com/boschrexroth/json-schema/tree/master/ctrlx-automation/ctrlx-core/apps/fossinfo

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>