### PR TITLE
Improvements to the `helper-cli`'s scan storage "delete" subcommand

### DIFF
--- a/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
@@ -113,6 +113,10 @@ internal class DeleteCommand : CliktCommand(
             }
 
             println("Would delete $count scan result(s).")
+
+            if (log.delegate.isDebugEnabled) {
+                ScanResults.slice(ScanResults.identifier).select { condition }.forEach(log::debug)
+            }
         } else {
             val count = database.transaction {
                 ScanResults.deleteWhere { condition }

--- a/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
@@ -94,8 +94,8 @@ internal class DeleteCommand : CliktCommand(
 
         val typeCondition = packageType?.let { ScanResults.identifier like "$it:%" }
         val provenanceConditions = provenanceKeys.map { key ->
-                rawParam("scan_result->'provenance'->>'$key'").isNotNull()
-            }.takeIf { it.isNotEmpty() }?.compoundOr()
+            rawParam("scan_result->'provenance'->>'$key'").isNotNull()
+        }.takeIf { it.isNotEmpty() }?.compoundOr()
 
         val conditions = listOfNotNull(typeCondition, provenanceConditions)
         if (conditions.isEmpty()) {

--- a/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
@@ -25,6 +25,7 @@ import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.split
+import com.github.ajalt.clikt.parameters.types.enum
 import com.github.ajalt.clikt.parameters.types.file
 
 import org.jetbrains.exposed.sql.Database
@@ -67,9 +68,7 @@ internal class DeleteCommand : CliktCommand(
     private val sourceCodeOrigins by option(
         "--source-code-origins",
         help = "The origin of the scan results that should be deleted."
-    ).convert { SourceCodeOrigin.valueOf(it) }
-        .split(",")
-        .default(emptyList())
+    ).enum<SourceCodeOrigin>().split(",").default(emptyList())
 
     private val packageType by option(
         "--package-type",


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.