### PR TITLE
Consistently use ORT's own function for temporary files 

### DIFF
--- a/analyzer/src/funTest/kotlin/GitRepoFunTest.kt
+++ b/analyzer/src/funTest/kotlin/GitRepoFunTest.kt
@@ -48,8 +48,7 @@ class GitRepoFunTest : StringSpec() {
     private lateinit var outputDir: File
 
     override fun beforeSpec(spec: Spec) {
-        // Do not use the class name as a suffix here to shorten the path. Otherwise the path will get too long for
-        // Windows to handle.
+        // Do not use createSpecTempDir() here, as otherwise the path will get too long for Windows to handle.
         outputDir = createTempDirectory(ORT_NAME).toFile()
 
         val vcs = VcsInfo(VcsType.GIT_REPO, REPO_URL, REPO_REV, path = REPO_MANIFEST)

--- a/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
+++ b/analyzer/src/funTest/kotlin/integration/AbstractIntegrationSpec.kt
@@ -29,8 +29,6 @@ import io.kotest.matchers.types.shouldBeTypeOf
 
 import java.io.File
 
-import kotlin.io.path.createTempDirectory
-
 import org.ossreviewtoolkit.analyzer.ManagedProjectFiles
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.downloader.Downloader
@@ -39,12 +37,11 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
-import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
-import org.ossreviewtoolkit.utils.core.ORT_NAME
 import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
 import org.ossreviewtoolkit.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.createSpecTempDir
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 abstract class AbstractIntegrationSpec : StringSpec() {
@@ -75,14 +72,8 @@ abstract class AbstractIntegrationSpec : StringSpec() {
     protected lateinit var provenance: Provenance
 
     override fun beforeSpec(spec: Spec) {
-        // Do not use the usual simple class name as the suffix here to shorten the path which otherwise gets too long
-        // on Windows for SimpleFormIntegrationTest.
-        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
+        outputDir = createSpecTempDir()
         provenance = Downloader(DownloaderConfiguration()).download(pkg, outputDir)
-    }
-
-    override fun afterSpec(spec: Spec) {
-        outputDir.safeDeleteRecursively(force = true)
     }
 
     init {

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -26,8 +26,6 @@ import java.io.IOException
 import java.net.URI
 import java.nio.file.Paths
 
-import kotlin.io.path.createTempDirectory
-
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.downloader.VersionControlSystem
@@ -51,7 +49,7 @@ import org.ossreviewtoolkit.utils.common.realFile
 import org.ossreviewtoolkit.utils.common.safeCopyRecursively
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.common.toUri
-import org.ossreviewtoolkit.utils.core.ORT_NAME
+import org.ossreviewtoolkit.utils.core.createOrtTempDir
 import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.core.showStackTrace
 
@@ -97,7 +95,7 @@ class GoDep(
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {
         val projectDir = resolveProjectRoot(definitionFile)
         val projectVcs = processProjectVcs(projectDir)
-        val gopath = createTempDirectory("$ORT_NAME-${projectDir.name}-gopath").toFile()
+        val gopath = createOrtTempDir("${projectDir.name}-gopath")
         val workingDir = setUpWorkspace(projectDir, projectVcs, gopath)
 
         GO_LEGACY_MANIFESTS[definitionFile.name]?.let { lockfileName ->

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -53,6 +53,7 @@ import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.model.utils.DependencyGraphBuilder
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.temporaryProperties
+import org.ossreviewtoolkit.utils.core.createOrtTempFile
 import org.ossreviewtoolkit.utils.core.log
 
 private val GRADLE_USER_HOME = Os.env["GRADLE_USER_HOME"]?.let { File(it) } ?: Os.userHomeDirectory.resolve(".gradle")
@@ -180,7 +181,7 @@ class Gradle(
 
         return temporaryProperties("user.dir" to rootProjectDir.path) {
             gradleConnection.use { connection ->
-                val initScriptFile = File.createTempFile("init", ".gradle")
+                val initScriptFile = createOrtTempFile("init", ".gradle")
                 initScriptFile.writeBytes(javaClass.getResource("/scripts/init.gradle").readBytes())
 
                 val stdout = ByteArrayOutputStream()

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -28,8 +28,6 @@ import java.io.File
 import java.lang.IllegalArgumentException
 import java.util.SortedSet
 
-import kotlin.io.path.createTempDirectory
-
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.downloader.VersionControlSystem
@@ -52,8 +50,9 @@ import org.ossreviewtoolkit.utils.common.ProcessCapture
 import org.ossreviewtoolkit.utils.common.normalizeLineBreaks
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.common.textValueOrEmpty
-import org.ossreviewtoolkit.utils.core.ORT_NAME
 import org.ossreviewtoolkit.utils.core.OkHttpClientHelper
+import org.ossreviewtoolkit.utils.core.createOrtTempDir
+import org.ossreviewtoolkit.utils.core.createOrtTempFile
 import org.ossreviewtoolkit.utils.core.log
 
 // The lowest version that supports "--prefer-binary" and PEP 508 URL requirements to be used as dependencies.
@@ -102,7 +101,7 @@ object PythonVersion : CommandLineTool {
      * returned.
      */
     fun getPythonVersion(workingDir: File): Int {
-        val scriptFile = File.createTempFile("python_compatibility", ".py")
+        val scriptFile = createOrtTempFile("python_compatibility", ".py")
         scriptFile.writeBytes(javaClass.getResource("/scripts/python_compatibility.py").readBytes())
 
         try {
@@ -484,7 +483,7 @@ class Pip(
     }
 
     private fun createVirtualEnv(workingDir: File, pythonVersion: Int): File {
-        val virtualEnvDir = createTempDirectory("$ORT_NAME-${workingDir.name}-virtualenv").toFile()
+        val virtualEnvDir = createOrtTempDir("${workingDir.name}-virtualenv")
         val pythonInterpreter = requireNotNull(PythonVersion.getPythonInterpreter(pythonVersion)) {
             "No Python interpreter found for version $pythonVersion."
         }

--- a/downloader/src/funTest/kotlin/vcs/GitRepoDownloadFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitRepoDownloadFunTest.kt
@@ -21,19 +21,15 @@ package org.ossreviewtoolkit.downloader.vcs
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
-import io.kotest.core.test.TestResult
 import io.kotest.matchers.shouldBe
 
 import java.io.File
 
-import kotlin.io.path.createTempDirectory
-
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
-import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
-import org.ossreviewtoolkit.utils.core.ORT_NAME
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
+import org.ossreviewtoolkit.utils.test.createTestTempDir
 
 private const val REPO_URL = "https://github.com/oss-review-toolkit/ort-test-data-git-repo"
 private const val REPO_REV = "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
@@ -43,11 +39,7 @@ class GitRepoDownloadFunTest : StringSpec() {
     private lateinit var outputDir: File
 
     override fun beforeTest(testCase: TestCase) {
-        outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
-    }
-
-    override fun afterTest(testCase: TestCase, result: TestResult) {
-        outputDir.safeDeleteRecursively(force = true)
+        outputDir = createTestTempDir()
     }
 
     init {

--- a/downloader/src/funTest/kotlin/vcs/GitRepoDownloadFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitRepoDownloadFunTest.kt
@@ -43,8 +43,6 @@ class GitRepoDownloadFunTest : StringSpec() {
     private lateinit var outputDir: File
 
     override fun beforeTest(testCase: TestCase) {
-        // Do not use the class name as a suffix here to shorten the path. Otherwise the path will get too long for
-        // Windows to handle.
         outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile()
     }
 

--- a/downloader/src/main/kotlin/Downloader.kt
+++ b/downloader/src/main/kotlin/Downloader.kt
@@ -24,7 +24,6 @@ import java.io.File
 import java.io.IOException
 import java.net.URI
 
-import kotlin.io.path.createTempDirectory
 import kotlin.time.TimeSource
 
 import org.ossreviewtoolkit.downloader.vcs.GitRepo
@@ -44,7 +43,6 @@ import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.common.unpack
-import org.ossreviewtoolkit.utils.core.ORT_NAME
 import org.ossreviewtoolkit.utils.core.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.core.createOrtTempDir
 import org.ossreviewtoolkit.utils.core.log
@@ -315,7 +313,7 @@ class Downloader(private val config: DownloaderConfiguration) {
         try {
             if (sourceArchive.extension == "gem") {
                 // Unpack the nested data archive for Ruby Gems.
-                val gemDirectory = createTempDirectory("$ORT_NAME-gem").toFile()
+                val gemDirectory = createOrtTempDir("gem")
                 val dataFile = gemDirectory.resolve("data.tar.gz")
 
                 try {

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -21,8 +21,6 @@ package org.ossreviewtoolkit.model.licenses
 
 import java.util.concurrent.ConcurrentHashMap
 
-import kotlin.io.path.createTempDirectory
-
 import org.ossreviewtoolkit.model.CopyrightFinding
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.KnownProvenance
@@ -39,7 +37,7 @@ import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.FindingsMatcher
 import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
 import org.ossreviewtoolkit.model.utils.prependPath
-import org.ossreviewtoolkit.utils.core.ORT_NAME
+import org.ossreviewtoolkit.utils.core.createOrtTempDir
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
 
 class LicenseInfoResolver(
@@ -255,7 +253,7 @@ class LicenseInfoResolver(
         licenseInfo.flatMapTo(mutableSetOf()) { resolvedLicense ->
             resolvedLicense.locations.map { it.provenance }
         }.forEach { provenance ->
-            val archiveDir = createTempDirectory("$ORT_NAME-archive").toFile().apply { deleteOnExit() }
+            val archiveDir = createOrtTempDir("archive").apply { deleteOnExit() }
 
             when (provenance) {
                 is UnknownProvenance -> return@forEach

--- a/model/src/main/kotlin/utils/FileArchiver.kt
+++ b/model/src/main/kotlin/utils/FileArchiver.kt
@@ -22,7 +22,6 @@ package org.ossreviewtoolkit.model.utils
 import java.io.File
 import java.io.IOException
 
-import kotlin.io.path.createTempFile
 import kotlin.time.measureTime
 import kotlin.time.measureTimedValue
 
@@ -31,7 +30,7 @@ import org.ossreviewtoolkit.utils.common.FileMatcher
 import org.ossreviewtoolkit.utils.common.collectMessagesAsString
 import org.ossreviewtoolkit.utils.common.packZip
 import org.ossreviewtoolkit.utils.common.unpackZip
-import org.ossreviewtoolkit.utils.core.ORT_NAME
+import org.ossreviewtoolkit.utils.core.createOrtTempFile
 import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.core.ortDataDirectory
 import org.ossreviewtoolkit.utils.core.perf
@@ -84,7 +83,7 @@ class FileArchiver(
      * Archive all files in [directory] matching any of the configured patterns in the [storage].
      */
     fun archive(directory: File, provenance: KnownProvenance) {
-        val zipFile = createTempFile(ORT_NAME, ".zip").toFile()
+        val zipFile = createOrtTempFile(suffix = ".zip")
 
         val zipDuration = measureTime {
             directory.packZip(zipFile, overwrite = true) { file ->

--- a/model/src/main/kotlin/utils/FileArchiverFileStorage.kt
+++ b/model/src/main/kotlin/utils/FileArchiverFileStorage.kt
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.common.collectMessagesAsString
 import org.ossreviewtoolkit.utils.common.toHexString
-import org.ossreviewtoolkit.utils.core.ORT_NAME
+import org.ossreviewtoolkit.utils.core.createOrtTempFile
 import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.core.storage.FileStorage
 
@@ -55,7 +55,7 @@ class FileArchiverFileStorage(
     override fun getArchive(provenance: KnownProvenance): File? {
         val archivePath = getArchivePath(provenance)
 
-        val zipFile = kotlin.io.path.createTempFile(ORT_NAME, ".zip").toFile()
+        val zipFile = createOrtTempFile(suffix = ".zip")
 
         return try {
             storage.read(archivePath).use { inputStream ->

--- a/model/src/main/kotlin/utils/PostgresFileArchiverStorage.kt
+++ b/model/src/main/kotlin/utils/PostgresFileArchiverStorage.kt
@@ -24,8 +24,6 @@ import java.io.IOException
 
 import javax.sql.DataSource
 
-import kotlin.io.path.createTempFile
-
 import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
@@ -44,7 +42,7 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.utils.DatabaseUtils.checkDatabaseEncoding
 import org.ossreviewtoolkit.model.utils.DatabaseUtils.tableExists
 import org.ossreviewtoolkit.model.utils.DatabaseUtils.transaction
-import org.ossreviewtoolkit.utils.core.ORT_NAME
+import org.ossreviewtoolkit.utils.core.createOrtTempFile
 import org.ossreviewtoolkit.utils.core.log
 
 /**
@@ -97,7 +95,7 @@ class PostgresFileArchiverStorage(
             queryFileArchive(provenance)
         } ?: return null
 
-        val file = createTempFile(ORT_NAME, ".zip").toFile()
+        val file = createOrtTempFile(suffix = ".zip")
 
         try {
             file.writeBytes(fileArchive.zipData)

--- a/model/src/test/kotlin/utils/PostgresFileArchiverStorageTest.kt
+++ b/model/src/test/kotlin/utils/PostgresFileArchiverStorageTest.kt
@@ -52,7 +52,7 @@ private fun File.readTextAndDelete(): String {
     return text
 }
 
-private fun TestConfiguration.createTempFile(content: String): File =
+private fun TestConfiguration.writeTempFile(content: String): File =
     createTestTempFile().apply {
         writeText(content)
     }
@@ -73,7 +73,7 @@ class PostgresFileArchiverStorageTest : WordSpec({
         }
 
         "return true when an archive for the given provenance has been added" {
-            storage.addArchive(VCS_PROVENANCE, createTempFile("content"))
+            storage.addArchive(VCS_PROVENANCE, writeTempFile("content"))
 
             storage.hasArchive(VCS_PROVENANCE) shouldBe true
         }
@@ -81,8 +81,8 @@ class PostgresFileArchiverStorageTest : WordSpec({
 
     "getArchive()" should {
         "return the archives corresponding to the given provenance given such archive has been added" {
-            storage.addArchive(VCS_PROVENANCE, createTempFile("VCS"))
-            storage.addArchive(SOURCE_ARTIFACT_PROVENANCE, createTempFile("source artifact"))
+            storage.addArchive(VCS_PROVENANCE, writeTempFile("VCS"))
+            storage.addArchive(SOURCE_ARTIFACT_PROVENANCE, writeTempFile("source artifact"))
 
             storage.getArchive(VCS_PROVENANCE) shouldNotBeNull { readTextAndDelete() shouldBe "VCS" }
             storage.getArchive(SOURCE_ARTIFACT_PROVENANCE) shouldNotBeNull {

--- a/reporter/src/funTest/kotlin/reporters/ExcelReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/ExcelReporterFunTest.kt
@@ -28,8 +28,6 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
 
-import kotlin.io.path.createTempDirectory
-
 import org.apache.poi.ss.usermodel.Cell
 import org.apache.poi.ss.usermodel.Row
 import org.apache.poi.ss.usermodel.Sheet
@@ -37,14 +35,14 @@ import org.apache.poi.ss.usermodel.WorkbookFactory
 import org.apache.poi.ss.util.CellReference
 
 import org.ossreviewtoolkit.reporter.ReporterInput
-import org.ossreviewtoolkit.utils.core.ORT_NAME
+import org.ossreviewtoolkit.utils.core.createOrtTempDir
 import org.ossreviewtoolkit.utils.test.readOrtResult
 
 class ExcelReporterFunTest : WordSpec({
     "ExcelReporter" should {
         "successfully export to an Excel sheet" {
             // TODO: Find out why Apache POI seems to prevent immediate deletion of the written XLSX file on Windows.
-            val outputDir = createTempDirectory("$ORT_NAME-${javaClass.simpleName}").toFile().apply { deleteOnExit() }
+            val outputDir = createOrtTempDir().apply { deleteOnExit() }
             val ortResult = readOrtResult(
                 "../scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml"
             )

--- a/reporter/src/main/kotlin/reporters/freemarker/asciidoc/AsciiDocTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/asciidoc/AsciiDocTemplateReporter.kt
@@ -22,8 +22,6 @@ package org.ossreviewtoolkit.reporter.reporters.freemarker.asciidoc
 
 import java.io.File
 
-import kotlin.io.path.createTempDirectory
-
 import org.asciidoctor.Asciidoctor
 import org.asciidoctor.Attributes
 import org.asciidoctor.Options
@@ -33,7 +31,7 @@ import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.reporters.freemarker.FreemarkerTemplateProcessor
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
-import org.ossreviewtoolkit.utils.core.ORT_NAME
+import org.ossreviewtoolkit.utils.core.createOrtTempDir
 
 /**
  * An abstract [Reporter] that uses [Apache Freemarker][1] templates and [AsciiDoc][2] with [AsciidoctorJ][3] to create
@@ -65,7 +63,7 @@ abstract class AsciiDocTemplateReporter(private val backend: String, override va
         Attributes.builder().build()
 
     final override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
-        val asciiDocOutputDir = createTempDirectory("$ORT_NAME-asciidoc").toFile()
+        val asciiDocOutputDir = createOrtTempDir("asciidoc")
 
         val templateOptions = options.toMutableMap()
         val asciidoctorAttributes = processTemplateOptions(templateOptions)

--- a/scanner/src/main/kotlin/storages/Sw360Storage.kt
+++ b/scanner/src/main/kotlin/storages/Sw360Storage.kt
@@ -25,8 +25,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 
 import java.nio.file.Path
 
-import kotlin.io.path.createTempDirectory
-
 import org.eclipse.sw360.clients.adapter.AttachmentUploadRequest
 import org.eclipse.sw360.clients.adapter.SW360Connection
 import org.eclipse.sw360.clients.adapter.SW360ConnectionFactory
@@ -50,6 +48,7 @@ import org.ossreviewtoolkit.model.writeValue
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.utils.common.collectMessagesAsString
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
+import org.ossreviewtoolkit.utils.core.createOrtTempDir
 import org.ossreviewtoolkit.utils.core.log
 
 /**
@@ -164,6 +163,5 @@ private fun createAttachmentOfScanResult(release: SW360Release, cachedScanResult
         .build()
 
 private fun createTempFileForUpload(id: Identifier) =
-    createTempDirectory(id.toCoordinates())
+    createOrtTempDir(id.toCoordinates())
         .resolve(SCAN_RESULTS_FILE_NAME)
-        .toFile()


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.