### PR TITLE
fossid-webapp: Use the correct property for download failure logging

### DIFF
--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -614,7 +614,7 @@ class FossId internal constructor(
                 DownloadStatus.FINISHED -> return@wait true
 
                 DownloadStatus.FAILED -> throw IllegalStateException(
-                    "Could not download scan: ${response.error}."
+                    "Could not download scan: ${response.message}."
                 )
 
                 else -> {


### PR DESCRIPTION
When a download has status `FAILED`, the logs are not located in the
`error` property, they are in the `message` property.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>

