### PR TITLE
BabelFunTest: Recreate the lockfile in v2 using NPM 7.20.6

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -37,7 +37,7 @@ project:
               dependencies:
               - id: "NPM::ansi-regex:2.1.1"
             - id: "NPM::supports-color:2.0.0"
-          - id: "NPM::esutils:2.0.2"
+          - id: "NPM::esutils:2.0.3"
           - id: "NPM::js-tokens:3.0.2"
         - id: "NPM::babel-generator:6.26.1"
           dependencies:
@@ -45,43 +45,41 @@ project:
             dependencies:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
-              - id: "NPM::core-js:2.6.9"
+              - id: "NPM::core-js:2.6.12"
               - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::babel-runtime:6.26.0"
             dependencies:
-            - id: "NPM::core-js:2.6.9"
+            - id: "NPM::core-js:2.6.12"
             - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::babel-types:6.26.0"
             dependencies:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
-              - id: "NPM::core-js:2.6.9"
+              - id: "NPM::core-js:2.6.12"
               - id: "NPM::regenerator-runtime:0.11.1"
-            - id: "NPM::esutils:2.0.2"
-            - id: "NPM::lodash:4.17.15"
+            - id: "NPM::esutils:2.0.3"
+            - id: "NPM::lodash:4.17.21"
             - id: "NPM::to-fast-properties:1.0.3"
           - id: "NPM::detect-indent:4.0.0"
             dependencies:
             - id: "NPM::repeating:2.0.1"
               dependencies:
-              - id: "NPM::is-finite:1.0.2"
-                dependencies:
-                - id: "NPM::number-is-nan:1.0.1"
+              - id: "NPM::is-finite:1.1.0"
           - id: "NPM::jsesc:1.3.0"
-          - id: "NPM::lodash:4.17.15"
+          - id: "NPM::lodash:4.17.21"
           - id: "NPM::source-map:0.5.7"
           - id: "NPM::trim-right:1.0.1"
         - id: "NPM::babel-helpers:6.24.1"
           dependencies:
           - id: "NPM::babel-runtime:6.26.0"
             dependencies:
-            - id: "NPM::core-js:2.6.9"
+            - id: "NPM::core-js:2.6.12"
             - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::babel-template:6.26.0"
             dependencies:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
-              - id: "NPM::core-js:2.6.9"
+              - id: "NPM::core-js:2.6.12"
               - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-traverse:6.26.0"
               dependencies:
@@ -98,26 +96,26 @@ project:
                     dependencies:
                     - id: "NPM::ansi-regex:2.1.1"
                   - id: "NPM::supports-color:2.0.0"
-                - id: "NPM::esutils:2.0.2"
+                - id: "NPM::esutils:2.0.3"
                 - id: "NPM::js-tokens:3.0.2"
               - id: "NPM::babel-messages:6.23.0"
                 dependencies:
                 - id: "NPM::babel-runtime:6.26.0"
                   dependencies:
-                  - id: "NPM::core-js:2.6.9"
+                  - id: "NPM::core-js:2.6.12"
                   - id: "NPM::regenerator-runtime:0.11.1"
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
-                - id: "NPM::core-js:2.6.9"
+                - id: "NPM::core-js:2.6.12"
                 - id: "NPM::regenerator-runtime:0.11.1"
               - id: "NPM::babel-types:6.26.0"
                 dependencies:
                 - id: "NPM::babel-runtime:6.26.0"
                   dependencies:
-                  - id: "NPM::core-js:2.6.9"
+                  - id: "NPM::core-js:2.6.12"
                   - id: "NPM::regenerator-runtime:0.11.1"
-                - id: "NPM::esutils:2.0.2"
-                - id: "NPM::lodash:4.17.15"
+                - id: "NPM::esutils:2.0.3"
+                - id: "NPM::lodash:4.17.21"
                 - id: "NPM::to-fast-properties:1.0.3"
               - id: "NPM::babylon:6.18.0"
               - id: "NPM::debug:2.6.9"
@@ -129,51 +127,51 @@ project:
                 - id: "NPM::loose-envify:1.4.0"
                   dependencies:
                   - id: "NPM::js-tokens:3.0.2"
-              - id: "NPM::lodash:4.17.15"
+              - id: "NPM::lodash:4.17.21"
             - id: "NPM::babel-types:6.26.0"
               dependencies:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
-                - id: "NPM::core-js:2.6.9"
+                - id: "NPM::core-js:2.6.12"
                 - id: "NPM::regenerator-runtime:0.11.1"
-              - id: "NPM::esutils:2.0.2"
-              - id: "NPM::lodash:4.17.15"
+              - id: "NPM::esutils:2.0.3"
+              - id: "NPM::lodash:4.17.21"
               - id: "NPM::to-fast-properties:1.0.3"
             - id: "NPM::babylon:6.18.0"
-            - id: "NPM::lodash:4.17.15"
+            - id: "NPM::lodash:4.17.21"
         - id: "NPM::babel-messages:6.23.0"
           dependencies:
           - id: "NPM::babel-runtime:6.26.0"
             dependencies:
-            - id: "NPM::core-js:2.6.9"
+            - id: "NPM::core-js:2.6.12"
             - id: "NPM::regenerator-runtime:0.11.1"
         - id: "NPM::babel-register:6.26.0"
           dependencies:
           - id: "NPM::babel-runtime:6.26.0"
             dependencies:
-            - id: "NPM::core-js:2.6.9"
+            - id: "NPM::core-js:2.6.12"
             - id: "NPM::regenerator-runtime:0.11.1"
-          - id: "NPM::core-js:2.6.9"
+          - id: "NPM::core-js:2.6.12"
           - id: "NPM::home-or-tmp:2.0.0"
             dependencies:
             - id: "NPM::os-homedir:1.0.2"
             - id: "NPM::os-tmpdir:1.0.2"
-          - id: "NPM::lodash:4.17.15"
-          - id: "NPM::mkdirp:0.5.1"
+          - id: "NPM::lodash:4.17.21"
+          - id: "NPM::mkdirp:0.5.5"
             dependencies:
-            - id: "NPM::minimist:0.0.8"
+            - id: "NPM::minimist:1.2.5"
           - id: "NPM::source-map-support:0.4.18"
             dependencies:
             - id: "NPM::source-map:0.5.7"
         - id: "NPM::babel-runtime:6.26.0"
           dependencies:
-          - id: "NPM::core-js:2.6.9"
+          - id: "NPM::core-js:2.6.12"
           - id: "NPM::regenerator-runtime:0.11.1"
         - id: "NPM::babel-template:6.26.0"
           dependencies:
           - id: "NPM::babel-runtime:6.26.0"
             dependencies:
-            - id: "NPM::core-js:2.6.9"
+            - id: "NPM::core-js:2.6.12"
             - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::babel-traverse:6.26.0"
             dependencies:
@@ -190,26 +188,26 @@ project:
                   dependencies:
                   - id: "NPM::ansi-regex:2.1.1"
                 - id: "NPM::supports-color:2.0.0"
-              - id: "NPM::esutils:2.0.2"
+              - id: "NPM::esutils:2.0.3"
               - id: "NPM::js-tokens:3.0.2"
             - id: "NPM::babel-messages:6.23.0"
               dependencies:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
-                - id: "NPM::core-js:2.6.9"
+                - id: "NPM::core-js:2.6.12"
                 - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
-              - id: "NPM::core-js:2.6.9"
+              - id: "NPM::core-js:2.6.12"
               - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-types:6.26.0"
               dependencies:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
-                - id: "NPM::core-js:2.6.9"
+                - id: "NPM::core-js:2.6.12"
                 - id: "NPM::regenerator-runtime:0.11.1"
-              - id: "NPM::esutils:2.0.2"
-              - id: "NPM::lodash:4.17.15"
+              - id: "NPM::esutils:2.0.3"
+              - id: "NPM::lodash:4.17.21"
               - id: "NPM::to-fast-properties:1.0.3"
             - id: "NPM::babylon:6.18.0"
             - id: "NPM::debug:2.6.9"
@@ -221,18 +219,18 @@ project:
               - id: "NPM::loose-envify:1.4.0"
                 dependencies:
                 - id: "NPM::js-tokens:3.0.2"
-            - id: "NPM::lodash:4.17.15"
+            - id: "NPM::lodash:4.17.21"
           - id: "NPM::babel-types:6.26.0"
             dependencies:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
-              - id: "NPM::core-js:2.6.9"
+              - id: "NPM::core-js:2.6.12"
               - id: "NPM::regenerator-runtime:0.11.1"
-            - id: "NPM::esutils:2.0.2"
-            - id: "NPM::lodash:4.17.15"
+            - id: "NPM::esutils:2.0.3"
+            - id: "NPM::lodash:4.17.21"
             - id: "NPM::to-fast-properties:1.0.3"
           - id: "NPM::babylon:6.18.0"
-          - id: "NPM::lodash:4.17.15"
+          - id: "NPM::lodash:4.17.21"
         - id: "NPM::babel-traverse:6.26.0"
           dependencies:
           - id: "NPM::babel-code-frame:6.26.0"
@@ -248,26 +246,26 @@ project:
                 dependencies:
                 - id: "NPM::ansi-regex:2.1.1"
               - id: "NPM::supports-color:2.0.0"
-            - id: "NPM::esutils:2.0.2"
+            - id: "NPM::esutils:2.0.3"
             - id: "NPM::js-tokens:3.0.2"
           - id: "NPM::babel-messages:6.23.0"
             dependencies:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
-              - id: "NPM::core-js:2.6.9"
+              - id: "NPM::core-js:2.6.12"
               - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::babel-runtime:6.26.0"
             dependencies:
-            - id: "NPM::core-js:2.6.9"
+            - id: "NPM::core-js:2.6.12"
             - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::babel-types:6.26.0"
             dependencies:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
-              - id: "NPM::core-js:2.6.9"
+              - id: "NPM::core-js:2.6.12"
               - id: "NPM::regenerator-runtime:0.11.1"
-            - id: "NPM::esutils:2.0.2"
-            - id: "NPM::lodash:4.17.15"
+            - id: "NPM::esutils:2.0.3"
+            - id: "NPM::lodash:4.17.21"
             - id: "NPM::to-fast-properties:1.0.3"
           - id: "NPM::babylon:6.18.0"
           - id: "NPM::debug:2.6.9"
@@ -279,30 +277,30 @@ project:
             - id: "NPM::loose-envify:1.4.0"
               dependencies:
               - id: "NPM::js-tokens:3.0.2"
-          - id: "NPM::lodash:4.17.15"
+          - id: "NPM::lodash:4.17.21"
         - id: "NPM::babel-types:6.26.0"
           dependencies:
           - id: "NPM::babel-runtime:6.26.0"
             dependencies:
-            - id: "NPM::core-js:2.6.9"
+            - id: "NPM::core-js:2.6.12"
             - id: "NPM::regenerator-runtime:0.11.1"
-          - id: "NPM::esutils:2.0.2"
-          - id: "NPM::lodash:4.17.15"
+          - id: "NPM::esutils:2.0.3"
+          - id: "NPM::lodash:4.17.21"
           - id: "NPM::to-fast-properties:1.0.3"
         - id: "NPM::babylon:6.18.0"
-        - id: "NPM::convert-source-map:1.6.0"
+        - id: "NPM::convert-source-map:1.8.0"
           dependencies:
           - id: "NPM::safe-buffer:5.1.2"
         - id: "NPM::debug:2.6.9"
           dependencies:
           - id: "NPM::ms:2.0.0"
         - id: "NPM::json5:0.5.1"
-        - id: "NPM::lodash:4.17.15"
+        - id: "NPM::lodash:4.17.21"
         - id: "NPM::minimatch:3.0.4"
           dependencies:
           - id: "NPM::brace-expansion:1.1.11"
             dependencies:
-            - id: "NPM::balanced-match:1.0.0"
+            - id: "NPM::balanced-match:1.0.2"
             - id: "NPM::concat-map:0.0.1"
         - id: "NPM::path-is-absolute:1.0.1"
         - id: "NPM::private:0.1.8"
@@ -312,9 +310,9 @@ project:
         dependencies:
         - id: "NPM::babel-runtime:6.26.0"
           dependencies:
-          - id: "NPM::core-js:2.6.9"
+          - id: "NPM::core-js:2.6.12"
           - id: "NPM::regenerator-runtime:0.11.1"
-        - id: "NPM::core-js:2.6.9"
+        - id: "NPM::core-js:2.6.12"
         - id: "NPM::regenerator-runtime:0.10.5"
       - id: "NPM::babel-register:6.26.0"
         dependencies:
@@ -333,7 +331,7 @@ project:
                 dependencies:
                 - id: "NPM::ansi-regex:2.1.1"
               - id: "NPM::supports-color:2.0.0"
-            - id: "NPM::esutils:2.0.2"
+            - id: "NPM::esutils:2.0.3"
             - id: "NPM::js-tokens:3.0.2"
           - id: "NPM::babel-generator:6.26.1"
             dependencies:
@@ -341,43 +339,41 @@ project:
               dependencies:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
-                - id: "NPM::core-js:2.6.9"
+                - id: "NPM::core-js:2.6.12"
                 - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
-              - id: "NPM::core-js:2.6.9"
+              - id: "NPM::core-js:2.6.12"
               - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-types:6.26.0"
               dependencies:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
-                - id: "NPM::core-js:2.6.9"
+                - id: "NPM::core-js:2.6.12"
                 - id: "NPM::regenerator-runtime:0.11.1"
-              - id: "NPM::esutils:2.0.2"
-              - id: "NPM::lodash:4.17.15"
+              - id: "NPM::esutils:2.0.3"
+              - id: "NPM::lodash:4.17.21"
               - id: "NPM::to-fast-properties:1.0.3"
             - id: "NPM::detect-indent:4.0.0"
               dependencies:
               - id: "NPM::repeating:2.0.1"
                 dependencies:
-                - id: "NPM::is-finite:1.0.2"
-                  dependencies:
-                  - id: "NPM::number-is-nan:1.0.1"
+                - id: "NPM::is-finite:1.1.0"
             - id: "NPM::jsesc:1.3.0"
-            - id: "NPM::lodash:4.17.15"
+            - id: "NPM::lodash:4.17.21"
             - id: "NPM::source-map:0.5.7"
             - id: "NPM::trim-right:1.0.1"
           - id: "NPM::babel-helpers:6.24.1"
             dependencies:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
-              - id: "NPM::core-js:2.6.9"
+              - id: "NPM::core-js:2.6.12"
               - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-template:6.26.0"
               dependencies:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
-                - id: "NPM::core-js:2.6.9"
+                - id: "NPM::core-js:2.6.12"
                 - id: "NPM::regenerator-runtime:0.11.1"
               - id: "NPM::babel-traverse:6.26.0"
                 dependencies:
@@ -394,26 +390,26 @@ project:
                       dependencies:
                       - id: "NPM::ansi-regex:2.1.1"
                     - id: "NPM::supports-color:2.0.0"
-                  - id: "NPM::esutils:2.0.2"
+                  - id: "NPM::esutils:2.0.3"
                   - id: "NPM::js-tokens:3.0.2"
                 - id: "NPM::babel-messages:6.23.0"
                   dependencies:
                   - id: "NPM::babel-runtime:6.26.0"
                     dependencies:
-                    - id: "NPM::core-js:2.6.9"
+                    - id: "NPM::core-js:2.6.12"
                     - id: "NPM::regenerator-runtime:0.11.1"
                 - id: "NPM::babel-runtime:6.26.0"
                   dependencies:
