### PR TITLE
Gradle: Set the ORT version on each subproject

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,7 @@ buildscript {
     }
 }
 
+// Only override a default version (which usually is "unspecified"), but not a custom version.
 if (version == Project.DEFAULT_VERSION) {
     version = org.eclipse.jgit.api.Git.open(rootDir).use { git ->
         // Make the output exactly match "git describe --abbrev=7 --always --tags --dirty", which is what is used in
@@ -185,6 +186,8 @@ allprojects {
 }
 
 subprojects {
+    version = rootProject.version
+
     if (name == "reporter-web-app") return@subprojects
 
     // Apply core plugins.
@@ -364,6 +367,10 @@ subprojects {
     tasks.withType<Jar>().configureEach {
         isPreserveFileTimestamps = false
         isReproducibleFileOrder = true
+
+        manifest {
+            attributes["Implementation-Version"] = project.version
+        }
     }
 
     tasks.register<Jar>("sourcesJar").configure {

--- a/utils/core/build.gradle.kts
+++ b/utils/core/build.gradle.kts
@@ -43,12 +43,3 @@ dependencies {
 
     testImplementation("io.mockk:mockk:$mockkVersion")
 }
-
-tasks.withType<Jar>().configureEach {
-    manifest {
-        val versionCandidates = listOf(project.version, rootProject.version)
-        attributes["Implementation-Version"] = versionCandidates.find {
-            it != Project.DEFAULT_VERSION
-        } ?: "GRADLE-SNAPSHOT"
-    }
-}


### PR DESCRIPTION
This also fixes the ORT version to be available inside the shadow JAR
for the `cli` module.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>