### PR TITLE
Avoid Codecov to comment on pull-requests before all reports are uploaded

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+comment:
+  # Keep this in sync with the number of codecov-action calls.
+  after_n_builds: 4


### PR DESCRIPTION
See [1].

[1]: https://docs.codecov.com/docs/pull-request-comments#after_n_builds

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>