### PR TITLE
helper-cli: Allow for mapping VCS URLs when importing / exporting path excludes

### DIFF
--- a/helper-cli/src/main/kotlin/commands/packageconfig/ImportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/ImportPathExcludesCommand.kt
@@ -27,6 +27,7 @@ import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
 import org.ossreviewtoolkit.helper.common.findFilesRecursive
+import org.ossreviewtoolkit.helper.common.findRepositoryPaths
 import org.ossreviewtoolkit.helper.common.importPathExcludes
 import org.ossreviewtoolkit.helper.common.mergePathExcludes
 import org.ossreviewtoolkit.helper.common.sortPathExcludes
@@ -69,11 +70,11 @@ class ImportPathExcludesCommand : CliktCommand(
 
     override fun run() {
         val allFiles = findFilesRecursive(sourceCodeDir)
-
         val packageConfiguration = packageConfigurationFile.readValue<PackageConfiguration>()
 
         val existingPathExcludes = packageConfiguration.pathExcludes
-        val importedPathExcludes = importPathExcludes(sourceCodeDir, pathExcludesFile).filter { pathExclude ->
+        val repositoryPaths = findRepositoryPaths(sourceCodeDir)
+        val importedPathExcludes = importPathExcludes(repositoryPaths, pathExcludesFile).filter { pathExclude ->
             allFiles.any { pathExclude.matches(it) }
         }
 

--- a/helper-cli/src/main/kotlin/commands/packageconfig/ImportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/ImportPathExcludesCommand.kt
@@ -26,10 +26,12 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
+import org.ossreviewtoolkit.helper.common.VcsUrlMapping
 import org.ossreviewtoolkit.helper.common.findFilesRecursive
 import org.ossreviewtoolkit.helper.common.findRepositoryPaths
 import org.ossreviewtoolkit.helper.common.importPathExcludes
 import org.ossreviewtoolkit.helper.common.mergePathExcludes
+import org.ossreviewtoolkit.helper.common.orEmpty
 import org.ossreviewtoolkit.helper.common.sortPathExcludes
 import org.ossreviewtoolkit.helper.common.write
 import org.ossreviewtoolkit.model.config.PackageConfiguration
@@ -68,15 +70,23 @@ class ImportPathExcludesCommand : CliktCommand(
         help = "If enabled, only entries are imported for which an entry with the same pattern already exists."
     ).flag()
 
+    private val vcsUrlMappingFile by option(
+        "--vcs-url-mapping-file",
+        help = "A YAML or JSON file containing a mapping of VCS URLs to other VCS URLs which will be replaced during " +
+                "the import."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+
     override fun run() {
         val allFiles = findFilesRecursive(sourceCodeDir)
         val packageConfiguration = packageConfigurationFile.readValue<PackageConfiguration>()
+        val vcsUrlMapping = vcsUrlMappingFile?.readValue<VcsUrlMapping>().orEmpty()
 
         val existingPathExcludes = packageConfiguration.pathExcludes
         val repositoryPaths = findRepositoryPaths(sourceCodeDir)
-        val importedPathExcludes = importPathExcludes(repositoryPaths, pathExcludesFile).filter { pathExclude ->
-            allFiles.any { pathExclude.matches(it) }
-        }
+        val importedPathExcludes = importPathExcludes(repositoryPaths, pathExcludesFile, vcsUrlMapping)
+            .filter { pathExclude -> allFiles.any { pathExclude.matches(it) } }
 
         val pathExcludes = existingPathExcludes
             .mergePathExcludes(importedPathExcludes, updateOnlyExisting)

--- a/helper-cli/src/main/kotlin/commands/repoconfig/ImportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/repoconfig/ImportPathExcludesCommand.kt
@@ -82,7 +82,8 @@ internal class ImportPathExcludesCommand : CliktCommand(
         }
 
         val existingPathExcludes = repositoryConfiguration.excludes.paths
-        val importedPathExcludes = importPathExcludes(ortResult, pathExcludesFile).filter { pathExclude ->
+        val repositoryPaths = ortResult.getRepositoryPaths()
+        val importedPathExcludes = importPathExcludes(repositoryPaths, pathExcludesFile).filter { pathExclude ->
             allFiles.any { pathExclude.matches(it) }
         }
 

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -665,6 +665,19 @@ internal fun RepositoryPathExcludes.write(targetFile: File) {
 }
 
 /**
+ * Apply the [vcsUrlMapping] to this [RepositoryPathExcludes].
+ */
+internal fun RepositoryPathExcludes.mapVcsUrls(vcsUrlMapping: VcsUrlMapping): RepositoryPathExcludes {
+    val result = mutableMapOf<String, MutableList<PathExclude>>()
+
+    forEach { (vcsUrl, pathExcludes) ->
+        result.getOrPut(vcsUrlMapping.map(vcsUrl)) { mutableListOf() } += pathExcludes
+    }
+
+    return result.mapValues { (_, pathExcludes) -> pathExcludes.distinct() }
+}
+
+/**
  * Merge the given [IssueResolution]s replacing entries with equal [IssueResolution.message].
  */
 internal fun Collection<IssueResolution>.mergeIssueResolutions(

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -880,13 +880,11 @@ internal fun importPathExcludes(
     pathExcludesFile: File,
     vcsUrlMapping: VcsUrlMapping
 ): List<PathExclude> {
-    println("Found ${repositoryPaths.size} repositories in ${repositoryPaths.values.sumOf { it.size }} locations.")
-
-    println("Loading $pathExcludesFile...")
-    val pathExcludes = pathExcludesFile.readValue<RepositoryPathExcludes>()
-    println("Found ${pathExcludes.values.sumOf { it.size }} excludes for ${pathExcludes.size} repositories.")
-
     val result = mutableListOf<PathExclude>()
+    val pathExcludes = pathExcludesFile.readValue<RepositoryPathExcludes>()
+
+    println("Found ${repositoryPaths.size} repositories in ${repositoryPaths.values.sumOf { it.size }} locations.")
+    println("Found ${pathExcludes.values.sumOf { it.size }} excludes for ${pathExcludes.size} repositories.")
 
     repositoryPaths.mapKeys { vcsUrlMapping.map(it.key) }.forEach { (vcsUrl, relativePaths) ->
         pathExcludes[vcsUrl]?.let { pathExcludesForRepository ->

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -875,13 +875,7 @@ private fun createBlockYamlMapper(): ObjectMapper =
         .disable(YAMLGenerator.Feature.SPLIT_LINES)
         .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
 
-internal fun importPathExcludes(ortResult: OrtResult, pathExcludesFile: File): List<PathExclude> =
-    importPathExcludes(ortResult.getRepositoryPaths(), pathExcludesFile)
-
-internal fun importPathExcludes(sourceCodeDir: File, pathExcludesFile: File): List<PathExclude> =
-    importPathExcludes(findRepositoryPaths(sourceCodeDir), pathExcludesFile)
-
-private fun importPathExcludes(repositoryPaths: Map<String, Set<String>>, pathExcludesFile: File): List<PathExclude> {
+internal fun importPathExcludes(repositoryPaths: Map<String, Set<String>>, pathExcludesFile: File): List<PathExclude> {
     println("Found ${repositoryPaths.size} repositories in ${repositoryPaths.values.sumOf { it.size }} locations.")
 
     println("Loading $pathExcludesFile...")

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -875,7 +875,11 @@ private fun createBlockYamlMapper(): ObjectMapper =
         .disable(YAMLGenerator.Feature.SPLIT_LINES)
         .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
 
-internal fun importPathExcludes(repositoryPaths: Map<String, Set<String>>, pathExcludesFile: File): List<PathExclude> {
+internal fun importPathExcludes(
+    repositoryPaths: Map<String, Set<String>>,
+    pathExcludesFile: File,
+    vcsUrlMapping: VcsUrlMapping
+): List<PathExclude> {
     println("Found ${repositoryPaths.size} repositories in ${repositoryPaths.values.sumOf { it.size }} locations.")
 
     println("Loading $pathExcludesFile...")
@@ -884,7 +888,7 @@ internal fun importPathExcludes(repositoryPaths: Map<String, Set<String>>, pathE
 
     val result = mutableListOf<PathExclude>()
 
-    repositoryPaths.forEach { (vcsUrl, relativePaths) ->
+    repositoryPaths.mapKeys { vcsUrlMapping.map(it.key) }.forEach { (vcsUrl, relativePaths) ->
         pathExcludes[vcsUrl]?.let { pathExcludesForRepository ->
             pathExcludesForRepository.forEach { pathExclude ->
                 relativePaths.forEach { path ->

--- a/helper-cli/src/main/kotlin/common/VcsUrlMapping.kt
+++ b/helper-cli/src/main/kotlin/common/VcsUrlMapping.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.common
+
+import java.net.URI
+import java.util.SortedMap
+
+/**
+ * Defines a mapping for VCS URLs which can be used to derive the original VCS URL from a VCS URL for a repository
+ * mirror.
+ */
+internal data class VcsUrlMapping(
+    /**
+     * Map the hostname of a VCS mirror to the hostname of the original VCS.
+     */
+    val hostnames: SortedMap<String, String> = sortedMapOf()
+) {
+    /**
+     * Applies the mapping defined by this [VcsUrlMapping].
+     */
+    fun map(vcsUrl: String): String {
+        var uri = URI(vcsUrl)
+
+        return hostnames[uri.host]?.let { uri.replaceHost(it) } ?: vcsUrl
+    }
+}
+
+internal fun VcsUrlMapping?.orEmpty() = this ?: VcsUrlMapping()
+
+private fun URI.replaceHost(host: String) = URI(scheme, userInfo, host, port, path, query, fragment).toString()


### PR DESCRIPTION
Some VCSes are hosted on multiple hosts, e.g. a original repository and a mirror repository.
Allow for mapping the `host` part of the VCS URL so that redundant entries can be avoided as well as the
inconvenience which that'd brings.
