### PR TITLE
helper-cli: Fix a potential NPE with the path exclude import

### DIFF
--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -947,5 +947,15 @@ internal fun OrtResult.getRepositoryPaths(): Map<String, Set<String>> {
         result.getOrPut(vcsInfo.url) { mutableSetOf() } += path
     }
 
+    // For some Git-repo projects `OrtResult.repository.nestedRepositories´ misses some nested repositories for Git
+    // submodules. FIXME: Ensure that the OrtResult holds all nested repositories and remove below workaround.
+    getProjects().forEach { project ->
+        val vcs = project.vcsProcessed
+        val projectPath = getDefinitionFilePathRelativeToAnalyzerRoot(project).substringBeforeLast("/")
+        val path = projectPath.removeSuffix("/${vcs.path}")
+
+        result.getOrPut(vcs.url) { mutableSetOf() } += path
+    }
+
     return result
 }


### PR DESCRIPTION
The import path excludes command makes the assumption that each
nested repository is contained in
`OrtResult.repsitory.nestedRepositories`. This assumtpion does not
always hold for Git submodules of Git repositories cloned via Git-Repo
for unknown reason. Work around that creating additional entries from
the VCS info of the projects.

The (broken) assumption has been introduced by [1].

[1] 23dfaca4cc287b88c83ea438839924b7657b27ff

