### PR TITLE
LocalScanner: Remove the version requirement for scanners

### DIFF
--- a/scanner/src/main/kotlin/LocalScanner.kt
+++ b/scanner/src/main/kotlin/LocalScanner.kt
@@ -115,8 +115,14 @@ abstract class LocalScanner(
     private val scannerDir by lazy {
         val scannerExe = command()
 
-        Os.getPathFromEnvironment(scannerExe)?.parentFile?.takeIf {
-            getVersion(it) == expectedVersion
+        Os.getPathFromEnvironment(scannerExe)?.parentFile?.also {
+            val actualVersion = getVersion(it)
+            if (actualVersion != expectedVersion) {
+                log.info {
+                    "ORT is currently tested with $name version $expectedVersion, but you are using version " +
+                            "$actualVersion. This could lead to problems with parsing the $name output."
+                }
+            }
         } ?: run {
             if (scannerExe.isNotEmpty()) {
                 log.info {


### PR DESCRIPTION
Do not require that the installed version of a scanner matches the
expected version. Instead print a message if the installed version is
not the expected version, but continue using it for scanning.