### PR TITLE
AnalyzerCommand: Use the ORT curation provider together with local providers

### DIFF
--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -212,7 +212,9 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
         val repositoryConfiguration = actualRepositoryConfigurationFile.takeIf { it.isFile }?.readValueOrNull()
             ?: RepositoryConfiguration()
 
-        val localCurationProviders = buildList {
+        val defaultCurationProviders = buildList {
+            if (useOrtCurations) add(OrtConfigPackageCurationProvider())
+
             add(FilePackageCurationProvider.from(packageCurationsFile, packageCurationsDir))
 
             val repositoryPackageCurations = repositoryConfiguration.curations.packages
@@ -228,11 +230,10 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
         }
 
         val curationProviders = listOfNotNull(
-            CompositePackageCurationProvider(localCurationProviders),
+            CompositePackageCurationProvider(defaultCurationProviders),
             config.analyzer.sw360Configuration?.let {
                 Sw360PackageCurationProvider(it).takeIf { useSw360Curations }
             },
-            OrtConfigPackageCurationProvider().takeIf { useOrtCurations },
             ClearlyDefinedPackageCurationProvider().takeIf { useClearlyDefinedCurations }
         )
 


### PR DESCRIPTION
Combine curations from the ORT configuration repository [1] with local
curations by default, where the latter override the former if in
conflict.

[1]: https://github.com/oss-review-toolkit/ort-config

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>