-                  - id: "NPM::core-js:2.6.9"
+                  - id: "NPM::core-js:2.6.12"
                   - id: "NPM::regenerator-runtime:0.11.1"
                 - id: "NPM::babel-types:6.26.0"
                   dependencies:
                   - id: "NPM::babel-runtime:6.26.0"
                     dependencies:
-                    - id: "NPM::core-js:2.6.9"
+                    - id: "NPM::core-js:2.6.12"
                     - id: "NPM::regenerator-runtime:0.11.1"
-                  - id: "NPM::esutils:2.0.2"
-                  - id: "NPM::lodash:4.17.15"
+                  - id: "NPM::esutils:2.0.3"
+                  - id: "NPM::lodash:4.17.21"
                   - id: "NPM::to-fast-properties:1.0.3"
                 - id: "NPM::babylon:6.18.0"
                 - id: "NPM::debug:2.6.9"
@@ -425,33 +421,33 @@ project:
                   - id: "NPM::loose-envify:1.4.0"
                     dependencies:
                     - id: "NPM::js-tokens:3.0.2"
-                - id: "NPM::lodash:4.17.15"
+                - id: "NPM::lodash:4.17.21"
               - id: "NPM::babel-types:6.26.0"
                 dependencies:
                 - id: "NPM::babel-runtime:6.26.0"
                   dependencies:
-                  - id: "NPM::core-js:2.6.9"
+                  - id: "NPM::core-js:2.6.12"
                   - id: "NPM::regenerator-runtime:0.11.1"
-                - id: "NPM::esutils:2.0.2"
-                - id: "NPM::lodash:4.17.15"
+                - id: "NPM::esutils:2.0.3"
+                - id: "NPM::lodash:4.17.21"
                 - id: "NPM::to-fast-properties:1.0.3"
               - id: "NPM::babylon:6.18.0"
-              - id: "NPM::lodash:4.17.15"
+              - id: "NPM::lodash:4.17.21"
           - id: "NPM::babel-messages:6.23.0"
             dependencies:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
-              - id: "NPM::core-js:2.6.9"
+              - id: "NPM::core-js:2.6.12"
               - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::babel-runtime:6.26.0"
             dependencies:
-            - id: "NPM::core-js:2.6.9"
+            - id: "NPM::core-js:2.6.12"
             - id: "NPM::regenerator-runtime:0.11.1"
           - id: "NPM::babel-template:6.26.0"
             dependencies:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
-              - id: "NPM::core-js:2.6.9"
+              - id: "NPM::core-js:2.6.12"
               - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-traverse:6.26.0"
               dependencies:
@@ -468,26 +464,26 @@ project:
                     dependencies:
                     - id: "NPM::ansi-regex:2.1.1"
                   - id: "NPM::supports-color:2.0.0"
-                - id: "NPM::esutils:2.0.2"
+                - id: "NPM::esutils:2.0.3"
                 - id: "NPM::js-tokens:3.0.2"
               - id: "NPM::babel-messages:6.23.0"
                 dependencies:
                 - id: "NPM::babel-runtime:6.26.0"
                   dependencies:
-                  - id: "NPM::core-js:2.6.9"
+                  - id: "NPM::core-js:2.6.12"
                   - id: "NPM::regenerator-runtime:0.11.1"
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
-                - id: "NPM::core-js:2.6.9"
+                - id: "NPM::core-js:2.6.12"
                 - id: "NPM::regenerator-runtime:0.11.1"
               - id: "NPM::babel-types:6.26.0"
                 dependencies:
                 - id: "NPM::babel-runtime:6.26.0"
                   dependencies:
-                  - id: "NPM::core-js:2.6.9"
+                  - id: "NPM::core-js:2.6.12"
                   - id: "NPM::regenerator-runtime:0.11.1"
-                - id: "NPM::esutils:2.0.2"
-                - id: "NPM::lodash:4.17.15"
+                - id: "NPM::esutils:2.0.3"
+                - id: "NPM::lodash:4.17.21"
                 - id: "NPM::to-fast-properties:1.0.3"
               - id: "NPM::babylon:6.18.0"
               - id: "NPM::debug:2.6.9"
@@ -499,18 +495,18 @@ project:
                 - id: "NPM::loose-envify:1.4.0"
                   dependencies:
                   - id: "NPM::js-tokens:3.0.2"
-              - id: "NPM::lodash:4.17.15"
+              - id: "NPM::lodash:4.17.21"
             - id: "NPM::babel-types:6.26.0"
               dependencies:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
-                - id: "NPM::core-js:2.6.9"
+                - id: "NPM::core-js:2.6.12"
                 - id: "NPM::regenerator-runtime:0.11.1"
-              - id: "NPM::esutils:2.0.2"
-              - id: "NPM::lodash:4.17.15"
+              - id: "NPM::esutils:2.0.3"
+              - id: "NPM::lodash:4.17.21"
               - id: "NPM::to-fast-properties:1.0.3"
             - id: "NPM::babylon:6.18.0"
-            - id: "NPM::lodash:4.17.15"
+            - id: "NPM::lodash:4.17.21"
           - id: "NPM::babel-traverse:6.26.0"
             dependencies:
             - id: "NPM::babel-code-frame:6.26.0"
@@ -526,26 +522,26 @@ project:
                   dependencies:
                   - id: "NPM::ansi-regex:2.1.1"
                 - id: "NPM::supports-color:2.0.0"
-              - id: "NPM::esutils:2.0.2"
+              - id: "NPM::esutils:2.0.3"
               - id: "NPM::js-tokens:3.0.2"
             - id: "NPM::babel-messages:6.23.0"
               dependencies:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
-                - id: "NPM::core-js:2.6.9"
+                - id: "NPM::core-js:2.6.12"
                 - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
-              - id: "NPM::core-js:2.6.9"
+              - id: "NPM::core-js:2.6.12"
               - id: "NPM::regenerator-runtime:0.11.1"
             - id: "NPM::babel-types:6.26.0"
               dependencies:
               - id: "NPM::babel-runtime:6.26.0"
                 dependencies:
-                - id: "NPM::core-js:2.6.9"
+                - id: "NPM::core-js:2.6.12"
                 - id: "NPM::regenerator-runtime:0.11.1"
-              - id: "NPM::esutils:2.0.2"
-              - id: "NPM::lodash:4.17.15"
+              - id: "NPM::esutils:2.0.3"
+              - id: "NPM::lodash:4.17.21"
               - id: "NPM::to-fast-properties:1.0.3"
             - id: "NPM::babylon:6.18.0"
             - id: "NPM::debug:2.6.9"
@@ -557,30 +553,30 @@ project:
               - id: "NPM::loose-envify:1.4.0"
                 dependencies:
                 - id: "NPM::js-tokens:3.0.2"
-            - id: "NPM::lodash:4.17.15"
+            - id: "NPM::lodash:4.17.21"
           - id: "NPM::babel-types:6.26.0"
             dependencies:
             - id: "NPM::babel-runtime:6.26.0"
               dependencies:
-              - id: "NPM::core-js:2.6.9"
+              - id: "NPM::core-js:2.6.12"
               - id: "NPM::regenerator-runtime:0.11.1"
-            - id: "NPM::esutils:2.0.2"
-            - id: "NPM::lodash:4.17.15"
+            - id: "NPM::esutils:2.0.3"
+            - id: "NPM::lodash:4.17.21"
             - id: "NPM::to-fast-properties:1.0.3"
           - id: "NPM::babylon:6.18.0"
-          - id: "NPM::convert-source-map:1.6.0"
+          - id: "NPM::convert-source-map:1.8.0"
             dependencies:
             - id: "NPM::safe-buffer:5.1.2"
           - id: "NPM::debug:2.6.9"
             dependencies:
             - id: "NPM::ms:2.0.0"
           - id: "NPM::json5:0.5.1"
-          - id: "NPM::lodash:4.17.15"
+          - id: "NPM::lodash:4.17.21"
           - id: "NPM::minimatch:3.0.4"
             dependencies:
             - id: "NPM::brace-expansion:1.1.11"
               dependencies:
-              - id: "NPM::balanced-match:1.0.0"
+              - id: "NPM::balanced-match:1.0.2"
               - id: "NPM::concat-map:0.0.1"
           - id: "NPM::path-is-absolute:1.0.1"
           - id: "NPM::private:0.1.8"
@@ -588,23 +584,23 @@ project:
           - id: "NPM::source-map:0.5.7"
         - id: "NPM::babel-runtime:6.26.0"
           dependencies:
-          - id: "NPM::core-js:2.6.9"
+          - id: "NPM::core-js:2.6.12"
           - id: "NPM::regenerator-runtime:0.11.1"
-        - id: "NPM::core-js:2.6.9"
+        - id: "NPM::core-js:2.6.12"
         - id: "NPM::home-or-tmp:2.0.0"
           dependencies:
           - id: "NPM::os-homedir:1.0.2"
           - id: "NPM::os-tmpdir:1.0.2"
-        - id: "NPM::lodash:4.17.15"
-        - id: "NPM::mkdirp:0.5.1"
+        - id: "NPM::lodash:4.17.21"
+        - id: "NPM::mkdirp:0.5.5"
           dependencies:
-          - id: "NPM::minimist:0.0.8"
+          - id: "NPM::minimist:1.2.5"
         - id: "NPM::source-map-support:0.4.18"
           dependencies:
           - id: "NPM::source-map:0.5.7"
       - id: "NPM::babel-runtime:6.26.0"
         dependencies:
-        - id: "NPM::core-js:2.6.9"
+        - id: "NPM::core-js:2.6.12"
         - id: "NPM::regenerator-runtime:0.11.1"
       - id: "NPM::chokidar:1.7.0"
         dependencies:
@@ -633,12 +629,12 @@ project:
                   - id: "NPM::randomatic:3.1.1"
                     dependencies:
                     - id: "NPM::is-number:4.0.0"
-                    - id: "NPM::kind-of:6.0.2"
+                    - id: "NPM::kind-of:6.0.3"
                     - id: "NPM::math-random:1.0.4"
-                  - id: "NPM::repeat-element:1.1.3"
+                  - id: "NPM::repeat-element:1.1.4"
                   - id: "NPM::repeat-string:1.6.1"
               - id: "NPM::preserve:0.2.0"
-              - id: "NPM::repeat-element:1.1.3"
+              - id: "NPM::repeat-element:1.1.4"
             - id: "NPM::expand-brackets:0.1.5"
               dependencies:
               - id: "NPM::is-posix-bracket:0.1.1"
@@ -688,143 +684,6 @@ project:
             dependencies:
             - id: "NPM::remove-trailing-separator:1.1.0"
         - id: "NPM::async-each:1.0.3"
-        - id: "NPM::fsevents:1.2.9"
-          dependencies:
-          - id: "NPM::nan:2.14.0"
-          - id: "NPM::node-pre-gyp:0.12.0"
-            dependencies:
-            - id: "NPM::detect-libc:1.0.3"
-            - id: "NPM::mkdirp:0.5.1"
-              dependencies:
-              - id: "NPM::minimist:0.0.8"
-            - id: "NPM::needle:2.3.0"
-              dependencies:
-              - id: "NPM::debug:4.1.1"
-                dependencies:
-                - id: "NPM::ms:2.1.1"
-              - id: "NPM::iconv-lite:0.4.24"
-                dependencies:
-                - id: "NPM::safer-buffer:2.1.2"
-              - id: "NPM::sax:1.2.4"
-            - id: "NPM::nopt:4.0.1"
-              dependencies:
-              - id: "NPM::abbrev:1.1.1"
-              - id: "NPM::osenv:0.1.5"
-                dependencies:
-                - id: "NPM::os-homedir:1.0.2"
-                - id: "NPM::os-tmpdir:1.0.2"
-            - id: "NPM::npm-packlist:1.4.1"
-              dependencies:
-              - id: "NPM::ignore-walk:3.0.1"
-                dependencies:
-                - id: "NPM::minimatch:3.0.4"
-                  dependencies:
-                  - id: "NPM::brace-expansion:1.1.11"
-                    dependencies:
-                    - id: "NPM::balanced-match:1.0.0"
-                    - id: "NPM::concat-map:0.0.1"
-              - id: "NPM::npm-bundled:1.0.6"
-            - id: "NPM::npmlog:4.1.2"
-              dependencies:
-              - id: "NPM::are-we-there-yet:1.1.5"
-                dependencies:
-                - id: "NPM::delegates:1.0.0"
-                - id: "NPM::readable-stream:2.3.6"
-                  dependencies:
-                  - id: "NPM::core-util-is:1.0.2"
-                  - id: "NPM::inherits:2.0.3"
-                  - id: "NPM::isarray:1.0.0"
-                  - id: "NPM::process-nextick-args:2.0.0"
-                  - id: "NPM::safe-buffer:5.1.2"
-                  - id: "NPM::string_decoder:1.1.1"
-                    dependencies:
-                    - id: "NPM::safe-buffer:5.1.2"
-                  - id: "NPM::util-deprecate:1.0.2"
-              - id: "NPM::console-control-strings:1.1.0"
-              - id: "NPM::gauge:2.7.4"
-                dependencies:
-                - id: "NPM::aproba:1.2.0"
-                - id: "NPM::console-control-strings:1.1.0"
-                - id: "NPM::has-unicode:2.0.1"
-                - id: "NPM::object-assign:4.1.1"
-                - id: "NPM::signal-exit:3.0.2"
-                - id: "NPM::string-width:1.0.2"
-                  dependencies:
-                  - id: "NPM::code-point-at:1.1.0"
-                  - id: "NPM::is-fullwidth-code-point:1.0.0"
-                    dependencies:
-                    - id: "NPM::number-is-nan:1.0.1"
-                  - id: "NPM::strip-ansi:3.0.1"
-                    dependencies:
-                    - id: "NPM::ansi-regex:2.1.1"
-                - id: "NPM::strip-ansi:3.0.1"
-                  dependencies:
-                  - id: "NPM::ansi-regex:2.1.1"
-                - id: "NPM::wide-align:1.1.3"
-                  dependencies:
-                  - id: "NPM::string-width:1.0.2"
-                    dependencies:
-                    - id: "NPM::code-point-at:1.1.0"
-                    - id: "NPM::is-fullwidth-code-point:1.0.0"
-                      dependencies:
-                      - id: "NPM::number-is-nan:1.0.1"
-                    - id: "NPM::strip-ansi:3.0.1"
-                      dependencies:
-                      - id: "NPM::ansi-regex:2.1.1"
-              - id: "NPM::set-blocking:2.0.0"
-            - id: "NPM::rc:1.2.8"
-              dependencies:
-              - id: "NPM::deep-extend:0.6.0"
-              - id: "NPM::ini:1.3.5"
-              - id: "NPM::minimist:1.2.0"
-              - id: "NPM::strip-json-comments:2.0.1"
-            - id: "NPM::rimraf:2.6.3"
-              dependencies:
-              - id: "NPM::glob:7.1.3"
-                dependencies:
-                - id: "NPM::fs.realpath:1.0.0"
-                - id: "NPM::inflight:1.0.6"
-                  dependencies:
-                  - id: "NPM::once:1.4.0"
-                    dependencies:
-                    - id: "NPM::wrappy:1.0.2"
-                  - id: "NPM::wrappy:1.0.2"
-                - id: "NPM::inherits:2.0.3"
-                - id: "NPM::minimatch:3.0.4"
-                  dependencies:
-                  - id: "NPM::brace-expansion:1.1.11"
-                    dependencies:
-                    - id: "NPM::balanced-match:1.0.0"
-                    - id: "NPM::concat-map:0.0.1"
-                - id: "NPM::once:1.4.0"
-                  dependencies:
-                  - id: "NPM::wrappy:1.0.2"
-                - id: "NPM::path-is-absolute:1.0.1"
-            - id: "NPM::semver:5.7.0"
-            - id: "NPM::tar:4.4.8"
-              dependencies:
-              - id: "NPM::chownr:1.1.1"
-              - id: "NPM::fs-minipass:1.2.5"
-                dependencies:
-                - id: "NPM::minipass:2.3.5"
-                  dependencies:
-                  - id: "NPM::safe-buffer:5.1.2"
-                  - id: "NPM::yallist:3.0.3"
-              - id: "NPM::minipass:2.3.5"
-                dependencies:
-                - id: "NPM::safe-buffer:5.1.2"
-                - id: "NPM::yallist:3.0.3"
-              - id: "NPM::minizlib:1.2.1"
-                dependencies:
-                - id: "NPM::minipass:2.3.5"
-                  dependencies:
-                  - id: "NPM::safe-buffer:5.1.2"
-                  - id: "NPM::yallist:3.0.3"
-              - id: "NPM::mkdirp:0.5.1"
-                dependencies:
-                - id: "NPM::minimist:0.0.8"
-              - id: "NPM::safe-buffer:5.1.2"
-              - id: "NPM::yallist:3.0.3"
         - id: "NPM::glob-parent:2.0.0"
           dependencies:
           - id: "NPM::is-glob:2.0.1"
