### PR TITLE
Consistenly switch from AdoptOpenJDK to Eclipse Temurin

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
-        distribution: adopt
+        distribution: temurin
         java-version: 11
         cache: gradle
     - name: Build all classes
@@ -34,7 +34,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
-        distribution: adopt
+        distribution: temurin
         java-version: 11
         cache: gradle
     - name: Build the reporter-web-app
@@ -50,7 +50,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
-        distribution: adopt
+        distribution: temurin
         java-version: 11
         cache: gradle
     - name: Run unit tests
@@ -80,7 +80,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
-        distribution: adopt
+        distribution: temurin
         java-version: 11
         cache: gradle
     - name: Run functional tests
@@ -97,7 +97,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
-        distribution: adopt
+        distribution: temurin
         java-version: 11
         cache: gradle
     - name: Run functional tests
@@ -113,7 +113,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
-        distribution: adopt
+        distribution: temurin
         java-version: 11
         cache: gradle
     - name: Run functional tests

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
-        distribution: adopt
+        distribution: temurin
         java-version: 11
         cache: gradle
     - name: Check for Detekt Issues

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ARG CRT_FILES=""
 # Set this to the ScanCode version to use.
 ARG SCANCODE_VERSION="30.1.0"
 
-FROM adoptopenjdk:11-jdk-hotspot-focal AS build
+FROM eclipse-temurin:11-jdk-focal AS build
 
 COPY . /usr/local/src/ort
 
@@ -44,7 +44,7 @@ RUN --mount=type=cache,target=/tmp/.gradle/ \
     sed -i -r '/distributionSha256Sum=[0-9a-f]{64}/d' gradle/wrapper/gradle-wrapper.properties && \
     ./gradlew --no-daemon --stacktrace -Pversion=$ORT_VERSION :cli:distTar :helper-cli:startScripts
 
-FROM adoptopenjdk:11-jdk-hotspot-focal AS run
+FROM eclipse-temurin:11-jdk-focal AS run
 
 ENV \
     # Package manager versions.

--- a/batect.yml
+++ b/batect.yml
@@ -46,7 +46,7 @@ config_variables:
 
 containers:
   build:
-    image: adoptopenjdk:11-jdk-hotspot-focal
+    image: eclipse-temurin:11-jdk-focal
     <<: *common-container-config
   run:
     build_directory: <{batect.project_directory}


### PR DESCRIPTION
The former is deprecated in favor of the latter, see [1].

[1]: https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>