### PR TITLE
SpdxDocumentModelMapper: Add verification code only if available

### DIFF
--- a/reporter/src/main/kotlin/reporters/spdx/SpdxDocumentModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/spdx/SpdxDocumentModelMapper.kt
@@ -114,14 +114,21 @@ object SpdxDocumentModelMapper {
                     ortResult.getScanResultsForId(curatedPackage.pkg.id).find { it.provenance is RepositoryProvenance }
                 val provenance = vcsScanResult?.provenance as? RepositoryProvenance
 
+                val (filesAnalyzed, packageVerificationCode) =
+                    if (vcsScanResult?.summary?.packageVerificationCode?.isNotEmpty() == true) {
+                        true to vcsScanResult.toSpdxPackageVerificationCode()
+                    } else {
+                        false to null
+                    }
+
                 // TODO: The copyright text contains copyrights from all scan results.
                 val vcsPackage = binaryPackage.copy(
                     spdxId = spdxPackageIdGenerator.nextId("${pkg.id.name}-vcs"),
-                    filesAnalyzed = vcsScanResult != null,
+                    filesAnalyzed = filesAnalyzed,
                     downloadLocation = pkg.vcsProcessed.toSpdxDownloadLocation(provenance?.resolvedRevision),
                     licenseConcluded = SpdxConstants.NOASSERTION,
                     licenseDeclared = SpdxConstants.NOASSERTION,
-                    packageVerificationCode = vcsScanResult?.toSpdxPackageVerificationCode()
+                    packageVerificationCode = packageVerificationCode
                 )
 
                 val vcsPackageRelationShip = SpdxRelationship(
@@ -138,14 +145,21 @@ object SpdxDocumentModelMapper {
                 val sourceArtifactScanResult =
                     ortResult.getScanResultsForId(curatedPackage.pkg.id).find { it.provenance is ArtifactProvenance }
 
+                val (filesAnalyzed, packageVerificationCode) =
+                    if (sourceArtifactScanResult?.summary?.packageVerificationCode?.isNotEmpty() == true) {
+                        true to sourceArtifactScanResult.toSpdxPackageVerificationCode()
+                    } else {
+                        false to null
+                    }
+
                 // TODO: The copyright text contains copyrights from all scan results.
                 val sourceArtifactPackage = binaryPackage.copy(
                     spdxId = spdxPackageIdGenerator.nextId("${curatedPackage.pkg.id.name}-source-artifact"),
-                    filesAnalyzed = sourceArtifactScanResult != null,
+                    filesAnalyzed = filesAnalyzed,
                     downloadLocation = curatedPackage.pkg.sourceArtifact.url.nullOrBlankToSpdxNone(),
                     licenseConcluded = SpdxConstants.NOASSERTION,
                     licenseDeclared = SpdxConstants.NOASSERTION,
-                    packageVerificationCode = sourceArtifactScanResult?.toSpdxPackageVerificationCode()
+                    packageVerificationCode = packageVerificationCode
                 )
 
                 val sourceArtifactPackageRelationship = SpdxRelationship(


### PR DESCRIPTION
The package verification code is not always available in scan results.
This is currently the case for the `FossId` scanner and for the
`ExperimentalScanner`. As a result the `SdpxDocumentModelMapper` can
fail because it requires a package verification code if a scan result
for a package is available.

From the SPDX specification is not totally clear if a package
verification code [1] is always required if the `FilesAnalyzer` property
[2] is set to `true`, but the SPDX validation tool [3] rejects such
files.

Therefore only set `FilesAnalyzed` to `true` if we can provide a package
verification code, to make sure that the generated documents pass the
SPDX validation.

[1]: https://spdx.github.io/spdx-spec/package-information/#7.9
[2]: https://spdx.github.io/spdx-spec/package-information/#7.8
[3]: https://tools.spdx.org/app/validate/