### PR TITLE
Fix an IllegalArgumentException in the Excel reporter

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -70,6 +70,7 @@ postgresEmbeddedVersion = 0.13.4
 reflectionsVersion = 0.9.12
 retrofitVersion = 2.9.0
 retrofitKotlinxSerializationConverterVersion = 0.8.0
+saxonHeVersion = 10.6
 scanossVersion = 1.1.5
 semverVersion = 3.1.0
 simpleExcelVersion = 1.1

--- a/reporter/build.gradle.kts
+++ b/reporter/build.gradle.kts
@@ -32,6 +32,7 @@ val kotlinxCoroutinesVersion: String by project
 val kotlinxHtmlVersion: String by project
 val mockkVersion: String by project
 val retrofitVersion: String by project
+val saxonHeVersion: String by project
 val simpleExcelVersion: String by project
 val xalanVersion: String by project
 
@@ -80,6 +81,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     implementation("com.squareup.retrofit2:retrofit:$retrofitVersion")
     implementation("com.vladsch.flexmark:flexmark:$flexmarkVersion")
+    implementation("net.sf.saxon:Saxon-HE:$saxonHeVersion")
     implementation("org.apache.commons:commons-compress:$commonsCompressVersion")
     implementation("org.apache.poi:poi-ooxml:$apachePoiVersion")
     implementation("org.asciidoctor:asciidoctorj:$asciidoctorjVersion")


### PR DESCRIPTION
The root cause of the exception is a XSLT feature requested by Apache POI-OOXML excel generation.

Given the Xalan implementation ceased active development a couple of years ago, the only feasible solution is to use an i
up-to-date XSLT processor implementation.

A viable solution appears to be using Saxon HE as a XSLT implementation.

Signed-off-by: Rainer Bieniek <extern.rainer.bieniek@porsche.de>

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/ort/blob/master/CONTRIBUTING.md). Thank you!
