### PR TITLE
Npm: Performance and debug logging

### DIFF
--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -519,15 +519,12 @@ open class Npm(
             return null
         }
 
-        log.debug { "Building dependency tree for '${moduleInfo.name}' from directory '$moduleDir'." }
-
         val pathToRoot = listOf(moduleDir) + ancestorModuleDirs
         moduleInfo.dependencyNames.forEach { dependencyName ->
             val dependencyModuleDirPath = findDependencyModuleDir(dependencyName, pathToRoot)
 
             if (dependencyModuleDirPath.isNotEmpty()) {
                 val dependencyModuleDir = dependencyModuleDirPath.first()
-                log.debug { "Found module dir for '$dependencyName' at '$dependencyModuleDir'." }
 
                 getModuleInfo(
                     moduleDir = dependencyModuleDir,


### PR DESCRIPTION
Some `debug` log statements may trash the analysis execution performance as they are to frequent. So, reduce the level to `trace`. Apart from that save I/Os by a factor of about 1000 and add some alternative debug logging so that there is at least some status output on the `debug` log level.