@@ -840,7 +699,7 @@ project:
         - id: "NPM::path-is-absolute:1.0.1"
         - id: "NPM::readdirp:2.2.1"
           dependencies:
-          - id: "NPM::graceful-fs:4.2.0"
+          - id: "NPM::graceful-fs:4.2.8"
           - id: "NPM::micromatch:3.1.10"
             dependencies:
             - id: "NPM::arr-diff:4.0.0"
@@ -872,7 +731,7 @@ project:
                       - id: "NPM::is-buffer:1.1.6"
                   - id: "NPM::repeat-string:1.6.1"
               - id: "NPM::isobject:3.0.1"
-              - id: "NPM::repeat-element:1.1.3"
+              - id: "NPM::repeat-element:1.1.4"
               - id: "NPM::snapdragon:0.8.2"
                 dependencies:
                 - id: "NPM::base:0.11.2"
@@ -1028,11 +887,11 @@ project:
                       dependencies:
                       - id: "NPM::is-accessor-descriptor:1.0.0"
                         dependencies:
-                        - id: "NPM::kind-of:6.0.2"
+                        - id: "NPM::kind-of:6.0.3"
                       - id: "NPM::is-data-descriptor:1.0.0"
                         dependencies:
-                        - id: "NPM::kind-of:6.0.2"
-                      - id: "NPM::kind-of:6.0.2"
+                        - id: "NPM::kind-of:6.0.3"
+                      - id: "NPM::kind-of:6.0.3"
                   - id: "NPM::isobject:3.0.1"
                   - id: "NPM::mixin-deep:1.3.2"
                     dependencies:
@@ -1066,12 +925,12 @@ project:
                   - id: "NPM::is-extendable:0.1.1"
                 - id: "NPM::map-cache:0.2.2"
                 - id: "NPM::source-map:0.5.7"
-                - id: "NPM::source-map-resolve:0.5.2"
+                - id: "NPM::source-map-resolve:0.5.3"
                   dependencies:
                   - id: "NPM::atob:2.1.2"
                   - id: "NPM::decode-uri-component:0.2.0"
                   - id: "NPM::resolve-url:0.2.1"
-                  - id: "NPM::source-map-url:0.4.0"
+                  - id: "NPM::source-map-url:0.4.1"
                   - id: "NPM::urix:0.1.0"
                 - id: "NPM::use:3.1.1"
               - id: "NPM::snapdragon-node:2.1.1"
@@ -1082,11 +941,11 @@ project:
                     dependencies:
                     - id: "NPM::is-accessor-descriptor:1.0.0"
                       dependencies:
-                      - id: "NPM::kind-of:6.0.2"
+                      - id: "NPM::kind-of:6.0.3"
                     - id: "NPM::is-data-descriptor:1.0.0"
                       dependencies:
-                      - id: "NPM::kind-of:6.0.2"
-                    - id: "NPM::kind-of:6.0.2"
+                      - id: "NPM::kind-of:6.0.3"
+                    - id: "NPM::kind-of:6.0.3"
                 - id: "NPM::isobject:3.0.1"
                 - id: "NPM::snapdragon-util:3.0.1"
                   dependencies:
@@ -1111,11 +970,11 @@ project:
                     dependencies:
                     - id: "NPM::is-accessor-descriptor:1.0.0"
                       dependencies:
-                      - id: "NPM::kind-of:6.0.2"
+                      - id: "NPM::kind-of:6.0.3"
                     - id: "NPM::is-data-descriptor:1.0.0"
                       dependencies:
-                      - id: "NPM::kind-of:6.0.2"
-                    - id: "NPM::kind-of:6.0.2"
+                      - id: "NPM::kind-of:6.0.3"
+                    - id: "NPM::kind-of:6.0.3"
                   - id: "NPM::isobject:3.0.1"
                 - id: "NPM::extend-shallow:3.0.2"
                   dependencies:
@@ -1147,11 +1006,11 @@ project:
                 dependencies:
                 - id: "NPM::is-accessor-descriptor:1.0.0"
                   dependencies:
-                  - id: "NPM::kind-of:6.0.2"
+                  - id: "NPM::kind-of:6.0.3"
                 - id: "NPM::is-data-descriptor:1.0.0"
                   dependencies:
-                  - id: "NPM::kind-of:6.0.2"
-                - id: "NPM::kind-of:6.0.2"
+                  - id: "NPM::kind-of:6.0.3"
+                - id: "NPM::kind-of:6.0.3"
               - id: "NPM::isobject:3.0.1"
             - id: "NPM::extend-shallow:3.0.2"
               dependencies:
@@ -1170,11 +1029,11 @@ project:
                   dependencies:
                   - id: "NPM::is-accessor-descriptor:1.0.0"
                     dependencies:
-                    - id: "NPM::kind-of:6.0.2"
+                    - id: "NPM::kind-of:6.0.3"
                   - id: "NPM::is-data-descriptor:1.0.0"
                     dependencies:
-                    - id: "NPM::kind-of:6.0.2"
-                  - id: "NPM::kind-of:6.0.2"
+                    - id: "NPM::kind-of:6.0.3"
+                  - id: "NPM::kind-of:6.0.3"
               - id: "NPM::expand-brackets:2.1.4"
                 dependencies:
                 - id: "NPM::debug:2.6.9"
@@ -1367,11 +1226,11 @@ project:
                         dependencies:
                         - id: "NPM::is-accessor-descriptor:1.0.0"
                           dependencies:
-                          - id: "NPM::kind-of:6.0.2"
+                          - id: "NPM::kind-of:6.0.3"
                         - id: "NPM::is-data-descriptor:1.0.0"
                           dependencies:
-                          - id: "NPM::kind-of:6.0.2"
-                        - id: "NPM::kind-of:6.0.2"
+                          - id: "NPM::kind-of:6.0.3"
+                        - id: "NPM::kind-of:6.0.3"
                     - id: "NPM::isobject:3.0.1"
                     - id: "NPM::mixin-deep:1.3.2"
                       dependencies:
@@ -1405,12 +1264,12 @@ project:
                     - id: "NPM::is-extendable:0.1.1"
                   - id: "NPM::map-cache:0.2.2"
                   - id: "NPM::source-map:0.5.7"
-                  - id: "NPM::source-map-resolve:0.5.2"
+                  - id: "NPM::source-map-resolve:0.5.3"
                     dependencies:
                     - id: "NPM::atob:2.1.2"
                     - id: "NPM::decode-uri-component:0.2.0"
                     - id: "NPM::resolve-url:0.2.1"
-                    - id: "NPM::source-map-url:0.4.0"
+                    - id: "NPM::source-map-url:0.4.1"
                     - id: "NPM::urix:0.1.0"
                   - id: "NPM::use:3.1.1"
                 - id: "NPM::to-regex:3.0.2"
@@ -1421,11 +1280,11 @@ project:
                       dependencies:
                       - id: "NPM::is-accessor-descriptor:1.0.0"
                         dependencies:
-                        - id: "NPM::kind-of:6.0.2"
+                        - id: "NPM::kind-of:6.0.3"
                       - id: "NPM::is-data-descriptor:1.0.0"
                         dependencies:
-                        - id: "NPM::kind-of:6.0.2"
-                      - id: "NPM::kind-of:6.0.2"
+                        - id: "NPM::kind-of:6.0.3"
+                      - id: "NPM::kind-of:6.0.3"
                     - id: "NPM::isobject:3.0.1"
                   - id: "NPM::extend-shallow:3.0.2"
                     dependencies:
@@ -1625,11 +1484,11 @@ project:
                       dependencies:
                       - id: "NPM::is-accessor-descriptor:1.0.0"
                         dependencies:
-                        - id: "NPM::kind-of:6.0.2"
+                        - id: "NPM::kind-of:6.0.3"
                       - id: "NPM::is-data-descriptor:1.0.0"
                         dependencies:
-                        - id: "NPM::kind-of:6.0.2"
-                      - id: "NPM::kind-of:6.0.2"
+                        - id: "NPM::kind-of:6.0.3"
+                      - id: "NPM::kind-of:6.0.3"
                   - id: "NPM::isobject:3.0.1"
                   - id: "NPM::mixin-deep:1.3.2"
                     dependencies:
@@ -1663,12 +1522,12 @@ project:
                   - id: "NPM::is-extendable:0.1.1"
                 - id: "NPM::map-cache:0.2.2"
                 - id: "NPM::source-map:0.5.7"
-                - id: "NPM::source-map-resolve:0.5.2"
+                - id: "NPM::source-map-resolve:0.5.3"
                   dependencies:
                   - id: "NPM::atob:2.1.2"
                   - id: "NPM::decode-uri-component:0.2.0"
                   - id: "NPM::resolve-url:0.2.1"
-                  - id: "NPM::source-map-url:0.4.0"
+                  - id: "NPM::source-map-url:0.4.1"
                   - id: "NPM::urix:0.1.0"
                 - id: "NPM::use:3.1.1"
               - id: "NPM::to-regex:3.0.2"
@@ -1679,11 +1538,11 @@ project:
                     dependencies:
                     - id: "NPM::is-accessor-descriptor:1.0.0"
                       dependencies:
-                      - id: "NPM::kind-of:6.0.2"
+                      - id: "NPM::kind-of:6.0.3"
                     - id: "NPM::is-data-descriptor:1.0.0"
                       dependencies:
-                      - id: "NPM::kind-of:6.0.2"
-                    - id: "NPM::kind-of:6.0.2"
+                      - id: "NPM::kind-of:6.0.3"
+                    - id: "NPM::kind-of:6.0.3"
                   - id: "NPM::isobject:3.0.1"
                 - id: "NPM::extend-shallow:3.0.2"
                   dependencies:
@@ -1712,7 +1571,7 @@ project:
             - id: "NPM::fragment-cache:0.2.1"
               dependencies:
               - id: "NPM::map-cache:0.2.2"
-            - id: "NPM::kind-of:6.0.2"
+            - id: "NPM::kind-of:6.0.3"
             - id: "NPM::nanomatch:1.2.13"
               dependencies:
               - id: "NPM::arr-diff:4.0.0"
@@ -1723,11 +1582,11 @@ project:
                   dependencies:
                   - id: "NPM::is-accessor-descriptor:1.0.0"
                     dependencies:
-                    - id: "NPM::kind-of:6.0.2"
+                    - id: "NPM::kind-of:6.0.3"
                   - id: "NPM::is-data-descriptor:1.0.0"
                     dependencies:
-                    - id: "NPM::kind-of:6.0.2"
-                  - id: "NPM::kind-of:6.0.2"
+                    - id: "NPM::kind-of:6.0.3"
+                  - id: "NPM::kind-of:6.0.3"
                 - id: "NPM::isobject:3.0.1"
               - id: "NPM::extend-shallow:3.0.2"
                 dependencies:
@@ -1741,7 +1600,7 @@ project:
                 dependencies:
                 - id: "NPM::map-cache:0.2.2"
               - id: "NPM::is-windows:1.0.2"
-              - id: "NPM::kind-of:6.0.2"
+              - id: "NPM::kind-of:6.0.3"
               - id: "NPM::object.pick:1.3.0"
                 dependencies:
                 - id: "NPM::isobject:3.0.1"
@@ -1913,11 +1772,11 @@ project:
                       dependencies:
                       - id: "NPM::is-accessor-descriptor:1.0.0"
                         dependencies:
-                        - id: "NPM::kind-of:6.0.2"
+                        - id: "NPM::kind-of:6.0.3"
                       - id: "NPM::is-data-descriptor:1.0.0"
                         dependencies:
-                        - id: "NPM::kind-of:6.0.2"
-                      - id: "NPM::kind-of:6.0.2"
+                        - id: "NPM::kind-of:6.0.3"
+                      - id: "NPM::kind-of:6.0.3"
                   - id: "NPM::isobject:3.0.1"
                   - id: "NPM::mixin-deep:1.3.2"
                     dependencies:
@@ -1951,12 +1810,12 @@ project:
                   - id: "NPM::is-extendable:0.1.1"
                 - id: "NPM::map-cache:0.2.2"
                 - id: "NPM::source-map:0.5.7"
-                - id: "NPM::source-map-resolve:0.5.2"
+                - id: "NPM::source-map-resolve:0.5.3"
                   dependencies:
                   - id: "NPM::atob:2.1.2"
                   - id: "NPM::decode-uri-component:0.2.0"
                   - id: "NPM::resolve-url:0.2.1"
-                  - id: "NPM::source-map-url:0.4.0"
+                  - id: "NPM::source-map-url:0.4.1"
                   - id: "NPM::urix:0.1.0"
                 - id: "NPM::use:3.1.1"
               - id: "NPM::to-regex:3.0.2"
@@ -1967,11 +1826,11 @@ project:
                     dependencies:
                     - id: "NPM::is-accessor-descriptor:1.0.0"
                       dependencies:
-                      - id: "NPM::kind-of:6.0.2"
+                      - id: "NPM::kind-of:6.0.3"
                     - id: "NPM::is-data-descriptor:1.0.0"
                       dependencies:
-                      - id: "NPM::kind-of:6.0.2"
-                    - id: "NPM::kind-of:6.0.2"
+                      - id: "NPM::kind-of:6.0.3"
+                    - id: "NPM::kind-of:6.0.3"
                   - id: "NPM::isobject:3.0.1"
                 - id: "NPM::extend-shallow:3.0.2"
                   dependencies:
@@ -2168,11 +2027,11 @@ project:
                     dependencies:
                     - id: "NPM::is-accessor-descriptor:1.0.0"
                       dependencies:
-                      - id: "NPM::kind-of:6.0.2"
+                      - id: "NPM::kind-of:6.0.3"
                     - id: "NPM::is-data-descriptor:1.0.0"
                       dependencies:
-                      - id: "NPM::kind-of:6.0.2"
-                    - id: "NPM::kind-of:6.0.2"
+                      - id: "NPM::kind-of:6.0.3"
+                    - id: "NPM::kind-of:6.0.3"
                 - id: "NPM::isobject:3.0.1"
                 - id: "NPM::mixin-deep:1.3.2"
                   dependencies:
@@ -2206,12 +2065,12 @@ project:
                 - id: "NPM::is-extendable:0.1.1"
               - id: "NPM::map-cache:0.2.2"
               - id: "NPM::source-map:0.5.7"
