### PR TITLE
spdx-utils: Ignore the '+' operator for SPDX license texts

### DIFF
--- a/utils/spdx/src/main/kotlin/Utils.kt
+++ b/utils/spdx/src/main/kotlin/Utils.kt
@@ -150,7 +150,7 @@ fun getLicenseTextReader(
                 getLicenseTextFile(id, it)?.let { file -> { file.readText() } }
             }
     } else {
-        SpdxLicense.forId(id)?.let { { it.text } }
+        SpdxLicense.forId(id.removeSuffix("+"))?.let { { it.text } }
             ?: SpdxLicenseException.forId(id)?.takeIf { handleExceptions }?.let { { it.text } }
     }
 }

--- a/utils/spdx/src/test/kotlin/UtilsTest.kt
+++ b/utils/spdx/src/test/kotlin/UtilsTest.kt
@@ -142,6 +142,13 @@ class UtilsTest : WordSpec() {
                 text should endWith("limitations under the License.")
             }
 
+            "return the full license text for a valid SPDX license id with the '+' operator" {
+                val text = getLicenseText("Apache-2.0+")?.trim()
+
+                text should startWith("Apache License")
+                text should endWith("limitations under the License.")
+            }
+
             "return null for an invalid SPDX license id" {
                 getLicenseText("FooBar-1.0") should beNull()
             }


### PR DESCRIPTION
Ignore the '+' operator when getting the license text of an SPDX license.
For example, for the id 'Apache-2.0+' return the license text for
'Apache-2.0'. This is valid, because in the example 'Apache-2.0' is a
valid license for the expression.

Choosing a later version of the license should be implemented as an
extension of the license choice feature.

Fixes #5004.