### PR TITLE
Gradle: Upgrade the "versions" plugin to version 0.40.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ kotlinPluginVersion = 1.6.10
 shadowPluginVersion = 7.1.2
 svntoolsPluginVersion = 3.1
 taskinfoPluginVersion = 1.3.1
-versionsPluginVersion = 0.39.0
+versionsPluginVersion = 0.40.0
 
 antlrVersion = 4.9.3
 apacheCommonsEmailVersion = 1.5


### PR DESCRIPTION
See [1].

[1]: https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.40.0

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>