### PR TITLE
Use runCatching for catching generic exceptions

### DIFF
--- a/advisor/src/main/kotlin/advisors/VulnerableCode.kt
+++ b/advisor/src/main/kotlin/advisors/VulnerableCode.kt
@@ -65,15 +65,14 @@ class VulnerableCode(name: String, vulnerableCodeConfiguration: VulnerableCodeCo
     override suspend fun retrievePackageFindings(packages: List<Package>): Map<Package, List<AdvisorResult>> {
         val startTime = Instant.now()
 
-        @Suppress("TooGenericExceptionCaught")
-        return try {
+        return runCatching {
             mutableMapOf<Package, List<AdvisorResult>>().also {
                 packages.chunked(BULK_FETCH_SIZE).forEach { pkg ->
                     it += loadVulnerabilities(pkg, startTime)
                 }
             }
-        } catch (e: Exception) {
-            createFailedResults(startTime, packages, e)
+        }.getOrElse {
+            createFailedResults(startTime, packages, it)
         }
     }
 

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -238,15 +238,14 @@ abstract class PackageManager(
             log.info { "Resolving $managerName dependencies for '$relativePath'..." }
 
             val duration = measureTime {
-                @Suppress("TooGenericExceptionCaught")
-                try {
+                runCatching {
                     result[definitionFile] = resolveDependencies(definitionFile, labels)
-                } catch (e: Exception) {
-                    e.showStackTrace()
+                }.onFailure {
+                    it.showStackTrace()
 
                     // In case of Maven we might be able to do better than inferring the name from the path.
-                    val id = if (e is ProjectBuildingException && e.projectId?.isEmpty() == false) {
-                        Identifier("Maven:${e.projectId}")
+                    val id = if (it is ProjectBuildingException && it.projectId?.isEmpty() == false) {
+                        Identifier("Maven:${it.projectId}")
                     } else {
                         Identifier.EMPTY.copy(type = managerName, name = relativePath)
                     }
@@ -263,7 +262,7 @@ abstract class PackageManager(
                         createAndLogIssue(
                             source = managerName,
                             message = "Resolving $managerName dependencies for '$relativePath' failed with: " +
-                                    e.collectMessagesAsString()
+                                    it.collectMessagesAsString()
                         )
                     )
 

--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -541,16 +541,15 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
 
                 val transporter = transporterProvider.newTransporter(repositorySystemSession, repository)
 
-                @Suppress("TooGenericExceptionCaught")
-                val actualChecksum = try {
+                val actualChecksum = runCatching {
                     val task = GetTask(checksum.location)
                     transporter.get(task)
 
                     trimChecksumData(task.dataString)
-                } catch (e: Exception) {
-                    e.showStackTrace()
+                }.getOrElse {
+                    it.showStackTrace()
 
-                    log.warn { "Could not get checksum for '$artifact': ${e.collectMessagesAsString()}" }
+                    log.warn { "Could not get checksum for '$artifact': ${it.collectMessagesAsString()}" }
 
                     // Fall back to an empty checksum string.
                     ""

--- a/cli/src/main/kotlin/commands/RequirementsCommand.kt
+++ b/cli/src/main/kotlin/commands/RequirementsCommand.kt
@@ -47,8 +47,7 @@ class RequirementsCommand : CliktCommand(help = "Check for the command line tool
         classes.filterNot {
             Modifier.isAbstract(it.modifiers) || it.isAnonymousClass || it.isLocalClass
         }.sortedBy { it.simpleName }.forEach {
-            @Suppress("TooGenericExceptionCaught")
-            try {
+            runCatching {
                 val kotlinObject = it.kotlin.objectInstance
 
                 var category = "Other tool"
@@ -99,7 +98,7 @@ class RequirementsCommand : CliktCommand(help = "Check for the command line tool
                 if (instance.command().isNotEmpty()) {
                     allTools.getOrPut(category) { mutableListOf() } += instance
                 }
-            } catch (e: Exception) {
+            }.onFailure { e ->
                 log.error { "There was an error instantiating $it: $e." }
                 throw ProgramResult(1)
             }

--- a/utils/core/src/main/kotlin/OkHttpClientHelper.kt
+++ b/utils/core/src/main/kotlin/OkHttpClientHelper.kt
@@ -85,8 +85,7 @@ object OkHttpClientHelper {
         return OkHttpClient.Builder()
             .addNetworkInterceptor { chain ->
                 val request = chain.request()
-                @Suppress("TooGenericExceptionCaught")
-                try {
+                runCatching {
                     chain.proceed(
                         if (request.header("User-Agent") == null) {
                             request.newBuilder().header("User-Agent", Environment.ORT_USER_AGENT).build()
@@ -94,13 +93,13 @@ object OkHttpClientHelper {
                             request
                         }
                     )
-                } catch (e: Exception) {
-                    e.showStackTrace()
+                }.getOrElse {
+                    it.showStackTrace()
                     log.error {
-                        "HTTP request to '${request.url}' failed with an exception: ${e.collectMessagesAsString()}"
+                        "HTTP request to '${request.url}' failed with an exception: ${it.collectMessagesAsString()}"
                     }
 
-                    throw e
+                    throw it
                 }
             }
             .cache(cache)


### PR DESCRIPTION
Consistently use `runCatching` when catching the generic `Exception`
class to avoid having to use `@Suppress("TooGenericExceptionCaught")`.