### PR TITLE
Improve startup performance

### DIFF
--- a/reporter/src/main/kotlin/reporters/ExcelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ExcelReporter.kt
@@ -74,12 +74,12 @@ class ExcelReporter : Reporter {
     private val defaultColumns = 5
 
     private val colorMap = DefaultIndexedColorMap()
-    private val borderColor = XSSFColor(Color(211, 211, 211), colorMap)
-    private val errorColor = XSSFColor(Color(240, 128, 128), colorMap)
-    private val excludedColor = XSSFColor(Color(180, 180, 180), colorMap)
-    private val excludedFontColor = XSSFColor(Color(100, 100, 100), colorMap)
-    private val successColor = XSSFColor(Color(173, 216, 230), colorMap)
-    private val warningColor = XSSFColor(Color(255, 255, 224), colorMap)
+    private val borderColor by lazy { XSSFColor(Color(211, 211, 211), colorMap) }
+    private val errorColor by lazy { XSSFColor(Color(240, 128, 128), colorMap) }
+    private val excludedColor by lazy { XSSFColor(Color(180, 180, 180), colorMap) }
+    private val excludedFontColor by lazy { XSSFColor(Color(100, 100, 100), colorMap) }
+    private val successColor by lazy { XSSFColor(Color(173, 216, 230), colorMap) }
+    private val warningColor by lazy { XSSFColor(Color(255, 255, 224), colorMap) }
 
     private lateinit var defaultStyle: CellStyle
     private lateinit var excludedStyle: CellStyle

--- a/reporter/src/main/kotlin/reporters/freemarker/asciidoc/AsciiDocTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/asciidoc/AsciiDocTemplateReporter.kt
@@ -58,7 +58,7 @@ abstract class AsciiDocTemplateReporter(private val backend: String, override va
         ASCII_DOC_FILE_EXTENSION,
         ASCII_DOC_TEMPLATE_DIRECTORY
     )
-    private val asciidoctor = Asciidoctor.Factory.create()
+    private val asciidoctor by lazy { Asciidoctor.Factory.create() }
 
     protected open fun processTemplateOptions(options: MutableMap<String, String>): Attributes =
         Attributes.builder().build()


### PR DESCRIPTION
Reduce the duration of running `ort --help` from ~13s to ~2s, see the commit messages for details.
