### PR TITLE
Npm/Yarn: Run `view`/ `info` in the package directory

### DIFF
--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -356,7 +356,7 @@ open class Npm(
                     || hash == Hash.NONE || vcsFromPackage == VcsInfo.EMPTY
 
             if (hasIncompleteData) {
-                val details = getRemotePackageDetails("$rawName@$version")
+                val details = getRemotePackageDetails(packageDir, "$rawName@$version")
 
                 if (description.isEmpty()) description = details["description"].textValueOrEmpty()
                 if (homepageUrl.isEmpty()) homepageUrl = details["homepage"].textValueOrEmpty()
@@ -408,8 +408,8 @@ open class Npm(
         return Pair(id.toCoordinates(), module)
     }
 
-    protected open fun getRemotePackageDetails(packageName: String): JsonNode {
-        val process = run("view", "--json", packageName)
+    protected open fun getRemotePackageDetails(workingDir: File, packageName: String): JsonNode {
+        val process = run(workingDir, "view", "--json", packageName)
         return jsonMapper.readTree(process.stdoutFile)
     }
 

--- a/analyzer/src/main/kotlin/managers/Yarn.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn.kt
@@ -67,8 +67,8 @@ class Yarn(
 
     override fun runInstall(workingDir: File) = run(workingDir, "install", "--ignore-scripts", "--ignore-engines")
 
-    override fun getRemotePackageDetails(packageName: String): JsonNode {
-        val process = run("info", "--json", packageName)
+    override fun getRemotePackageDetails(workingDir: File, packageName: String): JsonNode {
+        val process = run(workingDir, "info", "--json", packageName)
         return jsonMapper.readTree(process.stdoutFile)["data"]
     }
 }


### PR DESCRIPTION
This way `npm` / `yarn` should take a project's `.npmrc` / `.yarnrc`
into account.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>