### PR TITLE
Improve logging when archiving files

### DIFF
--- a/model/src/main/kotlin/utils/FileArchiver.kt
+++ b/model/src/main/kotlin/utils/FileArchiver.kt
@@ -83,6 +83,8 @@ class FileArchiver(
      * Archive all files in [directory] matching any of the configured patterns in the [storage].
      */
     fun archive(directory: File, provenance: KnownProvenance) {
+        log.info { "Archiving files matching ${matcher.patterns} from '$directory'..." }
+
         val zipFile = createOrtTempFile(suffix = ".zip")
 
         val zipDuration = measureTime {
@@ -101,15 +103,11 @@ class FileArchiver(
             }
         }
 
-        log.perf {
-            "Archived directory '${directory.invariantSeparatorsPath}' in $zipDuration."
-        }
+        log.perf { "Archived directory '${directory.invariantSeparatorsPath}' in $zipDuration." }
 
         val writeDuration = measureTime { storage.addArchive(provenance, zipFile) }
 
-        log.perf {
-            "Wrote archive of directory '${directory.invariantSeparatorsPath}' to storage in $writeDuration."
-        }
+        log.perf { "Wrote archive of directory '${directory.invariantSeparatorsPath}' to storage in $writeDuration." }
 
         zipFile.delete()
     }

--- a/scanner/src/main/kotlin/PathScanner.kt
+++ b/scanner/src/main/kotlin/PathScanner.kt
@@ -120,7 +120,7 @@ abstract class PathScanner(
     ): Map<Package, List<ScanResult>> {
         val scannerCriteria = getScannerCriteria()
 
-        log.info { "Searching scan results for ${packages.size} package(s)." }
+        log.info { "Searching scan results for ${packages.size} package(s)..." }
 
         val remainingPackages = packages.filterTo(mutableListOf()) { pkg ->
             !pkg.isMetaDataOnly.also {
@@ -130,7 +130,7 @@ abstract class PathScanner(
 
         val resultsFromStorage = readResultsFromStorage(packages, scannerCriteria)
 
-        log.info { "Found ${resultsFromStorage.size} stored scan result(s) matching $scannerCriteria." }
+        log.info { "Found scan results for ${resultsFromStorage.size} package(s) matching $scannerCriteria." }
 
         if (scannerConfig.createMissingArchives) {
             createMissingArchives(resultsFromStorage)
@@ -138,7 +138,7 @@ abstract class PathScanner(
 
         remainingPackages.removeAll { it in resultsFromStorage.keys }
 
-        log.info { "Scanning ${remainingPackages.size} package(s) for which no stored scan results were found." }
+        log.info { "Scanning ${remainingPackages.size} remaining of ${packages.size} total package(s)." }
 
         val downloadDirectory = createOrtTempDir()
 

--- a/scanner/src/main/kotlin/PathScanner.kt
+++ b/scanner/src/main/kotlin/PathScanner.kt
@@ -124,7 +124,7 @@ abstract class PathScanner(
 
         val remainingPackages = packages.filterTo(mutableListOf()) { pkg ->
             !pkg.isMetaDataOnly.also {
-                if (it) PathScanner.log.info { "Skipping '${pkg.id.toCoordinates()}' as it is metadata only." }
+                if (it) PathScanner.log.debug { "Skipping '${pkg.id.toCoordinates()}' as it is metadata only." }
             }
         }
 


### PR DESCRIPTION
Only log (the performance) in the downstream `archive()` function. The
package coordinates are still visible from the logged directory name.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>