### PR TITLE
CommandLineScanner: Do not require the expected version

### DIFF
--- a/scanner/src/main/kotlin/CommandLineScanner.kt
+++ b/scanner/src/main/kotlin/CommandLineScanner.kt
@@ -20,8 +20,6 @@
 
 package org.ossreviewtoolkit.scanner
 
-import com.vdurmont.semver4j.Requirement
-
 import java.io.File
 import java.io.IOException
 
@@ -101,8 +99,6 @@ abstract class CommandLineScanner(
      * The actual version of the scanner, or an empty string in case of failure.
      */
     override val version by lazy { getVersion(scannerDir) }
-
-    override fun getVersionRequirement(): Requirement = Requirement.buildLoose(expectedVersion)
 
     /**
      * Bootstrap the scanner to be ready for use, like downloading and / or configuring it.


### PR DESCRIPTION
Do not override `getVersionRequirement()` and instead use the default
implementation which allows any version.

Since 9af81d8 any version of the command line scanners is accepted, the
expected version is only used to bootstrap a scanner if it is not found
on the path. Therefore returning the expected version as a requirement
was wrong.