### PR TITLE
NuGet: Scopes and direct dependencies

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-direct-dependencies-only-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-direct-dependencies-only-expected-output.yml
@@ -1,0 +1,177 @@
+---
+project:
+  id: "DotNet::src/funTest/assets/projects/synthetic/dotnet/subProjectTest/test.csproj:"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/dotnet/subProjectTest/test.csproj"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scopes:
+  - name: "net45"
+    dependencies:
+    - id: "NuGet::System.Threading.Tasks.Extensions:4.5.4"
+  - name: "netcoreapp3.1"
+    dependencies:
+    - id: "NuGet::System.Globalization:4.3.0"
+    - id: "NuGet::System.Threading:4.0.11"
+  - name: "netcoreapp3.1-dev"
+    dependencies:
+    - id: "NuGet::WebGrease:1.5.2"
+packages:
+- id: "NuGet::System.Globalization:4.3.0"
+  purl: "pkg:nuget/System.Globalization@4.3.0"
+  authors:
+  - "Microsoft"
+  declared_licenses:
+  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  declared_licenses_processed:
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    mapped:
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+  description: "Provides classes that define culture-related information, including\
+    \ language, country/region, calendars in use, format patterns for dates, currency,\
+    \ and numbers, and sort order for strings.\n\nCommonly Used Types:\nSystem.Globalization.DateTimeFormatInfo\n\
+    System.Globalization.CultureInfo\nSystem.Globalization.NumberFormatInfo\nSystem.Globalization.CalendarWeekRule\n\
+    System.Globalization.TextInfo\nSystem.Globalization.Calendar\nSystem.Globalization.CompareInfo\n\
+    System.Globalization.CompareOptions\nSystem.Globalization.UnicodeCategory\n \n\
+    When using NuGet 3.x this package requires at least version 3.4."
+  homepage_url: "https://dot.net/"
+  binary_artifact:
+    url: "https://api.nuget.org/v3-flatcontainer/system.globalization/4.3.0/system.globalization.4.3.0.nupkg"
+    hash:
+      value: "823d2ba308cb073b40a3146ecccd0d9fd7b1615ac3fbefb16f73d873e411fd81c3bdc87df206d3dc7e2f14c9cd53aafca684a3570c25471280aada8de805ece2"
+      algorithm: "SHA-512"
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "NuGet::System.Threading:4.0.11"
+  purl: "pkg:nuget/System.Threading@4.0.11"
+  authors:
+  - "Microsoft"
+  declared_licenses:
+  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  declared_licenses_processed:
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    mapped:
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+  description: "Provides the fundamental synchronization primitives, including System.Threading.Monitor\
+    \ and System.Threading.Mutex, that are required when writing asynchronous code.\n\
+    \nCommonly Used Types:\nSystem.Threading.Monitor\nSystem.Threading.SynchronizationContext\n\
+    System.Threading.ManualResetEvent\nSystem.Threading.AutoResetEvent\nSystem.Threading.ThreadLocal<T>\n\
+    System.Threading.EventWaitHandle\nSystem.Threading.SemaphoreSlim\nSystem.Threading.Mutex\n\
+    \ \nWhen using NuGet 3.x this package requires at least version 3.4."
+  homepage_url: "https://dot.net/"
+  binary_artifact:
+    url: "https://api.nuget.org/v3-flatcontainer/system.threading/4.0.11/system.threading.4.0.11.nupkg"
+    hash:
+      value: "05c0dd1bbcfcedb6fc6c5f311c41920a4775f8a28a61ca246b6c65ad8afd9b04881d3357880af000ac056fd121fc5c3ec0b56d6fd607e0c27e7a639157c85e3e"
+      algorithm: "SHA-512"
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "NuGet::System.Threading.Tasks.Extensions:4.5.4"
+  purl: "pkg:nuget/System.Threading.Tasks.Extensions@4.5.4"
+  authors:
+  - "Microsoft"
+  declared_licenses:
+  - "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+    mapped:
+      https://github.com/dotnet/corefx/blob/master/LICENSE.TXT: "MIT"
+  description: "Provides additional types that simplify the work of writing concurrent\
+    \ and asynchronous code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.ValueTask<TResult>\n\
+    \ \n7601f4f6225089ffb291dc7d58293c7bbf5c5d4f"
+  homepage_url: "https://dot.net/"
+  binary_artifact:
+    url: "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.5.4/system.threading.tasks.extensions.4.5.4.nupkg"
+    hash:
+      value: "68052086e77d3c7198737a3da163d67740b7c44f93250c39659b3bf21b6547a9abf64cbf40481f5c78f24361af3aaf47d52d188b371554a0928a7f7665c1fc14"
+      algorithm: "SHA-512"
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "NuGet::WebGrease:1.5.2"
+  purl: "pkg:nuget/WebGrease@1.5.2"
+  authors:
+  - "webgrease@microsoft.com"
+  declared_licenses:
+  - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
+  declared_licenses_processed:
+    unmapped:
+    - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
+  description: "Web Grease is a suite of tools for optimizing javascript, css files\
+    \ and images."
+  homepage_url: ""
+  binary_artifact:
+    url: "https://api.nuget.org/v3-flatcontainer/webgrease/1.5.2/webgrease.1.5.2.nupkg"
+    hash:
+      value: "453fa7a3483b424dbc27f5d5c07827e6527faa6e21c96169ef0b7423bd54c348f749f4df3a636a3ccc5f79d1da9c08ed7f7741dbfd0a8d0ddf424bd57b0b2fb0"
+      algorithm: "SHA-512"
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+issues:
+- timestamp: "1970-01-01T00:00:00Z"
+  source: "NuGet"
+  message: "Failed to get package data for 'NuGet::foobar:1.2.3': IOException: Failed\
+    \ to retrieve package data for 'foobar' from any of [https://api.nuget.org/v3/registration5-gz-semver2,\
+    \ https://pkgs.dev.azure.com/ms/20953fb4-d427-4ad6-b78c-13142d0c5462/_packaging/64e3bf16-3e04-41cd-b90f-60fdc9ccf494/nuget/v3/registrations2-semver2]."
+  severity: "ERROR"

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output-with-nuspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output-with-nuspec.yml
@@ -22,24 +22,8 @@ project:
     path: "<REPLACE_PATH>"
   homepage_url: ""
   scopes:
