### PR TITLE
Gradle: Use extensions to configure source sets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,6 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
-import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val detektPluginVersion: String by project
@@ -168,9 +167,7 @@ subprojects {
     apply(plugin = "org.jetbrains.dokka")
 
     sourceSets.create("funTest") {
-        withConvention(KotlinSourceSet::class) {
-            kotlin.srcDirs("src/funTest/kotlin")
-        }
+        kotlin.sourceSets.getByName(name).kotlin.srcDirs("src/funTest/kotlin")
     }
 
     // Associate the "funTest" compilation with the "main" compilation to be able to access "internal" objects from


### PR DESCRIPTION
The concept of conventions is deprecated.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>