### PR TITLE
DeleteCommand: Fix the `slice` command to be executed in a transaction

### DIFF
--- a/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
@@ -115,7 +115,10 @@ internal class DeleteCommand : CliktCommand(
             println("Would delete $count scan result(s).")
 
             if (log.delegate.isDebugEnabled) {
-                ScanResults.slice(ScanResults.identifier).select { condition }.forEach(log::debug)
+                database.transaction {
+                    ScanResults.slice(ScanResults.identifier).select { condition }
+                        .forEach(this@DeleteCommand.log::debug)
+                }
             }
         } else {
             val count = database.transaction {

--- a/model/src/main/kotlin/Identifier.kt
+++ b/model/src/main/kotlin/Identifier.kt
@@ -80,7 +80,7 @@ data class Identifier(
     constructor(identifier: String) : this(identifier.split(':', limit = 4))
 
     private val sanitizedComponents = listOf(type, namespace, name, version).map { component ->
-            component.trim().filterNot { it < ' ' }
+        component.trim().filterNot { it < ' ' }
     }
 
     init {

--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -43,14 +43,14 @@ class FindingsMatcher(
 ) {
     companion object {
         /**
-         * The default value of 5 seems to be a good balance between associating findings separated by blank lines but
-         * not skipping complete license statements.
+         * The default value seems to be a good balance between associating findings separated by blank lines but not
+         * skipping complete license statements.
          */
         const val DEFAULT_TOLERANCE_LINES = 5
 
         /**
-         * The default value of 2 seems to be a good balance between associating findings separated by blank lines but
-         * not skipping complete license statements.
+         * The default value seems to be a good balance between associating findings separated by blank lines but not
+         * skipping complete license statements.
          */
         const val DEFAULT_EXPAND_TOLERANCE_LINES = 2
     }


### PR DESCRIPTION
This is a fixup for 4679077.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>