### PR TITLE
helper-cli: Allow mapping VCS URLs for the import / export of license finding curations

### DIFF
--- a/helper-cli/src/main/kotlin/commands/packageconfig/ExportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/ExportLicenseFindingCurationsCommand.kt
@@ -27,9 +27,12 @@ import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
 import org.ossreviewtoolkit.helper.common.RepositoryLicenseFindingCurations
+import org.ossreviewtoolkit.helper.common.VcsUrlMapping
 import org.ossreviewtoolkit.helper.common.findRepositories
 import org.ossreviewtoolkit.helper.common.getLicenseFindingCurationsByRepository
+import org.ossreviewtoolkit.helper.common.mapLicenseFindingCurationsVcsUrls
 import org.ossreviewtoolkit.helper.common.mergeLicenseFindingCurations
+import org.ossreviewtoolkit.helper.common.orEmpty
 import org.ossreviewtoolkit.helper.common.write
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.readValue
@@ -69,14 +72,24 @@ internal class ExportLicenseFindingCurationsCommand : CliktCommand(
         .convert { it.absoluteFile.normalize() }
         .required()
 
+    private val vcsUrlMappingFile by option(
+        "--vcs-url-mapping-file",
+        help = "A YAML or JSON file containing a mapping of VCS URLs to other VCS URLs which will be replaced during " +
+                "the export."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+
     override fun run() {
+        val vcsUrlMapping = vcsUrlMappingFile?.readValue<VcsUrlMapping>().orEmpty()
+
         val localLicenseFindingCurations = getLicenseFindingCurationsByRepository(
             curations = packageConfigurationFile.readValue<PackageConfiguration>().licenseFindingCurations,
             nestedRepositories = findRepositories(sourceCodeDir)
-        )
+        ).mapLicenseFindingCurationsVcsUrls(vcsUrlMapping)
 
         val globalLicenseFindingCurations = licenseFindingCurationsFile.takeIf { it.isFile }
-            ?.readValue<RepositoryLicenseFindingCurations>().orEmpty()
+            ?.readValue<RepositoryLicenseFindingCurations>().orEmpty().mapLicenseFindingCurationsVcsUrls(vcsUrlMapping)
 
         globalLicenseFindingCurations
             .mergeLicenseFindingCurations(localLicenseFindingCurations, updateOnlyExisting = updateOnlyExisting)

--- a/helper-cli/src/main/kotlin/commands/packageconfig/ExportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/ExportPathExcludesCommand.kt
@@ -30,7 +30,7 @@ import org.ossreviewtoolkit.helper.common.RepositoryPathExcludes
 import org.ossreviewtoolkit.helper.common.VcsUrlMapping
 import org.ossreviewtoolkit.helper.common.findRepositories
 import org.ossreviewtoolkit.helper.common.getPathExcludesByRepository
-import org.ossreviewtoolkit.helper.common.mapVcsUrls
+import org.ossreviewtoolkit.helper.common.mapPathExcludesVcsUrls
 import org.ossreviewtoolkit.helper.common.mergePathExcludes
 import org.ossreviewtoolkit.helper.common.orEmpty
 import org.ossreviewtoolkit.helper.common.write
@@ -85,12 +85,12 @@ class ExportPathExcludesCommand : CliktCommand(
             pathExcludesFile.readValue<RepositoryPathExcludes>()
         } else {
             mapOf()
-        }.mapVcsUrls(vcsUrlMapping)
+        }.mapPathExcludesVcsUrls(vcsUrlMapping)
 
         val localPathExcludes = getPathExcludesByRepository(
             pathExcludes = packageConfigurationFile.readValue<PackageConfiguration>().pathExcludes,
             nestedRepositories = findRepositories(sourceCodeDir)
-        ).mapVcsUrls(vcsUrlMapping)
+        ).mapPathExcludesVcsUrls(vcsUrlMapping)
 
         globalPathExcludes
             .mergePathExcludes(localPathExcludes, updateOnlyExisting = updateOnlyExisting)

--- a/helper-cli/src/main/kotlin/commands/packageconfig/ImportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/ImportLicenseFindingCurationsCommand.kt
@@ -26,6 +26,7 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
+import org.ossreviewtoolkit.helper.common.findRepositoryPaths
 import org.ossreviewtoolkit.helper.common.getScanResultFor
 import org.ossreviewtoolkit.helper.common.importLicenseFindingCurations
 import org.ossreviewtoolkit.helper.common.mergeLicenseFindingCurations
