### PR TITLE
github-workflows: Disable the reporter-web-app build for now

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,6 +28,7 @@ jobs:
       with:
         arguments: --stacktrace classes -x :reporter-web-app:yarnBuild
   build-reporter-web-app:
+    if: ${{ false }}
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This job suffers from [1].

[1]: https://github.com/burrunan/gradle-cache-action/issues/40

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>