### PR TITLE
Model: Add support for CPE identifiers

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
@@ -64,6 +64,7 @@ packages:
     path: ""
 - id: "SpdxDocumentFile::zlib:1.2.11"
   purl: "pkg:spdxdocumentfile/zlib@1.2.11"
+  cpe: "cpe:/a:compress:zlib:1.2.11:::en-us"
   authors:
   - "Jean-loup Gailly"
   - "Mark Adler"
@@ -95,6 +96,7 @@ packages:
     path: "analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/zlib"
 - id: "SpdxDocumentFile:OpenSSL Development Team:openssl:1.1.1g"
   purl: "pkg:a-name/openssl@1.1.1g"
+  cpe: "cpe:2.3:a:a-name:openssl:1.1.1g:*:*:*:*:*:*:*"
   authors:
   - "OpenSSL Development Team"
   declared_licenses:

--- a/analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl/package.spdx.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/curl/package.spdx.yml
@@ -19,6 +19,10 @@ packages:
   copyrightText: "Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many
     contributors, see the THANKS file."
   downloadLocation: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
+  externalRefs:
+  - referenceCategory: "SECURITY"
+    referenceLocator: "cpe:2.3:a:http:curl:7.70.0:*:*:*:*:*:*:*"
+    referenceType: "cpe23Type"
   filesAnalyzed: false
   homepage: "https://curl.haxx.se/"
   licenseConcluded: "NOASSERTION"

--- a/analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/zlib/package.spdx.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/zlib/package.spdx.yml
@@ -14,6 +14,10 @@ packages:
   description: "zlib 1.2.11 is a general purpose data compression library."
   copyrightText: "(C) 1995-2017 Jean-loup Gailly and Mark Adler"
   downloadLocation: "http://zlib.net/zlib-1.2.11.tar.gz"
+  externalRefs:
+  - referenceCategory: "SECURITY"
+    referenceLocator: "cpe:/a:compress:zlib:1.2.11:::en-us"
+    referenceType: "cpe22Type"
   filesAnalyzed: true
   homepage: "http://zlib.net"
   licenseConcluded: "NOASSERTION"

--- a/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
@@ -20,7 +20,7 @@ externalDocumentRefs:
 - externalDocumentId: "DocumentRef-zlib-1.2.11"
   checksum:
     algorithm: "SHA1"
-    checksumValue: "9ffefb62ce14b40f675345a05b45846900740689"
+    checksumValue: "31ac790fa33d3e54d1bd98390ab94a212f52d63e"
   spdxDocument: "../package/libs/zlib/package.spdx.yml"
 packages:
 - SPDXID: "SPDXRef-Package-xyz"
@@ -42,6 +42,9 @@ packages:
   - referenceCategory: "PACKAGE_MANAGER"
     referenceLocator: "pkg:a-name/openssl@1.1.1g"
     referenceType: "purl"
+  - referenceCategory: "SECURITY"
+    referenceLocator: "cpe:2.3:a:a-name:openssl:1.1.1g:*:*:*:*:*:*:*"
+    referenceType: "cpe23Type"
   filesAnalyzed: false
   homepage: "https://www.openssl.org/"
   licenseConcluded: "NOASSERTION"

