### PR TITLE
CocoaPods: Do not take empty declared licenses for packages

### DIFF
--- a/analyzer/src/main/kotlin/managers/CocoaPods.kt
+++ b/analyzer/src/main/kotlin/managers/CocoaPods.kt
@@ -186,7 +186,7 @@ class CocoaPods(
         return Package(
             id = id,
             authors = sortedSetOf(),
-            declaredLicenses = listOf(podspec.license).toSortedSet(),
+            declaredLicenses = podspec.license.takeUnless { it.isEmpty() }?.let { sortedSetOf(it) } ?: sortedSetOf(),
             description = podspec.summary,
             homepageUrl = podspec.homepage,
             binaryArtifact = RemoteArtifact.EMPTY,


### PR DESCRIPTION
Fixes #5144.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>