### PR TITLE
Experimental scanner: Add provenance storages

### DIFF
--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -72,6 +72,7 @@ import org.ossreviewtoolkit.scanner.experimental.DefaultPackageProvenanceResolve
 import org.ossreviewtoolkit.scanner.experimental.DefaultProvenanceDownloader
 import org.ossreviewtoolkit.scanner.experimental.DefaultWorkingTreeCache
 import org.ossreviewtoolkit.scanner.experimental.ExperimentalScanner
+import org.ossreviewtoolkit.scanner.experimental.FileBasedNestedProvenanceStorage
 import org.ossreviewtoolkit.scanner.experimental.FileBasedPackageProvenanceStorage
 import org.ossreviewtoolkit.scanner.experimental.ProvenanceBasedFileStorage
 import org.ossreviewtoolkit.scanner.experimental.ProvenanceBasedPostgresStorage
@@ -312,6 +313,9 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
         val packageProvenanceStorage = FileBasedPackageProvenanceStorage(
             LocalFileStorage(ortDataDirectory.resolve("$TOOL_NAME/package_provenance"))
         )
+        val nestedProvenanceStorage = FileBasedNestedProvenanceStorage(
+            LocalFileStorage(ortDataDirectory.resolve("$TOOL_NAME/nested_provenance"))
+        )
         val workingTreeCache = DefaultWorkingTreeCache()
 
         try {
@@ -325,7 +329,7 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
                     packageProvenanceStorage,
                     workingTreeCache
                 ),
-                nestedProvenanceResolver = DefaultNestedProvenanceResolver(workingTreeCache),
+                nestedProvenanceResolver = DefaultNestedProvenanceResolver(nestedProvenanceStorage, workingTreeCache),
                 scannerWrappers = listOf(scannerWrapper)
             )
 

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -23,7 +23,6 @@ val hikariVersion: String by project
 val hopliteVersion: String by project
 val jacksonVersion: String by project
 val jsonSchemaValidatorVersion: String by project
-val postgresEmbeddedVersion: String by project
 val postgresVersion: String by project
 val mockkVersion: String by project
 val semverVersion: String by project
@@ -56,6 +55,5 @@ dependencies {
     implementation("org.postgresql:postgresql:$postgresVersion")
 
     testImplementation("com.networknt:json-schema-validator:$jsonSchemaValidatorVersion")
-    testImplementation("com.opentable.components:otj-pg-embedded:$postgresEmbeddedVersion")
     testImplementation("io.mockk:mockk:$mockkVersion")
 }

--- a/scanner/build.gradle.kts
+++ b/scanner/build.gradle.kts
@@ -24,7 +24,6 @@ val jacksonVersion: String by project
 val kotlinxCoroutinesVersion: String by project
 val mockkVersion: String by project
 val postgresVersion: String by project
-val postgresEmbeddedVersion: String by project
 val retrofitVersion: String by project
 val scancodeVersion: String by project
 val sw360ClientVersion: String by project
