### PR TITLE
AnalyzerConfiguration: Fix-up the removal of 'ignore_tool_versions'

### DIFF
--- a/model/src/main/kotlin/config/AnalyzerConfiguration.kt
+++ b/model/src/main/kotlin/config/AnalyzerConfiguration.kt
@@ -20,8 +20,10 @@
 
 package org.ossreviewtoolkit.model.config
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 
+@JsonIgnoreProperties(value = ["ignore_tool_versions"]) // Backwards compatibility.
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class AnalyzerConfiguration(
     /**


### PR DESCRIPTION
Allow de-serializing analyzer results created prior to the removal of
that property, see also 97eca89064f6e82ee9e605e242c0a7b556e24ff9.