### PR TITLE
Work around Artifactory returning API URLs instead of download URLs for NPM

### DIFF
--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -318,7 +318,6 @@ open class Npm(
      * Construct a [Package] by parsing its _package.json_ file and - if applicable - querying additional
      * content via the `npm view` command. The result is a [Pair] with the raw identifier and the new package.
      */
-    @Suppress("HttpUrlsUsage")
     internal fun parsePackage(workingDir: File, packageFile: File): Pair<String, Package> {
         val packageDir = packageFile.parentFile
 
@@ -382,6 +381,7 @@ open class Npm(
             }
         }
 
+        @Suppress("HttpUrlsUsage")
         downloadUrl = downloadUrl
             // Work around the issue described at
             // https://npm.community/t/some-packages-have-dist-tarball-as-http-and-not-https/285/19.

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -196,6 +196,7 @@ open class Npm(
         }
     }
 
+    private val artifactoryApiPathPattern = Regex("(.*artifactory.*)(?:/api/npm/)(.*)")
     private val graphBuilder = DependencyGraphBuilder(NpmDependencyHandler(this))
 
     protected open fun hasLockFile(projectDir: File) = hasNpmLockFile(projectDir)
@@ -386,6 +387,10 @@ open class Npm(
             // Work around the issue described at
             // https://npm.community/t/some-packages-have-dist-tarball-as-http-and-not-https/285/19.
             .replace("http://registry.npmjs.org/", "https://registry.npmjs.org/")
+            // Work around Artifactory returning API URLs instead of download URLs. See these somewhat related issues:
+            // https://www.jfrog.com/jira/browse/RTFACT-8727
+            // https://www.jfrog.com/jira/browse/RTFACT-18463
+            .replace(artifactoryApiPathPattern, "$1/$2")
 
         val vcsFromDownloadUrl = VcsHost.toVcsInfo(downloadUrl)
         if (vcsFromDownloadUrl.url != downloadUrl) {


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.