### PR TITLE
Rename the downloader's `BabelFunTest` to `BabelDownloaderFunTest`

### DIFF
--- a/downloader/src/funTest/kotlin/BabelDownloaderFunTest.kt
+++ b/downloader/src/funTest/kotlin/BabelDownloaderFunTest.kt
@@ -38,7 +38,7 @@ import org.ossreviewtoolkit.utils.core.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.createTestTempDir
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
-class BabelFunTest : StringSpec() {
+class BabelDownloaderFunTest : StringSpec() {
     private lateinit var outputDir: File
 
     override fun beforeTest(testCase: TestCase) {


### PR DESCRIPTION
To deduplicate from "analyzer/src/funTest/kotlin/managers/BabelFunTest.kt".

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>