### PR TITLE
ScanResultsStorage: Turn the word "configure" into a function reference

### DIFF
--- a/scanner/src/main/kotlin/ScanResultsStorage.kt
+++ b/scanner/src/main/kotlin/ScanResultsStorage.kt
@@ -66,7 +66,7 @@ abstract class ScanResultsStorage : PackageBasedScanStorage {
         val EMPTY_RESULT = Result.success<List<ScanResult>>(emptyList())
 
         /**
-         * The scan result storage in use. Needs to be set via the corresponding configure function.
+         * The scan result storage in use. Needs to be set via the corresponding [configure] function.
          */
         var storage: ScanResultsStorage = NoStorage()
 


### PR DESCRIPTION
This addresses a grammar hint.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>