### PR TITLE
Identifier: Allow Maven namespaces without TLD

### DIFF
--- a/model/src/main/kotlin/Identifier.kt
+++ b/model/src/main/kotlin/Identifier.kt
@@ -102,7 +102,7 @@ data class Identifier(
             val lowerName = name.lowercase()
             val vendorNamespace = when (type) {
                 "NPM" -> "@$lowerName"
-                "Gradle", "Maven", "SBT" -> "(com|io|net|org)\\.$lowerName(\\..+)?"
+                "Gradle", "Maven", "SBT" -> "((com|io|net|org)\\.)?$lowerName(\\..+)?"
                 else -> ""
             }
 

--- a/model/src/test/kotlin/IdentifierTest.kt
+++ b/model/src/test/kotlin/IdentifierTest.kt
@@ -220,6 +220,7 @@ class IdentifierTest : WordSpec({
                     .isFromOrg("ossreviewtoolkit") shouldBe true
                 Identifier("Maven:org.apache:name:version").isFromOrg("apache") shouldBe true
                 Identifier("NPM:@scope:name:version").isFromOrg("scope") shouldBe true
+                Identifier("Maven:example:name:version").isFromOrg("example") shouldBe true
 
                 Identifier("").isFromOrg("ossreviewtoolkit") shouldBe false
                 Identifier("type:namespace:name:version").isFromOrg("ossreviewtoolkit") shouldBe false


### PR DESCRIPTION
While it is a good practice to use the dot notation in the Maven
groupId, it is not required [1]. See [2] for a popular example.

[1]: https://maven.apache.org/pom.html#maven-coordinates
[2]: https://github.com/junit-team/junit4/blob/main/pom.xml

