### PR TITLE
NuGetSupport: Replace license URLs with SWH content hashes

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-direct-dependencies-only-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-direct-dependencies-only-expected-output.yml
@@ -32,11 +32,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides classes that define culture-related information, including\
     \ language, country/region, calendars in use, format patterns for dates, currency,\
     \ and numbers, and sort order for strings.\n\nCommonly Used Types:\nSystem.Globalization.DateTimeFormatInfo\n\
@@ -70,11 +70,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental synchronization primitives, including System.Threading.Monitor\
     \ and System.Threading.Mutex, that are required when writing asynchronous code.\n\
     \nCommonly Used Types:\nSystem.Threading.Monitor\nSystem.Threading.SynchronizationContext\n\
@@ -107,11 +107,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+  - "LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT"
   declared_licenses_processed:
     spdx_expression: "MIT"
     mapped:
-      https://github.com/dotnet/corefx/blob/master/LICENSE.TXT: "MIT"
+      LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT: "MIT"
   description: "Provides additional types that simplify the work of writing concurrent\
     \ and asynchronous code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.ValueTask<TResult>\n\
     \ \n7601f4f6225089ffb291dc7d58293c7bbf5c5d4f"
@@ -141,10 +141,9 @@ packages:
   authors:
   - "webgrease@microsoft.com"
   declared_licenses:
-  - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
+  - "LicenseRef-ort-SWHID-690b6577ac26dcdbea2dfe93a2a0dd1c08e6e6fd-msn-webgrease-eula.htm"
   declared_licenses_processed:
-    unmapped:
-    - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
+    spdx_expression: "LicenseRef-ort-SWHID-690b6577ac26dcdbea2dfe93a2a0dd1c08e6e6fd-msn-webgrease-eula.htm"
   description: "Web Grease is a suite of tools for optimizing javascript, css files\
     \ and images."
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output-with-nuspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output-with-nuspec.yml
@@ -103,11 +103,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides runtime information required to resolve target framework,\
     \ platform, and runtime specific implementations of .NETCore packages. \nWhen\
     \ using NuGet 3.x this package requires at least version 3.4."
@@ -137,11 +137,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides runtime information required to resolve target framework,\
     \ platform, and runtime specific implementations of .NETCore packages. \nWhen\
     \ using NuGet 3.x this package requires at least version 3.4."
@@ -171,11 +171,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides supporting infrastructure for portable projects: support\
     \ identifiers that define framework and runtime for support targets and packages\
     \ that reference the minimum supported package versions when targeting these.\
@@ -206,11 +206,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides supporting infrastructure for portable projects: support\
     \ identifiers that define framework and runtime for support targets and packages\
     \ that reference the minimum supported package versions when targeting these.\
@@ -273,11 +273,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides classes that define generic collections, which allow developers\
     \ to create strongly typed collections that provide better type safety and performance\
     \ than non-generic strongly typed collections.\n\nCommonly Used Types:\nSystem.Collections.Generic.List<T>\n\
@@ -312,11 +312,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides classes that define culture-related information, including\
     \ language, country/region, calendars in use, format patterns for dates, currency,\
     \ and numbers, and sort order for strings.\n\nCommonly Used Types:\nSystem.Globalization.DateTimeFormatInfo\n\
@@ -350,11 +350,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental primitives, classes and base classes that\
     \ define commonly-used value and reference data types, events and event handlers,\
     \ interfaces, attributes, and exceptions. This packages represents the core package,\
@@ -390,11 +390,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental primitives, classes and base classes that\
     \ define commonly-used value and reference data types, events and event handlers,\
     \ interfaces, attributes, and exceptions. This packages represents the core package,\
@@ -430,11 +430,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+  - "LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT"
   declared_licenses_processed:
     spdx_expression: "MIT"
     mapped:
