### PR TITLE
Dockerfile: Delete the Gradle wrapper's `distributionSha256Sum`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN --mount=type=cache,target=/tmp/.gradle/ \
     scripts/import_proxy_certs.sh && \
     scripts/set_gradle_proxy.sh && \
     sed -i -r 's,(^distributionUrl=)(.+)-all\.zip$,\1\2-bin.zip,' gradle/wrapper/gradle-wrapper.properties && \
+    sed -i -r '/distributionSha256Sum=[0-9a-f]{64}/d' gradle/wrapper/gradle-wrapper.properties && \
     ./gradlew --no-daemon --stacktrace -Pversion=$ORT_VERSION :cli:distTar :helper-cli:startScripts
 
 FROM adoptopenjdk:11-jre-hotspot-bionic


### PR DESCRIPTION
As the Gradle distribution to use is changed, the checksum is not
applicable anymore. This is a fixup for 91f071f.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>