### PR TITLE
ExperimentalScanner refactoring

### DIFF
--- a/scanner/src/funTest/kotlin/experimental/DefaultPackageProvenanceResolverFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/DefaultPackageProvenanceResolverFunTest.kt
@@ -20,9 +20,12 @@
 
 package org.ossreviewtoolkit.scanner.experimental
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
+
+import java.io.IOException
 
 import kotlinx.coroutines.runBlocking
 
@@ -33,7 +36,6 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.SourceCodeOrigin
-import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 
@@ -71,7 +73,7 @@ class DefaultPackageProvenanceResolverFunTest : WordSpec() {
                     )
                 )
 
-                resolver.resolveProvenance(pkg, listOf(SourceCodeOrigin.ARTIFACT)) shouldBe UnknownProvenance
+                shouldThrow<IOException> { resolver.resolveProvenance(pkg, listOf(SourceCodeOrigin.ARTIFACT)) }
             }
         }
 
@@ -117,7 +119,7 @@ class DefaultPackageProvenanceResolverFunTest : WordSpec() {
                     )
                 )
 
-                resolver.resolveProvenance(pkg, listOf(SourceCodeOrigin.VCS)) shouldBe UnknownProvenance
+                shouldThrow<IOException> { resolver.resolveProvenance(pkg, listOf(SourceCodeOrigin.VCS)) }
             }
 
             "Guess the correct tag for a package" {

--- a/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
+++ b/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
@@ -169,7 +169,19 @@ class ExperimentalScanner(
             log.info { "\t${scanner.name}: Results for ${results.size} of ${allKnownProvenances.size} provenances." }
         }
 
-        // Run PackageScannerWrappers for packages with incomplete scan results.
+        runPackageScanners(controller, context)
+        runProvenanceScanners(controller, context)
+        runPathScanners(controller, context)
+
+        createFileArchives(controller.getNestedProvenancesByPackage())
+
+        return controller.getNestedScanResultsByPackage()
+    }
+
+    /**
+     * Run package scanners for packages with incomplete scan results.
+     */
+    private fun runPackageScanners(controller: ScanController, context: ScanContext) {
         controller.packages.forEach { pkg ->
             // TODO: Use coroutines to execute scanners in parallel.
             controller.getPackageScanners().forEach scanner@{ scanner ->
@@ -199,8 +211,12 @@ class ExperimentalScanner(
                 }
             }
         }
+    }
 
-        // Run provenance scanners for provenances with missing scan results.
+    /**
+     * Run provenance scanners for provenances with missing scan results.
+     */
+    private fun runProvenanceScanners(controller: ScanController, context: ScanContext) {
         controller.getAllProvenances().forEach { provenance ->
             // TODO: Use coroutines to execute scanners in parallel.
             controller.getProvenanceScanners().forEach scanner@{ scanner ->
@@ -228,8 +244,12 @@ class ExperimentalScanner(
                 }
             }
         }
+    }
 
-        // Run path scanners for provenances with missing scan results.
+    /**
+     * Run path scanners for provenances with missing scan results.
+     */
+    private fun runPathScanners(controller: ScanController, context: ScanContext) {
         controller.getAllProvenances().forEach { provenance ->
             val scannersForProvenance =
                 controller.getPathScanners().filterNot { controller.hasScanResult(it, provenance) }
@@ -250,10 +270,6 @@ class ExperimentalScanner(
                 }
             }
         }
-
-        createFileArchives(controller.getNestedProvenancesByPackage())
-
-        return controller.getNestedScanResultsByPackage()
     }
 
     private fun Collection<Package>.filterNotConcluded(): Collection<Package> =

