### PR TITLE
Codecov: Allow the coverage to drop by up to 0.1%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,8 @@
 comment:
   # Keep this in sync with the number of codecov-action calls.
   after_n_builds: 4
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.1%


### PR DESCRIPTION
Add a threshold to not report a failure when adding small amounts of
code without coverage. For reference see [1].

[1]: https://docs.codecov.com/docs/commit-status

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>