-      https://github.com/dotnet/corefx/blob/master/LICENSE.TXT: "MIT"
+      LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT: "MIT"
   description: "Provides the System.Runtime.CompilerServices.Unsafe class, which provides\
     \ generic, low-level functionality for manipulating pointers.\n\nCommonly Used\
     \ Types:\nSystem.Runtime.CompilerServices.Unsafe\n \n7601f4f6225089ffb291dc7d58293c7bbf5c5d4f\
@@ -465,11 +465,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental synchronization primitives, including System.Threading.Monitor\
     \ and System.Threading.Mutex, that are required when writing asynchronous code.\n\
     \nCommonly Used Types:\nSystem.Threading.Monitor\nSystem.Threading.SynchronizationContext\n\
@@ -502,11 +502,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides types that simplify the work of writing concurrent and asynchronous\
     \ code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.Task<TResult>\nSystem.Runtime.CompilerServices.TaskAwaiter<TResult>\n\
     System.Threading.Tasks.TaskCompletionSource<TResult>\nSystem.Threading.Tasks.Task\n\
@@ -538,11 +538,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides types that simplify the work of writing concurrent and asynchronous\
     \ code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.Task<TResult>\nSystem.Runtime.CompilerServices.TaskAwaiter<TResult>\n\
     System.Threading.Tasks.TaskCompletionSource<TResult>\nSystem.Threading.Tasks.Task\n\
@@ -574,11 +574,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+  - "LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT"
   declared_licenses_processed:
     spdx_expression: "MIT"
     mapped:
-      https://github.com/dotnet/corefx/blob/master/LICENSE.TXT: "MIT"
+      LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT: "MIT"
   description: "Provides additional types that simplify the work of writing concurrent\
     \ and asynchronous code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.ValueTask<TResult>\n\
     \ \n7601f4f6225089ffb291dc7d58293c7bbf5c5d4f"
@@ -608,10 +608,9 @@ packages:
   authors:
   - "webgrease@microsoft.com"
   declared_licenses:
-  - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
+  - "LicenseRef-ort-SWHID-690b6577ac26dcdbea2dfe93a2a0dd1c08e6e6fd-msn-webgrease-eula.htm"
   declared_licenses_processed:
-    unmapped:
-    - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
+    spdx_expression: "LicenseRef-ort-SWHID-690b6577ac26dcdbea2dfe93a2a0dd1c08e6e6fd-msn-webgrease-eula.htm"
   description: "Web Grease is a suite of tools for optimizing javascript, css files\
     \ and images."
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
@@ -97,11 +97,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides runtime information required to resolve target framework,\
     \ platform, and runtime specific implementations of .NETCore packages. \nWhen\
     \ using NuGet 3.x this package requires at least version 3.4."
@@ -131,11 +131,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides runtime information required to resolve target framework,\
     \ platform, and runtime specific implementations of .NETCore packages. \nWhen\
     \ using NuGet 3.x this package requires at least version 3.4."
@@ -165,11 +165,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides supporting infrastructure for portable projects: support\
     \ identifiers that define framework and runtime for support targets and packages\
     \ that reference the minimum supported package versions when targeting these.\
@@ -200,11 +200,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides supporting infrastructure for portable projects: support\
     \ identifiers that define framework and runtime for support targets and packages\
     \ that reference the minimum supported package versions when targeting these.\
@@ -267,11 +267,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides classes that define generic collections, which allow developers\
     \ to create strongly typed collections that provide better type safety and performance\
     \ than non-generic strongly typed collections.\n\nCommonly Used Types:\nSystem.Collections.Generic.List<T>\n\
@@ -306,11 +306,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides classes that define culture-related information, including\
     \ language, country/region, calendars in use, format patterns for dates, currency,\
     \ and numbers, and sort order for strings.\n\nCommonly Used Types:\nSystem.Globalization.DateTimeFormatInfo\n\
@@ -344,11 +344,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental primitives, classes and base classes that\
     \ define commonly-used value and reference data types, events and event handlers,\
     \ interfaces, attributes, and exceptions. This packages represents the core package,\
@@ -384,11 +384,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental primitives, classes and base classes that\
     \ define commonly-used value and reference data types, events and event handlers,\
     \ interfaces, attributes, and exceptions. This packages represents the core package,\
