### PR TITLE
Align on using find instead of firstOrNull, continued

### DIFF
--- a/scanner/src/main/kotlin/experimental/PostgresNestedProvenanceStorage.kt
+++ b/scanner/src/main/kotlin/experimental/PostgresNestedProvenanceStorage.kt
@@ -70,7 +70,7 @@ class PostgresNestedProvenanceStorage(
                 table.vcsType eq root.vcsInfo.type.toString() and
                         (table.vcsUrl eq root.vcsInfo.url) and
                         (table.vcsRevision eq root.resolvedRevision)
-            }.map { it[table.result] }.firstOrNull { it.nestedProvenance.root == root }
+            }.map { it[table.result] }.find { it.nestedProvenance.root == root }
         }
 
     override fun putNestedProvenance(root: RepositoryProvenance, result: NestedProvenanceResolutionResult) {


### PR DESCRIPTION
This is a follow-up to f70ac03.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>