### PR TITLE
MavenSupport: Also treat Spring Cloud Starter projects as `isMetaDataOnly`

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -678,8 +678,10 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
             PackageManager.processProjectVcs(it, vcsFromPackage, *vcsFallbackUrls)
         } ?: PackageManager.processPackageVcs(vcsFromPackage, *vcsFallbackUrls)
 
-        val isSpringBootStarter = with(mavenProject) {
-            groupId == "org.springframework.boot" && artifactId.startsWith("spring-boot-starter-")
+        val isSpringStarterProject = with(mavenProject) {
+            listOf("boot", "cloud").any {
+                groupId == "org.springframework.$it" && artifactId.startsWith("spring-$it-starter-")
+            }
         }
 
         return Package(
@@ -698,7 +700,7 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
             sourceArtifact = sourceRemoteArtifact,
             vcs = vcsFromPackage,
             vcsProcessed = vcsProcessed,
-            isMetaDataOnly = mavenProject.packaging == "pom" || isSpringBootStarter,
+            isMetaDataOnly = mavenProject.packaging == "pom" || isSpringStarterProject,
             isModified = isBinaryArtifactModified || isSourceArtifactModified
         )
     }


### PR DESCRIPTION
See e.g. [1], whose JAR is empty besides some META-INF entries.

[1]: https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-starter-stream-rabbit/3.1.3/

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>