### PR TITLE
analyzer: Remove `peerDependencies` from NPM / Yarn test assets

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/npm/no-lockfile/package.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm/no-lockfile/package.json
@@ -15,9 +15,6 @@
   "devDependencies": {
     "cson": "~4.1.0"
   },
-  "peerDependencies": {
-    "tea": "0.x"
-  },
   "optionalDependencies": {
     "promise": "~7.3.1"
   }

--- a/analyzer/src/funTest/assets/projects/synthetic/npm/node-modules/package.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm/node-modules/package.json
@@ -17,9 +17,6 @@
   "devDependencies": {
     "cson": "~4.1.0"
   },
-  "peerDependencies": {
-    "tea": "0.x"
-  },
   "optionalDependencies": {
     "promise": "~7.3.1"
   }

--- a/analyzer/src/funTest/assets/projects/synthetic/npm/package-lock/package.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm/package-lock/package.json
@@ -17,9 +17,6 @@
   "devDependencies": {
     "cson": "~4.1.0"
   },
-  "peerDependencies": {
-    "tea": "0.x"
-  },
   "optionalDependencies": {
     "promise": "~7.3.1"
   }

--- a/analyzer/src/funTest/assets/projects/synthetic/npm/shrinkwrap/package.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm/shrinkwrap/package.json
@@ -21,9 +21,6 @@
   "devDependencies": {
     "cson": "~4.1.0"
   },
-  "peerDependencies": {
-    "tea": "0.x"
-  },
   "optionalDependencies": {
     "promise": "~7.3.1"
   }

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn/package.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn/package.json
@@ -15,9 +15,6 @@
   "devDependencies": {
     "cson": "~4.1.0"
   },
-  "peerDependencies": {
-    "tea": "0.x"
-  },
   "optionalDependencies": {
     "promise": "~7.3.1"
   }


### PR DESCRIPTION
ORT does not support `peerDependencies` yet [1]. That is mostly because
handling of peer dependencies varies with NPM versions: Some versions do
install them by default, some do not [2]. This results in ORT's functional
tests to fail depending on the NPM version, and as it turns out, they
would fail with the NPM version 7 currently used in ORT's `Dockerfile`.
However, tests succeed on Azure CI which uses NPM 6.  Avoid that
inconsistency by simply not using peer dependencies at all for testing for
now.

[1]: https://github.com/oss-review-toolkit/ort/issues/95
[2]: https://nodejs.org/en/blog/npm/peer-dependencies#using-peer-dependencies

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>