### PR TITLE
scanner: Add a working tree cache for the experimental scanner

### DIFF
--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -300,7 +300,7 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
                 storageReaders = readers,
                 storageWriters = writers,
                 packageProvenanceResolver = DefaultPackageProvenanceResolver(workingTreeCache),
-                nestedProvenanceResolver = DefaultNestedProvenanceResolver(),
+                nestedProvenanceResolver = DefaultNestedProvenanceResolver(workingTreeCache),
                 scannerWrappers = listOf(scannerWrapper)
             )
 

--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -296,7 +296,7 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
             val scanner = ExperimentalScanner(
                 scannerConfig = config.scanner,
                 downloaderConfig = config.downloader,
-                provenanceDownloader = DefaultProvenanceDownloader(config.downloader),
+                provenanceDownloader = DefaultProvenanceDownloader(config.downloader, workingTreeCache),
                 storageReaders = readers,
                 storageWriters = writers,
                 packageProvenanceResolver = DefaultPackageProvenanceResolver(workingTreeCache),

--- a/scanner/src/funTest/kotlin/experimental/DefaultNestedProvenanceResolverFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/DefaultNestedProvenanceResolverFunTest.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 HERE Europe B.V.
+ * Copyright (C) 2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +21,14 @@
 package org.ossreviewtoolkit.scanner.experimental
 
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import java.io.IOException
+
+import kotlinx.coroutines.runBlocking
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.Hash
@@ -36,7 +40,12 @@ import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.test.containExactly
 
 class DefaultNestedProvenanceResolverFunTest : WordSpec() {
-    private val resolver = DefaultNestedProvenanceResolver()
+    private val workingTreeCache = DefaultWorkingTreeCache()
+    private val resolver = DefaultNestedProvenanceResolver(workingTreeCache)
+
+    override fun afterSpec(spec: Spec) {
+        runBlocking { workingTreeCache.shutdown() }
+    }
 
     init {
         "Resolving an artifact provenance" should {

--- a/scanner/src/funTest/kotlin/experimental/DefaultPackageProvenanceResolverFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/DefaultPackageProvenanceResolverFunTest.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 HERE Europe B.V.
+ * Copyright (C) 2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +20,11 @@
 
 package org.ossreviewtoolkit.scanner.experimental
 
+import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
+
+import kotlinx.coroutines.runBlocking
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.Hash
@@ -34,11 +38,16 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 
 class DefaultPackageProvenanceResolverFunTest : WordSpec() {
-    private val resolver = DefaultPackageProvenanceResolver()
+    private val workingTreeCache = DefaultWorkingTreeCache()
+    private val resolver = DefaultPackageProvenanceResolver(workingTreeCache)
 
     private val sourceArtifactUrl =
         "https://github.com/oss-review-toolkit/ort-test-data-npm/blob/test-1.0.0/README.md"
     private val repositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-npm"
+
+    override fun afterSpec(spec: Spec) {
+        runBlocking { workingTreeCache.shutdown() }
+    }
 
     init {
         "Resolving an artifact provenance" should {

--- a/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
+++ b/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
@@ -40,7 +40,6 @@ import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.utils.common.collectMessagesAsString
 import org.ossreviewtoolkit.utils.core.Environment
-import org.ossreviewtoolkit.utils.core.createOrtTempDir
 import org.ossreviewtoolkit.utils.core.log
 
 class ExperimentalScanner(
@@ -320,10 +319,8 @@ class ExperimentalScanner(
         provenance: KnownProvenance,
         scanners: List<LocalScannerWrapper>
     ): Map<LocalScannerWrapper, ScanResult> {
-        val downloadDir = createOrtTempDir() // TODO: Use provided download dir instead.
-
-        try {
-            provenanceDownloader.download(provenance, downloadDir)
+        val downloadDir = try {
+            provenanceDownloader.download(provenance)
         } catch (e: DownloadException) {
             val message = "Could not download provenance $provenance: ${e.collectMessagesAsString()}"
             log.error { message }

--- a/scanner/src/main/kotlin/experimental/ProvenanceDownloader.kt
+++ b/scanner/src/main/kotlin/experimental/ProvenanceDownloader.kt
@@ -29,16 +29,19 @@ import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
+import org.ossreviewtoolkit.utils.core.createOrtTempDir
 
 /**
  * An interface that provides functionality to download source code.
  */
 interface ProvenanceDownloader {
     /**
-     * Download the source code specified by the provided [provenance] to the [downloadDir]. Throws a
-     * [DownloadException] if the download fails.
+     * Download the source code specified by the provided [provenance] and return the path to the directory that
+     * contains the downloaded source code.
+     *
+     * Throws a [DownloadException] if the download fails.
      */
-    fun download(provenance: KnownProvenance, downloadDir: File)
+    fun download(provenance: KnownProvenance): File
 }
 
 /**
@@ -48,7 +51,9 @@ interface ProvenanceDownloader {
 class DefaultProvenanceDownloader(config: DownloaderConfiguration) : ProvenanceDownloader {
     private val downloader = Downloader(config)
 
-    override fun download(provenance: KnownProvenance, downloadDir: File) {
+    override fun download(provenance: KnownProvenance): File {
+        val downloadDir = createOrtTempDir()
+
         when (provenance) {
             // TODO: Add dedicated download functions for VcsInfo and RemoteArtifact to the Downloader.
             is ArtifactProvenance -> {
@@ -63,5 +68,7 @@ class DefaultProvenanceDownloader(config: DownloaderConfiguration) : ProvenanceD
                 downloader.downloadFromVcs(pkg, downloadDir, recursive = false)
             }
         }
+
+        return downloadDir
     }
 }

--- a/scanner/src/main/kotlin/experimental/WorkingTreeCache.kt
+++ b/scanner/src/main/kotlin/experimental/WorkingTreeCache.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import java.io.IOException
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.downloader.WorkingTree
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
+import org.ossreviewtoolkit.utils.core.createOrtTempDir
+
+/**
+ * A cache for [VCS][VersionControlSystem] [WorkingTree]s that manages one working tree for each triple of
+ * [VcsInfo.type], [VcsInfo.url], and [VcsInfo.path].
+ */
+interface WorkingTreeCache {
+    /**
+     * Apply the [block] to the working tree defined by [vcsInfo]. The [VcsInfo.revision] is ignored during
+     * initialization of the working tree, it is the caller's responsibility to update the working tree to the correct
+     * revision. It is ensured that only one [block] at a time can access a single working tree, separate working trees
+     * can be accessed in parallel.
+     *
+     * Throws an [IllegalStateException] if the cache was already [shut down][shutdown].
+     */
+    suspend fun <T> use(vcsInfo: VcsInfo, block: (VersionControlSystem, WorkingTree) -> T): T
+
+    /**
+     * Shut down the cache and clear all cached working trees from the file system. The function waits for all currently
+     * running operations on the working trees to finish before deleting them.
+     */
+    suspend fun shutdown()
+}
+
+class DefaultWorkingTreeCache : WorkingTreeCache {
+    private val mutex = Mutex()
+    private val workingTreeMutexes = mutableMapOf<String, Mutex>()
+    private val workingTrees = mutableMapOf<String, WorkingTree>()
+
+    private var terminated = false
+
+    override suspend fun <T> use(vcsInfo: VcsInfo, block: (VersionControlSystem, WorkingTree) -> T): T {
+        val vcs = getVcs(vcsInfo)
+        return getWorkingTreeMutex(vcsInfo).withLock { block(vcs, getWorkingTree(vcsInfo, vcs)) }
+    }
+
+    private fun getKey(vcsInfo: VcsInfo) = "${vcsInfo.type}|${vcsInfo.url}|${vcsInfo.path}"
+
+    private suspend fun getWorkingTreeMutex(vcsInfo: VcsInfo) =
+        mutex.withLock {
+            if (terminated) throw IllegalStateException("The cache was already shut down.")
+
+            workingTreeMutexes.getOrPut(getKey(vcsInfo)) { Mutex() }
+        }
+
+    private fun getVcs(vcsInfo: VcsInfo) =
+        VersionControlSystem.forType(vcsInfo.type)
+            ?: VersionControlSystem.forUrl(vcsInfo.url)
+            ?: throw IOException("Could not determine VCS type for (type=$${vcsInfo.type}, url=${vcsInfo.url}).")
+
+    private fun getWorkingTree(vcsInfo: VcsInfo, vcs: VersionControlSystem) =
+        workingTrees.getOrPut(getKey(vcsInfo)) {
+            val dir = createOrtTempDir()
+            vcs.initWorkingTree(dir, vcsInfo.copy(revision = ""))
+        }
+
+    override suspend fun shutdown() {
+        mutex.withLock {
+            terminated = true
+
+            workingTreeMutexes.forEach { (key, workingTreeMutex) ->
+                workingTreeMutex.withLock {
+                    workingTrees[key]?.getRootPath()?.safeDeleteRecursively(force = true)
+                }
+            }
+            workingTrees.clear()
+            workingTreeMutexes.clear()
+        }
+    }
+}

--- a/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
+++ b/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
@@ -56,6 +56,7 @@ import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.scanner.ScannerCriteria
+import org.ossreviewtoolkit.utils.core.createOrtTempDir
 import org.ossreviewtoolkit.utils.test.containExactly
 
 class ExperimentalScannerTest : WordSpec({
@@ -110,7 +111,7 @@ class ExperimentalScannerTest : WordSpec({
 
             scanner.scan(setOf(pkgWithArtifact, pkgWithVcs))
 
-            verify(exactly = 0) { provenanceDownloader.download(any(), any()) }
+            verify(exactly = 0) { provenanceDownloader.download(any()) }
         }
     }
 
@@ -152,7 +153,7 @@ class ExperimentalScannerTest : WordSpec({
 
             scanner.scan(setOf(pkgWithArtifact, pkgWithVcs))
 
-            verify(exactly = 0) { provenanceDownloader.download(any(), any()) }
+            verify(exactly = 0) { provenanceDownloader.download(any()) }
         }
     }
 
@@ -194,8 +195,8 @@ class ExperimentalScannerTest : WordSpec({
             scanner.scan(setOf(pkgWithArtifact, pkgWithVcs))
 
             verify(exactly = 1) {
-                provenanceDownloader.download(pkgWithArtifact.artifactProvenance(), any())
-                provenanceDownloader.download(pkgWithVcs.repositoryProvenance(), any())
+                provenanceDownloader.download(pkgWithArtifact.artifactProvenance())
+                provenanceDownloader.download(pkgWithVcs.repositoryProvenance())
             }
         }
     }
@@ -601,10 +602,11 @@ private class FakeLocalScannerWrapper : LocalScannerWrapper {
  * provenance, instead of actually downloading the source code.
  */
 private class FakeProvenanceDownloader : ProvenanceDownloader {
-    override fun download(provenance: KnownProvenance, downloadDir: File) {
+    override fun download(provenance: KnownProvenance): File {
         // TODO: Should downloadDir be created if it does not exist?
-        val file = downloadDir.resolve("provenance.txt")
+        val file = createOrtTempDir().resolve("provenance.txt")
         file.writeText(yamlMapper.writeValueAsString(provenance))
+        return file.parentFile
     }
 }
 


### PR DESCRIPTION
Add a working tree cache to avoid downloading the same sources multiple times. See the commit messages for details.