### PR TITLE
Upgrade the Licensee version to bootstrap to 9.15.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -95,7 +95,7 @@ kotlin.stdlib.default.dependency = false
 # Declare the path scanner versions to bootstrap if no version is present in the PATH environment.
 askalonoVersion = 0.4.4
 boyterLcVersion = 1.3.1
-licenseeVersion = 9.13.0
+licenseeVersion = 9.15.1
 scancodeVersion = 30.1.0
 
 # The version of the SPDX license list which is used to import license texts and generate SPDX enums. Must be a valid

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -67,13 +67,6 @@ class Licensee(
     override fun bootstrap(): File {
         val gem = if (Os.isWindows) "gem.cmd" else "gem"
 
-        if (Os.isWindows) {
-            // Version 0.28.0 of rugged broke building on Windows and the fix is unreleased yet, see
-            // https://github.com/libgit2/rugged/commit/2f5a8f6c8f4ae9b94a2d1f6ffabc315f2592868d. So install the latest
-            // version < 0.28.0 (and => 0.24.0) manually to satisfy Licensee's needs.
-            ProcessCapture(gem, "install", "rugged", "-v", "0.27.10.1").requireSuccess()
-        }
-
         ProcessCapture(gem, "install", "--user-install", "licensee", "-v", expectedVersion).requireSuccess()
 
         val ruby = ProcessCapture("ruby", "-r", "rubygems", "-e", "puts Gem.user_dir").requireSuccess()


### PR DESCRIPTION
See [1].

[1]: https://github.com/licensee/licensee/releases/tag/v9.15.1

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>