@@ -424,11 +424,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+  - "LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT"
   declared_licenses_processed:
     spdx_expression: "MIT"
     mapped:
-      https://github.com/dotnet/corefx/blob/master/LICENSE.TXT: "MIT"
+      LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT: "MIT"
   description: "Provides the System.Runtime.CompilerServices.Unsafe class, which provides\
     \ generic, low-level functionality for manipulating pointers.\n\nCommonly Used\
     \ Types:\nSystem.Runtime.CompilerServices.Unsafe\n \n7601f4f6225089ffb291dc7d58293c7bbf5c5d4f\
@@ -459,11 +459,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental synchronization primitives, including System.Threading.Monitor\
     \ and System.Threading.Mutex, that are required when writing asynchronous code.\n\
     \nCommonly Used Types:\nSystem.Threading.Monitor\nSystem.Threading.SynchronizationContext\n\
@@ -496,11 +496,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides types that simplify the work of writing concurrent and asynchronous\
     \ code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.Task<TResult>\nSystem.Runtime.CompilerServices.TaskAwaiter<TResult>\n\
     System.Threading.Tasks.TaskCompletionSource<TResult>\nSystem.Threading.Tasks.Task\n\
@@ -532,11 +532,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides types that simplify the work of writing concurrent and asynchronous\
     \ code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.Task<TResult>\nSystem.Runtime.CompilerServices.TaskAwaiter<TResult>\n\
     System.Threading.Tasks.TaskCompletionSource<TResult>\nSystem.Threading.Tasks.Task\n\
@@ -568,11 +568,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+  - "LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT"
   declared_licenses_processed:
     spdx_expression: "MIT"
     mapped:
-      https://github.com/dotnet/corefx/blob/master/LICENSE.TXT: "MIT"
+      LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT: "MIT"
   description: "Provides additional types that simplify the work of writing concurrent\
     \ and asynchronous code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.ValueTask<TResult>\n\
     \ \n7601f4f6225089ffb291dc7d58293c7bbf5c5d4f"
@@ -602,10 +602,9 @@ packages:
   authors:
   - "webgrease@microsoft.com"
   declared_licenses:
-  - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
+  - "LicenseRef-ort-SWHID-690b6577ac26dcdbea2dfe93a2a0dd1c08e6e6fd-msn-webgrease-eula.htm"
   declared_licenses_processed:
-    unmapped:
-    - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
+    spdx_expression: "LicenseRef-ort-SWHID-690b6577ac26dcdbea2dfe93a2a0dd1c08e6e6fd-msn-webgrease-eula.htm"
   description: "Web Grease is a suite of tools for optimizing javascript, css files\
     \ and images."
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-direct-dependencies-only-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-direct-dependencies-only-expected-output.yml
@@ -32,11 +32,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides classes that define culture-related information, including\
     \ language, country/region, calendars in use, format patterns for dates, currency,\
     \ and numbers, and sort order for strings.\n\nCommonly Used Types:\nSystem.Globalization.DateTimeFormatInfo\n\
@@ -70,11 +70,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental synchronization primitives, including System.Threading.Monitor\
     \ and System.Threading.Mutex, that are required when writing asynchronous code.\n\
     \nCommonly Used Types:\nSystem.Threading.Monitor\nSystem.Threading.SynchronizationContext\n\
@@ -107,11 +107,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+  - "LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT"
   declared_licenses_processed:
     spdx_expression: "MIT"
     mapped:
-      https://github.com/dotnet/corefx/blob/master/LICENSE.TXT: "MIT"
+      LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT: "MIT"
   description: "Provides additional types that simplify the work of writing concurrent\
     \ and asynchronous code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.ValueTask<TResult>\n\
     \ \n7601f4f6225089ffb291dc7d58293c7bbf5c5d4f"
@@ -141,10 +141,9 @@ packages:
   authors:
   - "webgrease@microsoft.com"
   declared_licenses:
-  - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
+  - "LicenseRef-ort-SWHID-690b6577ac26dcdbea2dfe93a2a0dd1c08e6e6fd-msn-webgrease-eula.htm"
   declared_licenses_processed:
