### PR TITLE
clients: Use imports instead of fully qualified Gradle task names

### DIFF
--- a/clients/nexus-iq/build.gradle.kts
+++ b/clients/nexus-iq/build.gradle.kts
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 val kotlinxSerializationVersion: String by project
 val retrofitVersion: String by project
 val retrofitKotlinxSerializationConverterVersion: String by project
@@ -37,7 +39,7 @@ dependencies {
             retrofitKotlinxSerializationConverterVersion)
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+tasks.withType<KotlinCompile> {
     val customCompilerArgs = listOf(
         "-opt-in=kotlinx.serialization.ExperimentalSerializationApi"
     )

--- a/clients/scanoss/build.gradle.kts
+++ b/clients/scanoss/build.gradle.kts
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 val kotlinxSerializationVersion: String by project
 val retrofitVersion: String by project
 val retrofitKotlinxSerializationConverterVersion: String by project
@@ -40,7 +42,7 @@ dependencies {
     testImplementation("com.github.tomakehurst:wiremock-jre8:$wiremockVersion")
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+tasks.withType<KotlinCompile> {
     val customCompilerArgs = listOf(
         "-opt-in=kotlinx.serialization.ExperimentalSerializationApi"
     )


### PR DESCRIPTION
This aligns with the majority of existing code.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>