### PR TITLE
The rationale behind this helper command is the need to 'condense' th…

### DIFF
--- a/helper-cli/src/main/kotlin/HelperMain.kt
+++ b/helper-cli/src/main/kotlin/HelperMain.kt
@@ -41,6 +41,7 @@ import org.ossreviewtoolkit.helper.commands.ListLicensesCommand
 import org.ossreviewtoolkit.helper.commands.ListPackagesCommand
 import org.ossreviewtoolkit.helper.commands.ListStoredScanResultsCommand
 import org.ossreviewtoolkit.helper.commands.MapCopyrightsCommand
+import org.ossreviewtoolkit.helper.commands.MergeAnalyzerResultsCommand
 import org.ossreviewtoolkit.helper.commands.MergeRepositoryConfigurationsCommand
 import org.ossreviewtoolkit.helper.commands.SetDependencyRepresentationCommand
 import org.ossreviewtoolkit.helper.commands.SetLabelsCommand
@@ -86,6 +87,7 @@ internal class HelperMain : CliktCommand(name = ORTH_NAME, epilog = "* denotes r
             ListPackagesCommand(),
             ListStoredScanResultsCommand(),
             MapCopyrightsCommand(),
+            MergeAnalyzerResultsCommand(),
             MergeRepositoryConfigurationsCommand(),
             PackageConfigurationCommand(),
             PackageCurationsCommand(),

--- a/helper-cli/src/main/kotlin/commands/MergeAnalyzerResultsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/MergeAnalyzerResultsCommand.kt
@@ -1,0 +1,283 @@
+/*
+ * Copyright (C) 2021 Porsche AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.options.split
+import com.github.ajalt.clikt.parameters.types.file
+
+import java.io.File
+import java.time.Clock
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.util.LinkedList
+import java.util.HashMap
+import java.util.SortedMap
+import java.util.SortedSet
+import java.util.TreeMap
+import java.util.TreeSet
+
+import org.ossreviewtoolkit.model.AnalyzerResult
+import org.ossreviewtoolkit.model.AnalyzerRun
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.PackageReference
+import org.ossreviewtoolkit.model.Project
+import org.ossreviewtoolkit.model.Repository
+import org.ossreviewtoolkit.model.Scope
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
+import org.ossreviewtoolkit.model.config.Curations
+import org.ossreviewtoolkit.model.config.Excludes
+import org.ossreviewtoolkit.model.config.LicenseChoices
+import org.ossreviewtoolkit.model.config.RepositoryConfiguration
+import org.ossreviewtoolkit.model.config.Resolutions
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.writeValue
+import org.ossreviewtoolkit.utils.common.expandTilde
+import org.ossreviewtoolkit.utils.core.Environment
+
+class MergeAnalyzerResultsCommand : CliktCommand(
+    help = "Read multiple analyzer result files and merge them into one combined analyzer result file."
+) {
+    companion object {
+        private val utcClock = Clock.systemUTC()
+        private fun now(): Instant = ZonedDateTime.now(utcClock).toInstant()
+    }
+
+    private val inputAnalyzerResultFiles by option(
+        "--input-analyzer-result-files", "-i",
+        help = "A comma separated list of analyzer result files to be merged."
+    ).convert { File(it.expandTilde()).absoluteFile.normalize() }.split(",").required()
+
+    private val outputAnalyzerResultFile by option(
+        "--output-analyzer-result-file", "-o",
+        help = "The output analyer file."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    override fun run() {
+        val inputOrtResults: MutableList<AnalyzerRun> = LinkedList()
+        val inputRepositories: MutableList<Repository> = LinkedList()
+
+        inputAnalyzerResultFiles.stream()
+            .map { it.readValue<OrtResult>() }
+            .forEach {
+                it.analyzer.let { value -> inputOrtResults.add(value!!) }
+                inputRepositories.add(it.repository)
+            }
+
+        val analyzerRun = AnalyzerRun(
+            startTime = now(),
+            endTime = now(),
+            environment = Environment(),
+            config = aggregateAnalyzerConfiguration(inputOrtResults),
+            result = aggregrateAnalyzerRun(inputOrtResults)
+        )
+
+        val repository = Repository(
+            vcs = analyzerRun.result.projects.first().vcs,
+            vcsProcessed = analyzerRun.result.projects.first().vcsProcessed,
+            config = aggregateRepositoryConfigurations(inputRepositories)
+        )
+
+        val outputFile = OrtResult(
+            repository = repository,
+            analyzer = analyzerRun
+        )
+
+        outputAnalyzerResultFile.writeValue(outputFile)
+    }
+
+    private fun aggregateRepositoryConfigurations(repositories: List<Repository>): RepositoryConfiguration {
+        fun mergeExcludes(leftExlcudes: Excludes, rightExcludes: Excludes): Excludes = Excludes(
+            paths = (leftExlcudes.paths + rightExcludes.paths).distinct(),
+            scopes = (leftExlcudes.scopes + rightExcludes.scopes).distinct()
+        )
+
+        fun mergeResolutions(leftResolutions: Resolutions, rightResolutions: Resolutions): Resolutions =
+            Resolutions(
+                issues = (leftResolutions.issues + rightResolutions.issues).distinct(),
+                ruleViolations = (leftResolutions.ruleViolations + rightResolutions.ruleViolations).distinct(),
+                vulnerabilities = (leftResolutions.vulnerabilities + rightResolutions.vulnerabilities).distinct()
+            )
+
+        fun mergeCurations(leftCurations: Curations, rightCurations: Curations): Curations =
+            Curations(
+                licenseFindings = (leftCurations.licenseFindings + rightCurations.licenseFindings).distinct()
+            )
+
+        fun mergeLicenseChoices(leftChoices: LicenseChoices, rightChoices: LicenseChoices): LicenseChoices =
+            LicenseChoices(
+                repositoryLicenseChoices = (leftChoices.repositoryLicenseChoices
+                        + rightChoices.repositoryLicenseChoices).distinct(),
+                packageLicenseChoices = (leftChoices.packageLicenseChoices
+                        + rightChoices.packageLicenseChoices).distinct()
+            )
+
+        return repositories.stream()
+            .map { it.config }
+            .reduce { leftConfig, rightConfig ->
+                RepositoryConfiguration(
+                    excludes = mergeExcludes(leftConfig.excludes, rightConfig.excludes),
+                    resolutions = mergeResolutions(leftConfig.resolutions, rightConfig.resolutions),
+                    curations = mergeCurations(leftConfig.curations, rightConfig.curations),
+                    licenseChoices = mergeLicenseChoices(leftConfig.licenseChoices, rightConfig.licenseChoices)
+                )
+            }
+            .orElse(RepositoryConfiguration())
+    }
+
+    private fun aggregateAnalyzerConfiguration(inputOrtResults: List<AnalyzerRun>): AnalyzerConfiguration {
+        return inputOrtResults.stream()
+            .map { it.config }
+            .reduce { a, b ->
+                AnalyzerConfiguration(
+                    ignoreToolVersions = a.ignoreToolVersions or b.ignoreToolVersions,
+                    allowDynamicVersions = a.allowDynamicVersions or b.allowDynamicVersions
+                )
+            }.orElse(AnalyzerConfiguration(ignoreToolVersions = false, allowDynamicVersions = false))
+    }
+
+    private fun aggregrateAnalyzerRun(inputOrtResults: List<AnalyzerRun>): AnalyzerResult {
+        return inputOrtResults.stream()
+            .map { it.result }
+            .reduce { leftResult, rightResult ->
+                AnalyzerResult(
+                    projects = wrapValueInSortedSet(
+                        mergeProjects(
+                            mergeSortedSets(
+                                leftResult.projects,
+                                rightResult.projects
+                            )
+                        )
+                    ),
+                    packages = mergeSortedSets(leftResult.packages, rightResult.packages),
+                    issues = mergeIssues(leftResult.issues, rightResult.issues)
+                )
+            }.orElse(AnalyzerResult.EMPTY)
+    }
+
+    private fun <T> mergeSortedSets(left: SortedSet<T>, right: SortedSet<T>): SortedSet<T> {
+        val set = TreeSet<T>()
+
+        set.addAll(left)
+        set.addAll(right)
+
+        return set
+    }
+
+    private fun mergeIssues(
+        left: SortedMap<Identifier, List<OrtIssue>>,
+        right: SortedMap<Identifier, List<OrtIssue>>
+    ): SortedMap<Identifier, List<OrtIssue>> {
+        val result = TreeMap<Identifier, List<OrtIssue>>()
+
+        result.putAll(left)
+
+        right.forEach { identifier, issuesList ->
+            val mergedList = LinkedList<OrtIssue>()
+
+            result.get(identifier)?.let { mergedList.addAll(it) }
+            mergedList.addAll(issuesList)
+
+            result.put(identifier, mergedList)
+        }
+
+        return result
+    }
+
+    private fun mergeProjects(projects: SortedSet<Project>): Project = projects
+        .stream()
+        .reduce { leftProject, rightProject ->
+            Project(
+                id = if (leftProject.id != Identifier.EMPTY) leftProject.id else rightProject.id,
+                definitionFilePath = firstNotEmptyString(
+                    leftProject.definitionFilePath,
+                    rightProject.definitionFilePath
+                ),
+                authors = mergeSortedSets(leftProject.authors, rightProject.authors),
+                declaredLicenses = mergeSortedSets(leftProject.declaredLicenses, rightProject.declaredLicenses),
+                vcs = if (leftProject.vcs != VcsInfo.EMPTY) leftProject.vcs else rightProject.vcs,
+                homepageUrl = firstNotEmptyString(leftProject.homepageUrl, rightProject.homepageUrl),
+                scopeDependencies = mergeScopes(leftProject.scopes, rightProject.scopes)
+            )
+        }.orElse(Project.EMPTY)
+
+    private fun mergeScopes(leftScopes: SortedSet<Scope>, rightScopes: SortedSet<Scope>): SortedSet<Scope> {
+        val scopeMap = HashMap<String, Scope>()
+
+        leftScopes.forEach { scope -> scopeMap.put(scope.name, scope) }
+
+        rightScopes.forEach { scope ->
+            scopeMap.merge(scope.name, scope,
+                { left, right ->
+                    Scope(
+                        name = left.name,
+                        dependencies = mergeSortedSets(
+                            flattenDepdendencies(left.dependencies),
+                            flattenDepdendencies(right.dependencies)
+                        )
+                    )
+                })
+        }
+
+        val resultScopes = TreeSet<Scope>()
+
+        resultScopes.addAll(scopeMap.values)
+
+        return resultScopes
+    }
+
+    private fun <T : Comparable<T>> wrapValueInSortedSet(value: T): SortedSet<T> {
+        val set = TreeSet<T>()
+
+        set.add(value)
+
+        return set
+    }
+
+    private fun firstNotEmptyString(left: String, right: String) = left.ifEmpty { right }
+
+    private fun flattenDepdendencies(dependencyTrees: SortedSet<PackageReference>): SortedSet<PackageReference> {
+        fun flattenDependenciesInternal(treeNode: PackageReference): SortedSet<PackageReference> {
+            val resultSet = TreeSet<PackageReference>()
+
+            resultSet.add(treeNode)
+
+            treeNode.dependencies.forEach { dependency -> resultSet.addAll(flattenDependenciesInternal(dependency)) }
+            treeNode.dependencies.clear()
+
+            return resultSet
+        }
+
+        val resultSet = TreeSet<PackageReference>()
+
+        dependencyTrees.forEach { dependency -> resultSet.addAll(flattenDependenciesInternal(dependency)) }
+
+        return resultSet
+    }
+}


### PR DESCRIPTION
…e analyzer result files

delivered by multiple product teams into one summary analyzer result to be processed by the
ORT pipeline.
In this specific use case, the exact relationship of dependencies does not matter and it is
totally acceptable to work with a flat list of dependencies in the result reports.

This commit extends the helper CLI with a command to merge multiple analyzer result files into
one analyzer result file.

The algorithm to condense the result file work the following way:
1. Take the first and second item from the input list of analyzer result files
2. Flatten the dependency tree per scope in an analyzer result into a simple list of dependencies, thus already eliminating eventual duplicates
3. Merge VCS info, repository configurations   and dependency lists
4. Put the result analyzer result back in the first position of the analyzer result files list
5. Repeat with Step 1 unless the analyzer result file list contains only one entry

After the merge, the resulting VCS info of the only analyzer result is patched into the top-level VCS info for the overall project

Signed-Off: Rainer Bieniek <extern.rainer.bieniek@porsche.de>
