### PR TITLE
ScanCode: Work around an underscore in a SPDX license key

### DIFF
--- a/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
@@ -209,7 +209,7 @@ private fun getLicenseFindings(result: JsonNode, parseExpressions: Boolean): Lis
  */
 private fun getSpdxLicenseId(license: JsonNode): String {
     // There is a bug in ScanCode 3.0.2 that returns an empty string instead of null for licenses unknown to SPDX.
-    val id = license["spdx_license_key"].textValueOrEmpty()
+    val id = license["spdx_license_key"].textValueOrEmpty().replace('_', '-')
 
     // For regular SPDX IDs, return early here.
     if (id.isNotEmpty() && !id.startsWith(LICENSE_REF_PREFIX)) return id

--- a/utils/spdx/src/main/kotlin/Utils.kt
+++ b/utils/spdx/src/main/kotlin/Utils.kt
@@ -162,11 +162,15 @@ private val LICENSE_REF_FILENAME_REGEX by lazy { Regex("^LicenseRef-\\w+-") }
 
 private fun getLicenseTextFile(id: String, dir: File): File? =
     id.replace(LICENSE_REF_FILENAME_REGEX, "").let { idWithoutLicenseRefNamespace ->
-        sequenceOf(
+        listOfNotNull(
             id,
             id.removePrefix("LicenseRef-"),
             idWithoutLicenseRefNamespace,
-            "$idWithoutLicenseRefNamespace.LICENSE"
+            "$idWithoutLicenseRefNamespace.LICENSE",
+            "x11-xconsortium_veillard.LICENSE".takeIf {
+                // Work around for https://github.com/nexB/scancode-toolkit/issues/2813.
+                id == "LicenseRef-scancode-x11-xconsortium-veillard"
+            }
         ).mapNotNull { filename ->
             dir.resolve(filename).takeIf { it.isFile }
         }.firstOrNull()


### PR DESCRIPTION
ScanCode has one SPDX license key containing an underscore characters
which is not allwed, see [1]. This results in ORT's scanner crashing
due to an SpdxException when it tries to parse the SPDX license key.

This issue has first occured in 2020 and been fixed by [2]. It got
re-introduced recently by [3].

Deliberatly don't fix the general problem with underscores in
`getLicenseTextFile()` in favor of a license ID specific work around,
because this can be implemented efficiently without doing a refactoring
first.

[1] nexB/scancode-toolkit#2813
[2] fb0370f
[3] #4523
