### PR TITLE
Add a defect report

### DIFF
--- a/reporter/src/funTest/kotlin/TestData.kt
+++ b/reporter/src/funTest/kotlin/TestData.kt
@@ -19,9 +19,16 @@
 
 package org.ossreviewtoolkit.reporter
 
+import java.net.URI
 import java.time.Instant
 
 import org.ossreviewtoolkit.model.AccessStatistics
+import org.ossreviewtoolkit.model.AdvisorCapability
+import org.ossreviewtoolkit.model.AdvisorDetails
+import org.ossreviewtoolkit.model.AdvisorRecord
+import org.ossreviewtoolkit.model.AdvisorResult
+import org.ossreviewtoolkit.model.AdvisorRun
+import org.ossreviewtoolkit.model.AdvisorSummary
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.AnalyzerRun
 import org.ossreviewtoolkit.model.ArtifactProvenance
@@ -46,11 +53,15 @@ import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.Vulnerability
+import org.ossreviewtoolkit.model.VulnerabilityReference
+import org.ossreviewtoolkit.model.config.AdvisorConfiguration
 import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.config.PathExcludeReason
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.core.Environment
 import org.ossreviewtoolkit.utils.spdx.toSpdx
 import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
@@ -423,3 +434,30 @@ val ORT_RESULT = OrtResult(
         )
     )
 )
+
+val VULNERABILITY = Vulnerability(
+    "CVE-2021-1234",
+    listOf(
+        VulnerabilityReference(URI("https://cves.example.org/cve1"), "Cvss2", "MEDIUM")
+    )
+)
+
+val ADVISOR_WITH_VULNERABILITIES = AdvisorRun(
+    startTime = Instant.now(),
+    endTime = Instant.now(),
+    environment = Environment(),
+    config = AdvisorConfiguration(),
+    results = AdvisorRecord(
+        sortedMapOf(
+            Identifier("NPM:@ort:declared-license:1.0") to listOf(
+                AdvisorResult(
+                    advisor = AdvisorDetails("VulnerableCode", enumSetOf(AdvisorCapability.VULNERABILITIES)),
+                    summary = AdvisorSummary(Instant.now(), Instant.now()),
+                    vulnerabilities = listOf(VULNERABILITY)
+                )
+            )
+        )
+    )
+)
+
+val ORT_RESULT_WITH_VULNERABILITIES = ORT_RESULT.copy(advisor = ADVISOR_WITH_VULNERABILITIES)

--- a/reporter/src/funTest/kotlin/reporters/freemarker/asciidoc/PdfTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/freemarker/asciidoc/PdfTemplateReporterFunTest.kt
@@ -21,10 +21,12 @@ package org.ossreviewtoolkit.reporter.reporters.freemarker.asciidoc
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.contain
 import io.kotest.matchers.longs.beInRange
 import io.kotest.matchers.should
 
 import org.ossreviewtoolkit.reporter.ORT_RESULT
+import org.ossreviewtoolkit.reporter.ORT_RESULT_WITH_VULNERABILITIES
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.test.createTestTempDir
 
@@ -53,5 +55,14 @@ class PdfTemplateReporterFunTest : StringSpec({
                 mapOf("pdf.fonts.dir" to "fake.path")
             )
         }
+    }
+
+    "Advisor reports are generated if the result contains an advisor section" {
+        val reports =
+            PdfTemplateReporter().generateReport(ReporterInput(ORT_RESULT_WITH_VULNERABILITIES), createTestTempDir())
+
+        val reportFileNames = reports.map { it.name }
+        reportFileNames should contain("AsciiDoc_vulnerability_report.pdf")
+        reportFileNames should contain("AsciiDoc_defect_report.pdf")
     }
 })

--- a/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
@@ -30,6 +30,8 @@ import java.util.SortedMap
 
 import org.ossreviewtoolkit.model.AdvisorCapability
 import org.ossreviewtoolkit.model.AdvisorRecord
+import org.ossreviewtoolkit.model.AdvisorResult
+import org.ossreviewtoolkit.model.AdvisorResultFilter
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
@@ -363,6 +365,34 @@ class FreemarkerTemplateProcessor(
                     minSeverity = severity
                 )
             )?.isNotEmpty() ?: false
+
+        /**
+         * Return the subset of the available advisor results produced by an advisor with the given [capability] that
+         * have an issue with at least the given [severity]. With this function packages can be identified whose
+         * results may be incomplete.
+         */
+        fun advisorResultsWithIssues(
+            capability: AdvisorCapability,
+            severity: Severity
+        ): Map<Identifier, List<AdvisorResult>> =
+            input.filteredAdvisorResults(
+                AdvisorRecord.resultsWithIssues(
+                    capability = capability,
+                    minSeverity = severity
+                )
+            )
+
+        /**
+         * Return the subset of the available advisor results that contain vulnerabilities.
+         */
+        fun advisorResultsWithVulnerabilities(): Map<Identifier, List<AdvisorResult>> =
+            input.filteredAdvisorResults(AdvisorRecord.RESULTS_WITH_VULNERABILITIES)
+
+        /**
+         * Return the subset of the available advisor results that contain defects.
+         */
+        fun advisorResultsWithDefects(): Map<Identifier, List<AdvisorResult>> =
+            input.filteredAdvisorResults(AdvisorRecord.RESULTS_WITH_DEFECTS)
     }
 }
 
