### PR TITLE
OkHttpClientHelper: Improve exception handling in downloadText()

### DIFF
--- a/utils/core/src/main/kotlin/OkHttpClientHelper.kt
+++ b/utils/core/src/main/kotlin/OkHttpClientHelper.kt
@@ -219,7 +219,7 @@ fun OkHttpClient.downloadFile(url: String, directory: File): Result<File> =
  * [Result] wrapping an [IOException] (which might be a [HttpDownloadError]) on failure.
  */
 fun OkHttpClient.downloadText(url: String): Result<String> =
-    download(url).map { (_, body) ->
+    download(url).mapCatching { (_, body) ->
         body.use { it.string() }
     }
 


### PR DESCRIPTION
Make sure that exceptions thrown when accessing the response body are
handled by replacing map with mapCatching.
