### PR TITLE
Avoid fully qualified matcher names in tests for readability

### DIFF
--- a/advisor/src/test/kotlin/advisors/OssIndexTest.kt
+++ b/advisor/src/test/kotlin/advisors/OssIndexTest.kt
@@ -28,10 +28,12 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.maps.beEmpty
+import io.kotest.matchers.maps.beEmpty as beEmptyMap
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
@@ -76,7 +78,7 @@ class OssIndexTest : WordSpec({
 
             val result = ossIndex.retrievePackageFindings(packages).mapKeys { it.key.id }
 
-            result shouldNot beEmpty()
+            result shouldNot beEmptyMap()
             result.keys should containExactlyInAnyOrder(ID_JUNIT)
             result[ID_JUNIT] shouldNotBeNull {
                 this should haveSize(1)
@@ -121,14 +123,14 @@ class OssIndexTest : WordSpec({
             val result = ossIndex.retrievePackageFindings(packages).mapKeys { it.key.id }
 
             result shouldNotBeNull {
-                keys should io.kotest.matchers.collections.containExactly(COMPONENTS_REQUEST_IDS)
+                keys should containExactly(COMPONENTS_REQUEST_IDS)
 
                 COMPONENTS_REQUEST_IDS.forEach { pkg ->
                     val pkgResults = getValue(pkg)
                     pkgResults shouldHaveSize 1
                     val pkgResult = pkgResults[0]
                     pkgResult.advisor shouldBe ossIndex.details
-                    pkgResult.vulnerabilities should io.kotest.matchers.collections.beEmpty()
+                    pkgResult.vulnerabilities should beEmpty()
                     pkgResult.summary.issues shouldHaveSize 1
                     val issue = pkgResult.summary.issues[0]
                     issue.severity shouldBe Severity.ERROR

--- a/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
+++ b/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
@@ -28,6 +28,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
+import io.kotest.matchers.string.include
 import io.kotest.matchers.string.shouldStartWith
 
 import java.io.File
@@ -111,7 +112,7 @@ class ClearlyDefinedServiceFunTest : WordSpec({
 
             val patchJson = ClearlyDefinedService.JSON_MAPPER.writeValueAsString(contributionPatch)
 
-            patchJson shouldNot io.kotest.matchers.string.include("null")
+            patchJson shouldNot include("null")
         }
 
         // Disable this test by default as it talks to the real development instance of ClearlyDefined and creates


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>