### PR TITLE
PackageManager: Ignore "META-INF/maven" directories

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -77,6 +77,7 @@ abstract class PackageManager(
             ".gradle",
             "node_modules",
             // Ignore resources in a standard Maven / Gradle project layout.
+            "META-INF/maven",
             "src/main/resources",
             "src/test/resources",
             // Ignore virtual environments in Python.


### PR DESCRIPTION
Inside a JAR, the "META-INF/maven" directory usually contains the
"pom.xml" file that was used to build the JAR [1]. Ignore such POMs if for
whatever reason they are committed to the repository being analyzed.

[1]: https://maven.apache.org/guides/mini/guide-archive-configuration.html

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>