### PR TITLE
GradleDependencyHandler: Also catch RepositoryException

### DIFF
--- a/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/GradleDependencyHandler.kt
@@ -23,6 +23,7 @@ import Dependency
 
 import org.apache.maven.project.ProjectBuildingException
 
+import org.eclipse.aether.RepositoryException
 import org.eclipse.aether.artifact.DefaultArtifact
 import org.eclipse.aether.repository.RemoteRepository
 
@@ -96,18 +97,24 @@ class GradleDependencyHandler(
             dependency.extension, dependency.version
         )
 
-        return try {
+        return runCatching {
             maven.parsePackage(artifact, repositories)
-        } catch (e: ProjectBuildingException) {
-            e.showStackTrace()
+        }.getOrElse { e ->
+            when (e) {
+                is ProjectBuildingException, is RepositoryException -> {
+                    e.showStackTrace()
 
-            issues += createAndLogIssue(
-                source = managerName,
-                message = "Could not get package information for dependency '${artifact.identifier()}': " +
-                        e.collectMessagesAsString()
-            )
+                    issues += createAndLogIssue(
+                        source = managerName,
+                        message = "Could not get package information for dependency '${artifact.identifier()}': " +
+                                e.collectMessagesAsString()
+                    )
 
-            null
+                    null
+                }
+
+                else -> throw e
+            }
         }
     }
 


### PR DESCRIPTION
If a package cannot be created because of a `RepositoryException` which
occurs during downloading the metadata of the package, handle this
gracefully instead of failing the whole dependency resolution for the
package.