### PR TITLE
Align on using find instead of firstOrNull

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -153,7 +153,7 @@ abstract class PackageManager(
 
             val fallbackVcs = fallbackUrls.mapTo(mutableListOf(VcsHost.toVcsInfo(normalizedVcsFromPackage.url))) {
                 VcsHost.toVcsInfo(normalizeVcsUrl(it))
-            }.firstOrNull {
+            }.find {
                 // Ignore fallback VCS information that changes a known type, or where the VCS type is unknown.
                 if (normalizedVcsFromPackage.type != VcsType.UNKNOWN) {
                     it.type == normalizedVcsFromPackage.type

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -544,7 +544,7 @@ class StaticHtmlReporter : Reporter {
                     dl {
                         dd {
                             row.detectedLicenses.forEach { license ->
-                                val firstFinding = license.locations.firstOrNull { it.matchingPathExcludes.isEmpty() }
+                                val firstFinding = license.locations.find { it.matchingPathExcludes.isEmpty() }
                                     ?: license.locations.firstOrNull()
 
                                 val permalink = firstFinding?.permalink(row.id)

--- a/utils/common/src/main/kotlin/Os.kt
+++ b/utils/common/src/main/kotlin/Os.kt
@@ -78,7 +78,7 @@ object Os {
         val fallbackUserHome = listOfNotNull(
             env["HOME"],
             env["USERPROFILE"]
-        ).firstOrNull {
+        ).find {
             it.isNotBlank()
         } ?: throw IllegalArgumentException("Unable to determine a user home directory.")
 


### PR DESCRIPTION
`find` is an alias for `firstOrNull`. Since `find` is already used far
mor often in the codebase, align on using `find`.