### PR TITLE
(helper-)cli: Stop using the deprecated `mainClassName`

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -47,7 +47,7 @@ plugins {
 
 application {
     applicationName = "ort"
-    mainClassName = "org.ossreviewtoolkit.cli.OrtMainKt"
+    mainClass.set("org.ossreviewtoolkit.cli.OrtMainKt")
 }
 
 graal {

--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -38,7 +38,7 @@ plugins {
 
 application {
     applicationName = "orth"
-    mainClassName = "org.ossreviewtoolkit.helper.HelperMainKt"
+    mainClass.set("org.ossreviewtoolkit.helper.HelperMainKt")
 }
 
 tasks.withType<ShadowJar> {


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>