-  - name: "dependencies"
+  - name: "net45"
     dependencies:
-    - id: "NuGet::System.Globalization:4.3.0"
-      dependencies:
-      - id: "NuGet::Microsoft.NETCore.Platforms:1.1.0"
-      - id: "NuGet::Microsoft.NETCore.Targets:1.1.0"
-      - id: "NuGet::System.Runtime:4.3.0"
-    - id: "NuGet::System.Threading:4.0.11"
-      dependencies:
-      - id: "NuGet::System.Runtime:4.1.0"
-        dependencies:
-        - id: "NuGet::Microsoft.NETCore.Platforms:1.0.1"
-        - id: "NuGet::Microsoft.NETCore.Targets:1.0.1"
-      - id: "NuGet::System.Threading.Tasks:4.0.11"
-        dependencies:
-        - id: "NuGet::Microsoft.NETCore.Platforms:1.0.1"
-        - id: "NuGet::Microsoft.NETCore.Targets:1.0.1"
-        - id: "NuGet::System.Runtime:4.1.0"
     - id: "NuGet::System.Threading.Tasks.Extensions:4.5.4"
       dependencies:
       - id: "NuGet::System.Collections:4.3.0"
@@ -59,6 +43,26 @@ project:
         - id: "NuGet::Microsoft.NETCore.Platforms:1.1.0"
         - id: "NuGet::Microsoft.NETCore.Targets:1.1.0"
         - id: "NuGet::System.Runtime:4.3.0"
+  - name: "netcoreapp3.1"
+    dependencies:
+    - id: "NuGet::System.Globalization:4.3.0"
+      dependencies:
+      - id: "NuGet::Microsoft.NETCore.Platforms:1.1.0"
+      - id: "NuGet::Microsoft.NETCore.Targets:1.1.0"
+      - id: "NuGet::System.Runtime:4.3.0"
+    - id: "NuGet::System.Threading:4.0.11"
+      dependencies:
+      - id: "NuGet::System.Runtime:4.1.0"
+        dependencies:
+        - id: "NuGet::Microsoft.NETCore.Platforms:1.0.1"
+        - id: "NuGet::Microsoft.NETCore.Targets:1.0.1"
+      - id: "NuGet::System.Threading.Tasks:4.0.11"
+        dependencies:
+        - id: "NuGet::Microsoft.NETCore.Platforms:1.0.1"
+        - id: "NuGet::Microsoft.NETCore.Targets:1.0.1"
+        - id: "NuGet::System.Runtime:4.1.0"
+  - name: "netcoreapp3.1-dev"
+    dependencies:
     - id: "NuGet::WebGrease:1.5.2"
       dependencies:
       - id: "NuGet::Antlr:3.4.1.9004"

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
@@ -16,24 +16,8 @@ project:
     path: "<REPLACE_PATH>"
   homepage_url: ""
   scopes:
