### PR TITLE
common-utils: Also ignore the "CVSROOT" VCS directory

### DIFF
--- a/utils/common/src/main/kotlin/Utils.kt
+++ b/utils/common/src/main/kotlin/Utils.kt
@@ -32,7 +32,8 @@ val VCS_DIRECTORIES = listOf(
     ".hg",
     ".repo",
     ".svn",
-    "CVS"
+    "CVS",
+    "CVSROOT"
 )
 
 /**


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>