### PR TITLE
Gradle: Fix some potential issues with the filtering of definition files

### DIFF
--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -134,8 +134,8 @@ class Gradle(
     // The path to the root project. In a single-project, just points to the project path.
     private lateinit var rootProjectDir: File
 
-    // Filter Gradle projects that are managed via Flutter / Pub. These projects are analyzed from within Pub.
     override fun mapDefinitionFiles(definitionFiles: List<File>): List<File> {
+        // Filter Gradle projects that are managed via Flutter / Pub. These projects are analyzed from within Pub.
         val pubDefinitionFiles = findManagedFiles(analysisRoot, setOf(Pub.Factory())).values.flatten()
 
         return definitionFiles.filter { gradleDefinitionFile ->

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -52,7 +52,6 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.model.utils.DependencyGraphBuilder
 import org.ossreviewtoolkit.utils.common.Os
-import org.ossreviewtoolkit.utils.common.searchUpwardsForFile
 import org.ossreviewtoolkit.utils.common.temporaryProperties
 import org.ossreviewtoolkit.utils.core.createOrtTempFile
 import org.ossreviewtoolkit.utils.core.log
@@ -137,11 +136,11 @@ class Gradle(
 
     // Filter Gradle projects that are managed via Flutter / Pub. These projects are analyzed from within Pub.
     override fun mapDefinitionFiles(definitionFiles: List<File>): List<File> {
-        val pubFactory = Pub.Factory()
+        val pubDefinitionFiles = findManagedFiles(analysisRoot, setOf(Pub.Factory())).values.flatten()
 
         return definitionFiles.filter { gradleDefinitionFile ->
-            pubFactory.globsForDefinitionFiles.none { pubDefinitionFile ->
-                gradleDefinitionFile.parentFile.searchUpwardsForFile(pubDefinitionFile) != null
+            pubDefinitionFiles.none { pubDefinitionFile ->
+                gradleDefinitionFile.parentFile.canonicalFile.startsWith(pubDefinitionFile.parentFile.canonicalFile)
             }
         }
     }


### PR DESCRIPTION
Remove a redundant and inconsistent code path for finding the files
managed by Pub by calling the dedicated `findManagedFiles()`. This
removes the assumption that `Pub.Factory.globsForDefinitionFiles` only
contains filenames and properly applies IGNORED_DIRECTORY_MATCHERS, see
`findManagedFiles()`.
