### PR TITLE
utils-spdx: Do not search license text of ScanCode by default

### DIFF
--- a/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
+++ b/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
@@ -10,13 +10,6 @@
   "name" : "some document name",
   "dataLicense" : "CC0-1.0",
   "comment" : "some document comment",
-  "hasExtractedLicensingInfos" : [ {
-    "extractedText" : "ASMUS License\n\nDisclaimer and legal rights\n---------------------------\n\nThis file contains bugs. All representations to the contrary are void.\n\nSource code in this file and the accompanying headers and included \nfiles may be distributed free of charge by anyone, as long as full \ncredit is given and any and all liabilities are assumed by the \nrecipient.\n",
-    "licenseId" : "LicenseRef-scancode-asmus"
-  }, {
-    "extractedText" : "To anyone who acknowledges that the file \"sRGB Color Space Profile.icm\" \nis provided \"AS IS\" WITH NO EXPRESS OR IMPLIED WARRANTY:\npermission to use, copy and distribute this file for any purpose is hereby \ngranted without fee, provided that the file is not changed including the HP \ncopyright notice tag, and that the name of Hewlett-Packard Company not be \nused in advertising or publicity pertaining to distribution of the software \nwithout specific, written prior permission. Hewlett-Packard Company makes \nno representations about the suitability of this software for any purpose.",
-    "licenseId" : "LicenseRef-scancode-srgb"
-  } ],
   "documentNamespace" : "<REPLACE_DOCUMENT_NAMESPACE>",
   "documentDescribes" : [ "SPDXRef-Package-0-root-package" ],
   "packages" : [ {

--- a/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
+++ b/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
@@ -10,22 +10,6 @@ creationInfo:
 name: "some document name"
 dataLicense: "CC0-1.0"
 comment: "some document comment"
-hasExtractedLicensingInfos:
-- extractedText: "ASMUS License\n\nDisclaimer and legal rights\n---------------------------\n\
-    \nThis file contains bugs. All representations to the contrary are void.\n\nSource\
-    \ code in this file and the accompanying headers and included \nfiles may be distributed\
-    \ free of charge by anyone, as long as full \ncredit is given and any and all\
-    \ liabilities are assumed by the \nrecipient.\n"
-  licenseId: "LicenseRef-scancode-asmus"
-- extractedText: "To anyone who acknowledges that the file \"sRGB Color Space Profile.icm\"\
-    \ \nis provided \"AS IS\" WITH NO EXPRESS OR IMPLIED WARRANTY:\npermission to\
-    \ use, copy and distribute this file for any purpose is hereby \ngranted without\
-    \ fee, provided that the file is not changed including the HP \ncopyright notice\
-    \ tag, and that the name of Hewlett-Packard Company not be \nused in advertising\
-    \ or publicity pertaining to distribution of the software \nwithout specific,\
-    \ written prior permission. Hewlett-Packard Company makes \nno representations\
-    \ about the suitability of this software for any purpose."
-  licenseId: "LicenseRef-scancode-srgb"
 documentNamespace: "<REPLACE_DOCUMENT_NAMESPACE>"
 documentDescribes:
 - "SPDXRef-Package-0-root-package"

--- a/reporter/src/funTest/kotlin/DefaultLicenseTextProviderFunTest.kt
+++ b/reporter/src/funTest/kotlin/DefaultLicenseTextProviderFunTest.kt
@@ -31,11 +31,4 @@ class DefaultLicenseTextProviderFunTest : StringSpec({
         resolver.hasLicenseText("Apache-2.0") shouldBe true
         resolver.getLicenseText("Apache-2.0") shouldNot beEmpty()
     }
-
-    "Can provide a LicenseRef-scancode license text" {
-        val resolver = DefaultLicenseTextProvider()
-
-        resolver.hasLicenseText("LicenseRef-scancode-mit-modern") shouldBe true
-        resolver.getLicenseText("LicenseRef-scancode-mit-modern") shouldNot beEmpty()
-    }
 })

--- a/scanner/src/funTest/kotlin/scanners/scancode/ScanCodeScannerFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/scancode/ScanCodeScannerFunTest.kt
@@ -36,16 +36,20 @@ class ScanCodeScannerFunTest : AbstractScannerFunTest(setOf(ExpensiveTag, ScanCo
     override val expectedFileLicenses = setOf("Apache-2.0".toSpdx())
     override val expectedDirectoryLicenses = setOf("Apache-2.0".toSpdx())
 
+    val licenseTextDirs = listOfNotNull(scanner.licenseTextDir)
+
     init {
         "return the full license text for the HERE proprietary license" {
-            val text = getLicenseText("LicenseRef-scancode-here-proprietary")?.trim()
+            val text =
+                getLicenseText("LicenseRef-scancode-here-proprietary", licenseTextDirectories = licenseTextDirs)?.trim()
 
             text should startWith("This software and other materials contain proprietary information")
             text should endWith("allowed.")
         }
 
         "return the full license text for a known SPDX LicenseRef" {
-            val text = getLicenseText("LicenseRef-scancode-indiana-extreme")?.trim()
+            val text =
+                getLicenseText("LicenseRef-scancode-indiana-extreme", licenseTextDirectories = licenseTextDirs)?.trim()
 
             text should startWith("Indiana University Extreme! Lab Software License Version 1.1.1")
             text should endWith("EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.")
@@ -57,7 +61,8 @@ class ScanCodeScannerFunTest : AbstractScannerFunTest(setOf(ExpensiveTag, ScanCo
 
             val outputDir = createOrtTempDir().apply { resolve(id).apply { writeText(text) } }
 
-            getLicenseText(id, true, listOf(outputDir)) shouldBe getLicenseText(id, true)
+            getLicenseText(id, true, licenseTextDirs + listOf(outputDir)) shouldBe
+                    getLicenseText(id, true, licenseTextDirectories = licenseTextDirs)
         }
     }
 }

--- a/utils/spdx/src/main/kotlin/Utils.kt
+++ b/utils/spdx/src/main/kotlin/Utils.kt
@@ -27,11 +27,9 @@ import java.io.File
 import java.net.URL
 import java.security.MessageDigest
 
-import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
 import org.ossreviewtoolkit.utils.common.calculateHash
 import org.ossreviewtoolkit.utils.common.isSymbolicLink
-import org.ossreviewtoolkit.utils.common.realFile
 import org.ossreviewtoolkit.utils.common.toHexString
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants.LICENSE_REF_PREFIX
 
@@ -44,29 +42,6 @@ internal val PATH_STRING_COMPARATOR = compareBy<String>({ path -> path.count { i
  * A mapper to read license mapping from YAML resource files.
  */
 internal val yamlMapper = YAMLMapper().registerKotlinModule()
-
-/**
- * The directory that contains the ScanCode license texts. This is located using a heuristic based on the path of the
- * ScanCode binary.
- */
-private val scanCodeLicenseTextDir by lazy {
-    val scanCodeDir = Os.getPathFromEnvironment("scancode")?.realFile()?.parentFile
-
-    // Locate directories that contain the Python version in their name.
-    val candidates = scanCodeDir?.resolve("../lib")?.listFiles().orEmpty()
-        .filter { it.isDirectory && it.name.startsWith("python") }
-        .map { "../lib/${it.name}/site-packages/licensedcode/data/licenses" }
-
-    sequenceOf(
-        "src/licensedcode/data/licenses",
-        "../src/licensedcode/data/licenses",
-        "../site-packages/licensedcode/data/licenses",
-        "../lib/site-packages/licensedcode/data/licenses",
-        *candidates.toTypedArray()
-    ).firstNotNullOfOrNull { relativePath ->
-        scanCodeDir?.resolve(relativePath)?.takeIf { it.isDirectory }
-    }
-}
 
 /**
  * Calculate the [SPDX package verification code][1] for a list of [known SHA1s][sha1sums] of files and [excludes].
@@ -131,13 +106,13 @@ fun getLicenseText(
     id: String,
     handleExceptions: Boolean = false,
     licenseTextDirectories: List<File> = emptyList()
-): String? = getLicenseTextReader(id, handleExceptions, addScanCodeLicenseTextsDir(licenseTextDirectories))?.invoke()
+): String? = getLicenseTextReader(id, handleExceptions, licenseTextDirectories)?.invoke()
 
 fun hasLicenseText(
     id: String,
     handleExceptions: Boolean = false,
     licenseTextDirectories: List<File> = emptyList()
-): Boolean = getLicenseTextReader(id, handleExceptions, addScanCodeLicenseTextsDir(licenseTextDirectories)) != null
+): Boolean = getLicenseTextReader(id, handleExceptions, licenseTextDirectories) != null
 
 fun getLicenseTextReader(
     id: String,
@@ -146,7 +121,7 @@ fun getLicenseTextReader(
 ): (() -> String)? {
     return if (id.startsWith(LICENSE_REF_PREFIX)) {
         getLicenseTextResource(id)?.let { { it.readText() } }
-            ?: addScanCodeLicenseTextsDir(licenseTextDirectories).asSequence().firstNotNullOfOrNull {
+            ?: licenseTextDirectories.asSequence().firstNotNullOfOrNull {
                 getLicenseTextFile(id, it)?.let { file -> { file.readText() } }
             }
     } else {
@@ -175,6 +150,3 @@ private fun getLicenseTextFile(id: String, dir: File): File? =
             dir.resolve(filename).takeIf { it.isFile }
         }
     }
-
-private fun addScanCodeLicenseTextsDir(licenseTextDirectories: List<File>): List<File> =
-    (listOfNotNull(scanCodeLicenseTextDir) + licenseTextDirectories).distinct()


### PR DESCRIPTION
Do not search license text of ScanCode by default in utils-spdx, instead adding directory of ScanCode license text in search path of `getLicenseText` when we need it.  By doing this, we can detangle between utils-spdx and ScanCode.

And this commit also can fix oss-review-toolkit/ort#5002