@@ -86,8 +87,8 @@ class ImportLicenseFindingCurationsCommand : CliktCommand(
         val packageConfiguration = packageConfigurationFile.readValue<PackageConfiguration>()
 
         val allLicenseFindings = ortResult.getScanResultFor(packageConfiguration)?.summary?.licenseFindings.orEmpty()
-
-        val importedCurations = importLicenseFindingCurations(sourceCodeDir, licenseFindingCurationsFile)
+        val repositoryPaths = findRepositoryPaths(sourceCodeDir)
+        val importedCurations = importLicenseFindingCurations(repositoryPaths, licenseFindingCurationsFile)
             .filter { curation ->
                 allLicenseFindings.any { finding ->
                     findingCurationMatcher.matches(finding, curation)

--- a/helper-cli/src/main/kotlin/commands/repoconfig/ExportPathExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/repoconfig/ExportPathExcludesCommand.kt
@@ -29,7 +29,7 @@ import com.github.ajalt.clikt.parameters.types.file
 import org.ossreviewtoolkit.helper.common.RepositoryPathExcludes
 import org.ossreviewtoolkit.helper.common.VcsUrlMapping
 import org.ossreviewtoolkit.helper.common.getRepositoryPathExcludes
-import org.ossreviewtoolkit.helper.common.mapVcsUrls
+import org.ossreviewtoolkit.helper.common.mapPathExcludesVcsUrls
 import org.ossreviewtoolkit.helper.common.mergePathExcludes
 import org.ossreviewtoolkit.helper.common.orEmpty
 import org.ossreviewtoolkit.helper.common.readOrtResult
@@ -84,13 +84,13 @@ internal class ExportPathExcludesCommand : CliktCommand(
         val localPathExcludes = readOrtResult(ortFile)
             .replaceConfig(repositoryConfigurationFile)
             .getRepositoryPathExcludes()
-            .mapVcsUrls(vcsUrlMapping)
+            .mapPathExcludesVcsUrls(vcsUrlMapping)
 
         val globalPathExcludes = if (pathExcludesFile.isFile) {
             pathExcludesFile.readValue<RepositoryPathExcludes>()
         } else {
             mapOf()
-        }.mapVcsUrls(vcsUrlMapping)
+        }.mapPathExcludesVcsUrls(vcsUrlMapping)
 
         globalPathExcludes
             .mergePathExcludes(localPathExcludes, updateOnlyExisting = updateOnlyExisting)

--- a/helper-cli/src/main/kotlin/commands/repoconfig/ImportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/repoconfig/ImportLicenseFindingCurationsCommand.kt
@@ -26,9 +26,11 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
+import org.ossreviewtoolkit.helper.common.VcsUrlMapping
 import org.ossreviewtoolkit.helper.common.getRepositoryPaths
 import org.ossreviewtoolkit.helper.common.importLicenseFindingCurations
 import org.ossreviewtoolkit.helper.common.mergeLicenseFindingCurations
+import org.ossreviewtoolkit.helper.common.orEmpty
 import org.ossreviewtoolkit.helper.common.readOrtResult
 import org.ossreviewtoolkit.helper.common.replaceLicenseFindingCurations
 import org.ossreviewtoolkit.helper.common.sortLicenseFindingCurations
@@ -74,6 +76,14 @@ internal class ImportLicenseFindingCurationsCommand : CliktCommand(
                 "of its concluded license, comment or reason."
     ).flag()
 
+    private val vcsUrlMappingFile by option(
+        "--vcs-url-mapping-file",
+        help = "A YAML or JSON file containing a mapping of VCS URLs to other VCS URLs which will be replaced during " +
+                "the import."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+
     private val findingCurationMatcher = FindingCurationMatcher()
 
     override fun run() {
@@ -83,16 +93,18 @@ internal class ImportLicenseFindingCurationsCommand : CliktCommand(
         } else {
             RepositoryConfiguration()
         }
+        val vcsUrlMapping = vcsUrlMappingFile?.readValue<VcsUrlMapping>().orEmpty()
 
         val allLicenseFindings = ortResult.getLicenseFindingsForAllProjects()
         val repositoryPaths = ortResult.getRepositoryPaths()
-        val importedCurations = importLicenseFindingCurations(repositoryPaths, licenseFindingCurationsFile)
-            .filter { curation ->
-                allLicenseFindings.any { finding ->
-                    findingCurationMatcher.matches(finding, curation)
-                }
-            }
-        
+        val importedCurations = importLicenseFindingCurations(
+            repositoryPaths,
+            licenseFindingCurationsFile,
+            vcsUrlMapping
+        ).filter { curation ->
+            allLicenseFindings.any { finding -> findingCurationMatcher.matches(finding, curation) }
+        }
+
         val existingCurations = repositoryConfiguration.curations.licenseFindings
         val curations = existingCurations.mergeLicenseFindingCurations(importedCurations, updateOnlyExisting)
 

--- a/helper-cli/src/main/kotlin/commands/repoconfig/ImportLicenseFindingCurationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/repoconfig/ImportLicenseFindingCurationsCommand.kt
@@ -92,6 +92,7 @@ internal class ImportLicenseFindingCurationsCommand : CliktCommand(
                     findingCurationMatcher.matches(finding, curation)
                 }
             }
+        
         val existingCurations = repositoryConfiguration.curations.licenseFindings
         val curations = existingCurations.mergeLicenseFindingCurations(importedCurations, updateOnlyExisting)
 

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -900,11 +900,9 @@ internal fun importPathExcludes(
 }
 
 internal fun importLicenseFindingCurations(
-    sourceCodeDir: File,
+    repositoryPaths: Map<String, Set<String>>,
     licenseFindingCurationsFile: File
 ): List<LicenseFindingCuration> {
-    println("Analyzing $sourceCodeDir...")
-    val repositoryPaths = findRepositoryPaths(sourceCodeDir)
     println("Found ${repositoryPaths.size} repositories in ${repositoryPaths.values.sumOf { it.size }} locations.")
 
     println("Loading $licenseFindingCurationsFile...")

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -678,6 +678,21 @@ internal fun RepositoryPathExcludes.mapPathExcludesVcsUrls(vcsUrlMapping: VcsUrl
 }
 
 /**
+ * Apply the [vcsUrlMapping] to this [RepositoryLicenseFindingCurations].
+ */
+internal fun RepositoryLicenseFindingCurations.mapLicenseFindingCurationsVcsUrls(
+    vcsUrlMapping: VcsUrlMapping
+): RepositoryLicenseFindingCurations {
+    val result = mutableMapOf<String, MutableList<LicenseFindingCuration>>()
+
+    forEach { (vcsUrl, curations) ->
+        result.getOrPut(vcsUrlMapping.map(vcsUrl)) { mutableListOf() } += curations
+    }
+
+    return result.mapValues { (_, pathExcludes) -> pathExcludes.distinct() }
+}
+
+/**
  * Merge the given [IssueResolution]s replacing entries with equal [IssueResolution.message].
  */
 internal fun Collection<IssueResolution>.mergeIssueResolutions(

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -667,7 +667,7 @@ internal fun RepositoryPathExcludes.write(targetFile: File) {
 /**
  * Apply the [vcsUrlMapping] to this [RepositoryPathExcludes].
  */
-internal fun RepositoryPathExcludes.mapVcsUrls(vcsUrlMapping: VcsUrlMapping): RepositoryPathExcludes {
+internal fun RepositoryPathExcludes.mapPathExcludesVcsUrls(vcsUrlMapping: VcsUrlMapping): RepositoryPathExcludes {
     val result = mutableMapOf<String, MutableList<PathExclude>>()
 
     forEach { (vcsUrl, pathExcludes) ->

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -904,13 +904,11 @@ internal fun importLicenseFindingCurations(
     licenseFindingCurationsFile: File,
     vcsUrlMapping: VcsUrlMapping
 ): List<LicenseFindingCuration> {
-    println("Found ${repositoryPaths.size} repositories in ${repositoryPaths.values.sumOf { it.size }} locations.")
-
-    println("Loading $licenseFindingCurationsFile...")
     val curations = licenseFindingCurationsFile.readValue<RepositoryLicenseFindingCurations>()
-    println("Found ${curations.values.sumOf { it.size }} curations for ${curations.size} repositories.")
-
     val result = mutableListOf<LicenseFindingCuration>()
+
+    println("Found ${repositoryPaths.size} repositories in ${repositoryPaths.values.sumOf { it.size }} locations.")
+    println("Found ${curations.values.sumOf { it.size }} curations for ${curations.size} repositories.")
 
     repositoryPaths.mapKeys { vcsUrlMapping.map(it.key) }.forEach { (vcsUrl, relativePaths) ->
         curations[vcsUrl]?.let { curationsForRepository ->

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -901,7 +901,8 @@ internal fun importPathExcludes(
 
 internal fun importLicenseFindingCurations(
     repositoryPaths: Map<String, Set<String>>,
-    licenseFindingCurationsFile: File
+    licenseFindingCurationsFile: File,
+    vcsUrlMapping: VcsUrlMapping
 ): List<LicenseFindingCuration> {
     println("Found ${repositoryPaths.size} repositories in ${repositoryPaths.values.sumOf { it.size }} locations.")
 
@@ -911,7 +912,7 @@ internal fun importLicenseFindingCurations(
 
     val result = mutableListOf<LicenseFindingCuration>()
 
-    repositoryPaths.forEach { (vcsUrl, relativePaths) ->
+    repositoryPaths.mapKeys { vcsUrlMapping.map(it.key) }.forEach { (vcsUrl, relativePaths) ->
         curations[vcsUrl]?.let { curationsForRepository ->
             curationsForRepository.forEach { curation ->
                 relativePaths.forEach { path ->


### PR DESCRIPTION
The implementation is analog to the existing one for path excludes.