### PR TITLE
Disable Sonatype Lift's JavaScript checks

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -2,7 +2,7 @@
 
 jdk11 = true
 
-disableTools = [ "detekt" ]
+disableTools = [ "detekt", "eslint" ]
 
 ignoreFiles = """
 **/funTest/assets/


### PR DESCRIPTION
ESLint is already run as part of ORT's build and Lift is returning tens of
false-positives in pull requests see for example [1].

[1]: https://github.com/oss-review-toolkit/ort/pull/5012