-              - id: "NPM::source-map-resolve:0.5.2"
+              - id: "NPM::source-map-resolve:0.5.3"
                 dependencies:
                 - id: "NPM::atob:2.1.2"
                 - id: "NPM::decode-uri-component:0.2.0"
                 - id: "NPM::resolve-url:0.2.1"
-                - id: "NPM::source-map-url:0.4.0"
+                - id: "NPM::source-map-url:0.4.1"
                 - id: "NPM::urix:0.1.0"
               - id: "NPM::use:3.1.1"
             - id: "NPM::to-regex:3.0.2"
@@ -2222,11 +2081,11 @@ project:
                   dependencies:
                   - id: "NPM::is-accessor-descriptor:1.0.0"
                     dependencies:
-                    - id: "NPM::kind-of:6.0.2"
+                    - id: "NPM::kind-of:6.0.3"
                   - id: "NPM::is-data-descriptor:1.0.0"
                     dependencies:
-                    - id: "NPM::kind-of:6.0.2"
-                  - id: "NPM::kind-of:6.0.2"
+                    - id: "NPM::kind-of:6.0.3"
+                  - id: "NPM::kind-of:6.0.3"
                 - id: "NPM::isobject:3.0.1"
               - id: "NPM::extend-shallow:3.0.2"
                 dependencies:
@@ -2252,9 +2111,9 @@ project:
               - id: "NPM::safe-regex:1.1.0"
                 dependencies:
                 - id: "NPM::ret:0.1.15"
-          - id: "NPM::readable-stream:2.3.6"
+          - id: "NPM::readable-stream:2.3.7"
             dependencies:
-            - id: "NPM::core-util-is:1.0.2"
+            - id: "NPM::core-util-is:1.0.3"
             - id: "NPM::inherits:2.0.4"
             - id: "NPM::isarray:1.0.0"
             - id: "NPM::process-nextick-args:2.0.1"
@@ -2263,12 +2122,12 @@ project:
               dependencies:
               - id: "NPM::safe-buffer:5.1.2"
             - id: "NPM::util-deprecate:1.0.2"
-      - id: "NPM::commander:2.20.0"
-      - id: "NPM::convert-source-map:1.6.0"
+      - id: "NPM::commander:2.20.3"
+      - id: "NPM::convert-source-map:1.8.0"
         dependencies:
         - id: "NPM::safe-buffer:5.1.2"
       - id: "NPM::fs-readdir-recursive:1.1.0"
-      - id: "NPM::glob:7.1.4"
+      - id: "NPM::glob:7.2.0"
         dependencies:
         - id: "NPM::fs.realpath:1.0.0"
         - id: "NPM::inflight:1.0.6"
@@ -2282,19 +2141,19 @@ project:
           dependencies:
           - id: "NPM::brace-expansion:1.1.11"
             dependencies:
-            - id: "NPM::balanced-match:1.0.0"
+            - id: "NPM::balanced-match:1.0.2"
             - id: "NPM::concat-map:0.0.1"
         - id: "NPM::once:1.4.0"
           dependencies:
           - id: "NPM::wrappy:1.0.2"
         - id: "NPM::path-is-absolute:1.0.1"
-      - id: "NPM::lodash:4.17.15"
+      - id: "NPM::lodash:4.17.21"
       - id: "NPM::output-file-sync:1.1.2"
         dependencies:
-        - id: "NPM::graceful-fs:4.2.0"
-        - id: "NPM::mkdirp:0.5.1"
+        - id: "NPM::graceful-fs:4.2.8"
+        - id: "NPM::mkdirp:0.5.5"
           dependencies:
-          - id: "NPM::minimist:0.0.8"
+          - id: "NPM::minimist:1.2.5"
         - id: "NPM::object-assign:4.1.1"
       - id: "NPM::path-is-absolute:1.0.1"
       - id: "NPM::slash:1.0.0"
@@ -2303,36 +2162,6 @@ project:
         dependencies:
         - id: "NPM::user-home:1.1.1"
 packages:
-- id: "NPM::abbrev:1.1.1"
-  purl: "pkg:npm/abbrev@1.1.1"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "Like ruby's abbrev module, but in js"
-  homepage_url: "https://github.com/isaacs/abbrev-js#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz"
-    hash:
-      value: "f8f2c887ad10bf67f634f005b6987fed3179aac8"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+ssh://git@github.com/isaacs/abbrev-js.git"
-    revision: "a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "ssh://git@github.com/isaacs/abbrev-js.git"
-    revision: "a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb"
-    path: ""
 - id: "NPM::ansi-regex:2.1.1"
   purl: "pkg:npm/ansi-regex@2.1.1"
   authors:
@@ -2423,66 +2252,6 @@ packages:
     type: "Git"
     url: "https://github.com/es128/anymatch.git"
     revision: "a16f5bd07f1e36c4eef08c1291c6c119d1663639"
-    path: ""
-- id: "NPM::aproba:1.2.0"
-  purl: "pkg:npm/aproba@1.2.0"
-  authors:
-  - "Rebecca Turner"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "A ridiculously light-weight argument validator (now browser friendly)"
-  homepage_url: "https://github.com/iarna/aproba"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz"
-    hash:
-      value: "6802e6264efd18c790a1b0d517f0f2627bf2c94a"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/iarna/aproba.git"
-    revision: "ee43ce68c9992e8f9d0d925dc2b1f2e1e5c976de"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/iarna/aproba.git"
-    revision: "ee43ce68c9992e8f9d0d925dc2b1f2e1e5c976de"
-    path: ""
-- id: "NPM::are-we-there-yet:1.1.5"
-  purl: "pkg:npm/are-we-there-yet@1.1.5"
-  authors:
-  - "Rebecca Turner"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "Keep track of the overall completion of many disparate processes"
-  homepage_url: "https://github.com/iarna/are-we-there-yet"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz"
-    hash:
-      value: "4b35c2944f062a8bfcda66410760350fe9ddfc21"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/iarna/are-we-there-yet.git"
-    revision: "b4d023b8b754b9d2d540c9db21cc7edf2962ea63"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/iarna/are-we-there-yet.git"
-    revision: "b4d023b8b754b9d2d540c9db21cc7edf2962ea63"
     path: ""
 - id: "NPM::arr-diff:2.0.0"
   purl: "pkg:npm/arr-diff@2.0.0"
@@ -3152,8 +2921,8 @@ packages:
     url: "https://github.com/babel/babylon.git"
     revision: "da66d3f65b0d305c0bb042873d57f26f0c0b0538"
     path: ""
-- id: "NPM::balanced-match:1.0.0"
-  purl: "pkg:npm/balanced-match@1.0.0"
+- id: "NPM::balanced-match:1.0.2"
+  purl: "pkg:npm/balanced-match@1.0.2"
   authors:
   - "Julian Gruber"
   declared_licenses:
@@ -3168,19 +2937,19 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+    url: "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
     hash:
-      value: "89b4d199ab2bee49de164ea02b89ce462d71b767"
+      value: "e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
     url: "git://github.com/juliangruber/balanced-match.git"
-    revision: "d701a549a7653a874eebce7eca25d3577dc868ac"
+    revision: "c7412e09b95d6ad97fd1e2996f6adca7626a9ae8"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/juliangruber/balanced-match.git"
-    revision: "d701a549a7653a874eebce7eca25d3577dc868ac"
+    revision: "c7412e09b95d6ad97fd1e2996f6adca7626a9ae8"
     path: ""
 - id: "NPM::base:0.11.2"
   purl: "pkg:npm/base@0.11.2"
@@ -3426,36 +3195,6 @@ packages:
     url: "https://github.com/paulmillr/chokidar.git"
     revision: "3b1071a6dd82397842f4f7dc63b72c703bd06275"
     path: ""
-- id: "NPM::chownr:1.1.1"
-  purl: "pkg:npm/chownr@1.1.1"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "like `chown -R`"
-  homepage_url: "https://github.com/isaacs/chownr#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz"
-    hash:
-      value: "54726b8b8fff4df053c42187e801fb4412df1494"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/isaacs/chownr.git"
-    revision: "7a5c3d57c3691eebb9c66fa00fa6003d02ef9440"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/isaacs/chownr.git"
-    revision: "7a5c3d57c3691eebb9c66fa00fa6003d02ef9440"
-    path: ""
 - id: "NPM::class-utils:0.3.6"
   purl: "pkg:npm/class-utils@0.3.6"
   authors:
@@ -3485,36 +3224,6 @@ packages:
     type: "Git"
     url: "https://github.com/jonschlinkert/class-utils.git"
     revision: "0ad9e639d6a63d6dc04043ac5931df85fb898e06"
-    path: ""
-- id: "NPM::code-point-at:1.1.0"
-  purl: "pkg:npm/code-point-at@1.1.0"
-  authors:
-  - "Sindre Sorhus"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "ES2015 `String#codePointAt()` ponyfill"
-  homepage_url: "https://github.com/sindresorhus/code-point-at#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
-    hash:
-      value: "0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/sindresorhus/code-point-at.git"
-    revision: "f8f21c8df2d40248fef1b36ca9076e59c0c34791"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/sindresorhus/code-point-at.git"
-    revision: "f8f21c8df2d40248fef1b36ca9076e59c0c34791"
     path: ""
 - id: "NPM::collection-visit:1.0.0"
   purl: "pkg:npm/collection-visit@1.0.0"
@@ -3547,8 +3256,8 @@ packages:
     url: "https://github.com/jonschlinkert/collection-visit.git"
     revision: "39c229dceb7e124cb821b59668df5da1d5c81a6c"
     path: ""
-- id: "NPM::commander:2.20.0"
-  purl: "pkg:npm/commander@2.20.0"
+- id: "NPM::commander:2.20.3"
+  purl: "pkg:npm/commander@2.20.3"
   authors:
   - "TJ Holowaychuk"
   declared_licenses:
@@ -3563,19 +3272,19 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz"
+    url: "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
     hash:
-      value: "d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+      value: "fd485e84c03eb4881c20722ba48035e8531aeb33"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
     url: "git+https://github.com/tj/commander.js.git"
-    revision: "3e8bf54b9b2fb3960fc2320a4174aa79efca90fa"
+    revision: "6b8499b24f4f6498ad630c50c8a00c9579a8536b"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/tj/commander.js.git"
-    revision: "3e8bf54b9b2fb3960fc2320a4174aa79efca90fa"
+    revision: "6b8499b24f4f6498ad630c50c8a00c9579a8536b"
     path: ""
 - id: "NPM::component-emitter:1.3.0"
   purl: "pkg:npm/component-emitter@1.3.0"
@@ -3635,41 +3344,8 @@ packages:
     url: "https://github.com/substack/node-concat-map.git"
     revision: ""
     path: ""
-- id: "NPM::console-control-strings:1.1.0"
-  purl: "pkg:npm/console-control-strings@1.1.0"
-  authors:
-  - "Rebecca Turner"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "A library of cross-platform tested terminal/console command strings\
-    \ for doing things like color and cursor positioning.  This is a subset of both\
-    \ ansi and vt100.  All control codes included work on both Windows & Unix-like\
-    \ OSes, except where noted."
-  homepage_url: "https://github.com/iarna/console-control-strings#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
-    hash:
-      value: "3d7cf4464db6446ea644bf4b39507f9851008e8e"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/iarna/console-control-strings.git"
-    revision: "722439b4998d2964ac3d3f9ec175c008aa9b7b4b"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/iarna/console-control-strings.git"
-    revision: "722439b4998d2964ac3d3f9ec175c008aa9b7b4b"
-    path: ""
-- id: "NPM::convert-source-map:1.6.0"
-  purl: "pkg:npm/convert-source-map@1.6.0"
+- id: "NPM::convert-source-map:1.8.0"
+  purl: "pkg:npm/convert-source-map@1.8.0"
   authors:
   - "Thorsten Lorenz"
   declared_licenses:
@@ -3685,19 +3361,19 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz"
+    url: "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz"
     hash:
-      value: "51b537a8c43e0f04dec1993bffcdd504e758ac20"
+      value: "f3373c32d21b4d780dd8004514684fb791ca4369"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
     url: "git://github.com/thlorenz/convert-source-map.git"
-    revision: "ad25a3e4373c641a2241cf1470b81ae123e4c23d"
+    revision: "df4deb60fcdc20ec2dcaff7fc284bfb139d1b2fc"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/thlorenz/convert-source-map.git"
-    revision: "ad25a3e4373c641a2241cf1470b81ae123e4c23d"
+    revision: "df4deb60fcdc20ec2dcaff7fc284bfb139d1b2fc"
     path: ""
 - id: "NPM::copy-descriptor:0.1.1"
   purl: "pkg:npm/copy-descriptor@0.1.1"
@@ -3729,8 +3405,8 @@ packages:
     url: "https://github.com/jonschlinkert/copy-descriptor.git"
     revision: "572c31416d4538b7ba5f52e2bb0765ac237f79e2"
     path: ""
-- id: "NPM::core-js:2.6.9"
-  purl: "pkg:npm/core-js@2.6.9"
+- id: "NPM::core-js:2.6.12"
+  purl: "pkg:npm/core-js@2.6.12"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -3743,22 +3419,22 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz"
+    url: "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz"
     hash:
-      value: "6b4b214620c834152e179323727fc19741b084f2"
+      value: "d9333dfa7b065e347cc5682219d6f690859cc2ec"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
     url: "git+https://github.com/zloirock/core-js.git"
-    revision: "6a3fe85136aaae0e3b099c96a05a5ceb1f515a50"
+    revision: "ffb783b746849c2b14258e6bef6106f1dcab2a66"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/zloirock/core-js.git"
-    revision: "6a3fe85136aaae0e3b099c96a05a5ceb1f515a50"
+    revision: "ffb783b746849c2b14258e6bef6106f1dcab2a66"
     path: ""
-- id: "NPM::core-util-is:1.0.2"
-  purl: "pkg:npm/core-util-is@1.0.2"
+- id: "NPM::core-util-is:1.0.3"
+  purl: "pkg:npm/core-util-is@1.0.3"
   authors:
   - "Isaac Z. Schlueter"
   declared_licenses:
@@ -3773,19 +3449,19 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+    url: "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"
     hash:
-      value: "b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+      value: "a6042d3634c2b27e9328f837b965fac83808db85"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
     url: "git://github.com/isaacs/core-util-is.git"
-    revision: "a177da234df5638b363ddc15fa324619a38577c8"
+    revision: "85f4620829d1b6079fd7b351f040b6ea7e184970"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/isaacs/core-util-is.git"
-    revision: "a177da234df5638b363ddc15fa324619a38577c8"
+    revision: "85f4620829d1b6079fd7b351f040b6ea7e184970"
     path: ""
 - id: "NPM::debug:2.6.9"
   purl: "pkg:npm/debug@2.6.9"
@@ -3817,36 +3493,6 @@ packages:
     url: "https://github.com/visionmedia/debug.git"
     revision: "13abeae468fea297d0dccc50bc55590809241083"
     path: ""
-- id: "NPM::debug:4.1.1"
-  purl: "pkg:npm/debug@4.1.1"
-  authors:
-  - "TJ Holowaychuk"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "small debugging utility"
-  homepage_url: "https://github.com/visionmedia/debug#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz"
-    hash:
-      value: "3b72260255109c6b589cee050f1d516139664791"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/visionmedia/debug.git"
-    revision: "68b4dc8d8549d3924673c38fccc5d594f0a38da1"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/visionmedia/debug.git"
-    revision: "68b4dc8d8549d3924673c38fccc5d594f0a38da1"
-    path: ""
 - id: "NPM::decode-uri-component:0.2.0"
   purl: "pkg:npm/decode-uri-component@0.2.0"
   authors:
