### PR TITLE
Pub: Fix several issues with the analysis of Gradle projects

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -179,7 +179,7 @@ class Pub(
                     findManagedFiles(analysisRoot, setOf(gradleFactory)).getOrDefault(gradleFactory, emptyList())
 
                 if (gradleDefinitionFiles.isNotEmpty()) {
-                    log.info { "Found ${gradleDefinitionFiles.size} ${gradleFactory.managerName} project(s) at:" }
+                    log.info { "Found ${gradleDefinitionFiles.size} Gradle definition file(s) at:" }
 
                     gradleDefinitionFiles.forEach { gradleDefinitionFile ->
                         val relativePath =


### PR DESCRIPTION
The existing implementation exhibits several issues in case there is more than one Pub definition file under the `analysis root` directory. Fix a couple of them, see individual commits.

See also #5100.