### PR TITLE
purls: Extract 'toPurl' function's content

### DIFF
--- a/model/src/test/kotlin/IdentifierTest.kt
+++ b/model/src/test/kotlin/IdentifierTest.kt
@@ -31,6 +31,7 @@ import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.string.shouldNotStartWith
 import io.kotest.matchers.string.shouldStartWith
 
+import org.ossreviewtoolkit.model.utils.createPurl
 import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.utils.test.containExactly
 
@@ -171,6 +172,42 @@ class IdentifierTest : WordSpec({
             val purl = Identifier("type", "namespace", "name", "release candidate").toPurl()
 
             purl shouldBe "pkg:type/namespace/name@release%20candidate"
+        }
+
+        "allow qualifiers" {
+            val purl = createPurl(
+                "type",
+                "namespace",
+                "name",
+                "version",
+                mapOf("argName" to "argValue")
+            )
+
+            purl shouldBe "pkg:type/namespace/name@version?argName=argValue"
+        }
+
+        "allow multiple qualifiers" {
+            val purl = createPurl(
+                "type",
+                "namespace",
+                "name",
+                "version",
+                mapOf("argName1" to "argValue1", "argName2" to "argValue2")
+            )
+
+            purl shouldBe "pkg:type/namespace/name@version?argName1=argValue1&argName2=argValue2"
+        }
+
+        "allow subpath" {
+            val purl = createPurl(
+                "type",
+                "namespace",
+                "name",
+                "version",
+                subpath = "value1/value2"
+            )
+
+            purl shouldBe "pkg:type/namespace/name@version#value1/value2"
         }
     }
 


### PR DESCRIPTION
This allows to customize the creation of purls in plugins i.e. create
[Package] instances with a special purl.
The extracted function offers also the possible to pass additional
query parameters to the purls that the previous implementation didn't.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>


