### PR TITLE
github-workflows: Trigger only on the "virtual merge" with `master`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - master
-  push:
-    branches:
-      - master
 
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,6 +1,9 @@
 name: Validate Gradle Wrapper
 
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   wrapper-validation:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - master
-  push:
-    branches:
-      - master
 
 jobs:
   detekt-issues:


### PR DESCRIPTION
Save some build minutes by not also running on `master` after the merge.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>