### PR TITLE
`ExperimentalScanner`: Plugin support

### DIFF
--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.core.requireObject
+import com.github.ajalt.clikt.parameters.groups.default
 import com.github.ajalt.clikt.parameters.groups.mutuallyExclusiveOptions
 import com.github.ajalt.clikt.parameters.groups.required
 import com.github.ajalt.clikt.parameters.groups.single
@@ -65,6 +66,7 @@ import org.ossreviewtoolkit.model.utils.mergeLabels
 import org.ossreviewtoolkit.scanner.PathScanner
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.scanner.Scanner
+import org.ossreviewtoolkit.scanner.ScannerFactory
 import org.ossreviewtoolkit.scanner.TOOL_NAME
 import org.ossreviewtoolkit.scanner.experimental.DefaultNestedProvenanceResolver
 import org.ossreviewtoolkit.scanner.experimental.DefaultPackageProvenanceResolver
@@ -81,11 +83,8 @@ import org.ossreviewtoolkit.scanner.experimental.ProvenanceBasedFileStorage
 import org.ossreviewtoolkit.scanner.experimental.ProvenanceBasedPostgresStorage
 import org.ossreviewtoolkit.scanner.experimental.ScanStorage
 import org.ossreviewtoolkit.scanner.experimental.ScannerWrapper
+import org.ossreviewtoolkit.scanner.experimental.ScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.scanOrtResult
-import org.ossreviewtoolkit.scanner.scanners.Askalono
-import org.ossreviewtoolkit.scanner.scanners.BoyterLc
-import org.ossreviewtoolkit.scanner.scanners.Licensee
-import org.ossreviewtoolkit.scanner.scanners.fossid.FossId
 import org.ossreviewtoolkit.scanner.scanners.scancode.ScanCode
 import org.ossreviewtoolkit.scanner.storages.ClearlyDefinedStorage
 import org.ossreviewtoolkit.scanner.storages.FileBasedStorage
@@ -100,11 +99,28 @@ import org.ossreviewtoolkit.utils.core.ortDataDirectory
 import org.ossreviewtoolkit.utils.core.storage.LocalFileStorage
 import org.ossreviewtoolkit.utils.core.storage.XZCompressedLocalFileStorage
 
+sealed class ScannerOption {
+    data class Stable(val scannerFactory: ScannerFactory) : ScannerOption()
+    data class Experimental(val scannerWrapperFactories: List<ScannerWrapperFactory>) : ScannerOption()
+}
+
 private fun RawOption.convertToScanner() =
     convert { scannerName ->
         // TODO: Consider allowing to enable multiple scanners (and potentially running them in parallel).
-        Scanner.ALL.find { it.scannerName.equals(scannerName, ignoreCase = true) }
-            ?: throw BadParameterValue("Scanner '$scannerName' is not one of ${Scanner.ALL}.")
+        ScannerOption.Stable(
+            Scanner.ALL.find { it.scannerName.equals(scannerName, ignoreCase = true) }
+                ?: throw BadParameterValue("Scanner '$scannerName' is not one of ${Scanner.ALL}.")
+        )
+    }
+
+private fun RawOption.convertToScannerWrapperFactories() =
+    convert { scannerNames ->
+        ScannerOption.Experimental(
+            scannerNames.split(",").map { name ->
+                ScannerWrapper.ALL.find { it.scannerName.equals(name, ignoreCase = true) }
+                    ?: throw BadParameterValue("Scanner '$name' is not one of ${ScannerWrapper.ALL}.")
+            }
+        )
     }
 
 class ScannerCommand : CliktCommand(name = "scan", help = "Run external license / copyright scanners.") {
@@ -145,16 +161,37 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
                 "times. For example: --label distribution=external"
     ).associate()
 
