### PR TITLE
 EvaluatedModel: Add some statistics about the repository configuration

### DIFF
--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -843,6 +843,14 @@
     "resolutions" : [ ]
   } ],
   "statistics" : {
+    "repository_configuration" : {
+      "path_excludes" : 2,
+      "scope_exclude" : 1,
+      "license_choices" : 2,
+      "license_finding_curations" : 0,
+      "rule_violation_resolutions" : 1,
+      "issue_resolutions" : 0
+    },
     "open_issues" : {
       "errors" : 1,
       "warnings" : 0,

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -766,6 +766,13 @@ vulnerabilities:
     severity: "ERROR"
   resolutions: []
 statistics:
+  repository_configuration:
+    path_excludes: 2
+    scope_exclude: 1
+    license_choices: 2
+    license_finding_curations: 0
+    rule_violation_resolutions: 1
+    issue_resolutions: 0
   open_issues:
     errors: 1
     warnings: 0

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/Statistics.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/Statistics.kt
@@ -29,11 +29,22 @@ import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.model.config.IssueResolution
+import org.ossreviewtoolkit.model.config.LicenseChoices
+import org.ossreviewtoolkit.model.config.LicenseFindingCuration
+import org.ossreviewtoolkit.model.config.PathExclude
+import org.ossreviewtoolkit.model.config.RuleViolationResolution
+import org.ossreviewtoolkit.model.config.ScopeExclude
 
 /**
  * A class containing statistics for an [OrtResult].
  */
 data class Statistics(
+    /**
+     * Statistics for the repository configuration.
+     */
+    val repositoryConfiguration: RepositoryConfigurationStatistics,
+
     /**
      * The number of [OrtIssue]s by severity which are not resolved and not excluded.
      */
@@ -133,4 +144,39 @@ data class LicenseStatistics(
      * All detected licenses, mapped to the number of [Project]s and [Package]s they were detected in.
      */
     val detected: SortedMap<String, Int>
+)
+
+/**
+ * A class containing statistics about the repository configuration
+ */
+data class RepositoryConfigurationStatistics(
+    /**
+     * The number of [PathExclude]s.
+     */
+    val pathExcludes: Int,
+
+    /**
+     * The number of [ScopeExclude]s.
+     */
+    val scopeExclude: Int,
+
+    /**
+     * The number of [LicenseChoices].
+     */
+    val licenseChoices: Int,
+
+    /**
+     * The number of [LicenseFindingCuration]s.
+     */
+    val licenseFindingCurations: Int,
+
+    /**
+     * The number of [RuleViolationResolution]s.
+     */
+    val ruleViolationResolutions: Int,
+
+    /**
+     * The number of [IssueResolution]s.
+     */
+    val issueResolutions: Int
 )

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/StatisticsCalculator.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/StatisticsCalculator.kt
@@ -42,6 +42,7 @@ internal class StatisticsCalculator {
         resolutionProvider: ResolutionProvider,
         licenseInfoResolver: LicenseInfoResolver
     ) = Statistics(
+        repositoryConfiguration = getRepositoryConfigurationStatistics(ortResult),
         openIssues = getOpenIssues(ortResult, resolutionProvider),
         openRuleViolations = getOpenRuleViolations(ortResult, resolutionProvider),
         dependencyTree = DependencyTreeStatistics(
@@ -129,6 +130,21 @@ internal class StatisticsCalculator {
         return LicenseStatistics(
             declared = declaredLicenses,
             detected = detectedLicenses
+        )
+    }
+
+    private fun getRepositoryConfigurationStatistics(ortResult: OrtResult): RepositoryConfigurationStatistics {
+        val config = ortResult.repository.config
+
+        return RepositoryConfigurationStatistics(
+            pathExcludes = config.excludes.paths.size,
+            scopeExclude = config.excludes.scopes.size,
+            licenseChoices = config.licenseChoices.let {
+                it.packageLicenseChoices.size + it.repositoryLicenseChoices.size
+            },
+            licenseFindingCurations = config.curations.licenseFindings.size,
+            ruleViolationResolutions = config.resolutions.ruleViolations.size,
+            issueResolutions = config.resolutions.issues.size
         )
     }
 }

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/StatisticsCalculator.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/StatisticsCalculator.kt
@@ -30,7 +30,7 @@ import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.model.utils.ResolutionProvider
 
 /**
- * This class calculates [Statistics] for a given [OrtResult] and applicable [IssueResolution]s and applicable
+ * This class calculates [Statistics] for a given [OrtResult] and the applicable [IssueResolution]s and
  * [RuleViolationResolution]s.
  */
 internal class StatisticsCalculator {


### PR DESCRIPTION
Can be useful as an overview and as input for a simple heuristic
which guesses whether there was a significant change in-between two
revisions of a repository configuration.