### PR TITLE
Dockerfile: Extend PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ ENV \
     GOPATH=$HOME/go
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    PATH="$PATH:$HOME/.local/bin:$GOPATH/bin:/opt/go/bin:$GEM_PATH/bin"
+    PATH="$PATH:$HOME/.local/bin:$GOPATH/bin:/opt/go/bin:$GEM_PATH/bin:/opt/ort/bin"
 
 # Apt install commands.
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \


### PR DESCRIPTION
Add ORT binary directory to the path variable to enable the shell to
find the ORT tool.
This is useful if the container is used with its entry point overridden
and to run multiple ORT commands sequentially without restarting the
container.

Signed-off-by: Jens Erdmann <jens.erdmann@web.de>
