### PR TITLE
Analyzer: Prepend the logger to log with ORT class

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -235,7 +235,7 @@ abstract class PackageManager(
         definitionFiles.forEach { definitionFile ->
             val relativePath = definitionFile.relativeTo(analysisRoot).invariantSeparatorsPath
 
-            log.info { "Resolving $managerName dependencies for '$relativePath'..." }
+            PackageManager.log.info { "Resolving $managerName dependencies for '$relativePath'..." }
 
             val duration = measureTime {
                 @Suppress("TooGenericExceptionCaught")
@@ -271,7 +271,9 @@ abstract class PackageManager(
                 }
             }
 
-            log.info { "Resolving $managerName dependencies for '$relativePath' took ${duration.inWholeSeconds}s." }
+            PackageManager.log.info {
+                "Resolving $managerName dependencies for '$relativePath' took ${duration.inWholeSeconds}s."
+            }
         }
 
         afterResolution(definitionFiles)


### PR DESCRIPTION
This prevents an error when an Analyzer plugin is used which does not use the ORT package name.

```
12:13:17.890 [DefaultDispatcher-worker-3] INFO  org.ossreviewtoolkit.utils.core.OrtProxySelector - Proxy selector was successfully installed.
Exception in thread "main" java.lang.IllegalArgumentException: Logging is only allowed on ORT classes, but 'io.bosch.ort.plugins.MySuperPlugin' is used.
	at org.ossreviewtoolkit.analyzer.PackageManager.resolveDependencies(PackageManager.kt:389)
	at org.ossreviewtoolkit.analyzer.Analyzer$analyzeInParallel$1$1$1.invokeSuspend(Analyzer.kt:132)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```
I assume that this occurs because the `open fun` of `PackageManager` gets inlined in the plugin.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>

