### PR TITLE
WindowsAnalyzerTest: Shorten the temporary directory paths (fixes `PipenvFunTest`)

### DIFF
--- a/.azure-pipelines/WindowsAnalyzerTest.yml
+++ b/.azure-pipelines/WindowsAnalyzerTest.yml
@@ -105,7 +105,7 @@ jobs:
     inputs:
       gradleWrapperFile: gradlew.bat
       # TODO: Only exclude ExpensiveTag on PR builds.
-      options: --no-daemon --stacktrace -x reporter-web-app:yarnBuild -Dkotest.tags.exclude=ExpensiveTag -Dkotest.assertions.multi-line-diff=simple -PbuildCacheRetentionDays=3
+      options: --no-daemon --stacktrace -x reporter-web-app:yarnBuild -Djava.io.tmpdir=C:/temp -Dkotest.tags.exclude=ExpensiveTag -Dkotest.assertions.multi-line-diff=simple -PbuildCacheRetentionDays=3
       tasks: analyzer:test analyzer:funTest
       publishJUnitResults: true
       testResultsFiles: '**/flattened/TEST-*.xml'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -282,6 +282,7 @@ subprojects {
             val testSystemProperties = mutableListOf("gradle.build.dir" to project.buildDir.path)
 
             listOf(
+                "java.io.tmpdir",
                 "kotest.assertions.multi-line-diff",
                 "kotest.tags.include",
                 "kotest.tags.exclude"


### PR DESCRIPTION
This makes `PipenvFunTest` on Azure pass again, which (for whatever
reason) recently started to use a very long temporary directory path
with a duplicated user home directory, like

'C:\\\\Users\\\\VssAdministrator\\\\AppData\\\\Local\\\\Temp\\\\pip-uninstall-539z9bgr\\\\users\\\\vssadministrator\\\\appdata\\\\local\\\\temp\\\\ort-pipenv-python3-virtualenv16189861807346217886\\\\lib\\\\\site-packages\\\\pip\\\\_vendor\\\\urllib3\\\\packages\\\\ssl_match_hostname\\\\__pycache__\\\\__init__.cpython-39.pyc'

The shortending is achieved by setting the JVM's `java.io.tmpdir` system
property to some short path, and ensuring the property to be passed on
to the separate JVM that runs the tests.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>