### PR TITLE
Use `GENERATED_FROM` SPDX relations to distinguish between source and binary artifacts

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx-project-expected-output.yml
@@ -44,12 +44,12 @@ packages:
     \ of powerful features."
   homepage_url: "https://curl.haxx.se/"
   binary_artifact:
-    url: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
+    url: ""
     hash:
       value: ""
       algorithm: ""
   source_artifact:
-    url: ""
+    url: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
     hash:
       value: ""
       algorithm: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/zlib/package.spdx.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx/package/libs/zlib/package.spdx.yml
@@ -18,7 +18,7 @@ packages:
   - referenceCategory: "SECURITY"
     referenceLocator: "cpe:/a:compress:zlib:1.2.11:::en-us"
     referenceType: "cpe22Type"
-  filesAnalyzed: true
+  filesAnalyzed: false
   homepage: "http://zlib.net"
   licenseConcluded: "NOASSERTION"
   licenseDeclared: "Zlib"

--- a/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx/project/project.spdx.yml
@@ -20,7 +20,7 @@ externalDocumentRefs:
 - externalDocumentId: "DocumentRef-zlib-1.2.11"
   checksum:
     algorithm: "SHA1"
-    checksumValue: "31ac790fa33d3e54d1bd98390ab94a212f52d63e"
+    checksumValue: "c3d22d3fbff30a845d57e9fa19e0b5f453b7b0ee"
   spdxDocument: "../package/libs/zlib/package.spdx.yml"
 packages:
 - SPDXID: "SPDXRef-Package-xyz"

--- a/analyzer/src/test/kotlin/managers/SpdxDocumentFileTest.kt
+++ b/analyzer/src/test/kotlin/managers/SpdxDocumentFileTest.kt
@@ -28,9 +28,7 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
-import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.OrtIssue
-import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
@@ -93,38 +91,6 @@ private fun createSpdxDocument(): SpdxDocument {
 }
 
 class SpdxDocumentFileTest : WordSpec({
-    "getBinaryArtifact()" should {
-        "return a RemoteArtifact for a downloadLocation that points to a binary artifact" {
-            pkgForBinaryArtifact.getBinaryArtifact() shouldBe RemoteArtifact(
-                url = "https://repo1.maven.org/maven2/junit/junit/4.11/junit-4.11.jar",
-                hash = Hash.NONE
-            )
-        }
-
-        "return null for a downloadLocation that does not point to a binary artifact" {
-            pkgForBinaryArtifact.copy(downloadLocation = SpdxConstants.NONE).getBinaryArtifact() should beNull()
-            pkgForBinaryArtifact.copy(downloadLocation = SpdxConstants.NOASSERTION).getBinaryArtifact() should beNull()
-            pkgForSourceArtifact.getBinaryArtifact() should beNull()
-            pkgForVcs.getBinaryArtifact() should beNull()
-        }
-    }
-
-    "getSourceArtifact()" should {
-        "return a RemoteArtifact for a downloadLocation that points to a source artifact" {
-            pkgForSourceArtifact.getSourceArtifact() shouldBe RemoteArtifact(
-                url = "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz",
-                hash = Hash.NONE
-            )
-        }
-
-        "return null for a downloadLocation that does not point to a source artifact" {
-            pkgForSourceArtifact.copy(downloadLocation = SpdxConstants.NONE).getSourceArtifact() should beNull()
-            pkgForSourceArtifact.copy(downloadLocation = SpdxConstants.NOASSERTION).getSourceArtifact() should beNull()
-            pkgForBinaryArtifact.getSourceArtifact() should beNull()
-            pkgForVcs.getSourceArtifact() should beNull()
-        }
-    }
-
     "getVcsInfo()" should {
         "return the VcsInfo for a downloadLocation that points to a VCS" {
             pkgForVcs.getVcsInfo() shouldBe VcsInfo(

--- a/analyzer/src/test/kotlin/managers/SpdxDocumentFileTest.kt
+++ b/analyzer/src/test/kotlin/managers/SpdxDocumentFileTest.kt
@@ -138,7 +138,7 @@ class SpdxDocumentFileTest : WordSpec({
         "throw if an external package id does not match relationship id" {
             val externalDocumentReference = SpdxExternalDocumentReference(
                 "DocumentRef-zlib-1.2.11",
-                SpdxChecksum(SpdxChecksum.Algorithm.SHA1, "31ac790fa33d3e54d1bd98390ab94a212f52d63e"),
+                SpdxChecksum(SpdxChecksum.Algorithm.SHA1, "c3d22d3fbff30a845d57e9fa19e0b5f453b7b0ee"),
                 "../package/libs/zlib/package.spdx.yml"
             )
             val issues = mutableListOf<OrtIssue>()


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.