### PR TITLE
declared-license-mapping: Map "LGPLv3+" to `LGPL-3.0-or-later`

### DIFF
--- a/utils/spdx/src/main/resources/simple-license-mapping.yml
+++ b/utils/spdx/src/main/resources/simple-license-mapping.yml
@@ -37,6 +37,7 @@ LGPL2: LGPL-2.1-only
 LGPL3: LGPL-3.0-only
 LGPL: LGPL-2.0-or-later
 LGPLv2: LGPL-2.1-only
+LGPLv3+: LGPL-3.0-or-later
 LGPLv3: LGPL-3.0-only
 MIT-like: MIT
 MIT-style: MIT


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>