### PR TITLE
helper-cli: Add a command to download results from Postgres

### DIFF
--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -23,6 +23,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import java.nio.charset.Charset
 
 val cliktVersion: String by project
+val commonsCompressVersion: String by project
 val exposedVersion: String by project
 val hikariVersion: String by project
 val jsltVersion: String by project
@@ -92,6 +93,7 @@ dependencies {
     implementation("com.github.ajalt.clikt:clikt:$cliktVersion")
     implementation("com.schibsted.spt.data:jslt:$jsltVersion")
     implementation("com.zaxxer:HikariCP:$hikariVersion")
+    implementation("org.apache.commons:commons-compress:$commonsCompressVersion")
     implementation("org.apache.logging.log4j:log4j-core:$log4jCoreVersion")
     implementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jCoreVersion")
     implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")

--- a/helper-cli/src/main/kotlin/HelperMain.kt
+++ b/helper-cli/src/main/kotlin/HelperMain.kt
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.core.config.Configurator
 
 import org.ossreviewtoolkit.helper.commands.CreateAnalyzerResultCommand
+import org.ossreviewtoolkit.helper.commands.DownloadResultsFromPostgresCommand
 import org.ossreviewtoolkit.helper.commands.ExtractRepositoryConfigurationCommand
 import org.ossreviewtoolkit.helper.commands.GenerateTimeoutErrorResolutionsCommand
 import org.ossreviewtoolkit.helper.commands.GetPackageLicensesCommand
@@ -80,6 +81,7 @@ internal class HelperMain : CliktCommand(name = ORTH_NAME, epilog = "* denotes r
             ExtractRepositoryConfigurationCommand(),
             GenerateTimeoutErrorResolutionsCommand(),
             GetPackageLicensesCommand(),
+            DownloadResultsFromPostgresCommand(),
             ImportCopyrightGarbageCommand(),
             ImportScanResultsCommand(),
             ListCopyrightsCommand(),

--- a/helper-cli/src/main/kotlin/commands/CreateAnalyzerResultCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/CreateAnalyzerResultCommand.kt
@@ -139,7 +139,7 @@ private fun getScannedPackages(
             scan_results s 
         WHERE
             $whereClause;
-        """.trimMargin()
+    """.trimIndent()
 
     val resultSet = connection.prepareStatement(query).apply {
         val array = connection.createArrayOf("VARCHAR", ids.distinct().map { it.toCoordinates() }.toTypedArray())

--- a/helper-cli/src/main/kotlin/commands/DownloadResultsFromPostgresCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/DownloadResultsFromPostgresCommand.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.associate
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.file
+
+import java.io.File
+import java.sql.Connection
+
+import kotlin.time.measureTime
+
+import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream
+
+import org.ossreviewtoolkit.helper.common.ORTH_NAME
+import org.ossreviewtoolkit.model.HashAlgorithm
+import org.ossreviewtoolkit.model.config.OrtConfiguration
+import org.ossreviewtoolkit.model.config.PostgresStorageConfiguration
+import org.ossreviewtoolkit.model.utils.DatabaseUtils
+import org.ossreviewtoolkit.utils.common.expandTilde
+import org.ossreviewtoolkit.utils.core.ORT_CONFIG_FILENAME
+import org.ossreviewtoolkit.utils.core.ortConfigDirectory
+
+class DownloadResultsFromPostgresCommand : CliktCommand(
+    name = "download-results-from-postgres",
+    help = "Download an ORT result from a PostgreSQL database. The symmetric command to ORT's " +
+            " upload-result-to-postgres command."
+) {
+    private val outputDir by option(
+        "--output-dir", "-o",
+        help = "The directory to write the ORT results to."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = false, canBeDir = true, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+        .required()
+
+    private val tableName by option(
+        "--table-name",
+        help = "The name of the table which holds the ORT results."
+    ).required()
+
+    private val columnName by option(
+        "--column-name",
+        help = "The name of the JSONB column containing the ORT result."
+    ).required()
+
+    private val configFile by option(
+        "--config",
+        help = "The path to the ORT configuration file that configures the scan results storage."
+    ).convert { it.expandTilde() }
+        .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)
+        .convert { it.absoluteFile.normalize() }
+        .default(ortConfigDirectory.resolve(ORT_CONFIG_FILENAME))
+
+    private val configArguments by option(
+        "-P",
+        help = "Override a key-value pair in the configuration file. For example: " +
+                "-P ort.scanner.storages.postgres.schema=testSchema"
+    ).associate()
+
+    private val startId by option(
+        "--start-id",
+        help = "The smallest row-id to download."
+    ).convert { it.toInt() }
+        .default(-1)
+
+    override fun run() {
+        if (!outputDir.exists()) outputDir.mkdirs()
+
+        val localStorage = OrtResultStorage(outputDir)
+        val localRowIds = localStorage.getIds()
+
+        openDatabaseConnection().use { connection ->
+            val remoteRowIds = fetchRowIds(connection)
+            val missingRowIds = remoteRowIds - localRowIds
+            println("Requested the download of ${remoteRowIds.size} results of which ${missingRowIds.size} " +
+                    "are missing.")
+
+            missingRowIds.forEachIndexed { i, rowId ->
+                println("[${i + 1} / ${missingRowIds.size}] downloading row $rowId")
+
+                val duration = measureTime {
+                    val ortResultJson = fetchOrtResult(connection, rowId)
+
+                    if (ortResultJson != null) localStorage.add(rowId, ortResultJson)
+                }
+
+                println("[${i + 1} / ${missingRowIds.size}] took $duration.")
+            }
+        }
+    }
+
+    private fun fetchOrtResult(connection: Connection, rowId: Int): String? {
+        // TODO: The transmission is relatively slow currently due to lack of compression. Check whether
+        // the gzip extension can help speed this up https://github.com/pramsey/pgsql-gzip.
+
+        val query = "SELECT t.$columnName::TEXT AS result FROM $tableName t WHERE id = ?;"
+
+        val resultSet = connection.prepareStatement(query).apply { setInt(1, rowId) }.executeQuery()
+
+        return if (resultSet.next()) {
+            resultSet.getString("result")
+        } else {
+            null
+        }
+    }
+
+    private fun fetchRowIds(connection: Connection): Set<Int> {
+        val query = "SELECT t.id FROM $tableName t WHERE id >= ?;"
+
+        val resultSet = connection.prepareStatement(query).apply {
+            setInt(1, startId)
+        }.executeQuery()
+
+        val result = mutableSetOf<Int>()
+
+        while (resultSet.next()) {
+            result += resultSet.getInt("id")
+        }
+
+        return result
+    }
+
+    private fun openDatabaseConnection(): Connection {
+        val storageConfig = OrtConfiguration.load(configArguments, configFile).scanner.storages?.values
+            ?.filterIsInstance<PostgresStorageConfiguration>()?.firstOrNull()
+            ?: throw IllegalArgumentException("postgresStorage not configured.")
+
+        return DatabaseUtils.createHikariDataSource(
+            config = storageConfig,
+            applicationNameSuffix = ORTH_NAME,
+            maxPoolSize = 1
+        ).connection
+    }
+}
+
+private class OrtResultStorage(private val storageDir: File) {
+    fun getIds(): Set<Int> {
+        val ids = storageDir.listFiles { file, _ -> file.isDirectory }.mapNotNull { file -> file.name.toIntOrNull() }
+
+        return ids.filterTo(mutableSetOf()) { hasFile(it) }
+    }
+
+    fun add(id: Int, ortResultJson: String) {
+        val ortResultFile = ortResultFile(id)
+        ortResultFile.parentFile.mkdirs()
+
+        XZCompressorOutputStream(ortResultFile.outputStream()).use {
+            ortResultJson.byteInputStream().copyTo(it)
+        }
+
+        val hash = HashAlgorithm.MD5.calculate(ortResultFile)
+        md5sumFile(id).writeText(hash)
+    }
+
+    private fun hasFile(id: Int): Boolean {
+        val md5sumFile = md5sumFile(id)
+        val ortResultFile = ortResultFile(id)
+
+        return md5sumFile.isFile && ortResultFile.isFile &&
+                HashAlgorithm.MD5.calculate(ortResultFile) == md5sumFile.readText()
+    }
+
+    private fun ortResultFile(id: Int): File = storageDir.resolve("$id/ort-result.json.xz")
+
+    private fun md5sumFile(id: Int): File = storageDir.resolve("$id/ort-result.json.xz.md5")
+}


### PR DESCRIPTION
The `cli` module provides the UploadResultToPostgresCommand. Add a
command to retrieve the previously uploaded commands. This can be useful
to synchronize a local directory with the database incrementally, in
order to play around with the latest data on the local machine.

Use md5sums to detect broken files, so that the download is gracefully
resumed after a hard exit or a connectivity issue. The need for md5sums
prevented the re-use of the LocalFileStorage class.
