### PR TITLE
spdx-utils: Generalize the `scanCodeLicenseTextDir` logic

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -150,6 +150,7 @@ dependencies {
     implementation(project(":reporter"))
     implementation(project(":scanner"))
     implementation(project(":utils:core-utils"))
+    implementation(project(":utils:spdx-utils"))
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     implementation("com.github.ajalt.clikt:clikt:$cliktVersion")

--- a/cli/src/main/kotlin/commands/RequirementsCommand.kt
+++ b/cli/src/main/kotlin/commands/RequirementsCommand.kt
@@ -34,6 +34,7 @@ import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.Scanner
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.core.log
+import org.ossreviewtoolkit.utils.spdx.scanCodeLicenseTextDir
 
 import org.reflections.Reflections
 
@@ -166,6 +167,13 @@ class RequirementsCommand : CliktCommand(help = "Check for the command line tool
         println("\t- The tool was not found in the PATH environment.")
         println("\t+ The tool was found in the PATH environment, but not in the required version.")
         println("\t* The tool was found in the PATH environment in the required version.")
+
+        println()
+        if (scanCodeLicenseTextDir != null) {
+            println("ScanCode license texts found in '$scanCodeLicenseTextDir'.")
+        } else {
+            println("ScanCode license texts not found.")
+        }
 
         if (statusCode != 0) {
             println()

--- a/utils/spdx/src/main/kotlin/Utils.kt
+++ b/utils/spdx/src/main/kotlin/Utils.kt
@@ -49,7 +49,7 @@ internal val yamlMapper = YAMLMapper().registerKotlinModule()
  * The directory that contains the ScanCode license texts. This is located using a heuristic based on the path of the
  * ScanCode binary.
  */
-private val scanCodeLicenseTextDir by lazy {
+val scanCodeLicenseTextDir by lazy {
     val scanCodeExeDir = Os.getPathFromEnvironment("scancode")?.realFile()?.parentFile
 
     val pythonBinDir = listOf("bin", "Scripts")

--- a/utils/spdx/src/main/kotlin/Utils.kt
+++ b/utils/spdx/src/main/kotlin/Utils.kt
@@ -50,22 +50,12 @@ internal val yamlMapper = YAMLMapper().registerKotlinModule()
  * ScanCode binary.
  */
 private val scanCodeLicenseTextDir by lazy {
-    val scanCodeDir = Os.getPathFromEnvironment("scancode")?.realFile()?.parentFile
+    val scanCodeExeDir = Os.getPathFromEnvironment("scancode")?.realFile()?.parentFile
 
-    // Locate directories that contain the Python version in their name.
-    val candidates = scanCodeDir?.resolve("../lib")?.listFiles().orEmpty()
-        .filter { it.isDirectory && it.name.startsWith("python") }
-        .map { "../lib/${it.name}/site-packages/licensedcode/data/licenses" }
+    val pythonBinDir = listOf("bin", "Scripts")
+    val scanCodeBaseDir = scanCodeExeDir?.takeUnless { it.name in pythonBinDir } ?: scanCodeExeDir?.parentFile
 
-    sequenceOf(
-        "src/licensedcode/data/licenses",
-        "../src/licensedcode/data/licenses",
-        "../site-packages/licensedcode/data/licenses",
-        "../lib/site-packages/licensedcode/data/licenses",
-        *candidates.toTypedArray()
-    ).firstNotNullOfOrNull { relativePath ->
-        scanCodeDir?.resolve(relativePath)?.takeIf { it.isDirectory }
-    }
+    scanCodeBaseDir?.walkTopDown()?.find { it.isDirectory && it.endsWith("licensedcode/data/licenses") }
 }
 
 /**


### PR DESCRIPTION
As of 9946f7e, ScanCode gets installed via `pip` in the `Dockerfile`,
resulting the ScanCode binary to be placed in

    /usr/local/bin/scancode

and the licenses in

    /usr/local/lib/python3.8/dist-packages/licensedcode/data/licenses

This causes non-SPDX license texts to not be found anymore as the
"dist-packages" sub-directory is no search candidate. Instead of adding
it as a candidate, generalize the lookup logic to avoid such issues in
the future.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>