### PR TITLE
helper-cli: Support conversions to the dependency tree format

### DIFF
--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -193,7 +193,7 @@ class AnalyzerResultBuilderTest : WordSpec() {
                 val serializedResult = yamlMapper.writeValueAsString(result)
                 val deserializedResult = yamlMapper.readValue<AnalyzerResult>(serializedResult)
 
-                deserializedResult.withScopesResolved() shouldBe result.withScopesResolved()
+                deserializedResult.withResolvedScopes() shouldBe result.withResolvedScopes()
             }
         }
 
@@ -220,9 +220,9 @@ class AnalyzerResultBuilderTest : WordSpec() {
                     .addResult(analyzerResult1)
                     .addResult(analyzerResult2)
                     .build()
-                    .withScopesResolved()
+                    .withResolvedScopes()
 
-                analyzerResult.withScopesResolved() should beTheSameInstanceAs(analyzerResult)
+                analyzerResult.withResolvedScopes() should beTheSameInstanceAs(analyzerResult)
             }
 
             "resolve the dependency information in affected projects" {
@@ -236,7 +236,7 @@ class AnalyzerResultBuilderTest : WordSpec() {
                     .addDependencyGraph(p2.id.type, graph2)
                     .build()
 
-                val resolvedResult = analyzerResult.withScopesResolved()
+                val resolvedResult = analyzerResult.withResolvedScopes()
 
                 resolvedResult.dependencyGraphs.isEmpty() shouldBe true
 

--- a/helper-cli/src/main/kotlin/commands/SetDependencyRepresentationCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/SetDependencyRepresentationCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,11 @@ class SetDependencyRepresentationCommand : CliktCommand(
         GRAPH {
             override fun convert(result: AnalyzerResult): AnalyzerResult =
                 DependencyGraphConverter.convert(result)
+        },
+
+        /** The classic dependency tree format. */
+        TREE {
+            override fun convert(result: AnalyzerResult): AnalyzerResult = result.withResolvedScopes()
         };
 
         /**

--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -107,7 +107,7 @@ data class AnalyzerResult(
      * instances that store their dependencies in the classic [Scope]-based format. Otherwise, this instance is
      * returned without changes.
      */
-    fun withScopesResolved(): AnalyzerResult =
+    fun withResolvedScopes(): AnalyzerResult =
         if (dependencyGraphs.isNotEmpty()) {
             copy(
                 projects = projects.map { it.withResolvedScopes(dependencyGraphs[it.id.type]) }.toSortedSet(),

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -477,7 +477,7 @@ data class OrtResult(
     fun withResolvedScopes(): OrtResult =
         copy(
             analyzer = analyzer?.copy(
-                result = analyzer.result.withScopesResolved()
+                result = analyzer.result.withResolvedScopes()
             )
         )
 

--- a/model/src/test/kotlin/utils/DependencyGraphConverterTest.kt
+++ b/model/src/test/kotlin/utils/DependencyGraphConverterTest.kt
@@ -79,7 +79,7 @@ class DependencyGraphConverterTest : WordSpec({
                 it.scopeNames shouldNot beNull()
             }
 
-            convertedResult.withScopesResolved() shouldBe result
+            convertedResult.withResolvedScopes() shouldBe result
             convertedResult.packages should beTheSameInstanceAs(result.packages)
         }
 

--- a/reporter/src/main/kotlin/reporters/OpossumReporter.kt
+++ b/reporter/src/main/kotlin/reporters/OpossumReporter.kt
@@ -528,7 +528,7 @@ class OpossumReporter : Reporter {
             opossumInput.frequentLicenses += OpossumFrequentLicense(it.id, it.fullName, licenseText)
         }
 
-        val analyzerResult = ortResult.analyzer?.result?.withScopesResolved() ?: return opossumInput
+        val analyzerResult = ortResult.analyzer?.result?.withResolvedScopes() ?: return opossumInput
         val analyzerResultProjects = analyzerResult.projects
         val analyzerResultPackages = analyzerResult.packages
         analyzerResultProjects.forEachIndexed { index, project ->


### PR DESCRIPTION
SetDependencyRepresentationCommand currently only supports conversions
to the dependency graph format. Conversions to the tree format are
useful as well, as this format is more readable and is better suited
to analyze dependencies. So, extend the command to support conversions
in this direction, too.
