### PR TITLE
MavenSupport: Fixup VCS paths that contain the project name as a prefix

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -236,7 +236,18 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
                             }
                         }
 
-                        else -> VcsInfo(type = VcsType(type), url = url, revision = tag)
+                        else -> {
+                            VcsHost.fromUrl(url)?.let { host ->
+                                host.toVcsInfo(url)?.let { vcsInfo ->
+                                    // Fixup paths that are specified as part of the URL and contain the project name as
+                                    // a prefix.
+                                    val projectPrefix = "${host.getProject(url)}-"
+                                    vcsInfo.path.withoutPrefix(projectPrefix)?.let { path ->
+                                        vcsInfo.copy(path = path)
+                                    }
+                                }
+                            } ?: VcsInfo(type = VcsType(type), url = url, revision = tag)
+                        }
                     }
                 } else {
                     val userHostMatcher = USER_HOST_REGEX.matcher(connection)

--- a/analyzer/src/test/kotlin/managers/utils/MavenSupportTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/MavenSupportTest.kt
@@ -84,5 +84,20 @@ class MavenSupportTest : WordSpec({
                 revision = ""
             )
         }
+
+        "handle GitHub URLs with the project name as a path prefix" {
+            val mavenProject = MavenProject().apply {
+                scm = Scm().apply {
+                    connection = "scm:git:git://github.com/netty/netty-tcnative.git/netty-tcnative-boringssl-static"
+                }
+            }
+
+            MavenSupport.parseVcsInfo(mavenProject) shouldBe VcsInfo(
+                type = VcsType.GIT,
+                url = "git://github.com/netty/netty-tcnative.git",
+                revision = "",
+                path = "boringssl-static"
+            )
+        }
     }
 })


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>