### PR TITLE
NestedProvenanceScanResult: Deduplicate issues when merging results

### DIFF
--- a/scanner/src/main/kotlin/experimental/NestedProvenanceScanResult.kt
+++ b/scanner/src/main/kotlin/experimental/NestedProvenanceScanResult.kt
@@ -84,7 +84,7 @@ data class NestedProvenanceScanResult(
 
             val startTime = allScanResults.minByOrNull { it.summary.startTime }?.summary?.startTime ?: Instant.now()
             val endTime = allScanResults.maxByOrNull { it.summary.endTime }?.summary?.endTime ?: startTime
-            val issues = allScanResults.flatMap { it.summary.issues }
+            val issues = allScanResults.flatMap { it.summary.issues }.distinct()
 
             val licenseFindings = scanResultsForScanner.mergeLicenseFindings()
             val copyrightFindings = scanResultsForScanner.mergeCopyrightFindings()


### PR DESCRIPTION
If the merged scan results come from a package based storage, they can
contain the identical issues, because it is not possible to associate
scanner issues with files when splitting the package based result by
provenance. Therefore deduplicate issues when merging them for the ORT
result file, otherwise it can happen that the identical issue appears
multiple times in the ORT result and therefore also in the reports.