### PR TITLE
ScanCodeResultParser: Fix replacing a key multiple times in an expression

### DIFF
--- a/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
@@ -239,14 +239,11 @@ private fun getSpdxLicenseId(license: JsonNode): String {
  */
 internal fun replaceLicenseKeys(licenseExpression: String, replacements: Collection<LicenseKeyReplacement>): String =
     replacements.fold(licenseExpression) { expression, replacement ->
-        var result = expression
-        val regex = "(?:^| |\\()(${replacement.scanCodeLicenseKey})(?:$| |\\))".toRegex()
+        val regex = "(^| |\\()(${replacement.scanCodeLicenseKey})($| |\\))".toRegex()
 
-        regex.findAll(expression).forEach {
-            result = expression.replaceRange(it.groups[1]!!.range, replacement.spdxExpression)
+        regex.replace(expression) {
+            "${it.groupValues[1]}${replacement.spdxExpression}${it.groupValues[3]}"
         }
-
-        result
     }
 
 /**

--- a/scanner/src/test/kotlin/scanners/scancode/ScanCodeResultParserTest.kt
+++ b/scanner/src/test/kotlin/scanners/scancode/ScanCodeResultParserTest.kt
@@ -622,6 +622,18 @@ class ScanCodeResultParserTest : FreeSpec({
             result shouldBe "LicenseRef-scancode-public-domain"
         }
 
+        "properly replace the same license multiple times" {
+            val expression = "gpl-2.0 AND (gpl-2.0 OR gpl-2.0-plus)"
+            val replacements = listOf(
+                LicenseKeyReplacement("gpl-2.0", "GPL-2.0-only"),
+                LicenseKeyReplacement("gpl-2.0-plus", "GPL-2.0-or-later")
+            )
+
+            val result = replaceLicenseKeys(expression, replacements)
+
+            result shouldBe "GPL-2.0-only AND (GPL-2.0-only OR GPL-2.0-or-later)"
+        }
+
         "properly handle replacements with a license key being a suffix of another" {
             val expression = "agpl-3.0-openssl"
             val replacements = listOf(


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>