### PR TITLE
Gradle: Apply the `gradle-graal` plugin to experiment with native images

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -42,11 +42,31 @@ plugins {
 
     // Apply third-party plugins.
     id("com.github.johnrengelman.shadow")
+    id("com.palantir.graal")
 }
 
 application {
     applicationName = "ort"
     mainClassName = "org.ossreviewtoolkit.cli.OrtMainKt"
+}
+
+graal {
+    graalVersion("21.3.0")
+    javaVersion("11")
+
+    option("--no-fallback")
+
+    // Work-around for:
+    // "com.oracle.graal.pointsto.constraints.UnresolvedElementException:
+    //  Discovered unresolved type during parsing: android.os.Build$VERSION"
+    option("--allow-incomplete-classpath")
+
+    // Work-around for:
+    // "Error: Classes that should be initialized at run time got initialized during image building"
+    option("--initialize-at-build-time=org.jruby.util.RubyFileTypeDetector")
+
+    mainClass("org.ossreviewtoolkit.cli.OrtMainKt")
+    outputName("ort")
 }
 
 tasks.withType<ShadowJar> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,7 @@
 buildconfigPluginVersion = 3.0.3
 detektPluginVersion = 1.19.0
 dokkaPluginVersion = 1.6.10
+graalPluginVersion = 0.10.0
 graphqlPluginVersion = 5.3.2
 ideaExtPluginVersion = 1.1.1
 kotlinPluginVersion = 1.6.10


### PR DESCRIPTION
Run it like `./gradlew :cli:nativeImage`. While this does not succeed yet,
there seem to only be a few blockers to get it running, so still make
this publicly available for people to play with.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>