### PR TITLE
Slightly increase the default findings matcher tolerance lines to 7

### DIFF
--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -43,14 +43,14 @@ class FindingsMatcher(
 ) {
     companion object {
         /**
-         * The default value of 5 seems to be a good balance between associating findings separated by blank lines but
-         * not skipping complete license statements.
+         * The default value seems to be a good balance between associating findings separated by blank lines but not
+         * skipping complete license statements.
          */
         const val DEFAULT_TOLERANCE_LINES = 5
 
         /**
-         * The default value of 2 seems to be a good balance between associating findings separated by blank lines but
-         * not skipping complete license statements.
+         * The default value seems to be a good balance between associating findings separated by blank lines but not
+         * skipping complete license statements.
          */
         const val DEFAULT_EXPAND_TOLERANCE_LINES = 2
     }

--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -46,7 +46,7 @@ class FindingsMatcher(
          * The default value seems to be a good balance between associating findings separated by blank lines but not
          * skipping complete license statements.
          */
-        const val DEFAULT_TOLERANCE_LINES = 5
+        const val DEFAULT_TOLERANCE_LINES = 7
 
         /**
          * The default value seems to be a good balance between associating findings separated by blank lines but not


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.