### PR TITLE
git-repo: Store the manifest path in the VCS URL instead of the VCS path

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -2,14 +2,14 @@
 repository:
   vcs:
     type: "GitRepo"
-    url: "https://github.com/oss-review-toolkit/ort-test-data-git-repo"
+    url: "https://github.com/oss-review-toolkit/ort-test-data-git-repo?manifest=manifest.xml"
     revision: "<REPLACE_REVISION>"
-    path: "manifest.xml"
+    path: ""
   vcs_processed:
     type: "GitRepo"
-    url: "https://github.com/oss-review-toolkit/ort-test-data-git-repo.git"
+    url: "https://github.com/oss-review-toolkit/ort-test-data-git-repo.git?manifest=manifest.xml"
     revision: "<REPLACE_REVISION>"
-    path: "manifest.xml"
+    path: ""
   nested_repositories:
     spdx-tools:
       type: "Git"
@@ -388,9 +388,9 @@ analyzer:
         path: ""
       vcs_processed:
         type: "GitRepo"
-        url: "https://github.com/oss-review-toolkit/ort-test-data-git-repo"
+        url: "https://github.com/oss-review-toolkit/ort-test-data-git-repo?manifest=manifest.xml"
         revision: "<REPLACE_REVISION>"
-        path: "manifest.xml"
+        path: ""
       homepage_url: ""
       scope_names: []
     packages:

--- a/analyzer/src/funTest/kotlin/GitRepoFunTest.kt
+++ b/analyzer/src/funTest/kotlin/GitRepoFunTest.kt
@@ -38,9 +38,8 @@ import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
-private const val REPO_URL = "https://github.com/oss-review-toolkit/ort-test-data-git-repo"
+private const val REPO_URL = "https://github.com/oss-review-toolkit/ort-test-data-git-repo?manifest=manifest.xml"
 private const val REPO_REV = "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