-    private val scannerFactory by option(
-        "--scanner", "-s",
-        help = "The scanner to use, one of ${Scanner.ALL}."
-    ).convertToScanner().default(ScanCode.Factory())
+    private val scannerOption by mutuallyExclusiveOptions(
+        option(
+            "--scanner", "-s",
+            help = "The scanner to use.\nPossible values are: ${Scanner.ALL}"
+        ).convertToScanner(),
+        option(
+            "--experimental-scanners",
+            help = "A comma-separated list of experimental scanners to use. This option is mutually exclusive with " +
+                    "'--scanner'. The experimental scanner implementation scans by provenance instead of by package. " +
+                    "This improves reuse of stored scan results and increases performance if multiple packages are " +
+                    "coming from the same source code repository. The experimental scanner is work in progress and " +
+                    "it is therefore not recommended to use it in production.\n" +
+                    "Possible values are: ${ScannerWrapper.ALL}"
+        ).convertToScannerWrapperFactories()
+    ).single().default(ScannerOption.Stable(ScanCode.Factory()))
 
-    private val projectScannerFactory by option(
-        "--project-scanner",
-        help = "The scanner to use for scanning the source code of projects. By default, projects and packages are " +
-                "scanned with the same scanner as specified by '--scanner'."
-    ).convertToScanner()
+    private val projectScannerOption by mutuallyExclusiveOptions(
+        option(
+            "--project-scanner",
+            help = "The scanner to use for scanning the source code of projects. By default, projects and packages " +
+                    "are scanned with the same scanner as specified by '--scanner'.\n" +
+                    "Possible values are: ${Scanner.ALL}"
+        ).convertToScanner(),
+        option(
+            "--experimental-project-scanners",
+            help = "A comma-separated list of experimental scanners to use for scanning the source code of projects. " +
+                    "By default, projects and packages are scanned with the same scanner as specified by " +
+                    "'--experimental-scanner'.\n" +
+                    "Possible values are: ${ScannerWrapper.ALL}"
+        ).convertToScannerWrapperFactories()
+    ).single()
 
     private val packageTypes by option(
         "--package-types",
@@ -175,14 +212,6 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
         .default(ortConfigDirectory.resolve(ORT_RESOLUTIONS_FILENAME))
         .configurationGroup()
 
-    private val experimental by option(
-        "--experimental",
-        help = "Use a new experimental implementation of the scanner which scans by provenance instead of by " +
-                "package. This improves reuse of stored scan results and increases performance if multiple packages " +
-                "are coming from the same source code repository. The experimental scanner is work in progress and " +
-                "it is therefore not recommended to use it in production."
-    ).flag()
-
     private val globalOptionsForSubcommands by requireObject<GlobalOptions>()
 
     override fun run() {
@@ -199,10 +228,20 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
 
         val config = globalOptionsForSubcommands.config
 
-        val ortResult = if (experimental) {
-            runExperimental(config)
-        } else {
-            run(config)
+        val ortResult = when (val scanner = scannerOption) {
+            is ScannerOption.Stable -> {
+                val projectScannerFactory = (projectScannerOption as? ScannerOption.Stable)?.scannerFactory
+
+                run(scanner.scannerFactory, projectScannerFactory, config)
+            }
+
+            is ScannerOption.Experimental -> {
+                val projectScannerWrapperFactories =
+                    (projectScannerOption as? ScannerOption.Experimental)?.scannerWrapperFactories
+                        ?: scanner.scannerWrapperFactories
+
+                runExperimental(scanner.scannerWrapperFactories, projectScannerWrapperFactories, config)
+            }
         }.mergeLabels(labels)
 
         // Write the result.
@@ -224,7 +263,11 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
         severityStats.print().conclude(config.severeIssueThreshold, 2)
     }
 
-    private fun run(config: OrtConfiguration): OrtResult {
+    private fun run(
+        scannerFactory: ScannerFactory,
+        projectScannerFactory: ScannerFactory?,
+        config: OrtConfiguration
+    ): OrtResult {
         // Configure the scan storage, which is common to all scanners.
         ScanResultsStorage.configure(config.scanner)
 
@@ -278,29 +321,13 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
         }
     }
 
-    private fun runExperimental(config: OrtConfiguration): OrtResult {
-        // TODO: The experimental scanner supports using multiple scanner wrappers for projects and packages at once,
-        //       for now use only one for each to stay compatible with the existing scanner command. Once the
-        //       experimental flag is removed this command can support multiple scanners and use the proper
-        //       ScannerWrapperFactories.
-        fun createScannerWrapper(name: String): ScannerWrapper =
-            when (name) {
-                "Askalono" -> Askalono.Factory().create(config.scanner, config.downloader)
-                "BoyterLc" -> BoyterLc.Factory().create(config.scanner, config.downloader)
-                "FossId" -> FossId.Factory().create(config.scanner, config.downloader)
-                "Licensee" -> Licensee.Factory().create(config.scanner, config.downloader)
-                "ScanCode" -> ScanCode.Factory().create(config.scanner, config.downloader)
-                else -> {
-                    throw IllegalArgumentException(
-                        "The scanner ${scannerFactory.scannerName} is not supported by the experimental scanner."
-                    )
-                }
-            }
-
-        val packageScannerWrapper =
-            scannerFactory.scannerName.takeIf { PackageType.PACKAGE in packageTypes }?.let { createScannerWrapper(it) }
-        val projectScannerWrapper = (projectScannerFactory?.scannerName ?: scannerFactory.scannerName)
-            .takeIf { PackageType.PROJECT in packageTypes }?.let { createScannerWrapper(it) }
+    private fun runExperimental(
+        scannerWrapperFactories: List<ScannerWrapperFactory>,
+        projectScannerWrapperFactories: List<ScannerWrapperFactory>,
+        config: OrtConfiguration
+    ): OrtResult {
+        val packageScannerWrappers = scannerWrapperFactories.map { it.create(config.scanner, config.downloader) }
+        val projectScannerWrappers = projectScannerWrapperFactories.map { it.create(config.scanner, config.downloader) }
 
         val storages = config.scanner.storages.orEmpty().mapValues { createStorage(it.value) }
 
@@ -330,8 +357,8 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
                 ),
                 nestedProvenanceResolver = DefaultNestedProvenanceResolver(nestedProvenanceStorage, workingTreeCache),
                 scannerWrappers = mapOf(
-                    PackageType.PACKAGE to listOfNotNull(packageScannerWrapper),
-                    PackageType.PROJECT to listOfNotNull(projectScannerWrapper)
+                    PackageType.PACKAGE to packageScannerWrappers,
+                    PackageType.PROJECT to projectScannerWrappers
                 )
             )
 

--- a/scanner/src/main/kotlin/experimental/ScannerWrapper.kt
+++ b/scanner/src/main/kotlin/experimental/ScannerWrapper.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2021 HERE Europe B.V.
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 package org.ossreviewtoolkit.scanner.experimental
 
 import java.io.File
+import java.util.ServiceLoader
 
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.Package
@@ -36,6 +37,17 @@ import org.ossreviewtoolkit.scanner.ScannerCriteria
  * The base interface for all types of scanners.
  */
 sealed interface ScannerWrapper {
+    companion object {
+        private val LOADER = ServiceLoader.load(ScannerWrapperFactory::class.java)!!
+
+        /**
+         * The set of all available [scanner wrapper factories][ScannerWrapperFactory] in the classpath, sorted by name.
+         */
+        val ALL: Set<ScannerWrapperFactory> by lazy {
+            LOADER.iterator().asSequence().toSortedSet(compareBy { it.scannerName })
+        }
+    }
+
     /**
      * The name of the scanner.
      */

--- a/scanner/src/main/kotlin/experimental/ScannerWrapperFactory.kt
+++ b/scanner/src/main/kotlin/experimental/ScannerWrapperFactory.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.experimental
+
+import java.util.ServiceLoader
+
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+
+/**
+ * A common interface for use with [ServiceLoader] that all [ScannerWrapperFactory] classes need to implement.
+ */
+interface ScannerWrapperFactory {
+    /**
+     * The name to use to refer to the scanner wrapper.
+     */
+    val scannerName: String
+
+    /**
+     * Create a [ScannerWrapper] using the specified [scannerConfig] and [downloaderConfig].
+     */
+    fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration): ScannerWrapper
+}
+
+/**
+ * A generic factory class for a [ScannerWrapper].
+ */
+abstract class AbstractScannerWrapperFactory<out T : ScannerWrapper>(
+    override val scannerName: String
+) : ScannerWrapperFactory {
+    abstract override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration): T
+
+    /**
+     * Return the scanner wrapper's name here to allow Clikt to display something meaningful when listing the scanners
+     * which are enabled by default via their factories.
+     */
+    override fun toString() = scannerName
+}

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.ossreviewtoolkit.scanner.AbstractScannerFactory
 import org.ossreviewtoolkit.scanner.BuildConfig
 import org.ossreviewtoolkit.scanner.CommandLineScanner
 import org.ossreviewtoolkit.scanner.ScanException
+import org.ossreviewtoolkit.scanner.experimental.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.experimental.PathScannerWrapper
 import org.ossreviewtoolkit.scanner.experimental.ScanContext
 import org.ossreviewtoolkit.utils.common.Os
@@ -48,6 +49,11 @@ class Askalono internal constructor(
     scannerConfig: ScannerConfiguration,
     downloaderConfig: DownloaderConfiguration
 ) : CommandLineScanner(name, scannerConfig, downloaderConfig), PathScannerWrapper {
+    class AskalonoFactory : AbstractScannerWrapperFactory<Askalono>("Askalono") {
+        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
+            Askalono(scannerName, scannerConfig, downloaderConfig)
+    }
+
     class Factory : AbstractScannerFactory<Askalono>("Askalono") {
         override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
             Askalono(scannerName, scannerConfig, downloaderConfig)

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.ossreviewtoolkit.scanner.AbstractScannerFactory
 import org.ossreviewtoolkit.scanner.BuildConfig
 import org.ossreviewtoolkit.scanner.CommandLineScanner
 import org.ossreviewtoolkit.scanner.ScanException
+import org.ossreviewtoolkit.scanner.experimental.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.experimental.PathScannerWrapper
 import org.ossreviewtoolkit.scanner.experimental.ScanContext
 import org.ossreviewtoolkit.utils.common.Os
@@ -50,6 +51,11 @@ class BoyterLc internal constructor(
     scannerConfig: ScannerConfiguration,
     downloaderConfig: DownloaderConfiguration
 ) : CommandLineScanner(name, scannerConfig, downloaderConfig), PathScannerWrapper {
+    class BoyterLcFactory : AbstractScannerWrapperFactory<BoyterLc>("BoyterLc") {
+        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
+            BoyterLc(scannerName, scannerConfig, downloaderConfig)
+    }
+
     class Factory : AbstractScannerFactory<BoyterLc>("BoyterLc") {
         override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
             BoyterLc(scannerName, scannerConfig, downloaderConfig)

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.ossreviewtoolkit.scanner.AbstractScannerFactory
 import org.ossreviewtoolkit.scanner.BuildConfig
 import org.ossreviewtoolkit.scanner.CommandLineScanner
 import org.ossreviewtoolkit.scanner.ScanException
+import org.ossreviewtoolkit.scanner.experimental.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.experimental.PathScannerWrapper
 import org.ossreviewtoolkit.scanner.experimental.ScanContext
 import org.ossreviewtoolkit.utils.common.Os
@@ -45,6 +46,11 @@ class Licensee internal constructor(
     scannerConfig: ScannerConfiguration,
     downloaderConfig: DownloaderConfiguration
 ) : CommandLineScanner(name, scannerConfig, downloaderConfig), PathScannerWrapper {
+    class LicenseeFactory : AbstractScannerWrapperFactory<Licensee>("Licensee") {
+        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
+            Licensee(scannerName, scannerConfig, downloaderConfig)
+    }
+
     class Factory : AbstractScannerFactory<Licensee>("Licensee") {
         override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
             Licensee(scannerName, scannerConfig, downloaderConfig)

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.scanner.AbstractScannerFactory
 import org.ossreviewtoolkit.scanner.Scanner
 import org.ossreviewtoolkit.scanner.ScannerCriteria
+import org.ossreviewtoolkit.scanner.experimental.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.experimental.PackageScannerWrapper
 import org.ossreviewtoolkit.scanner.experimental.ScanContext
 import org.ossreviewtoolkit.utils.common.enumSetOf
@@ -89,6 +90,11 @@ class FossId internal constructor(
     downloaderConfig: DownloaderConfiguration,
     private val config: FossIdConfig
 ) : Scanner(name, scannerConfig, downloaderConfig), PackageScannerWrapper {
+    class FossIdFactory : AbstractScannerWrapperFactory<FossId>("FossId") {
+        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
+            FossId(scannerName, scannerConfig, downloaderConfig, FossIdConfig.create(scannerConfig))
+    }
+
     class Factory : AbstractScannerFactory<FossId>("FossId") {
         override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
             FossId(scannerName, scannerConfig, downloaderConfig, FossIdConfig.create(scannerConfig))

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -34,6 +34,7 @@ import org.ossreviewtoolkit.scanner.AbstractScannerFactory
 import org.ossreviewtoolkit.scanner.BuildConfig
 import org.ossreviewtoolkit.scanner.CommandLineScanner
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
+import org.ossreviewtoolkit.scanner.experimental.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.experimental.PathScannerWrapper
 import org.ossreviewtoolkit.scanner.experimental.ScanContext
 import org.ossreviewtoolkit.utils.common.Os
@@ -66,6 +67,11 @@ class ScanCode internal constructor(
     scannerConfig: ScannerConfiguration,
     downloaderConfig: DownloaderConfiguration
 ) : CommandLineScanner(name, scannerConfig, downloaderConfig), PathScannerWrapper {
+    class ScanCodeFactory : AbstractScannerWrapperFactory<ScanCode>(SCANNER_NAME) {
+        override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
+            ScanCode(scannerName, scannerConfig, downloaderConfig)
+    }
+
     class Factory : AbstractScannerFactory<ScanCode>(SCANNER_NAME) {
         override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
             ScanCode(scannerName, scannerConfig, downloaderConfig)

--- a/scanner/src/main/resources/META-INF/services/org.ossreviewtoolkit.scanner.ScannerWrapperFactory
+++ b/scanner/src/main/resources/META-INF/services/org.ossreviewtoolkit.scanner.ScannerWrapperFactory
@@ -1,4 +1,0 @@
-org.ossreviewtoolkit.scanner.scanners.Askalono$AskalonoFactory
-org.ossreviewtoolkit.scanner.scanners.BoyterLc$BoyterLcFactory
-org.ossreviewtoolkit.scanner.scanners.Licensee$LicenseeFactory
-org.ossreviewtoolkit.scanner.scanners.scancode.ScanCode$ScanCodeFactory

--- a/scanner/src/main/resources/META-INF/services/org.ossreviewtoolkit.scanner.experimental.ScannerWrapperFactory
+++ b/scanner/src/main/resources/META-INF/services/org.ossreviewtoolkit.scanner.experimental.ScannerWrapperFactory
@@ -3,3 +3,4 @@ org.ossreviewtoolkit.scanner.scanners.BoyterLc$BoyterLcFactory
 org.ossreviewtoolkit.scanner.scanners.Licensee$LicenseeFactory
 org.ossreviewtoolkit.scanner.scanners.fossid.FossId$FossIdFactory
 org.ossreviewtoolkit.scanner.scanners.scancode.ScanCode$ScanCodeFactory
+org.ossreviewtoolkit.scanner.scanners.scanoss.ScanOss$ScanOssFactory

--- a/scanner/src/main/resources/META-INF/services/org.ossreviewtoolkit.scanner.experimental.ScannerWrapperFactory
+++ b/scanner/src/main/resources/META-INF/services/org.ossreviewtoolkit.scanner.experimental.ScannerWrapperFactory
@@ -1,0 +1,5 @@
+org.ossreviewtoolkit.scanner.scanners.Askalono$AskalonoFactory
+org.ossreviewtoolkit.scanner.scanners.BoyterLc$BoyterLcFactory
+org.ossreviewtoolkit.scanner.scanners.Licensee$LicenseeFactory
+org.ossreviewtoolkit.scanner.scanners.fossid.FossId$FossIdFactory
+org.ossreviewtoolkit.scanner.scanners.scancode.ScanCode$ScanCodeFactory


### PR DESCRIPTION
Add support for plugins for the experimental scanner, and for using multiple scanners at once. See the commit messages for details.