@@ -3876,36 +3522,6 @@ packages:
     type: "Git"
     url: "https://github.com/samverschueren/decode-uri-component.git"
     revision: "52782a347527a6a05fed02434ffcf8f2ba1b19a3"
-    path: ""
-- id: "NPM::deep-extend:0.6.0"
-  purl: "pkg:npm/deep-extend@0.6.0"
-  authors:
-  - "Viacheslav Lotsmanov"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "Recursive object extending"
-  homepage_url: "https://github.com/unclechu/node-deep-extend"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz"
-    hash:
-      value: "c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/unclechu/node-deep-extend.git"
-    revision: "f3f2b4f30fffe8abc9a99a7d6469fb354ca206e9"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/unclechu/node-deep-extend.git"
-    revision: "f3f2b4f30fffe8abc9a99a7d6469fb354ca206e9"
     path: ""
 - id: "NPM::define-property:0.2.5"
   purl: "pkg:npm/define-property@0.2.5"
@@ -3998,34 +3614,6 @@ packages:
     url: "https://github.com/jonschlinkert/define-property.git"
     revision: "04717307be822f2ca2544778b92e5d2cbe300c55"
     path: ""
-- id: "NPM::delegates:1.0.0"
-  purl: "pkg:npm/delegates@1.0.0"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "delegate methods and accessors to another property"
-  homepage_url: "https://github.com/visionmedia/node-delegates#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
-    hash:
-      value: "84c6e159b81904fdca59a0ef44cd870d31250f9a"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/visionmedia/node-delegates.git"
-    revision: "c4dc07ef1ed51c2b2a63f3585e5ef949ee577a49"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/visionmedia/node-delegates.git"
-    revision: "c4dc07ef1ed51c2b2a63f3585e5ef949ee577a49"
-    path: ""
 - id: "NPM::detect-indent:4.0.0"
   purl: "pkg:npm/detect-indent@4.0.0"
   authors:
@@ -4055,37 +3643,6 @@ packages:
     type: "Git"
     url: "https://github.com/sindresorhus/detect-indent.git"
     revision: "dbbc78fcb37907116eb120a8324070a1df0e8d86"
-    path: ""
-- id: "NPM::detect-libc:1.0.3"
-  purl: "pkg:npm/detect-libc@1.0.3"
-  authors:
-  - "Lovell Fuller"
-  declared_licenses:
-  - "Apache-2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-  description: "Node.js module to detect the C standard library (libc) implementation\
-    \ family and version"
-  homepage_url: "https://github.com/lovell/detect-libc#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz"
-    hash:
-      value: "fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/lovell/detect-libc.git"
-    revision: "88df1a5950bf3cd9bffa1e0137ab6471c4546118"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/lovell/detect-libc.git"
-    revision: "88df1a5950bf3cd9bffa1e0137ab6471c4546118"
     path: ""
 - id: "NPM::escape-string-regexp:1.0.5"
   purl: "pkg:npm/escape-string-regexp@1.0.5"
@@ -4117,14 +3674,12 @@ packages:
     url: "https://github.com/sindresorhus/escape-string-regexp.git"
     revision: "db124a3e1aae9d692c4899e42a5c6c3e329eaa20"
     path: ""
-- id: "NPM::esutils:2.0.2"
-  purl: "pkg:npm/esutils@2.0.2"
+- id: "NPM::esutils:2.0.3"
+  purl: "pkg:npm/esutils@2.0.3"
   declared_licenses:
-  - "BSD"
+  - "BSD-2-Clause"
   declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD: "BSD-3-Clause"
+    spdx_expression: "BSD-2-Clause"
   description: "utility box for ECMAScript language tools"
   homepage_url: "https://github.com/estools/esutils"
   binary_artifact:
@@ -4133,19 +3688,19 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+    url: "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
     hash:
-      value: "0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+      value: "74d2eb4de0b8da1293711910d50775b9b710ef64"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
-    url: "http://github.com/estools/esutils.git"
-    revision: "3ffd1c403f3f29db9e8a9574b1895682e57b6a7f"
+    url: "git+ssh://git@github.com/estools/esutils.git"
+    revision: "8c2741c0154723fb92da137a0c97845b03b0943a"
     path: ""
   vcs_processed:
     type: "Git"
-    url: "https://github.com/estools/esutils.git"
-    revision: "3ffd1c403f3f29db9e8a9574b1895682e57b6a7f"
+    url: "ssh://git@github.com/estools/esutils.git"
+    revision: "8c2741c0154723fb92da137a0c97845b03b0943a"
     path: ""
 - id: "NPM::expand-brackets:0.1.5"
   purl: "pkg:npm/expand-brackets@0.1.5"
@@ -4548,36 +4103,6 @@ packages:
     url: "https://github.com/jonschlinkert/fragment-cache.git"
     revision: "33583b03f505c67479ddbc66f825b0e653704207"
     path: ""
-- id: "NPM::fs-minipass:1.2.5"
-  purl: "pkg:npm/fs-minipass@1.2.5"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "fs read and write streams based on minipass"
-  homepage_url: "https://github.com/npm/fs-minipass#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz"
-    hash:
-      value: "06c277218454ec288df77ada54a03b8702aacb9d"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/npm/fs-minipass.git"
-    revision: "fceb43535c348c9cd1ad08edb6c188e04850c245"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/npm/fs-minipass.git"
-    revision: "fceb43535c348c9cd1ad08edb6c188e04850c245"
-    path: ""
 - id: "NPM::fs-readdir-recursive:1.1.0"
   purl: "pkg:npm/fs-readdir-recursive@1.1.0"
   authors:
@@ -4639,66 +4164,6 @@ packages:
     url: "https://github.com/isaacs/fs.realpath.git"
     revision: "03e7c884431fe185dfebbc9b771aeca339c1807a"
     path: ""
-- id: "NPM::fsevents:1.2.9"
-  purl: "pkg:npm/fsevents@1.2.9"
-  authors:
-  - "Philipp Dunkel"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "Native Access to Mac OS-X FSEvents"
-  homepage_url: "https://github.com/strongloop/fsevents"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz"
-    hash:
-      value: "3f5ed66583ccd6f400b5a00db6f7e861363e388f"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/strongloop/fsevents.git"
-    revision: "0a052f6c0adb5b066cd1c1c2fcfb04e22ccb0fbc"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/strongloop/fsevents.git"
-    revision: "0a052f6c0adb5b066cd1c1c2fcfb04e22ccb0fbc"
-    path: ""
-- id: "NPM::gauge:2.7.4"
-  purl: "pkg:npm/gauge@2.7.4"
-  authors:
-  - "Rebecca Turner"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "A terminal based horizontal guage"
-  homepage_url: "https://github.com/iarna/gauge"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz"
-    hash:
-      value: "2c03405c7538c39d7eb37b317022e325fb018bf7"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/iarna/gauge.git"
-    revision: "1011abf6c2cb7ae89a3ee76fb447d3182d4e8d3a"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/iarna/gauge.git"
-    revision: "1011abf6c2cb7ae89a3ee76fb447d3182d4e8d3a"
-    path: ""
 - id: "NPM::get-value:2.0.6"
   purl: "pkg:npm/get-value@2.0.6"
   authors:
@@ -4729,8 +4194,8 @@ packages:
     url: "https://github.com/jonschlinkert/get-value.git"
     revision: "5dc7466a65eec37e3b9e3d94f274b7aba193ea60"
     path: ""
-- id: "NPM::glob:7.1.3"
-  purl: "pkg:npm/glob@7.1.3"
+- id: "NPM::glob:7.2.0"
+  purl: "pkg:npm/glob@7.2.0"
   authors:
   - "Isaac Z. Schlueter"
   declared_licenses:
@@ -4745,49 +4210,19 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
+    url: "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz"
     hash:
-      value: "3960832d3f1574108342dafd3a67b332c0969df1"
+      value: "d15535af7732e02e948f4c41628bd910293f6023"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
     url: "git://github.com/isaacs/node-glob.git"
-    revision: "8882c8fccabbe459465e73cc2581e121a5fdd25b"
+    revision: "3bfec21dd180ddf4672880176ad33af6296a167e"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/isaacs/node-glob.git"
-    revision: "8882c8fccabbe459465e73cc2581e121a5fdd25b"
-    path: ""
-- id: "NPM::glob:7.1.4"
-  purl: "pkg:npm/glob@7.1.4"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "a little globber"
-  homepage_url: "https://github.com/isaacs/node-glob#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz"
-    hash:
-      value: "aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/isaacs/node-glob.git"
-    revision: "2da9af3ed730811d0fe743bec1281e169374428e"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/isaacs/node-glob.git"
-    revision: "2da9af3ed730811d0fe743bec1281e169374428e"
+    revision: "3bfec21dd180ddf4672880176ad33af6296a167e"
     path: ""
 - id: "NPM::glob-base:0.3.0"
   purl: "pkg:npm/glob-base@0.3.0"
@@ -4879,8 +4314,8 @@ packages:
     url: "https://github.com/sindresorhus/globals.git"
     revision: "09ba8754235e5953507b8d0543d65098bc7bb78d"
     path: ""
-- id: "NPM::graceful-fs:4.2.0"
-  purl: "pkg:npm/graceful-fs@4.2.0"
+- id: "NPM::graceful-fs:4.2.8"
+  purl: "pkg:npm/graceful-fs@4.2.8"
   declared_licenses:
   - "ISC"
   declared_licenses_processed:
@@ -4893,19 +4328,19 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz"
+    url: "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz"
     hash:
-      value: "8d8fdc73977cb04104721cb53666c1ca64cd328b"
+      value: "e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
     url: "git+https://github.com/isaacs/node-graceful-fs.git"
-    revision: "585df780323740a2b562677caa08a80de1f56c62"
+    revision: "9ec3413c8eb1c073c42262bf5a2a8cdf556f68a7"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/isaacs/node-graceful-fs.git"
-    revision: "585df780323740a2b562677caa08a80de1f56c62"
+    revision: "9ec3413c8eb1c073c42262bf5a2a8cdf556f68a7"
     path: ""
 - id: "NPM::has-ansi:2.0.0"
   purl: "pkg:npm/has-ansi@2.0.0"
@@ -4936,36 +4371,6 @@ packages:
     type: "Git"
     url: "https://github.com/sindresorhus/has-ansi.git"
     revision: "0722275e1bef139fcd09137da6e5550c3cd368b9"
-    path: ""
-- id: "NPM::has-unicode:2.0.1"
-  purl: "pkg:npm/has-unicode@2.0.1"
-  authors:
-  - "Rebecca Turner"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "Try to guess if your terminal supports unicode"
-  homepage_url: "https://github.com/iarna/has-unicode"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
-    hash:
-      value: "e0e6fe6a28cf51138855e086d1691e771de2a8b9"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/iarna/has-unicode.git"
-    revision: "0a05df154e8d89a7fb9798da60b68c78c2df6646"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/iarna/has-unicode.git"
-    revision: "0a05df154e8d89a7fb9798da60b68c78c2df6646"
     path: ""
 - id: "NPM::has-value:0.3.1"
   purl: "pkg:npm/has-value@0.3.1"
@@ -5121,66 +4526,6 @@ packages:
     url: "https://github.com/sindresorhus/home-or-tmp.git"
     revision: "dd1411a0b2531a4e2c592ae733fd45dd0f9c7163"
     path: ""
-- id: "NPM::iconv-lite:0.4.24"
-  purl: "pkg:npm/iconv-lite@0.4.24"
-  authors:
-  - "Alexander Shtuchkin"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "Convert character encodings in pure javascript."
-  homepage_url: "https://github.com/ashtuchkin/iconv-lite"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
-    hash:
-      value: "2022b4b25fbddc21d2f524974a474aafe733908b"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/ashtuchkin/iconv-lite.git"
-    revision: "efbbb0937ca8dda1c14e0b69958b9d6f20771f7a"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/ashtuchkin/iconv-lite.git"
-    revision: "efbbb0937ca8dda1c14e0b69958b9d6f20771f7a"
-    path: ""
-- id: "NPM::ignore-walk:3.0.1"
-  purl: "pkg:npm/ignore-walk@3.0.1"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "Nested/recursive `.gitignore`/`.npmignore` parsing and filtering."
-  homepage_url: "https://github.com/isaacs/ignore-walk#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz"
-    hash:
-      value: "a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/isaacs/ignore-walk.git"
-    revision: "2b610fce2c19a5555d4bd74859950d086938c70e"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/isaacs/ignore-walk.git"
-    revision: "2b610fce2c19a5555d4bd74859950d086938c70e"
-    path: ""
 - id: "NPM::inflight:1.0.6"
   purl: "pkg:npm/inflight@1.0.6"
   authors:
@@ -5211,35 +4556,6 @@ packages:
     url: "https://github.com/npm/inflight.git"
     revision: "a547881738c8f57b27795e584071d67cf6ac1a57"
     path: ""
-- id: "NPM::inherits:2.0.3"
-  purl: "pkg:npm/inherits@2.0.3"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "Browser-friendly inheritance fully compatible with standard node.js\
-    \ inherits()"
-  homepage_url: "https://github.com/isaacs/inherits#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-    hash:
-      value: "633c2c83e3da42a502f52466022480f4208261de"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/isaacs/inherits.git"
-    revision: "e05d0fb27c61a3ec687214f0476386b765364d5f"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/isaacs/inherits.git"
-    revision: "e05d0fb27c61a3ec687214f0476386b765364d5f"
-    path: ""
 - id: "NPM::inherits:2.0.4"
   purl: "pkg:npm/inherits@2.0.4"
   declared_licenses:
@@ -5268,36 +4584,6 @@ packages:
     type: "Git"
     url: "https://github.com/isaacs/inherits.git"
     revision: "9a2c29400c6d491e0b7beefe0c32efa3b462545d"
-    path: ""
-- id: "NPM::ini:1.3.5"
-  purl: "pkg:npm/ini@1.3.5"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "An ini encoder/decoder for node"
-  homepage_url: "https://github.com/isaacs/ini#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz"
-    hash:
-      value: "eee25f56db1c9ec6085e0c22778083f596abf927"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/isaacs/ini.git"
-    revision: "738eca59d77d8cfdddf5c477c17a0d8f8fbfe0fd"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/isaacs/ini.git"
-    revision: "738eca59d77d8cfdddf5c477c17a0d8f8fbfe0fd"
     path: ""
 - id: "NPM::invariant:2.2.4"
   purl: "pkg:npm/invariant@2.2.4"
@@ -5729,8 +5015,8 @@ packages:
     url: "https://github.com/jonschlinkert/is-extglob.git"
     revision: ""
     path: ""
-- id: "NPM::is-finite:1.0.2"
-  purl: "pkg:npm/is-finite@1.0.2"
+- id: "NPM::is-finite:1.1.0"
+  purl: "pkg:npm/is-finite@1.1.0"
   authors:
   - "Sindre Sorhus"
   declared_licenses:
@@ -5745,50 +5031,19 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+    url: "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz"
     hash:
-      value: "cc6677695602be550ef11e8b4aa6305342b6d0aa"
+      value: "904135c77fb42c0641d6aa1bcdbc4daa8da082f3"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
     url: "git+https://github.com/sindresorhus/is-finite.git"
