### PR TITLE
declared-license-mapping: Fix mappings for .NET licenses

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-direct-dependencies-only-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-direct-dependencies-only-expected-output.yml
@@ -34,9 +34,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides classes that define culture-related information, including\
     \ language, country/region, calendars in use, format patterns for dates, currency,\
     \ and numbers, and sort order for strings.\n\nCommonly Used Types:\nSystem.Globalization.DateTimeFormatInfo\n\
@@ -72,9 +72,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental synchronization primitives, including System.Threading.Monitor\
     \ and System.Threading.Mutex, that are required when writing asynchronous code.\n\
     \nCommonly Used Types:\nSystem.Threading.Monitor\nSystem.Threading.SynchronizationContext\n\

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output-with-nuspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output-with-nuspec.yml
@@ -105,9 +105,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides runtime information required to resolve target framework,\
     \ platform, and runtime specific implementations of .NETCore packages. \nWhen\
     \ using NuGet 3.x this package requires at least version 3.4."
@@ -139,9 +139,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides runtime information required to resolve target framework,\
     \ platform, and runtime specific implementations of .NETCore packages. \nWhen\
     \ using NuGet 3.x this package requires at least version 3.4."
@@ -173,9 +173,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides supporting infrastructure for portable projects: support\
     \ identifiers that define framework and runtime for support targets and packages\
     \ that reference the minimum supported package versions when targeting these.\
@@ -208,9 +208,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides supporting infrastructure for portable projects: support\
     \ identifiers that define framework and runtime for support targets and packages\
     \ that reference the minimum supported package versions when targeting these.\
@@ -275,9 +275,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides classes that define generic collections, which allow developers\
     \ to create strongly typed collections that provide better type safety and performance\
     \ than non-generic strongly typed collections.\n\nCommonly Used Types:\nSystem.Collections.Generic.List<T>\n\
@@ -314,9 +314,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides classes that define culture-related information, including\
     \ language, country/region, calendars in use, format patterns for dates, currency,\
     \ and numbers, and sort order for strings.\n\nCommonly Used Types:\nSystem.Globalization.DateTimeFormatInfo\n\
@@ -352,9 +352,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental primitives, classes and base classes that\
     \ define commonly-used value and reference data types, events and event handlers,\
     \ interfaces, attributes, and exceptions. This packages represents the core package,\
@@ -392,9 +392,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental primitives, classes and base classes that\
     \ define commonly-used value and reference data types, events and event handlers,\
     \ interfaces, attributes, and exceptions. This packages represents the core package,\
@@ -467,9 +467,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental synchronization primitives, including System.Threading.Monitor\
     \ and System.Threading.Mutex, that are required when writing asynchronous code.\n\
     \nCommonly Used Types:\nSystem.Threading.Monitor\nSystem.Threading.SynchronizationContext\n\
@@ -504,9 +504,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides types that simplify the work of writing concurrent and asynchronous\
     \ code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.Task<TResult>\nSystem.Runtime.CompilerServices.TaskAwaiter<TResult>\n\
     System.Threading.Tasks.TaskCompletionSource<TResult>\nSystem.Threading.Tasks.Task\n\
@@ -540,9 +540,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides types that simplify the work of writing concurrent and asynchronous\
     \ code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.Task<TResult>\nSystem.Runtime.CompilerServices.TaskAwaiter<TResult>\n\
     System.Threading.Tasks.TaskCompletionSource<TResult>\nSystem.Threading.Tasks.Task\n\

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
@@ -99,9 +99,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides runtime information required to resolve target framework,\
     \ platform, and runtime specific implementations of .NETCore packages. \nWhen\
     \ using NuGet 3.x this package requires at least version 3.4."
@@ -133,9 +133,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides runtime information required to resolve target framework,\
     \ platform, and runtime specific implementations of .NETCore packages. \nWhen\
     \ using NuGet 3.x this package requires at least version 3.4."
@@ -167,9 +167,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides supporting infrastructure for portable projects: support\
     \ identifiers that define framework and runtime for support targets and packages\
     \ that reference the minimum supported package versions when targeting these.\