-  - name: "dependencies"
+  - name: "net45"
     dependencies:
-    - id: "NuGet::System.Globalization:4.3.0"
-      dependencies:
-      - id: "NuGet::Microsoft.NETCore.Platforms:1.1.0"
-      - id: "NuGet::Microsoft.NETCore.Targets:1.1.0"
-      - id: "NuGet::System.Runtime:4.3.0"
-    - id: "NuGet::System.Threading:4.0.11"
-      dependencies:
-      - id: "NuGet::System.Runtime:4.1.0"
-        dependencies:
-        - id: "NuGet::Microsoft.NETCore.Platforms:1.0.1"
-        - id: "NuGet::Microsoft.NETCore.Targets:1.0.1"
-      - id: "NuGet::System.Threading.Tasks:4.0.11"
-        dependencies:
-        - id: "NuGet::Microsoft.NETCore.Platforms:1.0.1"
-        - id: "NuGet::Microsoft.NETCore.Targets:1.0.1"
-        - id: "NuGet::System.Runtime:4.1.0"
     - id: "NuGet::System.Threading.Tasks.Extensions:4.5.4"
       dependencies:
       - id: "NuGet::System.Collections:4.3.0"
@@ -53,6 +37,26 @@ project:
         - id: "NuGet::Microsoft.NETCore.Platforms:1.1.0"
         - id: "NuGet::Microsoft.NETCore.Targets:1.1.0"
         - id: "NuGet::System.Runtime:4.3.0"
