### PR TITLE
declared-license-mapping: Add "Apache Licence 2.0"

### DIFF
--- a/utils/spdx/src/main/resources/declared-license-mapping.yml
+++ b/utils/spdx/src/main/resources/declared-license-mapping.yml
@@ -24,6 +24,7 @@
 "Apache 2": Apache-2.0
 "Apache 2.0 License": Apache-2.0
 "Apache 2.0": Apache-2.0
+"Apache Licence 2.0": Apache-2.0
 "Apache License (2.0)": Apache-2.0
 "Apache License (v2.0)": Apache-2.0
 "Apache License 2": Apache-2.0


### PR DESCRIPTION
Found in [1].

[1] https://github.com/wdtinc/mapbox-vector-tile-java/blob/81d2ea92fe255eab5c1005ec86c8a9160fdf44dd/pom.xml#L18
