### PR TITLE
scanner: Do not create a "native-scan-results" directory anymore

### DIFF
--- a/scanner/src/funTest/kotlin/scanners/AbstractScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/AbstractScannerFunTest.kt
@@ -22,7 +22,6 @@ package org.ossreviewtoolkit.scanner.scanners
 import io.kotest.core.Tag
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.core.test.TestCase
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.file.shouldNotStartWithPath
 import io.kotest.matchers.shouldBe
@@ -34,7 +33,6 @@ import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.PathScanner
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.test.createSpecTempDir
-import org.ossreviewtoolkit.utils.test.createTestTempDir
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 abstract class AbstractScannerFunTest(testTags: Set<Tag> = emptySet()) : StringSpec() {
@@ -46,7 +44,6 @@ abstract class AbstractScannerFunTest(testTags: Set<Tag> = emptySet()) : StringS
     private val commonlyDetectedFiles = listOf("LICENSE", "LICENCE", "COPYING")
 
     private lateinit var inputDir: File
-    protected lateinit var outputDir: File
 
     abstract val scanner: PathScanner
     abstract val expectedFileLicenses: Set<SpdxExpression>
@@ -60,13 +57,9 @@ abstract class AbstractScannerFunTest(testTags: Set<Tag> = emptySet()) : StringS
         commonlyDetectedFiles.forEach { ortLicense.copyTo(inputDir.resolve(it), overwrite = true) }
     }
 