+  - name: "netcoreapp3.1"
+    dependencies:
+    - id: "NuGet::System.Globalization:4.3.0"
+      dependencies:
+      - id: "NuGet::Microsoft.NETCore.Platforms:1.1.0"
+      - id: "NuGet::Microsoft.NETCore.Targets:1.1.0"
+      - id: "NuGet::System.Runtime:4.3.0"
+    - id: "NuGet::System.Threading:4.0.11"
+      dependencies:
+      - id: "NuGet::System.Runtime:4.1.0"
+        dependencies:
+        - id: "NuGet::Microsoft.NETCore.Platforms:1.0.1"
+        - id: "NuGet::Microsoft.NETCore.Targets:1.0.1"
+      - id: "NuGet::System.Threading.Tasks:4.0.11"
+        dependencies:
+        - id: "NuGet::Microsoft.NETCore.Platforms:1.0.1"
+        - id: "NuGet::Microsoft.NETCore.Targets:1.0.1"
+        - id: "NuGet::System.Runtime:4.1.0"
+  - name: "netcoreapp3.1-dev"
+    dependencies:
     - id: "NuGet::WebGrease:1.5.2"
       dependencies:
       - id: "NuGet::Antlr:3.4.1.9004"

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-direct-dependencies-only-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-direct-dependencies-only-expected-output.yml
@@ -1,0 +1,177 @@
+---
+project:
+  id: "NuGet::src/funTest/assets/projects/synthetic/nuget/packages.config:"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/nuget/packages.config"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scopes:
+  - name: "net45"
+    dependencies:
+    - id: "NuGet::System.Threading.Tasks.Extensions:4.5.4"
+  - name: "netcoreapp3.1"
+    dependencies:
+    - id: "NuGet::System.Globalization:4.3.0"
+    - id: "NuGet::System.Threading:4.0.11"
+  - name: "netcoreapp3.1-dev"
+    dependencies:
+    - id: "NuGet::WebGrease:1.5.2"
+packages:
+- id: "NuGet::System.Globalization:4.3.0"
+  purl: "pkg:nuget/System.Globalization@4.3.0"
+  authors:
+  - "Microsoft"
+  declared_licenses:
+  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  declared_licenses_processed:
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    mapped:
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+  description: "Provides classes that define culture-related information, including\
+    \ language, country/region, calendars in use, format patterns for dates, currency,\
+    \ and numbers, and sort order for strings.\n\nCommonly Used Types:\nSystem.Globalization.DateTimeFormatInfo\n\
+    System.Globalization.CultureInfo\nSystem.Globalization.NumberFormatInfo\nSystem.Globalization.CalendarWeekRule\n\
+    System.Globalization.TextInfo\nSystem.Globalization.Calendar\nSystem.Globalization.CompareInfo\n\
+    System.Globalization.CompareOptions\nSystem.Globalization.UnicodeCategory\n \n\
+    When using NuGet 3.x this package requires at least version 3.4."
+  homepage_url: "https://dot.net/"
+  binary_artifact:
+    url: "https://api.nuget.org/v3-flatcontainer/system.globalization/4.3.0/system.globalization.4.3.0.nupkg"
+    hash:
+      value: "823d2ba308cb073b40a3146ecccd0d9fd7b1615ac3fbefb16f73d873e411fd81c3bdc87df206d3dc7e2f14c9cd53aafca684a3570c25471280aada8de805ece2"
+      algorithm: "SHA-512"
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "NuGet::System.Threading:4.0.11"
+  purl: "pkg:nuget/System.Threading@4.0.11"
+  authors:
+  - "Microsoft"
+  declared_licenses:
+  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  declared_licenses_processed:
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    mapped:
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+  description: "Provides the fundamental synchronization primitives, including System.Threading.Monitor\
+    \ and System.Threading.Mutex, that are required when writing asynchronous code.\n\
+    \nCommonly Used Types:\nSystem.Threading.Monitor\nSystem.Threading.SynchronizationContext\n\
+    System.Threading.ManualResetEvent\nSystem.Threading.AutoResetEvent\nSystem.Threading.ThreadLocal<T>\n\
+    System.Threading.EventWaitHandle\nSystem.Threading.SemaphoreSlim\nSystem.Threading.Mutex\n\
+    \ \nWhen using NuGet 3.x this package requires at least version 3.4."
+  homepage_url: "https://dot.net/"
+  binary_artifact:
+    url: "https://api.nuget.org/v3-flatcontainer/system.threading/4.0.11/system.threading.4.0.11.nupkg"
+    hash:
+      value: "05c0dd1bbcfcedb6fc6c5f311c41920a4775f8a28a61ca246b6c65ad8afd9b04881d3357880af000ac056fd121fc5c3ec0b56d6fd607e0c27e7a639157c85e3e"
+      algorithm: "SHA-512"
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "NuGet::System.Threading.Tasks.Extensions:4.5.4"
+  purl: "pkg:nuget/System.Threading.Tasks.Extensions@4.5.4"
+  authors:
+  - "Microsoft"
+  declared_licenses:
+  - "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+    mapped:
+      https://github.com/dotnet/corefx/blob/master/LICENSE.TXT: "MIT"
+  description: "Provides additional types that simplify the work of writing concurrent\
+    \ and asynchronous code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.ValueTask<TResult>\n\
+    \ \n7601f4f6225089ffb291dc7d58293c7bbf5c5d4f"
+  homepage_url: "https://dot.net/"
+  binary_artifact:
+    url: "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.5.4/system.threading.tasks.extensions.4.5.4.nupkg"
+    hash:
+      value: "68052086e77d3c7198737a3da163d67740b7c44f93250c39659b3bf21b6547a9abf64cbf40481f5c78f24361af3aaf47d52d188b371554a0928a7f7665c1fc14"
+      algorithm: "SHA-512"
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+- id: "NuGet::WebGrease:1.5.2"
+  purl: "pkg:nuget/WebGrease@1.5.2"
+  authors:
+  - "webgrease@microsoft.com"
+  declared_licenses:
+  - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
+  declared_licenses_processed:
+    unmapped:
+    - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
+  description: "Web Grease is a suite of tools for optimizing javascript, css files\
+    \ and images."
+  homepage_url: ""
+  binary_artifact:
+    url: "https://api.nuget.org/v3-flatcontainer/webgrease/1.5.2/webgrease.1.5.2.nupkg"
+    hash:
+      value: "453fa7a3483b424dbc27f5d5c07827e6527faa6e21c96169ef0b7423bd54c348f749f4df3a636a3ccc5f79d1da9c08ed7f7741dbfd0a8d0ddf424bd57b0b2fb0"
+      algorithm: "SHA-512"
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+issues:
+- timestamp: "1970-01-01T00:00:00Z"
+  source: "NuGet"
+  message: "Failed to get package data for 'NuGet::foobar:1.2.3': IOException: Failed\
+    \ to retrieve package data for 'foobar' from any of [https://api.nuget.org/v3/registration5-gz-semver2,\
+    \ https://pkgs.dev.azure.com/ms/20953fb4-d427-4ad6-b78c-13142d0c5462/_packaging/64e3bf16-3e04-41cd-b90f-60fdc9ccf494/nuget/v3/registrations2-semver2]."
+  severity: "ERROR"

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
@@ -16,7 +16,25 @@ project:
     path: "<REPLACE_PATH>"
   homepage_url: ""
   scopes:
