### PR TITLE
Evaluator: Pass the current time to the policy rules script

### DIFF
--- a/evaluator/src/main/kotlin/Evaluator.kt
+++ b/evaluator/src/main/kotlin/Evaluator.kt
@@ -39,7 +39,8 @@ import org.ossreviewtoolkit.utils.scripting.ScriptRunner
 class Evaluator(
     ortResult: OrtResult = OrtResult.EMPTY,
     licenseInfoResolver: LicenseInfoResolver = OrtResult.EMPTY.createLicenseInfoResolver(),
-    licenseClassifications: LicenseClassifications = LicenseClassifications()
+    licenseClassifications: LicenseClassifications = LicenseClassifications(),
+    time: Instant = Instant.now()
 ) : ScriptRunner() {
     override val compConfig = createJvmCompilationConfigurationFromTemplate<RulesScriptTemplate> {
         defaultImports(
@@ -49,7 +50,7 @@ class Evaluator(
     }
 
     override val evalConfig = ScriptEvaluationConfiguration {
-        constructorArgs(ortResult, licenseInfoResolver, licenseClassifications)
+        constructorArgs(ortResult, licenseInfoResolver, licenseClassifications, time)
         scriptsInstancesSharing(true)
     }
 

--- a/utils/scripting/src/main/kotlin/RulesScriptConfiguration.kt
+++ b/utils/scripting/src/main/kotlin/RulesScriptConfiguration.kt
@@ -21,6 +21,7 @@
 package org.ossreviewtoolkit.utils.scripting
 
 import java.security.MessageDigest
+import java.time.Instant
 
 import kotlin.script.experimental.annotations.KotlinScript
 import kotlin.script.experimental.api.ScriptAcceptedLocation
@@ -53,7 +54,8 @@ import org.ossreviewtoolkit.utils.core.ortDataDirectory
 open class RulesScriptTemplate(
     val ortResult: OrtResult = OrtResult.EMPTY,
     val licenseInfoResolver: LicenseInfoResolver = OrtResult.EMPTY.createLicenseInfoResolver(),
-    val licenseClassifications: LicenseClassifications = LicenseClassifications()
+    val licenseClassifications: LicenseClassifications = LicenseClassifications(),
+    val time: Instant
 ) {
     val ruleViolations = mutableListOf<RuleViolation>()
 }


### PR DESCRIPTION
Policy rules may require the current date and time as input, such as
e.g. checks for copyright year ranges. Constructor inject the date and
time into the script to avoid a direct dependency on the system time in
order not to sacrifice testability.
