### PR TITLE
Subversion: Force a similar behavior as Git

### DIFF
--- a/downloader/src/main/kotlin/vcs/Subversion.kt
+++ b/downloader/src/main/kotlin/vcs/Subversion.kt
@@ -79,9 +79,21 @@ class Subversion : VersionControlSystem() {
 
             override fun isShallow() = false
 
-            override fun getRemoteUrl() = doSvnInfo()?.url?.toString().orEmpty()
+            override fun getRemoteUrl(): String {
+                val svnInfo = doSvnInfo() ?: return ""
 
-            override fun getRevision() = doSvnInfo()?.committedRevision?.number?.toString().orEmpty()
+                val file = svnInfo.file
+                val workingCopyRoot = svnInfo.workingCopyRoot
+                val svnUrl = svnInfo.url.toString()
+
+                return when {
+                    file.startsWith(workingCopyRoot) ->
+                        svnUrl.removeSuffix(file.path.removePrefix(workingCopyRoot.path))
+                    else -> svnUrl
+                }
+            }
+
+            override fun getRevision() = doSvnInfo()?.revision?.number?.toString().orEmpty()
 
             override fun getRootPath() = doSvnInfo()?.workingCopyRoot ?: workingDir
 


### PR DESCRIPTION
Try to fix #5232

The aim is to have a similar analyzer result file between SVN and Git.
If we got a svn repo like : svn+ssh://svn.company.com/svnroot/Products/my-project/trunk
and a subproject : my-project/trunk/Prj/Src/module/module.vcxproj
Then the analyzer result will be like : 
```
    projects:
    - id: "DotNet::Prj/Src/module/module.vcxproj:"
      definition_file_path: "Prj/Src/module/module.vcxproj"
      declared_licenses: []
      declared_licenses_processed: {}
      vcs:
        type: ""
        url: ""
        revision: ""
        path: ""
      vcs_processed:
        type: "Subversion"
        url: "svn+ssh://svn.company.com/svnroot/Products/my-project/trunk/Prj/Src/module"
        revision: "110884"
        path: "Prj/Src/module"
      homepage_url: ""
      scopes: []
```
And this will fail the scan in OrtResult on (due to a null vcsPath) : 
```
    fun getFilePathRelativeToAnalyzerRoot(project: Project, path: String): String {
        val vcsPath = relativeProjectVcsPath.getValue(project.id)

        requireNotNull(vcsPath) {
            "The ${project.vcsProcessed} of project '${project.id.toCoordinates()}' cannot be found in $repository."
        }
```
because the map of relativePath (https://github.com/oss-review-toolkit/ort/blob/main/model/src/main/kotlin/OrtResult.kt#L259) seems not to be correctly filled https://github.com/oss-review-toolkit/ort/blob/main/model/src/main/kotlin/Repository.kt#L71.

The same project store in Git works well.
So, this fix try to make analyzer result from SVN similar to Git.
Now the result looks like : 
```
    projects:
    - id: "DotNet::Prj/Src/module/module.vcxproj:"
      definition_file_path: "Prj/Src/module/module.vcxproj"
      declared_licenses: []
      declared_licenses_processed: {}
      vcs:
        type: ""
        url: ""
        revision: ""
        path: ""
      vcs_processed:
        type: "Subversion"
        url: "svn+ssh://svn.company.com/svnroot/Products/my-project/trunk"
        revision: "110100"
        path: "Prj/Src/module"
      homepage_url: ""
      scopes: []
```
This unlocked the analysis of my projects in svn