### PR TITLE
github: Use latest installation instructions for the rebase action

### DIFF
--- a/.github/workflows/automatic-rebase.yml
+++ b/.github/workflows/automatic-rebase.yml
@@ -12,8 +12,9 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v2
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0
     - name: Rebase Branch
-      uses: cirrus-actions/rebase@1
+      uses: cirrus-actions/rebase@1.5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See [1]. This hopefully fixes the "unable to find version `1`" error
[2].

[1]: https://github.com/cirrus-actions/rebase#installation
[2]: https://github.com/oss-review-toolkit/ort/actions/runs/1678809665

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>