### PR TITLE
github-workflows: Give some jobs more speaking names

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -3,7 +3,7 @@ name: Validate Gradle Wrapper
 on: pull_request
 
 jobs:
-  validation:
+  wrapper-validation:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  detekt:
+  detekt-issues:
     runs-on: ubuntu-latest
     env:
       GRADLE_OPTS: -Dorg.gradle.daemon=false
@@ -31,7 +31,7 @@ jobs:
       if: ${{ always() }} # Upload even if the previous step failed.
       with:
         sarif_file: build/reports/detekt/merged.sarif
-  markdown:
+  markdown-links:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
@@ -42,7 +42,7 @@ jobs:
         check-modified-files-only: yes
         max-depth: 2
         use-quiet-mode: yes
-  reuse:
+  reuse-tool:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository


### PR DESCRIPTION
The branch protection settings in GitHub show job names without their
belonging workflow names, so improve names a bit for readability.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>