### PR TITLE
Gradle: Switch to wiremock-jre8 instead of using the Java 7 version

### DIFF
--- a/advisor/build.gradle.kts
+++ b/advisor/build.gradle.kts
@@ -36,6 +36,6 @@ dependencies {
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
 
-    testImplementation("com.github.tomakehurst:wiremock:$wiremockVersion")
+    testImplementation("com.github.tomakehurst:wiremock-jre8:$wiremockVersion")
     testImplementation("io.mockk:mockk:$mockkVersion")
 }

--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -85,6 +85,6 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
     implementation("org.jruby:jruby-complete:$jrubyVersion")
 
-    testImplementation("com.github.tomakehurst:wiremock:$wiremockVersion")
+    testImplementation("com.github.tomakehurst:wiremock-jre8:$wiremockVersion")
     testImplementation("io.mockk:mockk:$mockkVersion")
 }

--- a/clients/fossid-webapp/build.gradle.kts
+++ b/clients/fossid-webapp/build.gradle.kts
@@ -34,5 +34,5 @@ dependencies {
     implementation("com.squareup.retrofit2:converter-jackson:$retrofitVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
 
-    testImplementation("com.github.tomakehurst:wiremock:$wiremockVersion")
+    testImplementation("com.github.tomakehurst:wiremock-jre8:$wiremockVersion")
 }

--- a/clients/github-graphql/build.gradle.kts
+++ b/clients/github-graphql/build.gradle.kts
@@ -49,5 +49,5 @@ dependencies {
     implementation("org.apache.logging.log4j:log4j-api-kotlin:$log4jApiKotlinVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
 
-    testImplementation("com.github.tomakehurst:wiremock:$wiremockVersion")
+    testImplementation("com.github.tomakehurst:wiremock-jre8:$wiremockVersion")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -77,7 +77,7 @@ springCoreVersion = 5.3.14
 svnkitVersion = 1.10.3
 sw360ClientVersion = 13.2.0-28
 toml4jVersion = 0.7.2
-wiremockVersion = 2.27.2
+wiremockVersion = 2.32.0
 xalanVersion = 2.7.2
 xzVersion = 1.9
 

--- a/notifier/build.gradle.kts
+++ b/notifier/build.gradle.kts
@@ -50,6 +50,6 @@ dependencies {
     }
     implementation("org.apache.commons:commons-email:$apacheCommonsEmailVersion")
 
-    testImplementation("com.github.tomakehurst:wiremock:$wiremockVersion")
+    testImplementation("com.github.tomakehurst:wiremock-jre8:$wiremockVersion")
     testImplementation("io.mockk:mockk:$mockkVersion")
 }

--- a/scanner/build.gradle.kts
+++ b/scanner/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
     implementation("org.postgresql:postgresql:$postgresVersion")
 
-    testImplementation("com.github.tomakehurst:wiremock:$wiremockVersion")
+    testImplementation("com.github.tomakehurst:wiremock-jre8:$wiremockVersion")
     testImplementation("io.mockk:mockk:$mockkVersion")
 }
 


### PR DESCRIPTION
Also see [1].

[1]: http://wiremock.org/docs/download-and-installation/

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>