### PR TITLE
Pip: Extend the work-around for declared license parsing

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -438,10 +438,13 @@ class Pip(
             it.isBlank() || it == "UNKNOWN"
         }
 
-    private fun getLicenseFromClassifier(classifier: String): String? =
+    private fun getLicenseFromClassifier(classifier: String): String? {
         // Example license classifier:
         // "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)"
-        classifier.split(" :: ").takeIf { it.first() == "License" }?.last()?.takeUnless { it == "OSI Approved" }
+        val classifiers = classifier.split(" :: ").map { it.trim() }
+        val license = classifiers.takeIf { it.first() == "License" }?.last()
+        return license?.takeUnless { it in listOf("License", "OSI Approved") }
+    }
 
     private fun setupVirtualEnv(workingDir: File, definitionFile: File): File {
         // Create an out-of-tree virtualenv.

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -442,8 +442,9 @@ class Pip(
         // Example license classifier:
         // "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)"
         val classifiers = classifier.split(" :: ").map { it.trim() }
-        val license = classifiers.takeIf { it.first() == "License" }?.last()
-        return license?.takeUnless { it in listOf("License", "OSI Approved") }
+        val licenseClassifiers = listOf("License", "OSI Approved")
+        val license = classifiers.takeIf { it.first() in licenseClassifiers }?.last()
+        return license?.takeUnless { it in licenseClassifiers }
     }
 
     private fun setupVirtualEnv(workingDir: File, definitionFile: File): File {


### PR DESCRIPTION
When the classifier format is accidentally used in the `license` property, it happens that just "OSI Approved :: " is used accidentally as the prefix instead of "License :: OSI Approved :: ". Add a work-around so this gets properly parsed.