-    revision: "43f8bb814834d8573d11ba4a631d19006d0c8897"
+    revision: "1001187ed027a76051c066408358e769fb61786e"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/sindresorhus/is-finite.git"
-    revision: "43f8bb814834d8573d11ba4a631d19006d0c8897"
-    path: ""
-- id: "NPM::is-fullwidth-code-point:1.0.0"
-  purl: "pkg:npm/is-fullwidth-code-point@1.0.0"
-  authors:
-  - "Sindre Sorhus"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "Check if the character represented by a given Unicode code point is\
-    \ fullwidth"
-  homepage_url: "https://github.com/sindresorhus/is-fullwidth-code-point"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
-    hash:
-      value: "ef9e31386f031a7f0d643af82fde50c457ef00cb"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "https://github.com/sindresorhus/is-fullwidth-code-point"
-    revision: "f2152d357f41f82785436d428e4f8ede143b7548"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/sindresorhus/is-fullwidth-code-point.git"
-    revision: "f2152d357f41f82785436d428e4f8ede143b7548"
+    revision: "1001187ed027a76051c066408358e769fb61786e"
     path: ""
 - id: "NPM::is-glob:2.0.1"
   purl: "pkg:npm/is-glob@2.0.1"
@@ -6306,8 +5561,8 @@ packages:
     url: "https://github.com/jonschlinkert/kind-of.git"
     revision: "ed479b6ee194dc1edff852f17095ae1de40bafbc"
     path: ""
-- id: "NPM::kind-of:6.0.2"
-  purl: "pkg:npm/kind-of@6.0.2"
+- id: "NPM::kind-of:6.0.3"
+  purl: "pkg:npm/kind-of@6.0.3"
   authors:
   - "Jon Schlinkert"
   declared_licenses:
@@ -6322,22 +5577,22 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz"
+    url: "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz"
     hash:
-      value: "01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+      value: "07c05034a6c349fa06e24fa35aa76db4580ce4dd"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
     url: "git+https://github.com/jonschlinkert/kind-of.git"
-    revision: "1491da72e8d276479f5f6198a9e79c1379c5d0c7"
+    revision: "abab085d65f7ee978011da8f135291892fcd97db"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/jonschlinkert/kind-of.git"
-    revision: "1491da72e8d276479f5f6198a9e79c1379c5d0c7"
+    revision: "abab085d65f7ee978011da8f135291892fcd97db"
     path: ""
-- id: "NPM::lodash:4.17.15"
-  purl: "pkg:npm/lodash@4.17.15"
+- id: "NPM::lodash:4.17.21"
+  purl: "pkg:npm/lodash@4.17.21"
   authors:
   - "John-David Dalton"
   declared_licenses:
@@ -6352,19 +5607,19 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz"
+    url: "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
     hash:
-      value: "b447f6670a0455bbfeedd11392eff330ea097548"
+      value: "679591c564c3bffaae8454cf0b3df370c3d6911c"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
     url: "git+https://github.com/lodash/lodash.git"
-    revision: ""
+    revision: "c6e281b878b315c7a10d90f9c2af4cdb112d9625"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/lodash/lodash.git"
-    revision: ""
+    revision: "c6e281b878b315c7a10d90f9c2af4cdb112d9625"
     path: ""
 - id: "NPM::loose-envify:1.4.0"
   purl: "pkg:npm/loose-envify@1.4.0"
@@ -6581,8 +5836,8 @@ packages:
     url: "https://github.com/isaacs/minimatch.git"
     revision: "e46989a323d5f0aa4781eff5e2e6e7aafa223321"
     path: ""
-- id: "NPM::minimist:0.0.8"
-  purl: "pkg:npm/minimist@0.0.8"
+- id: "NPM::minimist:1.2.5"
+  purl: "pkg:npm/minimist@1.2.5"
   authors:
   - "James Halliday"
   declared_licenses:
@@ -6597,110 +5852,19 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+    url: "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz"
     hash:
-      value: "857fcabfc3397d2625b8228262e86aa7a011b05d"
+      value: "67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
     url: "git://github.com/substack/minimist.git"
-    revision: ""
+    revision: "aeb3e27dae0412de5c0494e9563a5f10c82cc7a9"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/substack/minimist.git"
-    revision: ""
-    path: ""
-- id: "NPM::minimist:1.2.0"
-  purl: "pkg:npm/minimist@1.2.0"
-  authors:
-  - "James Halliday"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "parse argument options"
-  homepage_url: "https://github.com/substack/minimist"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-    hash:
-      value: "a35008b20f41383eec1fb914f4cd5df79a264284"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/substack/minimist.git"
-    revision: "dc624482fcfec5bc669c68cdb861f00573ed4e64"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/substack/minimist.git"
-    revision: "dc624482fcfec5bc669c68cdb861f00573ed4e64"
-    path: ""
-- id: "NPM::minipass:2.3.5"
-  purl: "pkg:npm/minipass@2.3.5"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "minimal implementation of a PassThrough stream"
-  homepage_url: "https://github.com/isaacs/minipass#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz"
-    hash:
-      value: "cacebe492022497f656b0f0f51e2682a9ed2d848"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/isaacs/minipass.git"
-    revision: "d362cb255c2b2ad24b0b6bf8cef35c522ba29019"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/isaacs/minipass.git"
-    revision: "d362cb255c2b2ad24b0b6bf8cef35c522ba29019"
-    path: ""
-- id: "NPM::minizlib:1.2.1"
-  purl: "pkg:npm/minizlib@1.2.1"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "A small fast zlib stream built on [minipass](http://npm.im/minipass)\
-    \ and Node.js's zlib binding."
-  homepage_url: "https://github.com/isaacs/minizlib#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz"
-    hash:
-      value: "dd27ea6136243c7c880684e8672bb3a45fd9b614"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/isaacs/minizlib.git"
-    revision: "ad2e969851c3573eff84a5ddfe906344c814581b"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/isaacs/minizlib.git"
-    revision: "ad2e969851c3573eff84a5ddfe906344c814581b"
+    revision: "aeb3e27dae0412de5c0494e9563a5f10c82cc7a9"
     path: ""
 - id: "NPM::mixin-deep:1.3.2"
   purl: "pkg:npm/mixin-deep@1.3.2"
@@ -6733,8 +5897,8 @@ packages:
     url: "https://github.com/jonschlinkert/mixin-deep.git"
     revision: "754f0c20e1bc13ea5a21a64fbc7d6ba5f7b359b9"
     path: ""
-- id: "NPM::mkdirp:0.5.1"
-  purl: "pkg:npm/mkdirp@0.5.1"
+- id: "NPM::mkdirp:0.5.5"
+  purl: "pkg:npm/mkdirp@0.5.5"
   authors:
   - "James Halliday"
   declared_licenses:
@@ -6749,19 +5913,19 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+    url: "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz"
     hash:
-      value: "30057438eac6cf7f8c4767f38648d6697d75c903"
+      value: "d91cefd62d1436ca0f41620e251288d420099def"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
     url: "git+https://github.com/substack/node-mkdirp.git"
-    revision: "d4eff0f06093aed4f387e88e9fc301cb76beedc7"
+    revision: "049cf185c9e91727bc505b796a2d16a4fe70d64d"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/substack/node-mkdirp.git"
-    revision: "d4eff0f06093aed4f387e88e9fc301cb76beedc7"
+    revision: "049cf185c9e91727bc505b796a2d16a4fe70d64d"
     path: ""
 - id: "NPM::ms:2.0.0"
   purl: "pkg:npm/ms@2.0.0"
@@ -6790,62 +5954,6 @@ packages:
     type: "Git"
     url: "https://github.com/zeit/ms.git"
     revision: "9b88d1568a52ec9bb67ecc8d2aa224fa38fd41f4"
-    path: ""
-- id: "NPM::ms:2.1.1"
-  purl: "pkg:npm/ms@2.1.1"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "Tiny millisecond conversion utility"
-  homepage_url: "https://github.com/zeit/ms#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz"
-    hash:
-      value: "30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/zeit/ms.git"
-    revision: "fe0bae301a6c41f68a01595658a4f4f0dcba0e84"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/zeit/ms.git"
-    revision: "fe0bae301a6c41f68a01595658a4f4f0dcba0e84"
-    path: ""
-- id: "NPM::nan:2.14.0"
-  purl: "pkg:npm/nan@2.14.0"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "Native Abstractions for Node.js: C++ header for Node 0.8 -> 11 compatibility"
-  homepage_url: "https://github.com/nodejs/nan#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz"
-    hash:
-      value: "7818f722027b2459a86f0295d434d1fc2336c52c"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/nodejs/nan.git"
-    revision: "1dcc61bd06d84e389bfd5311b2b1492a14c74201"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/nodejs/nan.git"
-    revision: "1dcc61bd06d84e389bfd5311b2b1492a14c74201"
     path: ""
 - id: "NPM::nanomatch:1.2.13"
   purl: "pkg:npm/nanomatch@1.2.13"
@@ -6879,97 +5987,6 @@ packages:
     url: "https://github.com/micromatch/nanomatch.git"
     revision: "d2af1083ae338c6c9a5834ee85ae40679be60a46"
     path: ""
-- id: "NPM::needle:2.3.0"
-  purl: "pkg:npm/needle@2.3.0"
-  authors:
-  - "Tomás Pollak"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "The leanest and most handsome HTTP client in the Nodelands."
-  homepage_url: "https://github.com/tomas/needle#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz"
-    hash:
-      value: "ce3fea21197267bacb310705a7bbe24f2a3a3492"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/tomas/needle.git"
-    revision: "0cec93fb08ae9f9ec541b9c4170d748b8f4b80f2"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/tomas/needle.git"
-    revision: "0cec93fb08ae9f9ec541b9c4170d748b8f4b80f2"
-    path: ""
-- id: "NPM::node-pre-gyp:0.12.0"
-  purl: "pkg:npm/node-pre-gyp@0.12.0"
-  authors:
-  - "Dane Springmeyer"
-  declared_licenses:
-  - "BSD-3-Clause"
-  declared_licenses_processed:
-    spdx_expression: "BSD-3-Clause"
-  description: "Node.js native addon binary install tool"
-  homepage_url: "https://github.com/mapbox/node-pre-gyp#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz"
-    hash:
-      value: "39ba4bb1439da030295f899e3b520b7785766149"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/mapbox/node-pre-gyp.git"
-    revision: "ff9e93e969d2e385c22901a3c16cb8877dd1d01c"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/mapbox/node-pre-gyp.git"
-    revision: "ff9e93e969d2e385c22901a3c16cb8877dd1d01c"
-    path: ""
-- id: "NPM::nopt:4.0.1"
-  purl: "pkg:npm/nopt@4.0.1"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "Option parsing for Node, supporting types, shorthands, etc. Used by\
-    \ npm."
-  homepage_url: "https://github.com/npm/nopt#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz"
-    hash:
-      value: "d0d4685afd5415193c8c7505602d0d17cd64474d"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/npm/nopt.git"
-    revision: "24921187dc52825d628042c9708bbd8e8734698c"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/npm/nopt.git"
-    revision: "24921187dc52825d628042c9708bbd8e8734698c"
-    path: ""
 - id: "NPM::normalize-path:2.1.1"
   purl: "pkg:npm/normalize-path@2.1.1"
   authors:
@@ -7001,127 +6018,6 @@ packages:
     type: "Git"
     url: "https://github.com/jonschlinkert/normalize-path.git"
     revision: "da1a45e7a514910ce39875b5327b1d0fa9be3d3e"
-    path: ""
-- id: "NPM::npm-bundled:1.0.6"
-  purl: "pkg:npm/npm-bundled@1.0.6"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "list things in node_modules that are bundledDependencies, or transitive\
-    \ dependencies thereof"
-  homepage_url: "https://github.com/npm/npm-bundled#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz"
-    hash:
-      value: "e7ba9aadcef962bb61248f91721cd932b3fe6bdd"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/npm/npm-bundled.git"
-    revision: "59c71778359f7801b8fe5070f2c87a5a31974304"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/npm/npm-bundled.git"
-    revision: "59c71778359f7801b8fe5070f2c87a5a31974304"
-    path: ""
-- id: "NPM::npm-packlist:1.4.1"
-  purl: "pkg:npm/npm-packlist@1.4.1"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "Get a list of the files to add from a folder into an npm package"
-  homepage_url: "https://www.npmjs.com/package/npm-packlist"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz"
-    hash:
-      value: "19064cdf988da80ea3cee45533879d90192bbfbc"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/npm/npm-packlist.git"
-    revision: "1a4c8bfe712f8b2804c0ae48fb2a9dd99c78ef99"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/npm/npm-packlist.git"
-    revision: "1a4c8bfe712f8b2804c0ae48fb2a9dd99c78ef99"
-    path: ""
-- id: "NPM::npmlog:4.1.2"
-  purl: "pkg:npm/npmlog@4.1.2"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "logger for npm"
-  homepage_url: "https://github.com/npm/npmlog#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz"
-    hash:
-      value: "08a7f2a8bf734604779a9efa4ad5cc717abb954b"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/npm/npmlog.git"
-    revision: "f7f9516d35b873c4e45b1aaeb78cff4e43b72c31"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/npm/npmlog.git"
-    revision: "f7f9516d35b873c4e45b1aaeb78cff4e43b72c31"
-    path: ""
-- id: "NPM::number-is-nan:1.0.1"
-  purl: "pkg:npm/number-is-nan@1.0.1"
-  authors:
-  - "Sindre Sorhus"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "ES2015 Number.isNaN() ponyfill"
-  homepage_url: "https://github.com/sindresorhus/number-is-nan#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-    hash:
-      value: "097b602b53422a522c1afb8790318336941a011d"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/sindresorhus/number-is-nan.git"
-    revision: "ed9cdac3f428cc929b61bb230da42c87477af4b9"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/sindresorhus/number-is-nan.git"
-    revision: "ed9cdac3f428cc929b61bb230da42c87477af4b9"
     path: ""
 - id: "NPM::object-assign:4.1.1"
   purl: "pkg:npm/object-assign@4.1.1"
@@ -7366,36 +6262,6 @@ packages:
     url: "https://github.com/sindresorhus/os-tmpdir.git"
     revision: "1abf9cf5611b4be7377060ea67054b45cbf6813c"
     path: ""
-- id: "NPM::osenv:0.1.5"
-  purl: "pkg:npm/osenv@0.1.5"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "Look up environment settings specific to different operating systems"
-  homepage_url: "https://github.com/npm/osenv#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz"
-    hash:
-      value: "85cdfafaeb28e8677f416e287592b5f3f49ea410"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/npm/osenv.git"
-    revision: "1c642b8f5ddb1f99671a300a466bf42ffb9f5ea2"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/npm/osenv.git"
-    revision: "1c642b8f5ddb1f99671a300a466bf42ffb9f5ea2"
-    path: ""
 - id: "NPM::output-file-sync:1.1.2"
   purl: "pkg:npm/output-file-sync@1.1.2"
   authors:
@@ -7608,34 +6474,6 @@ packages:
     url: "https://github.com/benjamn/private.git"
     revision: "8fde2c4c9f760c0ae17f3ff375c02d6498472fbc"
     path: ""
-- id: "NPM::process-nextick-args:2.0.0"
-  purl: "pkg:npm/process-nextick-args@2.0.0"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "process.nextTick but always with args"
-  homepage_url: "https://github.com/calvinmetcalf/process-nextick-args"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz"
-    hash:
-      value: "a37d732f4271b4ab1ad070d35508e8290788ffaa"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/calvinmetcalf/process-nextick-args.git"
-    revision: "8407900951af3e7651fca50f127f0e4ddc01ad55"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/calvinmetcalf/process-nextick-args.git"
-    revision: "8407900951af3e7651fca50f127f0e4ddc01ad55"
-    path: ""
 - id: "NPM::process-nextick-args:2.0.1"
   purl: "pkg:npm/process-nextick-args@2.0.1"
   declared_licenses:
@@ -7695,38 +6533,8 @@ packages:
     url: "https://github.com/jonschlinkert/randomatic.git"
     revision: "b7451f4dac44a9920790f76a4d8a1dd081c37a5a"
     path: ""