--- a/scanner/src/main/kotlin/experimental/ScanController.kt
+++ b/scanner/src/main/kotlin/experimental/ScanController.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2022 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.ScanResult
+
+/**
+ * A controller for the data related to a run of the [ExperimentalScanner].
+ */
+@Suppress("TooManyFunctions")
+class ScanController(
+    /**
+     * The set of [Package]s to be scanned.
+     */
+    val packages: Set<Package>,
+
+    /**
+     * The list of [ScannerWrapper]s used for scanning.
+     */
+    val scanners: List<ScannerWrapper>
+) {
+    /**
+     * A map of [KnownProvenance]s to their resolved [NestedProvenance]s.
+     */
+    private val nestedProvenances = mutableMapOf<KnownProvenance, NestedProvenance>()
+
+    /**
+     * A map of package [Identifier]s to their resolved [KnownProvenance]s.
+     */
+    private val packageProvenances = mutableMapOf<Identifier, KnownProvenance>()
+
+    /**
+     * The [ScanResult]s for each [KnownProvenance] and [ScannerWrapper].
+     */
+    private val scanResults = mutableMapOf<ScannerWrapper, MutableMap<KnownProvenance, MutableList<ScanResult>>>()
+
+    /**
+     * Add an entry to [packageProvenances], overwriting any existing values.
+     */
+    fun addPackageProvenance(id: Identifier, provenance: KnownProvenance) {
+        packageProvenances[id] = provenance
+    }
+
+    /**
+     * Add an entry to [nestedProvenances], overwriting any existing values.
+     */
+    fun addNestedProvenance(root: KnownProvenance, nestedProvenance: NestedProvenance) {
+        nestedProvenances[root] = nestedProvenance
+    }
+
+    /**
+     * Add all scan results contained in the nested [result].
+     */
+    fun addNestedScanResult(scanner: ScannerWrapper, result: NestedProvenanceScanResult) {
+        result.scanResults.forEach { (provenance, results) ->
+            addScanResults(scanner, provenance, results)
+        }
+    }
+
+    /**
+     * Add all [results].
+     */
+    fun addScanResults(scanner: ScannerWrapper, provenance: KnownProvenance, results: List<ScanResult>) {
+        scanResults.getOrPut(scanner) { mutableMapOf() }.getOrPut(provenance) { mutableListOf() }.addAll(results)
+    }
+
+    /**
+     * Find the [NestedProvenance] for the provided [provenance].
+     */
+    fun findNestedProvenance(provenance: KnownProvenance): NestedProvenance? = nestedProvenances[provenance]
+
+    /**
+     * Find all packages for [provenance].
+     */
+    fun findPackages(provenance: KnownProvenance) =
+        packageProvenances.entries.filter { it.value == provenance }
+            .mapNotNull { (id, _) -> packages.find { it.id == id } }
+
+    /**
+     * Return all [KnownProvenance]s contained in [nestedProvenances] and [packageProvenances].
+     */
+    fun getAllProvenances(): Set<KnownProvenance> =
+        (packageProvenances.values + nestedProvenances.values.flatMap { it.getProvenances() }).toSet()
+
+    /**
+     * Get all provenances for which no scan result for the provided [scanner] is available.
+     */
+    fun getMissingProvenanceScans(scanner: ScannerWrapper, nestedProvenance: NestedProvenance) =
+        nestedProvenance.getProvenances().filter { hasScanResult(scanner, it) }
+
+    /**
+     * Get the [NestedProvenance] for the provided [id].
+     */
+    fun getNestedProvenance(id: Identifier): NestedProvenance =
+        nestedProvenances.getValue(packageProvenances.getValue(id))
+
+    /**
+     * Get all [NestedProvenance]s by [Package].
+     */
+    fun getNestedProvenancesByPackage(): Map<Package, NestedProvenance> =
+        packageProvenances.keys.associate { id ->
+            packages.first { it.id == id } to getNestedProvenance(id)
+        }
+
+    /**
+     * Get the [NestedProvenanceScanResult] for the provided [id].
+     */
+    fun getNestedScanResult(id: Identifier): NestedProvenanceScanResult =
+        buildNestedProvenanceScanResult(packageProvenances.getValue(id))
+
+    /**
+     * Get the [NestedProvenanceScanResult] for each [Package].
+     */
+    fun getNestedScanResultsByPackage(): Map<Package, NestedProvenanceScanResult> =
+        // TODO: Return map containing all packages with issues for packages that could not be completely scanned.
+        packageProvenances.entries.associate { (id, provenance) ->
+            packages.first { it.id == id } to buildNestedProvenanceScanResult(provenance)
+        }
+
+    /**
+     * Return all [Package]s for which adding a scan result for [scanner] and [provenance] would complete the scan of
+     * their [NestedProvenance] by the respective [scanner].
+     */
+    fun getPackagesCompletedByProvenance(scanner: ScannerWrapper, provenance: KnownProvenance): List<Package> =
+        packageProvenances.entries.filter { (_, packageProvenance) ->
+            val nestedProvenance = nestedProvenances[packageProvenance]
+            nestedProvenance != null && getMissingProvenanceScans(scanner, nestedProvenance) == listOf(provenance)
+        }.map { (id, _) -> packages.first { it.id == id } }
+
+    /**
+     * Return all [KnownProvenance]s for the [packages].
+     */
+    fun getPackageProvenances(): Set<KnownProvenance> = packageProvenances.values.toSet()
+
+    /**
+     * Return all [PackageScannerWrapper]s.
+     */
+    fun getPackageScanners(): List<PackageScannerWrapper> = scanners.filterIsInstance<PackageScannerWrapper>()
+
+    /**
+     * Return all [PathScannerWrapper]s.
+     */
+    fun getPathScanners(): List<PathScannerWrapper> = scanners.filterIsInstance<PathScannerWrapper>()
+
+    /**
+     * Return all [ProvenanceScannerWrapper]s.
+     */
+    fun getProvenanceScanners(): List<ProvenanceScannerWrapper> = scanners.filterIsInstance<ProvenanceScannerWrapper>()
+
+    /**
+     * Get all [ScanResult]s for the provided [provenance].
+     */
+    fun getScanResults(provenance: KnownProvenance): List<ScanResult> =
+        scanResults.values.flatMap { scanResultsByProvenance -> scanResultsByProvenance[provenance].orEmpty() }
+
+    /**
+     * Get all [ScanResult]s for the provided [scanner].
+     */
+    fun getScanResults(scanner: ScannerWrapper): Map<KnownProvenance, List<ScanResult>> = scanResults[scanner].orEmpty()
+
+    /**
+     * Get all [ScanResult]s for the provided [scanner] and [provenance].
+     */
+    fun getScanResults(scanner: ScannerWrapper, provenance: KnownProvenance): List<ScanResult> =
+        scanResults[scanner]?.get(provenance).orEmpty()
+
+    /**
+     * Return true if [ScanResult]s for the complete [NestedProvenance] of the package are available.
+     */
+    fun hasCompleteScanResult(scanner: ScannerWrapper, pkg: Package): Boolean =
+        getNestedProvenance(pkg.id).getProvenances().all { provenance -> hasScanResult(scanner, provenance) }
+
+    /**
+     * Return true if a [ScanResult] for the provided [scanner] and [provenance] is available.
+     */
+    fun hasScanResult(scanner: ScannerWrapper, provenance: Provenance) =
+        scanResults[scanner]?.get(provenance)?.isNotEmpty() == true
+
+    private fun buildNestedProvenanceScanResult(root: KnownProvenance): NestedProvenanceScanResult {
+        val nestedProvenance = nestedProvenances.getValue(root)
+        val scanResults = nestedProvenance.getProvenances().associateWith { provenance ->
+            getScanResults(provenance)
+        }
+
+        return NestedProvenanceScanResult(nestedProvenance, scanResults)
+    }
+}

