### PR TITLE
VcsHost: Also exit early in case of a blank `projectUrl`

### DIFF
--- a/downloader/src/main/kotlin/VcsHost.kt
+++ b/downloader/src/main/kotlin/VcsHost.kt
@@ -255,7 +255,7 @@ enum class VcsHost(
          */
         fun toVcsInfo(projectUrl: String): VcsInfo {
             val unknownVcs = VcsInfo(type = VcsType.UNKNOWN, url = projectUrl, revision = "")
-            val projectUri = projectUrl.toUri().getOrNull() ?: return unknownVcs
+            val projectUri = projectUrl.takeUnless { it.isBlank() }?.toUri()?.getOrNull() ?: return unknownVcs
 
             // Fall back to generic URL detection for unknown VCS hosts.
             val svnBranchOrTagMatch = SVN_BRANCH_OR_TAG_PATTERN.matchEntire(projectUrl)


### PR DESCRIPTION
This is a fixup for b39e446, which caused a NPE triggered by 13b70a7.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>