-    unmapped:
-    - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
+    spdx_expression: "LicenseRef-ort-SWHID-690b6577ac26dcdbea2dfe93a2a0dd1c08e6e6fd-msn-webgrease-eula.htm"
   description: "Web Grease is a suite of tools for optimizing javascript, css files\
     \ and images."
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
@@ -97,11 +97,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides runtime information required to resolve target framework,\
     \ platform, and runtime specific implementations of .NETCore packages. \nWhen\
     \ using NuGet 3.x this package requires at least version 3.4."
@@ -131,11 +131,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides runtime information required to resolve target framework,\
     \ platform, and runtime specific implementations of .NETCore packages. \nWhen\
     \ using NuGet 3.x this package requires at least version 3.4."
@@ -165,11 +165,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides supporting infrastructure for portable projects: support\
     \ identifiers that define framework and runtime for support targets and packages\
     \ that reference the minimum supported package versions when targeting these.\
@@ -200,11 +200,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides supporting infrastructure for portable projects: support\
     \ identifiers that define framework and runtime for support targets and packages\
     \ that reference the minimum supported package versions when targeting these.\
@@ -267,11 +267,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides classes that define generic collections, which allow developers\
     \ to create strongly typed collections that provide better type safety and performance\
     \ than non-generic strongly typed collections.\n\nCommonly Used Types:\nSystem.Collections.Generic.List<T>\n\
@@ -306,11 +306,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides classes that define culture-related information, including\
     \ language, country/region, calendars in use, format patterns for dates, currency,\
     \ and numbers, and sort order for strings.\n\nCommonly Used Types:\nSystem.Globalization.DateTimeFormatInfo\n\
@@ -344,11 +344,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental primitives, classes and base classes that\
     \ define commonly-used value and reference data types, events and event handlers,\
     \ interfaces, attributes, and exceptions. This packages represents the core package,\
@@ -384,11 +384,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental primitives, classes and base classes that\
     \ define commonly-used value and reference data types, events and event handlers,\
     \ interfaces, attributes, and exceptions. This packages represents the core package,\
@@ -424,11 +424,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+  - "LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT"
   declared_licenses_processed:
     spdx_expression: "MIT"
     mapped:
-      https://github.com/dotnet/corefx/blob/master/LICENSE.TXT: "MIT"
+      LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT: "MIT"
   description: "Provides the System.Runtime.CompilerServices.Unsafe class, which provides\
     \ generic, low-level functionality for manipulating pointers.\n\nCommonly Used\
     \ Types:\nSystem.Runtime.CompilerServices.Unsafe\n \n7601f4f6225089ffb291dc7d58293c7bbf5c5d4f\
@@ -459,11 +459,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental synchronization primitives, including System.Threading.Monitor\
     \ and System.Threading.Mutex, that are required when writing asynchronous code.\n\
     \nCommonly Used Types:\nSystem.Threading.Monitor\nSystem.Threading.SynchronizationContext\n\
@@ -496,11 +496,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides types that simplify the work of writing concurrent and asynchronous\
     \ code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.Task<TResult>\nSystem.Runtime.CompilerServices.TaskAwaiter<TResult>\n\
     System.Threading.Tasks.TaskCompletionSource<TResult>\nSystem.Threading.Tasks.Task\n\
@@ -532,11 +532,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "http://go.microsoft.com/fwlink/?LinkId=329770"
+  - "LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm"
   declared_licenses_processed:
     spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
+      LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides types that simplify the work of writing concurrent and asynchronous\
     \ code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.Task<TResult>\nSystem.Runtime.CompilerServices.TaskAwaiter<TResult>\n\
     System.Threading.Tasks.TaskCompletionSource<TResult>\nSystem.Threading.Tasks.Task\n\
@@ -568,11 +568,11 @@ packages:
   authors:
   - "Microsoft"
   declared_licenses:
-  - "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+  - "LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT"
   declared_licenses_processed:
     spdx_expression: "MIT"
     mapped:
