### PR TITLE
ScannerConfiguration: Exclude `META-INF/NOTICE` files by default

### DIFF
--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -85,7 +85,8 @@ data class ScannerConfiguration(
         "**/*.spdx.yml",
         "**/*.spdx.yaml",
         "**/*.spdx.json",
-        "**/META-INF/DEPENDENCIES"
+        "**/META-INF/DEPENDENCIES",
+        "**/META-INF/NOTICE"
     ),
 
     /**

--- a/scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
@@ -211,6 +211,7 @@ scanner:
     - "**/*.spdx.yaml"
     - "**/*.spdx.json"
     - "**/META-INF/DEPENDENCIES"
+    - "**/META-INF/NOTICE"
   results:
     scan_results:
       Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0:


### PR DESCRIPTION
`NOTICE` files are the Apache Foundation's convention "to collect
copyright notices and required attributions" [1] for which Maven has
built-in support [2]. As ORT collects this information on its own by
scanning the project's and dependencies' source code, scanning the
`NOTICE` file is deceptive as it is likely to contain information that
belongs to the dependencies, not to the project itself.

[1]: https://www.apache.org/legal/src-headers.html
[2]: https://maven.apache.org/apache-resource-bundles/

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>