### PR TITLE
Gradle: Set NodeJsRootExtension's node version to 16.13.0

### DIFF
--- a/reporter-web-app/build.gradle.kts
+++ b/reporter-web-app/build.gradle.kts
@@ -20,6 +20,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsSetupTask
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnSetupTask
@@ -27,6 +28,9 @@ import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnSetupTask
 // The Yarn plugin is only applied programmatically for Kotlin projects that target JavaScript. As we do not target
 // JavaScript from Kotlin (yet), manually apply the plugin to make its setup tasks available.
 YarnPlugin.apply(rootProject).version = "1.22.10"
+
+// Required for builds on ARM64 machines see: https://youtrack.jetbrains.com/issue/KT-49109.
+rootProject.the<NodeJsRootExtension>().nodeVersion = "16.13.0"
 
 // The Yarn plugin registers tasks always on the root project, see
 // https://github.com/JetBrains/kotlin/blob/1.4.0/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnPlugin.kt#L53-L57

--- a/reporter-web-app/build.gradle.kts
+++ b/reporter-web-app/build.gradle.kts
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnSetupTask
 
 // The Yarn plugin is only applied programmatically for Kotlin projects that target JavaScript. As we do not target
 // JavaScript from Kotlin (yet), manually apply the plugin to make its setup tasks available.
-YarnPlugin.apply(project).version = "1.22.10"
+YarnPlugin.apply(rootProject).version = "1.22.10"
 
 // The Yarn plugin registers tasks always on the root project, see
 // https://github.com/JetBrains/kotlin/blob/1.4.0/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnPlugin.kt#L53-L57


### PR DESCRIPTION
By default, the extension uses node version 14.17.0, which is not
available for ARM64 machines, see [1]. Update to version 16.13.0 to be
able to build ORT on these machines.

[1]: https://youtrack.jetbrains.com/issue/KT-49109.
