### PR TITLE
detekt-rules: Pass the config to the rules

### DIFF
--- a/.detekt.yml
+++ b/.detekt.yml
@@ -76,3 +76,9 @@ style:
       kotlinx.html.*,
       kotlinx.html.dom.*
       '
+
+ORT:
+  OrtImportOrder:
+    active: true
+  OrtPackageNaming:
+    active: true

--- a/detekt-rules/src/main/kotlin/OrtImportOrder.kt
+++ b/detekt-rules/src/main/kotlin/OrtImportOrder.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.detekt
 import io.github.detekt.psi.absolutePath
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
@@ -32,7 +33,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtImportList
 
-class OrtImportOrder : Rule() {
+class OrtImportOrder(config: Config) : Rule(config) {
     private val commonTopLevelDomains = listOf("com", "org", "io")
 
     override val issue = Issue(

--- a/detekt-rules/src/main/kotlin/OrtPackageNaming.kt
+++ b/detekt-rules/src/main/kotlin/OrtPackageNaming.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.detekt
 import io.github.detekt.psi.toFilePath
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
@@ -34,7 +35,7 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
 
 private const val ORT_PACKAGE_NAMESPACE = "org.ossreviewtoolkit"
 
-class OrtPackageNaming : Rule() {
+class OrtPackageNaming(config: Config) : Rule(config) {
     private val pathPattern = Regex("""[/\\]src[/\\][^/\\]+[/\\]kotlin[/\\]""")
     private val forwardOrBackwardSlashPattern = Regex("""[/\\]""")
 

--- a/detekt-rules/src/main/kotlin/OrtRuleSet.kt
+++ b/detekt-rules/src/main/kotlin/OrtRuleSet.kt
@@ -27,5 +27,5 @@ class OrtRuleSet : RuleSetProvider {
     override val ruleSetId: String = "ORT"
 
     override fun instance(config: Config) =
-        RuleSet(ruleSetId, listOf(OrtImportOrder(), OrtPackageNaming()))
+        RuleSet(ruleSetId, listOf(OrtImportOrder(config), OrtPackageNaming(config)))
 }


### PR DESCRIPTION
If no config object is passed to a rule it is always active. If a config
object is passed the rule is inactive by default, but can be activated
in the configuration.

Pass the config to both rules to allow to enable them selectively when
reusing them in another project.