@@ -490,3 +520,10 @@ private fun ReporterInput.replaceOrtResult(ortResult: OrtResult): ReporterInput 
             licenseFilenamePatterns = licenseInfoResolver.licenseFilenamePatterns
         )
     )
+
+/**
+ * Apply the given [filter] to the advisor results stored in this [ReporterInput]. Return an empty map if no advisor
+ * results are available.
+ */
+private fun ReporterInput.filteredAdvisorResults(filter: AdvisorResultFilter): Map<Identifier, List<AdvisorResult>> =
+    ortResult.advisor?.results?.filterResults(filter).orEmpty()

--- a/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
@@ -29,6 +29,7 @@ import java.io.File
 import java.util.SortedMap
 
 import org.ossreviewtoolkit.model.AdvisorCapability
+import org.ossreviewtoolkit.model.AdvisorRecord
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
@@ -356,11 +357,12 @@ class FreemarkerTemplateProcessor(
          * therefore, it should contain a corresponding warning.
          */
         fun hasAdvisorIssues(capability: AdvisorCapability, severity: Severity): Boolean =
-            input.ortResult.advisor?.results?.advisorResults.orEmpty()
-                .values
-                .flatten()
-                .filter { capability in it.advisor.capabilities }
-                .any { result -> result.summary.issues.any { it.severity >= severity } }
+            input.ortResult.advisor?.results?.filterResults(
+                AdvisorRecord.resultsWithIssues(
+                    capability = capability,
+                    minSeverity = severity
+                )
+            )?.isNotEmpty() ?: false
     }
 }
 

--- a/reporter/src/main/kotlin/reporters/freemarker/asciidoc/AsciiDocTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/asciidoc/AsciiDocTemplateReporter.kt
@@ -50,6 +50,7 @@ abstract class AsciiDocTemplateReporter(private val backend: String, override va
 
         private const val DISCLOSURE_TEMPLATE_ID = "disclosure_document"
         private const val VULNERABILITY_TEMPLATE_ID = "vulnerability_report"
+        private const val DEFECT_TEMPLATE_ID = "defect_report"
     }
 
     private val templateProcessor = FreemarkerTemplateProcessor(
@@ -90,7 +91,7 @@ abstract class AsciiDocTemplateReporter(private val backend: String, override va
                 append(DISCLOSURE_TEMPLATE_ID)
 
                 if (input.ortResult.getAdvisorResults().isNotEmpty()) {
-                    append(",$VULNERABILITY_TEMPLATE_ID")
+                    append(",$VULNERABILITY_TEMPLATE_ID,$DEFECT_TEMPLATE_ID")
                 }
             })
         }

