### PR TITLE
TemplateHelper: Allow access to packages by their identifiers

### DIFF
--- a/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
@@ -35,6 +35,7 @@ import org.ossreviewtoolkit.model.AdvisorResultFilter
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.ScanResult
@@ -393,6 +394,15 @@ class FreemarkerTemplateProcessor(
          */
         fun advisorResultsWithDefects(): Map<Identifier, List<AdvisorResult>> =
             input.filteredAdvisorResults(AdvisorRecord.RESULTS_WITH_DEFECTS)
+
+        /**
+         * Return the package from the current [OrtResult] with the given [id] or the empty package if the ID cannot be
+         * resolved. This function is useful for templates rendering advisor results, which contain only the
+         * identifiers of affected packages, but not the packages themselves.
+         */
+        fun getPackage(id: Identifier): Package =
+            input.ortResult.getPackage(id)?.pkg
+                ?: Package.EMPTY.also { log.warn { "Could not resolve package '${id.toCoordinates()}'." } }
     }
 }
 

--- a/reporter/src/test/kotlin/reporters/freemarker/FreeMarkerTemplateProcessorTest.kt
+++ b/reporter/src/test/kotlin/reporters/freemarker/FreeMarkerTemplateProcessorTest.kt
@@ -45,12 +45,14 @@ import org.ossreviewtoolkit.model.AdvisorSummary
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.AnalyzerRun
 import org.ossreviewtoolkit.model.CopyrightFinding
+import org.ossreviewtoolkit.model.CuratedPackage
 import org.ossreviewtoolkit.model.Defect
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.Repository
 import org.ossreviewtoolkit.model.RepositoryProvenance
@@ -626,6 +628,32 @@ class FreeMarkerTemplateProcessorTest : WordSpec({
             val results = helper.advisorResultsWithDefects()
 
             results should beEmpty()
+        }
+    }
+
+    "getPackage" should {
+        "return the correct package for the given ID" {
+            val id = Identifier.EMPTY.copy(name = "test-package", version = "1.0.1")
+            val pkg = Package.EMPTY.copy(
+                id = id,
+                cpe = "cpe:2.3:a:test:${id.name}:${id.version}:-:-:-:-:-:-:-"
+            )
+            val analyzerResult = ORT_RESULT.analyzer!!.result.copy(packages = sortedSetOf(CuratedPackage(pkg)))
+            val analyzerRun = ORT_RESULT.analyzer!!.copy(result = analyzerResult)
+
+            val input = ReporterInput(ORT_RESULT.copy(analyzer = analyzerRun))
+            val helper = FreemarkerTemplateProcessor.TemplateHelper(input)
+
+            helper.getPackage(id) shouldBe pkg
+        }
+
+        "return the empty package for an unknown ID" {
+            val id = Identifier.EMPTY.copy(name = "unknown-package")
+
+            val input = ReporterInput(ORT_RESULT)
+            val helper = FreemarkerTemplateProcessor.TemplateHelper(input)
+
+            helper.getPackage(id) shouldBe Package.EMPTY
         }
     }
 })


### PR DESCRIPTION
Templates rendering advisor results currently operate on package
identifiers only, since the results do not contain the packages
themselves. There is no direct way to obtain the referenced package.

As this is useful, e.g. to display additional metadata of a package,
provide a function in TemplateHelper that resolves a package for a
given ID.
