### PR TITLE
NPM: Upgrade to 8.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3
 
 # Copyright (C) 2020 Bosch Software Innovations GmbH
-# Copyright (C) 2021 Bosch.IO GmbH
+# Copyright (C) 2021-2022 Bosch.IO GmbH
 # Copyright (C) 2021 Alliander N.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,7 +56,7 @@ ENV \
     GO_DEP_VERSION=0.5.4 \
     GO_VERSION=1.16.5 \
     HASKELL_STACK_VERSION=2.1.3 \
-    NPM_VERSION=7.20.6 \
+    NPM_VERSION=8.5.0 \
     PYTHON_PIPENV_VERSION=2018.11.26 \
     PYTHON_VIRTUALENV_VERSION=15.1.0 \
     SBT_VERSION=1.6.1 \

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -197,7 +197,7 @@ open class Npm(
 
     override fun command(workingDir: File?) = if (Os.isWindows) "npm.cmd" else "npm"
 
-    override fun getVersionRequirement(): Requirement = Requirement.buildNPM("6.* - 7.20.*")
+    override fun getVersionRequirement(): Requirement = Requirement.buildNPM("6.* - 8.5.*")
 
     override fun mapDefinitionFiles(definitionFiles: List<File>) = mapDefinitionFilesForNpm(definitionFiles).toList()
 


### PR DESCRIPTION
To support projects that require a newer NPM version. NPM 8.5.0 is the
version used by the latest Node.js LTS version [1].

[1]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V16.md#nodejs-16-changelog

