### PR TITLE
PipFunTest: Enrich the synthetic project with metadata about the Python version

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/pip/setup.py
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip/setup.py
@@ -7,8 +7,10 @@ setup(
     url='https://example.org/app',
     license='MIT License',
     classifiers=[
-        'License :: OSI Approved :: MIT License'
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2'
     ],
+    python_requires='>=2, <3',
     install_requires=['Flask>=0.12, <1.1'],
     packages=find_packages(),
 )


### PR DESCRIPTION
Use both a classifier [1] and the `python_requires` parameter [2] to
declare that the project requires Python 2.

Note that "Although the list of classifiers is often used to declare what
Python versions a project supports, this information is only used for
searching & browsing projects on PyPI, not for installing projects. To
actually restrict what Python versions a project can be installed on, use
the `python_requires` argument."

Also, the project "must be built using at least version 24.2.0 of
setuptools in order for the python_requires argument to be recognized"
and "only versions 9.0.0 and higher of pip recognize the python_requires
metadata".

[1]: https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#classifiers
[2]: https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#python-requires

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>