### PR TITLE
OrtConfigPackageCurationProvider: Filter applicable curations

### DIFF
--- a/analyzer/src/main/kotlin/curation/OrtConfigPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/OrtConfigPackageCurationProvider.kt
@@ -58,7 +58,7 @@ open class OrtConfigPackageCurationProvider : PackageCurationProvider {
         val file = curationsDir.resolve("curations").resolve(pkgId.toCurationPath())
         return if (file.isFile) {
             runCatching {
-                yamlMapper.readValue<List<PackageCuration>>(file)
+                yamlMapper.readValue<List<PackageCuration>>(file).filter { it.isApplicable(pkgId) }
             }.onFailure {
                 log.warn { "Failed parsing package curation from '${file.absolutePath}'." }
             }.getOrThrow()


### PR DESCRIPTION
Return only curations which are applicable to the provided package id.
This is required because the curation files can contain curations for
multiple versions.