### PR TITLE
JiraNotifierTest: Add a function to setup the rest client

### DIFF
--- a/notifier/src/test/kotlin/modules/JiraNotifierTest.kt
+++ b/notifier/src/test/kotlin/modules/JiraNotifierTest.kt
@@ -19,12 +19,9 @@
 
 package org.ossreviewtoolkit.notifier.modules
 
-import com.atlassian.jira.rest.client.api.IssueRestClient
 import com.atlassian.jira.rest.client.api.JiraRestClient
 import com.atlassian.jira.rest.client.api.OptionalIterable
-import com.atlassian.jira.rest.client.api.ProjectRestClient
 import com.atlassian.jira.rest.client.api.RestClientException
-import com.atlassian.jira.rest.client.api.SearchRestClient
 import com.atlassian.jira.rest.client.api.domain.BasicIssue
 import com.atlassian.jira.rest.client.api.domain.Comment
 import com.atlassian.jira.rest.client.api.domain.Issue
@@ -51,14 +48,12 @@ class JiraNotifierTest : WordSpec({
     "createIssue" should {
         "succeed for valid input" {
             val project = createProject()
-            val issueClient = mockk<IssueRestClient>()
-            val projectClient = mockk<ProjectRestClient>()
-            val restClient = mockk<JiraRestClient>()
+            val basicIssue = BasicIssue(URI(""), "$PROJECT_KEY-1", 1L)
 
-            every { restClient.issueClient } returns issueClient
-            every { restClient.projectClient } returns projectClient
-            every { issueClient.createIssue(any()) } returns createPromise(BasicIssue(URI(""), "$PROJECT_KEY-1", 1L))
-            every { projectClient.getProject(any<String>()) } returns createPromise(project)
+            val restClient = createRestClient {
+                every { issueClient.createIssue(any()) } returns createPromise(basicIssue)
+                every { projectClient.getProject(any<String>()) } returns createPromise(project)
+            }
 
             val notifier = JiraNotifier(restClient)
 
@@ -79,22 +74,18 @@ class JiraNotifierTest : WordSpec({
 
         "fail if more than one duplicate issues exist" {
             val project = createProject()
-            val issueClient = mockk<IssueRestClient>()
-            val projectClient = mockk<ProjectRestClient>()
-            val searchClient = mockk<SearchRestClient>()
-            val restClient = mockk<JiraRestClient>()
 
             val summary = "Ticket summary"
             val query = "project = \"${project.key}\" AND summary ~ \"$summary\""
 
+            val basicIssue = BasicIssue(URI(""), "$PROJECT_KEY-1", 1L)
             val existingIssues = listOf(createIssue(id = 1, summary = summary), createIssue(id = 2, summary = summary))
 
-            every { restClient.issueClient } returns issueClient
-            every { restClient.projectClient } returns projectClient
-            every { restClient.searchClient } returns searchClient
-            every { issueClient.createIssue(any()) } returns createPromise(BasicIssue(URI(""), "$PROJECT_KEY-1", 1L))
-            every { projectClient.getProject(any<String>()) } returns createPromise(project)
-            every { searchClient.searchJql(query) } returns createPromise(SearchResult(0, 2, 2, existingIssues))
+            val restClient = createRestClient {
+                every { issueClient.createIssue(any()) } returns createPromise(basicIssue)
+                every { projectClient.getProject(any<String>()) } returns createPromise(project)
+                every { searchClient.searchJql(query) } returns createPromise(SearchResult(0, 2, 2, existingIssues))
+            }
 
             val notifier = JiraNotifier(restClient)
 
@@ -110,31 +101,29 @@ class JiraNotifierTest : WordSpec({
                 it.message shouldContain "more than 1 duplicate issues"
             }
 
-            verify(exactly = 0) {
-                issueClient.createIssue(any())
-                issueClient.addComment(any(), any())
+            with(restClient.issueClient) {
+                verify(exactly = 0) {
+                    createIssue(any())
+                    addComment(any(), any())
+                }
             }
         }
 
         "add a comment if one duplicate issue exists" {
             val project = createProject()
-            val issueClient = mockk<IssueRestClient>()
-            val projectClient = mockk<ProjectRestClient>()
-            val searchClient = mockk<SearchRestClient>()
-            val restClient = mockk<JiraRestClient>()
 
             val summary = "Ticket summary"
             val query = "project = \"${project.key}\" AND summary ~ \"$summary\""
 
+            val basicIssue = BasicIssue(URI(""), "$PROJECT_KEY-1", 1L)
             val existingIssues = listOf(createIssue(id = 1, summary = summary))
 
-            every { restClient.issueClient } returns issueClient
-            every { restClient.projectClient } returns projectClient
-            every { restClient.searchClient } returns searchClient
-            every { issueClient.createIssue(any()) } returns createPromise(BasicIssue(URI(""), "$PROJECT_KEY-1", 1L))
-            every { issueClient.addComment(any(), any()) } returns createVoidPromise()
-            every { projectClient.getProject(any<String>()) } returns createPromise(project)
-            every { searchClient.searchJql(query) } returns createPromise(SearchResult(0, 1, 1, existingIssues))
+            val restClient = createRestClient {
+                every { issueClient.createIssue(any()) } returns createPromise(basicIssue)
+                every { issueClient.addComment(any(), any()) } returns createVoidPromise()
+                every { projectClient.getProject(any<String>()) } returns createPromise(project)
+                every { searchClient.searchJql(query) } returns createPromise(SearchResult(0, 1, 1, existingIssues))
+            }
 
             val notifier = JiraNotifier(restClient)
 
@@ -147,31 +136,29 @@ class JiraNotifierTest : WordSpec({
                 avoidDuplicates = true
             )
 
-            verify(exactly = 1) {
-                issueClient.addComment(any(), any())
+            with(restClient.issueClient) {
+                verify(exactly = 1) {
+                    addComment(any(), any())
+                }
             }
         }
 
         "not add a comment if one duplicate issue exists that already has an identical comment" {
             val project = createProject()
-            val issueClient = mockk<IssueRestClient>()
-            val projectClient = mockk<ProjectRestClient>()
-            val searchClient = mockk<SearchRestClient>()
-            val restClient = mockk<JiraRestClient>()
 
             val summary = "Ticket summary"
             val description = "The description of the ticket."
             val query = "project = \"${project.key}\" AND summary ~ \"$summary\""
 
+            val basicIssue = BasicIssue(URI(""), "$PROJECT_KEY-1", 1L)
             val existingIssues =
                 listOf(createIssue(id = 1, summary = summary, comments = listOf("$summary\n$description")))
 
-            every { restClient.issueClient } returns issueClient
-            every { restClient.projectClient } returns projectClient
-            every { restClient.searchClient } returns searchClient
-            every { issueClient.createIssue(any()) } returns createPromise(BasicIssue(URI(""), "$PROJECT_KEY-1", 1L))
-            every { projectClient.getProject(any<String>()) } returns createPromise(project)
-            every { searchClient.searchJql(query) } returns createPromise(SearchResult(0, 1, 1, existingIssues))
+            val restClient = createRestClient {
+                every { issueClient.createIssue(any()) } returns createPromise(basicIssue)
+                every { projectClient.getProject(any<String>()) } returns createPromise(project)
+                every { searchClient.searchJql(query) } returns createPromise(SearchResult(0, 1, 1, existingIssues))
+            }
 
             val notifier = JiraNotifier(restClient)
 
@@ -184,20 +171,19 @@ class JiraNotifierTest : WordSpec({
                 avoidDuplicates = true
             )
 
-            verify(exactly = 0) {
-                issueClient.addComment(any(), any())
+            with(restClient.issueClient) {
+                verify(exactly = 0) {
+                    addComment(any(), any())
+                }
             }
         }
 
         "fail if the issue type is invalid" {
             val project = createProject()
-            val issueClient = mockk<IssueRestClient>()
-            val projectClient = mockk<ProjectRestClient>()
-            val restClient = mockk<JiraRestClient>()
 
-            every { restClient.issueClient } returns issueClient
-            every { restClient.projectClient } returns projectClient
-            every { projectClient.getProject(any<String>()) } returns createPromise(project)
+            val restClient = createRestClient {
+                every { projectClient.getProject(any<String>()) } returns createPromise(project)
+            }
 
             val notifier = JiraNotifier(restClient)
 
@@ -219,26 +205,24 @@ class JiraNotifierTest : WordSpec({
 
     "changeAssignee" should {
         "succeed for valid input" {
-            val issueClient = mockk<IssueRestClient>()
-            val restClient = mockk<JiraRestClient>()
-
-            every { restClient.issueClient } returns issueClient
-            every { issueClient.updateIssue(any(), any()) } returns createVoidPromise()
+            val restClient = createRestClient {
+                every { issueClient.updateIssue(any(), any()) } returns createVoidPromise()
+            }
 
             val notifier = JiraNotifier(restClient)
             notifier.changeAssignee("$PROJECT_KEY-1", "USER") shouldBe true
 
-            verify(exactly = 1) {
-                issueClient.updateIssue(any(), any())
+            with(restClient.issueClient) {
+                verify(exactly = 1) {
+                    updateIssue(any(), any())
+                }
             }
         }
 
         "fail if the assignee cannot be set" {
-            val issueClient = mockk<IssueRestClient>()
-            val restClient = mockk<JiraRestClient>()
-
-            every { restClient.issueClient } returns issueClient
-            every { issueClient.updateIssue(any(), any()) } throws RestClientException("Error", Exception())
+            val restClient = createRestClient {
+                every { issueClient.updateIssue(any(), any()) } throws RestClientException("Error", Exception())
+            }
 
             val notifier = JiraNotifier(restClient)
             notifier.changeAssignee("$PROJECT_KEY-1", "USER") shouldBe false
@@ -247,35 +231,35 @@ class JiraNotifierTest : WordSpec({
 
     "changeState" should {
         "succeed for valid input" {
-            val issueClient = mockk<IssueRestClient>()
-            val restClient = mockk<JiraRestClient>()
-
             val state = "Bug"
+            val issue = createIssue(id = 1, summary = "Ticket summary")
             val transitions = listOf(createTransition(id = 1, state = state))
 
-            every { restClient.issueClient } returns issueClient
-            every { issueClient.getIssue(any()) } returns createPromise(createIssue(id = 1, summary = "Ticket summary"))
-            every { issueClient.getTransitions(any<Issue>()) } returns createPromise(transitions)
+            val restClient = createRestClient {
+                every { issueClient.getIssue(any()) } returns createPromise(issue)
+                every { issueClient.getTransitions(any<Issue>()) } returns createPromise(transitions)
+            }
 
             val notifier = JiraNotifier(restClient)
             notifier.changeState("$PROJECT_KEY-1", state)
 
-            verify(exactly = 1) {
-                issueClient.transition(any<Issue>(), any())
+            with(restClient.issueClient) {
+                verify(exactly = 1) {
+                    transition(any<Issue>(), any())
+                }
             }
         }
 
         "fail if attempting an invalid transition" {
-            val issueClient = mockk<IssueRestClient>()
-            val restClient = mockk<JiraRestClient>()
-
             val validState = "Bug"
             val invalidState = "Task"
+            val issue = createIssue(id = 1, summary = "Ticket summary")
             val transitions = listOf(createTransition(id = 1, state = validState))
 
-            every { restClient.issueClient } returns issueClient
-            every { issueClient.getIssue(any()) } returns createPromise(createIssue(id = 1, summary = "Ticket summary"))
-            every { issueClient.getTransitions(any<Issue>()) } returns createPromise(transitions)
+            val restClient = createRestClient {
+                every { issueClient.getIssue(any()) } returns createPromise(issue)
+                every { issueClient.getTransitions(any<Issue>()) } returns createPromise(transitions)
+            }
 
             val notifier = JiraNotifier(restClient)
             notifier.changeState("$PROJECT_KEY-1", invalidState) shouldBe false
@@ -294,6 +278,15 @@ private val ISSUE_TYPES = listOf(
 
 private fun createIssueType(name: String) =
     IssueType(URI(""), 0L, name, false, "", URI(""))
+
+private fun createRestClient(block: JiraRestClient.() -> Unit): JiraRestClient =
+    mockk {
+        every { issueClient } returns mockk()
+        every { projectClient } returns mockk()
+        every { searchClient } returns mockk()
+
+        block()
+    }
 
 private fun <T> createPromise(value: T): Promise<T> =
     mockk {


### PR DESCRIPTION
Move the common code to setup the rest client to a helper function.