### PR TITLE
Gradle: Add a code comment why adding the Kotlin stdlib is disabled

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -86,7 +86,10 @@ org.gradle.parallel = true
 buildCacheRetentionDays = 7
 
 kotlin.code.style = official
-kotlin.stdlib.default.dependency=false
+
+# Disable the automatic addition of a dependency on the Kotlin standard library to work around a dependency resolution
+# issue, see https://youtrack.jetbrains.com/issue/KT-41642.
+kotlin.stdlib.default.dependency = false
 
 # Declare the path scanner versions to bootstrap if no version is present in the PATH environment.
 askalonoVersion = 0.4.4


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>