### PR TITLE
ScannerCommand: Also print the version of used scanners

### DIFF
--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -253,18 +253,18 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
 
         if (projectScanner != packageScanner) {
             if (projectScanner != null) {
-                println("Using project scanner '${projectScanner.scannerName}'.")
+                println("Using project scanner '${projectScanner.scannerName}' version ${projectScanner.version}.")
             } else {
                 println("Projects will not be scanned.")
             }
 
             if (packageScanner != null) {
-                println("Using package scanner '${packageScanner.scannerName}'.")
+                println("Using package scanner '${packageScanner.scannerName}' version ${packageScanner.version}.")
             } else {
                 println("Packages will not be scanned.")
             }
         } else {
-            println("Using scanner '${defaultScanner.scannerName}'.")
+            println("Using scanner '${defaultScanner.scannerName}' version ${defaultScanner.version}.")
         }
 
         // Perform the scan.


### PR DESCRIPTION
This is good for double-checking that the expected version is being used.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>