### PR TITLE
Utils: Support logging from classes that extend ORT base classes

### DIFF
--- a/detekt-rules/src/main/kotlin/OrtPackageNaming.kt
+++ b/detekt-rules/src/main/kotlin/OrtPackageNaming.kt
@@ -48,7 +48,9 @@ class OrtPackageNaming : Rule() {
     override fun visitPackageDirective(directive: KtPackageDirective) {
         super.visitPackageDirective(directive)
 
-        if (directive.qualifiedName.isEmpty()) return
+        // Exclusion of packages starting with "test." is required for OrtLogTestExtension used by LoggerTest, which
+        // simulates an ORT extension class in a different package.
+        if (directive.qualifiedName.isEmpty() || directive.qualifiedName.startsWith("test.")) return
 
         val path = directive.containingKtFile.toFilePath().relativePath.toString()
         if (!path.contains(pathPattern)) return

--- a/utils/core/src/test/kotlin/LoggerTest.kt
+++ b/utils/core/src/test/kotlin/LoggerTest.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.utils.core
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.kotest.matchers.types.shouldNotBeSameInstanceAs
 
@@ -29,6 +30,8 @@ import io.mockk.verify
 
 import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.kotlin.KotlinLogger
+
+import test.other.OrtLogTestExtension
 
 private class DummyClass
 private class OtherClass
@@ -55,6 +58,12 @@ class LoggerTest : WordSpec({
             shouldThrow<IllegalArgumentException> {
                 String().log.info { "Hello from a String." }
             }
+        }
+
+        "be available in non-ORT classes extending ORT base classes" {
+            val command = OrtLogTestExtension()
+
+            command.command() shouldBe "success"
         }
     }
 

--- a/utils/core/src/test/kotlin/test/other/OrtLogTestExtension.kt
+++ b/utils/core/src/test/kotlin/test/other/OrtLogTestExtension.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package test.other
+
+import java.io.File
+
+import org.ossreviewtoolkit.utils.common.CommandLineTool
+import org.ossreviewtoolkit.utils.core.log
+
+/**
+ * A test class simulating an external base class for ORT extensions. This is used to check whether extensions are
+ * correctly detected over more complex hierarchies.
+ */
+abstract class OrtLogTestBaseExtension : CommandLineTool
+
+/**
+ * A test class simulating an extension of ORT that produces log output. This is used to test whether classes from
+ * different packages extending ORT classes can use logging.
+ */
+class OrtLogTestExtension : OrtLogTestBaseExtension() {
+    override fun command(workingDir: File?): String {
+        log.info { "Test of the logger." }
+        return "success"
+    }
+}


### PR DESCRIPTION
ORT's logging mechanism currently checks whether the current class
belongs to a package in ORT's namespace; otherwise, an exception is
thrown. This check can fail for external classes that extend ORT
functionality, e.g. plugins - even if the logging code is in a base
class.

As a work-around, make the check more lenient to accept classes that
extend a class or interface from the ORT namespace.

To prevent a detekt failure with the corresponding test case (that
uses a class in a different namespace), the OrtPackageNaming rule
class had to be tweaked.
