### PR TITLE
Improve file assertions in tests

### DIFF
--- a/downloader/src/funTest/kotlin/DownloaderFunTest.kt
+++ b/downloader/src/funTest/kotlin/DownloaderFunTest.kt
@@ -22,6 +22,9 @@ package org.ossreviewtoolkit.downloader
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
+import io.kotest.matchers.file.aFile
+import io.kotest.matchers.file.haveFileSize
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeTypeOf
 
@@ -75,8 +78,8 @@ class DownloaderFunTest : StringSpec() {
                 sourceArtifact.hash shouldBe pkg.sourceArtifact.hash
             }
 
-            licenseFile.isFile shouldBe true
-            licenseFile.length() shouldBe 11376L
+            licenseFile shouldBe aFile()
+            licenseFile should haveFileSize(11376L)
 
             outputDir.walk().count() shouldBe 234
         }
@@ -147,8 +150,8 @@ class DownloaderFunTest : StringSpec() {
                 sourceArtifact.hash shouldBe pkg.sourceArtifact.hash
             }
 
-            licenseFile.isFile shouldBe true
-            licenseFile.length() shouldBe 11376L
+            licenseFile shouldBe aFile()
+            licenseFile should haveFileSize(11376L)
 
             outputDir.walk().count() shouldBe 234
         }
@@ -188,8 +191,8 @@ class DownloaderFunTest : StringSpec() {
                 vcsInfo.revision shouldBe pkg.vcs.revision
             }
 
-            licenseFile.isFile shouldBe true
-            licenseFile.length() shouldBe 11376L
+            licenseFile shouldBe aFile()
+            licenseFile should haveFileSize(11376L)
 
             outputDir.walk().count() shouldBe 608
         }

--- a/model/src/test/kotlin/utils/FileArchiverTest.kt
+++ b/model/src/test/kotlin/utils/FileArchiverTest.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.model.utils
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
+import io.kotest.matchers.file.aFile
 import io.kotest.matchers.file.exist
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
@@ -69,7 +70,7 @@ class FileArchiverTest : StringSpec() {
      */
     private fun File.shouldContainFileWithContent(path: String) {
         val file = resolve(path)
-        file.isFile shouldBe true
+        file shouldBe aFile()
         file.readText() shouldBe path
     }
 

--- a/utils/common/src/test/kotlin/ExtensionsTest.kt
+++ b/utils/common/src/test/kotlin/ExtensionsTest.kt
@@ -26,6 +26,7 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.file.aDirectory
+import io.kotest.matchers.file.aFile
 import io.kotest.matchers.file.exist
 import io.kotest.matchers.maps.containExactly
 import io.kotest.matchers.nulls.beNull
@@ -88,7 +89,7 @@ class ExtensionsTest : WordSpec({
         }
 
         "return 'false' for files" {
-            file.isFile shouldBe true
+            file shouldBe aFile()
             file.isSymbolicLink() shouldBe false
         }
 
@@ -101,7 +102,7 @@ class ExtensionsTest : WordSpec({
             ProcessCapture(tempDir, "cmd", "/c", "mklink", "/h", "hardlink", "file")
 
             tempDir.resolve("hardlink").let { hardlink ->
-                hardlink.isFile shouldBe true
+                hardlink shouldBe aFile()
                 hardlink.isSymbolicLink() shouldBe false
             }
         }
@@ -119,7 +120,7 @@ class ExtensionsTest : WordSpec({
             ProcessCapture(tempDir, "cmd", "/c", "mklink", "symlink-to-file", "file")
 
             tempDir.resolve("symlink-to-file").let { symlinkToFile ->
-                symlinkToFile.isFile shouldBe true
+                symlinkToFile shouldBe aFile()
                 symlinkToFile.isSymbolicLink() shouldBe true
             }
         }
@@ -204,9 +205,9 @@ class ExtensionsTest : WordSpec({
         "throw exception if file is not a directory" {
             val file = createTestTempFile()
 
-            file.isFile shouldBe true
+            file shouldBe aFile()
             shouldThrow<IOException> { file.safeMkdirs() }
-            file.isFile shouldBe true // should still be a file afterwards
+            file shouldBe aFile() // should still be a file afterwards
         }
     }
 
@@ -297,7 +298,7 @@ class ExtensionsTest : WordSpec({
             val tempDir = createTestTempDir()
             val fileFromStr = tempDir.resolve(str.fileSystemEncode()).apply { writeText("dummy") }
 
-            fileFromStr.isFile shouldBe true
+            fileFromStr shouldBe aFile()
         }
     }
 

--- a/utils/core/src/funTest/kotlin/storage/LocalFileStorageFunTest.kt
+++ b/utils/core/src/funTest/kotlin/storage/LocalFileStorageFunTest.kt
@@ -22,7 +22,10 @@ package org.ossreviewtoolkit.utils.core.storage
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.file.aFile
+import io.kotest.matchers.file.exist
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
 
 import java.io.BufferedReader
 import java.io.File
@@ -101,7 +104,7 @@ class LocalFileStorageFunTest : WordSpec() {
 
                     val file = directory.resolve("target/file")
 
-                    file.isFile shouldBe true
+                    file shouldBe aFile()
                     file.readText() shouldBe "content"
                 }
             }
@@ -113,7 +116,7 @@ class LocalFileStorageFunTest : WordSpec() {
 
                     storage.write("file", "content".byteInputStream())
 
-                    file.isFile shouldBe true
+                    file shouldBe aFile()
                     file.readText() shouldBe "content"
                 }
             }
@@ -126,7 +129,7 @@ class LocalFileStorageFunTest : WordSpec() {
 
                     val file = directory.resolve("../file")
 
-                    file.isFile shouldBe false
+                    file shouldNot exist()
                 }
             }
 


### PR DESCRIPTION
These matchers provide better messages on failures.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>