### PR TITLE
Gradle: Enforce the JVM running Gradle to use UTF-8 encoding for reading files

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -82,6 +82,7 @@ wiremockVersion = 2.33.1
 xzVersion = 1.9
 
 org.gradle.caching = true
+org.gradle.jvmargs = -Xmx512m -XX:MaxMetaspaceSize=256m -Dfile.encoding=UTF-8
 org.gradle.parallel = true
 
 buildCacheRetentionDays = 7


### PR DESCRIPTION
Repeat the default JVM arguments [1] and add `-Dfile.encoding=UTF-8`.

Fixes #5278.

[1]: https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>