### PR TITLE
SpdxResolvedDocument: Copy over query strings when resolving URIs

### DIFF
--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -26,6 +26,8 @@ import java.util.SortedSet
 
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
+import org.ossreviewtoolkit.analyzer.managers.utils.SpdxDocumentCache
+import org.ossreviewtoolkit.analyzer.managers.utils.SpdxResolvedDocument
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier

--- a/analyzer/src/main/kotlin/managers/utils/SpdxDocumentCache.kt
+++ b/analyzer/src/main/kotlin/managers/utils/SpdxDocumentCache.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.analyzer.managers
+package org.ossreviewtoolkit.analyzer.managers.utils
 
 import java.io.File
 

--- a/analyzer/src/main/kotlin/managers/utils/SpdxResolvedDocument.kt
+++ b/analyzer/src/main/kotlin/managers/utils/SpdxResolvedDocument.kt
@@ -227,7 +227,7 @@ private fun collectAndQualifyRelations(
  * A data class to hold the result of an operation to resolve an [SpdxDocument] from an external reference. Resolving
  * of the document may fail, then the document is *null*, and a corresponding [OrtIssue] is present.
  */
-private data class ResolutionResult(
+internal data class ResolutionResult(
     /**
      * The document the reference points to, if it could be resolved successfully.
      */
@@ -258,12 +258,15 @@ private fun URI.toDefinitionFile(): File? =
  * Return the [SpdxDocument] this [SpdxExternalDocumentReference]'s [SpdxDocument] refers to. Use [cache] to parse
  * the document, and [baseUri] to resolve relative references.
  */
-private fun SpdxExternalDocumentReference.resolve(
+internal fun SpdxExternalDocumentReference.resolve(
     cache: SpdxDocumentCache,
     baseUri: URI,
     managerName: String
 ): ResolutionResult {
-    val uri = runCatching { baseUri.resolve(spdxDocument) }.getOrElse {
+    val uri = runCatching {
+        val resolvedUri = baseUri.resolve(spdxDocument)
+        resolvedUri.takeUnless { baseUri.query != null } ?: URI("$resolvedUri?${baseUri.query}")
+    }.getOrElse {
         return ResolutionResult(
             null,
             baseUri,

--- a/analyzer/src/main/kotlin/managers/utils/SpdxResolvedDocument.kt
+++ b/analyzer/src/main/kotlin/managers/utils/SpdxResolvedDocument.kt
@@ -19,7 +19,7 @@
 
 @file:Suppress("TooManyFunctions")
 
-package org.ossreviewtoolkit.analyzer.managers
+package org.ossreviewtoolkit.analyzer.managers.utils
 
 import java.io.File
 import java.net.Authenticator

--- a/analyzer/src/test/kotlin/managers/utils/SpdxDocumentCacheTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/SpdxDocumentCacheTest.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.analyzer.managers
+package org.ossreviewtoolkit.analyzer.managers.utils
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.should

--- a/analyzer/src/test/kotlin/managers/utils/SpdxResolvedDocumentTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/SpdxResolvedDocumentTest.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.analyzer.managers
+package org.ossreviewtoolkit.analyzer.managers.utils
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse

--- a/analyzer/src/test/kotlin/managers/utils/SpdxResolvedDocumentTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/SpdxResolvedDocumentTest.kt
@@ -203,7 +203,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
             }
 
             "create an issue for an external reference with an invalid URI" {
-                val reference = SpdxExternalDocumentReference("someDocument", "?Not a valid URI?!!", DUMMY_CHECKSUM)
+                val reference = SpdxExternalDocumentReference("DocumentRef-ort", "?Not a valid URI?!!", DUMMY_CHECKSUM)
                 val identifier = "${reference.externalDocumentId}:somePackage"
                 val doc = createSpdxDocument(1, listOf(createPackage(1)), references = listOf(reference))
 
@@ -221,7 +221,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
             }
 
             "create an issue for an external reference pointing to a non-existing file" {
-                val reference = SpdxExternalDocumentReference("someDocument", "nonExisting.spdx.yml", DUMMY_CHECKSUM)
+                val reference = SpdxExternalDocumentReference("DocumentRef-ort", "absent.spdx.yml", DUMMY_CHECKSUM)
                 val identifier = "${reference.externalDocumentId}:somePackage"
                 val doc = createSpdxDocument(1, listOf(createPackage(1)), references = listOf(reference))
 
@@ -318,7 +318,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
 
             "handle a failure when downloading an external document" {
                 val errorRef = SpdxExternalDocumentReference(
-                    "error",
+                    "DocumentRef-ort",
                     "http://localhost:${server.port()}/doc.spdx.json",
                     DUMMY_CHECKSUM
                 )

--- a/analyzer/src/test/kotlin/managers/utils/SpdxResolvedDocumentTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/SpdxResolvedDocumentTest.kt
@@ -20,9 +20,12 @@
 package org.ossreviewtoolkit.analyzer.managers.utils
 
 import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
+import com.github.tomakehurst.wiremock.client.WireMock.exactly
 import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 
@@ -155,6 +158,20 @@ class SpdxResolvedDocumentTest : WordSpec() {
                 val resolvedDoc = SpdxResolvedDocument.load(SpdxDocumentCache(), rootFile, MANAGER_NAME)
 
                 resolvedDoc.referencedDocuments.keys should containExactlyInAnyOrder(ref1, ref2, ref3)
+            }
+        }
+
+        "SpdxExternalDocumentReference.resolve" should {
+            "maintain a query string" {
+                val ref = SpdxExternalDocumentReference("DocumentRef-ort", "../lib/package.spdx.yml", DUMMY_CHECKSUM)
+                val baseUri = URI("http://localhost:${server.port()}/documents/spdx/app/package.spdx.yml?branch=main")
+
+                ref.resolve(SpdxDocumentCache(), baseUri, MANAGER_NAME)
+
+                server.verify(
+                    exactly(1),
+                    getRequestedFor(WireMock.urlEqualTo("/documents/spdx/lib/package.spdx.yml?branch=main"))
+                )
             }
         }
 

--- a/utils/spdx/src/main/kotlin/model/SpdxDocument.kt
+++ b/utils/spdx/src/main/kotlin/model/SpdxDocument.kt
@@ -130,7 +130,7 @@ data class SpdxDocument(
     val relationships: List<SpdxRelationship> = emptyList()
 ) {
     init {
-        require(spdxId.isNotBlank()) { "The SPDX-Id must not be blank." }
+        require(spdxId.isNotBlank()) { "The SPDX-ID must not be blank." }
 
         require(spdxVersion.isNotBlank()) { "The SPDX version must not be blank." }
 

--- a/utils/spdx/src/main/kotlin/model/SpdxExternalDocumentReference.kt
+++ b/utils/spdx/src/main/kotlin/model/SpdxExternalDocumentReference.kt
@@ -40,7 +40,7 @@ data class SpdxExternalDocumentReference(
     val checksum: SpdxChecksum
 ) {
     init {
-        require(externalDocumentId.isNotBlank()) { "The external document Id must not be blank." }
+        require(externalDocumentId.isNotBlank()) { "The external document ID must not be blank." }
 
         require(spdxDocument.isNotBlank()) { "The SPDX document must not be blank." }
     }

--- a/utils/spdx/src/main/kotlin/model/SpdxExternalDocumentReference.kt
+++ b/utils/spdx/src/main/kotlin/model/SpdxExternalDocumentReference.kt
@@ -19,6 +19,8 @@
 
 package org.ossreviewtoolkit.utils.spdx.model
 
+import org.ossreviewtoolkit.utils.spdx.SpdxConstants
+
 /**
  * [SpdxExternalDocumentReference]s are used by [SpdxDocument]s to list all external documents which are referenced from
  * that particular [SpdxDocument].
@@ -41,6 +43,10 @@ data class SpdxExternalDocumentReference(
 ) {
     init {
         require(externalDocumentId.isNotBlank()) { "The external document ID must not be blank." }
+
+        require(externalDocumentId.startsWith(SpdxConstants.DOCUMENT_REF_PREFIX)) {
+            "The external document ID must start with '${SpdxConstants.DOCUMENT_REF_PREFIX}'."
+        }
 
         require(spdxDocument.isNotBlank()) { "The SPDX document must not be blank." }
     }

--- a/utils/spdx/src/main/kotlin/model/SpdxExtractedLicenseInfo.kt
+++ b/utils/spdx/src/main/kotlin/model/SpdxExtractedLicenseInfo.kt
@@ -62,6 +62,6 @@ data class SpdxExtractedLicenseInfo(
     init {
         require(extractedText.isNotBlank()) { "The extracted text must not be blank." }
 
-        require(licenseId.isNotBlank()) { "The license Id must not be blank." }
+        require(licenseId.isNotBlank()) { "The license ID must not be blank." }
     }
 }

--- a/utils/spdx/src/main/kotlin/model/SpdxRelationship.kt
+++ b/utils/spdx/src/main/kotlin/model/SpdxRelationship.kt
@@ -252,7 +252,7 @@ data class SpdxRelationship(
 
     init {
         require(spdxElementId.isNotBlank()) {
-            "The SPDX element Id must not be blank."
+            "The SPDX element ID must not be blank."
         }
 
         require(relatedSpdxElement.isNotBlank()) {


### PR DESCRIPTION
Resolving a path against a URI drops the original query string. However,
the query string might be required to get the right file, so copy an
existing query string over on resolution.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>