### PR TITLE
SpdxExpression: Simplify the DNF for compound expressions with equal operands

### DIFF
--- a/utils/spdx/src/main/kotlin/SpdxExpression.kt
+++ b/utils/spdx/src/main/kotlin/SpdxExpression.kt
@@ -246,6 +246,8 @@ class SpdxCompoundExpression(
         val leftDnf = left.disjunctiveNormalForm()
         val rightDnf = right.disjunctiveNormalForm()
 
+        if (leftDnf == rightDnf) return leftDnf
+
         return when (operator) {
             SpdxOperator.OR -> SpdxCompoundExpression(leftDnf, SpdxOperator.OR, rightDnf)
 

--- a/utils/spdx/src/test/kotlin/SpdxExpressionTest.kt
+++ b/utils/spdx/src/test/kotlin/SpdxExpressionTest.kt
@@ -349,6 +349,11 @@ class SpdxExpressionTest : WordSpec() {
         }
 
         "disjunctiveNormalForm()" should {
+            "simplify compound expressions with equal operands" {
+                "a AND a".toSpdx().disjunctiveNormalForm() should beString("a")
+                "a OR a".toSpdx().disjunctiveNormalForm() should beString("a")
+            }
+
             "not change an expression already in DNF" {
                 "a AND b OR c AND d".toSpdx().disjunctiveNormalForm() should beString("a AND b OR c AND d")
             }
@@ -407,8 +412,7 @@ class SpdxExpressionTest : WordSpec() {
             "not contain duplicate valid choice for a complex expression" {
                 "(a OR b) AND (a OR b)".toSpdx().validChoices() should containExactlyInAnyOrder(
                     "a".toSpdx(),
-                    "b".toSpdx(),
-                    "a AND b".toSpdx()
+                    "b".toSpdx()
                 )
             }
 


### PR DESCRIPTION
In contrast to the argumentation in fe1f1ff, this should not cause any
severe performance issues with large expressions as "equals()" does not
call `toString()`.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>