### PR TITLE
Fix the evaluator's `hasLicense()` for "not present" values 

### DIFF
--- a/evaluator/src/main/kotlin/PackageRule.kt
+++ b/evaluator/src/main/kotlin/PackageRule.kt
@@ -109,7 +109,7 @@ open class PackageRule(
         object : RuleMatcher {
             override val description = "hasLicense()"
 
-            override fun matches() = resolvedLicenseInfo.licenses.isNotEmpty()
+            override fun matches() = resolvedLicenseInfo.licenses.any { it.license.isPresent() }
         }
 
     /**

--- a/evaluator/src/main/kotlin/PackageRule.kt
+++ b/evaluator/src/main/kotlin/PackageRule.kt
@@ -31,9 +31,7 @@ import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.model.licenses.ResolvedLicense
 import org.ossreviewtoolkit.model.licenses.ResolvedLicenseInfo
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
-import org.ossreviewtoolkit.utils.spdx.SpdxLicense
-import org.ossreviewtoolkit.utils.spdx.SpdxLicenseIdExpression
-import org.ossreviewtoolkit.utils.spdx.SpdxLicenseWithExceptionExpression
+import org.ossreviewtoolkit.utils.spdx.SpdxLicenseReferenceExpression
 
 /**
  * A [Rule] to check a single [Package].
@@ -238,7 +236,7 @@ open class PackageRule(
             }
 
         /**
-         * A [RuleMatcher] that checks if the [license] is a valid [SpdxLicense].
+         * A [RuleMatcher] that checks if the [license] is a valid SPDX license.
          */
         fun isSpdxLicense() =
             object : RuleMatcher {
@@ -246,7 +244,7 @@ open class PackageRule(
 
                 override fun matches() =
                     when (license) {
-                        is SpdxLicenseIdExpression, is SpdxLicenseWithExceptionExpression ->
+                        !is SpdxLicenseReferenceExpression ->
                             license.isValid(SpdxExpression.Strictness.ALLOW_DEPRECATED)
                         else -> false
                     }

--- a/evaluator/src/test/kotlin/PackageRuleTest.kt
+++ b/evaluator/src/test/kotlin/PackageRuleTest.kt
@@ -76,6 +76,13 @@ class PackageRuleTest : WordSpec() {
 
                 matcher.matches() shouldBe false
             }
+
+            "return false if the package has only 'not present' licenses" {
+                val rule = createPackageRule(packageWithNotPresentLicense)
+                val matcher = rule.hasLicense()
+
+                matcher.matches() shouldBe false
+            }
         }
 
         "isExcluded()" should {

--- a/evaluator/src/test/kotlin/PackageRuleTest.kt
+++ b/evaluator/src/test/kotlin/PackageRuleTest.kt
@@ -83,6 +83,13 @@ class PackageRuleTest : WordSpec() {
 
                 matcher.matches() shouldBe false
             }
+
+            "return false for non-existing packages" {
+                val rule = createPackageRule(Package.EMPTY)
+                val matcher = rule.hasLicense()
+
+                matcher.matches() shouldBe false
+            }
         }
 
         "isExcluded()" should {

--- a/evaluator/src/test/kotlin/RuleSetTest.kt
+++ b/evaluator/src/test/kotlin/RuleSetTest.kt
@@ -79,7 +79,7 @@ class RuleSetTest : WordSpec() {
                     }
                 }
 
-                ruleSet.violations should haveSize(4)
+                ruleSet.violations should haveSize(6)
             }
         }
 
@@ -125,7 +125,7 @@ class RuleSetTest : WordSpec() {
                     }
                 }
 
-                ruleSet.violations should haveSize(4)
+                ruleSet.violations should haveSize(6)
             }
 
             "add no license errors if license is removed by package license choice in the correct order" {

--- a/evaluator/src/test/kotlin/TestData.kt
+++ b/evaluator/src/test/kotlin/TestData.kt
@@ -60,6 +60,7 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.utils.core.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.core.Environment
+import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.model.SpdxLicenseChoice
 import org.ossreviewtoolkit.utils.spdx.toSpdx
 
@@ -81,6 +82,11 @@ val packageStaticallyLinked = Package.EMPTY.copy(
 
 val packageWithoutLicense = Package.EMPTY.copy(
     id = Identifier("Maven:org.ossreviewtoolkit:package-without-license:1.0")
+)
+
+val packageWithNotPresentLicense = Package.EMPTY.copy(
+    id = Identifier("Maven:org.ossreviewtoolkit:package-with-not-present-license:1.0"),
+    concludedLicense = "${SpdxConstants.NONE} OR ${SpdxConstants.NOASSERTION}".toSpdx()
 )
 
 val packageWithOnlyConcludedLicense = Package.EMPTY.copy(
@@ -125,6 +131,7 @@ val allPackages = listOf(
     packageDynamicallyLinked,
     packageStaticallyLinked,
     packageWithoutLicense,
+    packageWithNotPresentLicense,
     packageWithOnlyConcludedLicense,
     packageWithOnlyDeclaredLicense,
     packageWithConcludedAndDeclaredLicense,
@@ -152,6 +159,7 @@ val scopeIncluded = Scope(
     name = "compile",
     dependencies = sortedSetOf(
         packageWithoutLicense.toReference(),
+        packageWithNotPresentLicense.toReference(),
         packageWithOnlyConcludedLicense.toReference(),
         packageWithOnlyDeclaredLicense.toReference(dependencies = sortedSetOf(packageDependency.toReference())),
         packageWithConcludedAndDeclaredLicense.toReference(),

--- a/utils/spdx/src/main/kotlin/SpdxConstants.kt
+++ b/utils/spdx/src/main/kotlin/SpdxConstants.kt
@@ -75,10 +75,12 @@ object SpdxConstants {
      */
     const val EMPTY_PACKAGE_VERIFICATION_CODE = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 
+    private val NOT_PRESENT_VALUES = setOf(null, NONE, NOASSERTION)
+
     /**
      * Return true if and only if the given value is null or equals [NONE] or [NOASSERTION].
      */
-    fun isNotPresent(value: String?) = value in setOf(null, NONE, NOASSERTION)
+    fun isNotPresent(value: String?) = value in NOT_PRESENT_VALUES
 
     /**
      * Return true if and only if the given value is not null and does not equal [NONE] or [NOASSERTION].

--- a/utils/spdx/src/main/kotlin/SpdxExpression.kt
+++ b/utils/spdx/src/main/kotlin/SpdxExpression.kt
@@ -555,7 +555,7 @@ class SpdxLicenseIdExpression(
     val id: String,
     val orLaterVersion: Boolean = false
 ) : SpdxSimpleExpression() {
-    private val spdxLicense = SpdxLicense.forId(id)
+    private val spdxLicense by lazy { SpdxLicense.forId(id) }
 
     override fun decompose() = setOf(this)
 

--- a/utils/spdx/src/main/kotlin/SpdxExpression.kt
+++ b/utils/spdx/src/main/kotlin/SpdxExpression.kt
@@ -158,6 +158,12 @@ sealed class SpdxExpression {
     protected open fun validChoicesForDnf(): Set<SpdxExpression> = setOf(this)
 
     /**
+     * Return whether this expression contains [present][SpdxConstants.isPresent] licenses, i.e. not all licenses in
+     * this expression are "not present" values.
+     */
+    fun isPresent() = licenses().any { SpdxConstants.isPresent(it) }
+
+    /**
      * Return if this expression is valid according to the [strictness]. Also see [validate].
      */
     fun isValid(strictness: Strictness = Strictness.ALLOW_CURRENT): Boolean =


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.