@@ -202,9 +202,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides supporting infrastructure for portable projects: support\
     \ identifiers that define framework and runtime for support targets and packages\
     \ that reference the minimum supported package versions when targeting these.\
@@ -269,9 +269,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides classes that define generic collections, which allow developers\
     \ to create strongly typed collections that provide better type safety and performance\
     \ than non-generic strongly typed collections.\n\nCommonly Used Types:\nSystem.Collections.Generic.List<T>\n\
@@ -308,9 +308,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides classes that define culture-related information, including\
     \ language, country/region, calendars in use, format patterns for dates, currency,\
     \ and numbers, and sort order for strings.\n\nCommonly Used Types:\nSystem.Globalization.DateTimeFormatInfo\n\
@@ -346,9 +346,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental primitives, classes and base classes that\
     \ define commonly-used value and reference data types, events and event handlers,\
     \ interfaces, attributes, and exceptions. This packages represents the core package,\
@@ -386,9 +386,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental primitives, classes and base classes that\
     \ define commonly-used value and reference data types, events and event handlers,\
     \ interfaces, attributes, and exceptions. This packages represents the core package,\
@@ -461,9 +461,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental synchronization primitives, including System.Threading.Monitor\
     \ and System.Threading.Mutex, that are required when writing asynchronous code.\n\
     \nCommonly Used Types:\nSystem.Threading.Monitor\nSystem.Threading.SynchronizationContext\n\
@@ -498,9 +498,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides types that simplify the work of writing concurrent and asynchronous\
     \ code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.Task<TResult>\nSystem.Runtime.CompilerServices.TaskAwaiter<TResult>\n\
     System.Threading.Tasks.TaskCompletionSource<TResult>\nSystem.Threading.Tasks.Task\n\
@@ -534,9 +534,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides types that simplify the work of writing concurrent and asynchronous\
     \ code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.Task<TResult>\nSystem.Runtime.CompilerServices.TaskAwaiter<TResult>\n\
     System.Threading.Tasks.TaskCompletionSource<TResult>\nSystem.Threading.Tasks.Task\n\

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-direct-dependencies-only-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-direct-dependencies-only-expected-output.yml
@@ -34,9 +34,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides classes that define culture-related information, including\
     \ language, country/region, calendars in use, format patterns for dates, currency,\
     \ and numbers, and sort order for strings.\n\nCommonly Used Types:\nSystem.Globalization.DateTimeFormatInfo\n\
@@ -72,9 +72,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental synchronization primitives, including System.Threading.Monitor\
     \ and System.Threading.Mutex, that are required when writing asynchronous code.\n\
     \nCommonly Used Types:\nSystem.Threading.Monitor\nSystem.Threading.SynchronizationContext\n\

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
@@ -99,9 +99,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides runtime information required to resolve target framework,\
     \ platform, and runtime specific implementations of .NETCore packages. \nWhen\
     \ using NuGet 3.x this package requires at least version 3.4."
@@ -133,9 +133,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides runtime information required to resolve target framework,\
     \ platform, and runtime specific implementations of .NETCore packages. \nWhen\
     \ using NuGet 3.x this package requires at least version 3.4."
@@ -167,9 +167,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides supporting infrastructure for portable projects: support\
     \ identifiers that define framework and runtime for support targets and packages\
     \ that reference the minimum supported package versions when targeting these.\
@@ -202,9 +202,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides supporting infrastructure for portable projects: support\
     \ identifiers that define framework and runtime for support targets and packages\
     \ that reference the minimum supported package versions when targeting these.\
@@ -269,9 +269,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides classes that define generic collections, which allow developers\
     \ to create strongly typed collections that provide better type safety and performance\
     \ than non-generic strongly typed collections.\n\nCommonly Used Types:\nSystem.Collections.Generic.List<T>\n\
@@ -308,9 +308,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides classes that define culture-related information, including\
     \ language, country/region, calendars in use, format patterns for dates, currency,\
     \ and numbers, and sort order for strings.\n\nCommonly Used Types:\nSystem.Globalization.DateTimeFormatInfo\n\
