### PR TITLE
Use the speaking `orEmpty()` in more places

### DIFF
--- a/reporter/src/main/kotlin/reporters/gitlab/GitLabLicenseModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/gitlab/GitLabLicenseModelMapper.kt
@@ -97,7 +97,7 @@ private fun SpdxSingleLicenseExpression.toLicenseName(): String {
         else -> ""
     }
 
-    return SpdxLicense.forId(spdxLicenseId)?.fullName ?: ""
+    return SpdxLicense.forId(spdxLicenseId)?.fullName.orEmpty()
 }
 
 /**

--- a/utils/core/src/main/kotlin/Utils.kt
+++ b/utils/core/src/main/kotlin/Utils.kt
@@ -197,7 +197,7 @@ fun normalizeVcsUrl(vcsUrl: String): String {
                     path.endsWith(".git") || path.count { it == '/' } != 2
                 } ?: "${uri.path}.git"
 
-                val query = uri.query?.takeIf { it.isNotBlank() }?.let { "?$it" } ?: ""
+                val query = uri.query?.takeIf { it.isNotBlank() }?.let { "?$it" }.orEmpty()
 
                 return if (uri.scheme == "ssh") {
                     // Ensure the generic "git" user name is specified.


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>