-private const val REPO_MANIFEST = "manifest.xml"
 
 class GitRepoFunTest : StringSpec({
     lateinit var outputDir: File
@@ -49,7 +48,7 @@ class GitRepoFunTest : StringSpec({
         // Do not use createSpecTempDir() here, as otherwise the path will get too long for Windows to handle.
         outputDir = createTempDirectory(ORT_NAME).toFile()
 
-        val vcs = VcsInfo(VcsType.GIT_REPO, REPO_URL, REPO_REV, path = REPO_MANIFEST)
+        val vcs = VcsInfo(VcsType.GIT_REPO, REPO_URL, REPO_REV)
         val pkg = Package.EMPTY.copy(vcsProcessed = vcs)
 
         GitRepo().download(pkg, outputDir)

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -31,6 +31,7 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
+import org.ossreviewtoolkit.model.utils.parseRepoManifestPath
 import org.ossreviewtoolkit.utils.core.log
 
 /**
@@ -86,10 +87,13 @@ class Unmanaged(
             vcsInfo.type == VcsType.GIT_REPO -> {
                 // For GitRepo looking at the URL and revision only is not enough, we also need to take the used
                 // manifest into account.
+                val manifestPath = vcsInfo.url.parseRepoManifestPath()
+
                 Identifier(
                     type = managerName,
-                    namespace = vcsInfo.path.substringBeforeLast('/'),
-                    name = vcsInfo.path.substringAfterLast('/').removeSuffix(".xml"),
+                    namespace = manifestPath?.substringBeforeLast('/').orEmpty(),
+                    name = manifestPath?.substringAfterLast('/')?.removeSuffix(".xml")
+                        ?: vcsInfo.url.split('/').last().removeSuffix(".git"),
                     version = vcsInfo.revision
                 )
             }

--- a/analyzer/src/test/kotlin/managers/utils/MavenSupportTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/MavenSupportTest.kt
@@ -33,6 +33,21 @@ class MavenSupportTest : WordSpec({
         "handle GitRepo URLs" {
             val mavenProject = MavenProject().apply {
                 scm = Scm().apply {
+                    connection = "scm:git-repo:ssh://host.com/project/foo?manifest=path/to/manifest.xml"
+                    tag = "v1.2.3"
+                }
+            }
+
+            MavenSupport.parseVcsInfo(mavenProject) shouldBe VcsInfo(
+                type = VcsType.GIT_REPO,
+                url = "ssh://host.com/project/foo?manifest=path/to/manifest.xml",
+                revision = "v1.2.3"
+            )
+        }
+
+        "handle deprecated GitRepo URLs" {
+            val mavenProject = MavenProject().apply {
+                scm = Scm().apply {
                     connection = "scm:git-repo:ssh://host.com/project/foo?path/to/manifest.xml"
                     tag = "v1.2.3"
                 }
@@ -40,9 +55,8 @@ class MavenSupportTest : WordSpec({
 
             MavenSupport.parseVcsInfo(mavenProject) shouldBe VcsInfo(
                 type = VcsType.GIT_REPO,
-                url = "ssh://host.com/project/foo",
-                revision = "v1.2.3",
-                path = "path/to/manifest.xml"
+                url = "ssh://host.com/project/foo?manifest=path/to/manifest.xml",
+                revision = "v1.2.3"
             )
         }
 

--- a/downloader/src/funTest/kotlin/vcs/GitRepoDownloadFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitRepoDownloadFunTest.kt
@@ -31,9 +31,8 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 import org.ossreviewtoolkit.utils.test.createTestTempDir
 
-private const val REPO_URL = "https://github.com/oss-review-toolkit/ort-test-data-git-repo"
+private const val REPO_URL = "https://github.com/oss-review-toolkit/ort-test-data-git-repo?manifest=manifest.xml"
 private const val REPO_REV = "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
-private const val REPO_MANIFEST = "manifest.xml"
 
 class GitRepoDownloadFunTest : StringSpec() {
     private lateinit var outputDir: File
@@ -44,7 +43,7 @@ class GitRepoDownloadFunTest : StringSpec() {
 
     init {
         "GitRepo can download a given revision".config(tags = setOf(ExpensiveTag)) {
-            val vcs = VcsInfo(VcsType.GIT_REPO, REPO_URL, REPO_REV, path = REPO_MANIFEST)
+            val vcs = VcsInfo(VcsType.GIT_REPO, REPO_URL, REPO_REV)
             val pkg = Package.EMPTY.copy(vcsProcessed = vcs)
             val workingTree = GitRepo().download(pkg, outputDir)
 

--- a/helper-cli/src/main/kotlin/commands/packageconfig/CreateCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/CreateCommand.kt
@@ -34,7 +34,6 @@ import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
-import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.VcsMatcher
 import org.ossreviewtoolkit.scanner.storages.FileBasedStorage
@@ -129,8 +128,7 @@ private fun createPackageConfiguration(id: Identifier, provenance: Provenance): 
                 vcs = VcsMatcher(
                     type = provenance.vcsInfo.type,
                     url = provenance.vcsInfo.url,
-                    revision = provenance.resolvedRevision,
-                    path = provenance.vcsInfo.path.takeIf { provenance.vcsInfo.type == VcsType.GIT_REPO }
+                    revision = provenance.resolvedRevision
                 )
             )
         }

--- a/model/src/main/kotlin/ScanResult.kt
+++ b/model/src/main/kotlin/ScanResult.kt
@@ -62,11 +62,7 @@ data class ScanResult(
      * Return a [ScanResult] whose [summary] contains only findings from the [provenance]'s [VcsInfo.path].
      */
     fun filterByVcsPath(): ScanResult =
-        if (provenance is RepositoryProvenance && provenance.vcsInfo.type != VcsType.GIT_REPO) {
-            filterByPath(provenance.vcsInfo.path)
-        } else {
-            this
-        }
+        if (provenance is RepositoryProvenance) filterByPath(provenance.vcsInfo.path) else this
 
     /**
      * Return a [ScanResult] whose [summary] contains only findings whose location / path is not matched by any glob

--- a/model/src/main/kotlin/VcsInfo.kt
+++ b/model/src/main/kotlin/VcsInfo.kt
@@ -53,9 +53,8 @@ data class VcsInfo(
     val revision: String,
 
     /**
-     * The path inside the VCS to take into account, if any. The actual meaning depends on the VCS type. For
-     * example, for Git only this subdirectory of the repository should be cloned, or for Git Repo it is
-     * interpreted as the path to the manifest file.
+     * The path inside the VCS to take into account. If the VCS supports checking out only a subdirectory, only this
+     * path is checked out.
      */
     val path: String = ""
 ) {

--- a/model/src/main/kotlin/config/PackageConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageConfiguration.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.model.config
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
@@ -84,6 +85,7 @@ data class PackageConfiguration(
 /**
  * A matcher which matches its properties against a [RepositoryProvenance].
  */
+@JsonIgnoreProperties("path")
 data class VcsMatcher(
     /**
      * The [type] to match for equality against [VcsInfo.type].
@@ -98,33 +100,15 @@ data class VcsMatcher(
     /**
      * The [revision] to match for equality against [RepositoryProvenance.resolvedRevision].
      */
-    val revision: String,
-
-    /**
-     * The [path] to match for equality against [VcsInfo.path]. Must only be specified in case [type] equals
-     * [VcsType.GIT_REPO].
-     */
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val path: String? = null
+    val revision: String
 ) {
     init {
         require(url.isNotBlank() && revision.isNotBlank())
-
-        if (type == VcsType.GIT_REPO) {
-            require(!path.isNullOrBlank()) {
-                "Matching against Git-Repo VCS info requires a non-blank path."
-            }
-        } else {
-            require(path == null) {
-                "A path must only be specified for matching Git-Repo VCS info."
-            }
-        }
     }
 
     fun matches(provenance: RepositoryProvenance): Boolean =
         type == provenance.vcsInfo.type &&
                 matchesWithoutCredentials(url, provenance.vcsInfo.url) &&
-                (path == null || path == provenance.vcsInfo.path) &&
                 revision == provenance.resolvedRevision
 }
 

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.model.utils
 
 import java.io.File
+import java.net.URI
 
 import org.ossreviewtoolkit.clients.clearlydefined.ComponentType
 import org.ossreviewtoolkit.clients.clearlydefined.Coordinates
@@ -235,6 +236,22 @@ fun List<ScanResult>.filterByProject(project: Project): List<ScanResult> {
         }
     }
 }
+
+/**
+ * Return the repo manifest path parsed from this string. The string is interpreted as a URL and the manifest path is
+ * expected as the value of the "manifest" query parameter, for example:
+ * http://example.com/repo.git?manifest=manifest.xml.
+ *
+ * Return an empty string if no "manifest" query parameter is found or this string cannot be parsed as a URL.
+ */
+fun String.parseRepoManifestPath() =
+    runCatching {
+        URI(this).query.splitToSequence("&")
+            .map { it.split("=", limit = 2) }
+            .find { it.first() == "manifest" }
+            ?.get(1)
+            ?.takeUnless { it.isEmpty() }
+    }.getOrNull()
 
 /**
  * Messages are not rendered using additional white spaces and newlines in the reports. However, resolutions are based

--- a/model/src/main/kotlin/utils/FileArchiverFileStorage.kt
+++ b/model/src/main/kotlin/utils/FileArchiverFileStorage.kt
@@ -26,7 +26,6 @@ import java.security.MessageDigest
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
-import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.common.collectMessagesAsString
 import org.ossreviewtoolkit.utils.common.toHexString
 import org.ossreviewtoolkit.utils.core.createOrtTempFile
@@ -81,13 +80,7 @@ private val SHA1_DIGEST by lazy { MessageDigest.getInstance("SHA-1") }
 private fun KnownProvenance.hash(): String {
     val key = when (this) {
         is ArtifactProvenance -> "${sourceArtifact.url}${sourceArtifact.hash.value}"
-        is RepositoryProvenance -> {
-            // The content on the archives does not depend on the VCS path in general, thus that path must not be part
-            // of the storage key. However, for Git-Repo that path must be part of the storage key because it denotes
-            // the Git-Repo manifest location rather than the path to be (sparse) checked out.
-            val path = vcsInfo.path.takeIf { vcsInfo.type == VcsType.GIT_REPO }.orEmpty()
-            "${vcsInfo.type}${vcsInfo.url}${resolvedRevision}$path"
-        }
+        is RepositoryProvenance -> "${vcsInfo.type}${vcsInfo.url}$resolvedRevision"
     }
 
     return SHA1_DIGEST.digest(key.toByteArray()).toHexString()

--- a/model/src/main/kotlin/utils/PostgresFileArchiverStorage.kt
+++ b/model/src/main/kotlin/utils/PostgresFileArchiverStorage.kt
@@ -38,7 +38,6 @@ import org.jetbrains.exposed.sql.SchemaUtils.withDataBaseLock
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
-import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.utils.DatabaseUtils.checkDatabaseEncoding
 import org.ossreviewtoolkit.model.utils.DatabaseUtils.tableExists
 import org.ossreviewtoolkit.model.utils.DatabaseUtils.transaction
@@ -125,13 +124,8 @@ internal class FileArchive(id: EntityID<Int>) : IntEntity(id) {
 private fun KnownProvenance.storageKey(): String =
     when (this) {
         is ArtifactProvenance -> "source-artifact|${sourceArtifact.url}|${sourceArtifact.hash}"
-        is RepositoryProvenance -> {
-            // The content on the archives does not depend on the VCS path in general, thus that path must not be part
-            // of the storage key. However, for Git-Repo that path must be part of the storage key because it denotes
-            // the Git-Repo manifest location rather than the path to be (sparse) checked out.
-            val path = vcsInfo.path.takeIf { vcsInfo.type == VcsType.GIT_REPO }.orEmpty()
-            "vcs|${vcsInfo.type}|${vcsInfo.url}|$resolvedRevision|$path"
-        }
+        // The trailing "|" is kept for backward compatibility because there used to be an additional parameter.
+        is RepositoryProvenance -> "vcs|${vcsInfo.type}|${vcsInfo.url}|$resolvedRevision|"
     }
 
 private fun queryFileArchive(provenance: KnownProvenance): FileArchive? =

--- a/model/src/test/kotlin/utils/ExtensionsTest.kt
+++ b/model/src/test/kotlin/utils/ExtensionsTest.kt
@@ -23,6 +23,25 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
 class ExtensionsTest : WordSpec({
+    "parseRepomanifestPath()" should {
+        "return the manifest path" {
+            "https://example.com/repo.git?manifest=default.xml".parseRepoManifestPath() shouldBe "default.xml"
+            "https://example.com/repo.git?other=param&manifest=default.xml".parseRepoManifestPath() shouldBe
+                    "default.xml"
+        }
+
+        "return null if no manifest is found" {
+            "https://example.com/repo.git".parseRepoManifestPath() shouldBe null
+            "https://example.com/repo.git?other=param".parseRepoManifestPath() shouldBe null
+            "https://example.com/repo.git?manifest=".parseRepoManifestPath() shouldBe null
+        }
+
+        "return null if the string is no valid URI" {
+            "^invalid-uri".parseRepoManifestPath() shouldBe null
+            "^invalid-uri?manifest=default.xml".parseRepoManifestPath() shouldBe null
+        }
+    }
+
     "sanitizeMessage()" should {
         "remove additional white spaces" {
             "String with additional   white spaces. ".sanitizeMessage() shouldBe "String with additional white spaces."

--- a/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
@@ -41,7 +41,6 @@ import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.Vulnerability
 import org.ossreviewtoolkit.model.VulnerabilityReference
 import org.ossreviewtoolkit.model.config.VulnerabilityResolution
@@ -439,14 +438,13 @@ internal fun OrtResult.deduplicateProjectScanResults(targetProjects: Set<Identif
         getScanResultsForId(id).forEach { scanResult ->
             val provenance = scanResult.provenance as RepositoryProvenance
             val vcsPath = provenance.vcsInfo.path
-            val isGitRepo = provenance.vcsInfo.type == VcsType.GIT_REPO
             val repositoryPath = getRepositoryPath(provenance)
 
             val findingPaths = with(scanResult.summary) {
                 copyrightFindings.mapTo(mutableSetOf()) { it.location.path } + licenseFindings.map { it.location.path }
             }
 
-            excludePaths += findingPaths.filter { it.startsWith(vcsPath) || isGitRepo }.map { "$repositoryPath$it" }
+            excludePaths += findingPaths.filter { it.startsWith(vcsPath) }.map { "$repositoryPath$it" }
         }
     }
 

--- a/reporter/src/test/kotlin/reporters/freemarker/FreeMarkerTemplateProcessorTest.kt
+++ b/reporter/src/test/kotlin/reporters/freemarker/FreeMarkerTemplateProcessorTest.kt
@@ -108,8 +108,7 @@ private fun scanResults(
 
 private val PROJECT_VCS_INFO = VcsInfo(
     type = VcsType.GIT_REPO,
-    url = "ssh://git@host/manifests/repo",
-    path = "path/to/manifest.xml",
+    url = "ssh://git@host/manifests/repo?manifest=path/to/manifest.xml",
     revision = "deadbeaf44444444333333332222222211111111"
 )
 private val NESTED_VCS_INFO = VcsInfo(

--- a/scanner/src/funTest/kotlin/experimental/DefaultNestedProvenanceResolverFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/DefaultNestedProvenanceResolverFunTest.kt
@@ -129,9 +129,8 @@ class DefaultNestedProvenanceResolverFunTest : WordSpec() {
                 val provenance = RepositoryProvenance(
                     vcsInfo = VcsInfo(
                         type = VcsType.GIT_REPO,
-                        url = "https://github.com/oss-review-toolkit/ort-test-data-git-repo.git",
-                        revision = "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa",
-                        path = "manifest.xml"
+                        url = "https://github.com/oss-review-toolkit/ort-test-data-git-repo.git?manifest=manifest.xml",
+                        revision = "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
                     ),
                     resolvedRevision = "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
                 )

--- a/scanner/src/main/kotlin/PathScanner.kt
+++ b/scanner/src/main/kotlin/PathScanner.kt
@@ -45,7 +45,6 @@ import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.ScannerRun
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.UnknownProvenance
-import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.config.createFileArchiver
@@ -282,9 +281,7 @@ abstract class PathScanner(
         }
 
         val (scanSummary, scanDuration) = measureTimedValue {
-            val vcsPath = (provenance as? RepositoryProvenance)?.vcsInfo?.takeUnless {
-                it.type == VcsType.GIT_REPO
-            }?.path.orEmpty()
+            val vcsPath = (provenance as? RepositoryProvenance)?.vcsInfo?.path.orEmpty()
             scanPathInternal(pkgDownloadDirectory).filterByPath(vcsPath)
         }
 

--- a/utils/core/src/main/kotlin/Utils.kt
+++ b/utils/core/src/main/kotlin/Utils.kt
@@ -197,14 +197,16 @@ fun normalizeVcsUrl(vcsUrl: String): String {
                     path.endsWith(".git") || path.count { it == '/' } != 2
                 } ?: "${uri.path}.git"
 
+                val query = uri.query?.takeIf { it.isNotBlank() }?.let { "?$it" } ?: ""
+
                 return if (uri.scheme == "ssh") {
                     // Ensure the generic "git" user name is specified.
                     val host = uri.authority.let { if (it.startsWith("git@")) it else "git@$it" }
-                    "ssh://$host$path"
+                    "ssh://$host$path$query"
                 } else {
                     // Remove any user name and "www" prefix.
                     val host = uri.authority.substringAfter('@').removePrefix("www.")
-                    "https://$host$path"
+                    "https://$host$path$query"
                 }
             }
         }

--- a/utils/core/src/test/kotlin/UtilsTest.kt
+++ b/utils/core/src/test/kotlin/UtilsTest.kt
@@ -353,5 +353,11 @@ class UtilsTest : WordSpec({
                 normalizeVcsUrl(actualUrl) shouldBe expectedUrl
             }
         }
+
+        "keep the query component" {
+            val url = "https://github.com/oss-review-toolkit/ort-test-data-git-repo.git?manifest=manifest.xml"
+
+            normalizeVcsUrl(url) shouldBe url
+        }
     }
 })


### PR DESCRIPTION
Store the git-repo manifest path in the VCS URL instead of the VCS path to remove the requirement to handle the path different in case the VCS type is git-repo.
This is breaking change because existing curations and package configurations need to be adapted. It does also invalidate stored scan results for git-repo projects because their provenance is changed.