### PR TITLE
ScanCodeResultParser: Also map "generic" licenses to `NOASSERTION`

### DIFF
--- a/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
@@ -68,12 +68,24 @@ private val TIMEOUT_ERROR_REGEX = Pattern.compile(
 )
 
 // A list of ScanCode-specific LicenseRefs that do not actually name concrete licenses, but which are generic findings
-// that "look like" licenses as per https://scancode-licensedb.aboutcode.org/?search=unknown.
+// that "look like" licenses.
 private val UNKNOWN_LICENSE_REF = listOf(
+    // https://scancode-licensedb.aboutcode.org/?search=unknown
     "LicenseRef-scancode-free-unknown",
     "LicenseRef-scancode-unknown",
     "LicenseRef-scancode-unknown-license-reference",
-    "LicenseRef-scancode-unknown-spdx"
+    "LicenseRef-scancode-unknown-spdx",
+
+    // https://scancode-licensedb.aboutcode.org/?search=generic
+    "LicenseRef-scancode-agpl-generic-additional-terms",
+    "LicenseRef-scancode-generic-cla",
+    "LicenseRef-scancode-generic-exception",
+    "LicenseRef-scancode-generic-export-compliance",
+    "LicenseRef-scancode-generic-tos",
+    "LicenseRef-scancode-generic-trademark",
+    "LicenseRef-scancode-gpl-generic-additional-terms",
+    "LicenseRef-scancode-patent-disclaimer",
+    "LicenseRef-scancode-warranty-disclaimer"
 )
 
 /**

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
@@ -69,7 +69,7 @@ private val TIMEOUT_ERROR_REGEX = Pattern.compile(
 
 // A list of ScanCode-specific LicenseRefs that do not actually name concrete licenses, but which are generic findings
 // that "look like" licenses.
-private val UNKNOWN_LICENSE_REF = listOf(
+private val NOASSERTION_LICENSE_REFS = listOf(
     // https://scancode-licensedb.aboutcode.org/?search=unknown
     "LicenseRef-scancode-free-unknown",
     "LicenseRef-scancode-unknown",
@@ -246,7 +246,7 @@ private fun getSpdxLicenseId(license: JsonNode): String {
         "$LICENSE_REF_PREFIX_SCAN_CODE$idFromKey"
     }
 
-    return id.takeUnless { it in UNKNOWN_LICENSE_REF } ?: SpdxConstants.NOASSERTION
+    return id.takeUnless { it in NOASSERTION_LICENSE_REFS } ?: SpdxConstants.NOASSERTION
 }
 
 /**


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.