### PR TITLE
fossid-webapp: Make Scan.id an integer

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/model/Scan.kt
+++ b/clients/fossid-webapp/src/main/kotlin/model/Scan.kt
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Scan(
-    val id: String?,
+    val id: Int,
     val created: String?,
     val updated: String?,
 

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -556,15 +556,20 @@ class FossIdTest : WordSpec({
             val scanCode = scanCode(PROJECT, FossId.DeltaTag.DELTA)
             val config = createConfig(deltaScanLimit = deltaScanLimit)
             val vcsInfo = createVcsInfo()
-            val originScan = createScan(vcsInfo.url, vcsInfo.revision, originCode, scanId = "${SCAN_ID}0")
-            val otherScan1 = createScan(vcsInfo.url, "${vcsInfo.revision}_other", "anotherCode")
-            val otherScan2 = createScan("someURL", "someRevision", "someCode", scanId = "zzz")
+            val originScan = createScan(vcsInfo.url, vcsInfo.revision, originCode, scanId = SCAN_ID)
+            val otherScan1 = createScan(
+                vcsInfo.url,
+                "${vcsInfo.revision}_other",
+                "anotherCode",
+                scanId = 0
+            )
+            val otherScan2 = createScan("someURL", "someRevision", "someCode", scanId = 999)
             val deltaScans = (1..numberOfDeltaScans).map {
                 createScan(
                     vcsInfo.url,
                     vcsInfo.revision,
                     scanCode = scanCode(PROJECT, FossId.DeltaTag.DELTA, it),
-                    "$SCAN_ID$it"
+                    SCAN_ID + it
                 )
             }
 
@@ -621,7 +626,7 @@ private const val REVISION = "test-revision"
 private const val FOSSID_VERSION = "2021.2.2"
 
 /** A test scan ID that is returned by default when mocking the creation of a scan. */
-private const val SCAN_ID = "testScanId"
+private const val SCAN_ID = 1
 
 /**
  * Create a new [FossId] instance with the specified [config].
@@ -709,7 +714,7 @@ private fun createScanDescription(state: ScanStatus): UnversionedScanDescription
 /**
  * Create a mock [Scan] with the given properties.
  */
-private fun createScan(url: String, revision: String, scanCode: String, scanId: String = SCAN_ID): Scan {
+private fun createScan(url: String, revision: String, scanCode: String, scanId: Int = SCAN_ID): Scan {
     val scan = mockk<Scan>()
     every { scan.gitRepoUrl } returns url
     every { scan.gitBranch } returns revision
@@ -887,7 +892,7 @@ private fun FossIdServiceWithVersion.expectCreateScan(
 ): FossIdServiceWithVersion {
     coEvery {
         createScan(USER, API_KEY, projectCode, scanCode, vcsInfo.url, vcsInfo.revision)
-    } returns MapResponseBody(status = 1, data = mapOf("scan_id" to SCAN_ID))
+    } returns MapResponseBody(status = 1, data = mapOf("scan_id" to SCAN_ID.toString()))
     return this
 }
 


### PR DESCRIPTION
Historically in ORT, the id was always a free nullable String even if
the FossID server in fact always returned the id as a non-nullable
integer.

This led to a subtle bug: when creating new delta scan,
FossID.recentScansForRepository was listing all the scans and sorting
them with .sortedByDescending { scan.id }, i.e. alphanumerically.
We didn't notice this behaviour because our scan ids were between 1000
and 9999 for a long time. As soon as the server went over 10000, the
lexicographic sorting order was wrong and led to cases where older scans
were used for delta scans basis, and also newer scans were automatically
deleted by ORT scanner.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>

