### PR TITLE
fossid-webapp: Make `ScanDescription.percentagedone` nullable

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/model/status/ScanDescription2021dot2.kt
+++ b/clients/fossid-webapp/src/main/kotlin/model/status/ScanDescription2021dot2.kt
@@ -38,7 +38,7 @@ data class ScanDescription2021dot2(
 
     val isFinished: Boolean,
 
-    val percentageDone: String,
+    val percentageDone: String?,
 
     val currentFile: String?,
     val currentFilename: String?,


### PR DESCRIPTION
It seems that, when triggering a scan and requesting its status
straightaway, FossID server answers with a `null` value for the
property `percentageDone` of a `ScanDescription`.

This seems to be a regression introduced in FossID 21.2.4.

This fixes forllowing exception

```
01:21:13.998 [main] INFO  org.ossreviewtoolkit.scanner.scanners.fossid.FossId - Waiting for scan 'IO_OSM_Standard_snippet_scanners-example-projects-csharp_20220304_012102_delta' to complete.
Exception in thread "main" com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException: Instantiation of [simple type, class org.ossreviewtoolkit.clients.fossid.model.status.ScanDescription2021dot2] value failed for JSON property percentage_done due to missing (therefore NULL) value for creator parameter percentageDone which is a non-nullable type
 at [Source: (okhttp3.ResponseBody$BomAwareReader); line: 1, column: 612] (through reference chain: org.ossreviewtoolkit.clients.fossid.EntityResponseBody["data"]->org.ossreviewtoolkit.clients.fossid.model.status.ScanDescription2021dot2["percentage_done"])
	at com.fasterxml.jackson.module.kotlin.KotlinValueInstantiator.createFromObjectWith(KotlinValueInstantiator.kt:121)
	at com.fasterxml.jackson.databind.deser.impl.PropertyBasedCreator.build(PropertyBasedCreator.java:202)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:443)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1405)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:351)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:184)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:542)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeWithErrorWrapping(BeanDeserializer.java:563)

```

