### PR TITLE
FindingsMatcherTest: Fix a typo in a test name

### DIFF
--- a/model/src/test/kotlin/utils/FindingsMatcherTest.kt
+++ b/model/src/test/kotlin/utils/FindingsMatcherTest.kt
@@ -250,7 +250,7 @@ class FindingsMatcherTest : WordSpec() {
                 )
             }
 
-            "not associate licenses and exceptions that do not belog together" {
+            "not associate licenses and exceptions that do not belong together" {
                 associateLicensesWithExceptions(
                     listOf(
                         LicenseFinding("LicenseRef-scancode-unknown", TextLocation("file", 1)),


### PR DESCRIPTION
This is a fixup for 60657e4.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>