### PR TITLE
Use Kotest's new upstream version of `containExactly` for map entries

### DIFF
--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.maps.containExactly
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.beTheSameInstanceAs
@@ -39,7 +40,6 @@ import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.RootDependencyIndex
 import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.yamlMapper
-import org.ossreviewtoolkit.utils.test.containExactly
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class AnalyzerResultBuilderTest : WordSpec() {

--- a/analyzer/src/test/kotlin/managers/utils/NodeSupportTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/NodeSupportTest.kt
@@ -27,6 +27,7 @@ import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.maps.beEmpty as beEmptyMap
+import io.kotest.matchers.maps.containExactly as containExactlyEntries
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
@@ -34,7 +35,6 @@ import java.io.File
 
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.core.ProtocolProxyMap
-import org.ossreviewtoolkit.utils.test.containExactly as containExactlyEntries
 import org.ossreviewtoolkit.utils.test.createTestTempDir
 import org.ossreviewtoolkit.utils.test.toGenericString
 

--- a/model/src/test/kotlin/AbstractDependencyNavigatorTest.kt
+++ b/model/src/test/kotlin/AbstractDependencyNavigatorTest.kt
@@ -27,6 +27,7 @@ import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.maps.containExactly as containExactlyEntries
 import io.kotest.matchers.sequences.beEmpty as beEmptySequence
 import io.kotest.matchers.sequences.containExactly as containSequenceExactly
 import io.kotest.matchers.should
@@ -37,7 +38,6 @@ import io.kotest.matchers.shouldNotBe
 import java.io.File
 import java.time.Instant
 
-import org.ossreviewtoolkit.utils.test.containExactly as containExactlyPairs
 import org.ossreviewtoolkit.utils.test.readOrtResult
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
@@ -237,7 +237,7 @@ abstract class AbstractDependencyNavigatorTest : WordSpec() {
                 paths.keys should haveSize(2)
 
                 paths["compile"] shouldNotBeNull {
-                    this should containExactlyPairs(
+                    this should containExactlyEntries(
                         Identifier("Maven:ch.qos.logback:logback-classic:1.2.3") to emptyList(),
                         Identifier("Maven:ch.qos.logback:logback-core:1.2.3") to listOf(
                             Identifier("Maven:ch.qos.logback:logback-classic:1.2.3")
@@ -348,7 +348,7 @@ abstract class AbstractDependencyNavigatorTest : WordSpec() {
 
                 val issues = navigator.projectIssues(project)
 
-                issues should org.ossreviewtoolkit.utils.test.containExactly(
+                issues should containExactlyEntries(
                     Identifier("Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0") to setOf(
                         OrtIssue(
                             Instant.EPOCH,

--- a/model/src/test/kotlin/DependencyTreeNavigatorTest.kt
+++ b/model/src/test/kotlin/DependencyTreeNavigatorTest.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.model
 
+import io.kotest.matchers.maps.containExactly
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
@@ -66,7 +67,7 @@ class DependencyTreeNavigatorTest : AbstractDependencyNavigatorTest() {
                 val project = Project.EMPTY.copy(scopeDependencies = sortedSetOf(scope))
                 val paths = navigator.getShortestPaths(project)[scope.name]!!
 
-                paths should org.ossreviewtoolkit.utils.test.containExactly(
+                paths should containExactly(
                     Identifier("A") to emptyList(),
                     Identifier("B") to emptyList(),
                     Identifier("C") to emptyList(),

--- a/model/src/test/kotlin/IdentifierTest.kt
+++ b/model/src/test/kotlin/IdentifierTest.kt
@@ -25,6 +25,7 @@ import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.maps.containExactly
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldNotContain
@@ -33,7 +34,6 @@ import io.kotest.matchers.string.shouldStartWith
 
 import org.ossreviewtoolkit.model.utils.createPurl
 import org.ossreviewtoolkit.model.utils.toPurl
-import org.ossreviewtoolkit.utils.test.containExactly
 
 class IdentifierTest : WordSpec({
     "String representations" should {

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -26,6 +26,7 @@ import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.maps.containExactly as containExactlyEntries
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -36,7 +37,6 @@ import java.io.File
 import java.lang.IllegalArgumentException
 
 import org.ossreviewtoolkit.model.SourceCodeOrigin
-import org.ossreviewtoolkit.utils.test.containExactly as containExactlyEntries
 import org.ossreviewtoolkit.utils.test.createTestTempFile
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 

--- a/scanner/src/funTest/kotlin/experimental/DefaultNestedProvenanceResolverFunTest.kt
+++ b/scanner/src/funTest/kotlin/experimental/DefaultNestedProvenanceResolverFunTest.kt
@@ -23,6 +23,7 @@ package org.ossreviewtoolkit.scanner.experimental
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.maps.containExactly
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
@@ -35,7 +36,6 @@ import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.common.Os
-import org.ossreviewtoolkit.utils.test.containExactly
 
 class DefaultNestedProvenanceResolverFunTest : WordSpec() {
     private val workingTreeCache = DefaultWorkingTreeCache()

--- a/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
+++ b/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
@@ -23,6 +23,7 @@ package org.ossreviewtoolkit.scanner.experimental
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.maps.beEmpty
+import io.kotest.matchers.maps.containExactly
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
@@ -60,7 +61,6 @@ import org.ossreviewtoolkit.model.config.ScannerOptions
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.utils.core.createOrtTempDir
-import org.ossreviewtoolkit.utils.test.containExactly
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class ExperimentalScannerTest : WordSpec({

--- a/utils/common/src/test/kotlin/ExtensionsTest.kt
+++ b/utils/common/src/test/kotlin/ExtensionsTest.kt
@@ -27,6 +27,7 @@ import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.file.aDirectory
 import io.kotest.matchers.file.exist
+import io.kotest.matchers.maps.containExactly
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -38,7 +39,6 @@ import java.io.IOException
 import java.time.DayOfWeek
 import java.util.Locale
 
-import org.ossreviewtoolkit.utils.test.containExactly
 import org.ossreviewtoolkit.utils.test.createSpecTempDir
 import org.ossreviewtoolkit.utils.test.createTestTempDir
 import org.ossreviewtoolkit.utils.test.createTestTempFile

--- a/utils/core/src/test/kotlin/DeclaredLicenseProcessorTest.kt
+++ b/utils/core/src/test/kotlin/DeclaredLicenseProcessorTest.kt
@@ -25,6 +25,7 @@ import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.maps.beEmpty as beEmptyMap
+import io.kotest.matchers.maps.containExactly as containExactlyEntries
 import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -39,7 +40,6 @@ import org.ossreviewtoolkit.utils.spdx.SpdxLicenseIdExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxSimpleLicenseMapping
 import org.ossreviewtoolkit.utils.spdx.toExpression
 import org.ossreviewtoolkit.utils.spdx.toSpdx
-import org.ossreviewtoolkit.utils.test.containExactly as containExactlyEntries
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class DeclaredLicenseProcessorTest : StringSpec() {

--- a/utils/test/src/main/kotlin/Utils.kt
+++ b/utils/test/src/main/kotlin/Utils.kt
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.module.kotlin.readValue
 
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.collections.beEmpty
-import io.kotest.matchers.maps.MapContainsMatcher
 import io.kotest.matchers.neverNullMatcher
 
 import java.io.File
@@ -46,8 +45,6 @@ private val ENV_VAR_REGEX = Regex("(\\s{4}variables:)\\n(?:\\s{6}.+)+")
 private val ENV_TOOL_REGEX = Regex("(\\s{4}tool_versions:)\\n(?:\\s{6}.+)+")
 private val START_AND_END_TIME_REGEX = Regex("((start|end)_time): \".*\"")
 private val TIMESTAMP_REGEX = Regex("(timestamp): \".*\"")
-
-fun <K, V> containExactly(vararg expected: Pair<K, V>): Matcher<Map<K, V>> = MapContainsMatcher(expected.toMap())
 
 fun patchExpectedResult(
     result: File,


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>