### PR TITLE
ScanCodeResultParser: Fix the license mapping to NOASSERTION

### DIFF
--- a/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
@@ -72,7 +72,8 @@ private val TIMEOUT_ERROR_REGEX = Pattern.compile(
 private val UNKNOWN_LICENSE_REF = listOf(
     "LicenseRef-scancode-free-unknown",
     "LicenseRef-scancode-unknown",
-    "LicenseRef-scancode-unknown-license-reference"
+    "LicenseRef-scancode-unknown-license-reference",
+    "LicenseRef-scancode-unknown-spdx"
 )
 
 /**

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
@@ -39,6 +39,7 @@ import org.ossreviewtoolkit.utils.common.textValueOrEmpty
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants.LICENSE_REF_PREFIX
 import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
+import org.ossreviewtoolkit.utils.spdx.toSpdxId
 
 private data class LicenseMatch(
     val expression: String,
@@ -66,10 +67,12 @@ private val TIMEOUT_ERROR_REGEX = Pattern.compile(
             "ERROR: Processing interrupted: timeout after (?<timeout>\\d+) seconds. \\(File: (?<file>.+)\\)"
 )
 
-private val UNKNOWN_LICENSE_KEYS = listOf(
-    "free-unknown",
-    "unknown",
-    "unknown-license-reference"
+// A list of ScanCode-specific LicenseRefs that do not actually name concrete licenses, but which are generic findings
+// that "look like" licenses as per https://scancode-licensedb.aboutcode.org/?search=unknown.
+private val UNKNOWN_LICENSE_REF = listOf(
+    "LicenseRef-scancode-free-unknown",
+    "LicenseRef-scancode-unknown",
+    "LicenseRef-scancode-unknown-license-reference"
 )
 
 /**
@@ -213,24 +216,24 @@ private fun getLicenseFindings(result: JsonNode, parseExpressions: Boolean): Lis
  */
 private fun getSpdxLicenseId(license: JsonNode): String {
     // There is a bug in ScanCode 3.0.2 that returns an empty string instead of null for licenses unknown to SPDX.
-    val id = license["spdx_license_key"].textValueOrEmpty().replace('_', '-')
+    val idFromSpdxKey = license["spdx_license_key"].textValueOrEmpty().toSpdxId(allowPlusSuffix = true)
 
     // For regular SPDX IDs, return early here.
-    if (id.isNotEmpty() && !id.startsWith(LICENSE_REF_PREFIX)) return id
+    if (idFromSpdxKey.isNotEmpty() && !idFromSpdxKey.startsWith(LICENSE_REF_PREFIX)) return idFromSpdxKey
 
     // Before version 2.9.8, ScanCode used SPDX LicenseRefs that did not include the "scancode" namespace, like
     // "LicenseRef-Proprietary-HERE" instead of now "LicenseRef-scancode-here-proprietary", see
     // https://github.com/nexB/scancode-toolkit/blob/f94f716/src/licensedcode/data/licenses/here-proprietary.yml#L6-L8
     // But if the "scancode" namespace is present, return early here.
-    if (id.startsWith(LICENSE_REF_PREFIX_SCAN_CODE)) return id
+    val id = idFromSpdxKey.takeIf { it.startsWith(LICENSE_REF_PREFIX_SCAN_CODE) } ?: run {
+        // At this point the ID is either empty or a non-ScanCode SPDX LicenseRef, so fall back to building an ID based
+        // on the ScanCode-specific "key".
+        val idFromKey = license["key"].textValue().toSpdxId(allowPlusSuffix = true)
 
-    // At this point the ID is either empty or a non-"scancode" SPDX LicenseRef that needs to be fixed up.
-    val key = license["key"].textValue().replace('_', '-')
-    return if (key in UNKNOWN_LICENSE_KEYS) {
-        SpdxConstants.NOASSERTION
-    } else {
-        "$LICENSE_REF_PREFIX_SCAN_CODE$key"
+        "$LICENSE_REF_PREFIX_SCAN_CODE$idFromKey"
     }
+
+    return id.takeUnless { it in UNKNOWN_LICENSE_REF } ?: SpdxConstants.NOASSERTION
 }
 
 /**

--- a/scanner/src/test/kotlin/scanners/scancode/ScanCodeResultParserTest.kt
+++ b/scanner/src/test/kotlin/scanners/scancode/ScanCodeResultParserTest.kt
@@ -432,7 +432,7 @@ class ScanCodeResultParserTest : FreeSpec({
                         score = 100.0f
                     ),
                     LicenseFinding(
-                        license = "LicenseRef-scancode-free-unknown",
+                        license = "NOASSERTION",
                         location = TextLocation(
                             path = "Downloads/wasi-0.10.2+wasi-snapshot-preview1/ORG_CODE_OF_CONDUCT.md",
                             startLine = 106,
@@ -441,7 +441,7 @@ class ScanCodeResultParserTest : FreeSpec({
                         score = 50.0f
                     ),
                     LicenseFinding(
-                        license = "LicenseRef-scancode-unknown-license-reference",
+                        license = "NOASSERTION",
                         location = TextLocation("Downloads/wasi-0.10.2+wasi-snapshot-preview1/README.md", 88, 88),
                         score = 100.0f
                     ),

--- a/utils/spdx/src/test/kotlin/ExtensionsTest.kt
+++ b/utils/spdx/src/test/kotlin/ExtensionsTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.utils.spdx
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.beEmpty
+
+class ExtensionsTest : WordSpec({
+    "toSpdxId()" should {
+        "convert license strings" {
+            "GPL-2.0+".toSpdxId() shouldBe "GPL-2.0"
+            "GPL-2.0+".toSpdxId(allowPlusSuffix = true) shouldBe "GPL-2.0+"
+        }
+
+        "convert ORT Identifier coordinate strings" {
+            "Maven:org.eclipse.jetty:jetty-client:9.4.42.v20210604".toSpdxId() shouldBe
+                    "Maven-org.eclipse.jetty-jetty-client-9.4.42.v20210604"
+            "Pub:crypto:crypto:2.1.1+1".toSpdxId(allowPlusSuffix = true) shouldBe "Pub-crypto-crypto-2.1.1.1"
+            "NPM::lodash._reinterpolate:3.0.0".toSpdxId() shouldBe "NPM-lodash.reinterpolate-3.0.0"
+        }
+
+        "convert arbitrary strings" {
+            "+!§$%&/()=?\\:+".toSpdxId() should beEmpty()
+            "+!§$%foo&/(bar)=?\\:+".toSpdxId(allowPlusSuffix = true) shouldBe "foo.bar+"
+        }
+    }
+})


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.