### PR TITLE
github: Enable caching of pip dependencies

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -51,6 +51,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.6
+        cache: pip
     - name: Check REUSE Compliance
       run: |
         pip install --user reuse


### PR DESCRIPTION
See [1].

[1]: https://github.blog/changelog/2021-11-23-github-actions-setup-python-now-supports-dependency-caching/

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>