### PR TITLE
MavenSupport: Close the `RepositoryConnector` after use

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -529,9 +529,9 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
 
             try {
                 wrapMavenSession {
-                    val repositoryConnector = repositoryConnectorProvider
-                        .newRepositoryConnector(repositorySystemSession, repository)
-                    repositoryConnector.get(listOf(artifactDownload), null)
+                    repositoryConnectorProvider.newRepositoryConnector(repositorySystemSession, repository).use {
+                        it.get(listOf(artifactDownload), null)
+                    }
                 }
             } catch (e: NoRepositoryConnectorException) {
                 e.showStackTrace()


### PR DESCRIPTION
Fixes #5236.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>