### PR TITLE
Npm/Yarn: Use project root directory for `npm view` call

### DIFF
--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -270,7 +270,7 @@ open class Npm(
         nodeModulesDir.walk().filter {
             it.name == "package.json" && isValidNodeModulesDirectory(nodeModulesDir, nodeModulesDirForPackageJson(it))
         }.forEach { file ->
-            val (id, pkg) = parsePackage(file)
+            val (id, pkg) = parsePackage(rootDirectory, file)
             packages[id] = pkg
         }
 
@@ -309,7 +309,7 @@ open class Npm(
      * content via the `npm view` command. The result is a [Pair] with the raw identifier and the new package.
      */
     @Suppress("HttpUrlsUsage")
-    internal fun parsePackage(packageFile: File): Pair<String, Package> {
+    internal fun parsePackage(workingDir: File, packageFile: File): Pair<String, Package> {
         val packageDir = packageFile.parentFile
 
         log.debug { "Found a 'package.json' file in '$packageDir'." }
@@ -356,7 +356,7 @@ open class Npm(
                     || hash == Hash.NONE || vcsFromPackage == VcsInfo.EMPTY
 
             if (hasIncompleteData) {
-                val details = getRemotePackageDetails(packageDir, "$rawName@$version")
+                val details = getRemotePackageDetails(workingDir, "$rawName@$version")
 
                 if (description.isEmpty()) description = details["description"].textValueOrEmpty()
                 if (homepageUrl.isEmpty()) homepageUrl = details["homepage"].textValueOrEmpty()
@@ -516,7 +516,7 @@ open class Npm(
             getPackageReferenceForMissingModule(dependencyName, pathToRoot.first())
         }
 
-        return NpmModuleInfo(moduleId, moduleInfo.packageJson, dependencies)
+        return NpmModuleInfo(moduleId, moduleDir, moduleInfo.packageJson, dependencies)
     }
 
     /**

--- a/analyzer/src/main/kotlin/managers/utils/NpmDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NpmDependencyHandler.kt
@@ -39,6 +39,9 @@ data class NpmModuleInfo(
     /** The identifier for the represented module. */
     val id: Identifier,
 
+    /** The working directory of the NPM project. */
+    val workingDir: File,
+
     /** The file pointing to the package.json for this module. */
     val packageFile: File,
 
@@ -57,5 +60,5 @@ class NpmDependencyHandler(private val npm: Npm) : DependencyHandler<NpmModuleIn
     override fun linkageFor(dependency: NpmModuleInfo): PackageLinkage = PackageLinkage.DYNAMIC
 
     override fun createPackage(dependency: NpmModuleInfo, issues: MutableList<OrtIssue>): Package =
-        npm.parsePackage(dependency.packageFile).second
+        npm.parsePackage(dependency.workingDir, dependency.packageFile).second
 }

--- a/analyzer/src/test/kotlin/managers/utils/NpmDependencyHandlerTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/NpmDependencyHandlerTest.kt
@@ -94,9 +94,9 @@ private fun createIdentifier(name: String): Identifier =
  */
 private fun createModuleInfo(
     id: Identifier,
-    packageFile: File = File("package.json"),
+    packageFile: File = File("project/package.json"),
     dependencies: Set<NpmModuleInfo> = emptySet()
-): NpmModuleInfo = NpmModuleInfo(id, packageFile, dependencies)
+): NpmModuleInfo = NpmModuleInfo(id, packageFile.parentFile, packageFile, dependencies)
 
 /**
  * Creates an [NpmDependencyHandler] instance to be used by test cases.


### PR DESCRIPTION
In order to apply a project local `.npmrc`/`.yarnrc`, when calling
`view`/`info` the call has to be made in the directory containing this
configuration file.
