### PR TITLE
fossid-webapp: Make the timeout for FossID connections configurable

### DIFF
--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -119,6 +119,7 @@ ort {
 
         deltaScans = "true"
         deltaScanLimit = "10"
+        timeout = "60"
       }
     }
 

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -94,9 +94,6 @@ class FossId internal constructor(
         @JvmStatic
         private val WAIT_INTERVAL_MS = 10000L
 
-        @JvmStatic
-        private val WAIT_REPETITION = 360
-
         /**
          * The scan states for which a scan can be triggered.
          */
@@ -572,7 +569,7 @@ class FossId internal constructor(
      * Wait until the repository of a scan with [scanCode] has been downloaded.
      */
     private suspend fun waitDownloadComplete(scanCode: String) {
-        val result = wait(WAIT_INTERVAL_MS * WAIT_REPETITION, WAIT_INTERVAL_MS) {
+        val result = wait(config.timeout * 60000L, WAIT_INTERVAL_MS) {
             FossId.log.info { "Checking download status for scan '$scanCode'." }
 
             val response = service.checkDownloadStatus(config.user, config.apiKey, scanCode)
@@ -600,7 +597,7 @@ class FossId internal constructor(
      * Wait until a scan with [scanCode] has completed.
      */
     private suspend fun waitScanComplete(scanCode: String) {
-        val result = wait(WAIT_INTERVAL_MS * WAIT_REPETITION, WAIT_INTERVAL_MS) {
+        val result = wait(config.timeout * 60000L, WAIT_INTERVAL_MS) {
             FossId.log.info { "Waiting for scan '$scanCode' to complete." }
 
             val response = service.checkScanStatus(config.user, config.apiKey, scanCode)

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
@@ -80,6 +80,9 @@ internal data class FossIdConfig(
     /** A maximum number of delta scans to keep for a single repository. */
     val deltaScanLimit: Int,
 
+    /** Timeout in minutes for communication with FossID. */
+    val timeout: Int,
+
     /** Stores the map with FossID-specific configuration options. */
     private val options: Map<String, String>
 ) {
@@ -117,10 +120,19 @@ internal data class FossIdConfig(
         /** Name of the configuration property that limits the number of delta scans. */
         private const val DELTA_SCAN_LIMIT_PROPERTY = "deltaScanLimit"
 
+        /** Name of the configuration property defining the timeout in minutes for communication with FossID. */
+        private const val TIMEOUT = "timeout"
+
         /**
          * The scanner options beginning with this prefix will be used to parametrize project and scan names.
          */
         private const val NAMING_CONVENTION_VARIABLE_PREFIX = "namingVariable"
+
+        /**
+         * Default timeout in minutes for communication with FossID.
+         */
+        @JvmStatic
+        private val DEFAULT_TIMEOUT = 60
 
         fun create(scannerConfig: ScannerConfiguration): FossIdConfig {
             val fossIdScannerOptions = scannerConfig.options?.get("FossId")
@@ -140,6 +152,9 @@ internal data class FossIdConfig(
             val deltaScans = fossIdScannerOptions[DELTA_SCAN_PROPERTY]?.toBoolean() ?: false
 
             val deltaScanLimit = fossIdScannerOptions[DELTA_SCAN_LIMIT_PROPERTY]?.toInt() ?: Int.MAX_VALUE
+
+            val timeout = fossIdScannerOptions[TIMEOUT]?.toInt() ?: DEFAULT_TIMEOUT
+
             require(deltaScanLimit > 0) {
                 "deltaScanLimit must be > 0, current value is $deltaScanLimit."
             }
@@ -156,6 +171,7 @@ internal data class FossIdConfig(
                 addAuthenticationToUrl,
                 deltaScans,
                 deltaScanLimit,
+                timeout,
                 fossIdScannerOptions
             )
         }

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
@@ -52,6 +52,7 @@ class FossIdConfigTest : WordSpec({
                 "waitForResult" to "false",
                 "deltaScans" to "true",
                 "deltaScanLimit" to "42",
+                "timeout" to "300",
                 "addAuthenticationToUrl" to "false"
             )
             val scannerConfig = options.toScannerConfig()
@@ -68,6 +69,7 @@ class FossIdConfigTest : WordSpec({
                 deltaScans = true,
                 deltaScanLimit = 42,
                 addAuthenticationToUrl = false,
+                timeout = 300,
                 options = options
             )
         }
@@ -92,6 +94,7 @@ class FossIdConfigTest : WordSpec({
                 deltaScans = false,
                 deltaScanLimit = Int.MAX_VALUE,
                 addAuthenticationToUrl = false,
+                timeout = 60,
                 options = options
             )
         }

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -642,7 +642,7 @@ private fun createConfig(
     val config = FossIdConfig(
         "https://www.example.org/fossid",
         API_KEY, USER, waitForResult, packageNamespaceFilter, packageAuthorsFilter, addAuthenticationToUrl = false,
-        deltaScans, deltaScanLimit, emptyMap()
+        deltaScans, deltaScanLimit, 60, emptyMap()
     )
 
     val service = createServiceMock()


### PR DESCRIPTION
When ORT waits for FossID scan to complete, the current timeout is
hardcoded and is set to one hour.
We have some FossID scans lasting for longer therefore the timeout needs
to be configurable.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>

