### PR TITLE
VcsHost: Fix permalinks to Azure DevOps

### DIFF
--- a/downloader/src/main/kotlin/VcsHost.kt
+++ b/downloader/src/main/kotlin/VcsHost.kt
@@ -66,7 +66,7 @@ enum class VcsHost(
         override fun toPermalinkInternal(vcsInfo: VcsInfo, startLine: Int, endLine: Int): String {
             val actualEndLine = if (endLine != -1) endLine else startLine + 1
 
-            val lineQueryParam = "line=$startLine&lineEnd=$actualEndLine&lineColumn=1&lineEndColumn=1"
+            val lineQueryParam = "line=$startLine&lineEnd=$actualEndLine&lineStartColumn=1&lineEndColumn=1"
             val pathQueryParam = "&path=/${vcsInfo.path}".takeUnless { vcsInfo.path.isEmpty() }.orEmpty()
             val revisionQueryParam = "&version=$gitCommitPrefix${vcsInfo.revision}".takeUnless {
                 vcsInfo.revision.isEmpty()

--- a/downloader/src/test/kotlin/VcsHostTest.kt
+++ b/downloader/src/test/kotlin/VcsHostTest.kt
@@ -58,13 +58,13 @@ class VcsHostTest : WordSpec({
         "be able to create permalinks from VCS information" {
             AZURE_DEVOPS.toPermalink(vcsInfo, 1) shouldBe "https://dev.azure.com/oss-review-toolkit/kotlin-devs/_git/" +
                     "ort?line=1&lineEnd=2" +
-                    "&lineColumn=1&lineEndColumn=1" +
+                    "&lineStartColumn=1&lineEndColumn=1" +
                     "&path=/README.md" +
                     "&version=GC0000000000000000000000000000000000000000"
 
             AZURE_DEVOPS.toPermalink(vcsInfo, 1, 3) shouldBe "https://dev.azure.com/oss-review-toolkit/kotlin-devs/" +
                     "_git/ort?line=1&lineEnd=3" +
-                    "&lineColumn=1&lineEndColumn=1" +
+                    "&lineStartColumn=1&lineEndColumn=1" +
                     "&path=/README.md" +
                     "&version=GC0000000000000000000000000000000000000000"
         }


### PR DESCRIPTION
This is a fixup for 99a1ffc93e954343c0fc09a6e27085cc18474df9.