-- id: "NPM::rc:1.2.8"
-  purl: "pkg:npm/rc@1.2.8"
-  authors:
-  - "Dominic Tarr"
-  declared_licenses:
-  - "(BSD-2-Clause OR MIT OR Apache-2.0)"
-  declared_licenses_processed:
-    spdx_expression: "BSD-2-Clause OR MIT OR Apache-2.0"
-  description: "hardwired configuration loader"
-  homepage_url: "https://github.com/dominictarr/rc#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz"
-    hash:
-      value: "cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/dominictarr/rc.git"
-    revision: "a97f6adcc37ee1cad06ab7dc9b0bd842bbc5c664"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/dominictarr/rc.git"
-    revision: "a97f6adcc37ee1cad06ab7dc9b0bd842bbc5c664"
-    path: ""
-- id: "NPM::readable-stream:2.3.6"
-  purl: "pkg:npm/readable-stream@2.3.6"
+- id: "NPM::readable-stream:2.3.7"
+  purl: "pkg:npm/readable-stream@2.3.7"
   declared_licenses:
   - "MIT"
   declared_licenses_processed:
@@ -7739,19 +6547,19 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz"
+    url: "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz"
     hash:
-      value: "b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+      value: "1eca1cf711aef814c04f62252a36a62f6cb23b57"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
     url: "git://github.com/nodejs/readable-stream.git"
-    revision: "b3cf9b1f46eaa1865930ae03b96d7a4a570746f0"
+    revision: "2eb8861e029107b7e079e22c826835cad6ae7854"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/nodejs/readable-stream.git"
-    revision: "b3cf9b1f46eaa1865930ae03b96d7a4a570746f0"
+    revision: "2eb8861e029107b7e079e22c826835cad6ae7854"
     path: ""
 - id: "NPM::readdirp:2.2.1"
   purl: "pkg:npm/readdirp@2.2.1"
@@ -7936,8 +6744,8 @@ packages:
     url: "https://github.com/darsain/remove-trailing-separator.git"
     revision: "f4e8acca09106efeef5a5164f1ad2192fe97fd69"
     path: ""
-- id: "NPM::repeat-element:1.1.3"
-  purl: "pkg:npm/repeat-element@1.1.3"
+- id: "NPM::repeat-element:1.1.4"
+  purl: "pkg:npm/repeat-element@1.1.4"
   authors:
   - "Jon Schlinkert"
   declared_licenses:
@@ -7952,19 +6760,19 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz"
+    url: "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz"
     hash:
-      value: "782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
+      value: "be681520847ab58c7568ac75fbfad28ed42d39e9"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
     url: "git+https://github.com/jonschlinkert/repeat-element.git"
-    revision: "32af174b4218263952a77d881f37d6e545b7cfd0"
+    revision: "874e2b3843fb0ae342cb41f40e387f4908ee048d"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/jonschlinkert/repeat-element.git"
-    revision: "32af174b4218263952a77d881f37d6e545b7cfd0"
+    revision: "874e2b3843fb0ae342cb41f40e387f4908ee048d"
     path: ""
 - id: "NPM::repeat-string:1.6.1"
   purl: "pkg:npm/repeat-string@1.6.1"
@@ -8087,36 +6895,6 @@ packages:
     url: "https://github.com/fent/ret.js.git"
     revision: "7f7c436e2a85fbc068e6d94e2611ce78b3e9ad10"
     path: ""
-- id: "NPM::rimraf:2.6.3"
-  purl: "pkg:npm/rimraf@2.6.3"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "A deep deletion module for node (like `rm -rf`)"
-  homepage_url: "https://github.com/isaacs/rimraf#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz"
-    hash:
-      value: "b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/isaacs/rimraf.git"
-    revision: "9442819908e52f2c32620e8fa609d7a5d472cc2c"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/isaacs/rimraf.git"
-    revision: "9442819908e52f2c32620e8fa609d7a5d472cc2c"
-    path: ""
 - id: "NPM::safe-buffer:5.1.2"
   purl: "pkg:npm/safe-buffer@5.1.2"
   authors:
@@ -8177,125 +6955,6 @@ packages:
     url: "https://github.com/substack/safe-regex.git"
     revision: "d2570f31bd9d779515015917bb8297c753e46572"
     path: ""
-- id: "NPM::safer-buffer:2.1.2"
-  purl: "pkg:npm/safer-buffer@2.1.2"
-  authors:
-  - "Nikita Skovoroda"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "Modern Buffer API polyfill without footguns"
-  homepage_url: "https://github.com/ChALkeR/safer-buffer#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
-    hash:
-      value: "44fa161b0187b9549dd84bb91802f9bd8385cd6a"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/ChALkeR/safer-buffer.git"
-    revision: "e8ac214944eda30e1e6c6b7d7e7f6a21cf7dce7c"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/ChALkeR/safer-buffer.git"
-    revision: "e8ac214944eda30e1e6c6b7d7e7f6a21cf7dce7c"
-    path: ""
-- id: "NPM::sax:1.2.4"
-  purl: "pkg:npm/sax@1.2.4"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "An evented streaming XML parser in JavaScript"
-  homepage_url: "https://github.com/isaacs/sax-js#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
-    hash:
-      value: "2816234e2378bddc4e5354fab5caa895df7100d9"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git://github.com/isaacs/sax-js.git"
-    revision: "5aee2163d55cff24b817bbf550bac44841f9df45"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/isaacs/sax-js.git"
-    revision: "5aee2163d55cff24b817bbf550bac44841f9df45"
-    path: ""
-- id: "NPM::semver:5.7.0"
-  purl: "pkg:npm/semver@5.7.0"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "The semantic version parser used by npm."
-  homepage_url: "https://github.com/npm/node-semver#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz"
-    hash:
-      value: "790a7cf6fea5459bac96110b29b60412dc8ff96b"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/npm/node-semver.git"
-    revision: "8055dda0aee91372e3bfc47754a62f40e8a63b98"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/npm/node-semver.git"
-    revision: "8055dda0aee91372e3bfc47754a62f40e8a63b98"
-    path: ""
-- id: "NPM::set-blocking:2.0.0"
-  purl: "pkg:npm/set-blocking@2.0.0"
-  authors:
-  - "Ben Coe"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "set blocking stdio and stderr ensuring that terminal output does not\
-    \ truncate"
-  homepage_url: "https://github.com/yargs/set-blocking#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-    hash:
-      value: "045f9782d011ae9a6803ddd382b24392b3d890f7"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/yargs/set-blocking.git"
-    revision: "7eec10577b5fff264de477ba3b9d07f404946eff"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/yargs/set-blocking.git"
-    revision: "7eec10577b5fff264de477ba3b9d07f404946eff"
-    path: ""
 - id: "NPM::set-value:2.0.1"
   purl: "pkg:npm/set-value@2.0.1"
   authors:
@@ -8326,36 +6985,6 @@ packages:
     type: "Git"
     url: "https://github.com/jonschlinkert/set-value.git"
     revision: "bb0f0382f7d7637f3de1bba52d1b4abdbbbde4d4"
-    path: ""
-- id: "NPM::signal-exit:3.0.2"
-  purl: "pkg:npm/signal-exit@3.0.2"
-  authors:
-  - "Ben Coe"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "when you want to fire an event no matter how a process exits."
-  homepage_url: "https://github.com/tapjs/signal-exit"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-    hash:
-      value: "b5fdc08f1287ea1178628e415e25132b73646c6d"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/tapjs/signal-exit.git"
-    revision: "9c5ad9809fe6135ef22e2623989deaffe2a4fa8a"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/tapjs/signal-exit.git"
-    revision: "9c5ad9809fe6135ef22e2623989deaffe2a4fa8a"
     path: ""
 - id: "NPM::slash:1.0.0"
   purl: "pkg:npm/slash@1.0.0"
@@ -8508,8 +7137,8 @@ packages:
     url: "ssh://git@github.com/mozilla/source-map.git"
     revision: "326dd955a366569759d9537ef5f0f167c89d92d2"
     path: ""
-- id: "NPM::source-map-resolve:0.5.2"
-  purl: "pkg:npm/source-map-resolve@0.5.2"
+- id: "NPM::source-map-resolve:0.5.3"
+  purl: "pkg:npm/source-map-resolve@0.5.3"
   authors:
   - "Simon Lydell"
   declared_licenses:
@@ -8524,19 +7153,19 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz"
+    url: "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz"
     hash:
-      value: "72e2cc34095543e43b2c62b2c4c10d4a9054f259"
+      value: "190866bece7553e1f8f267a2ee82c606b5509a1a"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
     url: "git+https://github.com/lydell/source-map-resolve.git"
-    revision: "858cd9e2ecce25427761b8be616cabf704c69316"
+    revision: "b8244f108af0aaf34c32a61e97b66e38db682afc"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/lydell/source-map-resolve.git"
-    revision: "858cd9e2ecce25427761b8be616cabf704c69316"
+    revision: "b8244f108af0aaf34c32a61e97b66e38db682afc"
     path: ""
 - id: "NPM::source-map-support:0.4.18"
   purl: "pkg:npm/source-map-support@0.4.18"
@@ -8566,8 +7195,8 @@ packages:
     url: "https://github.com/evanw/node-source-map-support.git"
     revision: "b9b5a5576272916237a253393220770c858685d6"
     path: ""
-- id: "NPM::source-map-url:0.4.0"
-  purl: "pkg:npm/source-map-url@0.4.0"
+- id: "NPM::source-map-url:0.4.1"
+  purl: "pkg:npm/source-map-url@0.4.1"
   authors:
   - "Simon Lydell"
   declared_licenses:
@@ -8582,19 +7211,19 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz"
+    url: "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz"
     hash:
-      value: "3e935d7ddd73631b97659956d55128e87b5084a3"
+      value: "0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
       algorithm: "SHA-1"
   vcs:
     type: "Git"
     url: "git+https://github.com/lydell/source-map-url.git"
-    revision: "f13c43ca675379922f26c87737fdcbbeac07eb09"
+    revision: "b16c43ca630067c43a05cad7b6841d25e1248fb9"
     path: ""
   vcs_processed:
     type: "Git"
     url: "https://github.com/lydell/source-map-url.git"
-    revision: "f13c43ca675379922f26c87737fdcbbeac07eb09"
+    revision: "b16c43ca630067c43a05cad7b6841d25e1248fb9"
     path: ""
 - id: "NPM::split-string:3.1.0"
   purl: "pkg:npm/split-string@3.1.0"
@@ -8658,37 +7287,6 @@ packages:
     url: "https://github.com/jonschlinkert/static-extend.git"
     revision: "ce41369391163eb9403848a1b4daf00be981c56b"
     path: ""
-- id: "NPM::string-width:1.0.2"
-  purl: "pkg:npm/string-width@1.0.2"
-  authors:
-  - "Sindre Sorhus"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "Get the visual width of a string - the number of columns required\
-    \ to display it"
-  homepage_url: "https://github.com/sindresorhus/string-width#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-    hash:
-      value: "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/sindresorhus/string-width.git"
-    revision: "282cf3d53918a92cc3ee0778dcf938039bcbc47b"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/sindresorhus/string-width.git"
-    revision: "282cf3d53918a92cc3ee0778dcf938039bcbc47b"
-    path: ""
 - id: "NPM::string_decoder:1.1.1"
   purl: "pkg:npm/string_decoder@1.1.1"
   declared_licenses:
@@ -8747,36 +7345,6 @@ packages:
     url: "https://github.com/chalk/strip-ansi.git"
     revision: "8270705c704956da865623e564eba4875c3ea17f"
     path: ""
-- id: "NPM::strip-json-comments:2.0.1"
-  purl: "pkg:npm/strip-json-comments@2.0.1"
-  authors:
-  - "Sindre Sorhus"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "Strip comments from JSON. Lets you use comments in your JSON files!"
-  homepage_url: "https://github.com/sindresorhus/strip-json-comments#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
-    hash:
-      value: "3c531942e908c2697c0ec344858c286c7ca0a60a"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/sindresorhus/strip-json-comments.git"
-    revision: "1aef99eaa70d07981156e8aaa722e750c3b4eaf9"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/sindresorhus/strip-json-comments.git"
-    revision: "1aef99eaa70d07981156e8aaa722e750c3b4eaf9"
-    path: ""
 - id: "NPM::supports-color:2.0.0"
   purl: "pkg:npm/supports-color@2.0.0"
   authors:
@@ -8806,36 +7374,6 @@ packages:
     type: "Git"
     url: "https://github.com/chalk/supports-color.git"
     revision: "8400d98ade32b2adffd50902c06d9e725a5c6588"
-    path: ""
-- id: "NPM::tar:4.4.8"
-  purl: "pkg:npm/tar@4.4.8"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "tar for node"
-  homepage_url: "https://github.com/npm/node-tar#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz"
-    hash:
-      value: "b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/npm/node-tar.git"
-    revision: "074c89b1e639485468706af3c141a68ef8826728"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/npm/node-tar.git"
-    revision: "074c89b1e639485468706af3c141a68ef8826728"
     path: ""
 - id: "NPM::to-fast-properties:1.0.3"
   purl: "pkg:npm/to-fast-properties@1.0.3"
@@ -9199,37 +7737,6 @@ packages:
     url: "https://github.com/tkellen/node-v8flags.git"
     revision: "4c628146efa7eda11df0e10c73b3d8687873569e"
     path: ""
-- id: "NPM::wide-align:1.1.3"
-  purl: "pkg:npm/wide-align@1.1.3"
-  authors:
-  - "Rebecca Turner"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "A wide-character aware text alignment function for use on the console\
-    \ or with fixed width fonts."
-  homepage_url: "https://github.com/iarna/wide-align#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz"
-    hash:
-      value: "ae074e6bdc0c14a431e804e624549c633b000457"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/iarna/wide-align.git"
-    revision: "6b766c9874a1e5157eda2ac75b90ccc01b313620"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/iarna/wide-align.git"
-    revision: "6b766c9874a1e5157eda2ac75b90ccc01b313620"
-    path: ""
 - id: "NPM::wrappy:1.0.2"
   purl: "pkg:npm/wrappy@1.0.2"
   authors:
@@ -9259,34 +7766,4 @@ packages:
     type: "Git"
     url: "https://github.com/npm/wrappy.git"
     revision: "71d91b6dc5bdeac37e218c2cf03f9ab55b60d214"
-    path: ""
-- id: "NPM::yallist:3.0.3"
-  purl: "pkg:npm/yallist@3.0.3"
-  authors:
-  - "Isaac Z. Schlueter"
-  declared_licenses:
-  - "ISC"
-  declared_licenses_processed:
-    spdx_expression: "ISC"
-  description: "Yet Another Linked List"
-  homepage_url: "https://github.com/isaacs/yallist#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz"
-    hash:
-      value: "b4b049e314be545e3ce802236d6cd22cd91c3de9"
-      algorithm: "SHA-1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/isaacs/yallist.git"
-    revision: "47ab1ce288032985c90ee568681b35ad8978be41"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/isaacs/yallist.git"
-    revision: "47ab1ce288032985c90ee568681b35ad8978be41"
     path: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel/package-lock.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel/package-lock.json
