### PR TITLE
Scanner: Rename `filterOptionsForResult()` to `filterSecretOptions()`

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -161,13 +161,13 @@ fun scanOrtResult(
     val filteredScannerOptions = mutableMapOf<String, ScannerOptions>()
 
     packageScanner?.scannerConfig?.options?.get(packageScanner.scannerName)?.let { packageScannerOptions ->
-        val filteredPackageScannerOptions = packageScanner.filterOptionsForResult(packageScannerOptions)
+        val filteredPackageScannerOptions = packageScanner.filterSecretOptions(packageScannerOptions)
         filteredScannerOptions[packageScanner.scannerName] = filteredPackageScannerOptions
     }
 
     if (projectScanner != packageScanner) {
         projectScanner?.scannerConfig?.options?.get(projectScanner.scannerName)?.let { projectScannerOptions ->
-            val filteredProjectScannerOptions = projectScanner.filterOptionsForResult(projectScannerOptions)
+            val filteredProjectScannerOptions = projectScanner.filterSecretOptions(projectScannerOptions)
             filteredScannerOptions[projectScanner.scannerName] = filteredProjectScannerOptions
         }
     }
@@ -231,8 +231,7 @@ abstract class Scanner(
     ): Map<Package, List<ScanResult>>
 
     /**
-     * Filter the options specific to this scanner that will be included into the result, e.g. to perform obfuscation of
-     * credentials.
+     * Filter the scanner-specific options to remove / obfuscate any secrets, like credentials.
      */
-    open fun filterOptionsForResult(options: ScannerOptions) = options
+    open fun filterSecretOptions(options: ScannerOptions) = options
 }

--- a/scanner/src/main/kotlin/experimental/ScannerWrapper.kt
+++ b/scanner/src/main/kotlin/experimental/ScannerWrapper.kt
@@ -59,9 +59,9 @@ sealed interface ScannerWrapper {
     val criteria: ScannerCriteria?
 
     /**
-     * Filter the scanner specific options to remove any secrets, like credentials.
+     * Filter the scanner-specific options to remove / obfuscate any secrets, like credentials.
      */
-    fun filterSecretOptions(options: ScannerOptions) = options
+    fun filterSecretOptions(options: ScannerOptions): ScannerOptions
 }
 
 /**

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -190,7 +190,7 @@ class FossId internal constructor(
 
     override val configuration = ""
 
-    override fun filterOptionsForResult(options: ScannerOptions) =
+    override fun filterSecretOptions(options: ScannerOptions) =
         options.mapValues { (k, v) ->
             v.takeUnless { k in secretKeys }.orEmpty()
         }
@@ -697,6 +697,4 @@ class FossId internal constructor(
         runBlocking {
             scanPackages(setOf(pkg), context.labels).getValue(pkg).first()
         }
-
-    override fun filterSecretOptions(options: ScannerOptions): ScannerOptions = filterOptionsForResult(options)
 }

--- a/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
+++ b/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
@@ -56,6 +56,7 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.config.ScannerOptions
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.utils.core.createOrtTempDir
@@ -639,6 +640,8 @@ private class FakePackageScannerWrapper(
 
     override fun scanPackage(pkg: Package, context: ScanContext): ScanResult =
         createScanResult(packageProvenanceResolver.resolveProvenance(pkg, sourceCodeOriginPriority), details)
+
+    override fun filterSecretOptions(options: ScannerOptions) = options
 }
 
 /**
@@ -651,6 +654,8 @@ private class FakeProvenanceScannerWrapper : ProvenanceScannerWrapper {
 
     override fun scanProvenance(provenance: KnownProvenance, context: ScanContext): ScanResult =
         createScanResult(provenance, details)
+
+    override fun filterSecretOptions(options: ScannerOptions) = options
 }
 
 /**
@@ -668,6 +673,8 @@ private class FakePathScannerWrapper : PathScannerWrapper {
 
         return createScanSummary(licenseFindings = licenseFindings)
     }
+
+    override fun filterSecretOptions(options: ScannerOptions) = options
 }
 
 /**

--- a/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
+++ b/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
@@ -629,6 +629,7 @@ class ExperimentalScannerTest : WordSpec({
 /**
  * An implementation of [PackageScannerWrapper] that creates empty scan results.
  */
+@Suppress("RedundantNullableReturnType")
 private class FakePackageScannerWrapper(
     val packageProvenanceResolver: PackageProvenanceResolver = FakePackageProvenanceResolver(),
     val sourceCodeOriginPriority: List<SourceCodeOrigin> = listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT),


### PR DESCRIPTION
This is to match the `ScannerWrapper`s function name so both can be
implemented by the same code. While at it, also align function docs.

This also requires to remove the `ScannerWrapper`s default
implementation in the interface, as otherwise it would clash with the
`Scanner`s default implementation.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>