### PR TITLE
ScannerConfiguration: Also ignore `{DEPENDENCIES,NOTICE}.txt` files

### DIFF
--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -86,7 +86,9 @@ data class ScannerConfiguration(
         "**/*.spdx.yaml",
         "**/*.spdx.json",
         "**/META-INF/DEPENDENCIES",
-        "**/META-INF/NOTICE"
+        "**/META-INF/DEPENDENCIES.txt",
+        "**/META-INF/NOTICE",
+        "**/META-INF/NOTICE.txt"
     ),
 
     /**

--- a/scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
@@ -211,7 +211,9 @@ scanner:
     - "**/*.spdx.yaml"
     - "**/*.spdx.json"
     - "**/META-INF/DEPENDENCIES"
+    - "**/META-INF/DEPENDENCIES.txt"
     - "**/META-INF/NOTICE"
+    - "**/META-INF/NOTICE.txt"
   results:
     scan_results:
       Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0:


### PR DESCRIPTION
Sometimes these text files come with an explicit extension, so ignore
these, too.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>