### PR TITLE
CtrlXAutomationReporter: Ensure to always have at least one component license

### DIFF
--- a/reporter/src/main/kotlin/reporters/ctrlx/CtrlXAutomationReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ctrlx/CtrlXAutomationReporter.kt
@@ -25,6 +25,8 @@ import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.model.writeValue
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
+import org.ossreviewtoolkit.utils.spdx.SpdxConstants
+import org.ossreviewtoolkit.utils.spdx.toSpdx
 
 class CtrlXAutomationReporter : Reporter {
     companion object {
@@ -62,12 +64,21 @@ class CtrlXAutomationReporter : Reporter {
                 License(name = id, spdx = it, text = text.orEmpty())
             }
 
+            // The specification requires at least one license.
+            val componentLicenses = licenses.takeUnless { it.isNullOrEmpty() } ?: listOf(
+                License(
+                    name = SpdxConstants.NOASSERTION,
+                    spdx = SpdxConstants.NOASSERTION.toSpdx(),
+                    text = ""
+                )
+            )
+
             Component(
                 name = qualifiedName,
                 version = pkg.id.version,
                 homepage = pkg.homepageUrl.takeUnless { it.isEmpty() },
                 copyright = copyrights?.let { CopyrightInformation(it) },
-                licenses = licenses.orEmpty(),
+                licenses = componentLicenses,
                 usage = if (pkg.isModified) Usage.Modified else Usage.AsIs
                 // TODO: Map the PackageLinkage to an IntegrationMechanism.
             )


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>