### PR TITLE
spdx-utils: Add a constant for an empty package verification code

### DIFF
--- a/utils/spdx/src/main/kotlin/SpdxConstants.kt
+++ b/utils/spdx/src/main/kotlin/SpdxConstants.kt
@@ -71,6 +71,11 @@ object SpdxConstants {
     const val LICENSE_LIST_URL = "https://spdx.org/licenses/"
 
     /**
+     * The package verification code for no input.
+     */
+    const val EMPTY_PACKAGE_VERIFICATION_CODE = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+
+    /**
      * Return true if and only if the given value is null or equals [NONE] or [NOASSERTION].
      */
     fun isNotPresent(value: String?) = value in setOf(null, NONE, NOASSERTION)

--- a/utils/spdx/src/test/kotlin/UtilsTest.kt
+++ b/utils/spdx/src/test/kotlin/UtilsTest.kt
@@ -33,6 +33,7 @@ import io.kotest.matchers.string.startWith
 import java.io.File
 
 import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
+import org.ossreviewtoolkit.utils.spdx.SpdxConstants.EMPTY_PACKAGE_VERIFICATION_CODE
 import org.ossreviewtoolkit.utils.test.createTestTempDir
 
 class UtilsTest : WordSpec() {
@@ -47,6 +48,10 @@ class UtilsTest : WordSpec() {
 
     init {
         "calculatePackageVerificationCode" should {
+            "return the SHA1 for an empty string on no input" {
+                calculatePackageVerificationCode(emptySequence<String>()) shouldBe EMPTY_PACKAGE_VERIFICATION_CODE
+            }
+
             "work for given SHA1s and excludes" {
                 val sha1sums = sequenceOf(
                     "0811bcab4e7a186f4d0d08d44cc5f06d721e7f6d",


### PR DESCRIPTION
This is useful as a "real looking" code that in fact describes no input.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>