### PR TITLE
declared-license-mapping: Map 'CDDL+GPL' entries with 'OR'

### DIFF
--- a/utils/spdx/src/main/resources/declared-license-mapping.yml
+++ b/utils/spdx/src/main/resources/declared-license-mapping.yml
@@ -106,7 +106,7 @@
 "CC0 1.0 Universal (CC0 1.0) Public Domain Dedication": CC0-1.0
 "CC0 1.0 Universal License": CC0-1.0
 "CC0 1.0 Universal": CC0-1.0
-"CDDL + GPLv2 with classpath exception": CDDL-1.0 AND GPL-2.0-only WITH Classpath-exception-2.0
+"CDDL + GPLv2 with classpath exception": CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 "CDDL 1.0": CDDL-1.0
 "CDDL 1.1": CDDL-1.1
 "CDDL License": CDDL-1.0
@@ -114,9 +114,9 @@
 "CDDL or GPLv2 with exceptions": CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 "CDDL v1.0 / GPL v2 dual license": CDDL-1.0 OR GPL-2.0-only
 "CDDL v1.1 / GPL v2 dual license": CDDL-1.0 OR GPL-2.0-only
-"CDDL+GPL License": CDDL-1.0 AND GPL-2.0-or-later
-"CDDL+GPL": CDDL-1.0 AND GPL-2.0-or-later
-"CDDL+GPLv2": CDDL-1.0 AND GPL-2.0-only
+"CDDL+GPL License": CDDL-1.0 OR GPL-2.0-or-later
+"CDDL+GPL": CDDL-1.0 OR GPL-2.0-or-later
+"CDDL+GPLv2": CDDL-1.0 OR GPL-2.0-only
 "CDDL, v1.0": CDDL-1.0
 "CDDL/GPLv2 dual license": CDDL-1.0 OR GPL-2.0-only
 "CDDL/GPLv2+CE": CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
@@ -167,8 +167,8 @@
 "Creative Commons": CC-BY-3.0
 "DBAD": LicenseRef-scancode-dbad
 "DFSG approved": LicenseRef-scancode-free-unknown
-"Dual License: CDDL 1.0 and GPL V2 with Classpath Exception": CDDL-1.0 AND GPL-2.0-only
-"Dual license consisting of the CDDL v1.1 and GPL v2": CDDL-1.1 AND GPL-2.0-only
+"Dual License: CDDL 1.0 and GPL V2 with Classpath Exception": CDDL-1.0 OR GPL-2.0-only
+"Dual license consisting of the CDDL v1.1 and GPL v2": CDDL-1.1 OR GPL-2.0-only
 "EDL 1.0": BSD-3-Clause
 "EPL (Eclipse Public License), V1.0 or later": EPL-1.0
 "Eclipse Distribution License (EDL), Version 1.0": BSD-3-Clause


### PR DESCRIPTION
The 'CDDL+GPL' commonly refers to a license choice between these licenses
and not an 'AND' given by Sun/Oracle, see for example [1] and [2].
That the '+' is an 'OR' is also supported by the fact that many in the
community have argued that these licenses incompatible with each other, see
[3],[4] and [5].

[1]: https://repo.maven.apache.org/maven2/org/glassfish/gmbal/gmbal-api-only/3.0.0-b023/gmbal-api-only-3.0.0-b023.pom
[2]: https://web.archive.org/web/20150923052903/https://glassfish.java.net/public/faq/GF_FAQ_2.html#terms
[3]: https://lwn.net/Articles/687550/
[4]: https://www.whitesourcesoftware.com/resources/blog/top-10-cddl-questions-answered/#5_What_is_the_difference_between_the_CDDL_and_the_GNU_GPL_and_is_it_compatible_with_them
[5]: https://zonena.me/2019/01/the-cddl-is-not-incompatible-with-the-gpl/
