### PR TITLE
 ImportPathExcludesCommand: Avoid requiring the source code directory

### DIFF
--- a/helper-cli/src/main/kotlin/commands/repoconfig/ImportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/repoconfig/ImportLicenseFindingCurationsCommand.kt
@@ -27,6 +27,7 @@ import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
 import org.ossreviewtoolkit.helper.common.RepositoryLicenseFindingCurations
+import org.ossreviewtoolkit.helper.common.getRepositoryPaths
 import org.ossreviewtoolkit.helper.common.mergeLicenseFindingCurations
 import org.ossreviewtoolkit.helper.common.readOrtResult
 import org.ossreviewtoolkit.helper.common.replaceLicenseFindingCurations
@@ -119,16 +120,6 @@ internal class ImportLicenseFindingCurationsCommand : CliktCommand(
 
         return result
     }
-}
-
-private fun OrtResult.getRepositoryPaths(): Map<String, Set<String>> {
-    val result = mutableMapOf<String, MutableSet<String>>()
-
-    repository.nestedRepositories.mapValues { (path, vcsInfo) ->
-        result.getOrPut(vcsInfo.url) { mutableSetOf() } += path
-    }
-
-    return result
 }
 
 private fun OrtResult.getLicenseFindingsForAllProjects(): Set<LicenseFinding> {

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -937,7 +937,7 @@ internal fun writeOrtResult(ortResult: OrtResult, file: File): Unit = file.write
  * tree.
  */
 internal fun OrtResult.getRepositoryPaths(): Map<String, Set<String>> {
-    val result = mutableMapOf<String, MutableSet<String>>()
+    val result = mutableMapOf(repository.vcsProcessed.url to mutableSetOf(""))
 
     repository.nestedRepositories.mapValues { (path, vcsInfo) ->
         result.getOrPut(vcsInfo.url) { mutableSetOf() } += path

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -862,9 +862,13 @@ private fun createBlockYamlMapper(): ObjectMapper =
         .disable(YAMLGenerator.Feature.SPLIT_LINES)
         .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
 
-internal fun importPathExcludes(sourceCodeDir: File, pathExcludesFile: File): List<PathExclude> {
-    println("Analyzing $sourceCodeDir...")
-    val repositoryPaths = findRepositoryPaths(sourceCodeDir)
+internal fun importPathExcludes(ortResult: OrtResult, pathExcludesFile: File): List<PathExclude> =
+    importPathExcludes(ortResult.getRepositoryPaths(), pathExcludesFile)
+
+internal fun importPathExcludes(sourceCodeDir: File, pathExcludesFile: File): List<PathExclude> =
+    importPathExcludes(findRepositoryPaths(sourceCodeDir), pathExcludesFile)
+
+private fun importPathExcludes(repositoryPaths: Map<String, Set<String>>, pathExcludesFile: File): List<PathExclude> {
     println("Found ${repositoryPaths.size} repositories in ${repositoryPaths.values.sumOf { it.size }} locations.")
 
     println("Loading $pathExcludesFile...")

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -931,3 +931,17 @@ internal fun readOrtResult(ortFile: File): OrtResult = ortFile.readValue<OrtResu
  * Write the [ortResult] to [file].
  */
 internal fun writeOrtResult(ortResult: OrtResult, file: File): Unit = file.writeValue(ortResult)
+
+/**
+ * Return the URLs of the analyzed repository and its nested repository associated with their path(s) in the source
+ * tree.
+ */
+internal fun OrtResult.getRepositoryPaths(): Map<String, Set<String>> {
+    val result = mutableMapOf<String, MutableSet<String>>()
+
+    repository.nestedRepositories.mapValues { (path, vcsInfo) ->
+        result.getOrPut(vcsInfo.url) { mutableSetOf() } += path
+    }
+
+    return result
+}


### PR DESCRIPTION
Cloning for some projects is time consuming. So, match the path excludes
against the finding locations within the given ORT file in order to
speed-up that workflow.

Note: Excludes which don't match any finding won't get imported anymore.
That's not critical because such path excludes anyway don't have any
effect. Since ORT files will likely be extended to contain a full
listing of all scanned files in the future, it will be possible to
implement the same behavior as before this change.