### PR TITLE
utils: Add another Eclipse Distribution License mapping

### DIFF
--- a/utils/spdx/src/main/resources/declared-license-mapping.yml
+++ b/utils/spdx/src/main/resources/declared-license-mapping.yml
@@ -173,6 +173,7 @@
 "EPL (Eclipse Public License), V1.0 or later": EPL-1.0
 "Eclipse Distribution License (EDL), Version 1.0": BSD-3-Clause
 "Eclipse Distribution License (New BSD License)": BSD-3-Clause
+"Eclipse Distribution License - Version 1.0": BSD-3-Clause
 "Eclipse Distribution License - v 1.0": BSD-3-Clause
 "Eclipse Distribution License v. 1.0": BSD-3-Clause
 "Eclipse Public License (EPL) 1.0": EPL-1.0


### PR DESCRIPTION
As seen in [1].

[1]: https://repo1.maven.org/maven2/org/eclipse/californium/parent/2.7.0/parent-2.7.0.pom

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>