### PR TITLE
Create github action to build and upload Docker image

### DIFF
--- a/.github/workflows/build-and-upload-docker.yml
+++ b/.github/workflows/build-and-upload-docker.yml
@@ -1,0 +1,49 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches:
+      - master
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This github action builds a Docker image from the ort source, and uploads it to the github Docker container registry. This allows users to run ort by simply installing from the container registry with a one liner like:

$ docker pull ghcr.io/oss-review-toolkit/ort:master

and then running it via

$ docker run ort

Signed-off-by: Andreas Bogk <andreasdotorg@andreas.org>
