### PR TITLE
Gradle: Upgrade the Dokka plugin to version 1.6.21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 buildconfigPluginVersion = 3.0.3
 detektPluginVersion = 1.20.0
-dokkaPluginVersion = 1.6.20
+dokkaPluginVersion = 1.6.21
 graalPluginVersion = 0.10.0
 graphqlPluginVersion = 5.3.2
 ideaExtPluginVersion = 1.1.4


### PR DESCRIPTION
See [1].

[1]: https://github.com/Kotlin/dokka/releases/tag/v1.6.21

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>