-    override fun beforeTest(testCase: TestCase) {
-        outputDir = createTestTempDir()
-    }
-
     init {
         "Scanning a single file succeeds".config(tags = testTags) {
-            val result = scanner.scanPath(inputDir.resolve("LICENSE"), outputDir)
+            val result = scanner.scanPath(inputDir.resolve("LICENSE"))
             val summary = result.scanner?.results?.scanResults?.singleOrNull()?.singleOrNull()?.summary
 
             summary shouldNotBeNull {
@@ -78,7 +71,7 @@ abstract class AbstractScannerFunTest(testTags: Set<Tag> = emptySet()) : StringS
         }
 
         "Scanning a directory succeeds".config(tags = testTags) {
-            val result = scanner.scanPath(inputDir, outputDir)
+            val result = scanner.scanPath(inputDir)
             val summary = result.scanner?.results?.scanResults?.singleOrNull()?.singleOrNull()?.summary
 
             summary shouldNotBeNull {

--- a/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
@@ -28,33 +28,27 @@ import java.time.Instant
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.scanner.PathScanner
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.scanner.scanOrtResult
 import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
-import org.ossreviewtoolkit.utils.test.createTestTempDir
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class ScannerIntegrationFunTest : StringSpec() {
     private val assetsDir = File("src/funTest/assets")
 
-    private lateinit var outputDir: File
-
     init {
         "Gradle project scan results for a given analyzer result are correct".config(invocations = 3) {
-            outputDir = createTestTempDir()
-
             val analyzerResultFile = assetsDir.resolve("analyzer-result.yml")
             val expectedResult = patchExpectedResult(
                 assetsDir.resolve("dummy-expected-output-for-analyzer-result.yml")
             )
 
             val scanner = DummyScanner("Dummy", ScannerConfiguration(), DownloaderConfiguration())
-            val ortResult = scanOrtResult(scanner, analyzerResultFile.readValue(), outputDir)
+            val ortResult = scanOrtResult(scanner, analyzerResultFile.readValue())
             val result = yamlMapper.writeValueAsString(ortResult)
 
             patchActualResult(result, patchStartAndEndTime = true) shouldBe expectedResult
@@ -68,21 +62,18 @@ class ScannerIntegrationFunTest : StringSpec() {
         scannerConfig: ScannerConfiguration,
         downloaderConfig: DownloaderConfiguration
     ) : PathScanner(name, scannerConfig, downloaderConfig) {
-        override val resultFileExt = "json"
         override val expectedVersion = "1.0"
         override val version = expectedVersion
         override val configuration = ""
 
         override fun command(workingDir: File?) = ""
 
-        override fun scanPathInternal(path: File, resultsFile: File): ScanSummary {
-            val startTime = Instant.now()
-            resultsFile.writeText(jsonMapper.writeValueAsString("Dummy"))
-            val endTime = Instant.now()
+        override fun scanPathInternal(path: File): ScanSummary {
+            val time = Instant.now()
 
             return ScanSummary(
-                startTime = startTime,
-                endTime = endTime,
+                startTime = time,
+                endTime = time,
                 packageVerificationCode = calculatePackageVerificationCode(path),
                 licenseFindings = sortedSetOf(),
                 copyrightFindings = sortedSetOf(),

--- a/scanner/src/funTest/kotlin/scanners/scancode/ScanCodeScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/scancode/ScanCodeScannerFunTest.kt
@@ -25,6 +25,7 @@ import io.kotest.matchers.string.endWith
 import io.kotest.matchers.string.startWith
 
 import org.ossreviewtoolkit.scanner.scanners.AbstractScannerFunTest
+import org.ossreviewtoolkit.utils.core.createOrtTempDir
 import org.ossreviewtoolkit.utils.spdx.getLicenseText
 import org.ossreviewtoolkit.utils.spdx.toSpdx
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
@@ -34,9 +35,6 @@ class ScanCodeScannerFunTest : AbstractScannerFunTest(setOf(ExpensiveTag, ScanCo
     override val scanner = ScanCode("ScanCode", scannerConfig, downloaderConfig)
     override val expectedFileLicenses = setOf("Apache-2.0".toSpdx())
     override val expectedDirectoryLicenses = setOf("Apache-2.0".toSpdx())
-
-    private fun setupTempFile(filename: String, content: String) =
-        outputDir.resolve(filename).apply { writeText(content) }
 
     init {
         "return the full license text for the HERE proprietary license" {
@@ -57,7 +55,7 @@ class ScanCodeScannerFunTest : AbstractScannerFunTest(setOf(ExpensiveTag, ScanCo
             val id = "LicenseRef-scancode-here-proprietary"
             val text = "x\ny\n"
 
-            setupTempFile(id, text)
+            val outputDir = createOrtTempDir().apply { resolve(id).apply { writeText(text) } }
 
             getLicenseText(id, true, listOf(outputDir)) shouldBe getLicenseText(id, true)
         }

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.scanner
 
-import java.io.File
 import java.lang.IllegalArgumentException
 import java.time.Instant
 import java.util.ServiceLoader
@@ -56,31 +55,27 @@ private fun removeConcludedPackages(packages: Set<Package>, scanner: Scanner): S
         }
 
 /**
- * Use the [scanner] to scan the [Project]s and [Package]s specified in the [ortResult]. Scan results are stored in the
- * [outputDirectory]. If [skipExcluded] is true, packages for which excludes are defined are not scanned. Return scan
- * results as an [OrtResult].
+ * Use the [scanner] to scan the [Project]s and [Package]s specified in the [ortResult].  If [skipExcluded] is true,
+ * packages for which excludes are defined are not scanned. Return scan results as an [OrtResult].
  */
 @JvmOverloads
 fun scanOrtResult(
     scanner: Scanner,
     ortResult: OrtResult,
-    outputDirectory: File,
     skipExcluded: Boolean = false
-) = scanOrtResult(scanner, scanner, ortResult, outputDirectory, skipExcluded)
+) = scanOrtResult(scanner, scanner, ortResult, skipExcluded)
 
 /**
  * Use the [packageScanner] and / or [projectScanner] to scan the [Package]s and [Project]s specified in the
  * [ortResult]. If specified, scanners are expected to refer to the same global scanner configuration. If a scanner is
- * null, scanning of the respective entities is skipped. Scan results are stored in the [outputDirectory]. If
- * [skipExcluded] is true, packages for which excludes are defined are not scanned. Return scan results as an
- * [OrtResult].
+ * null, scanning of the respective entities is skipped. If [skipExcluded] is true, packages for which excludes are
+ * defined are not scanned. Return scan results as an [OrtResult].
  */
 @JvmOverloads
 fun scanOrtResult(
     packageScanner: Scanner?,
     projectScanner: Scanner?,
     ortResult: OrtResult,
-    outputDirectory: File,
     skipExcluded: Boolean = false
 ): OrtResult {
     require(packageScanner != null || projectScanner != null) {
@@ -115,8 +110,7 @@ fun scanOrtResult(
                 val filteredProjectPackages = removeConcludedPackages(projectPackages, projectScanner)
 
                 if (filteredProjectPackages.isEmpty()) emptyMap()
-                else projectScanner.scanPackages(filteredProjectPackages, outputDirectory, ortResult.labels)
-                    .mapKeys { it.key.id }
+                else projectScanner.scanPackages(filteredProjectPackages, ortResult.labels).mapKeys { it.key.id }
             }
         }
 
@@ -127,8 +121,7 @@ fun scanOrtResult(
                 val filteredPackages = removeConcludedPackages(packages.toSet(), packageScanner)
 
                 if (filteredPackages.isEmpty()) emptyMap()
-                else packageScanner.scanPackages(filteredPackages, outputDirectory, ortResult.labels)
-                    .mapKeys { it.key.id }
+                else packageScanner.scanPackages(filteredPackages, ortResult.labels).mapKeys { it.key.id }
             }
         }
 
@@ -227,15 +220,13 @@ abstract class Scanner(
     val details by lazy { ScannerDetails(scannerName, version, configuration) }
 
     /**
-     * Scan the [packages] and store the scan results in [outputDirectory]. [ScanResult]s are returned associated by
-     * [Package]. The map may contain multiple results for the same [Package] if the storage contains more than one
-     * result for the specification of this scanner.
-     * [labels] are the labels present in [OrtResult.labels], created by previous invocations of ORT tools. They can be
-     * used by scanner implementations to decide if and how packages are scanned.
+     * Scan the [packages] and return a map of [ScanResult]s associated by their [Package]. The map may contain multiple
+     * results for the same [Package] if the storage contains more than one result for the specification of this
+     * scanner. [labels] are the labels present in [OrtResult.labels], created by previous invocations of ORT tools.
+     * They can be used by scanner implementations to decide if and how packages are scanned.
      */
     abstract suspend fun scanPackages(
         packages: Set<Package>,
-        outputDirectory: File,
         labels: Map<String, String>
     ): Map<Package, List<ScanResult>>
 

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -39,7 +39,6 @@ import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.ProcessCapture
 import org.ossreviewtoolkit.utils.common.unpackZip
 import org.ossreviewtoolkit.utils.core.OkHttpClientHelper
-import org.ossreviewtoolkit.utils.core.createOrtTempDir
 import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.core.ortToolsDirectory
 import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
@@ -58,7 +57,6 @@ class Askalono(
     override val criteria by lazy { getScannerCriteria() }
     override val expectedVersion = BuildConfig.ASKALONO_VERSION
     override val configuration = ""
-    override val resultFileExt = "txt"
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "askalono.exe" else "askalono").joinToString(File.separator)
@@ -94,7 +92,7 @@ class Askalono(
         return unpackDir
     }
 
-    override fun scanPathInternal(path: File, resultsFile: File): ScanSummary {
+    override fun scanPathInternal(path: File): ScanSummary {
         val startTime = Instant.now()
 
         val process = ProcessCapture(
@@ -109,7 +107,6 @@ class Askalono(
             if (stderr.isNotBlank()) log.debug { stderr }
             if (isError) throw ScanException(errorMessage)
 
-            stdoutFile.copyTo(resultsFile)
             generateSummary(startTime, endTime, path, stdoutFile)
         }
     }
@@ -145,6 +142,5 @@ class Askalono(
         )
     }
 
-    override fun scanPath(path: File, context: ScanContext): ScanSummary =
-        scanPathInternal(path, createOrtTempDir(name).resolve("result.$resultFileExt"))
+    override fun scanPath(path: File, context: ScanContext) = scanPathInternal(path)
 }

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -37,7 +37,6 @@ import org.ossreviewtoolkit.scanner.experimental.PathScannerWrapper
 import org.ossreviewtoolkit.scanner.experimental.ScanContext
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.ProcessCapture
-import org.ossreviewtoolkit.utils.core.createOrtTempDir
 import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 
@@ -59,7 +58,6 @@ class Licensee(
     override val criteria by lazy { getScannerCriteria() }
     override val expectedVersion = BuildConfig.LICENSEE_VERSION
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
-    override val resultFileExt = "json"
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "licensee.bat" else "licensee").joinToString(File.separator)
@@ -84,7 +82,7 @@ class Licensee(
         return File(userDir, "bin")
     }
 
-    override fun scanPathInternal(path: File, resultsFile: File): ScanSummary {
+    override fun scanPathInternal(path: File): ScanSummary {
         val startTime = Instant.now()
 
         val process = ProcessCapture(
@@ -100,7 +98,6 @@ class Licensee(
             if (stderr.isNotBlank()) log.debug { stderr }
             if (isError) throw ScanException(errorMessage)
 
-            stdoutFile.copyTo(resultsFile)
             generateSummary(startTime, endTime, path, stdoutFile)
         }
     }
@@ -133,6 +130,5 @@ class Licensee(
         )
     }
 
-    override fun scanPath(path: File, context: ScanContext): ScanSummary =
-        scanPathInternal(path, createOrtTempDir(name).resolve("result.$resultFileExt"))
+    override fun scanPath(path: File, context: ScanContext) = scanPathInternal(path)
 }

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.scanner.scanners.fossid
 
-import java.io.File
 import java.io.IOException
 import java.net.Authenticator
 import java.time.Instant
@@ -71,7 +70,6 @@ import org.ossreviewtoolkit.scanner.experimental.ScanContext
 import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.common.toUri
-import org.ossreviewtoolkit.utils.core.createOrtTempDir
 import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.core.showStackTrace
 
@@ -216,7 +214,6 @@ class FossId internal constructor(
 
     override suspend fun scanPackages(
         packages: Set<Package>,
-        outputDirectory: File,
         labels: Map<String, String>
     ): Map<Package, List<ScanResult>> {
         val (results, duration) = measureTimedValue {
@@ -698,7 +695,7 @@ class FossId internal constructor(
 
     override fun scanPackage(pkg: Package, context: ScanContext): ScanResult =
         runBlocking {
-            scanPackages(setOf(pkg), createOrtTempDir(), context.labels).getValue(pkg).first()
+            scanPackages(setOf(pkg), context.labels).getValue(pkg).first()
         }
 
     override fun filterSecretOptions(options: ScannerOptions): ScannerOptions = filterOptionsForResult(options)

--- a/scanner/src/test/kotlin/PathScannerTest.kt
+++ b/scanner/src/test/kotlin/PathScannerTest.kt
@@ -102,13 +102,10 @@ private fun createScanner(
     object : PathScanner(SCANNER_NAME, scannerConfig, downloaderConfig) {
         override val configuration = "someConfig"
 
-        override val resultFileExt: String
-            get() = "xml"
-
         override val expectedVersion: String
             get() = SCANNER_VERSION
 
-        override fun scanPathInternal(path: File, resultsFile: File) = throw NotImplementedError()
+        override fun scanPathInternal(path: File) = throw NotImplementedError()
 
         override fun command(workingDir: File?) = throw NotImplementedError()
     }

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -389,7 +389,7 @@ class FossIdTest : WordSpec({
             shouldThrow<TimeoutCancellationException> {
                 withTimeout(1000) {
                     fossId.scanPackages(
-                        setOf(createPackage(createIdentifier(index = 1), vcsInfo)), File("output"), emptyMap()
+                        setOf(createPackage(createIdentifier(index = 1), vcsInfo)), emptyMap()
                     )
                 }
             }
@@ -956,7 +956,7 @@ private fun FossId.scan(packages: List<Package>): ScannerRun {
     every { mockResult.getPackages(any()) } returns curatedPackages
     every { mockResult.getProjects(any()) } returns emptySet()
 
-    val newResult = runBlocking { scanOrtResult(this@scan, mockResult, File("irrelevant")) }
+    val newResult = runBlocking { scanOrtResult(this@scan, mockResult) }
 
     return newResult.scanner!!
 }


### PR DESCRIPTION
The idea of collecting a scanner's native scan result files in addition
to ORT's scan result file had only `PathScanner`s in mind. But by now,
there are scanners that operate remotely, and which do not actually have
a native scan result file format.

So simplify the code by removing support for the "native-scan-results"
directory, and let individual scanners create temporary output
directories where needed.

This also allows to get rid of the `PathScanner`'s `resultFileExt`
property.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>