### PR TITLE
Fix the examples for overriding a postgres storage config property

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,13 +202,13 @@ customize the configuration to a specific environment. The following options are
 
 * Properties can be defined via environment variables by using the full property path as the variable name.
   For instance, one can override the Postgres schema by setting 
-  `ort.scanner.storages.postgresStorage.schema=test_schema`. The variable's name is case sensitive.
+  `ort.scanner.storages.postgres.schema=test_schema`. The variable's name is case sensitive.
   Some programs like Bash do not support dots in variable names. For this case, the dots can be
   replaced by double underscores, i.e., the above example is turned into 
-  `ort__scanner__storages__postgresStorage__schema=test_schema`.
+  `ort__scanner__storages__postgres__schema=test_schema`.
 * In addition to that, one can override the values of properties on the command line using the `-P` option. The option expects a
   key-value pair. Again, the key must define the full path to the property to be overridden, e.g.
-  `-P ort.scanner.storages.postgresStorage.schema=test_schema`. The `-P` option can be repeated on the command
+  `-P ort.scanner.storages.postgres.schema=test_schema`. The `-P` option can be repeated on the command
   line to override multiple properties.
 * Properties in the configuration file can reference environment variables using the syntax `${VAR}`.
   This is especially useful to reference dynamic or sensitive data. As an example, the credentials for the

--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -114,7 +114,7 @@ class OrtMain : CliktCommand(name = ORT_NAME, invokeWithoutSubcommand = true) {
     private val configArguments by option(
         "-P",
         help = "Override a key-value pair in the configuration file. For example: " +
-                "-P ort.scanner.storages.postgresStorage.schema=testSchema"
+                "-P ort.scanner.storages.postgres.schema=testSchema"
     ).associate()
 
     private val forceOverwrite by option(

--- a/helper-cli/src/main/kotlin/commands/GetPackageLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GetPackageLicensesCommand.kt
@@ -61,7 +61,7 @@ class GetPackageLicensesCommand : CliktCommand(
     private val configArguments by option(
         "-P",
         help = "Override a key-value pair in the configuration file. For example: " +
-                "-P scanner.postgresStorage.schema=testSchema"
+                "-P ort.scanner.storages.postgres.schema=testSchema"
     ).associate()
 
     private val packageId by option(

--- a/helper-cli/src/main/kotlin/commands/ListStoredScanResultsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListStoredScanResultsCommand.kt
@@ -59,7 +59,7 @@ internal class ListStoredScanResultsCommand : CliktCommand(
     private val configArguments by option(
         "-P",
         help = "Override a key-value pair in the configuration file. For example: " +
-                "-P scanner.postgresStorage.schema=testSchema"
+                "-P ort.scanner.storages.postgres.schema=testSchema"
     ).associate()
 
     override fun run() {

--- a/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
@@ -61,7 +61,7 @@ internal class DeleteCommand : CliktCommand(
     private val configArguments by option(
         "-P",
         help = "Override a key-value pair in the configuration file. For example: " +
-                "-P scanner.postgresStorage.schema=testSchema"
+                "-P ort.scanner.storages.postgres.schema=testSchema"
     ).associate()
 
     private val sourceCodeOrigins by option(


### PR DESCRIPTION
This is a fix-up for b70e3f4366d1401bc0f22493ff81a674060bc16e.