### PR TITLE
Gradle: Configure all test properties but JaCoCo early

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -290,6 +290,28 @@ subprojects {
         testClassesDirs = sourceSets["funTest"].output.classesDirs
     }
 
+    tasks.withType<Test>().configureEach {
+        val testSystemProperties = mutableListOf("gradle.build.dir" to project.buildDir.path)
+
+        listOf(
+            "java.io.tmpdir",
+            "kotest.assertions.multi-line-diff",
+            "kotest.tags.include",
+            "kotest.tags.exclude"
+        ).mapNotNullTo(testSystemProperties) { key ->
+            System.getProperty(key)?.let { key to it }
+        }
+
+        systemProperties = testSystemProperties.toMap()
+
+        testLogging {
+            events = setOf(TestLogEvent.STARTED, TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
+            exceptionFormat = TestExceptionFormat.FULL
+        }
+
+        useJUnitPlatform()
+    }
+
     // Enable JaCoCo only if a JacocoReport task is in the graph as JaCoCo
     // is using "append = true" which disables Gradle's build cache.
     gradle.taskGraph.whenReady {
@@ -299,26 +321,6 @@ subprojects {
             extensions.configure(JacocoTaskExtension::class) {
                 isEnabled = enabled
             }
-
-            val testSystemProperties = mutableListOf("gradle.build.dir" to project.buildDir.path)
-
-            listOf(
-                "java.io.tmpdir",
-                "kotest.assertions.multi-line-diff",
-                "kotest.tags.include",
-                "kotest.tags.exclude"
-            ).mapNotNullTo(testSystemProperties) { key ->
-                System.getProperty(key)?.let { key to it }
-            }
-
-            systemProperties = testSystemProperties.toMap()
-
-            testLogging {
-                events = setOf(TestLogEvent.STARTED, TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
-                exceptionFormat = TestExceptionFormat.FULL
-            }
-
-            useJUnitPlatform()
         }
     }
 


### PR DESCRIPTION
Esp. setting `useJUnitPlatform()` not only when the task graph is ready
avoids the bogus "Test framework is changing" message [1] from Gradle.

[1]: https://github.com/oss-review-toolkit/ort/runs/4658469363?check_suite_focus=true#step:4:74

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>