### PR TITLE
ScanResulsStorage(s): Fix an issue with VCS info based matching

### DIFF
--- a/model/src/main/kotlin/Provenance.kt
+++ b/model/src/main/kotlin/Provenance.kt
@@ -75,9 +75,9 @@ data class RepositoryProvenance(
     }
 
     /**
-     * Return true if this provenance matches the VCS information of the [package][pkg].
+     * Return true if this provenance matches the processed VCS information of the [package][pkg].
      */
-    override fun matches(pkg: Package): Boolean = vcsInfo == pkg.vcs || vcsInfo == pkg.vcsProcessed
+    override fun matches(pkg: Package): Boolean = vcsInfo == pkg.vcsProcessed
 }
 
 /**

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
@@ -70,15 +70,15 @@ abstract class AbstractStorageFunTest : WordSpec() {
     private val pkg1 = Package.EMPTY.copy(
         id = id1,
         sourceArtifact = sourceArtifact1,
-        vcs = vcs1,
-        vcsProcessed = vcs1.normalize()
+        vcs = VcsInfo.EMPTY,
+        vcsProcessed = vcs1
     )
 
     private val pkg2 = Package.EMPTY.copy(
         id = id2,
         sourceArtifact = sourceArtifact2,
-        vcs = vcs2,
-        vcsProcessed = vcs2.normalize()
+        vcs = VcsInfo.EMPTY,
+        vcsProcessed = vcs2
     )
 
     private val pkgWithoutRevision = pkg1.copy(vcs = vcsWithoutRevision, vcsProcessed = vcsWithoutRevision.normalize())
@@ -312,6 +312,23 @@ abstract class AbstractStorageFunTest : WordSpec() {
 
                 readResult.shouldBeSuccess()
                 readResult.result should containExactly(scanResult)
+            }
+
+            "not find a scan result if vcs matches (but not vcsProcessed)" {
+                val pkg = Package.EMPTY.copy(
+                    id = id1,
+                    sourceArtifact = RemoteArtifact.EMPTY,
+                    vcs = vcs1,
+                    vcsProcessed = VcsInfo.EMPTY
+                )
+                val scanResult = ScanResult(provenanceWithVcsInfo1, scannerDetails1, scanSummaryWithFiles)
+
+                storage.add(id1, scanResult).shouldBeSuccess()
+
+                val readResult = storage.read(pkg, criteriaForDetails(scannerDetails1))
+
+                readResult.shouldBeSuccess()
+                readResult.result should beEmpty()
             }
         }
 


### PR DESCRIPTION
The downloader uses only `Package.vcsProcessed`, not `Package.vcs`, for
downloading the sources of any package from a VCS. The scan results
storages match a scan result, if that scan result's provenance equals
either of `Package.vcs` and `Package.vcsProcessed`. This is inconsistent
with the downloader and does lead to the following issue:

If `vcs` and `vcsProcessed` of a package differ,
`ScanResultsStorage.read()` may return multiple scan results with
different provenance. For example, when a package's VCS path is set via
a curation, the OrtResult may contain (as of [1]) two scan results for
that package, one with- and the other without a VCS path.

Stop matching `Package.vcs` for consistency with the downloader and to
fix above issue.

Fixes #4679.

[1] #4653

Signed-off-by: Frank Viernau <frank.viernau@here.com>
