### PR TITLE
Remove the pull-request template in favor of a shared one

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,0 @@
-Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/ort/blob/master/CONTRIBUTING.md). Thank you!


### PR DESCRIPTION
See [1].

[1]: https://github.com/oss-review-toolkit/.github/pull/1

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>