@@ -68,8 +67,6 @@ dependencies {
 
     testImplementation("com.github.tomakehurst:wiremock:$wiremockVersion")
     testImplementation("io.mockk:mockk:$mockkVersion")
-
-    funTestImplementation("com.opentable.components:otj-pg-embedded:$postgresEmbeddedVersion")
 }
 
 buildConfig {

--- a/scanner/src/funTest/kotlin/experimental/AbstractNestedProvenanceStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/AbstractNestedProvenanceStorageFunTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.test.TestCase
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
+
+abstract class AbstractNestedProvenanceStorageFunTest : WordSpec() {
+    private lateinit var storage: NestedProvenanceStorage
+
+    override fun beforeTest(testCase: TestCase) {
+        storage = createStorage()
+    }
+
+    protected abstract fun createStorage(): NestedProvenanceStorage
+
+    init {
+        "Adding a result" should {
+            "succeed" {
+                val root = createRepositoryProvenance()
+                val result = NestedProvenanceResolutionResult(createNestedProvenance(root), true)
+
+                storage.putNestedProvenance(root, result)
+
+                storage.readNestedProvenance(root) shouldBe result
+            }
+
+            "overwrite a previously stored result" {
+                val root = createRepositoryProvenance()
+                val result1 = NestedProvenanceResolutionResult(
+                    createNestedProvenance(root, mapOf("path" to root)), true
+                )
+                val result2 = NestedProvenanceResolutionResult(createNestedProvenance(root), true)
+
+                storage.putNestedProvenance(root, result1)
+                storage.putNestedProvenance(root, result2)
+
+                storage.readNestedProvenance(root) shouldBe result2
+            }
+        }
+    }
+}
+
+private fun createVcsInfo(
+    type: VcsType = VcsType.GIT,
+    url: String = "https://github.com/apache/logging-log4j2.git",
+    revision: String = "be881e503e14b267fb8a8f94b6d15eddba7ed8c4"
+) = VcsInfo(type, url, revision)
+
+private fun createRepositoryProvenance(
+    vcsInfo: VcsInfo = createVcsInfo(),
+    resolvedRevision: String = vcsInfo.revision
+) = RepositoryProvenance(vcsInfo, resolvedRevision)
+
+private fun createNestedProvenance(
+    root: KnownProvenance,
+    subRepositories: Map<String, RepositoryProvenance> = emptyMap()
+) = NestedProvenance(root, subRepositories)

--- a/scanner/src/funTest/kotlin/experimental/AbstractPackageProvenanceStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/AbstractPackageProvenanceStorageFunTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.test.TestCase
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.model.ArtifactProvenance
+import org.ossreviewtoolkit.model.Hash
+import org.ossreviewtoolkit.model.HashAlgorithm
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
+
+abstract class AbstractPackageProvenanceStorageFunTest : WordSpec() {
+    private lateinit var storage: PackageProvenanceStorage
+
+    override fun beforeTest(testCase: TestCase) {
+        storage = createStorage()
+    }
+
+    protected abstract fun createStorage(): PackageProvenanceStorage
+
+    init {
+        "Adding a result" should {
+            "succeed for an artifact result" {
+                val id = createIdentifier()
+                val sourceArtifact = createRemoteArtifact()
+                val result = ResolvedArtifactProvenance(createArtifactProvenance(sourceArtifact))
+
+                storage.putProvenance(id, sourceArtifact, result)
+
+                storage.readProvenance(id, sourceArtifact) shouldBe result
+            }
+
+            "succeed for a repository result" {
+                val id = createIdentifier()
+                val vcs = createVcsInfo()
+                val result = ResolvedRepositoryProvenance(createRepositoryProvenance(vcs), vcs.revision, true)
+
+                storage.putProvenance(id, vcs, result)
+
+                storage.readProvenance(id, vcs) shouldBe result
+            }
+
+            "succeed for a failed result" {
+                val id = createIdentifier()
+                val vcs = createVcsInfo()
+                val result = UnresolvedPackageProvenance("message")
+
+                storage.putProvenance(id, vcs, result)
+
+                storage.readProvenance(id, vcs) shouldBe result
+            }
+
+            "overwrite a previously stored result" {
+                val id = createIdentifier()
+                val vcs = createVcsInfo()
+                val result1 = UnresolvedPackageProvenance("message")
+                val result2 = ResolvedRepositoryProvenance(createRepositoryProvenance(vcs), vcs.revision, true)
+
+                storage.putProvenance(id, vcs, result1)
+                storage.putProvenance(id, vcs, result2)
+
+                storage.readProvenance(id, vcs) shouldBe result2
+            }
+        }
+    }
+}
+
+private fun createIdentifier() = Identifier("Maven:org.apache.logging.log4j:log4j-api:2.14.1")
+
+private fun createRemoteArtifact() =
+    RemoteArtifact(
+        url = "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.14.1/log4j-api-2.14.1-sources.jar",
+        hash = Hash("b2327c47ca413c1ec183575b19598e281fcd74d8", HashAlgorithm.SHA1)
+    )
+
+private fun createArtifactProvenance(sourceArtifact: RemoteArtifact) = ArtifactProvenance(sourceArtifact)
+
+private fun createVcsInfo() =
+    VcsInfo(
+        type = VcsType.GIT,
+        url = "https://github.com/apache/logging-log4j2.git",
+        revision = "be881e503e14b267fb8a8f94b6d15eddba7ed8c4"
+    )
+
+private fun createRepositoryProvenance(
+    vcsInfo: VcsInfo = createVcsInfo(),
+    resolvedRevision: String = vcsInfo.revision
+) = RepositoryProvenance(vcsInfo, resolvedRevision)

--- a/scanner/src/funTest/kotlin/experimental/DefaultNestedProvenanceResolverFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/DefaultNestedProvenanceResolverFunTest.kt
@@ -41,7 +41,7 @@ import org.ossreviewtoolkit.utils.test.containExactly
 
 class DefaultNestedProvenanceResolverFunTest : WordSpec() {
     private val workingTreeCache = DefaultWorkingTreeCache()
-    private val resolver = DefaultNestedProvenanceResolver(workingTreeCache)
+    private val resolver = DefaultNestedProvenanceResolver(DummyNestedProvenanceStorage(), workingTreeCache)
 
     override fun afterSpec(spec: Spec) {
         runBlocking { workingTreeCache.shutdown() }
@@ -207,5 +207,12 @@ class DefaultNestedProvenanceResolverFunTest : WordSpec() {
                 }
             }
         }
+    }
+}
+
+private class DummyNestedProvenanceStorage : NestedProvenanceStorage {
+    override fun readNestedProvenance(root: RepositoryProvenance): NestedProvenanceResolutionResult? = null
+    override fun putNestedProvenance(root: RepositoryProvenance, result: NestedProvenanceResolutionResult) {
+        /** no-op */
     }
 }

--- a/scanner/src/funTest/kotlin/experimental/DefaultPackageProvenanceResolverFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/DefaultPackageProvenanceResolverFunTest.kt
@@ -39,7 +39,7 @@ import org.ossreviewtoolkit.model.VcsType
 
 class DefaultPackageProvenanceResolverFunTest : WordSpec() {
     private val workingTreeCache = DefaultWorkingTreeCache()
-    private val resolver = DefaultPackageProvenanceResolver(workingTreeCache)
+    private val resolver = DefaultPackageProvenanceResolver(DummyProvenanceStorage(), workingTreeCache)
 
     private val sourceArtifactUrl =
         "https://github.com/oss-review-toolkit/ort-test-data-npm/blob/test-1.0.0/README.md"
@@ -175,4 +175,19 @@ class DefaultPackageProvenanceResolverFunTest : WordSpec() {
             }
         }
     }
+}
+
+private class DummyProvenanceStorage : PackageProvenanceStorage {
+    override fun readProvenance(id: Identifier, sourceArtifact: RemoteArtifact): PackageProvenanceResolutionResult? =
+        null
+
+    override fun readProvenance(id: Identifier, vcs: VcsInfo): PackageProvenanceResolutionResult? = null
+
+    override fun putProvenance(id: Identifier, vcs: VcsInfo, result: PackageProvenanceResolutionResult) { /** no-op */ }
+
+    override fun putProvenance(
+        id: Identifier,
+        sourceArtifact: RemoteArtifact,
+        result: PackageProvenanceResolutionResult
+    ) { /** no-op */ }
 }

