### PR TITLE
SpdxDocumentCache: Log the file name before loading it

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/SpdxDocumentCache.kt
+++ b/analyzer/src/main/kotlin/managers/utils/SpdxDocumentCache.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.analyzer.managers.utils
 import java.io.File
 
 import org.ossreviewtoolkit.analyzer.managers.SpdxDocumentFile
+import org.ossreviewtoolkit.utils.core.log
 import org.ossreviewtoolkit.utils.spdx.SpdxModelMapper
 import org.ossreviewtoolkit.utils.spdx.model.SpdxDocument
 
@@ -44,6 +45,8 @@ internal class SpdxDocumentCache {
      */
     fun load(file: File): SpdxDocument =
         documentCache.getOrPut(file) {
+            log.info { "Loading SpdxDocument from '$file'." }
+
             SpdxModelMapper.read(file)
         }
 }


### PR DESCRIPTION
If a project contains multiple SPDX files and one of these is invalid
(so that it cannot be loaded), there is no indication in the log,
which file is affected. Therefore, add a log statement allowing to
keep track on the files that are processed.
