### PR TITLE
Gradle: Upgrade GraphQL dependencies to version 5.3.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@
 buildconfigPluginVersion = 3.0.3
 detektPluginVersion = 1.19.0
 dokkaPluginVersion = 1.6.0
-graphqlPluginVersion = 5.0.0
+graphqlPluginVersion = 5.3.0
 ideaExtPluginVersion = 1.1.1
 kotlinPluginVersion = 1.6.0
 shadowPluginVersion = 7.1.0
@@ -42,7 +42,7 @@ disklrucacheVersion = 2.0.2
 exposedVersion = 0.36.2
 flexmarkVersion = 0.62.2
 freemarkerVersion = 2.3.31
-graphQLKotlinVersion = 5.0.0
+graphQLKotlinVersion = 5.3.0
 greenMailVersion = 1.6.5
 hamcrestCoreVersion = 1.3
 hikariVersion = 5.0.0


### PR DESCRIPTION
See [1].

[1]: https://github.com/ExpediaGroup/graphql-kotlin/releases/tag/5.3.0

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>