### PR TITLE
DrupalIntegrationFunTest: Remove an empty `composer.json` from expected results

### DIFF
--- a/analyzer/src/funTest/kotlin/integration/DrupalIntegrationFunTest.kt
+++ b/analyzer/src/funTest/kotlin/integration/DrupalIntegrationFunTest.kt
@@ -52,7 +52,6 @@ class DrupalIntegrationFunTest : AbstractIntegrationSpec() {
     override val expectedManagedFiles by lazy {
         mapOf(
             Composer.Factory() as PackageManagerFactory to listOf(
-                outputDir.resolve("core/modules/system/tests/fixtures/HtaccessTest/composer.json"),
                 outputDir.resolve("core/lib/Drupal/Component/Uuid/composer.json"),
                 outputDir.resolve("core/lib/Drupal/Component/Utility/composer.json"),
                 outputDir.resolve("core/lib/Drupal/Component/Transliteration/composer.json"),


### PR DESCRIPTION
See [1]. Since https://github.com/oss-review-toolkit/ort/commit/a8bf05debf8f59a49b1f99eeb80dbfcf44e46cc3 empty definition files are skipped. This went
unnoticed until now as expensive functional tests are currently not run.

[1]: https://github.com/drupal/drupal/blob/4a76549/core/modules/system/tests/fixtures/HtaccessTest/composer.json

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>