### PR TITLE
OrtMain: Print the original command line arguments as a list

### DIFF
--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -187,7 +187,7 @@ class OrtMain : CliktCommand(name = ORT_NAME, invokeWithoutSubcommand = true) {
     override fun run() {
         Configurator.setRootLevel(logLevel)
 
-        log.debug { "Used command line arguments: ${currentContext.originalArgv.joinToString()}" }
+        log.debug { "Used command line arguments: ${currentContext.originalArgv}" }
 
         // Make the parameter globally available.
         printStackTrace = stacktrace


### PR DESCRIPTION
This reads better than a comma-separated list while still highlighting
the individual arguments vs. a single argument with spaces.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>