### PR TITLE
helper-cli: Add a command to save a result with resolved scopes

### DIFF
--- a/helper-cli/src/main/kotlin/HelperMain.kt
+++ b/helper-cli/src/main/kotlin/HelperMain.kt
@@ -43,6 +43,7 @@ import org.ossreviewtoolkit.helper.commands.ListPackagesCommand
 import org.ossreviewtoolkit.helper.commands.ListStoredScanResultsCommand
 import org.ossreviewtoolkit.helper.commands.MapCopyrightsCommand
 import org.ossreviewtoolkit.helper.commands.MergeRepositoryConfigurationsCommand
+import org.ossreviewtoolkit.helper.commands.SaveResultWithResolvedScopesCommand
 import org.ossreviewtoolkit.helper.commands.SetDependencyRepresentationCommand
 import org.ossreviewtoolkit.helper.commands.SetLabelsCommand
 import org.ossreviewtoolkit.helper.commands.SubtractScanResultsCommand
@@ -92,6 +93,7 @@ internal class HelperMain : CliktCommand(name = ORTH_NAME, epilog = "* denotes r
             PackageConfigurationCommand(),
             PackageCurationsCommand(),
             RepositoryConfigurationCommand(),
+            SaveResultWithResolvedScopesCommand(),
             ScanStorageCommand(),
             SetDependencyRepresentationCommand(),
             SetLabelsCommand(),

--- a/helper-cli/src/main/kotlin/commands/SaveResultWithResolvedScopesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/SaveResultWithResolvedScopesCommand.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.file
+
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.writeValue
+import org.ossreviewtoolkit.utils.common.expandTilde
+
+/**
+ * A command to save an ORT result with [resolved scopes][OrtResult.withResolvedScopes].
+ */
+class SaveResultWithResolvedScopesCommand : CliktCommand(
+     help = "Saves the provided ORT result with resolved scopes."
+) {
+    private val inputFile by option(
+        "--ort-file", "-i",
+        help = "The ORT result file to read as input."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val outputFile by option(
+        "--output-file", "-o",
+        help = "The file to write the ORT result with resolved scopes to."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    override fun run() {
+        val ortResult = inputFile.readValue<OrtResult>()
+        outputFile.writeValue(ortResult.withResolvedScopes())
+    }
+}


### PR DESCRIPTION
Add a helper-cli command to save an existing ORT result file with
resolved scopes. This is useful if the dependency tree in the file needs
to be investigated which is very difficult with the optimized format.