### PR TITLE
Ignore Gradle nightly versions when checking for dependency updates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,7 +114,7 @@ extensions.findByName("buildScan")?.withGroovyBuilder {
 
 tasks.named<DependencyUpdatesTask>("dependencyUpdates").configure {
     val nonFinalQualifiers = listOf(
-        "alpha", "b", "beta", "cr", "ea", "eap", "m", "milestone", "pr", "preview", "rc"
+        "alpha", "b", "beta", "cr", "ea", "eap", "m", "milestone", "pr", "preview", "rc", "\\d{14}"
     ).joinToString("|", "(", ")")
 
     val nonFinalQualifiersRegex = Regex(".*[.-]$nonFinalQualifiers[.\\d-+]*", RegexOption.IGNORE_CASE)


### PR DESCRIPTION
See the naming pattern at [1].

[1]: https://gradle.org/nightly/

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>