### PR TITLE
Set Gradle Proxy Script: Fix Home Variable and Add no_proxy

### DIFF
--- a/scripts/import_proxy_certs.sh
+++ b/scripts/import_proxy_certs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (C) 2020-2021 Bosch.IO GmbH
 #

--- a/scripts/set_gradle_proxy.sh
+++ b/scripts/set_gradle_proxy.sh
@@ -53,7 +53,7 @@ writeProxyStringToGradleProps () {
 }
 
 writeProxyEnvToGradleProps () {
-    local GRADLE_PROPS="$HOME/.gradle/gradle.properties"
+    local GRADLE_PROPS="${GRADLE_USER_HOME:-$HOME/.gradle}/gradle.properties"
 
     if [ -n "$http_proxy" ]; then
         echo "Setting HTTP proxy $http_proxy for Gradle in file '$GRADLE_PROPS'..."

--- a/scripts/set_gradle_proxy.sh
+++ b/scripts/set_gradle_proxy.sh
@@ -52,6 +52,17 @@ writeProxyStringToGradleProps () {
 	EOF
 }
 
+writeNoProxyEnvToGradleProps () {
+    local HOSTS=$1
+    local FILE=$2
+
+    grep -qF "systemProp.http.nonProxyHosts" $FILE 2>/dev/null && return 1
+
+    # Gradle / JVM expects a list separated by pipes instead of the comma that
+    # is used in shell environments
+    echo "systemProp.http.nonProxyHosts=${HOSTS//,/\|}" >> $FILE
+}
+
 writeProxyEnvToGradleProps () {
     local GRADLE_PROPS="${GRADLE_USER_HOME:-$HOME/.gradle}/gradle.properties"
 
@@ -66,6 +77,13 @@ writeProxyEnvToGradleProps () {
         echo "Setting HTTPS proxy $https_proxy for Gradle in file '$GRADLE_PROPS'..."
         if ! writeProxyStringToGradleProps $https_proxy "https" $GRADLE_PROPS; then
             echo "Not replacing existing HTTPS proxy."
+        fi
+    fi
+
+    if [ -n "$no_proxy" ]; then
+        echo "Setting proxy exemptions $no_proxy for Gradle in file '$GRADLE_PROPS'..."
+        if ! writeNoProxyEnvToGradleProps $no_proxy $GRADLE_PROPS; then
+            echo "Not replacing existing proxy exemptions."
         fi
     fi
 }

--- a/scripts/set_gradle_proxy.sh
+++ b/scripts/set_gradle_proxy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (C) 2020 Bosch.IO GmbH
 #


### PR DESCRIPTION
In https://github.com/oss-review-toolkit/ort/commit/c6b2818af7ed7b960ed8977449314eb4fc6ed783 the docker file was fixed to properly export the gradle
home variable for the gradle application to use.
The set_gradle_proxy.sh script needs to be modified to follow this
change. Up until now it was expecting gradle properties to reside in
$HOME while gradle is now expecting it at GRADLE_USER_HOME.

Whithout this adaptation gradle will fail with a
java.net.UnknownHostException error.
Complete error:
```
#17 1.561 Setting HTTP proxy http://proxy.example.com:3128 for Gradle in file '/root/.gradle/gradle.properties'...
#17 1.564 Setting HTTPS proxy http://proxy.example.com:3128 for Gradle in file '/root/.gradle/gradle.properties'...
#17 1.693 Downloading https://services.gradle.org/distributions/gradle-7.4.1-bin.zip
#17 1.910
#17 1.920 Exception in thread "main"    : services.gradle.org
#17 1.920       at java.base/java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:229)
#17 1.920       at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
#17 1.920       at java.base/java.net.Socket.connect(Socket.java:609)
#17 1.920       at java.base/sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:300)
#17 1.921       at java.base/sun.net.NetworkClient.doConnect(NetworkClient.java:177)
#17 1.921       at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:474)
#17 1.921       at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:569)
#17 1.921       at java.base/sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:266)
#17 1.921       at java.base/sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:373)
#17 1.921       at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:203)
#17 1.921       at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1187)
#17 1.921       at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1081)
#17 1.922       at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:189)
#17 1.922       at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1592)
#17 1.922       at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1520)
#17 1.922       at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:250)
#17 1.922       at org.gradle.wrapper.Download.downloadInternal(Download.java:100)
#17 1.922       at org.gradle.wrapper.Download.download(Download.java:80)
#17 1.922       at org.gradle.wrapper.Install$1.call(Install.java:82)
#17 1.923       at org.gradle.wrapper.Install$1.call(Install.java:62)
#17 1.923       at org.gradle.wrapper.ExclusiveFileAccessManager.access(ExclusiveFileAccessManager.java:69)
#17 1.923       at org.gradle.wrapper.Install.createDist(Install.java:62)
#17 1.923       at org.gradle.wrapper.WrapperExecutor.execute(WrapperExecutor.java:107)
#17 1.923       at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:63)
```

Also adding functionality to process no_proxy environment variable and to set gradle properties accordingly. 