--- a/scanner/src/funTest/kotlin/experimental/FileBasedNestedProvenanceStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/FileBasedNestedProvenanceStorageFunTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import org.ossreviewtoolkit.utils.core.storage.LocalFileStorage
+import org.ossreviewtoolkit.utils.test.createTestTempDir
+
+class FileBasedNestedProvenanceStorageFunTest : AbstractNestedProvenanceStorageFunTest() {
+    override fun createStorage(): NestedProvenanceStorage =
+        FileBasedNestedProvenanceStorage(LocalFileStorage(createTestTempDir()))
+}

--- a/scanner/src/funTest/kotlin/experimental/FileBasedPackageProvenanceStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/FileBasedPackageProvenanceStorageFunTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import org.ossreviewtoolkit.utils.core.storage.LocalFileStorage
+import org.ossreviewtoolkit.utils.test.createTestTempDir
+
+class FileBasedPackageProvenanceStorageFunTest : AbstractPackageProvenanceStorageFunTest() {
+    override fun createStorage(): PackageProvenanceStorage =
+        FileBasedPackageProvenanceStorage(LocalFileStorage(createTestTempDir()))
+}

--- a/scanner/src/funTest/kotlin/experimental/PostgresNestedProvenanceStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/PostgresNestedProvenanceStorageFunTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import com.opentable.db.postgres.embedded.EmbeddedPostgres
+
+import io.kotest.core.spec.Spec
+import io.kotest.core.test.TestCase
+
+import java.time.Duration
+
+private val PG_STARTUP_WAIT = Duration.ofSeconds(20)
+
+class PostgresNestedProvenanceStorageFunTest : AbstractNestedProvenanceStorageFunTest() {
+    private lateinit var postgres: EmbeddedPostgres
+
+    override fun beforeSpec(spec: Spec) {
+        postgres = EmbeddedPostgres.builder().setPGStartupWait(PG_STARTUP_WAIT).start()
+    }
+
+    override fun beforeTest(testCase: TestCase) {
+        postgres.postgresDatabase.connection.use { c ->
+            val s = c.createStatement()
+            s.execute("DROP SCHEMA public CASCADE")
+            s.execute("CREATE SCHEMA public")
+        }
+
+        super.beforeTest(testCase)
+    }
+
+    override fun afterSpec(spec: Spec) {
+        postgres.close()
+    }
+
+    override fun createStorage() = PostgresNestedProvenanceStorage(postgres.postgresDatabase)
+}

--- a/scanner/src/funTest/kotlin/experimental/PostgresNestedProvenanceStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/PostgresNestedProvenanceStorageFunTest.kt
@@ -19,35 +19,14 @@
 
 package org.ossreviewtoolkit.scanner.experimental
 
