### PR TITLE
examples: Ignore deprecation of `TEST_TOOL_OF` in a deprecation check

### DIFF
--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -249,6 +249,8 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver) {
 
     ortResultRule("DEPRECATED_SCOPE_EXCLUDE_REASON_IN_ORT_YML") {
         val reasons = ortResult.repository.config.excludes.scopes.mapTo(mutableSetOf()) { it.reason }
+
+        @Suppress("DEPRECATION")
         val deprecatedReasons = setOf(ScopeExcludeReason.TEST_TOOL_OF)
 
         reasons.intersect(deprecatedReasons).forEach { offendingReason ->


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>