### PR TITLE
Make the provenance storage configurable

### DIFF
--- a/model/src/main/kotlin/config/ProvenanceStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/ProvenanceStorageConfiguration.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.config
+
+import org.ossreviewtoolkit.utils.core.log
+
+/**
+ * Configuration of the storage to use for provenance information.
+ */
+data class ProvenanceStorageConfiguration(
+    /**
+     * Configuration of a file storage.
+     */
+    val fileStorage: FileStorageConfiguration? = null,
+
+    /**
+     * Configuration of a PostgreSQL storage.
+     */
+    val postgresStorage: PostgresStorageConfiguration? = null,
+) {
+    init {
+        if (fileStorage != null && postgresStorage != null) {
+            log.warn {
+                "'fileStorage' and 'postgresStorage' are both configured but only one storage can be used. Using " +
+                        "'fileStorage'."
+            }
+        }
+    }
+}

--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2021 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,5 +83,10 @@ data class ScannerConfiguration(
     val ignorePatterns: List<String> = listOf(
         "**/*.ort.yml",
         "**/META-INF/DEPENDENCIES"
-    )
+    ),
+
+    /**
+     * Configuration of the storage for provenance information.
+     */
+    val provenanceStorage: ProvenanceStorageConfiguration? = null
 )

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -188,6 +188,26 @@ ort {
     ignorePatterns = [
       "**/META-INF/DEPENDENCIES"
     ]
+
+    provenanceStorage {
+      fileStorage {
+        localFileStorage {
+          directory = ~/.ort/scanner/provenance
+          compression = false
+        }
+      }
+
+      postgresStorage {
+        url = "jdbc:postgresql://your-postgresql-server:5444/your-database"
+        schema = public
+        username = username
+        password = password
+        sslmode = required
+        sslcert = /defaultdir/postgresql.crt
+        sslkey = /defaultdir/postgresql.pk8
+        sslrootcert = /defaultdir/root.crt
+      }
+    }
   }
 
   notifier {

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -150,6 +150,26 @@ class OrtConfigurationTest : WordSpec({
                 storageWriters shouldContainExactly listOf("postgres")
 
                 ignorePatterns shouldContainExactly listOf("**/META-INF/DEPENDENCIES")
+
+                provenanceStorage shouldNotBeNull {
+                    fileStorage shouldNotBeNull {
+                        httpFileStorage should beNull()
+                        localFileStorage shouldNotBeNull {
+                            directory shouldBe File("~/.ort/scanner/provenance")
+                        }
+                    }
+
+                    postgresStorage shouldNotBeNull {
+                        url shouldBe "jdbc:postgresql://your-postgresql-server:5444/your-database"
+                        schema shouldBe "public"
+                        username shouldBe "username"
+                        password shouldBe "password"
+                        sslmode shouldBe "required"
+                        sslcert shouldBe "/defaultdir/postgresql.crt"
+                        sslkey shouldBe "/defaultdir/postgresql.pk8"
+                        sslrootcert shouldBe "/defaultdir/root.crt"
+                    }
+                }
             }
 
             with(ortConfig.notifier) {


### PR DESCRIPTION
Add configuration options to configure either a file storage or a
PostgreSQL storage to store provenance information. This is used only by
the experimental scanner.

By default a local file storage is used as prior to this commit.