@@ -346,9 +346,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental primitives, classes and base classes that\
     \ define commonly-used value and reference data types, events and event handlers,\
     \ interfaces, attributes, and exceptions. This packages represents the core package,\
@@ -386,9 +386,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental primitives, classes and base classes that\
     \ define commonly-used value and reference data types, events and event handlers,\
     \ interfaces, attributes, and exceptions. This packages represents the core package,\
@@ -461,9 +461,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides the fundamental synchronization primitives, including System.Threading.Monitor\
     \ and System.Threading.Mutex, that are required when writing asynchronous code.\n\
     \nCommonly Used Types:\nSystem.Threading.Monitor\nSystem.Threading.SynchronizationContext\n\
@@ -498,9 +498,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides types that simplify the work of writing concurrent and asynchronous\
     \ code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.Task<TResult>\nSystem.Runtime.CompilerServices.TaskAwaiter<TResult>\n\
     System.Threading.Tasks.TaskCompletionSource<TResult>\nSystem.Threading.Tasks.Task\n\
@@ -534,9 +534,9 @@ packages:
   declared_licenses:
   - "http://go.microsoft.com/fwlink/?LinkId=329770"
   declared_licenses_processed:
-    spdx_expression: "LicenseRef-scancode-ms-net-library-2018-11"
+    spdx_expression: "LicenseRef-scancode-ms-net-library-2019-06"
     mapped:
-      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2018-11"
+      http://go.microsoft.com/fwlink/?LinkId=329770: "LicenseRef-scancode-ms-net-library-2019-06"
   description: "Provides types that simplify the work of writing concurrent and asynchronous\
     \ code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.Task<TResult>\nSystem.Runtime.CompilerServices.TaskAwaiter<TResult>\n\
     System.Threading.Tasks.TaskCompletionSource<TResult>\nSystem.Threading.Tasks.Task\n\

--- a/utils/spdx/src/main/resources/declared-license-mapping.yml
+++ b/utils/spdx/src/main/resources/declared-license-mapping.yml
@@ -483,8 +483,8 @@
 "http://creativecommons.org/licenses/publicdomain": CC-PDDC
 "http://creativecommons.org/publicdomain/zero/1.0/legalcode": CC0-1.0
 "http://en.wikipedia.org/wiki/Zlib_License": Zlib
-"http://go.microsoft.com/fwlink/?LinkId=329770": LicenseRef-scancode-ms-net-library-2018-11
-"http://go.microsoft.com/fwlink/?LinkId=529443": LicenseRef-scancode-ms-net-library-2018-11
+"http://go.microsoft.com/fwlink/?LinkId=329770": LicenseRef-scancode-ms-net-library-2019-06
+"http://go.microsoft.com/fwlink/?LinkId=529443": LicenseRef-scancode-ms-net-library-2019-06
 "http://json.codeplex.com/license": MIT
 "http://polymer.github.io/LICENSE.txt": BSD-3-Clause
 "http://svnkit.com/license.html": TMate
@@ -495,7 +495,7 @@
 "http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt": CECILL-2.1
 "http://www.gnu.org/copyleft/lesser.html": LGPL-3.0-only
 "http://www.gwtproject.org/terms.html": Apache-2.0 AND BSD-3-Clause AND CC0-1.0 AND EPL-1.0 AND LGPL-2.1-only AND MPL-1.1
-"http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm": LicenseRef-scancode-ms-net-library-2018-11
+"http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm": LicenseRef-scancode-ms-net-library-2019-06
 "http://www.scala-lang.org/downloads/license.html": Apache-2.0 AND BSD-3-Clause AND MIT
 "http://www.scala-lang.org/node/146": Apache-2.0 AND BSD-3-Clause AND MIT
 "https://creativecommons.org/licenses/by-nc-nd/1.0": CC-BY-NC-ND-1.0


### PR DESCRIPTION
The mappings were determined by downloading the linked HTML pages and
scanning them with ScanCode 30.1.0.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>