### PR TITLE
ExperimentalScanner: Support skip options

### DIFF
--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -350,7 +350,7 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
 
             val ortResult = readOrtResult(input)
             return runBlocking {
-                scanner.scan(ortResult)
+                scanner.scan(ortResult, skipExcluded)
             }
         } finally {
             runBlocking { workingTreeCache.shutdown() }

--- a/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
+++ b/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
@@ -67,14 +67,14 @@ class ExperimentalScanner(
         }
     }
 
-    suspend fun scan(ortResult: OrtResult): OrtResult {
+    suspend fun scan(ortResult: OrtResult, skipExcluded: Boolean): OrtResult {
         val startTime = Instant.now()
 
         val projectScannerWrappers = scannerWrappers[PackageType.PROJECT].orEmpty()
         val packageScannerWrappers = scannerWrappers[PackageType.PACKAGE].orEmpty()
 
         val projectResults = if (projectScannerWrappers.isNotEmpty()) {
-            val packages = ortResult.getProjects().mapTo(mutableSetOf()) { it.toPackage() }
+            val packages = ortResult.getProjects(skipExcluded).mapTo(mutableSetOf()) { it.toPackage() }
 
             log.info { "Scanning ${packages.size} projects with ${projectScannerWrappers.size} scanners." }
 
@@ -86,7 +86,7 @@ class ExperimentalScanner(
         }
 
         val packageResults = if (packageScannerWrappers.isNotEmpty()) {
-            val packages = ortResult.getPackages().map { it.pkg }.filterNotConcluded().toSet()
+            val packages = ortResult.getPackages(skipExcluded).map { it.pkg }.filterNotConcluded().toSet()
 
             log.info { "Scanning ${packages.size} packages with ${packageScannerWrappers.size} scanners." }
 


### PR DESCRIPTION
Support the optional skipping of excluded packages and packages with concluded license.