### PR TITLE
azure-pipelines: Pin the NPM version to 7.20.6

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -19,6 +19,7 @@ variables:
   COMPOSER_VERSION: 5.1.0 # The version refers to the installer, not to Composer.
   CONAN_VERSION: 1.40.3
   GO_DEP_VERSION: 0.5.4
+  NPM_VERSION: 7.20.6
   PYTHON_PIPENV_VERSION: 2018.11.26
   RUST_VERSION: 1.35.0
   SCANCODE_VERSION: 3.2.1rc2

--- a/.azure-pipelines/LinuxAnalyzerTest.yml
+++ b/.azure-pipelines/LinuxAnalyzerTest.yml
@@ -19,7 +19,7 @@ jobs:
       sudo apt-get -qq remove mono-devel
 
       # Install NPM packages.
-      sudo npm install -g bower@$BOWER_VERSION
+      sudo npm install -g npm@$NPM_VERSION bower@$BOWER_VERSION
 
       # Install Python packages.
       pip install --user \

--- a/.azure-pipelines/WindowsAnalyzerTest.yml
+++ b/.azure-pipelines/WindowsAnalyzerTest.yml
@@ -24,7 +24,7 @@ jobs:
       #$env:PATH += ";C:\msys64\usr\bin"
 
       # Install NPM packages.
-      npm install -g bower@$env:BOWER_VERSION
+      npm install -g npm@$env:NPM_VERSION bower@$env:BOWER_VERSION
 
       # Install Python packages.
       pip install --user conan==$env:CONAN_VERSION pipenv==$env:PYTHON_PIPENV_VERSION virtualenv==$env:VIRTUALENV_VERSION

--- a/reporter-web-app/build.gradle.kts
+++ b/reporter-web-app/build.gradle.kts
@@ -90,6 +90,7 @@ tasks {
 
         dependsOn("yarnInstall")
 
+        inputs.files(".rescriptsrc.js")
         inputs.dir("node_modules")
         inputs.dir("public")
         inputs.dir("src")

--- a/reporter-web-app/build.gradle.kts
+++ b/reporter-web-app/build.gradle.kts
@@ -63,12 +63,18 @@ tasks.addRule("Pattern: yarn<Command>") {
 
 tasks {
     kotlinNodeJsSetup {
+        outputs.upToDateWhen { nodeExecutable.isFile }
+        outputs.cacheIf { true }
+
         doFirst {
             logger.quiet("Setting up Node.js / NPM in '$nodeDir'...")
         }
     }
 
     kotlinYarnSetup {
+        outputs.upToDateWhen { yarnJs.isFile }
+        outputs.cacheIf { true }
+
         doFirst {
             logger.quiet("Setting up Yarn in '$yarnDir'...")
         }

--- a/reporter-web-app/build.gradle.kts
+++ b/reporter-web-app/build.gradle.kts
@@ -80,7 +80,7 @@ tasks {
 
         dependsOn(kotlinYarnSetup)
 
-        inputs.files(listOf("package.json", "yarn.lock"))
+        inputs.files(".yarnrc", "package.json", "yarn.lock")
         outputs.dir("node_modules")
     }
 

--- a/reporter-web-app/build.gradle.kts
+++ b/reporter-web-app/build.gradle.kts
@@ -62,6 +62,18 @@ tasks.addRule("Pattern: yarn<Command>") {
  */
 
 tasks {
+    kotlinNodeJsSetup {
+        doFirst {
+            logger.quiet("Setting up Node.js / NPM in '$nodeDir'...")
+        }
+    }
+
+    kotlinYarnSetup {
+        doFirst {
+            logger.quiet("Setting up Yarn in '$yarnDir'...")
+        }
+    }
+
     "yarnInstall" {
         description = "Use Yarn to install the Node.js dependencies."
         group = "Node"


### PR DESCRIPTION
Use the same version of NPM as in the Dockerfile as Azure's new default
version 8.1.0 causes problems with the lockfiles committed as part of the
test assets.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>