### PR TITLE
Rename `DataEntity` to `PackageType`

### DIFF
--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -196,7 +196,7 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
 
     private fun downloadFromOrtResult(ortFile: File, failureMessages: MutableList<String>) {
         println(
-            "Downloading ${packageTypes.joinToString(" and ")} from ORT result file at " +
+            "Downloading ${packageTypes.joinToString(" and ") { "${it}s" }} from ORT result file at " +
                     "'${ortFile.canonicalPath}'..."
         )
 
@@ -213,11 +213,11 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
         }
 
         val packages = mutableListOf<Package>().apply {
-            if (PackageType.PROJECTS in packageTypes) {
+            if (PackageType.PROJECT in packageTypes) {
                 addAll(consolidateProjectPackagesByVcs(analyzerResult.projects).keys)
             }
 
-            if (PackageType.PACKAGES in packageTypes) {
+            if (PackageType.PACKAGE in packageTypes) {
                 addAll(analyzerResult.packages.map { it.pkg })
             }
         }

--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -255,9 +255,9 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
 
         // Configure the package and project scanners.
         val defaultScanner = scannerFactory.create(config.scanner, config.downloader)
-        val packageScanner = defaultScanner.takeIf { PackageType.PACKAGES in packageTypes }
+        val packageScanner = defaultScanner.takeIf { PackageType.PACKAGE in packageTypes }
         val projectScanner = (projectScannerFactory?.create(config.scanner, config.downloader) ?: defaultScanner)
-            .takeIf { PackageType.PROJECTS in packageTypes }
+            .takeIf { PackageType.PROJECT in packageTypes }
 
         if (projectScanner != packageScanner) {
             if (projectScanner != null) {
@@ -311,9 +311,9 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
             }
 
         val packageScannerWrapper =
-            scannerFactory.scannerName.takeIf { PackageType.PACKAGES in packageTypes }?.let { createScannerWrapper(it) }
+            scannerFactory.scannerName.takeIf { PackageType.PACKAGE in packageTypes }?.let { createScannerWrapper(it) }
         val projectScannerWrapper = (projectScannerFactory?.scannerName ?: scannerFactory.scannerName)
-            .takeIf { PackageType.PROJECTS in packageTypes }?.let { createScannerWrapper(it) }
+            .takeIf { PackageType.PROJECT in packageTypes }?.let { createScannerWrapper(it) }
 
         val storages = config.scanner.storages.orEmpty().mapValues { createStorage(it.value) }
 
@@ -343,8 +343,8 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
                 ),
                 nestedProvenanceResolver = DefaultNestedProvenanceResolver(nestedProvenanceStorage, workingTreeCache),
                 scannerWrappers = mapOf(
-                    PackageType.PACKAGES to listOfNotNull(packageScannerWrapper),
-                    PackageType.PROJECTS to listOfNotNull(projectScannerWrapper)
+                    PackageType.PACKAGE to listOfNotNull(packageScannerWrapper),
+                    PackageType.PROJECT to listOfNotNull(projectScannerWrapper)
                 )
             )
 

--- a/helper-cli/src/main/kotlin/commands/ListPackagesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListPackagesCommand.kt
@@ -31,8 +31,8 @@ import com.github.ajalt.clikt.parameters.types.file
 import org.ossreviewtoolkit.helper.common.readOrtResult
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.PackageType
-import org.ossreviewtoolkit.model.PackageType.PACKAGES
-import org.ossreviewtoolkit.model.PackageType.PROJECTS
+import org.ossreviewtoolkit.model.PackageType.PACKAGE
+import org.ossreviewtoolkit.model.PackageType.PROJECT
 import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.model.utils.createLicenseInfoResolver
 import org.ossreviewtoolkit.utils.common.expandTilde
@@ -55,7 +55,7 @@ class ListPackagesCommand : CliktCommand(
 
     private val type by option(
         "--type",
-        help = "Filter the output by type which can be either 'projects' or 'packages'."
+        help = "Filter the output by type which can be either 'project' or 'package'."
     ).enum<PackageType>().split(",").default(enumValues<PackageType>().asList())
 
     override fun run() {
@@ -69,7 +69,7 @@ class ListPackagesCommand : CliktCommand(
                 .map { it.license.toString() }
 
         val packages = ortResult.collectProjectsAndPackages().filter { id ->
-                (ortResult.isPackage(id) && PACKAGES in type) || (ortResult.isProject(id) && PROJECTS in type)
+                (ortResult.isPackage(id) && PACKAGE in type) || (ortResult.isProject(id) && PROJECT in type)
             }.filter {
                 matchDetectedLicenses.isEmpty() || (matchDetectedLicenses - getDetectedLicenses(it)).isEmpty()
             }.sortedBy { it }

--- a/helper-cli/src/main/kotlin/commands/ListPackagesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListPackagesCommand.kt
@@ -29,10 +29,10 @@ import com.github.ajalt.clikt.parameters.types.enum
 import com.github.ajalt.clikt.parameters.types.file
 
 import org.ossreviewtoolkit.helper.common.readOrtResult
-import org.ossreviewtoolkit.model.DataEntity
-import org.ossreviewtoolkit.model.DataEntity.PACKAGES
-import org.ossreviewtoolkit.model.DataEntity.PROJECTS
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.PackageType
+import org.ossreviewtoolkit.model.PackageType.PACKAGES
+import org.ossreviewtoolkit.model.PackageType.PROJECTS
 import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.model.utils.createLicenseInfoResolver
 import org.ossreviewtoolkit.utils.common.expandTilde
@@ -56,7 +56,7 @@ class ListPackagesCommand : CliktCommand(
     private val type by option(
         "--type",
         help = "Filter the output by type which can be either 'projects' or 'packages'."
-    ).enum<DataEntity>().split(",").default(enumValues<DataEntity>().asList())
+    ).enum<PackageType>().split(",").default(enumValues<PackageType>().asList())
 
     override fun run() {
         val ortResult = readOrtResult(ortFile)

--- a/helper-cli/src/main/kotlin/commands/ListPackagesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListPackagesCommand.kt
@@ -54,8 +54,9 @@ class ListPackagesCommand : CliktCommand(
     ).split(",").default(emptyList())
 
     private val type by option(
-        "--type",
-        help = "Filter the output by type which can be either 'project' or 'package'."
+        "--package-type",
+        help = "Filter the output by package type. Possible values are: " +
+                PackageType.values().joinToString { it.name }
     ).enum<PackageType>().split(",").default(enumValues<PackageType>().asList())
 
     override fun run() {

--- a/model/src/main/kotlin/PackageType.kt
+++ b/model/src/main/kotlin/PackageType.kt
@@ -21,16 +21,16 @@
 package org.ossreviewtoolkit.model
 
 /**
- * The choice of data entities to process.
+ * An enum to describe the different types of [Package]s.
  */
-enum class DataEntity {
+enum class PackageType {
     /**
-     * Identifier for package entities.
+     * A package that represents a dependency of a [Project] and is not a [Project] itself.
      */
     PACKAGES,
 
     /**
-     * Identifier for project entities.
+     * A package that was created from a [Project].
      */
     PROJECTS
 }

--- a/model/src/main/kotlin/PackageType.kt
+++ b/model/src/main/kotlin/PackageType.kt
@@ -27,10 +27,10 @@ enum class PackageType {
     /**
      * A package that represents a dependency of a [Project] and is not a [Project] itself.
      */
-    PACKAGES,
+    PACKAGE,
 
     /**
      * A package that was created from a [Project].
      */
-    PROJECTS
+    PROJECT
 }

--- a/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
+++ b/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
@@ -26,11 +26,11 @@ import kotlin.time.measureTimedValue
 
 import org.ossreviewtoolkit.downloader.DownloadException
 import org.ossreviewtoolkit.model.AccessStatistics
-import org.ossreviewtoolkit.model.DataEntity
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.ScanRecord
 import org.ossreviewtoolkit.model.ScanResult
@@ -52,7 +52,7 @@ class ExperimentalScanner(
     val storageWriters: List<ScanStorageWriter>,
     val packageProvenanceResolver: PackageProvenanceResolver,
     val nestedProvenanceResolver: NestedProvenanceResolver,
-    val scannerWrappers: Map<DataEntity, List<ScannerWrapper>>
+    val scannerWrappers: Map<PackageType, List<ScannerWrapper>>
 ) {
     init {
         require(scannerWrappers.isNotEmpty() && scannerWrappers.any { it.value.isNotEmpty() }) {
@@ -63,15 +63,15 @@ class ExperimentalScanner(
     suspend fun scan(ortResult: OrtResult): OrtResult {
         val startTime = Instant.now()
 
-        val projectScannerWrappers = scannerWrappers[DataEntity.PROJECTS].orEmpty()
-        val packageScannerWrappers = scannerWrappers[DataEntity.PACKAGES].orEmpty()
+        val projectScannerWrappers = scannerWrappers[PackageType.PROJECTS].orEmpty()
+        val packageScannerWrappers = scannerWrappers[PackageType.PACKAGES].orEmpty()
 
         val projectResults = if (projectScannerWrappers.isNotEmpty()) {
             val packages = ortResult.getProjects().mapTo(mutableSetOf()) { it.toPackage() }
 
             log.info { "Scanning ${packages.size} projects with ${projectScannerWrappers.size} scanners." }
 
-            scan(packages, ScanContext(ortResult.labels, DataEntity.PROJECTS))
+            scan(packages, ScanContext(ortResult.labels, PackageType.PROJECTS))
         } else {
             log.info { "Skipping scan of projects because no project scanner is configured." }
 
@@ -83,7 +83,7 @@ class ExperimentalScanner(
 
             log.info { "Scanning ${packages.size} packages with ${packageScannerWrappers.size} scanners." }
 
-            scan(packages, ScanContext(ortResult.labels, DataEntity.PACKAGES))
+            scan(packages, ScanContext(ortResult.labels, PackageType.PACKAGES))
         } else {
             log.info { "Skipping scan of packages because no package scanner is configured." }
 

--- a/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
+++ b/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
@@ -63,15 +63,15 @@ class ExperimentalScanner(
     suspend fun scan(ortResult: OrtResult): OrtResult {
         val startTime = Instant.now()
 
-        val projectScannerWrappers = scannerWrappers[PackageType.PROJECTS].orEmpty()
-        val packageScannerWrappers = scannerWrappers[PackageType.PACKAGES].orEmpty()
+        val projectScannerWrappers = scannerWrappers[PackageType.PROJECT].orEmpty()
+        val packageScannerWrappers = scannerWrappers[PackageType.PACKAGE].orEmpty()
 
         val projectResults = if (projectScannerWrappers.isNotEmpty()) {
             val packages = ortResult.getProjects().mapTo(mutableSetOf()) { it.toPackage() }
 
             log.info { "Scanning ${packages.size} projects with ${projectScannerWrappers.size} scanners." }
 
-            scan(packages, ScanContext(ortResult.labels, PackageType.PROJECTS))
+            scan(packages, ScanContext(ortResult.labels, PackageType.PROJECT))
         } else {
             log.info { "Skipping scan of projects because no project scanner is configured." }
 
@@ -83,7 +83,7 @@ class ExperimentalScanner(
 
             log.info { "Scanning ${packages.size} packages with ${packageScannerWrappers.size} scanners." }
 
-            scan(packages, ScanContext(ortResult.labels, PackageType.PACKAGES))
+            scan(packages, ScanContext(ortResult.labels, PackageType.PACKAGE))
         } else {
             log.info { "Skipping scan of packages because no package scanner is configured." }
 

--- a/scanner/src/main/kotlin/experimental/ScanContext.kt
+++ b/scanner/src/main/kotlin/experimental/ScanContext.kt
@@ -19,8 +19,8 @@
 
 package org.ossreviewtoolkit.scanner.experimental
 
-import org.ossreviewtoolkit.model.DataEntity
 import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.PackageType
 
 /**
  * Additional context information that can be used by a [ScannerWrapper] to alter its behavior.
@@ -32,7 +32,7 @@ data class ScanContext(
     val labels: Map<String, String>,
 
     /**
-     * The [type][DataEntity] of the packages to scan.
+     * The [type][PackageType] of the packages to scan.
      */
-    val packageType: DataEntity
+    val packageType: PackageType
 )

--- a/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
+++ b/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
@@ -81,8 +81,8 @@ class ExperimentalScannerTest : WordSpec({
                 projectScannerWrappers = listOf(projectScannerWrapper)
             )
 
-            val packageContext = createContext(type = PackageType.PACKAGES)
-            val projectContext = createContext(type = PackageType.PROJECTS)
+            val packageContext = createContext(type = PackageType.PACKAGE)
+            val projectContext = createContext(type = PackageType.PROJECT)
 
             scanner.scan(setOf(pkgWithArtifact), packageContext)[pkgWithArtifact] shouldNotBeNull {
                 scanResults shouldNot beEmpty()
@@ -103,7 +103,7 @@ class ExperimentalScannerTest : WordSpec({
                 projectScannerWrappers = emptyList()
             )
 
-            scanner.scan(setOf(pkgWithArtifact), createContext(type = PackageType.PROJECTS)) should beEmpty()
+            scanner.scan(setOf(pkgWithArtifact), createContext(type = PackageType.PROJECT)) should beEmpty()
         }
 
         "Not scan packages if no scanner wrapper for packages is configured" {
@@ -757,7 +757,7 @@ private class FakeProvenanceBasedStorageWriter : ProvenanceBasedScanStorageWrite
 
 private fun createContext(
     labels: Map<String, String> = emptyMap(),
-    type: PackageType = PackageType.PACKAGES
+    type: PackageType = PackageType.PACKAGE
 ) = ScanContext(labels, type)
 
 @Suppress("LongParameterList")
@@ -781,8 +781,8 @@ private fun createScanner(
         packageProvenanceResolver,
         nestedProvenanceResolver,
         mapOf(
-            PackageType.PROJECTS to projectScannerWrappers,
-            PackageType.PACKAGES to packageScannerWrappers
+            PackageType.PROJECT to projectScannerWrappers,
+            PackageType.PACKAGE to packageScannerWrappers
         )
     )
 

--- a/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
+++ b/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
@@ -36,13 +36,13 @@ import java.io.File
 import java.time.Instant
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
-import org.ossreviewtoolkit.model.DataEntity
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.HashAlgorithm
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.RepositoryProvenance
@@ -81,8 +81,8 @@ class ExperimentalScannerTest : WordSpec({
                 projectScannerWrappers = listOf(projectScannerWrapper)
             )
 
-            val packageContext = createContext(type = DataEntity.PACKAGES)
-            val projectContext = createContext(type = DataEntity.PROJECTS)
+            val packageContext = createContext(type = PackageType.PACKAGES)
+            val projectContext = createContext(type = PackageType.PROJECTS)
 
             scanner.scan(setOf(pkgWithArtifact), packageContext)[pkgWithArtifact] shouldNotBeNull {
                 scanResults shouldNot beEmpty()
@@ -103,7 +103,7 @@ class ExperimentalScannerTest : WordSpec({
                 projectScannerWrappers = emptyList()
             )
 
-            scanner.scan(setOf(pkgWithArtifact), createContext(type = DataEntity.PROJECTS)) should beEmpty()
+            scanner.scan(setOf(pkgWithArtifact), createContext(type = PackageType.PROJECTS)) should beEmpty()
         }
 
         "Not scan packages if no scanner wrapper for packages is configured" {
@@ -757,7 +757,7 @@ private class FakeProvenanceBasedStorageWriter : ProvenanceBasedScanStorageWrite
 
 private fun createContext(
     labels: Map<String, String> = emptyMap(),
-    type: DataEntity = DataEntity.PACKAGES
+    type: PackageType = PackageType.PACKAGES
 ) = ScanContext(labels, type)
 
 @Suppress("LongParameterList")
@@ -781,8 +781,8 @@ private fun createScanner(
         packageProvenanceResolver,
         nestedProvenanceResolver,
         mapOf(
-            DataEntity.PROJECTS to projectScannerWrappers,
-            DataEntity.PACKAGES to packageScannerWrappers
+            PackageType.PROJECTS to projectScannerWrappers,
+            PackageType.PACKAGES to packageScannerWrappers
         )
     )
 


### PR DESCRIPTION
`DataEntity` is a very generic name, replace it with a more specific
name that better describes the purpose of the enum. While at it, also
improve the documentation of the enum and rename the command line
parameters accordingly.