### PR TITLE
Dockerfile: Upgrade Bower to 1.8.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ FROM eclipse-temurin:11-jdk-focal AS run
 
 ENV \
     # Package manager versions.
-    BOWER_VERSION=1.8.8 \
+    BOWER_VERSION=1.8.12 \
     CARGO_VERSION=0.58.0-0ubuntu1~20.04.1 \
     COCOAPODS_VERSION=1.11.2 \
     COMPOSER_VERSION=1.10.1-1 \


### PR DESCRIPTION
For the release notes see [1].

[1]: https://github.com/bower/bower/releases