### PR TITLE
Handle part of the LicenseRef-ort license texts

### DIFF
--- a/utils/spdx/src/main/resources/declared-license-mapping.yml
+++ b/utils/spdx/src/main/resources/declared-license-mapping.yml
@@ -164,7 +164,7 @@
 "Creative Commons Public Domain": CC-PDDC
 "Creative Commons Zero": CC0-1.0
 "Creative Commons": CC-BY-3.0
-"DBAD": LicenseRef-ort-dbad
+"DBAD": LicenseRef-scancode-dbad
 "DFSG approved": LicenseRef-scancode-free-unknown
 "Dual License: CDDL 1.0 and GPL V2 with Classpath Exception": CDDL-1.0 AND GPL-2.0-only
 "Dual license consisting of the CDDL v1.1 and GPL v2": CDDL-1.1 AND GPL-2.0-only

--- a/utils/spdx/src/main/resources/declared-license-mapping.yml
+++ b/utils/spdx/src/main/resources/declared-license-mapping.yml
@@ -377,7 +377,7 @@
 "Ruby's": Ruby
 "SIL OPEN FONT LICENSE Version 1.1": OFL-1.1
 "SIL Open Font License 1.1 (OFL-1.1)": OFL-1.1
-"SOLACE CORPORATION LICENSE AGREEMENT": LicenseRef-ort-Solace-Software-EULA
+"SOLACE CORPORATION LICENSE AGREEMENT": LicenseRef-scancode-solace-software-eula-2020
 "Scala License": Apache-2.0 AND BSD-3-Clause AND MIT
 "Sequence Library License (BSD-like)": BSD-3-Clause
 "Similar to Apache License but with the acknowledgment clause removed": LicenseRef-scancode-jdom

--- a/utils/spdx/src/main/resources/licenserefs/LicenseRef-ort-oracle-futc
+++ b/utils/spdx/src/main/resources/licenserefs/LicenseRef-ort-oracle-futc
@@ -1,0 +1,111 @@
+Oracle Free Use Terms and Conditions
+
+Definitions
+
+"Oracle" refers to Oracle America, Inc. "You" and "Your" refers to (a) a company
+or organization (each an "Entity") accessing the Programs, if use of the
+Programs will be on behalf of such Entity; or (b) an individual accessing the
+Programs, if use of the Programs will not be on behalf of an Entity.
+"Program(s)" refers to Oracle software provided by Oracle pursuant to the
+following terms and any updates, error corrections, and/or Program Documentation
+provided by Oracle. "Program Documentation" refers to Program user manuals and
+Program installation manuals, if any. If available, Program Documentation may be
+delivered with the Programs and/or may be accessed from
+www.oracle.com/documentation. "Separate Terms" refers to separate license terms
+that are specified in the Program Documentation, readmes or notice files and
+that apply to Separately Licensed Technology. "Separately Licensed Technology"
+refers to Oracle or third party technology that is licensed under Separate Terms
+and not under the terms of this license.
+
+Separately Licensed Technology
+
+Oracle may provide certain notices to You in Program Documentation, readmes or
+notice files in connection with Oracle or third party technology provided as or
+with the Programs. If specified in the Program Documentation, readmes or notice
+files, such technology will be licensed to You under Separate Terms. Your rights
+to use Separately Licensed Technology under Separate Terms are not restricted in
+any way by the terms herein. For clarity, notwithstanding the existence of a
+notice, third party technology that is not Separately Licensed Technology shall
+be deemed part of the Programs licensed to You under the terms of this license.
+
+Source Code for Open Source Software
+
+For software that You receive from Oracle in binary form that is licensed under
+an open source license that gives You the right to receive the source code for
+that binary, You can obtain a copy of the applicable source code from
+https://oss.oracle.com/sources/ or http://www.oracle.com/goto/opensourcecode.
+If the source code for such software was not provided to You with the binary,
+You can also receive a copy of the source code on physical media by submitting a
+written request pursuant to the instructions in the "Written Offer for Source
+Code" section of the latter website.
+
+-------------------------------------------------------------------------------
+
+The following license terms apply to those Programs that are not provided to You
+under Separate Terms.
+
+License Rights and Restrictions
+
+Oracle grants to You, as a recipient of this Program, a nonexclusive,
+nontransferable, limited license to, subject to the conditions stated herein,
+(a) internally use the unmodified Programs for the purposes of developing,
+testing, prototyping and demonstrating your applications, and running the
+Programs for your own internal business operations; and (b) redistribute
+unmodified Programs and Programs Documentation, under the terms of this License,
+provided that You do not charge Your end users any additional fees for the use
+of the Programs. You may make copies of the Programs to the extent reasonably
+necessary for exercising the license rights granted herein and for backup
+purposes. You are granted the right to use the Programs to provide third party
+training in the use of the Programs and associated Separately Licensed
+Technology only if there is express authorization of such use by Oracle on the
+Program's download page or in the Program Documentation.
+
+Your license is contingent on Your compliance with the following conditions:
+
+- You include a copy of this license with any distribution by You of the
+  Programs;
+
+- You do not remove markings or notices of either Oracle's or a licensor's
+  proprietary rights from the Programs or Program Documentation;
+
+- You comply with all U.S. and applicable export control and economic sanctions
+  laws and regulations that govern Your use of the Programs (including technical
+  data);
+
+- You do not cause or permit reverse engineering, disassembly or decompilation
+  of the Programs (except as allowed by law) by You nor allow an associated
+  party to do so.
+
+For clarity, any source code that may be included in the distribution with the
+Programs is provided solely for reference purposes and may not be modified,
+unless such source code is under Separate Terms permitting modification.
+
+Ownership
+
+Oracle or its licensors retain all ownership and intellectual property rights to
+the Programs.
+
+Information Collection
+
+The Programs' installation and/or auto-update processes, if any, may transmit a
+limited amount of data to Oracle or its service provider about those processes
+to help Oracle understand and optimize them. Oracle does not associate the data
+with personally identifiable information. Refer to Oracle's Privacy Policy at
+www.oracle.com/privacy.
+
+Disclaimer of Warranties; Limitation of Liability
+
+THE PROGRAMS ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND. ORACLE FURTHER
+DISCLAIMS ALL WARRANTIES, EXPRESS AND IMPLIED, INCLUDING WITHOUT LIMITATION, ANY
+IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR
+NONINFRINGEMENT.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW WILL ORACLE BE LIABLE TO YOU FOR
+DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT
+LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+Last updated: 9 October 2018

--- a/utils/spdx/src/test/kotlin/UtilsTest.kt
+++ b/utils/spdx/src/test/kotlin/UtilsTest.kt
@@ -166,6 +166,13 @@ class UtilsTest : WordSpec() {
             "return null for an unknown SPDX LicenseRef" {
                 getLicenseText("LicenseRef-foo-bar") should beNull()
             }
+
+            "return the full license text for a LicenseRef-ort license" {
+                val text = getLicenseText("LicenseRef-ort-oracle-futc")?.trim()
+
+                text should startWith("Oracle Free Use Terms and Conditions")
+                text should endWith("Last updated: 9 October 2018")
+            }
         }
 
         "getLicenseText provided a custom dir" should {


### PR DESCRIPTION
Start addressing the missing license texts for LicenseRef-ort licenses from the declared license mapping (#3909). See the commit messages for details.
