### PR TITLE
Revert "Dockerfile: Build and run ORT with Java 17 LTS"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,16 @@ ARG CRT_FILES=""
 # Set this to the ScanCode version to use.
 ARG SCANCODE_VERSION="30.1.0"
 
-FROM eclipse-temurin:17-jdk-focal AS build
+FROM adoptopenjdk/openjdk11:alpine-slim AS build
+
+# Apk install commands.
+RUN apk add --no-cache \
+        # Required for Node.js to build the reporter-web-app.
+        libstdc++ \
+        # Required to allow to download via a proxy with a self-signed certificate.
+        ca-certificates \
+        coreutils \
+        openssl
 
 COPY . /usr/local/src/ort
 
@@ -44,7 +53,7 @@ RUN --mount=type=cache,target=/tmp/.gradle/ \
     sed -i -r '/distributionSha256Sum=[0-9a-f]{64}/d' gradle/wrapper/gradle-wrapper.properties && \
     ./gradlew --no-daemon --stacktrace -Pversion=$ORT_VERSION :cli:distTar :helper-cli:startScripts
 
-FROM eclipse-temurin:17-jdk-focal
+FROM adoptopenjdk:11-jre-hotspot-focal
 
 ENV \
     # Package manager versions.


### PR DESCRIPTION
This reverts commit 80d0d3e. Projects that use the Gradle wrapper to
bootstrap a version of Gradle prior to 7.3 cannot be analyzed with Java
17 as the version of Groovy / ASM used in those Gradle versions cannot
handle Java 17 bytecode, see [1].

[1]: https://github.com/gradle/gradle/issues/16857

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>