### PR TITLE
VcsHost: Fix end line for Azure DevOps permalink

### DIFF
--- a/downloader/src/main/kotlin/VcsHost.kt
+++ b/downloader/src/main/kotlin/VcsHost.kt
@@ -64,7 +64,7 @@ enum class VcsHost(
         }
 
         override fun toPermalinkInternal(vcsInfo: VcsInfo, startLine: Int, endLine: Int): String {
-            val actualEndLine = if (endLine != -1) endLine else startLine + 1
+            val actualEndLine = if (endLine != -1) endLine + 1 else startLine + 1
 
             val lineQueryParam = "line=$startLine&lineEnd=$actualEndLine&lineStartColumn=1&lineEndColumn=1"
             val pathQueryParam = "&path=/${vcsInfo.path}".takeUnless { vcsInfo.path.isEmpty() }.orEmpty()

--- a/downloader/src/test/kotlin/VcsHostTest.kt
+++ b/downloader/src/test/kotlin/VcsHostTest.kt
@@ -63,7 +63,7 @@ class VcsHostTest : WordSpec({
                     "&version=GC0000000000000000000000000000000000000000"
 
             AZURE_DEVOPS.toPermalink(vcsInfo, 1, 3) shouldBe "https://dev.azure.com/oss-review-toolkit/kotlin-devs/" +
-                    "_git/ort?line=1&lineEnd=3" +
+                    "_git/ort?line=1&lineEnd=4" +
                     "&lineStartColumn=1&lineEndColumn=1" +
                     "&path=/README.md" +
                     "&version=GC0000000000000000000000000000000000000000"


### PR DESCRIPTION
When selecting line 1-10 in Azure DevOps the generated link actually
points to line 1-11. Adapt this behavior in the VcsHost implementation.

