### PR TITLE
github-workflows: Enable the build-reporter-web-app job again

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,6 @@ jobs:
       with:
         arguments: --stacktrace classes -x :reporter-web-app:yarnBuild
   build-reporter-web-app:
-    if: ${{ false }}
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Try whether the caching issue from [1] has "disappeared".

[1]: https://github.com/burrunan/gradle-cache-action/issues/40

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>