### PR TITLE
github/workflows: Upgrade to checkout action v3

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
@@ -83,7 +83,7 @@ jobs:
           # Install ScanCode for license texts.
           pip install --user scancode-toolkit==$SCANCODE_VERSION
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: Setup Java
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: Setup Java

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Validate Wrapper
       uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -15,7 +15,7 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Check Links
       uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v3
     - name: Check Links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: oss-review-toolkit/github-action-markdown-link-check@unsafe-repository
       with:
         base-branch: main
         check-modified-files-only: yes


### PR DESCRIPTION
This fixes the issue with Git's new `safe.directory` setting, see [1].

[1]: https://github.com/actions/checkout/blob/main/CHANGELOG.md#v301

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>