### PR TITLE
Revert "github/workflows: Use ORT's fork of github-action-markdown-link-check"

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v3
     - name: Check Links
-      uses: oss-review-toolkit/github-action-markdown-link-check@unsafe-repository
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         base-branch: main
         check-modified-files-only: yes


### PR DESCRIPTION
This reverts commit 7b20661 as the upstream issue has been fixed, see
[1].

[1]: https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/132#issuecomment-1103553643

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>