### PR TITLE
Revert "SpdxExpression: Simplify the DNF for compound expressions with equal operands"

### DIFF
--- a/utils/spdx/src/main/kotlin/SpdxExpression.kt
+++ b/utils/spdx/src/main/kotlin/SpdxExpression.kt
@@ -246,8 +246,6 @@ class SpdxCompoundExpression(
         val leftDnf = left.disjunctiveNormalForm()
         val rightDnf = right.disjunctiveNormalForm()
 
-        if (leftDnf == rightDnf) return leftDnf
-
         return when (operator) {
             SpdxOperator.OR -> SpdxCompoundExpression(leftDnf, SpdxOperator.OR, rightDnf)
 

--- a/utils/spdx/src/test/kotlin/SpdxExpressionTest.kt
+++ b/utils/spdx/src/test/kotlin/SpdxExpressionTest.kt
@@ -349,11 +349,6 @@ class SpdxExpressionTest : WordSpec() {
         }
 
         "disjunctiveNormalForm()" should {
-            "simplify compound expressions with equal operands" {
-                "a AND a".toSpdx().disjunctiveNormalForm() should beString("a")
-                "a OR a".toSpdx().disjunctiveNormalForm() should beString("a")
-            }
-
             "not change an expression already in DNF" {
                 "a AND b OR c AND d".toSpdx().disjunctiveNormalForm() should beString("a AND b OR c AND d")
             }
@@ -412,7 +407,8 @@ class SpdxExpressionTest : WordSpec() {
             "not contain duplicate valid choice for a complex expression" {
                 "(a OR b) AND (a OR b)".toSpdx().validChoices() should containExactlyInAnyOrder(
                     "a".toSpdx(),
-                    "b".toSpdx()
+                    "b".toSpdx(),
+                    "a AND b".toSpdx()
                 )
             }
 


### PR DESCRIPTION
This reverts commit c1f60d0. For once, simplification of expressions
should not be part of canonization via the DNF. Secondly, "a AND b"
needs to stay a valid choice in the test, as the first occurrence of "a
OR b" and the second occurrence of "a OR b" might be located in different
packages, for which independent choices can be made.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>