--- a/analyzer/src/funTest/kotlin/managers/SpdxDocumentFileFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/SpdxDocumentFileFunTest.kt
@@ -70,6 +70,7 @@ class SpdxDocumentFileFunTest : WordSpec({
             actualResult.first() shouldBe ProjectAnalyzerResult(
                 Project(
                     id = Identifier("SpdxDocumentFile::curl:7.70.0"),
+                    cpe = "cpe:2.3:a:http:curl:7.70.0:*:*:*:*:*:*:*",
                     definitionFilePath = packageFileCurl.relativeTo(vcsDir.getRootPath()).invariantSeparatorsPath,
                     authors = sortedSetOf("Daniel Stenberg (daniel@haxx.se)"),
                     declaredLicenses = sortedSetOf("curl"),
@@ -89,6 +90,7 @@ class SpdxDocumentFileFunTest : WordSpec({
             actualResult.last() shouldBe ProjectAnalyzerResult(
                 Project(
                     id = Identifier("SpdxDocumentFile::zlib:1.2.11"),
+                    cpe = "cpe:/a:compress:zlib:1.2.11:::en-us",
                     definitionFilePath = packageFileZlib.relativeTo(vcsDir.getRootPath()).invariantSeparatorsPath,
                     authors = sortedSetOf("Jean-loup Gailly", "Mark Adler"),
                     declaredLicenses = sortedSetOf("Zlib"),

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -252,6 +252,13 @@ private fun SpdxPackage.locateExternalReference(type: SpdxExternalReference.Type
     externalRefs.find { it.referenceType == type }?.referenceLocator
 
 /**
+ * Return a CPE identifier for this package if present. Search for all CPE versions.
+ */
+private fun SpdxPackage.locateCpe(): String? =
+    locateExternalReference(SpdxExternalReference.Type.Cpe23Type)
+        ?: locateExternalReference(SpdxExternalReference.Type.Cpe22Type)
+
+/**
  * Return whether the string has the format of an [SpdxExternalDocumentReference], with or without an additional
  * package id.
  */
@@ -370,6 +377,7 @@ class SpdxDocumentFile(
         return Package(
             id = id,
             purl = locateExternalReference(SpdxExternalReference.Type.Purl) ?: id.toPurl(),
+            cpe = locateCpe(),
             authors = originator.wrapPresentInSortedSet(),
             declaredLicenses = sortedSetOf(licenseDeclared),
             concludedLicense = getConcludedLicense(),
@@ -567,6 +575,7 @@ class SpdxDocumentFile(
 
         val project = Project(
             id = projectPackage.toIdentifier(),
+            cpe = projectPackage.locateCpe(),
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
             authors = projectPackage.originator.wrapPresentInSortedSet(),
             declaredLicenses = sortedSetOf(projectPackage.licenseDeclared),

--- a/analyzer/src/test/kotlin/managers/SpdxDocumentFileTest.kt
+++ b/analyzer/src/test/kotlin/managers/SpdxDocumentFileTest.kt
@@ -172,7 +172,7 @@ class SpdxDocumentFileTest : WordSpec({
         "throw if an external package id does not match relationship id" {
             val externalDocumentReference = SpdxExternalDocumentReference(
                 "DocumentRef-zlib-1.2.11",
-                SpdxChecksum(SpdxChecksum.Algorithm.SHA1, "9ffefb62ce14b40f675345a05b45846900740689"),
+                SpdxChecksum(SpdxChecksum.Algorithm.SHA1, "31ac790fa33d3e54d1bd98390ab94a212f52d63e"),
                 "../package/libs/zlib/package.spdx.yml"
             )
             val issues = mutableListOf<OrtIssue>()

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -51,6 +51,12 @@ data class Package(
     val purl: String = id.toPurl(),
 
     /**
+     * An optional additional identifier in [CPE syntax](https://cpe.mitre.org/specification/).
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val cpe: String? = null,
+
+    /**
      * The list of authors declared for this package.
      */
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -47,6 +47,11 @@ data class PackageCurationData(
     val purl: String? = null,
 
     /**
+     * An optional additional identifier in [CPE syntax](https://cpe.mitre.org/specification/).
+     */
+    val cpe: String? = null,
+
+    /**
      * The list of authors of this package.
      */
     val authors: SortedSet<String>? = null,
@@ -127,6 +132,7 @@ private fun applyCurationToPackage(targetPackage: CuratedPackage, curation: Pack
     val pkg = Package(
         id = base.id,
         purl = curation.purl ?: base.purl,
+        cpe = curation.cpe ?: base.cpe,
         authors = authors,
         declaredLicenses = base.declaredLicenses,
         declaredLicensesProcessed = declaredLicensesProcessed,

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -45,6 +45,12 @@ data class Project(
     val id: Identifier,
 
     /**
+     * An optional additional identifier in [CPE syntax](https://cpe.mitre.org/specification/).
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val cpe: String? = null,
+
+    /**
      * The path to the definition file of this project, relative to the root of the repository described in [vcs]
      * and [vcsProcessed].
      */

--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -54,6 +54,7 @@ class PackageCurationTest : WordSpec({
                 id = pkg.id,
                 data = PackageCurationData(
                     purl = "pkg:maven/org.hamcrest/hamcrest-core@1.3#subpath=src/main/java/org/hamcrest/core",
+                    cpe = "cpe:2.3:a:apache:commons_io:2.8.0:rc2:*:*:*:*:*:*",
                     authors = sortedSetOf("author 1", "author 2"),
                     declaredLicenseMapping = mapOf("license a" to "Apache-2.0".toSpdx()),
                     concludedLicense = "license1 OR license2".toSpdx(),
@@ -83,6 +84,7 @@ class PackageCurationTest : WordSpec({
             with(curatedPkg.pkg) {
                 id.toCoordinates() shouldBe pkg.id.toCoordinates()
                 purl shouldBe curation.data.purl
+                cpe shouldBe curation.data.cpe
                 authors shouldBe curation.data.authors
                 declaredLicenses shouldBe pkg.declaredLicenses
                 declaredLicensesProcessed.spdxExpression shouldBe "Apache-2.0".toSpdx()
@@ -111,6 +113,7 @@ class PackageCurationTest : WordSpec({
                     name = "hamcrest-core",
                     version = "1.3"
                 ),
+                cpe = "cpe:2.3:a:apache:commons_io:2.8.0:rc2:*:*:*:*:*:*",
                 authors = sortedSetOf("author 1", "author 2"),
                 declaredLicenses = sortedSetOf("license a", "license b"),
                 description = "description",
@@ -142,6 +145,7 @@ class PackageCurationTest : WordSpec({
             with(curatedPkg.pkg) {
                 id.toCoordinates() shouldBe pkg.id.toCoordinates()
                 purl shouldBe pkg.purl
+                cpe shouldBe pkg.cpe
                 authors shouldBe pkg.authors
                 declaredLicenses shouldBe pkg.declaredLicenses
                 concludedLicense shouldBe pkg.concludedLicense


### PR DESCRIPTION
CPEs are an alternative mechanism to identify software components, and
in some areas, e.g. databases for security vulnerabilities, they are
in widespread use. To support use cases in these domains, enable ORT
to store these identifiers if they are available.

This PR is related to #4755.