### PR TITLE
utils-core: Make showStackTrace() an expression function

### DIFF
--- a/utils/core/src/main/kotlin/Extensions.kt
+++ b/utils/core/src/main/kotlin/Extensions.kt
@@ -52,8 +52,4 @@ fun Any.createOrtTempFile(prefix: String? = null, suffix: String? = null): File 
 /**
  * Print the stack trace of the [Throwable] if [printStackTrace] is set to true.
  */
-fun Throwable.showStackTrace() {
-    // We cannot use a function expression for a single "if"-statement, see
-    // https://discuss.kotlinlang.org/t/if-operator-in-function-expression/7227.
-    if (printStackTrace) printStackTrace()
-}
+fun Throwable.showStackTrace(): Unit = run { if (printStackTrace) printStackTrace() }


### PR DESCRIPTION
Use `let` to make the function an expression function.