### PR TITLE
scanoss: Use the new Retrofit-based client

### DIFF
--- a/clients/scanoss/src/main/kotlin/ScanOssService.kt
+++ b/clients/scanoss/src/main/kotlin/ScanOssService.kt
@@ -58,6 +58,7 @@ interface ScanOssService {
 
     /**
      * Scan a file using the SCANOSS streaming API.
+     * TODO: Implement support for scanning with SBOM.
      */
     @Multipart
     @POST("scan/direct")

--- a/clients/scanoss/src/main/kotlin/ScanOssService.kt
+++ b/clients/scanoss/src/main/kotlin/ScanOssService.kt
@@ -34,7 +34,7 @@ import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
 
-interface ScanossService {
+interface ScanOssService {
     companion object {
         /**
          * The JSON (de-)serialization object used by this service.
@@ -44,7 +44,7 @@ interface ScanossService {
         /**
          * Create a new service instance that connects to the [url] specified and uses the optionally provided [client].
          */
-        fun create(url: String, client: OkHttpClient? = null): ScanossService {
+        fun create(url: String, client: OkHttpClient? = null): ScanOssService {
             val contentType = "application/json".toMediaType()
             val retrofit = Retrofit.Builder()
                 .apply { if (client != null) client(client) }
@@ -52,7 +52,7 @@ interface ScanossService {
                 .addConverterFactory(JSON.asConverterFactory(contentType))
                 .build()
 
-            return retrofit.create(ScanossService::class.java)
+            return retrofit.create(ScanOssService::class.java)
         }
     }
 

--- a/clients/scanoss/src/test/kotlin/ScanOssDetailsTest.kt
+++ b/clients/scanoss/src/test/kotlin/ScanOssDetailsTest.kt
@@ -34,7 +34,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
 
-import org.ossreviewtoolkit.clients.scanoss.ScanossService
+import org.ossreviewtoolkit.clients.scanoss.ScanOssService
 import org.ossreviewtoolkit.clients.scanoss.model.Source
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
@@ -46,7 +46,7 @@ class ScanOssDetailsTest : StringSpec({
             .dynamicPort()
             .usingFilesUnderDirectory("src/test/assets/details")
     )
-    lateinit var service: ScanossService
+    lateinit var service: ScanOssService
 
     val sampleFile = File("src/test/assets/scan/file.wfp").let { file ->
         MultipartBody.Part.createFormData(
@@ -58,7 +58,7 @@ class ScanOssDetailsTest : StringSpec({
 
     beforeSpec {
         server.start()
-        service = ScanossService.create("http://localhost:${server.port()}")
+        service = ScanOssService.create("http://localhost:${server.port()}")
     }
 
     afterSpec {

--- a/clients/scanoss/src/test/kotlin/ScanOssServiceTest.kt
+++ b/clients/scanoss/src/test/kotlin/ScanOssServiceTest.kt
@@ -33,7 +33,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
 
-import org.ossreviewtoolkit.clients.scanoss.ScanossService
+import org.ossreviewtoolkit.clients.scanoss.ScanOssService
 import org.ossreviewtoolkit.clients.scanoss.model.IdentificationType
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
@@ -48,7 +48,7 @@ class ScanOssServiceTest : StringSpec({
             .dynamicPort()
             .usingFilesUnderDirectory("src/test/assets/scan")
     )
-    lateinit var service: ScanossService
+    lateinit var service: ScanOssService
 
     val sampleFile = File("src/test/assets/scan/file.wfp").let { file ->
         MultipartBody.Part.createFormData(
@@ -60,7 +60,7 @@ class ScanOssServiceTest : StringSpec({
 
     beforeSpec {
         server.start()
-        service = ScanossService.create("http://localhost:${server.port()}")
+        service = ScanOssService.create("http://localhost:${server.port()}")
     }
 
     afterSpec {

--- a/scanner/build.gradle.kts
+++ b/scanner/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
 
     implementation(project(":clients:clearly-defined"))
     implementation(project(":clients:fossid-webapp"))
+    implementation(project(":clients:scanoss"))
     implementation(project(":downloader"))
     implementation(project(":utils:core-utils"))
 

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -43,7 +43,7 @@ import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.core.ortToolsDirectory
 import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 
-class Askalono(
+class Askalono internal constructor(
     name: String,
     scannerConfig: ScannerConfiguration,
     downloaderConfig: DownloaderConfiguration

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -45,7 +45,7 @@ import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.core.ortToolsDirectory
 import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 
-class BoyterLc(
+class BoyterLc internal constructor(
     name: String,
     scannerConfig: ScannerConfiguration,
     downloaderConfig: DownloaderConfiguration

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -40,7 +40,7 @@ import org.ossreviewtoolkit.utils.common.ProcessCapture
 import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 
-class Licensee(
+class Licensee internal constructor(
     name: String,
     scannerConfig: ScannerConfiguration,
     downloaderConfig: DownloaderConfiguration

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -61,7 +61,7 @@ import org.ossreviewtoolkit.utils.core.ortToolsDirectory
  *   detected licenses. If this option is set to "true", the detected `license_expression` is used instead, which can
  *   contain an SPDX expression.
  */
-class ScanCode(
+class ScanCode internal constructor(
     name: String,
     scannerConfig: ScannerConfiguration,
     downloaderConfig: DownloaderConfiguration

--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
@@ -20,22 +20,34 @@
 
 package org.ossreviewtoolkit.scanner.scanners.scanoss
 
-import com.scanoss.scanner.ScanFormat
-import com.scanoss.scanner.Scanner
-import com.scanoss.scanner.ScannerConf
+import com.scanoss.scanner.BlacklistRules
+import com.scanoss.scanner.Winnowing
 
 import java.io.File
 import java.time.Instant
+import java.util.UUID
 
+import kotlinx.coroutines.runBlocking
+
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.toRequestBody
+
+import org.ossreviewtoolkit.clients.scanoss.ScanOssService
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.readJsonFile
 import org.ossreviewtoolkit.scanner.AbstractScannerFactory
 import org.ossreviewtoolkit.scanner.BuildConfig
 import org.ossreviewtoolkit.scanner.PathScanner
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.core.createOrtTempDir
+import org.ossreviewtoolkit.utils.core.log
+
+// An arbitrary name to use for the multipart body being sent.
+private const val FAKE_WFP_FILE_NAME = "fake.wfp"
 
 class ScanOss internal constructor(
     name: String,
@@ -47,30 +59,75 @@ class ScanOss internal constructor(
             ScanOss(scannerName, scannerConfig, downloaderConfig)
     }
 
+    private val config = ScanOssConfig.create(scannerConfig).also {
+        log.info { "The $scannerName API URL is ${it.apiUrl}." }
+    }
+
+    private val service = ScanOssService.create(config.apiUrl)
+
+    // TODO: Find out the best / cheapest way to query the SCANOSS server for its version.
     override val version = BuildConfig.SCANOSS_VERSION
+
     override val configuration = ""
+
+    /**
+     * The name of the file corresponding to the fingerprints can be sent to SCANOSS for more precise matches.
+     * However, for anonymity, a unique identifier should be generated and used instead. This property holds the
+     * mapping between the file paths and the unique identifiers. When receiving the response, the UUID will be
+     * replaced by the actual file path.
+     *
+     * TODO: This behavior should be driven by a configuration parameter enabled by default.
+     */
+    private val fileNamesAnonymizationMapping = mutableMapOf<UUID, String>()
 
     override fun scanPathInternal(path: File): ScanSummary {
         val resultFile = createOrtTempDir().resolve("result.json")
         val startTime = Instant.now()
 
-        // TODO: Support API configurations other than OSSKB.
-        val scannerConf = ScannerConf.defaultConf()
-        val scanner = Scanner(scannerConf)
-
-        val scanType = null
-        val sbomPath = ""
-
-        if (path.isDirectory) {
-            scanner.scanDirectory(path.absolutePath, scanType, sbomPath, ScanFormat.plain, resultFile.absolutePath)
-        } else if (path.isFile) {
-            scanner.scanFileAndSave(path.absolutePath, scanType, sbomPath, ScanFormat.plain, resultFile.absolutePath)
+        val wfpString = buildString {
+            path.walk()
+                // TODO: Consider not applying the (somewhat arbitrary) blacklist.
+                .filter { !it.isDirectory && !BlacklistRules.hasBlacklistedExt(it.name) }
+                .forEach {
+                    this@ScanOss.log.info { "Computing fingerprint for file ${it.absolutePath}..." }
+                    append(createWfpForFile(it.path))
+                }
         }
+
+        val response = runBlocking {
+            val wfpBody = wfpString.toRequestBody("application/octet-stream".toMediaType())
+            val wfpFile = MultipartBody.Part.createFormData(FAKE_WFP_FILE_NAME, FAKE_WFP_FILE_NAME, wfpBody)
+
+            service.scan(wfpFile)
+        }
+
+        // Replace the anonymized UUIDs by their file paths.
+        val resolvedResponse = response.map { entry ->
+            val uuid = UUID.fromString(entry.key)
+
+            require(uuid in fileNamesAnonymizationMapping) {
+                "The $scannerName server returned an UUID not present in the mapping."
+            }
+
+            fileNamesAnonymizationMapping[uuid] to entry.value
+        }.toMap()
+
+        jsonMapper.writeValue(resultFile, resolvedResponse)
 
         val endTime = Instant.now()
         val result = readJsonFile(resultFile)
         resultFile.parentFile.safeDeleteRecursively(force = true)
 
         return generateSummary(startTime, endTime, path, result)
+    }
+
+    internal fun generateRandomUUID() = UUID.randomUUID()
+
+    internal fun createWfpForFile(filePath: String): String {
+        generateRandomUUID().let { uuid ->
+            // TODO: Let's keep the original file extension to give SCANOSS some hint about the mime type.
+            fileNamesAnonymizationMapping[uuid] = filePath
+            return Winnowing.wfpForFile(uuid.toString(), filePath)
+        }
     }
 }

--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
@@ -37,7 +37,7 @@ import org.ossreviewtoolkit.scanner.PathScanner
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.core.createOrtTempDir
 
-class ScanOss(
+class ScanOss internal constructor(
     name: String,
     scannerConfig: ScannerConfiguration,
     downloaderConfig: DownloaderConfiguration

--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
@@ -58,7 +58,6 @@ class ScanOss(
         val scannerConf = ScannerConf.defaultConf()
         val scanner = Scanner(scannerConf)
 
-        // TODO: Implement support for scanning with SBOM.
         val scanType = null
         val sbomPath = ""
 

--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOssConfig.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOssConfig.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.scanoss
+
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+
+/**
+ * A data class that holds the configuration options supported by the [ScanOss] scanner. An instance of this class is
+ * created from the options contained in a [ScannerConfiguration] object under the key _ScanOss_. It offers the
+ * following configuration options:
+ */
+internal data class ScanOssConfig(
+    /** URL of the ScanOSS server. */
+    val apiUrl: String,
+
+    /** API Key required to authenticate with the ScanOSS server. */
+    val apiKey: String
+) {
+    companion object {
+        /** Name of the configuration property for the API URL. */
+        const val API_URL_PROPERTY = "apiUrl"
+
+        /** Name of the configuration property for the API key. */
+        const val API_KEY_PROPERTY = "apiKey"
+
+        fun create(scannerConfig: ScannerConfiguration): ScanOssConfig {
+            val scanOssIdScannerOptions = scannerConfig.options?.get("ScanOss")
+
+            requireNotNull(scanOssIdScannerOptions) { "No ScanOSS Scanner configuration found." }
+
+            val apiURL = scanOssIdScannerOptions[API_URL_PROPERTY] ?: "https://osskb.org/api/"
+            val apiKey = scanOssIdScannerOptions[API_KEY_PROPERTY].orEmpty()
+
+            return ScanOssConfig(apiURL, apiKey)
+        }
+    }
+}

--- a/scanner/src/test/assets/scanoss/filesToScan/ArchiveUtils.kt
+++ b/scanner/src/test/assets/scanoss/filesToScan/ArchiveUtils.kt
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+@file:Suppress("MatchingDeclarationName")
+
+package org.ossreviewtoolkit.utils
+
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.zip.Deflater
+
+import org.apache.commons.compress.archivers.ArchiveEntry
+import org.apache.commons.compress.archivers.ArchiveInputStream
+import org.apache.commons.compress.archivers.sevenz.SevenZFile
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
+import org.apache.commons.compress.archivers.zip.ZipFile
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
+import org.apache.commons.compress.compressors.xz.XZCompressorInputStream
+import org.apache.commons.compress.utils.SeekableInMemoryByteChannel
+
+enum class ArchiveType(vararg val extensions: String) {
+    TAR(".gem", ".tar"),
+    TAR_BZIP2(".tar.bz2", ".tbz2"),
+    TAR_GZIP(".crate", ".tar.gz", ".tgz"),
+    TAR_XZ(".tar.xz", ".txz"),
+    ZIP(".aar", ".egg", ".jar", ".war", ".whl", ".zip"),
+    SEVENZIP(".7z"),
+    NONE("");
+
+    companion object {
+        fun getType(filename: String): ArchiveType {
+            val lowerName = filename.toLowerCase()
+            return (enumValues<ArchiveType>().asList() - NONE).find { type ->
+                type.extensions.any { lowerName.endsWith(it) }
+            } ?: NONE
+        }
+    }
+}
+
+/**
+ * Unpack the [File] to [targetDirectory].
+ */
+fun File.unpack(targetDirectory: File) =
+    when (ArchiveType.getType(name)) {
+        ArchiveType.SEVENZIP -> unpack7Zip(targetDirectory)
+        ArchiveType.ZIP -> unpackZip(targetDirectory)
+
+        ArchiveType.TAR -> inputStream().unpackTar(targetDirectory)
+        ArchiveType.TAR_BZIP2 -> BZip2CompressorInputStream(inputStream()).unpackTar(targetDirectory)
+        ArchiveType.TAR_GZIP -> GzipCompressorInputStream(inputStream()).unpackTar(targetDirectory)
+        ArchiveType.TAR_XZ -> XZCompressorInputStream(inputStream()).unpackTar(targetDirectory)
+
+        ArchiveType.NONE -> {
+            throw IOException("Unable to guess compression scheme from file name '$name'.")
+        }
+    }
+
+/**
+ * Unpack the [File] assuming it is a 7-Zip archive. This implementation ignores empty directories and symbolic links.
+ */
+fun File.unpack7Zip(targetDirectory: File) {
+    SevenZFile(this).use { zipFile ->
+        while (true) {
+            val entry = zipFile.nextEntry ?: break
+
+            if (entry.isDirectory || entry.isAntiItem) {
+                continue
+            }
+
+            val target = targetDirectory.resolve(entry.name)
+
+            // There is no guarantee that directory entries appear before file entries, so ensure that the parent
+            // directory for a file exists.
+            target.parentFile.safeMkdirs()
+
+            target.outputStream().use { output ->
+                zipFile.getInputStream(entry).copyTo(output)
+            }
+        }
+    }
+}
+
+/**
+ * Unpack the [File] assuming it is a Zip archive.
+ */
+fun File.unpackZip(targetDirectory: File) = ZipFile(this).unpack(targetDirectory)
+
+/**
+ * Unpack the [ByteArray] assuming it is a Zip archive.
+ */
+fun ByteArray.unpackZip(targetDirectory: File) = ZipFile(SeekableInMemoryByteChannel(this)).unpack(targetDirectory)
+
+/**
+ * Pack the file into a ZIP [targetFile] using [Deflater.BEST_COMPRESSION]. If the file is a directory its content is
+ * recursively added to the archive. Only regular files are added, e.g. symbolic links or directories are skipped. If
+ * a [prefix] is specified, it is added to the file names in the ZIP file.
+ * If not all files shall be added to the archive a [filter] can be provided.
+ */
+fun File.packZip(
+    targetFile: File,
+    prefix: String = "",
+    overwrite: Boolean = false,
+    filter: (Path) -> Boolean = { true }
+) {
+    require(overwrite || !targetFile.exists()) {
+        "The target ZIP file '${targetFile.absolutePath}' must not exist."
+    }
+
+    ZipArchiveOutputStream(targetFile).use { output ->
+        output.setLevel(Deflater.BEST_COMPRESSION)
+        Files.walkFileTree(toPath(), object : SimpleFileVisitor<Path>() {
+            override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+                if (attrs.isRegularFile && filter(file)) {
+                    val entry = ZipArchiveEntry(file.toFile(), "$prefix${this@packZip.toPath().relativize(file)}")
+                    output.putArchiveEntry(entry)
+                    file.toFile().inputStream().use { input -> input.copyTo(output) }
+                    output.closeArchiveEntry()
+                }
+
+                return FileVisitResult.CONTINUE
+            }
+        })
+    }
+}
+
+/**
+ * Unpack the [InputStream] to [targetDirectory] assuming that it is a tape archive (TAR). This implementation ignores
+ * empty directories and symbolic links.
+ */
+fun InputStream.unpackTar(targetDirectory: File) =
+    TarArchiveInputStream(this).unpack(
+        targetDirectory,
+        { entry -> !(entry as TarArchiveEntry).isFile },
+        { entry -> (entry as TarArchiveEntry).mode }
+    )
+
+/**
+ * Unpack the [InputStream] to [targetDirectory] assuming that it is a ZIP archive. This implementation ignores empty
+ * directories and symbolic links.
+ */
+fun InputStream.unpackZip(targetDirectory: File) =
+    ZipArchiveInputStream(this).unpack(
+        targetDirectory,
+        { entry -> (entry as ZipArchiveEntry).let { it.isDirectory || it.isUnixSymlink } },
+        { entry -> (entry as ZipArchiveEntry).unixMode }
+    )
+
+/**
+ * Copy the executable bit contained in [mode] to the [target] file's mode bits.
+ */
+private fun copyExecutableModeBit(target: File, mode: Int) {
+    if (Os.isWindows) return
+
+    // Note: In contrast to Java, Kotlin does not support octal literals, see
+    // https://kotlinlang.org/docs/reference/basic-types.html#literal-constants.
+    // The bit-triplets from left to right stand for user, groups, other, respectively.
+    if (mode and 0b001_000_001 != 0) {
+        target.setExecutable(true, (mode and 0b000_000_001) == 0)
+    }
+}
+
+/**
+ * Unpack this [ArchiveInputStream] to the [targetDirectory], skipping all entries for which [shouldSkip] returns true,
+ * and using what [mode] returns as the file mode bits.
+ */
+private fun ArchiveInputStream.unpack(
+    targetDirectory: File,
+    shouldSkip: (ArchiveEntry) -> Boolean,
+    mode: (ArchiveEntry) -> Int
+) =
+    use { input ->
+        while (true) {
+            val entry = input.nextEntry ?: break
+
+            if (shouldSkip(entry)) continue
+
+            val target = targetDirectory.resolve(entry.name)
+
+            // There is no guarantee that directory entries appear before file entries, so ensure that the parent
+            // directory for a file exists.
+            target.parentFile.safeMkdirs()
+
+            target.outputStream().use { output ->
+                input.copyTo(output)
+            }
+
+            copyExecutableModeBit(target, mode(entry))
+        }
+    }
+
+/**
+ * Unpack the [ZipFile]. In contrast to [InputStream.unpackZip] this properly parses the ZIP's central directory, see
+ * https://commons.apache.org/proper/commons-compress/zip.html#ZipArchiveInputStream_vs_ZipFile.
+ */
+private fun ZipFile.unpack(targetDirectory: File) =
+    use { zipFile ->
+        val entries = zipFile.entries
+
+        while (entries.hasMoreElements()) {
+            val entry = entries.nextElement()
+
+            if (entry.isDirectory || entry.isUnixSymlink) {
+                continue
+            }
+
+            val target = targetDirectory.resolve(entry.name)
+
+            // There is no guarantee that directory entries appear before file entries, so ensure that the parent
+            // directory for a file exists.
+            target.parentFile.safeMkdirs()
+
+            target.outputStream().use { output ->
+                zipFile.getInputStream(entry).copyTo(output)
+            }
+
+            copyExecutableModeBit(target, entry.unixMode)
+        }
+    }

--- a/scanner/src/test/assets/scanoss/filesToScan/ScannerFactory.kt
+++ b/scanner/src/test/assets/scanoss/filesToScan/ScannerFactory.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner
+
+import java.util.ServiceLoader
+
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+
+/**
+ * A common interface for use with [ServiceLoader] that all [AbstractScannerFactory] classes need to implement.
+ */
+interface ScannerFactory {
+    /**
+     * The name to use to refer to the scanner.
+     */
+    val scannerName: String
+
+    /**
+     * Create a [Scanner] using the specified [config].
+     */
+    fun create(config: ScannerConfiguration): Scanner
+}
+
+/**
+ * A generic factory class for a [Scanner].
+ */
+abstract class AbstractScannerFactory<out T : Scanner>(
+    override val scannerName: String
+) : ScannerFactory {
+    abstract override fun create(config: ScannerConfiguration): T
+
+    /**
+     * Return the scanner's name here to allow Clikt to display something meaningful when listing the scanners
+     * which are enabled by default via their factories.
+     */
+    override fun toString() = scannerName
+}

--- a/scanner/src/test/assets/scanoss/scanMulti/mappings/scanoss-multi-response.json
+++ b/scanner/src/test/assets/scanoss/scanMulti/mappings/scanoss-multi-response.json
@@ -1,0 +1,23 @@
+{
+  "id" : "b28995c4-70e0-4fda-a1a8-c8a0ea1f1c85",
+  "name" : "scan_direct",
+  "request" : {
+    "url" : "/scan/direct",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "anything" : "anything"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{  \"c198b884-f6cf-496f-95eb-0e7968dd2ec6\": [    {      \"id\": \"snippet\",      \"status\": \"pending\",      \"lines\": \"1-240\",      \"oss_lines\": \"128-367\",      \"matched\": \"99%\",      \"purl\": [        \"pkg:github/scanoss/ort\"      ],      \"vendor\": \"scanoss\",      \"component\": \"ort\",      \"version\": \"e654028\",      \"latest\": \"b12f8ee\",      \"url\": \"https://github.com/scanoss/ort\",      \"release_date\": \"2021-03-18\",      \"file\": \"utils/src/main/kotlin/ArchiveUtils.kt\",      \"url_hash\": \"37faa38a820322fa93bf7a8fa8290bb8\",      \"file_hash\": \"871fb0c5188c2f620d9b997e225b0095\",      \"source_hash\": \"2e91edbe430c4eb195a977d326d6d6c0\",      \"file_url\": \"https://osskb.org/api/file_contents/871fb0c5188c2f620d9b997e225b0095\",      \"licenses\": [        {          \"name\": \"Apache-2.0\",          \"patent_hints\": \"yes\",          \"copyleft\": \"no\",          \"checklist_url\": \"https://www.osadl.org/fileadmin/checklists/unreflicenses/Apache-2.0.txt\",          \"osadl_updated\": \"2022-03-17 13:38\",          \"source\": \"file_spdx_tag\"        },        {          \"name\": \"Apache-2.0\",          \"patent_hints\": \"yes\",          \"copyleft\": \"no\",          \"checklist_url\": \"https://www.osadl.org/fileadmin/checklists/unreflicenses/Apache-2.0.txt\",          \"osadl_updated\": \"2022-03-17 13:38\",          \"source\": \"scancode\"        }      ],      \"server\": {        \"version\": \"4.4.2\",        \"kb_version\": {          \"monthly\": \"22.02\",          \"daily\": \"22.03.25\"        }      }    }  ],  \"5530105e-0752-4750-9c07-4e4604b879a5\": [    {      \"id\": \"file\",      \"status\": \"pending\",      \"lines\": \"all\",      \"oss_lines\": \"all\",      \"matched\": \"100%\",      \"purl\": [        \"pkg:github/scanoss/ort\"      ],      \"vendor\": \"scanoss\",      \"component\": \"ort\",      \"version\": \"e654028\",      \"latest\": \"b12f8ee\",      \"url\": \"https://github.com/scanoss/ort\",      \"release_date\": \"2021-03-18\",      \"file\": \"scanner/src/main/kotlin/ScannerFactory.kt\",      \"url_hash\": \"37faa38a820322fa93bf7a8fa8290bb8\",      \"file_hash\": \"5c8ab9be40df937e46c53509481107cd\",      \"source_hash\": \"5c8ab9be40df937e46c53509481107cd\",      \"file_url\": \"https://osskb.org/api/file_contents/5c8ab9be40df937e46c53509481107cd\",      \"licenses\": [        {          \"name\": \"Apache-2.0\",          \"patent_hints\": \"yes\",          \"copyleft\": \"no\",          \"checklist_url\": \"https://www.osadl.org/fileadmin/checklists/unreflicenses/Apache-2.0.txt\",          \"osadl_updated\": \"2022-03-17 13:38\",          \"source\": \"file_spdx_tag\"        },        {          \"name\": \"Apache-2.0\",          \"patent_hints\": \"yes\",          \"copyleft\": \"no\",          \"checklist_url\": \"https://www.osadl.org/fileadmin/checklists/unreflicenses/Apache-2.0.txt\",          \"osadl_updated\": \"2022-03-17 13:38\",          \"source\": \"scancode\"        }      ],      \"server\": {        \"version\": \"4.4.2\",        \"kb_version\": {          \"monthly\": \"22.02\",          \"daily\": \"22.03.25\"        }      }    }  ]}",
+    "headers" : {
+      "Server" : "nginx/1.14.2",
+      "Date" : "Wed, 16 Mar 2022 13:07:04 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "b28995c4-70e0-4fda-a1a8-c8a0ea1f1c85",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/scanner/src/test/assets/scanoss/scanSingle/mappings/scanoss-response.json
+++ b/scanner/src/test/assets/scanoss/scanSingle/mappings/scanoss-response.json
@@ -1,0 +1,23 @@
+{
+  "id" : "b28995c4-70e0-4fda-a1a8-c8a0ea1f1c85",
+  "name" : "scan_direct",
+  "request" : {
+    "url" : "/scan/direct",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "anything" : "anything"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{  \"bf5401e9-03b3-4c91-906c-cadb90487b8c\": [    {      \"id\": \"file\",      \"status\": \"pending\",      \"lines\": \"all\",      \"oss_lines\": \"all\",      \"matched\": \"100%\",      \"purl\": [        \"pkg:github/scanoss/ort\"      ],      \"vendor\": \"scanoss\",      \"component\": \"ort\",      \"version\": \"e654028\",      \"latest\": \"b12f8ee\",      \"url\": \"https://github.com/scanoss/ort\",      \"release_date\": \"2021-03-18\",      \"file\": \"scanner/src/main/kotlin/ScannerFactory.kt\",      \"url_hash\": \"37faa38a820322fa93bf7a8fa8290bb8\",      \"file_hash\": \"5c8ab9be40df937e46c53509481107cd\",      \"source_hash\": \"5c8ab9be40df937e46c53509481107cd\",      \"file_url\": \"https://osskb.org/api/file_contents/5c8ab9be40df937e46c53509481107cd\",      \"licenses\": [        {          \"name\": \"Apache-2.0\",          \"patent_hints\": \"yes\",          \"copyleft\": \"no\",          \"checklist_url\": \"https://www.osadl.org/fileadmin/checklists/unreflicenses/Apache-2.0.txt\",          \"osadl_updated\": \"2022-03-17 13:38\",          \"source\": \"file_spdx_tag\"        },        {          \"name\": \"Apache-2.0\",          \"patent_hints\": \"yes\",          \"copyleft\": \"no\",          \"checklist_url\": \"https://www.osadl.org/fileadmin/checklists/unreflicenses/Apache-2.0.txt\",          \"osadl_updated\": \"2022-03-17 13:38\",          \"source\": \"scancode\"        }      ],      \"server\": {        \"version\": \"4.4.2\",        \"kb_version\": {          \"monthly\": \"22.02\",          \"daily\": \"22.03.25\"        }      }    }  ]}",
+    "headers" : {
+      "Server" : "nginx/1.14.2",
+      "Date" : "Wed, 16 Mar 2022 13:07:04 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "b28995c4-70e0-4fda-a1a8-c8a0ea1f1c85",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/scanner/src/test/kotlin/scanners/scanoss/ScanOssScannerDirectoryTest.kt
+++ b/scanner/src/test/kotlin/scanners/scanoss/ScanOssScannerDirectoryTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2022 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.scanoss
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.maps.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+import io.mockk.every
+import io.mockk.spyk
+import io.mockk.verify
+
+import java.io.File
+import java.util.UUID
+
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
+
+const val TEST_DIRECTORY_TO_SCAN = "src/test/assets/scanoss/filesToScan"
+
+/**
+ * A test for scanning a directory with the [ScanOss] scanner.
+ */
+class ScanOssScannerDirectoryTest : StringSpec({
+    lateinit var scanner: ScanOss
+
+    val server = WireMockServer(
+        WireMockConfiguration.options()
+            .dynamicPort()
+            .usingFilesUnderDirectory("src/test/assets/scanoss/scanMulti")
+    )
+
+    beforeSpec {
+        server.start()
+        val scannerOptions = mapOf(ScanOssConfig.API_URL_PROPERTY to "http://localhost:${server.port()}")
+        val configuration = ScannerConfiguration(options = mapOf("ScanOss" to scannerOptions))
+        scanner = spyk(ScanOss.Factory().create(configuration, DownloaderConfiguration()))
+    }
+
+    afterSpec {
+        server.stop()
+    }
+
+    beforeTest {
+        server.resetAll()
+    }
+
+    "The scanner should scan a directory" {
+        // Manipulate the UUID generation to have the same IDs as in the response.
+        every {
+            scanner.generateRandomUUID()
+        } answers {
+            UUID.fromString("5530105e-0752-4750-9c07-4e4604b879a5")
+        } andThenAnswer {
+            UUID.fromString("c198b884-f6cf-496f-95eb-0e7968dd2ec6")
+        }
+        val result = scanner.scanPath(File(TEST_DIRECTORY_TO_SCAN))
+
+        verify(exactly = 1) {
+            scanner.createWfpForFile("$TEST_DIRECTORY_TO_SCAN/ArchiveUtils.kt")
+            scanner.createWfpForFile("$TEST_DIRECTORY_TO_SCAN/ScannerFactory.kt")
+        }
+
+        result.scanner shouldNotBeNull {
+            results.scanResults shouldHaveSize 1
+            results.scanResults[results.scanResults.firstKey()] shouldNotBeNull {
+                this shouldHaveSize 1
+                this.first() shouldNotBeNull {
+                    summary.packageVerificationCode shouldBe "07c881ae4fcc30a69f5d66453d54d194f062252e"
+                    summary.licenseFindings shouldHaveSize 2
+                    summary.licenseFindings.first().license.toString() shouldBe "Apache-2.0"
+                    summary.licenseFindings.last().license.toString() shouldBe "Apache-2.0"
+                }
+            }
+        }
+    }
+})

--- a/scanner/src/test/kotlin/scanners/scanoss/ScanOssScannerFileTest.kt
+++ b/scanner/src/test/kotlin/scanners/scanoss/ScanOssScannerFileTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2022 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.scanoss
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.maps.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+import io.mockk.every
+import io.mockk.spyk
+import io.mockk.verify
+
+import java.io.File
+import java.util.UUID
+
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
+
+const val TEST_FILE_TO_SCAN = "src/test/assets/scanoss/filesToScan/ScannerFactory.kt"
+
+/**
+ * A test for scanning a single file with the [ScanOss] scanner.
+ */
+class ScanOssScannerFileTest : StringSpec({
+    lateinit var scanner: ScanOss
+
+    val server = WireMockServer(
+        WireMockConfiguration.options()
+            .dynamicPort()
+            .usingFilesUnderDirectory("src/test/assets/scanoss/scanSingle")
+    )
+
+    beforeSpec {
+        server.start()
+        val scannerOptions = mapOf(ScanOssConfig.API_URL_PROPERTY to "http://localhost:${server.port()}")
+        val configuration = ScannerConfiguration(options = mapOf("ScanOss" to scannerOptions))
+        scanner = spyk(ScanOss.Factory().create(configuration, DownloaderConfiguration()))
+    }
+
+    afterSpec {
+        server.stop()
+    }
+
+    beforeTest {
+        server.resetAll()
+    }
+
+    "The scanner should scan a single file" {
+        // Manipulate the UUID generation to have the same IDs as in the response.
+        every {
+            scanner.generateRandomUUID()
+        } answers {
+            UUID.fromString("bf5401e9-03b3-4c91-906c-cadb90487b8c")
+        }
+        val result = scanner.scanPath(File(TEST_FILE_TO_SCAN))
+
+        verify(exactly = 1) {
+            scanner.createWfpForFile(TEST_FILE_TO_SCAN)
+        }
+
+        result.scanner shouldNotBeNull {
+            results.scanResults shouldHaveSize 1
+            results.scanResults[results.scanResults.firstKey()] shouldNotBeNull {
+                this shouldHaveSize 1
+                this.first() shouldNotBeNull {
+                    summary.packageVerificationCode shouldBe "027fef3ecf34d1069b3cd60dad127195aeb069be"
+                    summary.licenseFindings shouldHaveSize 1
+                    summary.licenseFindings.first().license.toString() shouldBe "Apache-2.0"
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
Please refer to individual commit messages for details.

The two sample Java classes are coming from https://github.com/vdurmont/semver4j.