-  - name: "dependencies"
+  - name: "net45"
+    dependencies:
+    - id: "NuGet::System.Threading.Tasks.Extensions:4.5.4"
+      dependencies:
+      - id: "NuGet::System.Collections:4.3.0"
+        dependencies:
+        - id: "NuGet::Microsoft.NETCore.Platforms:1.1.0"
+        - id: "NuGet::Microsoft.NETCore.Targets:1.1.0"
+        - id: "NuGet::System.Runtime:4.3.0"
+      - id: "NuGet::System.Runtime:4.3.0"
+      - id: "NuGet::System.Runtime.CompilerServices.Unsafe:4.5.3"
+        dependencies:
+        - id: "NuGet::System.Runtime:4.3.0"
+      - id: "NuGet::System.Threading.Tasks:4.3.0"
+        dependencies:
+        - id: "NuGet::Microsoft.NETCore.Platforms:1.1.0"
+        - id: "NuGet::Microsoft.NETCore.Targets:1.1.0"
+        - id: "NuGet::System.Runtime:4.3.0"
+  - name: "netcoreapp3.1"
     dependencies:
     - id: "NuGet::System.Globalization:4.3.0"
       dependencies:
@@ -37,22 +55,8 @@ project:
         - id: "NuGet::Microsoft.NETCore.Platforms:1.0.1"
         - id: "NuGet::Microsoft.NETCore.Targets:1.0.1"
         - id: "NuGet::System.Runtime:4.1.0"
-    - id: "NuGet::System.Threading.Tasks.Extensions:4.5.4"
-      dependencies:
-      - id: "NuGet::System.Collections:4.3.0"
-        dependencies:
-        - id: "NuGet::Microsoft.NETCore.Platforms:1.1.0"
-        - id: "NuGet::Microsoft.NETCore.Targets:1.1.0"
-        - id: "NuGet::System.Runtime:4.3.0"
-      - id: "NuGet::System.Runtime:4.3.0"
-      - id: "NuGet::System.Runtime.CompilerServices.Unsafe:4.5.3"
-        dependencies:
-        - id: "NuGet::System.Runtime:4.3.0"
-      - id: "NuGet::System.Threading.Tasks:4.3.0"
-        dependencies:
-        - id: "NuGet::Microsoft.NETCore.Platforms:1.1.0"
-        - id: "NuGet::Microsoft.NETCore.Targets:1.1.0"
-        - id: "NuGet::System.Runtime:4.3.0"
+  - name: "netcoreapp3.1-dev"
+    dependencies:
     - id: "NuGet::WebGrease:1.5.2"
       dependencies:
       - id: "NuGet::Antlr:3.4.1.9004"

--- a/analyzer/src/funTest/kotlin/managers/DotNetFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/DotNetFunTest.kt
@@ -29,6 +29,7 @@ import io.kotest.matchers.shouldBe
 import java.io.File
 
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetDependency
+import org.ossreviewtoolkit.analyzer.managers.utils.OPTION_DIRECT_DEPENDENCIES_ONLY
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.utils.core.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
@@ -83,6 +84,22 @@ class DotNetFunTest : StringSpec() {
             patchActualResult(result.toYaml()) shouldBe expectedResult
         }
 
