### PR TITLE
declared-license-mapping: Add "Go License"

### DIFF
--- a/utils/spdx/src/main/resources/declared-license-mapping.yml
+++ b/utils/spdx/src/main/resources/declared-license-mapping.yml
@@ -405,6 +405,7 @@
 "The GNU Lesser General Public License, Version 2.1": LGPL-2.1-only
 "The GNU Lesser General Public License, Version 3.0": LGPL-3.0-only
 "The Go license": BSD-3-Clause
+"The Go License": BSD-3-Clause
 "The JSON License": JSON
 "The MIT License (MIT)": MIT
 "The MIT License": MIT


### PR DESCRIPTION
Found in [1].

[1]: https://repo.maven.apache.org/maven2/com/google/re2j/re2j/1.3/re2j-1.3.pom

Signed-off-by: Shruti Dadoo <shruti.dadoo@here.com>

