### PR TITLE
SpdxExpression: Add parentheses in string representation

### DIFF
--- a/utils/spdx/src/main/kotlin/SpdxExpression.kt
+++ b/utils/spdx/src/main/kotlin/SpdxExpression.kt
@@ -382,20 +382,24 @@ class SpdxCompoundExpression(
 
     override fun hashCode() = decompose().sumOf { it.hashCode() }
 
-    override fun toString(): String {
-        // If the priority of this operator is higher than the binding of the left or right operator, we need to put the
-        // left or right expressions in parenthesis to not change the semantics of the expression.
-        val leftString = when {
-            left is SpdxCompoundExpression && operator.priority > left.operator.priority -> "($left)"
-            else -> "$left"
-        }
-        val rightString = when {
-            right is SpdxCompoundExpression && operator.priority > right.operator.priority -> "($right)"
-            else -> "$right"
-        }
+    override fun toString() =
+        // If the operator of the left or right expression is different from the operator of this expression, put the
+        // respective expression in parentheses. Semantically this would only be required if the priority of this
+        // operator is higher than the priority of the operator of the left or right expression, but always adding
+        // parentheses makes it easier to understand the expression.
+        buildString {
+            when {
+                left is SpdxCompoundExpression && operator != left.operator -> append("($left)")
+                else -> append("$left")
+            }
 
-        return "$leftString $operator $rightString"
-    }
+            append(" $operator ")
+
+            when {
+                right is SpdxCompoundExpression && operator != right.operator -> append("($right)")
+                else -> append("$right")
+            }
+        }
 }
 
 /**

--- a/utils/spdx/src/test/kotlin/SpdxExpressionTest.kt
+++ b/utils/spdx/src/test/kotlin/SpdxExpressionTest.kt
@@ -46,20 +46,15 @@ class SpdxExpressionTest : WordSpec() {
         "toString()" should {
             "return the textual SPDX expression" {
                 val expression = "license1+ AND (license2 WITH exception1 OR license3+) AND license4 WITH exception2"
-                val spdxExpression = expression.toSpdx()
 
-                val spdxString = spdxExpression.toString()
-
-                spdxString shouldBe expression
+                expression.toSpdx() should beString(expression)
             }
 
             "not include unnecessary parenthesis" {
-                val spdxExpression =
-                    "(license1 AND (license2 AND license3) AND (license4 OR (license5 WITH exception)))".toSpdx()
+                val expression = "(license1 AND (license2 AND license3) AND (license4 OR (license5 WITH exception)))"
 
-                val spdxString = spdxExpression.toString()
-
-                spdxString shouldBe "license1 AND license2 AND license3 AND (license4 OR license5 WITH exception)"
+                expression.toSpdx() should
+                        beString("license1 AND license2 AND license3 AND (license4 OR license5 WITH exception)")
             }
 
             "always add parentheses around groups with different operators" {

--- a/utils/spdx/src/test/kotlin/SpdxExpressionTest.kt
+++ b/utils/spdx/src/test/kotlin/SpdxExpressionTest.kt
@@ -61,6 +61,19 @@ class SpdxExpressionTest : WordSpec() {
 
                 spdxString shouldBe "license1 AND license2 AND license3 AND (license4 OR license5 WITH exception)"
             }
+
+            "always add parentheses around groups with different operators" {
+                val expression1 = "license1 AND license2 AND license3 OR license4 AND license5 AND license6"
+                val expression2 = "(license1 OR license2 OR license3) AND (license4 OR license5 OR license6)"
+                val expression3 = "(license1 OR license2 AND license3) AND (license4 AND license5 OR license6)"
+
+                expression1.toSpdx() should
+                        beString("(license1 AND license2 AND license3) OR (license4 AND license5 AND license6)")
+                expression2.toSpdx() should
+                        beString("(license1 OR license2 OR license3) AND (license4 OR license5 OR license6)")
+                expression3.toSpdx() should
+                        beString("(license1 OR (license2 AND license3)) AND ((license4 AND license5) OR license6)")
+            }
         }
 
         "A dummy SpdxExpression" should {
@@ -350,25 +363,25 @@ class SpdxExpressionTest : WordSpec() {
 
         "disjunctiveNormalForm()" should {
             "not change an expression already in DNF" {
-                "a AND b OR c AND d".toSpdx().disjunctiveNormalForm() should beString("a AND b OR c AND d")
+                "a AND b OR c AND d".toSpdx().disjunctiveNormalForm() should beString("(a AND b) OR (c AND d)")
             }
 
             "correctly convert an OR on the left side of an AND expression" {
-                "(a OR b) AND c".toSpdx().disjunctiveNormalForm() should beString("a AND c OR b AND c")
+                "(a OR b) AND c".toSpdx().disjunctiveNormalForm() should beString("(a AND c) OR (b AND c)")
             }
 
             "correctly convert an OR on the right side of an AND expression" {
-                "a AND (b OR c)".toSpdx().disjunctiveNormalForm() should beString("a AND b OR a AND c")
+                "a AND (b OR c)".toSpdx().disjunctiveNormalForm() should beString("(a AND b) OR (a AND c)")
             }
 
             "correctly convert ORs on both sides of an AND expression" {
                 "(a OR b) AND (c OR d)".toSpdx().disjunctiveNormalForm() should
-                        beString("a AND c OR a AND d OR b AND c OR b AND d")
+                        beString("(a AND c) OR (a AND d) OR (b AND c) OR (b AND d)")
             }
 
             "correctly convert a complex expression" {
                 "(a OR b) AND c AND (d OR e)".toSpdx().disjunctiveNormalForm() should
-                        beString("a AND c AND d OR a AND c AND e OR b AND c AND d OR b AND c AND e")
+                        beString("(a AND c AND d) OR (a AND c AND e) OR (b AND c AND d) OR (b AND c AND e)")
             }
         }
 
@@ -386,7 +399,7 @@ class SpdxExpressionTest : WordSpec() {
 
             "correctly sort a complex expression" {
                 "(h OR g) AND (f OR e) OR (c OR d) AND (a OR b)".toSpdx().sort() should
-                        beString("(a OR b) AND (c OR d) OR (e OR f) AND (g OR h)")
+                        beString("((a OR b) AND (c OR d)) OR ((e OR f) AND (g OR h))")
             }
         }
 
@@ -583,7 +596,7 @@ class SpdxExpressionTest : WordSpec() {
             }
 
             "return the correct result if multiple simple choices are applied" {
-                val expression = "a OR b AND c OR d".toSpdx()
+                val expression = "(a OR b) AND (c OR d)".toSpdx()
 
                 val choices = listOf(
                     SpdxLicenseChoice("a OR b".toSpdx(), "a".toSpdx()),

--- a/utils/spdx/src/test/kotlin/SpdxExpressionTest.kt
+++ b/utils/spdx/src/test/kotlin/SpdxExpressionTest.kt
@@ -45,34 +45,30 @@ class SpdxExpressionTest : WordSpec() {
     init {
         "toString()" should {
             "return the textual SPDX expression" {
-                val expression = "license1+ AND (license2 WITH exception1 OR license3+) AND license4 WITH exception2"
+                val expression = "a+ AND (b WITH exception1 OR c+) AND d WITH exception2"
 
                 expression.toSpdx() should beString(expression)
             }
 
             "not include unnecessary parenthesis" {
-                val expression = "(license1 AND (license2 AND license3) AND (license4 OR (license5 WITH exception)))"
+                val expression = "(a AND (b AND c) AND (d OR (e WITH exception)))"
 
-                expression.toSpdx() should
-                        beString("license1 AND license2 AND license3 AND (license4 OR license5 WITH exception)")
+                expression.toSpdx() should beString("a AND b AND c AND (d OR e WITH exception)")
             }
 
             "always add parentheses around groups with different operators" {
-                val expression1 = "license1 AND license2 AND license3 OR license4 AND license5 AND license6"
-                val expression2 = "(license1 OR license2 OR license3) AND (license4 OR license5 OR license6)"
-                val expression3 = "(license1 OR license2 AND license3) AND (license4 AND license5 OR license6)"
+                val expression1 = "a AND b AND c OR d AND e AND f"
+                val expression2 = "(a OR b OR c) AND (d OR e OR f)"
+                val expression3 = "(a OR b AND c) AND (d AND e OR f)"
 
-                expression1.toSpdx() should
-                        beString("(license1 AND license2 AND license3) OR (license4 AND license5 AND license6)")
-                expression2.toSpdx() should
-                        beString("(license1 OR license2 OR license3) AND (license4 OR license5 OR license6)")
-                expression3.toSpdx() should
-                        beString("(license1 OR (license2 AND license3)) AND ((license4 AND license5) OR license6)")
+                expression1.toSpdx() should beString("(a AND b AND c) OR (d AND e AND f)")
+                expression2.toSpdx() should beString("(a OR b OR c) AND (d OR e OR f)")
+                expression3.toSpdx() should beString("(a OR (b AND c)) AND ((d AND e) OR f)")
             }
         }
 
         "A dummy SpdxExpression" should {
-            val dummyExpression = "license1+ AND (license2 WITH exception1 OR license3+) AND license4 WITH exception2"
+            val dummyExpression = "a+ AND (b WITH exception1 OR c+) AND d WITH exception2"
 
             "be serializable to a string representation" {
                 val spdxExpression = dummyExpression.toSpdx()
@@ -89,20 +85,20 @@ class SpdxExpressionTest : WordSpec() {
 
                 deserializedExpression shouldBe SpdxCompoundExpression(
                     SpdxCompoundExpression(
-                        SpdxLicenseIdExpression("license1", true),
+                        SpdxLicenseIdExpression("a", true),
                         SpdxOperator.AND,
                         SpdxCompoundExpression(
                             SpdxLicenseWithExceptionExpression(
-                                SpdxLicenseIdExpression("license2"),
+                                SpdxLicenseIdExpression("b"),
                                 "exception1"
                             ),
                             SpdxOperator.OR,
-                            SpdxLicenseIdExpression("license3", true)
+                            SpdxLicenseIdExpression("c", true)
                         )
                     ),
                     SpdxOperator.AND,
                     SpdxLicenseWithExceptionExpression(
-                        SpdxLicenseIdExpression("license4"),
+                        SpdxLicenseIdExpression("d"),
                         "exception2"
                     )
                 )


### PR DESCRIPTION
Add parenthesis to the string representation and fix an issue with applying license choices. See the commit messages for details.