--- a/scanner/src/main/kotlin/experimental/ScanController.kt
+++ b/scanner/src/main/kotlin/experimental/ScanController.kt
@@ -86,6 +86,11 @@ class ScanController(
     }
 
     /**
+     * Find the [NestedProvenance] for the provided [id].
+     */
+    fun findNestedProvenance(id: Identifier): NestedProvenance? = nestedProvenances[packageProvenances[id]]
+
+    /**
      * Find the [NestedProvenance] for the provided [provenance].
      */
     fun findNestedProvenance(provenance: KnownProvenance): NestedProvenance? = nestedProvenances[provenance]

--- a/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
+++ b/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
@@ -33,6 +33,7 @@ import io.mockk.spyk
 import io.mockk.verify
 
 import java.io.File
+import java.io.IOException
 import java.time.Instant
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
@@ -51,7 +52,6 @@ import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.SourceCodeOrigin
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
@@ -696,7 +696,7 @@ private class FakeProvenanceDownloader(val filename: String = "fake.txt") : Prov
  * validation.
  */
 private class FakePackageProvenanceResolver : PackageProvenanceResolver {
-    override fun resolveProvenance(pkg: Package, sourceCodeOriginPriority: List<SourceCodeOrigin>): Provenance {
+    override fun resolveProvenance(pkg: Package, sourceCodeOriginPriority: List<SourceCodeOrigin>): KnownProvenance {
         sourceCodeOriginPriority.forEach { sourceCodeOrigin ->
             when (sourceCodeOrigin) {
                 SourceCodeOrigin.ARTIFACT -> {
@@ -713,7 +713,7 @@ private class FakePackageProvenanceResolver : PackageProvenanceResolver {
             }
         }
 
-        return UnknownProvenance
+        throw IOException()
     }
 }
 


### PR DESCRIPTION
Several refactorings of the experimental scanner code, see the commit messages for details. This is only the first part of the refactoring, another refactoring will follow which will add handling of issues during provenance resolution and might also include a cleaner implementation of #5047.