--- a/reporter/src/main/resources/templates/asciidoc/defect_report.ftl
+++ b/reporter/src/main/resources/templates/asciidoc/defect_report.ftl
@@ -1,0 +1,111 @@
+[#--
+Copyright (C) 2021 Bosch.IO GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+License-Filename: LICENSE
+--]
+
+[#assign ModelExtensions = statics['org.ossreviewtoolkit.model.utils.ExtensionsKt']]
+
+:title-page:
+:sectnums:
+:toc: preamble
+
+= Defect Report
+:author-name: OSS Review Toolkit
+[#assign now = .now]
+:revdate: ${now?date?iso_local}
+:revnumber: 1.0.0
+
+[#assign advisorResultsWithErrors = helper.advisorResultsWithIssues(AdvisorCapability.DEFECTS, Severity.ERROR)]
+[#if advisorResultsWithErrors?has_content]
+== Warning
+[.alert]
+Errors were encountered while retrieving defect information. Therefore, this report may be incomplete and
+lack relevant defects. Further details about the issues that occurred can be found in the <<Packages with errors>>
+section.
+
+<<<
+[/#if]
+
+== Packages
+[#assign advisorResults = helper.advisorResultsWithDefects()]
+[#list advisorResults as id, results]
+=== ${id.name}
+
+Package URL: _${ModelExtensions.toPurl(id)}_
+
+[#list results as result]
+
+*Advisor: ${result.advisor.name}*
+
+[#list result.defects as defect]
+
+* [#if defect.title??]*Title:* "pass:[${defect.title}]"[#else]*Id:* ${defect.id}[/#if]
++
+[cols="2,6",frame="none",grid="none"]
+|===
+|URL:|${defect.url}
+|Internal ID:|${defect.id}
+[#if defect.severity??]|Severity:|${defect.severity}[/#if]
+|Fix availability:|[#if defect.fixReleaseVersion??]Fixed in version ${defect.fixReleaseVersion}[#elseif defect.fixReleaseUrl??]Fixed in release ${defect.fixReleaseUrl}[#else]No known fix available.[/#if]
+|===
+[/#list]
+
+[#if result.summary.issues?has_content]
+.Issues
+[cols="1,5",options="header",caption=]
+|===
+|Severity|Message
+[#list result.summary.issues as issue]
+|${issue.severity}|${issue.message}
+[/#list]
+|===
+
+[/#if]
+
+[/#list]
+[/#list]
+
+[#if !advisorResults?has_content]
+No packages with defects have been found.
+[/#if]
+
+[#if advisorResultsWithErrors?has_content]
+<<<
+== Packages with errors
+
+When retrieving defect information for these packages, the advisor module encountered errors. Therefore, it is possible
+that existing defects are missing from the report. This section lists the issues that occurred when requesting defect
+information for the single packages.
+
+[#list advisorResultsWithErrors as id, results]
+=== ${id.name}
+
+${ModelExtensions.toPurl(id)}
+
+[#list results as result]
+
+[cols="1,5",options="header"]
+|===
+|Advisor|Message
+[#list result.summary.issues as issue]
+|${result.advisor.name}|${issue.message}
+[/#list]
+|===
+
+[/#list]
+[/#list]
+[/#if]

--- a/reporter/src/main/resources/templates/asciidoc/vulnerability_report.ftl
+++ b/reporter/src/main/resources/templates/asciidoc/vulnerability_report.ftl
@@ -30,38 +30,72 @@ License-Filename: LICENSE
 :revdate: ${now?date?iso_local}
 :revnumber: 1.0.0
 
-[#if helper.hasAdvisorIssues(AdvisorCapability.VULNERABILITIES, Severity.ERROR)]
+[#assign advisorResultsWithErrors = helper.advisorResultsWithIssues(AdvisorCapability.VULNERABILITIES, Severity.ERROR)]
+[#if advisorResultsWithErrors?has_content]
 == Warning
 [.alert]
 Errors were encountered while retrieving vulnerability information. Therefore, this report may be incomplete and
-lack relevant vulnerabilities. Further details about the issues that occurred can be found in the <<Packages>>
-section.
+lack relevant vulnerabilities. Further details about the issues that occurred can be found in the
+<<Packages with errors>> section.
 
 <<<
 [/#if]
 
 == Packages
-[#assign advisorResults = ortResult.getAdvisorResults(false)]
+[#assign advisorResults = helper.advisorResultsWithVulnerabilities()]
 [#list advisorResults as id, results]
-Package URL: *${ModelExtensions.toPurl(id)}*
+=== ${id.name}
+
+Package URL: _${ModelExtensions.toPurl(id)}_
 
 [#list results as result]
 
-* Advisor: ${result.advisor.name}
+*Advisor: ${result.advisor.name}*
 
 [#list helper.filterForUnresolvedVulnerabilities(result.vulnerabilities) as vulnerability]
 
-** ${vulnerability.id} +
-   [#list vulnerability.references as reference]
-   Source: ${reference.url},
-   Severity: [#if reference.severity??]${reference.severity} (${reference.scoringSystem})[#else]UNKNOWN[/#if] +
-   [/#list]
+* ${vulnerability.id} +
+  [#list vulnerability.references as reference]
+  Source: ${reference.url},
+  Severity: [#if reference.severity??]${reference.severity} (${reference.scoringSystem})[#else]UNKNOWN[/#if] +
+  [/#list]
 
 [/#list]
 
 [#list result.summary.issues as issue]
-** ${issue.severity}: ${issue.message}
+* ${issue.severity}: ${issue.message}
 [/#list]
 
 [/#list]
 [/#list]
+
+[#if !advisorResults?has_content]
+No packages with security vulnerabilities have been found.
+[/#if]
+
+[#if advisorResultsWithErrors?has_content]
+<<<
+== Packages with errors
+
+When retrieving vulnerability information for these packages, the advisor module encountered errors. Therefore, it is
+possible that existing security vulnerabilities are missing from the report. This section lists the issues that
+occurred when requesting vulnerability information for the single packages.
+
+[#list advisorResultsWithErrors as id, results]
+=== ${id.name}
+
+${ModelExtensions.toPurl(id)}
+
+[#list results as result]
+
+[cols="1,5",options="header"]
+|===
+|Advisor|Message
+[#list result.summary.issues as issue]
+|${result.advisor.name}|${issue.message}
+[/#list]
+|===
+
+[/#list]
+[/#list]
+[/#if]


### PR DESCRIPTION
Analogously to the vulnerability report, a report for defects is now be generated if the ORT result contains corresponding information. For this purpose, a new template was added.

This PR also adapts the existing template for vulnerabilities to make sure that information and issues from the different advisors do not interfere with each other.