### PR TITLE
MavenSupport: Handle Sprint Boot Starters as metadata-only packages

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -674,6 +674,10 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
             PackageManager.processProjectVcs(it, vcsFromPackage, *vcsFallbackUrls)
         } ?: PackageManager.processPackageVcs(vcsFromPackage, *vcsFallbackUrls)
 
+        val isSpringBootStarter = with(mavenProject) {
+            groupId == "org.springframework.boot" && artifactId.startsWith("spring-boot-starter-")
+        }
+
         return Package(
             id = Identifier(
                 type = "Maven",
@@ -690,7 +694,7 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
             sourceArtifact = sourceRemoteArtifact,
             vcs = vcsFromPackage,
             vcsProcessed = vcsProcessed,
-            isMetaDataOnly = mavenProject.packaging == "pom",
+            isMetaDataOnly = mavenProject.packaging == "pom" || isSpringBootStarter,
             isModified = isBinaryArtifactModified || isSourceArtifactModified
         )
     }


### PR DESCRIPTION
Starters are a set of convenient dependency descriptors that you can
include in your application, see [1].

Starters usually have no sources published at all (see e.g. [2]), and if
sources are published, they only contain metadata file in the `META-INF`
directory that can also be retrieved from the POM.

[1]: https://github.com/spring-projects/spring-boot#spring-boot-starters
[2]: https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-undertow/2.0.8.RELEASE/
[3]: https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-security/2.6.0/

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>