+        "Direct project dependencies are detected correctly" {
+            val vcsPath = vcsDir.getPathToRoot(projectDir)
+            val expectedResult = patchExpectedResult(
+                File(
+                    projectDir.parentFile,
+                    "dotnet-direct-dependencies-only-expected-output.yml"
+                ),
+                url = normalizeVcsUrl(vcsUrl),
+                revision = vcsRevision,
+                path = "$vcsPath/subProjectTest"
+            )
+            val result = createDotNet(directDependenciesOnly = true).resolveSingleProject(packageFile)
+
+            patchActualResult(result.toYaml()) shouldBe expectedResult
+        }
+
         "Project metadata is correctly extracted from a .nuspec file" {
             val vcsPath = vcsDir.getPathToRoot(projectDir)
             val expectedResult = patchExpectedResult(
@@ -101,6 +118,13 @@ class DotNetFunTest : StringSpec() {
         }
     }
 
-    private fun createDotNet() =
-        DotNet("DotNet", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+    private fun createDotNet(directDependenciesOnly: Boolean = false) =
+        DotNet(
+            "DotNet",
+            USER_DIR,
+            DEFAULT_ANALYZER_CONFIGURATION.copy(
+                options = mapOf("DotNet" to mapOf(OPTION_DIRECT_DEPENDENCIES_ONLY to "$directDependenciesOnly"))
+            ),
+            DEFAULT_REPOSITORY_CONFIGURATION
+        )
 }

--- a/analyzer/src/funTest/kotlin/managers/NuGetFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NuGetFunTest.kt
@@ -29,6 +29,7 @@ import io.kotest.matchers.shouldBe
 import java.io.File
 
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetDependency
+import org.ossreviewtoolkit.analyzer.managers.utils.OPTION_DIRECT_DEPENDENCIES_ONLY
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.utils.core.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
@@ -79,8 +80,28 @@ class NuGetFunTest : StringSpec() {
 
             patchActualResult(result.toYaml()) shouldBe expectedResult
         }
+
+        "Direct project dependencies are detected correctly" {
+            val vcsPath = vcsDir.getPathToRoot(projectDir)
+            val expectedResult = patchExpectedResult(
+                projectDir.parentFile.resolve("nuget-direct-dependencies-only-expected-output.yml"),
+                url = normalizeVcsUrl(vcsUrl),
+                revision = vcsRevision,
+                path = vcsPath
+            )
+            val result = createNuGet(directDependenciesOnly = true).resolveSingleProject(packageFile)
+
+            patchActualResult(result.toYaml()) shouldBe expectedResult
+        }
     }
 
-    private fun createNuGet() =
-        NuGet("NuGet", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+    private fun createNuGet(directDependenciesOnly: Boolean = false) =
+        NuGet(
+            "NuGet",
+            USER_DIR,
+            DEFAULT_ANALYZER_CONFIGURATION.copy(
+                options = mapOf("NuGet" to mapOf(OPTION_DIRECT_DEPENDENCIES_ONLY to "$directDependenciesOnly"))
+            ),
+            DEFAULT_REPOSITORY_CONFIGURATION
+        )
 }

--- a/analyzer/src/main/kotlin/managers/DotNet.kt
+++ b/analyzer/src/main/kotlin/managers/DotNet.kt
@@ -62,7 +62,14 @@ class DotNet(
     private val reader = DotNetPackageFileReader()
 
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> =
-        listOf(resolveNuGetDependencies(definitionFile, reader, NuGetSupport.create(definitionFile)))
+        listOf(
+            resolveNuGetDependencies(
+                definitionFile,
+                reader,
+                NuGetSupport.create(definitionFile),
+                directDependenciesOnly = false
+            )
+        )
 }
 
 /**

--- a/analyzer/src/main/kotlin/managers/DotNet.kt
+++ b/analyzer/src/main/kotlin/managers/DotNet.kt
@@ -33,6 +33,7 @@ import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetDependency
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetSupport
+import org.ossreviewtoolkit.analyzer.managers.utils.OPTION_DIRECT_DEPENDENCIES_ONLY
 import org.ossreviewtoolkit.analyzer.managers.utils.XmlPackageFileReader
 import org.ossreviewtoolkit.analyzer.managers.utils.resolveNuGetDependencies
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
@@ -42,6 +43,9 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 /**
  * A package manager implementation for [.NET](https://docs.microsoft.com/en-us/dotnet/core/tools/) project files that
  * embed NuGet package configuration.
+ *
+ * This package manager supports the following [options][AnalyzerConfiguration.options]:
+ * - *directDependenciesOnly*: If true, only direct dependencies are reported. Defaults to false.
  */
 class DotNet(
     name: String,
@@ -59,6 +63,9 @@ class DotNet(
         ) = DotNet(managerName, analysisRoot, analyzerConfig, repoConfig)
     }
 
+    private val directDependenciesOnly =
+        analyzerConfig.options?.get(managerName)?.get(OPTION_DIRECT_DEPENDENCIES_ONLY).toBoolean()
+
     private val reader = DotNetPackageFileReader()
 
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> =
@@ -67,7 +74,7 @@ class DotNet(
                 definitionFile,
                 reader,
                 NuGetSupport.create(definitionFile),
-                directDependenciesOnly = false
+                directDependenciesOnly
             )
         )
 }