-import com.opentable.db.postgres.embedded.EmbeddedPostgres
-
-import io.kotest.core.spec.Spec
-import io.kotest.core.test.TestCase
-
-import java.time.Duration
-
-private val PG_STARTUP_WAIT = Duration.ofSeconds(20)
+import org.ossreviewtoolkit.utils.test.PostgresListener
 
 class PostgresNestedProvenanceStorageFunTest : AbstractNestedProvenanceStorageFunTest() {
-    private lateinit var postgres: EmbeddedPostgres
+    private val postgresListener = PostgresListener()
 
-    override fun beforeSpec(spec: Spec) {
-        postgres = EmbeddedPostgres.builder().setPGStartupWait(PG_STARTUP_WAIT).start()
+    init {
+        listener(postgresListener)
     }
 
-    override fun beforeTest(testCase: TestCase) {
-        postgres.postgresDatabase.connection.use { c ->
-            val s = c.createStatement()
-            s.execute("DROP SCHEMA public CASCADE")
-            s.execute("CREATE SCHEMA public")
-        }
-
-        super.beforeTest(testCase)
-    }
-
-    override fun afterSpec(spec: Spec) {
-        postgres.close()
-    }
-
-    override fun createStorage() = PostgresNestedProvenanceStorage(postgres.postgresDatabase)
+    override fun createStorage() = PostgresNestedProvenanceStorage(postgresListener.dataSource)
 }

--- a/scanner/src/funTest/kotlin/experimental/PostgresPackageProvenanceStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/PostgresPackageProvenanceStorageFunTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import com.opentable.db.postgres.embedded.EmbeddedPostgres
+
+import io.kotest.core.spec.Spec
+import io.kotest.core.test.TestCase
+
+import java.time.Duration
+
+private val PG_STARTUP_WAIT = Duration.ofSeconds(20)
+
+class PostgresPackageProvenanceStorageFunTest : AbstractPackageProvenanceStorageFunTest() {
+    private lateinit var postgres: EmbeddedPostgres
+
+    override fun beforeSpec(spec: Spec) {
+        postgres = EmbeddedPostgres.builder().setPGStartupWait(PG_STARTUP_WAIT).start()
+    }
+
+    override fun beforeTest(testCase: TestCase) {
+        postgres.postgresDatabase.connection.use { c ->
+            val s = c.createStatement()
+            s.execute("DROP SCHEMA public CASCADE")
+            s.execute("CREATE SCHEMA public")
+        }
+
+        super.beforeTest(testCase)
+    }
+
+    override fun afterSpec(spec: Spec) {
+        postgres.close()
+    }
+
+    override fun createStorage() = PostgresPackageProvenanceStorage(postgres.postgresDatabase)
+}

--- a/scanner/src/funTest/kotlin/experimental/PostgresPackageProvenanceStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/PostgresPackageProvenanceStorageFunTest.kt
@@ -19,35 +19,14 @@
 
 package org.ossreviewtoolkit.scanner.experimental
 
-import com.opentable.db.postgres.embedded.EmbeddedPostgres
-
-import io.kotest.core.spec.Spec
-import io.kotest.core.test.TestCase
-
-import java.time.Duration
-
-private val PG_STARTUP_WAIT = Duration.ofSeconds(20)
+import org.ossreviewtoolkit.utils.test.PostgresListener
 
 class PostgresPackageProvenanceStorageFunTest : AbstractPackageProvenanceStorageFunTest() {
-    private lateinit var postgres: EmbeddedPostgres
+    private val postgresListener = PostgresListener()
 
-    override fun beforeSpec(spec: Spec) {
-        postgres = EmbeddedPostgres.builder().setPGStartupWait(PG_STARTUP_WAIT).start()
+    init {
+        listener(postgresListener)
     }
 
-    override fun beforeTest(testCase: TestCase) {
-        postgres.postgresDatabase.connection.use { c ->
-            val s = c.createStatement()
-            s.execute("DROP SCHEMA public CASCADE")
-            s.execute("CREATE SCHEMA public")
-        }
-
-        super.beforeTest(testCase)
-    }
-
-    override fun afterSpec(spec: Spec) {
-        postgres.close()
-    }
-
-    override fun createStorage() = PostgresPackageProvenanceStorage(postgres.postgresDatabase)
+    override fun createStorage() = PostgresPackageProvenanceStorage(postgresListener.dataSource)
 }

--- a/scanner/src/funTest/kotlin/experimental/ProvenanceBasedPostgresStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/ProvenanceBasedPostgresStorageFunTest.kt
@@ -19,35 +19,14 @@
 
 package org.ossreviewtoolkit.scanner.experimental
 
-import com.opentable.db.postgres.embedded.EmbeddedPostgres
-
-import io.kotest.core.spec.Spec
-import io.kotest.core.test.TestCase
-
-import java.time.Duration
-
-private val PG_STARTUP_WAIT = Duration.ofSeconds(20)
+import org.ossreviewtoolkit.utils.test.PostgresListener
 
 class ProvenanceBasedPostgresStorageFunTest : AbstractProvenanceBasedStorageFunTest() {
-    private lateinit var postgres: EmbeddedPostgres
+    private val postgresListener = PostgresListener()
 
-    override fun beforeSpec(spec: Spec) {
-        postgres = EmbeddedPostgres.builder().setPGStartupWait(PG_STARTUP_WAIT).start()
+    init {
+        listener(postgresListener)
     }
 
-    override fun beforeTest(testCase: TestCase) {
-        postgres.postgresDatabase.connection.use { c ->
-            val s = c.createStatement()
-            s.execute("DROP SCHEMA public CASCADE")
-            s.execute("CREATE SCHEMA public")
-        }
-
-        super.beforeTest(testCase)
-    }
-
-    override fun afterSpec(spec: Spec) {
-        postgres.close()
-    }
-
-    override fun createStorage() = ProvenanceBasedPostgresStorage(postgres.postgresDatabase)
+    override fun createStorage() = ProvenanceBasedPostgresStorage(postgresListener.dataSource)
 }

--- a/scanner/src/funTest/kotlin/storages/PostgresStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/PostgresStorageFunTest.kt
@@ -19,35 +19,14 @@
 
 package org.ossreviewtoolkit.scanner.storages
 
-import com.opentable.db.postgres.embedded.EmbeddedPostgres
-
-import io.kotest.core.spec.Spec
-import io.kotest.core.test.TestCase
-
-import java.time.Duration
-
-private val PG_STARTUP_WAIT = Duration.ofSeconds(20)
+import org.ossreviewtoolkit.utils.test.PostgresListener
 
 class PostgresStorageFunTest : AbstractStorageFunTest() {
-    private lateinit var postgres: EmbeddedPostgres
+    private val postgresListener = PostgresListener()
 
-    override fun beforeSpec(spec: Spec) {
-        postgres = EmbeddedPostgres.builder().setPGStartupWait(PG_STARTUP_WAIT).start()
+    init {
+        listener(postgresListener)
     }
 
-    override fun beforeTest(testCase: TestCase) {
-        postgres.postgresDatabase.connection.use { c ->
-            val s = c.createStatement()
-            s.execute("DROP SCHEMA public CASCADE")
-            s.execute("CREATE SCHEMA public")
-        }
-
-        super.beforeTest(testCase)
-    }
-
-    override fun afterSpec(spec: Spec) {
-        postgres.close()
-    }
-
-    override fun createStorage() = PostgresStorage(postgres.postgresDatabase)
+    override fun createStorage() = PostgresStorage(postgresListener.dataSource)
 }

--- a/scanner/src/main/kotlin/experimental/FileBasedNestedProvenanceStorage.kt
+++ b/scanner/src/main/kotlin/experimental/FileBasedNestedProvenanceStorage.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import com.fasterxml.jackson.module.kotlin.readValue
+
+import java.io.ByteArrayInputStream
+import java.io.FileNotFoundException
+import java.io.IOException
+
+import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.model.yamlMapper
+import org.ossreviewtoolkit.utils.common.collectMessagesAsString
+import org.ossreviewtoolkit.utils.common.fileSystemEncode
+import org.ossreviewtoolkit.utils.core.log
+import org.ossreviewtoolkit.utils.core.showStackTrace
+import org.ossreviewtoolkit.utils.core.storage.FileStorage
+
+class FileBasedNestedProvenanceStorage(private val backend: FileStorage) : NestedProvenanceStorage {
+    override fun readNestedProvenance(root: RepositoryProvenance): NestedProvenanceResolutionResult? =
+        readResults(root).find { it.nestedProvenance.root == root }
+
+    private fun readResults(root: RepositoryProvenance): List<NestedProvenanceResolutionResult> {
+        val path = storagePath(root)
+
+        return runCatching {
+            backend.read(path).use { input ->
+                yamlMapper.readValue<List<NestedProvenanceResolutionResult>>(input)
+            }
+        }.getOrElse {
+            when (it) {
+                is FileNotFoundException -> {
+                    // If the file cannot be found it means no scan results have been stored, yet.
+                    emptyList()
+                }
+                else -> {
+                    log.info {
+                        "Could not read resolved nested provenances for '$root' from path '$path': " +
+                                it.collectMessagesAsString()
+                    }
+
+                    emptyList()
+                }
+            }
+        }
+    }
+
+    override fun putNestedProvenance(root: RepositoryProvenance, result: NestedProvenanceResolutionResult) {
+        val results = readResults(root).toMutableList()
+        results.removeAll { it.nestedProvenance.root == root }
+        results += result
+
+        val path = storagePath(root)
+        val yamlBytes = yamlMapper.writeValueAsBytes(results)
+        val input = ByteArrayInputStream(yamlBytes)
+
+        runCatching {
+            backend.write(path, input)
+            log.debug { "Stored resolved nested provenance for '$root' at path '$path'." }
+        }.onFailure {
+            when (it) {
+                is IllegalArgumentException, is IOException -> {
+                    it.showStackTrace()
+
+                    log.warn {
+                        "Could not store resolved nested provenance for '$root' at path '$path': " +
+                                it.collectMessagesAsString()
+                    }
+                }
+                else -> throw it
+            }
+        }
+    }
+}
+
+private const val FILE_NAME = "resolved_nested_provenance.yml"
+
+private fun storagePath(root: RepositoryProvenance) =
+    "${root.vcsInfo.type.toString().fileSystemEncode()}/" +
+            "${root.vcsInfo.url.fileSystemEncode()}/" +
+            "${root.resolvedRevision.fileSystemEncode()}/" +
+            FILE_NAME

--- a/scanner/src/main/kotlin/experimental/FileBasedPackageProvenanceStorage.kt
+++ b/scanner/src/main/kotlin/experimental/FileBasedPackageProvenanceStorage.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.readValue
+
+import java.io.ByteArrayInputStream
+import java.io.FileNotFoundException
+import java.io.IOException
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.yamlMapper
+import org.ossreviewtoolkit.utils.common.collectMessagesAsString
+import org.ossreviewtoolkit.utils.core.log
+import org.ossreviewtoolkit.utils.core.showStackTrace
+import org.ossreviewtoolkit.utils.core.storage.FileStorage
+
+class FileBasedPackageProvenanceStorage(val backend: FileStorage) : PackageProvenanceStorage {
+    override fun readProvenance(id: Identifier, sourceArtifact: RemoteArtifact): PackageProvenanceResolutionResult? =
+        readResults(id).find { it.sourceArtifact == sourceArtifact }?.result
+
+    override fun readProvenance(id: Identifier, vcs: VcsInfo): PackageProvenanceResolutionResult? =
+        readResults(id).find { it.vcs == vcs }?.result
+
+    private fun readResults(id: Identifier): List<StorageEntry> {
+        val path = storagePath(id)
+
+        return runCatching {
+            backend.read(path).use { input ->
+                yamlMapper.readValue<List<StorageEntry>>(input)
+            }
+        }.getOrElse {
+            when (it) {
+                is FileNotFoundException -> {
+                    // If the file cannot be found it means no scan results have been stored yet.
+                    emptyList()
+                }
+                else -> {
+                    log.info {
+                        "Could not read resolved provenances for '${id.toCoordinates()}' from path '$path': " +
+                                it.collectMessagesAsString()
+                    }
+
+                    emptyList()
+                }
+            }
+        }
+    }
+
+    override fun putProvenance(
+        id: Identifier,
+        sourceArtifact: RemoteArtifact,
+        result: PackageProvenanceResolutionResult
+    ) = putProvenance(id, sourceArtifact, null, result)
+
+    override fun putProvenance(id: Identifier, vcs: VcsInfo, result: PackageProvenanceResolutionResult) =
+        putProvenance(id, null, vcs, result)
+
+    private fun putProvenance(
+        id: Identifier,
+        sourceArtifact: RemoteArtifact?,
+        vcs: VcsInfo?,
+        result: PackageProvenanceResolutionResult
+    ) {
+        val results = readResults(id).toMutableList()
+        if (sourceArtifact != null) results.removeAll { it.sourceArtifact == sourceArtifact }
+        if (vcs != null) results.removeAll { it.vcs == vcs }
+        results += StorageEntry(sourceArtifact, vcs, result)
+
+        val path = storagePath(id)
+        val yamlBytes = yamlMapper.writeValueAsBytes(results)
+        val input = ByteArrayInputStream(yamlBytes)
+
+        runCatching {
+            backend.write(path, input)
+            log.debug { "Stored resolved provenances for '${id.toCoordinates()}' at path '$path'." }
+        }.onFailure {
+            when (it) {
+                is IllegalArgumentException, is IOException -> {
+                    it.showStackTrace()
+
+                    log.warn {
+                        "Could not store resolved provenances for '${id.toCoordinates()}' at path '$path': " +
+                                it.collectMessagesAsString()
+                    }
+                }
+                else -> throw it
+            }
+        }
+    }
+}
+
+private const val FILE_NAME = "resolved_provenance.yml"
+
+private fun storagePath(id: Identifier) = "${id.toPath()}/$FILE_NAME"
+
+private data class StorageEntry(
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val sourceArtifact: RemoteArtifact?,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val vcs: VcsInfo?,
+    val result: PackageProvenanceResolutionResult
+)

--- a/scanner/src/main/kotlin/experimental/NestedProvenance.kt
+++ b/scanner/src/main/kotlin/experimental/NestedProvenance.kt
@@ -19,6 +19,8 @@
 
 package org.ossreviewtoolkit.scanner.experimental
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
@@ -42,6 +44,7 @@ data class NestedProvenance(
     /**
      * Return a set of all contained [KnownProvenance]s.
      */
+    @JsonIgnore
     fun getProvenances(): Set<KnownProvenance> =
         subRepositories.values.toMutableSet<KnownProvenance>().also { it += root }
 }

--- a/scanner/src/main/kotlin/experimental/NestedProvenanceStorage.kt
+++ b/scanner/src/main/kotlin/experimental/NestedProvenanceStorage.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import org.ossreviewtoolkit.model.RepositoryProvenance
+
+/**
+ * A storage for resolved [NestedProvenance]s.
+ */
+interface NestedProvenanceStorage {
+    /**
+     * Return the [NestedProvenanceResolutionResult] for the [root] provenance, or null if no result was stored.
+     */
+    fun readNestedProvenance(root: RepositoryProvenance): NestedProvenanceResolutionResult?
+
+    /**
+     * Put the resolution [result] for the [root] provenance into the storage. If the storage already contains an entry
+     * for [root] it is overwritten.
+     */
+    fun putNestedProvenance(root: RepositoryProvenance, result: NestedProvenanceResolutionResult)
+}
+
+/**
+ * The result of a [NestedProvenance] resolution.
+ */
+data class NestedProvenanceResolutionResult(
+    /**
+     * The resolved [NestedProvenance].
+     */
+    val nestedProvenance: NestedProvenance,
+
+    /**
+     * True if the revisions of all [RepositoryProvenance.vcsInfo] within [nestedProvenance] are fixed revisions.
+     */
+    val hasOnlyFixedRevisions: Boolean
+)

--- a/scanner/src/main/kotlin/experimental/PackageProvenanceResolver.kt
+++ b/scanner/src/main/kotlin/experimental/PackageProvenanceResolver.kt
@@ -133,10 +133,8 @@ class DefaultPackageProvenanceResolver(
 
     private suspend fun resolveVcs(pkg: Package): RepositoryProvenance {
         // TODO: Currently the commit revision is resolved by checking out the provided revision. There are probably
-        //       probably more efficient ways to do this depending on the VCS, especially for provides like GitHub
-        //       or GitLab which provide an API. Another option to prevent downloading the same repository multiple
-        //       times would be to improve the Downloader to manage the locations of already downloaded
-        //       repositories.
+        //       probably more efficient ways to do this depending on the VCS, especially for providers like GitHub
+        //       or GitLab which provide an API.
 
         when (val storedResult = storage.readProvenance(pkg.id, pkg.vcsProcessed)) {
             is ResolvedRepositoryProvenance -> {

--- a/scanner/src/main/kotlin/experimental/PackageProvenanceStorage.kt
+++ b/scanner/src/main/kotlin/experimental/PackageProvenanceStorage.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+
+import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.model.ArtifactProvenance
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.model.VcsInfo
+
+/**
+ * A storage for the resolved [RepositoryProvenance]s of [Package]s.
+ */
+interface PackageProvenanceStorage {
+    /**
+     * Return the [PackageProvenanceResolutionResult] for the [id] and [sourceArtifact], or null if no result was
+     * stored.
+     */
+    fun readProvenance(id: Identifier, sourceArtifact: RemoteArtifact): PackageProvenanceResolutionResult?
+
+    /**
+     * Return the [PackageProvenanceResolutionResult] for the [id] and [vcs], or null if no result was stored.
+     */
+    fun readProvenance(id: Identifier, vcs: VcsInfo): PackageProvenanceResolutionResult?
+
+    /**
+     * Put the resolution [result] for the [id] and [sourceArtifact] into the storage. If the storage already contains
+     * an entry for [id] and [sourceArtifact] it is overwritten.
+     */
+    fun putProvenance(id: Identifier, sourceArtifact: RemoteArtifact, result: PackageProvenanceResolutionResult)
+
+    /**
+     * Put the resolution [result] for the [id] and [vcs] into the storage. If the storage already contains an entry
+     * for [id] and [vcs] it is overwritten.
+     */
+    fun putProvenance(id: Identifier, vcs: VcsInfo, result: PackageProvenanceResolutionResult)
+}
+
+/**
+ * The result of a package provenance resolution.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+sealed class PackageProvenanceResolutionResult
+
+/**
+ * A successful package provenance resolution result for an [ArtifactProvenance].
+ */
+data class ResolvedArtifactProvenance(
+    /**
+     * The resolved [ArtifactProvenance].
+     */
+    val provenance: ArtifactProvenance
+) : PackageProvenanceResolutionResult()
+
+/**
+ * A successful package provenance resolution result for a [RepositoryProvenance].
+ */
+data class ResolvedRepositoryProvenance(
+    /**
+     * The resolved [RepositoryProvenance].
+     */
+    val provenance: RepositoryProvenance,
+
+    /**
+     * The revision that was used for cloning. This is either the revision from the
+     * [vcsInfo][RepositoryProvenance.vcsInfo] of [provenance] or a revision candidate obtained from
+     * [VersionControlSystem.getRevisionCandidates].
+     */
+    val clonedRevision: String,
+
+    /**
+     * True if the [clonedRevision] is a fixed revision.
+     */
+    val isFixedRevision: Boolean
+) : PackageProvenanceResolutionResult()
+
+/**
+ * A failed package provenance resolution result.
+ */
+data class UnresolvedPackageProvenance(
+    /**
+     * A message that describes the error that occurred during resolution.
+     */
+    val message: String
+) : PackageProvenanceResolutionResult()

--- a/scanner/src/main/kotlin/experimental/PostgresNestedProvenanceStorage.kt
+++ b/scanner/src/main/kotlin/experimental/PostgresNestedProvenanceStorage.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import javax.sql.DataSource
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.SchemaUtils.withDataBaseLock
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+
+import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.model.utils.DatabaseUtils.checkDatabaseEncoding
+import org.ossreviewtoolkit.model.utils.DatabaseUtils.tableExists
+import org.ossreviewtoolkit.model.utils.DatabaseUtils.transaction
+import org.ossreviewtoolkit.scanner.storages.utils.jsonb
+
+class PostgresNestedProvenanceStorage(
+    /**
+     * The JDBC data source to obtain database connections.
+     */
+    private val dataSource: DataSource,
+
+    /**
+     * The name of the table used for storing nested provenances.
+     */
+    private val tableName: String = "nested_provenances"
+) : NestedProvenanceStorage {
+    private val table = NestedProvenances(tableName)
+
+    /** The [Database] instance on which all operations are executed. */
+    private val database = setupDatabase()
+
+    private fun setupDatabase(): Database =
+        Database.connect(dataSource).apply {
+            transaction {
+                withDataBaseLock {
+                    if (!tableExists(tableName)) {
+                        checkDatabaseEncoding()
+                        SchemaUtils.createMissingTablesAndColumns(table)
+                    }
+                }
+            }
+        }
+
+    override fun readNestedProvenance(root: RepositoryProvenance): NestedProvenanceResolutionResult? =
+        database.transaction {
+            table.select {
+                table.vcsType eq root.vcsInfo.type.toString() and
+                        (table.vcsUrl eq root.vcsInfo.url) and
+                        (table.vcsRevision eq root.resolvedRevision)
+            }.map { it[table.result] }.firstOrNull { it.nestedProvenance.root == root }
+        }
+
+    override fun putNestedProvenance(root: RepositoryProvenance, result: NestedProvenanceResolutionResult) {
+        database.transaction {
+            val idsToRemove = table.select {
+                table.vcsType eq root.vcsInfo.type.toString() and
+                        (table.vcsUrl eq root.vcsInfo.url) and
+                        (table.vcsRevision eq root.resolvedRevision)
+            }.filter { it[table.result].nestedProvenance.root == root }.map { it[table.id].value }
+
+            table.deleteWhere { table.id inList idsToRemove }
+
+            table.insert {
+                it[vcsType] = root.vcsInfo.type.toString()
+                it[vcsUrl] = root.vcsInfo.url
+                it[vcsRevision] = root.resolvedRevision
+                it[table.result] = result
+            }
+        }
+    }
+}
+
+private class NestedProvenances(tableName: String) : IntIdTable(tableName) {
+    val vcsType = text("vcs_type")
+    val vcsUrl = text("vcs_url")
+    val vcsRevision = text("vcs_revision")
+    val result = jsonb("result", NestedProvenanceResolutionResult::class)
+
+    init {
+        // Index to improve lookup performance.
+        index(isUnique = false, vcsType, vcsUrl, vcsRevision)
+    }
+}

--- a/scanner/src/main/kotlin/experimental/PostgresPackageProvenanceStorage.kt
+++ b/scanner/src/main/kotlin/experimental/PostgresPackageProvenanceStorage.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import javax.sql.DataSource
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.SchemaUtils.withDataBaseLock
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.utils.DatabaseUtils.checkDatabaseEncoding
+import org.ossreviewtoolkit.model.utils.DatabaseUtils.tableExists
+import org.ossreviewtoolkit.model.utils.DatabaseUtils.transaction
+import org.ossreviewtoolkit.scanner.storages.utils.jsonb
+
+class PostgresPackageProvenanceStorage(
+    /**
+     * The JDBC data source to obtain database connections.
+     */
+    private val dataSource: DataSource,
+
+    /**
+     * The name of the table used for storing package provenances.
+     */
+    private val tableName: String = "package_provenances"
+) : PackageProvenanceStorage {
+    private val table = PackageProvenances(tableName)
+
+    /** The [Database] instance on which all operations are executed. */
+    private val database = setupDatabase()
+
+    private fun setupDatabase(): Database =
+        Database.connect(dataSource).apply {
+            transaction {
+                withDataBaseLock {
+                    if (!tableExists(tableName)) {
+                        checkDatabaseEncoding()
+                        SchemaUtils.createMissingTablesAndColumns(table)
+                    }
+                }
+            }
+        }
+
+    override fun readProvenance(id: Identifier, sourceArtifact: RemoteArtifact): PackageProvenanceResolutionResult? =
+        database.transaction {
+            table.select {
+                table.identifier eq id.toCoordinates() and
+                        (table.artifactUrl eq sourceArtifact.url) and
+                        (table.artifactHash eq sourceArtifact.hash.value)
+            }.map { it[table.result] }.firstOrNull()
+        }
+
+    override fun readProvenance(id: Identifier, vcs: VcsInfo): PackageProvenanceResolutionResult? =
+        database.transaction {
+            table.select {
+                table.identifier eq id.toCoordinates() and
+                        (table.vcsType eq vcs.type.toString()) and
+                        (table.vcsUrl eq vcs.url) and
+                        (table.vcsRevision eq vcs.revision) and
+                        (table.vcsPath eq vcs.path)
+            }.map { it[table.result] }.firstOrNull()
+        }
+
+    override fun putProvenance(
+        id: Identifier,
+        sourceArtifact: RemoteArtifact,
+        result: PackageProvenanceResolutionResult
+    ) {
+        database.transaction {
+            table.deleteWhere {
+                table.identifier eq id.toCoordinates() and
+                        (table.artifactUrl eq sourceArtifact.url) and
+                        (table.artifactHash eq sourceArtifact.hash.value)
+            }
+
+            table.insert {
+                it[identifier] = id.toCoordinates()
+                it[artifactUrl] = sourceArtifact.url
+                it[artifactHash] = sourceArtifact.hash.value
+                it[table.result] = result
+            }
+        }
+    }
+
+    override fun putProvenance(id: Identifier, vcs: VcsInfo, result: PackageProvenanceResolutionResult) {
+        database.transaction {
+            table.deleteWhere {
+                table.identifier eq id.toCoordinates() and
+                        (table.vcsType eq vcs.type.toString()) and
+                        (table.vcsUrl eq vcs.url) and
+                        (table.vcsRevision eq vcs.revision) and
+                        (table.vcsPath eq vcs.path)
+            }
+
+            table.insert {
+                it[identifier] = id.toCoordinates()
+                it[vcsType] = vcs.type.toString()
+                it[vcsUrl] = vcs.url
+                it[vcsRevision] = vcs.revision
+                it[vcsPath] = vcs.path
+                it[table.result] = result
+            }
+        }
+    }
+}
+
+private class PackageProvenances(tableName: String) : IntIdTable(tableName) {
+    val identifier = text("identifier").index()
+    val artifactUrl = text("artifact_url").nullable()
+    val artifactHash = text("artifact_hash").nullable()
+    val vcsType = text("vcs_type").nullable()
+    val vcsUrl = text("vcs_url").nullable()
+    val vcsRevision = text("vcs_revision").nullable()
+    val vcsPath = text("vcs_path").nullable()
+    val result = jsonb("result", PackageProvenanceResolutionResult::class)
+
+    init {
+        // Indices to prevent duplicate entries.
+        uniqueIndex(identifier, artifactUrl, artifactHash)
+        uniqueIndex(identifier, vcsType, vcsUrl, vcsRevision, vcsPath)
+    }
+}

--- a/utils/test/build.gradle.kts
+++ b/utils/test/build.gradle.kts
@@ -21,6 +21,7 @@
 val jacksonVersion: String by project
 val kotestVersion: String by project
 val log4jCoreVersion: String by project
+val postgresEmbeddedVersion: String by project
 
 plugins {
     // Apply core plugins.
@@ -35,6 +36,7 @@ dependencies {
     api("io.kotest:kotest-framework-api:$kotestVersion")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    implementation("com.opentable.components:otj-pg-embedded:$postgresEmbeddedVersion")
     implementation("io.kotest:kotest-extensions-junitxml:$kotestVersion")
     implementation("io.kotest:kotest-framework-engine:$kotestVersion")
     implementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jCoreVersion")

--- a/utils/test/src/main/kotlin/PostgresListener.kt
+++ b/utils/test/src/main/kotlin/PostgresListener.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.utils.test
+
+import com.opentable.db.postgres.embedded.EmbeddedPostgres
+
+import io.kotest.core.listeners.TestListener
+import io.kotest.core.spec.Spec
+import io.kotest.core.test.TestCase
+
+import java.time.Duration
+
+import javax.sql.DataSource
+
+/**
+ * A [TestListener] that starts an [EmbeddedPostgres] instance before running the spec and closes it after the spec has
+ * finished. The database is cleared before each test.
+ */
+class PostgresListener(private val startupWait: Duration = Duration.ofSeconds(20)) : TestListener {
+    private lateinit var postgres: EmbeddedPostgres
+
+    val dataSource: DataSource get() = postgres.postgresDatabase
+
+    override suspend fun beforeSpec(spec: Spec) {
+        postgres = EmbeddedPostgres.builder().setPGStartupWait(startupWait).start()
+    }
+
+    override suspend fun beforeTest(testCase: TestCase) {
+        postgres.postgresDatabase.connection.use { c ->
+            val s = c.createStatement()
+            s.execute("DROP SCHEMA public CASCADE")
+            s.execute("CREATE SCHEMA public")
+        }
+    }
+
+    override suspend fun afterSpec(spec: Spec) {
+        postgres.close()
+    }
+}


### PR DESCRIPTION
Add storages for resolved provenances, used by the experimental scanner. This provides a massive performance improvement by reducing the amount of required VCS operations. This PR adds the storages and configures a default local file storage for the experimental scanner. Configuration options will be added in another PR.
