### PR TITLE
scanner: Add scannerDir to PATH after bootstrapping

### DIFF
--- a/scanner/src/main/kotlin/CommandLineScanner.kt
+++ b/scanner/src/main/kotlin/CommandLineScanner.kt
@@ -69,6 +69,7 @@ abstract class CommandLineScanner(
                                         "$expectedVersion."
                             )
                         }
+                        Os.prependToPathEnvironment(it)
                     }
                 }
 

--- a/utils/common/src/main/kotlin/Os.kt
+++ b/utils/common/src/main/kotlin/Os.kt
@@ -119,6 +119,21 @@ object Os {
     }
 
     /**
+     * Prepend [path] to the system's PATH environment.
+     */
+    fun prependToPathEnvironment(path: File) {
+        val paths = env["PATH"]?.split(File.pathSeparatorChar)
+        val absolutePath = path.absolutePath
+        if (paths != null) {
+            if (absolutePath !in paths) {
+                env["PATH"] = absolutePath + File.pathSeparatorChar + env["PATH"]
+            }
+        } else {
+            env["PATH"] = absolutePath
+        }
+    }
+
+    /**
      * Resolve the Windows [executable] to its full name including the optional extension.
      */
     fun resolveWindowsExecutable(executable: File): File? {


### PR DESCRIPTION
These test cases of ScanCodeScannerFunTest failed because ScanCode is bootstrapped and is not in PATH, so `getLicenseText` cannot find license files in directory under ScanCode.  Adding `scannerDir` to PATH after bootstrapped ScanCode can fix #5002 