@@ -1,8 +1,2628 @@
 {
   "name": "npm-project-that-depends-on-babel",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "npm-project-that-depends-on-babel",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "babel-cli": "6.26.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "optional": true,
+      "dependencies": {
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
+      }
+    },
+    "node_modules/arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "optional": true,
+      "dependencies": {
+        "arr-flatten": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/async-each": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "optional": true
+    },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "optional": true,
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/babel-cli": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
+      "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+      "dependencies": {
+        "babel-core": "^6.26.0",
+        "babel-polyfill": "^6.26.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "commander": "^2.11.0",
+        "convert-source-map": "^1.5.0",
+        "fs-readdir-recursive": "^1.0.0",
+        "glob": "^7.1.2",
+        "lodash": "^4.17.4",
+        "output-file-sync": "^1.1.2",
+        "path-is-absolute": "^1.0.1",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.6",
+        "v8flags": "^2.1.1"
+      },
+      "bin": {
+        "babel": "bin/babel.js",
+        "babel-doctor": "bin/babel-doctor.js",
+        "babel-external-helpers": "bin/babel-external-helpers.js",
+        "babel-node": "bin/babel-node.js"
+      },
+      "optionalDependencies": {
+        "chokidar": "^1.6.1"
+      }
+    },
+    "node_modules/babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "node_modules/babel-core": {
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "dependencies": {
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
+      }
+    },
+    "node_modules/babel-generator": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "dependencies": {
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "node_modules/babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "node_modules/babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      }
+    },
+    "node_modules/babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dependencies": {
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
+      }
+    },
+    "node_modules/babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dependencies": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "node_modules/babel-runtime/node_modules/regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "node_modules/babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dependencies": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      }
+    },
+    "node_modules/babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "bin": {
+        "babylon": "bin/babylon.js"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "optional": true,
+      "dependencies": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "optional": true,
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base/node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "optional": true,
+      "dependencies": {
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "optional": true,
+      "dependencies": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cache-base/node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "deprecated": "Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.",
+      "optional": true,
+      "dependencies": {
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^1.0.0"
+      }
+    },
+    "node_modules/class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "optional": true,
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/class-utils/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "optional": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/class-utils/node_modules/is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/class-utils/node_modules/is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/class-utils/node_modules/is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "optional": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/class-utils/node_modules/is-descriptor/node_modules/kind-of": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/class-utils/node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "optional": true,
+      "dependencies": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "optional": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "dependencies": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+      "hasInstallScript": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "optional": true
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "optional": true,
+      "dependencies": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-property/node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dependencies": {
+        "repeating": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "optional": true,
+      "dependencies": {
+        "is-posix-bracket": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "optional": true,
+      "dependencies": {
+        "fill-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "optional": true,
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extend-shallow/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "optional": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "optional": true,
+      "dependencies": {
+        "is-extglob": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
+    "node_modules/filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "optional": true,
+      "dependencies": {
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "optional": true,
+      "dependencies": {
+        "for-in": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "optional": true,
+      "dependencies": {
+        "map-cache": "^0.2.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "node_modules/fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
+    "node_modules/get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "optional": true,
+      "dependencies": {
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "optional": true,
+      "dependencies": {
+        "is-glob": "^2.0.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "optional": true,
+      "dependencies": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-value/node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "optional": true,
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values/node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values/node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "optional": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values/node_modules/kind-of": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+      "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+      "optional": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dependencies": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-accessor-descriptor/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "optional": true,
+      "dependencies": {
+        "binary-extensions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "optional": true
+    },
+    "node_modules/is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-data-descriptor/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "optional": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-descriptor/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "optional": true,
+      "dependencies": {
+        "is-primitive": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "optional": true,
+      "dependencies": {
+        "is-extglob": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "optional": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object/node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "optional": true
+    },
+    "node_modules/isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "optional": true,
+      "dependencies": {
+        "isarray": "1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "node_modules/jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      }
+    },
+    "node_modules/json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "optional": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "optional": true,
+      "dependencies": {
+        "object-visit": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/math-random": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+      "optional": true
+    },
+    "node_modules/micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "optional": true,
+      "dependencies": {
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "node_modules/mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "optional": true,
+      "dependencies": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mixin-deep/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "optional": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "optional": true
+    },
+    "node_modules/nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "optional": true,
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nanomatch/node_modules/arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nanomatch/node_modules/array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nanomatch/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "optional": true,
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "optional": true,
+      "dependencies": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "optional": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy/node_modules/is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy/node_modules/is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy/node_modules/is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "optional": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "optional": true,
+      "dependencies": {
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-visit/node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "optional": true,
+      "dependencies": {
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "optional": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object.pick/node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/output-file-sync": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+      "dependencies": {
+        "graceful-fs": "^4.1.4",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "node_modules/parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "optional": true,
+      "dependencies": {
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "optional": true
+    },
+    "node_modules/randomatic": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "optional": true,
+      "dependencies": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/randomatic/node_modules/is-number": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+      "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/randomatic/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "optional": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "optional": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/readdirp/node_modules/arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "optional": true,
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "optional": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "optional": true,
+      "dependencies": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/expand-brackets/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "optional": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/expand-brackets/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "optional": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/expand-brackets/node_modules/is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "optional": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/expand-brackets/node_modules/kind-of": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "optional": true,
+      "dependencies": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/extglob/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "optional": true,
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/extglob/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "optional": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "optional": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/fill-range/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "optional": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/is-accessor-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "optional": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/is-data-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "optional": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "optional": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "optional": true,
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+    },
+    "node_modules/regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "optional": true,
+      "dependencies": {
+        "is-equal-shallow": "^0.1.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "optional": true,
+      "dependencies": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "optional": true
+    },
+    "node_modules/repeat-element": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dependencies": {
+        "is-finite": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
+      "optional": true
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "optional": true,
+      "dependencies": {
+        "ret": "~0.1.10"
+      }
+    },
+    "node_modules/set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "optional": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/set-value/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "optional": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "optional": true,
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "optional": true,
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "optional": true,
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node/node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "optional": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "optional": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "optional": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/is-descriptor/node_modules/kind-of": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "optional": true,
+      "dependencies": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dependencies": {
+        "source-map": "^0.5.6"
+      }
+    },
+    "node_modules/source-map-url": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "optional": true
+    },
+    "node_modules/split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "optional": true,
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "optional": true,
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "optional": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend/node_modules/is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend/node_modules/is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend/node_modules/is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "optional": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend/node_modules/is-descriptor/node_modules/kind-of": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "optional": true,
+      "dependencies": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "optional": true,
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex-range/node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "optional": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "optional": true,
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "optional": true,
+      "dependencies": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-value": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+      "optional": true,
+      "dependencies": {
+        "get-value": "^2.0.3",
+        "has-values": "^0.1.4",
+        "isobject": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "optional": true,
+      "dependencies": {
+        "isarray": "1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-values": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
+      "optional": true
+    },
+    "node_modules/use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+      "bin": {
+        "user-home": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "optional": true
+    },
+    "node_modules/v8flags": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+      "dependencies": {
+        "user-home": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  },
   "dependencies": {
     "ansi-regex": {
       "version": "2.1.1",
@@ -36,12 +2656,14 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "optional": true
     },
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "optional": true
     },
     "array-unique": {
       "version": "0.2.1",
@@ -52,7 +2674,8 @@
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "optional": true
     },
     "async-each": {
       "version": "1.0.3",
@@ -63,7 +2686,8 @@
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "optional": true
     },
     "babel-cli": {
       "version": "6.26.0",
@@ -163,13 +2787,6 @@
         "babel-runtime": "^6.26.0",
         "core-js": "^2.5.0",
         "regenerator-runtime": "^0.10.5"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-        }
       }
     },
     "babel-register": {
@@ -193,6 +2810,13 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
       }
     },
     "babel-template": {
@@ -240,14 +2864,15 @@
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "optional": true,
       "requires": {
         "cache-base": "^1.0.1",
         "class-utils": "^0.3.5",
@@ -262,45 +2887,16 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "optional": true,
           "requires": {
             "is-descriptor": "^1.0.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
           }
         },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "optional": true
         }
       }
     },
@@ -309,6 +2905,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "optional": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -334,6 +2939,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "optional": true,
       "requires": {
         "collection-visit": "^1.0.0",
         "component-emitter": "^1.2.1",
@@ -349,7 +2955,8 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "optional": true
         }
       }
     },
@@ -386,6 +2993,7 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "optional": true,
       "requires": {
         "arr-union": "^3.1.0",
         "define-property": "^0.2.5",
@@ -397,14 +3005,53 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "optional": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "optional": true
+            }
           }
         },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "optional": true
         }
       }
     },
@@ -412,20 +3059,22 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "optional": true,
       "requires": {
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "optional": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -433,9 +3082,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "convert-source-map": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
       "requires": {
         "safe-buffer": "~5.1.1"
       }
@@ -443,17 +3092,18 @@
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "optional": true
     },
     "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "optional": true
     },
     "debug": {
@@ -467,52 +3117,24 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "optional": true
     },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "optional": true,
       "requires": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
       },
       "dependencies": {
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "optional": true
         }
       }
     },
@@ -530,9 +3152,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "expand-brackets": {
       "version": "0.1.5",
@@ -556,6 +3178,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "optional": true,
       "requires": {
         "assign-symbols": "^1.0.0",
         "is-extendable": "^1.0.1"
@@ -565,6 +3188,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "optional": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -579,6 +3203,12 @@
       "requires": {
         "is-extglob": "^1.0.0"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -602,7 +3232,8 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "optional": true
     },
     "for-own": {
       "version": "0.1.5",
@@ -617,6 +3248,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "optional": true,
       "requires": {
         "map-cache": "^0.2.2"
       }
@@ -632,476 +3264,25 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "optional": true,
       "requires": {
-        "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "4.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "minipass": {
-          "version": "2.3.5",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.2.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.3.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "debug": "^4.1.0",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.12.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.6",
-          "bundled": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.4.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.7.0",
-          "bundled": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "bundled": true
-        }
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
       }
     },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "optional": true
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1125,6 +3306,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -1135,9 +3317,9 @@
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
     "graceful-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
     },
     "has-ansi": {
       "version": "2.0.0",
@@ -1151,6 +3333,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "optional": true,
       "requires": {
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
@@ -1160,7 +3343,8 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "optional": true
         }
       }
     },
@@ -1168,6 +3352,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "optional": true,
       "requires": {
         "is-number": "^3.0.0",
         "kind-of": "^4.0.0"
@@ -1177,6 +3362,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -1185,6 +3371,7 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -1195,6 +3382,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -1233,11 +3421,20 @@
       }
     },
     "is-accessor-descriptor": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "optional": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "^6.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "optional": true
+        }
       }
     },
     "is-binary-path": {
@@ -1252,30 +3449,42 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "optional": true
     },
     "is-data-descriptor": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "optional": true,
       "requires": {
-        "kind-of": "^3.0.2"
-      }
-    },
-    "is-descriptor": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-      "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "kind-of": "^6.0.0"
       },
       "dependencies": {
         "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "optional": true
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "optional": true,
+      "requires": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "optional": true
         }
       }
     },
@@ -1297,25 +3506,25 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "optional": true
     },
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "optional": true
     },
     "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
     },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -1333,6 +3542,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "optional": true,
       "requires": {
         "isobject": "^3.0.1"
       },
@@ -1340,7 +3550,8 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "optional": true
         }
       }
     },
@@ -1365,7 +3576,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "optional": true
     },
     "isobject": {
       "version": "2.1.0",
@@ -1395,14 +3607,15 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -1415,12 +3628,14 @@
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "optional": true
     },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "optional": true,
       "requires": {
         "object-visit": "^1.0.0"
       }
@@ -1461,14 +3676,15 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "optional": true,
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -1478,6 +3694,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "optional": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -1485,11 +3702,11 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "ms": {
@@ -1498,9 +3715,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
       "optional": true
     },
     "nanomatch": {
@@ -1535,9 +3752,9 @@
           "optional": true
         },
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "optional": true
         }
       }
@@ -1546,14 +3763,10 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -1564,6 +3777,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "optional": true,
       "requires": {
         "copy-descriptor": "^0.1.0",
         "define-property": "^0.2.5",
@@ -1574,8 +3788,46 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "optional": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "optional": true
+            }
           }
         }
       }
@@ -1584,6 +3836,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "optional": true,
       "requires": {
         "isobject": "^3.0.0"
       },
@@ -1591,7 +3844,8 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "optional": true
         }
       }
     },
@@ -1609,6 +3863,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "optional": true,
       "requires": {
         "isobject": "^3.0.1"
       },
@@ -1616,7 +3871,8 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "optional": true
         }
       }
     },
@@ -1663,7 +3919,8 @@
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "optional": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1711,17 +3968,17 @@
           "optional": true
         },
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "optional": true
         }
       }
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "optional": true,
       "requires": {
         "core-util-is": "~1.0.0",
@@ -1753,7 +4010,8 @@
         "array-unique": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "optional": true
         },
         "braces": {
           "version": "2.3.2",
@@ -1815,46 +4073,6 @@
               "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-              "optional": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "optional": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-              "optional": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "optional": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
               }
             },
             "is-descriptor": {
@@ -1936,32 +4154,43 @@
           }
         },
         "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "optional": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "optional": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
           }
         },
         "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "optional": true,
           "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "optional": true,
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "optional": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
           }
         },
         "is-number": {
@@ -1991,9 +4220,10 @@
           "optional": true
         },
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "optional": true
         },
         "micromatch": {
           "version": "3.1.10",
@@ -2019,9 +4249,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "regex-cache": {
       "version": "0.4.4",
@@ -2036,6 +4266,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "optional": true,
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
@@ -2044,17 +4275,20 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "optional": true
     },
     "repeat-element": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "optional": true
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "optional": true
     },
     "repeating": {
       "version": "2.0.1",
@@ -2067,12 +4301,14 @@
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "optional": true
     },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "optional": true
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -2083,6 +4319,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "optional": true,
       "requires": {
         "ret": "~0.1.10"
       }
@@ -2091,6 +4328,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "optional": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -2102,6 +4340,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -2117,6 +4356,7 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "optional": true,
       "requires": {
         "base": "^0.11.1",
         "debug": "^2.2.0",
@@ -2132,6 +4372,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -2140,8 +4381,46 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "optional": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "optional": true
+            }
           }
         }
       }
@@ -2166,45 +4445,11 @@
             "is-descriptor": "^1.0.0"
           }
         },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "optional": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "optional": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "optional": true,
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "optional": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -2223,11 +4468,12 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "optional": true,
       "requires": {
-        "atob": "^2.1.1",
+        "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
@@ -2243,14 +4489,16 @@
       }
     },
     "source-map-url": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "optional": true
     },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "optional": true,
       "requires": {
         "extend-shallow": "^3.0.0"
       }
@@ -2259,6 +4507,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "optional": true,
       "requires": {
         "define-property": "^0.2.5",
         "object-copy": "^0.1.0"
@@ -2268,8 +4517,46 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "optional": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "optional": true
+            }
           }
         }
       }
@@ -2305,6 +4592,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
@@ -2313,6 +4601,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "optional": true,
       "requires": {
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
@@ -2350,6 +4639,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "optional": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
@@ -2361,6 +4651,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "optional": true,
       "requires": {
         "has-value": "^0.3.1",
         "isobject": "^3.0.0"
@@ -2370,6 +4661,7 @@
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "optional": true,
           "requires": {
             "get-value": "^2.0.3",
             "has-values": "^0.1.4",
@@ -2380,6 +4672,7 @@
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "optional": true,
               "requires": {
                 "isarray": "1.0.0"
               }
@@ -2389,24 +4682,28 @@
         "has-values": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "optional": true
         },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "optional": true
         }
       }
     },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "optional": true
     },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "optional": true
     },
     "user-home": {
       "version": "1.1.1",


### PR DESCRIPTION
This should fix the error with NPM trying to install the optional
fsevents package on a non-darwin platform. Also see [1].

[1]: https://github.com/npm/cli/issues/2291

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>