### PR TITLE
declared-license-mapping: Add EUPL-1-1 mapping

### DIFF
--- a/utils/spdx/src/main/resources/declared-license-mapping.yml
+++ b/utils/spdx/src/main/resources/declared-license-mapping.yml
@@ -193,6 +193,7 @@
 "Eiffel Forum License (EFL)": EFL-2.0
 "Eiffel Forum License (EFL-2.0)": EFL-2.0
 "Eiffel Forum License": EFL-2.0
+"European Union Public Licence (EUPL v.1.1)": EUPL-1.1
 "European Union Public Licence 1.0": EUPL-1.0
 "European Union Public Licence 1.1": EUPL-1.1
 "European Union Public Licence 1.2": EUPL-1.2


### PR DESCRIPTION
Found "European Union Public Licence (EUPL v.1.1)" in [1].

[1]: https://github.com/felleslosninger/efm-commons-libs/blob/master/commons-bdx/pom.xml#L41

