### PR TITLE
Vulnerability report: Improve error handling

### DIFF
--- a/advisor/src/main/kotlin/AdviceProvider.kt
+++ b/advisor/src/main/kotlin/AdviceProvider.kt
@@ -45,6 +45,11 @@ abstract class AdviceProvider(val providerName: String) {
     ): Map<Package, List<AdvisorResult>>
 
     /**
+     * An object with detail information about this [AdviceProvider].
+     */
+    abstract val details: AdvisorDetails
+
+    /**
      * A generic method that creates a failed [AdvisorResult] for [Package]s if there was an issue
      * constructing the provider-specific information.
      */
@@ -60,7 +65,7 @@ abstract class AdviceProvider(val providerName: String) {
         val failedResults = listOf(
             AdvisorResult(
                 vulnerabilities = emptyList(),
-                advisor = AdvisorDetails(providerName),
+                advisor = details,
                 summary = AdvisorSummary(
                     startTime = startTime,
                     endTime = endTime,

--- a/advisor/src/main/kotlin/advisors/GitHubDefects.kt
+++ b/advisor/src/main/kotlin/advisors/GitHubDefects.kt
@@ -37,6 +37,7 @@ import org.ossreviewtoolkit.clients.github.QueryResult
 import org.ossreviewtoolkit.clients.github.issuesquery.Issue
 import org.ossreviewtoolkit.clients.github.labels
 import org.ossreviewtoolkit.clients.github.releasesquery.Release
+import org.ossreviewtoolkit.model.AdvisorCapability
 import org.ossreviewtoolkit.model.AdvisorDetails
 import org.ossreviewtoolkit.model.AdvisorResult
 import org.ossreviewtoolkit.model.AdvisorSummary
@@ -48,6 +49,7 @@ import org.ossreviewtoolkit.model.config.AdvisorConfiguration
 import org.ossreviewtoolkit.model.config.GitHubDefectsConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.utils.common.collectMessagesAsString
+import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.core.filterVersionNames
 import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.core.showStackTrace
@@ -92,7 +94,7 @@ class GitHubDefects(name: String, gitHubConfiguration: GitHubDefectsConfiguratio
      * The details returned with each [AdvisorResult] produced by this instance. As this is constant, it can be
      * created once beforehand.
      */
-    private val details = AdvisorDetails(providerName)
+    override val details = AdvisorDetails(providerName, enumSetOf(AdvisorCapability.DEFECTS))
 
     /** The filters to be applied to issue labels. */
     private val labelFilters = gitHubConfiguration.labelFilter.toLabelFilters()

--- a/advisor/src/main/kotlin/advisors/OssIndex.kt
+++ b/advisor/src/main/kotlin/advisors/OssIndex.kt
@@ -26,6 +26,7 @@ import java.time.Instant
 import org.ossreviewtoolkit.advisor.AbstractAdviceProviderFactory
 import org.ossreviewtoolkit.advisor.AdviceProvider
 import org.ossreviewtoolkit.clients.ossindex.OssIndexService
+import org.ossreviewtoolkit.model.AdvisorCapability
 import org.ossreviewtoolkit.model.AdvisorDetails
 import org.ossreviewtoolkit.model.AdvisorResult
 import org.ossreviewtoolkit.model.AdvisorSummary
@@ -34,6 +35,7 @@ import org.ossreviewtoolkit.model.Vulnerability
 import org.ossreviewtoolkit.model.VulnerabilityReference
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
 import org.ossreviewtoolkit.model.utils.toPurl
+import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.core.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.core.log
 
@@ -51,6 +53,8 @@ class OssIndex(name: String, serverUrl: String = OssIndexService.DEFAULT_BASE_UR
     class Factory : AbstractAdviceProviderFactory<OssIndex>("OssIndex") {
         override fun create(config: AdvisorConfiguration) = OssIndex(providerName)
     }
+
+    override val details = AdvisorDetails(providerName, enumSetOf(AdvisorCapability.VULNERABILITIES))
 
     private val service by lazy {
         OssIndexService.create(
@@ -81,7 +85,7 @@ class OssIndex(name: String, serverUrl: String = OssIndexService.DEFAULT_BASE_UR
                 componentReports[pkg.id.toPurl()]?.let { report ->
                     pkg to listOf(
                         AdvisorResult(
-                            AdvisorDetails(providerName),
+                            details,
                             AdvisorSummary(startTime, endTime),
                             vulnerabilities = report.vulnerabilities.map { it.toVulnerability() }
                         )

--- a/advisor/src/main/kotlin/advisors/VulnerableCode.kt
+++ b/advisor/src/main/kotlin/advisors/VulnerableCode.kt
@@ -26,6 +26,7 @@ import org.ossreviewtoolkit.advisor.AbstractAdviceProviderFactory
 import org.ossreviewtoolkit.advisor.AdviceProvider
 import org.ossreviewtoolkit.clients.vulnerablecode.VulnerableCodeService
 import org.ossreviewtoolkit.clients.vulnerablecode.VulnerableCodeService.PackagesWrapper
+import org.ossreviewtoolkit.model.AdvisorCapability
 import org.ossreviewtoolkit.model.AdvisorDetails
 import org.ossreviewtoolkit.model.AdvisorResult
 import org.ossreviewtoolkit.model.AdvisorSummary
@@ -34,6 +35,7 @@ import org.ossreviewtoolkit.model.Vulnerability
 import org.ossreviewtoolkit.model.VulnerabilityReference
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
 import org.ossreviewtoolkit.model.config.VulnerableCodeConfiguration
+import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.core.OkHttpClientHelper
 
 /**
@@ -56,7 +58,7 @@ class VulnerableCode(name: String, vulnerableCodeConfiguration: VulnerableCodeCo
      * The details returned with each [AdvisorResult] produced by this instance. As this is constant, it can be
      * created once beforehand.
      */
-    private val details = AdvisorDetails(providerName)
+    override val details = AdvisorDetails(providerName, enumSetOf(AdvisorCapability.VULNERABILITIES))
 
     private val service by lazy {
         VulnerableCodeService.create(vulnerableCodeConfiguration.serverUrl, OkHttpClientHelper.buildClient())

--- a/advisor/src/test/kotlin/advisors/GitHubDefectsTest.kt
+++ b/advisor/src/test/kotlin/advisors/GitHubDefectsTest.kt
@@ -47,6 +47,8 @@ import org.ossreviewtoolkit.clients.github.issuesquery.LabelConnection
 import org.ossreviewtoolkit.clients.github.issuesquery.LabelEdge
 import org.ossreviewtoolkit.clients.github.releasesquery.Commit
 import org.ossreviewtoolkit.clients.github.releasesquery.Release
+import org.ossreviewtoolkit.model.AdvisorCapability
+import org.ossreviewtoolkit.model.AdvisorDetails
 import org.ossreviewtoolkit.model.AdvisorResult
 import org.ossreviewtoolkit.model.Defect
 import org.ossreviewtoolkit.model.Identifier
@@ -56,6 +58,7 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
 import org.ossreviewtoolkit.model.config.GitHubDefectsConfiguration
+import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class GitHubDefectsTest : WordSpec({
@@ -385,6 +388,14 @@ class GitHubDefectsTest : WordSpec({
             )
         }
     }
+
+    "details" should {
+        "contain correct advisor details" {
+            val advisor = createAdvisor()
+
+            advisor.details shouldBe AdvisorDetails("GitHubDefects", enumSetOf(AdvisorCapability.DEFECTS))
+        }
+    }
 })
 
 private const val GITHUB_TOKEN = "<github_access_token>"
@@ -436,6 +447,7 @@ private suspend fun GitHubDefects.getSingleResult(pkg: Package): AdvisorResult {
     results.keys should containExactly(pkg)
     val result = results.getValue(pkg).single()
     result.advisor.name shouldBe "GitHubDefects"
+    result.advisor.capabilities shouldBe enumSetOf(AdvisorCapability.DEFECTS)
 
     return result
 }

--- a/advisor/src/test/kotlin/advisors/OssIndexTest.kt
+++ b/advisor/src/test/kotlin/advisors/OssIndexTest.kt
@@ -40,12 +40,15 @@ import io.kotest.matchers.shouldNot
 
 import java.net.URI
 
+import org.ossreviewtoolkit.model.AdvisorCapability
+import org.ossreviewtoolkit.model.AdvisorDetails
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.Vulnerability
 import org.ossreviewtoolkit.model.VulnerabilityReference
 import org.ossreviewtoolkit.model.utils.toPurl
+import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class OssIndexTest : WordSpec({
@@ -81,7 +84,7 @@ class OssIndexTest : WordSpec({
             result[ID_JUNIT] shouldNotBeNull {
                 this should haveSize(1)
                 with(single()) {
-                    advisor.name shouldBe ADVISOR_NAME
+                    advisor shouldBe ossIndex.details
                     vulnerabilities should containExactlyInAnyOrder(
                         Vulnerability(
                             id = "CVE-2020-15250",
@@ -127,12 +130,19 @@ class OssIndexTest : WordSpec({
                     val pkgResults = getValue(pkg)
                     pkgResults shouldHaveSize 1
                     val pkgResult = pkgResults[0]
+                    pkgResult.advisor shouldBe ossIndex.details
                     pkgResult.vulnerabilities should io.kotest.matchers.collections.beEmpty()
                     pkgResult.summary.issues shouldHaveSize 1
                     val issue = pkgResult.summary.issues[0]
                     issue.severity shouldBe Severity.ERROR
                 }
             }
+        }
+
+        "provide correct details" {
+            val ossIndex = OssIndex(ADVISOR_NAME, "http://localhost:${server.port()}")
+
+            ossIndex.details shouldBe AdvisorDetails(ADVISOR_NAME, enumSetOf(AdvisorCapability.VULNERABILITIES))
         }
     }
 })

--- a/advisor/src/test/kotlin/advisors/VulnerableCodeTest.kt
+++ b/advisor/src/test/kotlin/advisors/VulnerableCodeTest.kt
@@ -42,6 +42,8 @@ import io.kotest.matchers.shouldBe
 import java.io.File
 import java.net.URI
 
+import org.ossreviewtoolkit.model.AdvisorCapability
+import org.ossreviewtoolkit.model.AdvisorDetails
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
@@ -51,6 +53,7 @@ import org.ossreviewtoolkit.model.VulnerabilityReference
 import org.ossreviewtoolkit.model.config.VulnerableCodeConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.utils.toPurl
+import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class VulnerableCodeTest : WordSpec({
@@ -86,7 +89,7 @@ class VulnerableCodeTest : WordSpec({
 
             val langResults = result.getValue(idLang)
             langResults shouldHaveSize(1)
-            langResults[0].advisor.name shouldBe ADVISOR_NAME
+            langResults[0].advisor shouldBe vulnerableCode.details
             val expLangVulnerability = Vulnerability(
                 id = "CVE-2014-8242",
                 listOf(
@@ -162,6 +165,7 @@ class VulnerableCodeTest : WordSpec({
                     val pkgResults = getValue(pkg)
                     pkgResults shouldHaveSize 1
                     val pkgResult = pkgResults[0]
+                    pkgResult.advisor shouldBe vulnerableCode.details
                     pkgResult.vulnerabilities should beEmpty()
                     pkgResult.summary.issues shouldHaveSize 1
                     val issue = pkgResult.summary.issues[0]
@@ -188,6 +192,15 @@ class VulnerableCodeTest : WordSpec({
             val result = vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
             result.keys should containExactlyInAnyOrder(idLang, idStruts)
+        }
+
+        "provide correct AdvisorDetails" {
+            val vulnerableCode = createVulnerableCode(wiremock)
+
+            vulnerableCode.details shouldBe AdvisorDetails(
+                ADVISOR_NAME,
+                enumSetOf(AdvisorCapability.VULNERABILITIES)
+            )
         }
     }
 })

--- a/model/src/main/kotlin/AdvisorCapability.kt
+++ b/model/src/main/kotlin/AdvisorCapability.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+/**
+ * An enum class that defines the capabilities of a specific advisor implementation.
+ *
+ * There are multiple types of findings that can be retrieved by an advisor, such as security vulnerabilities or
+ * defects. An [AdvisorResult] has different fields for the different findings types. This enum corresponds to these
+ * fields. It allows an advisor implementation to declare, which of these fields it can populate. This information is
+ * of interest, for instance, when generating reports for specific findings to determine, which advisor may have
+ * contributed.
+ */
+enum class AdvisorCapability {
+    /** Indicates that an advisor can retrieve information about defects. */
+    DEFECTS,
+
+    /** Indicates that an advisor can retrieve information about security vulnerabilities. */
+    VULNERABILITIES
+}

--- a/model/src/main/kotlin/AdvisorDetails.kt
+++ b/model/src/main/kotlin/AdvisorDetails.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Bosch.IO GmbH
+ * Copyright (C) 2020-2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,10 @@
 
 package org.ossreviewtoolkit.model
 
+import java.util.EnumSet
+
+import org.ossreviewtoolkit.utils.common.enumSetOf
+
 /**
  * Details about the used provider of vulnerability information.
  */
@@ -26,7 +30,13 @@ data class AdvisorDetails(
     /**
      * The name of the used advisor.
      */
-    val name: String
+    val name: String,
+
+    /**
+     * The capabilities of the used advisor. This property indicates, which kind of findings are retrieved by the
+     * advisor.
+     */
+    val capabilities: EnumSet<AdvisorCapability> = enumSetOf()
 ) {
     companion object {
         val EMPTY = AdvisorDetails(

--- a/reporter/src/main/resources/templates/asciidoc/vulnerability_report.ftl
+++ b/reporter/src/main/resources/templates/asciidoc/vulnerability_report.ftl
@@ -30,7 +30,17 @@ License-Filename: LICENSE
 :revdate: ${now?date?iso_local}
 :revnumber: 1.0.0
 
-== Packages:
+[#if helper.hasAdvisorIssues(AdvisorCapability.VULNERABILITIES, Severity.ERROR)]
+== Warning
+[.alert]
+Errors were encountered while retrieving vulnerability information. Therefore, this report may be incomplete and
+lack relevant vulnerabilities. Further details about the issues that occurred can be found in the <<Packages>>
+section.
+
+<<<
+[/#if]
+
+== Packages
 [#assign advisorResults = ortResult.getAdvisorResults(false)]
 [#list advisorResults as id, results]
 Package URL: *${ModelExtensions.toPurl(id)}*
@@ -47,6 +57,10 @@ Package URL: *${ModelExtensions.toPurl(id)}*
    Severity: [#if reference.severity??]${reference.severity} (${reference.scoringSystem})[#else]UNKNOWN[/#if] +
    [/#list]
 
+[/#list]
+
+[#list result.summary.issues as issue]
+** ${issue.severity}: ${issue.message}
 [/#list]
 
 [/#list]


### PR DESCRIPTION
If no vulnerabilities can be retrieved due to errors, the vulnerability report is currently misleading, since it only lists packages without further information. ORT issues are not shown, so there can be the false impression that no vulnerabilities have been found.

This PR changes the template for the vulnerability report to show a prominent warning if there were errors during the advisor run, so that it is obvious that the report is incomplete. Also, the issues assigned to the single packages are now shown.

When deciding whether or not to display this warning, there is the problem that there are now advisor implementations retrieving different findings, e.g. defects. The warning is, however, relevant only if an advisor for vulnerabilities is affected. To handle this, the PR extends the `AdvisorDetails` class to contain the advisor's _capabilities_, i.e. the type of findings the advisor produces. That way it can be figured out whether errors of a specific advisor impact the vulnerabilities report or not.