### PR TITLE
README: Remove the explicit default branch names from status badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,7 +669,7 @@ following formats are supported (reporter names are case-insensitive):
     * Man page (`-f ManPageTemplate`)
     * AsciiDoc (`-f AdocTemplate`): Does not convert the created AsciiDoc files but writes the generated files as
       reports.
-* [ctrlX AUTOMATION](https://ctrlx-automation.com/) platform
+* [ctrlX AUTOMATION](https://apps.boschrexroth.com/microsites/ctrlx-automation/) platform
   [FOSS information](https://github.com/boschrexroth/json-schema/tree/master/ctrlx-automation/ctrlx-core/apps/fossinfo) (`-f CtrlXAutomation`)
 * [CycloneDX](https://cyclonedx.org/) BOM (`-f CycloneDx`)
 * [Excel](https://products.office.com/excel) sheet (`-f Excel`)

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 
 [1]: https://img.shields.io/badge/Join_us_on_Slack!-ort--talk-blue.svg?longCache=true&logo=slack
 [2]: https://join.slack.com/t/ort-talk/shared_invite/enQtMzk3MDU5Njk0Njc1LThiNmJmMjc5YWUxZTU4OGI5NmY3YTFlZWM5YTliZmY5ODc0MGMyOWIwYmRiZWFmNGMzOWY2NzVhYTI0NTJkNmY
-[3]: https://github.com/oss-review-toolkit/ort/actions/workflows/gradle-wrapper-validation.yml/badge.svg?branch=main
+[3]: https://github.com/oss-review-toolkit/ort/actions/workflows/gradle-wrapper-validation.yml/badge.svg
 [4]: https://github.com/oss-review-toolkit/ort/actions/workflows/gradle-wrapper-validation.yml
-[5]: https://github.com/oss-review-toolkit/ort/actions/workflows/static-analysis.yml/badge.svg?branch=main
+[5]: https://github.com/oss-review-toolkit/ort/actions/workflows/static-analysis.yml/badge.svg
 [6]: https://github.com/oss-review-toolkit/ort/actions/workflows/static-analysis.yml
-[7]: https://github.com/oss-review-toolkit/ort/actions/workflows/build-and-test.yml/badge.svg?branch=main
+[7]: https://github.com/oss-review-toolkit/ort/actions/workflows/build-and-test.yml/badge.svg
 [8]: https://github.com/oss-review-toolkit/ort/actions/workflows/build-and-test.yml
 [9]: https://jitpack.io/v/oss-review-toolkit/ort.svg
 [10]: https://jitpack.io/#oss-review-toolkit/ort

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,6 +1,9 @@
 {
     "ignorePatterns": [
         {
+            "pattern": "^#.*$"
+        },
+        {
             "pattern": "^https://fpchat-invite.herokuapp.com/$"
         },
         {


### PR DESCRIPTION
Simply let GitHub determine the default branch.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>