### PR TITLE
Utils: Allow `filterVersionNames()` to strip some prefix and suffix strings

### DIFF
--- a/utils/core/src/main/kotlin/Utils.kt
+++ b/utils/core/src/main/kotlin/Utils.kt
@@ -66,6 +66,12 @@ val ortDataDirectory by lazy {
 var printStackTrace = false
 
 private val versionSeparators = listOf('-', '_', '.')
+private val versionSeparatorsPattern = versionSeparators.joinToString("", "[", "]")
+
+private val ignorablePrefixSuffixPattern = listOf("rel", "release", "final").joinToString("|", "(", ")")
+private val ignorablePrefixSuffixRegex = Regex(
+    "(^$ignorablePrefixSuffixPattern$versionSeparatorsPattern|$versionSeparatorsPattern$ignorablePrefixSuffixPattern$)"
+)
 
 /**
  * Filter a list of [names] to include only those that likely belong to the given [version] of an optional [project].
@@ -92,7 +98,7 @@ fun filterVersionNames(version: String, names: List<String>, project: String? = 
     }
 
     val filteredNames = names.filter {
-        val name = it.lowercase()
+        val name = it.lowercase().replace(ignorablePrefixSuffixRegex, "")
 
         versionVariants.any { versionVariant ->
             // Allow to ignore suffixes in names that are separated by something else than the current separator, e.g.

--- a/utils/core/src/main/kotlin/Utils.kt
+++ b/utils/core/src/main/kotlin/Utils.kt
@@ -96,13 +96,13 @@ fun filterVersionNames(version: String, names: List<String>, project: String? = 
         versionVariants.any { versionVariant ->
             // Allow to ignore suffixes in names that are separated by something else than the current separator, e.g.
             // for version "3.3.1" accept "3.3.1-npm-packages" but not "3.3.1.0".
-            val hasIgnorableSuffix = name.withoutPrefix(versionVariant.name)?.let { tail ->
+            val hasIgnorableSuffixOnly = name.withoutPrefix(versionVariant.name)?.let { tail ->
                 tail.firstOrNull() !in versionVariant.separators
             } ?: false
 
             // Allow to ignore prefixes in names that are separated by something else than the current separator, e.g.
             // for version "0.10" accept "docutils-0.10" but not "1.0.10".
-            val hasIgnorablePrefix = name.withoutSuffix(versionVariant.name)?.let { head ->
+            val hasIgnorablePrefixOnly = name.withoutSuffix(versionVariant.name)?.let { head ->
                 val last = head.lastOrNull()
                 val forelast = head.dropLast(1).lastOrNull()
 
@@ -118,7 +118,7 @@ fun filterVersionNames(version: String, names: List<String>, project: String? = 
                         || (last == 'v' && (forelast == null || forelast in currentSeparators))
             } ?: false
 
-            hasIgnorableSuffix || hasIgnorablePrefix
+            hasIgnorableSuffixOnly || hasIgnorablePrefixOnly
         }
     }
 

--- a/utils/core/src/main/kotlin/Utils.kt
+++ b/utils/core/src/main/kotlin/Utils.kt
@@ -65,6 +65,8 @@ val ortDataDirectory by lazy {
  */
 var printStackTrace = false
 
+private val versionSeparators = listOf('-', '_', '.')
+
 /**
  * Filter a list of [names] to include only those that likely belong to the given [version] of an optional [project].
  */
@@ -76,7 +78,6 @@ fun filterVersionNames(version: String, names: List<String>, project: String? = 
     if (fullMatches.isNotEmpty()) return fullMatches
 
     // The list of supported version separators.
-    val versionSeparators = listOf('-', '_', '.')
     val versionHasSeparator = versionSeparators.any { it in version }
 
     // Create variants of the version string to recognize.

--- a/utils/core/src/test/kotlin/UtilsTest.kt
+++ b/utils/core/src/test/kotlin/UtilsTest.kt
@@ -22,6 +22,8 @@ package org.ossreviewtoolkit.utils.core
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
@@ -68,9 +70,9 @@ class UtilsTest : WordSpec({
                 "before_debug_changes"
             )
 
-            filterVersionNames("1.0.3", names).joinToString("\n") shouldBe "PROD_1_0_3"
-            filterVersionNames("1", names).joinToString("\n") shouldBe ""
-            filterVersionNames("0.3", names).joinToString("\n") shouldBe ""
+            filterVersionNames("1.0.3", names) shouldHaveSingleElement "PROD_1_0_3"
+            filterVersionNames("1", names) should beEmpty()
+            filterVersionNames("0.3", names) should beEmpty()
         }
 
         "find names separated by dots" {
@@ -84,10 +86,10 @@ class UtilsTest : WordSpec({
                 "0.9.0"
             )
 
-            filterVersionNames("0.10.0", names).joinToString("\n") shouldBe "0.10.0"
-            filterVersionNames("0.10", names).joinToString("\n") shouldBe ""
-            filterVersionNames("10.0", names).joinToString("\n") shouldBe ""
-            filterVersionNames("1", names).joinToString("\n") shouldBe ""
+            filterVersionNames("0.10.0", names) shouldHaveSingleElement "0.10.0"
+            filterVersionNames("0.10", names) should beEmpty()
+            filterVersionNames("10.0", names) should beEmpty()
+            filterVersionNames("1", names) should beEmpty()
         }
 
         "find names with mixed separators" {
@@ -118,18 +120,18 @@ class UtilsTest : WordSpec({
                 "start"
             )
 
-            filterVersionNames("0.3.9", names).joinToString("\n") shouldBe "docutils-0.3.9"
-            filterVersionNames("0.14", names).joinToString("\n") shouldBe "docutils-0.14"
-            filterVersionNames("0.3.10", names).joinToString("\n") shouldBe "prest-0.3.10"
-            filterVersionNames("0.13", names).joinToString("\n") shouldBe ""
-            filterVersionNames("13.1", names).joinToString("\n") shouldBe ""
-            filterVersionNames("1.0", names).joinToString("\n") shouldBe ""
+            filterVersionNames("0.3.9", names) shouldHaveSingleElement "docutils-0.3.9"
+            filterVersionNames("0.14", names) shouldHaveSingleElement "docutils-0.14"
+            filterVersionNames("0.3.10", names) shouldHaveSingleElement "prest-0.3.10"
+            filterVersionNames("0.13", names) should beEmpty()
+            filterVersionNames("13.1", names) should beEmpty()
+            filterVersionNames("1.0", names) should beEmpty()
         }
 
         "find names with mixed separators and different capitalization" {
             val names = listOf("CLASSWORLDS_1_1_ALPHA_2")
 
-            filterVersionNames("1.1-alpha-2", names).joinToString("\n") shouldBe "CLASSWORLDS_1_1_ALPHA_2"
+            filterVersionNames("1.1-alpha-2", names) shouldHaveSingleElement "CLASSWORLDS_1_1_ALPHA_2"
         }
 
         "find names with a 'v' prefix" {
@@ -158,10 +160,10 @@ class UtilsTest : WordSpec({
                 "v7.0.0-beta.3"
             )
 
-            filterVersionNames("6.26.0", names).joinToString("\n") shouldBe "v6.26.0"
-            filterVersionNames("7.0.0-beta.2", names).joinToString("\n") shouldBe "v7.0.0-beta.2"
-            filterVersionNames("7.0.0", names).joinToString("\n") shouldBe ""
-            filterVersionNames("2.0", names).joinToString("\n") shouldBe ""
+            filterVersionNames("6.26.0", names) shouldHaveSingleElement "v6.26.0"
+            filterVersionNames("7.0.0-beta.2", names) shouldHaveSingleElement "v7.0.0-beta.2"
+            filterVersionNames("7.0.0", names) should beEmpty()
+            filterVersionNames("2.0", names) should beEmpty()
         }
 
         "find names with the project name as the prefix" {
@@ -171,8 +173,11 @@ class UtilsTest : WordSpec({
                 "babel-plugin-transform-property-literals@6.9.0"
             )
 
-            filterVersionNames("6.9.0", names, "babel-plugin-transform-simplify-comparison-operators")
-                .joinToString("\n") shouldBe "babel-plugin-transform-simplify-comparison-operators@6.9.0"
+            filterVersionNames(
+                "6.9.0",
+                names,
+                "babel-plugin-transform-simplify-comparison-operators"
+            ) shouldHaveSingleElement "babel-plugin-transform-simplify-comparison-operators@6.9.0"
         }
 
         "find names when others with trailing digits are present" {
@@ -181,26 +186,26 @@ class UtilsTest : WordSpec({
                 "1.11.68", "1.11.69"
             )
 
-            filterVersionNames("1.11.6", names).joinToString("\n") shouldBe "1.11.6"
+            filterVersionNames("1.11.6", names) shouldHaveSingleElement "1.11.6"
         }
 
         "find names with only a single revision number as the version" {
             val names = listOf("my_project-123", "my_project-4711", "my_project-8888")
 
-            filterVersionNames("4711", names).joinToString("\n") shouldBe "my_project-4711"
+            filterVersionNames("4711", names) shouldHaveSingleElement "my_project-4711"
         }
 
         "find names that have a numeric suffix as part of the name" {
             val names = listOf("my_project_v1-1.0.2", "my_project_v1-1.0.3", "my_project_v1-1.1.0")
 
-            filterVersionNames("1.0.3", names).joinToString("\n") shouldBe "my_project_v1-1.0.3"
+            filterVersionNames("1.0.3", names) shouldHaveSingleElement "my_project_v1-1.0.3"
         }
 
         "find names that use an abbreviated SHA1 as the suffix" {
             val names = listOf("3.9.0.99-a3d9827", "sdk-3.9.0.99", "v3.9.0.99")
 
-            filterVersionNames("3.9.0.99", names).joinToString("\n") shouldBe
-                    listOf("3.9.0.99-a3d9827", "sdk-3.9.0.99", "v3.9.0.99").joinToString("\n")
+            filterVersionNames("3.9.0.99", names) shouldContainExactly
+                    listOf("3.9.0.99-a3d9827", "sdk-3.9.0.99", "v3.9.0.99")
         }
     }
 

--- a/utils/core/src/test/kotlin/UtilsTest.kt
+++ b/utils/core/src/test/kotlin/UtilsTest.kt
@@ -75,6 +75,20 @@ class UtilsTest : WordSpec({
             filterVersionNames("0.3", names) should beEmpty()
         }
 
+        "find names separated by underscores that include a prefix / suffix" {
+            val names = listOf(
+                "REL_4_0_0_FINAL",
+                "REL_3_16_FINAL",
+                "REL_3_16_BETA2",
+                "REL_3_16_BETA1",
+                "before_junit5_update"
+            )
+
+            filterVersionNames("4.0.0", names) shouldHaveSingleElement "REL_4_0_0_FINAL"
+            filterVersionNames("3.16", names) shouldHaveSingleElement "REL_3_16_FINAL"
+            filterVersionNames("before_junit5_update", names) shouldHaveSingleElement "before_junit5_update"
+        }
+
         "find names separated by dots" {
             val names = listOf(
                 "0.10.0",


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.