-      https://github.com/dotnet/corefx/blob/master/LICENSE.TXT: "MIT"
+      LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT: "MIT"
   description: "Provides additional types that simplify the work of writing concurrent\
     \ and asynchronous code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.ValueTask<TResult>\n\
     \ \n7601f4f6225089ffb291dc7d58293c7bbf5c5d4f"
@@ -602,10 +602,9 @@ packages:
   authors:
   - "webgrease@microsoft.com"
   declared_licenses:
-  - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
+  - "LicenseRef-ort-SWHID-690b6577ac26dcdbea2dfe93a2a0dd1c08e6e6fd-msn-webgrease-eula.htm"
   declared_licenses_processed:
-    unmapped:
-    - "http://www.microsoft.com/web/webpi/eula/msn_webgrease_eula.htm"
+    spdx_expression: "LicenseRef-ort-SWHID-690b6577ac26dcdbea2dfe93a2a0dd1c08e6e6fd-msn-webgrease-eula.htm"
   description: "Web Grease is a suite of tools for optimizing javascript, css files\
     \ and images."
   homepage_url: ""

--- a/utils/core/src/main/kotlin/DeclaredLicenseProcessor.kt
+++ b/utils/core/src/main/kotlin/DeclaredLicenseProcessor.kt
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 
 import org.ossreviewtoolkit.utils.common.collectMessagesAsString
+import org.ossreviewtoolkit.utils.common.isValidUri
+import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.spdx.SpdxCompoundExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxDeclaredLicenseMapping
@@ -30,6 +32,7 @@ import org.ossreviewtoolkit.utils.spdx.SpdxException
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxOperator
 import org.ossreviewtoolkit.utils.spdx.toSpdx
