### PR TITLE
Add JVM overloads for main API functions with default arguments

### DIFF
--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -52,6 +52,7 @@ class Advisor(
         val ALL by lazy { LOADER.iterator().asSequence().toList().sortedBy { it.providerName } }
     }
 
+    @JvmOverloads
     fun retrieveFindings(ortResult: OrtResult, skipExcluded: Boolean = false): OrtResult {
         val startTime = Instant.now()
 

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -49,6 +49,7 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
         val repositoryConfiguration: RepositoryConfiguration
     )
 
+    @JvmOverloads
     fun findManagedFiles(
         absoluteProjectPath: File,
         packageManagers: List<PackageManagerFactory> = PackageManager.ALL,
@@ -88,6 +89,7 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
         return ManagedFileInfo(absoluteProjectPath, managedFiles, repositoryConfiguration)
     }
 
+    @JvmOverloads
     fun analyze(
         info: ManagedFileInfo,
         curationProvider: PackageCurationProvider = PackageCurationProvider.EMPTY

--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -176,6 +176,7 @@ class Downloader(private val config: DownloaderConfiguration) {
      * is `true`, any nested repositories (like Git submodules or Mercurial subrepositories) are downloaded, too. A
      * [Provenance] is returned on success or a [DownloadException] is thrown in case of failure.
      */
+    @JvmOverloads
     fun downloadFromVcs(
         pkg: Package,
         outputDirectory: File,

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -48,6 +48,7 @@ const val TOOL_NAME = "scanner"
  * [outputDirectory]. If [skipExcluded] is true, packages for which excludes are defined are not scanned. Return scan
  * results as an [OrtResult].
  */
+@JvmOverloads
 fun scanOrtResult(
     scanner: Scanner,
     ortResult: OrtResult,
@@ -60,6 +61,7 @@ fun scanOrtResult(
  * respectively. Scan results are stored in the [outputDirectory]. If [skipExcluded] is true, packages for which
  * excludes are defined are not scanned. Return scan results as an [OrtResult].
  */
+@JvmOverloads
 fun scanOrtResult(
     scanner: Scanner,
     projectScanner: Scanner,


### PR DESCRIPTION
This allows to benefit from default arguments also when ORT in called
from Java.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>