### PR TITLE
Gomod: Reduce over-reporting of packages

### DIFF
--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -149,8 +149,6 @@ class GoMod(
             .toSet()
 
     private fun getDependencyGraph(projectDir: File): Graph {
-        val graph = run("mod", "graph", workingDir = projectDir).requireSuccess().stdout
-
         fun parsePackageEntry(entry: String) =
             Identifier(
                 type = managerName,
@@ -160,7 +158,8 @@ class GoMod(
             )
 
         val result = Graph()
-        for (line in graph.lines()) {
+
+        for (line in run("mod", "graph", workingDir = projectDir).requireSuccess().stdout.lines()) {
             if (line.isBlank()) continue
 
             val columns = line.split(' ')

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -157,7 +157,7 @@ class GoMod(
                 version = entry.substringAfter('@', "")
             )
 
-        val result = Graph()
+        val graph = Graph()
 
         for (line in run("mod", "graph", workingDir = projectDir).requireSuccess().stdout.lines()) {
             if (line.isBlank()) continue
@@ -168,10 +168,10 @@ class GoMod(
             val parent = parsePackageEntry(columns[0])
             val child = parsePackageEntry(columns[1])
 
-            result.addEdge(parent, child)
+            graph.addEdge(parent, child)
         }
 
-        return result
+        return graph
     }
 
     /**

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -91,10 +91,8 @@ class GoMod(
         val projectDir = definitionFile.parentFile
 
         stashDirectories(projectDir.resolve("vendor")).use {
-            val fullGraph = getDependencyGraph(projectDir)
-            val projectId = fullGraph.projectId()
-
-            val graph = fullGraph.subgraph(getUsedPackages(fullGraph, projectDir, projectId))
+            val graph = getDependencyGraph(projectDir)
+            val projectId = graph.projectId()
             val vendorModules = getVendorModules(projectDir)
 
             val packageIds = graph.nodes() - projectId
@@ -171,7 +169,7 @@ class GoMod(
             graph.addEdge(parent, child)
         }
 
-        return graph
+        return graph.subgraph(getUsedPackages(graph, projectDir, graph.projectId()))
     }
 
     /**


### PR DESCRIPTION
The analysis result may contain packages which are not referenced from the dependency tree.
Remove these package as they are not needed and find the rationale for it in the commit.