### PR TITLE
#4699: analyzer/npm :: Add usage of --ignore-scripts parameter to "npm ci" in order to prevent unnecessary and risky script execution

### DIFF
--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -649,7 +649,7 @@ open class Npm(
 
         // Install all NPM dependencies to enable NPM to list dependencies.
         if (hasLockFile(workingDir) && this::class.java == Npm::class.java) {
-            run(workingDir, "ci")
+            run(workingDir, "ci", *installParameters)
         } else {
             run(workingDir, "install", *installParameters)
         }


### PR DESCRIPTION
PR attempts to use `--ignore-scripts` parameter also in `npm ci` cases, not only for `npm install`.
(cmp. #4699 for respective issue description)