### PR TITLE
SpdxDocumentFile: Introduce a helper class to load documents

### DIFF
--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -56,7 +56,6 @@ import org.ossreviewtoolkit.utils.core.downloadFile
 import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
-import org.ossreviewtoolkit.utils.spdx.SpdxModelMapper
 import org.ossreviewtoolkit.utils.spdx.model.SpdxDocument
 import org.ossreviewtoolkit.utils.spdx.model.SpdxExternalDocumentReference
 import org.ossreviewtoolkit.utils.spdx.model.SpdxExternalReference
@@ -106,15 +105,16 @@ internal fun SpdxDocument.projectPackage(): SpdxPackage? =
         ?.singleOrNull { it.packageFilename.isEmpty() || it.packageFilename == "." }
 
 /**
- * Get the [SpdxPackage] from the [SpdxExternalDocumentReference] that the [packageId] refers to, where [definitionFile]
- * is used to resolve local relative URIs to files.
+ * Use [loader] to get the [SpdxPackage] from the [SpdxExternalDocumentReference] that the [packageId] refers to, where
+ * [definitionFile] is used to resolve local relative URIs to files.
  */
 internal fun SpdxExternalDocumentReference.getSpdxPackage(
+    loader: SpdxDocumentLoader,
     packageId: String,
     definitionFile: File,
     issues: MutableList<OrtIssue>
 ): SpdxPackage? {
-    val externalSpdxDocument = resolve(definitionFile, issues) ?: return null
+    val externalSpdxDocument = resolve(loader, definitionFile, issues) ?: return null
 
     val spdxDocumentPath = URI(spdxDocument).path
     val spdxDocumentFile = definitionFile.resolveSibling(spdxDocumentPath).normalize()
@@ -134,7 +134,11 @@ internal fun SpdxExternalDocumentReference.getSpdxPackage(
 /**
  * Return the [SpdxDocument] this [SpdxExternalDocumentReference]'s [SpdxDocument] refers to.
  */
-private fun SpdxExternalDocumentReference.resolve(definitionFile: File, issues: MutableList<OrtIssue>): SpdxDocument? {
+private fun SpdxExternalDocumentReference.resolve(
+    loader: SpdxDocumentLoader,
+    definitionFile: File,
+    issues: MutableList<OrtIssue>
+): SpdxDocument? {
     val uri = runCatching { URI(spdxDocument) }.getOrElse {
         issues += createAndLogIssue(
             source = MANAGER_NAME,
@@ -184,17 +188,19 @@ private fun SpdxExternalDocumentReference.resolve(definitionFile: File, issues: 
         }
     }
 
-    val hash = Hash.create(checksum.checksumValue, checksum.algorithm.name)
-    if (!hash.verify(spdxFile)) {
+    val verifiedDocument = loader.loadAndVerify(spdxFile, checksum)
+    if (!verifiedDocument.valid) {
         val referencedFile = tempDir?.let { uri } ?: spdxFile
         issues += createAndLogIssue(
             source = MANAGER_NAME,
-            message = "The file '$referencedFile' referred from '$definitionFile' does not match the expected $hash.",
+            message = "The file '$referencedFile' referred from '$definitionFile' does not match the expected " +
+                    "$checksum.",
             severity = Severity.WARNING
         )
     }
 
-    return SpdxModelMapper.read<SpdxDocument>(spdxFile).also { tempDir?.safeDeleteRecursively(force = true) }
+    tempDir?.safeDeleteRecursively(force = true)
+    return verifiedDocument.document
 }
 
 /**
@@ -335,7 +341,7 @@ class SpdxDocumentFile(
     analyzerConfig: AnalyzerConfiguration,
     repoConfig: RepositoryConfiguration
 ) : PackageManager(managerName, analysisRoot, analyzerConfig, repoConfig) {
-    private val spdxDocumentForFile = mutableMapOf<File, SpdxDocument>()
+    private val spdxDocumentLoader = SpdxDocumentLoader()
     private val packageForExternalDocumentId = mutableMapOf<String, SpdxPackage>()
 
     class Factory : AbstractPackageManagerFactory<SpdxDocumentFile>(MANAGER_NAME) {
@@ -420,7 +426,12 @@ class SpdxDocumentFile(
         }
 
         return packageForExternalDocumentId.getOrPut(externalDocumentReference.externalDocumentId) {
-            externalDocumentReference.getSpdxPackage(identifier.substringAfter(":"), definitionFile, issues)
+            externalDocumentReference.getSpdxPackage(
+                spdxDocumentLoader,
+                identifier.substringAfter(":"),
+                definitionFile,
+                issues
+            )
                 ?: return null
         }
     }
@@ -534,9 +545,7 @@ class SpdxDocumentFile(
         }
 
     override fun mapDefinitionFiles(definitionFiles: List<File>): List<File> =
-        definitionFiles.associateWith {
-            SpdxModelMapper.read<SpdxDocument>(it)
-        }.filterTo(spdxDocumentForFile) { (_, spdxDocument) ->
+        definitionFiles.associateWith(spdxDocumentLoader::load).filter { (_, spdxDocument) ->
             // Distinguish whether we have a project-style SPDX document that describes a project and its dependencies,
             // or a package-style SPDX document that describes a single (dependency-)package.
             spdxDocument.isProject()
@@ -554,7 +563,7 @@ class SpdxDocumentFile(
 
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {
         // For direct callers of this function mapDefinitionFiles() did not populate the map before, so add a fallback.
-        val spdxDocument = spdxDocumentForFile.getOrPut(definitionFile) { SpdxModelMapper.read(definitionFile) }
+        val spdxDocument = spdxDocumentLoader.load(definitionFile)
 
         val packages = mutableSetOf<Package>()
         val scopes = sortedSetOf<Scope>()

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentLoader.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentLoader.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers
+
+import java.io.File
+
+import org.ossreviewtoolkit.model.Hash
+import org.ossreviewtoolkit.utils.spdx.SpdxModelMapper
+import org.ossreviewtoolkit.utils.spdx.model.SpdxChecksum
+import org.ossreviewtoolkit.utils.spdx.model.SpdxDocument
+
+/**
+ * A helper class for [[SpdxDocumentFile]] that deals with loading of SPDX documents.
+ *
+ * While loading of SPDX documents is not that complicated, this class mainly is responsible for caching loaded
+ * documents to prevent that they are loaded multiple times - which could be the case for instance if multiple
+ * packages are resolved from an external document reference.
+ *
+ * Implementation note: This implementation is not thread-safe.
+ */
+internal class SpdxDocumentLoader {
+    /** A cache for the documents that have already been loaded. */
+    private val documentCache = mutableMapOf<File, DocumentEntry>()
+
+    /**
+     * Load the given [file] and parse it to an [SpdxDocument]. Cache the resulting document in case the file is
+     * queried again.
+     */
+    fun load(file: File): SpdxDocument =
+        fetch(file).document
+
+    /**
+     * Load the given [file], parse it to an [SpdxDocument], and verify that it matches the given [checksum].
+     */
+    fun loadAndVerify(file: File, checksum: SpdxChecksum): VerifiedDocument {
+        val entry = fetch(file)
+
+        return VerifiedDocument(entry.document, entry.verify(file, checksum))
+    }
+
+    /**
+     * Fetch the [DocumentEntry] for the given [File]. Either load it or get it from the cache.
+     */
+    private fun fetch(file: File) =
+        documentCache.getOrPut(file) {
+            DocumentEntry(SpdxModelMapper.read(file), mutableMapOf())
+        }
+}
+
+/**
+ * A data class combining an [SpdxDocument] with a flag whether it has been successfully validated against a checksum.
+ * Instances of this class are returned by [SpdxDocumentLoader.loadAndVerify] to represent the two return values: the
+ * document itself and the result of the checksum verification.
+ */
+internal data class VerifiedDocument(
+    /** The [SpdxDocument] that was loaded. */
+    val document: SpdxDocument,
+
+    /** Flag whether verification against the provided checksum was successful. */
+    val valid: Boolean
+)
+
+/**
+ * An internal data class to store information about SPDX documents that have been loaded. In addition to the document
+ * itself, the verified checksums are recorded.
+ */
+private data class DocumentEntry(
+    /** The [SpdxDocument] that was loaded. */
+    val document: SpdxDocument,
+
+    /** A map with checksums that have been validated. */
+    val checksums: MutableMap<SpdxChecksum, Boolean>
+) {
+    /**
+     * Verify this document [file] against the given [checksum]. Record checksums that have been verified.
+     */
+    fun verify(file: File, checksum: SpdxChecksum): Boolean =
+        checksums.getOrPut(checksum) {
+            val hash = Hash.create(checksum.checksumValue, checksum.algorithm.name)
+            hash.verify(file)
+        }
+}

--- a/analyzer/src/test/kotlin/managers/SpdxDocumentFileTest.kt
+++ b/analyzer/src/test/kotlin/managers/SpdxDocumentFileTest.kt
@@ -128,7 +128,12 @@ class SpdxDocumentFileTest : WordSpec({
             )
             val issues = mutableListOf<OrtIssue>()
 
-            externalDocumentReference.getSpdxPackage("SPDXRef-Package_wrong_id", spdxProjectFile, issues)
+            externalDocumentReference.getSpdxPackage(
+                SpdxDocumentLoader(),
+                "SPDXRef-Package_wrong_id",
+                spdxProjectFile,
+                issues
+            )
 
             issues shouldHaveSize 1
             issues shouldHaveSingleElement { externalDocumentReference.externalDocumentId in it.message }
@@ -142,7 +147,12 @@ class SpdxDocumentFileTest : WordSpec({
             )
 
             val spdxPackageId = "SPDXRef-Package-zlib"
-            val spdxPackage = externalDocumentReference.getSpdxPackage(spdxPackageId, spdxProjectFile, mutableListOf())
+            val spdxPackage = externalDocumentReference.getSpdxPackage(
+                SpdxDocumentLoader(),
+                spdxPackageId,
+                spdxProjectFile,
+                mutableListOf()
+            )
 
             spdxPackage shouldNotBeNull {
                 spdxId shouldBe spdxPackageId

--- a/analyzer/src/test/kotlin/managers/SpdxDocumentLoaderTest.kt
+++ b/analyzer/src/test/kotlin/managers/SpdxDocumentLoaderTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2021 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.beTheSameInstanceAs
+
+import java.io.File
+
+import org.ossreviewtoolkit.utils.spdx.model.SpdxChecksum
+import org.ossreviewtoolkit.utils.test.createTestTempDir
+
+class SpdxDocumentLoaderTest : WordSpec({
+    "load" should {
+        "return a parsed document" {
+            val loader = SpdxDocumentLoader()
+
+            val document = loader.load(TEST_DOCUMENT)
+
+            document.spdxId shouldBe "SPDXRef-DOCUMENT"
+            document.name shouldBe "xyz-0.1.0"
+        }
+
+        "return a document from the cache" {
+            val loader = SpdxDocumentLoader()
+
+            val document1 = loader.load(TEST_DOCUMENT)
+            val document2 = loader.load(TEST_DOCUMENT)
+
+            document1 should beTheSameInstanceAs(document2)
+        }
+    }
+
+    "loadAndVerify" should {
+        "return a parsed document" {
+            val loader = SpdxDocumentLoader()
+
+            val verifiedDocument = loader.loadAndVerify(TEST_DOCUMENT, TEST_DOCUMENT_CHECKSUM)
+
+            verifiedDocument.document.spdxId shouldBe "SPDXRef-DOCUMENT"
+            verifiedDocument.document.name shouldBe "xyz-0.1.0"
+            verifiedDocument.valid shouldBe true
+        }
+
+        "verify the checksum of the document" {
+            val wrongChecksum = SpdxChecksum(SpdxChecksum.Algorithm.SHA1, "87f1e4bdce8313e928b8a5fc311bcadb95df3b94")
+            val loader = SpdxDocumentLoader()
+
+            val verifiedDocument = loader.loadAndVerify(TEST_DOCUMENT, wrongChecksum)
+
+            verifiedDocument.document.spdxId shouldBe "SPDXRef-DOCUMENT"
+            verifiedDocument.valid shouldBe false
+        }
+
+        "cache the document and the verification result" {
+            val tempDir = createTestTempDir()
+            val documentFile = tempDir.resolve("test.spdx.yml")
+            TEST_DOCUMENT.copyTo(documentFile)
+
+            val loader = SpdxDocumentLoader()
+
+            val verifiedDocument = loader.loadAndVerify(TEST_DOCUMENT, TEST_DOCUMENT_CHECKSUM)
+            documentFile.delete()
+
+            val verifiedDocument2 = loader.loadAndVerify(TEST_DOCUMENT, TEST_DOCUMENT_CHECKSUM)
+            verifiedDocument2.document should beTheSameInstanceAs(verifiedDocument.document)
+            verifiedDocument2.valid shouldBe true
+        }
+    }
+})
+
+/** A test document that is loaded by the test cases. */
+private val TEST_DOCUMENT =
+    File("src/funTest/assets/projects/synthetic/spdx/project-xyz-with-inline-packages.spdx.yml").absoluteFile
+
+/** The checksum of the test document. */
+private val TEST_DOCUMENT_CHECKSUM =
+    SpdxChecksum(SpdxChecksum.Algorithm.SHA1, "87f1e4bdce8313e928b8a5fc311bcadb95df3b93")


### PR DESCRIPTION
The class offers functionality to load SPDX documents from files,
cache the loaded documents, and verify their checksums. It is going to
be used by SpdxDocumentFile to prevent that local files are parsed
multiple times.

This PR is a preparation for upcoming improvements on the SPDX package manager to detect all transitive dependencies.