### PR TITLE
Gradle: Target the latest version supported by the current JVM

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -238,7 +238,7 @@ subprojects {
 
         kotlinOptions {
             allWarningsAsErrors = true
-            jvmTarget = "11"
+            jvmTarget = javaVersion.majorVersion
             apiVersion = "1.6"
             freeCompilerArgs = freeCompilerArgs + customCompilerArgs
         }


### PR DESCRIPTION
To benefit from bytecode optimizations, always use the latest supported
JVM target. Note that at a minimum still Java 11 is required.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>