### PR TITLE
RulesScriptTemplate: Use a more specific name for a variable

### DIFF
--- a/utils/scripting/src/main/kotlin/RulesScriptConfiguration.kt
+++ b/utils/scripting/src/main/kotlin/RulesScriptConfiguration.kt
@@ -55,7 +55,7 @@ open class RulesScriptTemplate(
     val ortResult: OrtResult = OrtResult.EMPTY,
     val licenseInfoResolver: LicenseInfoResolver = OrtResult.EMPTY.createLicenseInfoResolver(),
     val licenseClassifications: LicenseClassifications = LicenseClassifications(),
-    val time: Instant
+    val executionTime: Instant
 ) {
     val ruleViolations = mutableListOf<RuleViolation>()
 }


### PR DESCRIPTION
The name `time` is too generic given the large size of it's visibility
scope. Use a more specific name to avoid naming conflicts and reduce the
risk of undesired variable name shadowing.