+import org.ossreviewtoolkit.utils.spdx.toSpdxId
 
 object DeclaredLicenseProcessor {
     private val urlPrefixesToRemove = listOf(
@@ -53,20 +56,13 @@ object DeclaredLicenseProcessor {
      * Return a declared license that has known URL prefixes and file suffixes stripped, so that the remaining string
      * can more generally be mapped in further processing steps.
      */
-    internal fun preprocess(declaredLicense: String): String {
+    internal fun extractLicenseNameFromUrl(declaredLicense: String): String {
         val licenseWithoutPrefix = urlPrefixesToRemove.fold(declaredLicense) { license, url ->
             license.removePrefix(url)
         }
 
-        // Only also strip suffixes if at least one prefix was stripped. Otherwise URLs like
-        // "http://ant-contrib.sourceforge.net/tasks/LICENSE.txt" would be stripped, but for such URLs separate
-        // mappings might exist.
-        return if (licenseWithoutPrefix != declaredLicense) {
-            fileSuffixesToRemove.fold(licenseWithoutPrefix) { license, extension ->
-                license.removeSuffix(extension)
-            }
-        } else {
-            licenseWithoutPrefix
+        return fileSuffixesToRemove.fold(licenseWithoutPrefix) { license, extension ->
+            license.removeSuffix(extension)
         }
     }
 
@@ -80,10 +76,25 @@ object DeclaredLicenseProcessor {
         declaredLicense: String,
         declaredLicenseMapping: Map<String, SpdxExpression> = emptyMap()
     ): SpdxExpression? {
-        val licenseWithoutPrefixOrSuffix = preprocess(declaredLicense)
-        val mappedLicense = declaredLicenseMapping[licenseWithoutPrefixOrSuffix]
-            ?: SpdxDeclaredLicenseMapping.map(licenseWithoutPrefixOrSuffix)
-            ?: parseLicense(licenseWithoutPrefixOrSuffix)
+        val licenseName = extractLicenseNameFromUrl(declaredLicense)
+
+        if (licenseName.isValidUri()) {
+            val tempDir = createOrtTempDir("NuGetSupport")
+
+            val licenseDownloadUrl = VcsHost.toRawDownloadUrl(licenseUrl) ?: licenseUrl
+            val licenseFromUrl = OkHttpClientHelper.downloadFile(licenseDownloadUrl, tempDir).map {
+                val algorithm = HashAlgorithm.SHA1GIT
+                val hash = algorithm.calculate(it)
+                "${SpdxConstants.LICENSE_REF_PREFIX}$ORT_NAME-SWHID-$hash-${it.name}".toSpdxId()
+            }.getOrDefault(licenseUrl)
+
+            tempDir.safeDeleteRecursively()
+
+        }
+
+        val mappedLicense = declaredLicenseMapping[licenseName]
+            ?: SpdxDeclaredLicenseMapping.map(licenseName)
+            ?: parseLicense(licenseName)
 
         return mappedLicense?.normalize()?.takeIf { it.isValid() || it.toString() == SpdxConstants.NONE }
     }

--- a/utils/core/src/test/kotlin/DeclaredLicenseProcessorTest.kt
+++ b/utils/core/src/test/kotlin/DeclaredLicenseProcessorTest.kt
@@ -94,7 +94,7 @@ class DeclaredLicenseProcessorTest : StringSpec() {
 
         "Preprocessing licenses does not make mapping redundant" {
             val processableLicenses = SpdxDeclaredLicenseMapping.mapping.keys.filter { declaredLicense ->
-                SpdxSimpleLicenseMapping.map(DeclaredLicenseProcessor.preprocess(declaredLicense)) != null
+                SpdxSimpleLicenseMapping.map(DeclaredLicenseProcessor.extractLicenseNameFromUrl(declaredLicense)) != null
             }
 
             processableLicenses should beEmpty()

--- a/utils/spdx/src/main/resources/declared-license-mapping.yml
+++ b/utils/spdx/src/main/resources/declared-license-mapping.yml
@@ -318,6 +318,8 @@
 "Lesser General Public License (LGPL)": LGPL-2.1-or-later
 "Lesser General Public License, version 3 or greater": LGPL-3.0-or-later
 "License Agreement For Open Source Computer Vision Library (3-clause BSD License)": BSD-3-Clause
+"LicenseRef-ort-SWHID-1096f5766ea09cfffebc364f1cd38664fc181269-dotnet-library-license.htm": LicenseRef-scancode-ms-net-library-2019-06
+"LicenseRef-ort-SWHID-984713a49622a96da110443c15477613bc12656b-LICENSE.TXT": MIT
 "MIT (http://mootools.net/license.txt)": MIT
 "MIT -or- Apache License 2.0": MIT OR Apache-2.0
 "MIT / http://rem.mit-license.org": MIT
@@ -483,7 +485,6 @@
 "http://creativecommons.org/licenses/publicdomain": CC-PDDC
 "http://creativecommons.org/publicdomain/zero/1.0/legalcode": CC0-1.0
 "http://en.wikipedia.org/wiki/Zlib_License": Zlib
-"http://go.microsoft.com/fwlink/?LinkId=329770": LicenseRef-scancode-ms-net-library-2019-06
 "http://go.microsoft.com/fwlink/?LinkId=529443": LicenseRef-scancode-ms-net-library-2019-06
 "http://json.codeplex.com/license": MIT
 "http://polymer.github.io/LICENSE.txt": BSD-3-Clause
@@ -526,7 +527,6 @@
 "https://creativecommons.org/publicdomain/zero/1.0/": CC0-1.0
 "https://dotnet.microsoft.com/en/dotnet_library_license.htm": LicenseRef-scancode-ms-net-library-2018-11
 "https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT": MIT
-"https://github.com/dotnet/corefx/blob/master/LICENSE.TXT": MIT
 "https://raw.github.com/RDFLib/rdflib/master/LICENSE": BSD-3-Clause
 "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt": Apache-2.0
 "https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt": Apache-2.0


### PR DESCRIPTION
Many NuGet packages only declare license URLs which, in contrast to
license names, cannot reliably be mapped to SPDX license expressions as
the content the URL refers to might change over time.

To support a reliable mapping if only a license URL is present, do not
use the URL itself as a declared license, but replace it with an
ORT-specific SPDX `LicenseRef` that includes the Software Heritage
hash over the content of the file the license URL refers to.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>