### PR TITLE
Consistently map references to unknown licenses to NOASSERTION

### DIFF
--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -52,6 +52,7 @@ import org.ossreviewtoolkit.utils.common.textValueOrEmpty
 import org.ossreviewtoolkit.utils.core.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.core.ProcessedDeclaredLicense
 import org.ossreviewtoolkit.utils.core.log
+import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxOperator
 
 /**
@@ -251,7 +252,7 @@ private fun parseDeclaredLicenses(node: JsonNode): SortedSet<String> {
     // point.
     // See: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields
     if (node["license_file"].textValueOrEmpty().isNotBlank()) {
-        declaredLicenses += "LicenseRef-ort-unknown-license-reference"
+        declaredLicenses += SpdxConstants.NOASSERTION
     }
 
     return declaredLicenses

--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -247,7 +247,7 @@ private fun parseDeclaredLicenses(node: JsonNode): SortedSet<String> {
         .filterTo(sortedSetOf()) { it.isNotEmpty() }
 
     // Cargo allows to declare non-SPDX licenses only by referencing a license file. If a license file is specified, add
-    // an unknown declared license to indicate that there is a declared license but we cannot know which it is at this
+    // an unknown declared license to indicate that there is a declared license, but we cannot know which it is at this
     // point.
     // See: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields
     if (node["license_file"].textValueOrEmpty().isNotBlank()) {

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -138,7 +138,7 @@ open class Npm(
 
                     // NPM allows to declare non-SPDX licenses only by referencing a license file. Avoid reporting an
                     // [OrtIssue] by mapping this to a valid license identifier.
-                    declaredLicense.startsWith("SEE LICENSE IN ") -> "LicenseRef-ort-unknown-license-reference"
+                    declaredLicense.startsWith("SEE LICENSE IN ") -> SpdxConstants.NOASSERTION
 
                     else -> declaredLicense.takeUnless { it.isBlank() }
                 }


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.