### PR TITLE
Gradle: Use the merged report created by detekt itself

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -27,7 +27,7 @@ jobs:
       uses: github/codeql-action/upload-sarif@v1
       if: ${{ always() }} # Upload even if the previous step failed.
       with:
-        sarif_file: build/reports/detekt/merged.sarif
+        sarif_file: build/reports/detekt/detekt.sarif
   markdown-links:
     runs-on: ubuntu-latest
     steps:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,6 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 import io.gitlab.arturbosch.detekt.Detekt
-import io.gitlab.arturbosch.detekt.report.ReportMergeTask
 
 import java.net.URL
 
@@ -127,10 +126,6 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates").configure {
     }
 }
 
-val mergeDetektReports by tasks.registering(ReportMergeTask::class) {
-    output.set(rootProject.buildDir.resolve("reports/detekt/merged.sarif"))
-}
-
 allprojects {
     buildscript {
         repositories {
@@ -175,12 +170,6 @@ allprojects {
             sarif.required.set(true)
             txt.required.set(false)
             xml.required.set(false)
-        }
-
-        finalizedBy(mergeDetektReports)
-
-        mergeDetektReports {
-            input.from(this@detekt.sarifReportFile)
         }
     }
 }


### PR DESCRIPTION
detekt 1.19.0 creates the merged SARIF report by itself, so just use
that.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>