### PR TITLE
Gradle: Explicitly add Maven Central as a repository for the Dokka plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,13 @@
  */
 
 pluginManagement {
+    repositories {
+        gradlePluginPortal()
+
+        // For Dokka, see https://github.com/Kotlin/dokka/issues/1918.
+        mavenCentral()
+    }
+
     resolutionStrategy {
         eachPlugin {
             // Work around https://github.com/gradle/gradle/issues/1697.


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>