### PR TITLE
ScannerConfiguration: Ignore SPDX files by default

### DIFF
--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -82,6 +82,9 @@ data class ScannerConfiguration(
      */
     val ignorePatterns: List<String> = listOf(
         "**/*.ort.yml",
+        "**/*.spdx.yml",
+        "**/*.spdx.yaml",
+        "**/*.spdx.json",
         "**/META-INF/DEPENDENCIES"
     ),
 

--- a/scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
@@ -207,6 +207,9 @@ scanner:
     create_missing_archives: false
     ignore_patterns:
     - "**/*.ort.yml"
+    - "**/*.spdx.yml"
+    - "**/*.spdx.yaml"
+    - "**/*.spdx.json"
     - "**/META-INF/DEPENDENCIES"
   results:
     scan_results:


### PR DESCRIPTION
SPDX files declare metadata and might contain license identifiers and
license texts. As these are already picked up by the `SpdxDocumentFile`
analyzer, they should not be picked up by scanners again to generate
detected findings.

At the example of ScanCode, ORT runs ScanCode without `-p` /
`--package`, so ScanCode does not scan / interpret "package manifests and
build scripts". Thus ignoring SPDX project / package files is in line
with that.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>