### PR TITLE
Gradle: Remove manual definition of node version

### DIFF
--- a/reporter-web-app/build.gradle.kts
+++ b/reporter-web-app/build.gradle.kts
@@ -20,7 +20,6 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsSetupTask
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnSetupTask
@@ -28,9 +27,6 @@ import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnSetupTask
 // The Yarn plugin is only applied programmatically for Kotlin projects that target JavaScript. As we do not target
 // JavaScript from Kotlin (yet), manually apply the plugin to make its setup tasks available.
 YarnPlugin.apply(rootProject).version = "1.22.10"
-
-// Required for builds on ARM64 machines see: https://youtrack.jetbrains.com/issue/KT-49109.
-rootProject.the<NodeJsRootExtension>().nodeVersion = "16.13.0"
 
 // The Yarn plugin registers tasks always on the root project, see
 // https://github.com/JetBrains/kotlin/blob/1.4.0/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnPlugin.kt#L53-L57


### PR DESCRIPTION
Kotlin 1.6.20 contains node version 16.13.0 [1], therefore the manual
declaration is no longer required.

[1]: https://youtrack.jetbrains.com/issue/KT-49109
