### PR TITLE
CtrlXAutomationModel: Relax the SPDX check to allow LicenseRef exceptions

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -273,7 +273,7 @@ abstract class PackageManager(
                 }
             }
 
-            log.info { "Resolving $managerName dependencies for '$relativePath' took ${duration.inWholeSeconds}s." }
+            log.info { "Resolving $managerName dependencies for '$relativePath' took $duration." }
         }
 
         afterResolution(definitionFiles)

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -276,23 +276,23 @@ class ReporterCommand : CliktCommand(
 
         reportDurationMap.value.forEach { (reporter, timedValue) ->
             val name = reporter.reporterName
-            val durationInSeconds = timedValue.duration.inWholeSeconds
 
             timedValue.value.onSuccess { files ->
                 val fileList = files.joinToString { "'$it'" }
-                println("Successfully created '$name' report(s) at $fileList in ${durationInSeconds}s.")
+                println("Successfully created '$name' report(s) at $fileList in ${timedValue.duration}.")
             }.onFailure { e ->
                 e.showStackTrace()
 
-                log.error { "Could not create '$name' report in ${durationInSeconds}s: ${e.collectMessagesAsString()}" }
+                log.error {
+                    "Could not create '$name' report in ${timedValue.duration}: ${e.collectMessagesAsString()}"
+                }
 
                 ++failureCount
             }
         }
 
         val successCount = reportFormats.size - failureCount
-        println("Created $successCount of ${reportFormats.size} report(s) in " +
-                "${reportDurationMap.duration.inWholeSeconds}s.")
+        println("Created $successCount of ${reportFormats.size} report(s) in ${reportDurationMap.duration}.")
 
         if (failureCount > 0) throw ProgramResult(2)
     }

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -122,7 +122,7 @@ data class OrtResult(
             )
         }
 
-        log.perf { "Computing excluded projects took ${duration.inWholeSeconds}s." }
+        log.perf { "Computing excluded projects took $duration." }
 
         result
     }
@@ -163,7 +163,7 @@ data class OrtResult(
             }
         }
 
-        log.perf { "Computing excluded packages took ${duration.inWholeSeconds}s." }
+        log.perf { "Computing excluded packages took $duration." }
 
         result
     }

--- a/reporter/src/main/kotlin/reporters/ctrlx/CtrlXAutomationModel.kt
+++ b/reporter/src/main/kotlin/reporters/ctrlx/CtrlXAutomationModel.kt
@@ -165,7 +165,7 @@ data class License(
             "The '$name' value of the 'name' field must not contain any leading or trailing whitespaces."
         }
 
-        require(spdx?.isValid() != false) {
+        require(spdx?.isValid(SpdxExpression.Strictness.ALLOW_LICENSEREF_EXCEPTIONS) != false) {
             "The '$spdx' value of the 'spdx' field must be a valid SPDX identifier."
         }
 

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -358,7 +358,7 @@ class FossId internal constructor(
             results
         }
 
-        log.info { "Scan has been performed. Total time was ${duration.inWholeSeconds}s." }
+        log.info { "Scan has been performed. Total time was $duration." }
 
         return results
     }


### PR DESCRIPTION
Otherwise writing the report for such scan results would fail.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>