### PR TITLE
reporter: Replace the Xalan TransformerFactory with Saxon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -70,6 +70,7 @@ postgresEmbeddedVersion = 1.0.0
 reflectionsVersion = 0.10.2
 retrofitVersion = 2.9.0
 retrofitKotlinxSerializationConverterVersion = 0.8.0
+saxonHeVersion = 11.1.1
 scanossVersion = 1.1.5
 semverVersion = 3.1.0
 simpleExcelVersion = 1.1
@@ -78,7 +79,6 @@ svnkitVersion = 1.10.4
 sw360ClientVersion = 13.2.0-28
 toml4jVersion = 0.7.2
 wiremockVersion = 2.32.0
-xalanVersion = 2.7.2
 xzVersion = 1.9
 
 org.gradle.caching = true

--- a/reporter/build.gradle.kts
+++ b/reporter/build.gradle.kts
@@ -32,8 +32,8 @@ val kotlinxCoroutinesVersion: String by project
 val kotlinxHtmlVersion: String by project
 val mockkVersion: String by project
 val retrofitVersion: String by project
+val saxonHeVersion: String by project
 val simpleExcelVersion: String by project
-val xalanVersion: String by project
 
 plugins {
     // Apply core plugins.
@@ -91,7 +91,7 @@ dependencies {
 
     // This is required to not depend on the version of Apache Xalan bundled with the JDK. Otherwise the formatting of
     // the HTML generated in StaticHtmlReporter is slightly different with different Java versions.
-    implementation("xalan:xalan:$xalanVersion")
+    implementation("net.sf.saxon:Saxon-HE:$saxonHeVersion")
 
     testImplementation("io.mockk:mockk:$mockkVersion")
 }

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta content="width=device-width, initial-scale=1.0" name="viewport">
-    <title>Scan Report</title>
-    <style>
+<!DOCTYPE HTML><html lang="en">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+      <meta content="width=device-width, initial-scale=1.0" name="viewport">
+      <title>Scan Report</title>
+      <style>
 body {
     background-color: #f7f7f7;
     font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial,
@@ -270,7 +270,7 @@ table.ort-excluded tr.ort-excluded td li.ort-excluded {
     }
 }
 </style>
-    <style>
+      <style>
 /* PrismJS 1.16.0
 https://prismjs.com/download.html#themes=prism&languages=yaml */
 /**
@@ -414,498 +414,476 @@ pre[class*="language-"] {
 }
 
 </style>
-  </head>
-  <body>
-    <script type="text/javascript">
+   </head>
+   <body><script type="text/javascript">
 /* PrismJS 1.16.0
 https://prismjs.com/download.html#themes=prism&languages=yaml */
 var _self="undefined"!=typeof window?window:"undefined"!=typeof WorkerGlobalScope&&self instanceof WorkerGlobalScope?self:{},Prism=function(g){var c=/\blang(?:uage)?-([\w-]+)\b/i,a=0,C={manual:g.Prism&&g.Prism.manual,disableWorkerMessageHandler:g.Prism&&g.Prism.disableWorkerMessageHandler,util:{encode:function(e){return e instanceof M?new M(e.type,C.util.encode(e.content),e.alias):Array.isArray(e)?e.map(C.util.encode):e.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/\u00a0/g," ")},type:function(e){return Object.prototype.toString.call(e).slice(8,-1)},objId:function(e){return e.__id||Object.defineProperty(e,"__id",{value:++a}),e.__id},clone:function t(e,n){var r,a,i=C.util.type(e);switch(n=n||{},i){case"Object":if(a=C.util.objId(e),n[a])return n[a];for(var l in r={},n[a]=r,e)e.hasOwnProperty(l)&&(r[l]=t(e[l],n));return r;case"Array":return a=C.util.objId(e),n[a]?n[a]:(r=[],n[a]=r,e.forEach(function(e,a){r[a]=t(e,n)}),r);default:return e}}},languages:{extend:function(e,a){var t=C.util.clone(C.languages[e]);for(var n in a)t[n]=a[n];return t},insertBefore:function(t,e,a,n){var r=(n=n||C.languages)[t],i={};for(var l in r)if(r.hasOwnProperty(l)){if(l==e)for(var o in a)a.hasOwnProperty(o)&&(i[o]=a[o]);a.hasOwnProperty(l)||(i[l]=r[l])}var s=n[t];return n[t]=i,C.languages.DFS(C.languages,function(e,a){a===s&&e!=t&&(this[e]=i)}),i},DFS:function e(a,t,n,r){r=r||{};var i=C.util.objId;for(var l in a)if(a.hasOwnProperty(l)){t.call(a,l,a[l],n||l);var o=a[l],s=C.util.type(o);"Object"!==s||r[i(o)]?"Array"!==s||r[i(o)]||(r[i(o)]=!0,e(o,t,l,r)):(r[i(o)]=!0,e(o,t,null,r))}}},plugins:{},highlightAll:function(e,a){C.highlightAllUnder(document,e,a)},highlightAllUnder:function(e,a,t){var n={callback:t,selector:'code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code'};C.hooks.run("before-highlightall",n);for(var r,i=n.elements||e.querySelectorAll(n.selector),l=0;r=i[l++];)C.highlightElement(r,!0===a,n.callback)},highlightElement:function(e,a,t){for(var n,r,i=e;i&&!c.test(i.className);)i=i.parentNode;i&&(n=(i.className.match(c)||[,""])[1].toLowerCase(),r=C.languages[n]),e.className=e.className.replace(c,"").replace(/\s+/g," ")+" language-"+n,e.parentNode&&(i=e.parentNode,/pre/i.test(i.nodeName)&&(i.className=i.className.replace(c,"").replace(/\s+/g," ")+" language-"+n));var l={element:e,language:n,grammar:r,code:e.textContent},o=function(e){l.highlightedCode=e,C.hooks.run("before-insert",l),l.element.innerHTML=l.highlightedCode,C.hooks.run("after-highlight",l),C.hooks.run("complete",l),t&&t.call(l.element)};if(C.hooks.run("before-sanity-check",l),l.code)if(C.hooks.run("before-highlight",l),l.grammar)if(a&&g.Worker){var s=new Worker(C.filename);s.onmessage=function(e){o(e.data)},s.postMessage(JSON.stringify({language:l.language,code:l.code,immediateClose:!0}))}else o(C.highlight(l.code,l.grammar,l.language));else o(C.util.encode(l.code));else C.hooks.run("complete",l)},highlight:function(e,a,t){var n={code:e,grammar:a,language:t};return C.hooks.run("before-tokenize",n),n.tokens=C.tokenize(n.code,n.grammar),C.hooks.run("after-tokenize",n),M.stringify(C.util.encode(n.tokens),n.language)},matchGrammar:function(e,a,t,n,r,i,l){for(var o in t)if(t.hasOwnProperty(o)&&t[o]){if(o==l)return;var s=t[o];s="Array"===C.util.type(s)?s:[s];for(var g=0;g<s.length;++g){var c=s[g],u=c.inside,h=!!c.lookbehind,f=!!c.greedy,d=0,m=c.alias;if(f&&!c.pattern.global){var p=c.pattern.toString().match(/[imuy]*$/)[0];c.pattern=RegExp(c.pattern.source,p+"g")}c=c.pattern||c;for(var y=n,v=r;y<a.length;v+=a[y].length,++y){var k=a[y];if(a.length>e.length)return;if(!(k instanceof M)){if(f&&y!=a.length-1){if(c.lastIndex=v,!(x=c.exec(e)))break;for(var b=x.index+(h?x[1].length:0),w=x.index+x[0].length,A=y,P=v,O=a.length;A<O&&(P<w||!a[A].type&&!a[A-1].greedy);++A)(P+=a[A].length)<=b&&(++y,v=P);if(a[y]instanceof M)continue;N=A-y,k=e.slice(v,P),x.index-=v}else{c.lastIndex=0;var x=c.exec(k),N=1}if(x){h&&(d=x[1]?x[1].length:0);w=(b=x.index+d)+(x=x[0].slice(d)).length;var j=k.slice(0,b),S=k.slice(w),E=[y,N];j&&(++y,v+=j.length,E.push(j));var _=new M(o,u?C.tokenize(x,u):x,m,x,f);if(E.push(_),S&&E.push(S),Array.prototype.splice.apply(a,E),1!=N&&C.matchGrammar(e,a,t,y,v,!0,o),i)break}else if(i)break}}}}},tokenize:function(e,a){var t=[e],n=a.rest;if(n){for(var r in n)a[r]=n[r];delete a.rest}return C.matchGrammar(e,t,a,0,0,!1),t},hooks:{all:{},add:function(e,a){var t=C.hooks.all;t[e]=t[e]||[],t[e].push(a)},run:function(e,a){var t=C.hooks.all[e];if(t&&t.length)for(var n,r=0;n=t[r++];)n(a)}},Token:M};function M(e,a,t,n,r){this.type=e,this.content=a,this.alias=t,this.length=0|(n||"").length,this.greedy=!!r}if(g.Prism=C,M.stringify=function(e,a){if("string"==typeof e)return e;if(Array.isArray(e))return e.map(function(e){return M.stringify(e,a)}).join("");var t={type:e.type,content:M.stringify(e.content,a),tag:"span",classes:["token",e.type],attributes:{},language:a};if(e.alias){var n=Array.isArray(e.alias)?e.alias:[e.alias];Array.prototype.push.apply(t.classes,n)}C.hooks.run("wrap",t);var r=Object.keys(t.attributes).map(function(e){return e+'="'+(t.attributes[e]||"").replace(/"/g,"&quot;")+'"'}).join(" ");return"<"+t.tag+' class="'+t.classes.join(" ")+'"'+(r?" "+r:"")+">"+t.content+"</"+t.tag+">"},!g.document)return g.addEventListener&&(C.disableWorkerMessageHandler||g.addEventListener("message",function(e){var a=JSON.parse(e.data),t=a.language,n=a.code,r=a.immediateClose;g.postMessage(C.highlight(n,C.languages[t],t)),r&&g.close()},!1)),C;var e=document.currentScript||[].slice.call(document.getElementsByTagName("script")).pop();return e&&(C.filename=e.src,C.manual||e.hasAttribute("data-manual")||("loading"!==document.readyState?window.requestAnimationFrame?window.requestAnimationFrame(C.highlightAll):window.setTimeout(C.highlightAll,16):document.addEventListener("DOMContentLoaded",C.highlightAll))),C}(_self);"undefined"!=typeof module&&module.exports&&(module.exports=Prism),"undefined"!=typeof global&&(global.Prism=Prism);
 Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:((?:\r?\n|\r)[ \t]+)[^\r\n]+(?:\2[^\r\n]+)*)/,lookbehind:!0,alias:"string"},comment:/#.*/,key:{pattern:/(\s*(?:^|[:\-,[{\r\n?])[ \t]*(?:![^\s]+)?[ \t]*)[^\r\n{[\]},#\s]+?(?=\s*:\s)/,lookbehind:!0,alias:"atrule"},directive:{pattern:/(^[ \t]*)%.+/m,lookbehind:!0,alias:"important"},datetime:{pattern:/([:\-,[{]\s*(?:![^\s]+)?[ \t]*)(?:\d{4}-\d\d?-\d\d?(?:[tT]|[ \t]+)\d\d?:\d{2}:\d{2}(?:\.\d*)?[ \t]*(?:Z|[-+]\d\d?(?::\d{2})?)?|\d{4}-\d{2}-\d{2}|\d\d?:\d{2}(?::\d{2}(?:\.\d*)?)?)(?=[ \t]*(?:$|,|]|}))/m,lookbehind:!0,alias:"number"},boolean:{pattern:/([:\-,[{]\s*(?:![^\s]+)?[ \t]*)(?:true|false)[ \t]*(?=$|,|]|})/im,lookbehind:!0,alias:"important"},null:{pattern:/([:\-,[{]\s*(?:![^\s]+)?[ \t]*)(?:null|~)[ \t]*(?=$|,|]|})/im,lookbehind:!0,alias:"important"},string:{pattern:/([:\-,[{]\s*(?:![^\s]+)?[ \t]*)("|')(?:(?!\2)[^\\\r\n]|\\.)*\2(?=[ \t]*(?:$|,|]|}|\s*#))/m,lookbehind:!0,greedy:!0},number:{pattern:/([:\-,[{]\s*(?:![^\s]+)?[ \t]*)[+-]?(?:0x[\da-f]+|0o[0-7]+|(?:\d+\.?\d*|\.?\d+)(?:e[+-]?\d+)?|\.inf|\.nan)[ \t]*(?=$|,|]|})/im,lookbehind:!0},tag:/![^\s]+/,important:/[&*][\w]+/,punctuation:/---|[:[\]{}\-,|>?]|\.\.\./},Prism.languages.yml=Prism.languages.yaml;
-</script>
-    <div id="report-container">
-      <div class="ort-report-label">Scan Report</div>
-      <div>Created by <strong>ORT</strong>, the <a href="https://oss-review-toolkit.org/">OSS Review Toolkit</a>, version <REPLACE_ORT_VERSION> on <REPLACE_TIMESTAMP>.</div>
-      <h2>Project</h2>
-      <div>Scanned revision master of Git repository https://github.com/oss-review-toolkit/ort.git</div>
-      <h2>Labels</h2>
-      <table class="ort-report-labels">
-        <tbody>
-          <tr>
-            <td>JOB_PARAM_1</td><td>label job param 1</td>
-          </tr>
-          <tr>
-            <td>JOB_PARAM_2</td><td>label job param 2</td>
-          </tr>
-          <tr>
-            <td>PROCESS_PARAM_1</td><td>label process param 1</td>
-          </tr>
-          <tr>
-            <td>PROCESS_PARAM_2</td><td>label process param 2</td>
-          </tr>
-          <tr>
-            <td>OTHER</td><td>label other</td>
-          </tr>
-        </tbody>
-      </table>
-      <h2>Index</h2>
-      <ul>
-        <li>
-          <a href="#rule-violation-summary">Rule Violation Summary (1 errors, 1 warnings, 0 hints to resolve)</a>
-        </li>
-        <li>
-          <a href="#issue-summary">Issue Summary (1 errors, 0 warnings, 0 hints to resolve)</a>
-        </li>
-        <li>
-          <a href="#Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0">Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0 <div class="ort-reason">Excluded: EXAMPLE_OF - The project is an example.</div>
-          </a>
-        </li>
-        <li>
-          <a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a>
-        </li>
-        <li>
-          <a href="#repository-configuration">Repository Configuration</a>
-        </li>
-      </ul>
-      <h2 id="rule-violation-summary">Rule Violation Summary (1 errors, 1 warnings, 0 hints to resolve)</h2>
-      <table class="ort-report-table ort-violations">
-        <thead>
-          <tr>
-            <th>#</th><th>Rule</th><th>Package</th><th>License</th><th>Message</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr class="ort-error" id="violation-1">
-            <td><a href="#violation-1">1</a></td><td>rule 1</td><td>Ant:junit:junit:4.12</td><td>DETECTED: EPL-1.0</td><td>
-              <p>EPL-1.0 error</p>
-              <details>
-                <summary>How to fix</summary>
-                <ul>
-
-                  <li>
-                    <em>Step 1</em>
-                  </li>
-
-                  <li>
-                    <strong>Step 2</strong>
-                  </li>
-
-                  <li>
-                    <em><strong>Step 3</strong></em>
-                  </li>
-
-                </ul>
-
-                <pre>
-                  <code>Some long text verify that overflow:scroll is working as expected.
-</code>
-                </pre>
-
-              </details>
-            </td>
-          </tr>
-          <tr class="ort-warning" id="violation-2">
-            <td><a href="#violation-2">2</a></td><td>rule 3</td><td>Maven:org.hamcrest:hamcrest-core:1.3</td><td>CONCLUDED: BSD-3-Clause</td><td>
-              <p>BSD-3-Clause warning</p>
-              <details>
-                <summary>How to fix</summary>
-                <ul>
-
-                  <li>
-                    <em>Step 1</em>
-                  </li>
-
-                  <li>
-                    <strong>Step 2</strong>
-                  </li>
-
-                  <li>
-                    <em><strong>Step 3</strong></em>
-                  </li>
-
-                </ul>
-
-                <pre>
-                  <code>Some long text verify that overflow:scroll is working as expected.
-</code>
-                </pre>
-
-              </details>
-            </td>
-          </tr>
-          <tr class="ort-resolved" id="violation-3">
-            <td><a href="#violation-3">3</a></td><td>rule 2</td><td>Maven:org.apache.commons:commons-text:1.1</td><td>DECLARED: Apache-2.0</td><td>
-              <p>Apache-2.0 hint</p>
-              <p>
-Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <h2 id="issue-summary">Issue Summary (1 errors, 0 warnings, 0 hints to resolve)</h2>
-      <p>Issues from excluded components are not shown in this summary.</p>
-      <h3>Packages</h3>
-      <table class="ort-report-table">
-        <thead>
-          <tr>
-            <th>#</th><th>Package</th><th>Analyzer Issues</th><th>Scanner Issues</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr class="ort-error" id="issue-1">
-            <td><a href="#issue-1">1</a></td><td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td><td></td><td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a>
-              <ul>
-                <li>
-                  <p>Unknown time [ERROR]: Dummy - DownloadException: No source artifact URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.<br>Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'. Please make sure the published POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom</p>
-                  <p></p>
-                </li>
-                <details>
-                  <summary>How to fix</summary>
-                  <ul>
-
-                    <li>
-                      <em>Step 1</em>
-                    </li>
-
-                    <li>
-                      <strong>Step 2</strong>
-                    </li>
-
-                    <li>
-                      <em><strong>Step 3</strong></em>
-<code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code>
-                    </li>
-
-                  </ul>
-
-                </details>
-              </ul>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <h2 id="Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0">Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0 (sub/module/project/build.gradle)</h2>
-      <h3>Project is Excluded</h3>
-      <p>The project is excluded for the following reason(s):</p>
-      <p>
-        <div class="ort-reason">EXAMPLE_OF - The project is an example.</div>
-      </p>
-      <h3 class="ort-excluded">VCS Information</h3>
-      <table class="ort-report-labels ort-excluded">
-        <tbody>
-          <tr>
-            <td>Type</td><td>Git</td>
-          </tr>
-          <tr>
-            <td>URL</td><td>https://example.com/git</td>
-          </tr>
-          <tr>
-            <td>Path</td><td>project</td>
-          </tr>
-          <tr>
-            <td>Revision</td><td>master</td>
-          </tr>
-        </tbody>
-      </table>
-      <h3 class="ort-excluded">Packages</h3>
-      <table class="ort-report-table ort-packages ort-excluded">
-        <thead>
-          <tr>
-            <th>#</th><th>Package</th><th>Scopes</th><th>Licenses</th><th>Analyzer Issues</th><th>Scanner Issues</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr class="ort-success " id="Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0-pkg-1">
-            <td><a href="#Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0-pkg-1">1</a></td><td>Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0</td><td></td><td><em>Declared Licenses:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:197ec4de65a2e5414b290fb46dee75f55e1b69e8">CC-BY-NC-3.0</a>
-                  </div>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:f288702d2fa16d3cdf0035b15a9fcbc552cd88e7">GPL-3.0-only</a> WITH <a href="https://archive.softwareheritage.org/browse/content/sha1_git:e86f7fb58a4656330ebdfab5e75d72f86f5e9af9">GCC-exception-3.1</a>
-                  </div>
-                </dd>
-              </dl>
-              <em>Detected Licenses (from <a href="https://example.com/git">VCS</a>):</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a>
-                  </div>
-                  <div class="ort-excluded">MIT (Excluded: EXAMPLE_OF - These are example files.)</div>
-                </dd>
-              </dl>
-              <em>Effective License:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a> AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:197ec4de65a2e5414b290fb46dee75f55e1b69e8">CC-BY-NC-3.0</a> AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:f288702d2fa16d3cdf0035b15a9fcbc552cd88e7">GPL-3.0-only</a> WITH <a href="https://archive.softwareheritage.org/browse/content/sha1_git:e86f7fb58a4656330ebdfab5e75d72f86f5e9af9">GCC-exception-3.1</a>
-                  </div>
-                </dd>
-              </dl>
-            </td><td>
-              <ul></ul>
-            </td><td>
-              <ul></ul>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <h2 id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0 (analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle)</h2>
-      <h3 class="">VCS Information</h3>
-      <table class="ort-report-labels ">
-        <tbody>
-          <tr>
-            <td>Type</td><td>Git</td>
-          </tr>
-          <tr>
-            <td>URL</td><td>https://github.com/oss-review-toolkit/ort.git</td>
-          </tr>
-          <tr>
-            <td>Path</td><td>analyzer/src/funTest/assets/projects/synthetic/gradle/lib</td>
-          </tr>
-          <tr>
-            <td>Revision</td><td>master</td>
-          </tr>
-        </tbody>
-      </table>
-      <h3 class="">Packages</h3>
-      <table class="ort-report-table ort-packages ">
-        <thead>
-          <tr>
-            <th>#</th><th>Package</th><th>Scopes</th><th>Licenses</th><th>Analyzer Issues</th><th>Scanner Issues</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr class="ort-error " id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-1">
-            <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-1">1</a></td><td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td><td></td><td><em>Detected Licenses (from <a href="https://github.com/oss-review-toolkit/ort.git">VCS</a>):</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:c329ef6d12d2a701a57fedeab0437884fe0d8de2">BSD-3-Clause</a> (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:d159169d1050894d3ea3b98e1c965c4058208fe1">GPL-2.0-only</a> WITH <a href="https://archive.softwareheritage.org/browse/content/sha1_git:63ae6d171e2da985784f3e0ac865491fa093521d">Classpath-exception-2.0</a> (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
-                  <div>LicenseRef-test-Apache-2.0-multi-line (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle#L19-L20">link</a> to the location)</div>
-                  <div>LicenseRef-test-Apache-2.0-single-line (exemplary <a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle#L19">link</a> to the first of 2 locations)</div>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a> (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
-                </dd>
-              </dl>
-              <em>Effective License:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:c329ef6d12d2a701a57fedeab0437884fe0d8de2">BSD-3-Clause</a> AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:d159169d1050894d3ea3b98e1c965c4058208fe1">GPL-2.0-only</a> WITH <a href="https://archive.softwareheritage.org/browse/content/sha1_git:63ae6d171e2da985784f3e0ac865491fa093521d">Classpath-exception-2.0</a> AND LicenseRef-test-Apache-2.0-multi-line AND LicenseRef-test-Apache-2.0-single-line OR LicenseRef-test-Apache-2.0-multi-line AND LicenseRef-test-Apache-2.0-single-line AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a>
-                  </div>
-                </dd>
-              </dl>
-            </td><td>
-              <ul></ul>
-            </td><td>
-              <ul>
-                <li>
-                  <p>Unknown time [ERROR]: Dummy - DownloadException: No source artifact URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.<br>Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'. Please make sure the published POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom</p>
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr class="ort-success ort-excluded" id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-2">
-            <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-2">2</a></td><td>Ant:junit:junit:4.12</td><td>
-              <ul>
-                <li class="ort-excluded">testCompile <div class="ort-reason">Excluded: TEST_DEPENDENCY_OF - The scope only contains test dependencies.</div>
-                </li>
-              </ul>
-            </td><td><em>Declared Licenses:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:2aa9b989e0fec475baf21544f8613cb53d03c3f7">EPL-1.0</a>
-                  </div>
-                </dd>
-              </dl>
-              <em>Effective License:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:2aa9b989e0fec475baf21544f8613cb53d03c3f7">EPL-1.0</a>
-                  </div>
-                </dd>
-              </dl>
-            </td><td>
-              <ul></ul>
-            </td><td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr class="ort-success ort-excluded" id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-3">
-            <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-3">3</a></td><td>Maven:com.foobar:foobar:1.0</td><td>
-              <ul>
-                <li class="ort-excluded">testCompile <div class="ort-reason">Excluded: TEST_DEPENDENCY_OF - The scope only contains test dependencies.</div>
-                </li>
-              </ul>
-            </td><td><em>Concluded License:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:d159169d1050894d3ea3b98e1c965c4058208fe1">GPL-2.0-only</a> OR <a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a>
-                  </div>
-                </dd>
-              </dl>
-              <em>Declared Licenses:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:d159169d1050894d3ea3b98e1c965c4058208fe1">GPL-2.0-only</a>
-                  </div>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a>
-                  </div>
-                </dd>
-              </dl>
-              <em>Effective License:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a>
-                  </div>
-                </dd>
-              </dl>
-            </td><td>
-              <ul></ul>
-            </td><td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr class="ort-success ort-excluded" id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-4">
-            <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-4">4</a></td><td>Maven:com.h2database:h2:1.4.200</td><td>
-              <ul>
-                <li class="ort-excluded">testCompile <div class="ort-reason">Excluded: TEST_DEPENDENCY_OF - The scope only contains test dependencies.</div>
-                </li>
-              </ul>
-            </td><td><em>Concluded License:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:a612ad9813b006ce81d1ee438dd784da99a54007">MPL-2.0</a> OR <a href="https://archive.softwareheritage.org/browse/content/sha1_git:2aa9b989e0fec475baf21544f8613cb53d03c3f7">EPL-1.0</a>
-                  </div>
-                </dd>
-              </dl>
-              <em>Declared Licenses:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:2aa9b989e0fec475baf21544f8613cb53d03c3f7">EPL-1.0</a>
-                  </div>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:a612ad9813b006ce81d1ee438dd784da99a54007">MPL-2.0</a>
-                  </div>
-                </dd>
-              </dl>
-              <em>Effective License:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:a612ad9813b006ce81d1ee438dd784da99a54007">MPL-2.0</a>
-                  </div>
-                </dd>
-              </dl>
-            </td><td>
-              <ul></ul>
-            </td><td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr class="ort-success " id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-5">
-            <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-5">5</a></td><td>Maven:org.apache.commons:commons-lang3:3.5</td><td>
-              <ul>
-                <li class="">compile</li>
-                <li class="ort-excluded">testCompile <div class="ort-reason">Excluded: TEST_DEPENDENCY_OF - The scope only contains test dependencies.</div>
-                </li>
-              </ul>
-            </td><td><em>Declared Licenses:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a>
-                  </div>
-                </dd>
-              </dl>
-              <em>Effective License:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a>
-                  </div>
-                </dd>
-              </dl>
-            </td><td>
-              <ul></ul>
-            </td><td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr class="ort-success " id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-6">
-            <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-6">6</a></td><td>Maven:org.apache.commons:commons-text:1.1</td><td>
-              <ul>
-                <li class="">compile</li>
-                <li class="ort-excluded">testCompile <div class="ort-reason">Excluded: TEST_DEPENDENCY_OF - The scope only contains test dependencies.</div>
-                </li>
-              </ul>
-            </td><td><em>Declared Licenses:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a>
-                  </div>
-                </dd>
-              </dl>
-              <em>Effective License:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a>
-                  </div>
-                </dd>
-              </dl>
-            </td><td>
-              <ul></ul>
-            </td><td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr class="ort-success ort-excluded" id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-7">
-            <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-7">7</a></td><td>Maven:org.hamcrest:hamcrest-core:1.3</td><td>
-              <ul>
-                <li class="ort-excluded">testCompile <div class="ort-reason">Excluded: TEST_DEPENDENCY_OF - The scope only contains test dependencies.</div>
-                </li>
-              </ul>
-            </td><td><em>Declared Licenses:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:c329ef6d12d2a701a57fedeab0437884fe0d8de2">BSD-3-Clause</a>
-                  </div>
-                </dd>
-              </dl>
-              <em>Effective License:</em>
-              <dl>
-                <dd>
-                  <div>
-                    <a href="https://archive.softwareheritage.org/browse/content/sha1_git:c329ef6d12d2a701a57fedeab0437884fe0d8de2">BSD-3-Clause</a>
-                  </div>
-                </dd>
-              </dl>
-            </td><td>
-              <ul></ul>
-            </td><td>
-              <ul></ul>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <h2 id="repository-configuration">Repository Configuration</h2>
-      <pre>
-        <code class="language-yaml">
+</script><div id="report-container">
+         <div class="ort-report-label">Scan Report</div>
+         <div>Created by <strong>ORT</strong>, the <a href="https://oss-review-toolkit.org/">OSS Review Toolkit</a>, version <REPLACE_ORT_VERSION> on <REPLACE_TIMESTAMP>.</div>
+         <h2>Project</h2>
+         <div>Scanned revision master of Git repository https://github.com/oss-review-toolkit/ort.git</div>
+         <h2>Labels</h2>
+         <table class="ort-report-labels">
+            <tbody>
+               <tr>
+                  <td>JOB_PARAM_1</td>
+                  <td>label job param 1</td>
+               </tr>
+               <tr>
+                  <td>JOB_PARAM_2</td>
+                  <td>label job param 2</td>
+               </tr>
+               <tr>
+                  <td>PROCESS_PARAM_1</td>
+                  <td>label process param 1</td>
+               </tr>
+               <tr>
+                  <td>PROCESS_PARAM_2</td>
+                  <td>label process param 2</td>
+               </tr>
+               <tr>
+                  <td>OTHER</td>
+                  <td>label other</td>
+               </tr>
+            </tbody>
+         </table>
+         <h2>Index</h2>
+         <ul>
+            <li><a href="#rule-violation-summary">Rule Violation Summary (1 errors, 1 warnings, 0 hints to resolve)</a></li>
+            <li><a href="#issue-summary">Issue Summary (1 errors, 0 warnings, 0 hints to resolve)</a></li>
+            <li><a href="#Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0">Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0 
+                  <div class="ort-reason">Excluded: EXAMPLE_OF - The project is an example.</div></a></li>
+            <li><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a></li>
+            <li><a href="#repository-configuration">Repository Configuration</a></li>
+         </ul>
+         <h2 id="rule-violation-summary">Rule Violation Summary (1 errors, 1 warnings, 0 hints to resolve)</h2>
+         <table class="ort-report-table ort-violations">
+            <thead>
+               <tr>
+                  <th>#</th>
+                  <th>Rule</th>
+                  <th>Package</th>
+                  <th>License</th>
+                  <th>Message</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr class="ort-error" id="violation-1">
+                  <td><a href="#violation-1">1</a></td>
+                  <td>rule 1</td>
+                  <td>Ant:junit:junit:4.12</td>
+                  <td>DETECTED: EPL-1.0</td>
+                  <td>
+                     <p>EPL-1.0 error</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em></li>
+                           </ul>
+                        
+                        <pre><code>Some long text verify that overflow:scroll is working as expected.
+</code></pre>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-warning" id="violation-2">
+                  <td><a href="#violation-2">2</a></td>
+                  <td>rule 3</td>
+                  <td>Maven:org.hamcrest:hamcrest-core:1.3</td>
+                  <td>CONCLUDED: BSD-3-Clause</td>
+                  <td>
+                     <p>BSD-3-Clause warning</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em></li>
+                           </ul>
+                        
+                        <pre><code>Some long text verify that overflow:scroll is working as expected.
+</code></pre>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-resolved" id="violation-3">
+                  <td><a href="#violation-3">3</a></td>
+                  <td>rule 2</td>
+                  <td>Maven:org.apache.commons:commons-text:1.1</td>
+                  <td>DECLARED: Apache-2.0</td>
+                  <td>
+                     <p>Apache-2.0 hint</p>
+                     <p>
+                        Resolved by: CANT_FIX_EXCEPTION - Apache-2 is not an issue.</p>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
+         <h2 id="issue-summary">Issue Summary (1 errors, 0 warnings, 0 hints to resolve)</h2>
+         <p>Issues from excluded components are not shown in this summary.</p>
+         <h3>Packages</h3>
+         <table class="ort-report-table">
+            <thead>
+               <tr>
+                  <th>#</th>
+                  <th>Package</th>
+                  <th>Analyzer Issues</th>
+                  <th>Scanner Issues</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr class="ort-error" id="issue-1">
+                  <td><a href="#issue-1">1</a></td>
+                  <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
+                  <td></td>
+                  <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a><ul>
+                        <li>
+                           <p>Unknown time [ERROR]: Dummy - DownloadException: No source artifact URL provided for
+                              'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.<br>Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.
+                              Please make sure the published POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom</p>
+                           <p></p>
+                        </li>
+                        <details>
+                           <summary>How to fix</summary>
+                           <ul>
+                              
+                              <li><em>Step 1</em></li>
+                              
+                              <li><strong>Step 2</strong></li>
+                              
+                              <li><em><strong>Step 3</strong></em>
+                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                              </ul>
+                           </details>
+                     </ul>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
+         <h2 id="Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0">Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0 (sub/module/project/build.gradle)</h2>
+         <h3>Project is Excluded</h3>
+         <p>The project is excluded for the following reason(s):</p>
+         <p>
+            <div class="ort-reason">EXAMPLE_OF - The project is an example.</div>
+         </p>
+         <h3 class="ort-excluded">VCS Information</h3>
+         <table class="ort-report-labels ort-excluded">
+            <tbody>
+               <tr>
+                  <td>Type</td>
+                  <td>Git</td>
+               </tr>
+               <tr>
+                  <td>URL</td>
+                  <td>https://example.com/git</td>
+               </tr>
+               <tr>
+                  <td>Path</td>
+                  <td>project</td>
+               </tr>
+               <tr>
+                  <td>Revision</td>
+                  <td>master</td>
+               </tr>
+            </tbody>
+         </table>
+         <h3 class="ort-excluded">Packages</h3>
+         <table class="ort-report-table ort-packages ort-excluded">
+            <thead>
+               <tr>
+                  <th>#</th>
+                  <th>Package</th>
+                  <th>Scopes</th>
+                  <th>Licenses</th>
+                  <th>Analyzer Issues</th>
+                  <th>Scanner Issues</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr class="ort-success " id="Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0-pkg-1">
+                  <td><a href="#Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0-pkg-1">1</a></td>
+                  <td>Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0</td>
+                  <td></td>
+                  <td><em>Declared Licenses:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:197ec4de65a2e5414b290fb46dee75f55e1b69e8">CC-BY-NC-3.0</a></div>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:f288702d2fa16d3cdf0035b15a9fcbc552cd88e7">GPL-3.0-only</a> WITH <a href="https://archive.softwareheritage.org/browse/content/sha1_git:e86f7fb58a4656330ebdfab5e75d72f86f5e9af9">GCC-exception-3.1</a></div>
+                        </dd>
+                     </dl><em>Detected Licenses (from <a href="https://example.com/git">VCS</a>):</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a></div>
+                           <div class="ort-excluded">MIT (Excluded: EXAMPLE_OF - These are example files.)</div>
+                        </dd>
+                     </dl><em>Effective License:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a> AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:197ec4de65a2e5414b290fb46dee75f55e1b69e8">CC-BY-NC-3.0</a> AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:f288702d2fa16d3cdf0035b15a9fcbc552cd88e7">GPL-3.0-only</a> WITH <a href="https://archive.softwareheritage.org/browse/content/sha1_git:e86f7fb58a4656330ebdfab5e75d72f86f5e9af9">GCC-exception-3.1</a></div>
+                        </dd>
+                     </dl>
+                  </td>
+                  <td>
+                     <ul></ul>
+                  </td>
+                  <td>
+                     <ul></ul>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
+         <h2 id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0 (analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle)</h2>
+         <h3 class="">VCS Information</h3>
+         <table class="ort-report-labels ">
+            <tbody>
+               <tr>
+                  <td>Type</td>
+                  <td>Git</td>
+               </tr>
+               <tr>
+                  <td>URL</td>
+                  <td>https://github.com/oss-review-toolkit/ort.git</td>
+               </tr>
+               <tr>
+                  <td>Path</td>
+                  <td>analyzer/src/funTest/assets/projects/synthetic/gradle/lib</td>
+               </tr>
+               <tr>
+                  <td>Revision</td>
+                  <td>master</td>
+               </tr>
+            </tbody>
+         </table>
+         <h3 class="">Packages</h3>
+         <table class="ort-report-table ort-packages ">
+            <thead>
+               <tr>
+                  <th>#</th>
+                  <th>Package</th>
+                  <th>Scopes</th>
+                  <th>Licenses</th>
+                  <th>Analyzer Issues</th>
+                  <th>Scanner Issues</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr class="ort-error " id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-1">
+                  <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-1">1</a></td>
+                  <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
+                  <td></td>
+                  <td><em>Detected Licenses (from <a href="https://github.com/oss-review-toolkit/ort.git">VCS</a>):</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:c329ef6d12d2a701a57fedeab0437884fe0d8de2">BSD-3-Clause</a> (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:d159169d1050894d3ea3b98e1c965c4058208fe1">GPL-2.0-only</a> WITH <a href="https://archive.softwareheritage.org/browse/content/sha1_git:63ae6d171e2da985784f3e0ac865491fa093521d">Classpath-exception-2.0</a> (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
+                           <div>LicenseRef-test-Apache-2.0-multi-line (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle#L19-L20">link</a> to the location)</div>
+                           <div>LicenseRef-test-Apache-2.0-single-line (exemplary <a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle#L19">link</a> to the first of 2 locations)</div>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a> (<a href="https://github.com/oss-review-toolkit/ort/tree/master/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp#L1">link</a> to the location)</div>
+                        </dd>
+                     </dl><em>Effective License:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:c329ef6d12d2a701a57fedeab0437884fe0d8de2">BSD-3-Clause</a> AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:d159169d1050894d3ea3b98e1c965c4058208fe1">GPL-2.0-only</a> WITH <a href="https://archive.softwareheritage.org/browse/content/sha1_git:63ae6d171e2da985784f3e0ac865491fa093521d">Classpath-exception-2.0</a> AND LicenseRef-test-Apache-2.0-multi-line AND LicenseRef-test-Apache-2.0-single-line OR LicenseRef-test-Apache-2.0-multi-line AND LicenseRef-test-Apache-2.0-single-line AND <a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a></div>
+                        </dd>
+                     </dl>
+                  </td>
+                  <td>
+                     <ul></ul>
+                  </td>
+                  <td>
+                     <ul>
+                        <li>
+                           <p>Unknown time [ERROR]: Dummy - DownloadException: No source artifact URL provided for
+                              'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.<br>Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.
+                              Please make sure the published POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom</p>
+                        </li>
+                     </ul>
+                  </td>
+               </tr>
+               <tr class="ort-success ort-excluded" id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-2">
+                  <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-2">2</a></td>
+                  <td>Ant:junit:junit:4.12</td>
+                  <td>
+                     <ul>
+                        <li class="ort-excluded">testCompile 
+                           <div class="ort-reason">Excluded: TEST_DEPENDENCY_OF - The scope only contains test dependencies.</div>
+                        </li>
+                     </ul>
+                  </td>
+                  <td><em>Declared Licenses:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:2aa9b989e0fec475baf21544f8613cb53d03c3f7">EPL-1.0</a></div>
+                        </dd>
+                     </dl><em>Effective License:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:2aa9b989e0fec475baf21544f8613cb53d03c3f7">EPL-1.0</a></div>
+                        </dd>
+                     </dl>
+                  </td>
+                  <td>
+                     <ul></ul>
+                  </td>
+                  <td>
+                     <ul></ul>
+                  </td>
+               </tr>
+               <tr class="ort-success ort-excluded" id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-3">
+                  <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-3">3</a></td>
+                  <td>Maven:com.foobar:foobar:1.0</td>
+                  <td>
+                     <ul>
+                        <li class="ort-excluded">testCompile 
+                           <div class="ort-reason">Excluded: TEST_DEPENDENCY_OF - The scope only contains test dependencies.</div>
+                        </li>
+                     </ul>
+                  </td>
+                  <td><em>Concluded License:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:d159169d1050894d3ea3b98e1c965c4058208fe1">GPL-2.0-only</a> OR <a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a></div>
+                        </dd>
+                     </dl><em>Declared Licenses:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:d159169d1050894d3ea3b98e1c965c4058208fe1">GPL-2.0-only</a></div>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a></div>
+                        </dd>
+                     </dl><em>Effective License:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:1bf98523e33170372cf0702f03e38dadec3c5094">MIT</a></div>
+                        </dd>
+                     </dl>
+                  </td>
+                  <td>
+                     <ul></ul>
+                  </td>
+                  <td>
+                     <ul></ul>
+                  </td>
+               </tr>
+               <tr class="ort-success ort-excluded" id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-4">
+                  <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-4">4</a></td>
+                  <td>Maven:com.h2database:h2:1.4.200</td>
+                  <td>
+                     <ul>
+                        <li class="ort-excluded">testCompile 
+                           <div class="ort-reason">Excluded: TEST_DEPENDENCY_OF - The scope only contains test dependencies.</div>
+                        </li>
+                     </ul>
+                  </td>
+                  <td><em>Concluded License:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:a612ad9813b006ce81d1ee438dd784da99a54007">MPL-2.0</a> OR <a href="https://archive.softwareheritage.org/browse/content/sha1_git:2aa9b989e0fec475baf21544f8613cb53d03c3f7">EPL-1.0</a></div>
+                        </dd>
+                     </dl><em>Declared Licenses:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:2aa9b989e0fec475baf21544f8613cb53d03c3f7">EPL-1.0</a></div>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:a612ad9813b006ce81d1ee438dd784da99a54007">MPL-2.0</a></div>
+                        </dd>
+                     </dl><em>Effective License:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:a612ad9813b006ce81d1ee438dd784da99a54007">MPL-2.0</a></div>
+                        </dd>
+                     </dl>
+                  </td>
+                  <td>
+                     <ul></ul>
+                  </td>
+                  <td>
+                     <ul></ul>
+                  </td>
+               </tr>
+               <tr class="ort-success " id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-5">
+                  <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-5">5</a></td>
+                  <td>Maven:org.apache.commons:commons-lang3:3.5</td>
+                  <td>
+                     <ul>
+                        <li class="">compile</li>
+                        <li class="ort-excluded">testCompile 
+                           <div class="ort-reason">Excluded: TEST_DEPENDENCY_OF - The scope only contains test dependencies.</div>
+                        </li>
+                     </ul>
+                  </td>
+                  <td><em>Declared Licenses:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a></div>
+                        </dd>
+                     </dl><em>Effective License:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a></div>
+                        </dd>
+                     </dl>
+                  </td>
+                  <td>
+                     <ul></ul>
+                  </td>
+                  <td>
+                     <ul></ul>
+                  </td>
+               </tr>
+               <tr class="ort-success " id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-6">
+                  <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-6">6</a></td>
+                  <td>Maven:org.apache.commons:commons-text:1.1</td>
+                  <td>
+                     <ul>
+                        <li class="">compile</li>
+                        <li class="ort-excluded">testCompile 
+                           <div class="ort-reason">Excluded: TEST_DEPENDENCY_OF - The scope only contains test dependencies.</div>
+                        </li>
+                     </ul>
+                  </td>
+                  <td><em>Declared Licenses:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a></div>
+                        </dd>
+                     </dl><em>Effective License:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64">Apache-2.0</a></div>
+                        </dd>
+                     </dl>
+                  </td>
+                  <td>
+                     <ul></ul>
+                  </td>
+                  <td>
+                     <ul></ul>
+                  </td>
+               </tr>
+               <tr class="ort-success ort-excluded" id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-7">
+                  <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-7">7</a></td>
+                  <td>Maven:org.hamcrest:hamcrest-core:1.3</td>
+                  <td>
+                     <ul>
+                        <li class="ort-excluded">testCompile 
+                           <div class="ort-reason">Excluded: TEST_DEPENDENCY_OF - The scope only contains test dependencies.</div>
+                        </li>
+                     </ul>
+                  </td>
+                  <td><em>Declared Licenses:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:c329ef6d12d2a701a57fedeab0437884fe0d8de2">BSD-3-Clause</a></div>
+                        </dd>
+                     </dl><em>Effective License:</em><dl>
+                        <dd>
+                           <div><a href="https://archive.softwareheritage.org/browse/content/sha1_git:c329ef6d12d2a701a57fedeab0437884fe0d8de2">BSD-3-Clause</a></div>
+                        </dd>
+                     </dl>
+                  </td>
+                  <td>
+                     <ul></ul>
+                  </td>
+                  <td>
+                     <ul></ul>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
+         <h2 id="repository-configuration">Repository Configuration</h2>
+         <pre><code class="language-yaml">
 ---
 excludes:
   paths:
@@ -933,8 +911,7 @@ license_choices:
     license_choices:
     - given: "MPL-2.0 OR EPL-1.0"
       choice: "MPL-2.0"
-</code>
-      </pre>
-    </div>
-  </body>
+</code></pre>
+      </div>
+   </body>
 </html>

--- a/reporter/src/funTest/kotlin/reporters/StaticHtmlReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/StaticHtmlReporterFunTest.kt
@@ -48,10 +48,10 @@ private val HOW_TO_FIX_TEXT_PROVIDER = HowToFixTextProvider {
 
 class StaticHtmlReporterFunTest : WordSpec({
     "StaticHtmlReporter" should {
-        "use the Apache Xalan TransformerFactory" {
+        "use the Saxon TransformerFactory" {
             val transformer = TransformerFactory.newInstance().newTransformer()
 
-            transformer.javaClass.name shouldBe "org.apache.xalan.transformer.TransformerIdentityImpl"
+            transformer.javaClass.name shouldBe "net.sf.saxon.jaxp.IdentityTransformer"
         }
 
         "successfully export to a static HTML page" {


### PR DESCRIPTION
The latest Apache Xalan 2.7.2 is 8 years old and does not support the
`accessExternalDTD` attribute that Apache POI requires, so switch to
the actively maintained Saxon TransformerFactory instead. Fixes #4830.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>