### PR TITLE
Disable running detekt as part of Lift

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -2,7 +2,8 @@
 
 jdk11 = true
 
-ignoreRules = [ "SpreadOperator" ]
+disableTools = [ "detekt" ]
+
 ignoreFiles = """
 **/funTest/assets/
 **/funTest/resources/


### PR DESCRIPTION
Detekt is already run separately, and this way detekt's "SpreadOperator"
rule does not need to be disabled via Lift.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>