### PR TITLE
VcsHost: Fix an NPE if there is no query in a TFS URL

### DIFF
--- a/downloader/src/main/kotlin/VcsHost.kt
+++ b/downloader/src/main/kotlin/VcsHost.kt
@@ -308,7 +308,7 @@ enum class VcsHost(
                 ("/tfs/" in projectUri.path || ".visualstudio.com" in projectUri.host) &&
                         "/_git/" in projectUri.path -> {
                     val url = "${projectUri.scheme}://${projectUri.authority}${projectUri.path}"
-                    val query = projectUri.query.split('&')
+                    val query = projectUri.query.orEmpty().split('&')
                         .associate { it.substringBefore('=') to it.substringAfter('=') }
                     val revision = query["version"].orEmpty().substringAfter("GB")
 

--- a/downloader/src/test/kotlin/VcsHostTest.kt
+++ b/downloader/src/test/kotlin/VcsHostTest.kt
@@ -274,7 +274,8 @@ class VcsHostTest : WordSpec({
         "recognize Git repositories on Team Foundation Server" {
             val actual = listOf(
                 "https://ibm-alm-server/tfs/org/project/_git/repo?version=GBmaster",
-                "https://hosted.visualstudio.com/org/project/_git/repo?foo=bar&version=GBmain"
+                "https://hosted.visualstudio.com/org/project/_git/repo?foo=bar&version=GBmain",
+                "https://hosted.visualstudio.com/tfs/project/_git/repo"
             ).map { VcsHost.toVcsInfo(it) }
 
             val expected = listOf(
@@ -288,6 +289,12 @@ class VcsHostTest : WordSpec({
                     type = VcsType.GIT,
                     url = "https://hosted.visualstudio.com/org/project/_git/repo",
                     revision = "main",
+                    path = ""
+                ),
+                VcsInfo(
+                    type = VcsType.GIT,
+                    url = "https://hosted.visualstudio.com/tfs/project/_git/repo",
+                    revision = "",
                     path = ""
                 )
             )


### PR DESCRIPTION
This is (another) fixup for 13b70a7.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>