--- a/analyzer/src/main/kotlin/managers/NuGet.kt
+++ b/analyzer/src/main/kotlin/managers/NuGet.kt
@@ -61,7 +61,14 @@ class NuGet(
     private val reader = NuGetPackageFileReader()
 
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> =
-        listOf(resolveNuGetDependencies(definitionFile, reader, NuGetSupport.create(definitionFile)))
+        listOf(
+            resolveNuGetDependencies(
+                definitionFile,
+                reader,
+                NuGetSupport.create(definitionFile),
+                directDependenciesOnly = false
+            )
+        )
 }
 
 /**

--- a/analyzer/src/main/kotlin/managers/NuGet.kt
+++ b/analyzer/src/main/kotlin/managers/NuGet.kt
@@ -33,6 +33,7 @@ import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetDependency
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetSupport
+import org.ossreviewtoolkit.analyzer.managers.utils.OPTION_DIRECT_DEPENDENCIES_ONLY
 import org.ossreviewtoolkit.analyzer.managers.utils.XmlPackageFileReader
 import org.ossreviewtoolkit.analyzer.managers.utils.resolveNuGetDependencies
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
@@ -41,6 +42,9 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 
 /**
  * The [NuGet](https://www.nuget.org/) package manager for .NET.
+ *
+ * This package manager supports the following [options][AnalyzerConfiguration.options]:
+ * - *directDependenciesOnly*: If true, only direct dependencies are reported. Defaults to false.
  */
 class NuGet(
     name: String,
@@ -58,6 +62,9 @@ class NuGet(
         ) = NuGet(managerName, analysisRoot, analyzerConfig, repoConfig)
     }
 
+    private val directDependenciesOnly =
+        analyzerConfig.options?.get(managerName)?.get(OPTION_DIRECT_DEPENDENCIES_ONLY).toBoolean()
+
     private val reader = NuGetPackageFileReader()
 
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> =
@@ -66,7 +73,7 @@ class NuGet(
                 definitionFile,
                 reader,
                 NuGetSupport.create(definitionFile),
-                directDependenciesOnly = false
+                directDependenciesOnly
             )
         )
 }

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -73,6 +73,8 @@ import org.ossreviewtoolkit.utils.core.await
 import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.core.logOnce
 
+internal const val OPTION_DIRECT_DEPENDENCIES_ONLY = "directDependenciesOnly"
+
 // See https://docs.microsoft.com/en-us/nuget/api/overview.
 private const val DEFAULT_SERVICE_INDEX_URL = "https://api.nuget.org/v3/index.json"
 private const val REGISTRATIONS_BASE_URL_TYPE = "RegistrationsBaseUrl/3.6.0"

--- a/model/src/main/kotlin/config/AnalyzerConfiguration.kt
+++ b/model/src/main/kotlin/config/AnalyzerConfiguration.kt
@@ -23,6 +23,8 @@ package org.ossreviewtoolkit.model.config
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 
+typealias PackageManagerOptions = Map<String, String>
+
 @JsonIgnoreProperties(value = ["ignore_tool_versions"]) // Backwards compatibility.
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class AnalyzerConfiguration(
@@ -34,6 +36,12 @@ data class AnalyzerConfiguration(
      * false.
      */
     val allowDynamicVersions: Boolean = false,
+
+    /**
+     * Package manager specific configuration options. The key needs to match the name of the package manager class,
+     * e.g. "NuGet" for the NuGet package manager. See the documentation of the respective class for available options.
+     */
+    val options: Map<String, PackageManagerOptions>? = null,
 
     /**
      * Configuration of the SW360 package curation provider.

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -16,6 +16,14 @@ ort {
   analyzer {
     allowDynamicVersions = true
 
+    options {
+      # A map of maps from package manager class names to package manager-specific key-value pairs.
+      # At the example of applying custom options for DotNet, this would look like:
+      DotNet {
+        directDependenciesOnly = true
+      }
+    }
+
     sw360Configuration {
       restUrl = "https://your-sw360-rest-url"
       authUrl = "https://your-authentication-url"


### PR DESCRIPTION
Add support for separate scopes and an option to resolve only direct dependencies to NuGet based package managers. See the commit messages for details.
