### PR TITLE
Identifier: Sort versions numerically, if possible

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
@@ -4211,6 +4211,36 @@ packages:
     url: "https://github.com/jonschlinkert/set-value.git"
     revision: "bb0f0382f7d7637f3de1bba52d1b4abdbbbde4d4"
     path: ""
+- id: "NPM::snapdragon:0.8.2"
+  purl: "pkg:npm/snapdragon@0.8.2"
+  authors:
+  - "Jon Schlinkert"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Fast, pluggable and easy-to-use parser-renderer factory."
+  homepage_url: "https://github.com/jonschlinkert/snapdragon"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz"
+    hash:
+      value: "64922e7c565b0e14204ba1aa7d6964278d25182d"
+      algorithm: "SHA1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/jonschlinkert/snapdragon.git"
+    revision: "6c952b12cabe896a86d9a4fe378f934bccbe6436"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jonschlinkert/snapdragon.git"
+    revision: "6c952b12cabe896a86d9a4fe378f934bccbe6436"
+    path: ""
 - id: "NPM::snapdragon:0.11.5"
   purl: "pkg:npm/snapdragon@0.11.5"
   authors:
@@ -4241,36 +4271,6 @@ packages:
     type: "Git"
     url: "https://github.com/here-be/snapdragon.git"
     revision: "3067f0fe16d5d2771aea793c450f09cb2da533ca"
-    path: ""
-- id: "NPM::snapdragon:0.8.2"
-  purl: "pkg:npm/snapdragon@0.8.2"
-  authors:
-  - "Jon Schlinkert"
-  declared_licenses:
-  - "MIT"
-  declared_licenses_processed:
-    spdx_expression: "MIT"
-  description: "Fast, pluggable and easy-to-use parser-renderer factory."
-  homepage_url: "https://github.com/jonschlinkert/snapdragon"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz"
-    hash:
-      value: "64922e7c565b0e14204ba1aa7d6964278d25182d"
-      algorithm: "SHA1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/jonschlinkert/snapdragon.git"
-    revision: "6c952b12cabe896a86d9a4fe378f934bccbe6436"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/jonschlinkert/snapdragon.git"
-    revision: "6c952b12cabe896a86d9a4fe378f934bccbe6436"
     path: ""
 - id: "NPM::snapdragon-node:1.0.6"
   purl: "pkg:npm/snapdragon-node@1.0.6"

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces-expected-output.yml
@@ -20,10 +20,10 @@ project:
   scopes:
   - name: "dependencies"
     dependencies:
-    - id: "NPM:@here:harp-fetch:0.11.0"
+    - id: "NPM:@here:harp-fetch:0.3.6"
       dependencies:
       - id: "NPM::node-fetch:2.6.0"
-    - id: "NPM:@here:harp-fetch:0.3.6"
+    - id: "NPM:@here:harp-fetch:0.11.0"
       dependencies:
       - id: "NPM::node-fetch:2.6.0"
 packages:
@@ -85,36 +85,6 @@ packages:
     url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg2"
-- id: "NPM:@here:harp-fetch:0.11.0"
-  purl: "pkg:npm/%40here/harp-fetch@0.11.0"
-  authors:
-  - "HERE Europe B.V."
-  declared_licenses:
-  - "Apache-2.0"
-  declared_licenses_processed:
-    spdx_expression: "Apache-2.0"
-  description: "This module adds a subset of the fetch API for Node.js"
-  homepage_url: "https://github.com/heremaps/harp.gl#readme"
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://registry.npmjs.org/@here/harp-fetch/-/harp-fetch-0.11.0.tgz"
-    hash:
-      value: "8d0e0bdb523c7c4f306f676aac65aa6bcb95da1c"
-      algorithm: "SHA1"
-  vcs:
-    type: "Git"
-    url: "git+https://github.com/heremaps/harp.gl.git"
-    revision: "ce42b2ce221de76b25ef8aea54f50ff007da2664"
-    path: "@here/harp-fetch"
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/heremaps/harp.gl.git"
-    revision: "ce42b2ce221de76b25ef8aea54f50ff007da2664"
-    path: "@here/harp-fetch"
 - id: "NPM:@here:harp-fetch:0.3.6"
   purl: "pkg:npm/%40here/harp-fetch@0.3.6"
   authors:
@@ -144,6 +114,36 @@ packages:
     type: "Git"
     url: "https://github.com/heremaps/harp.gl.git"
     revision: "0c2857f958a34ef7638384afada4fceec427d48d"
+    path: "@here/harp-fetch"
+- id: "NPM:@here:harp-fetch:0.11.0"
+  purl: "pkg:npm/%40here/harp-fetch@0.11.0"
+  authors:
+  - "HERE Europe B.V."
+  declared_licenses:
+  - "Apache-2.0"
+  declared_licenses_processed:
+    spdx_expression: "Apache-2.0"
+  description: "This module adds a subset of the fetch API for Node.js"
+  homepage_url: "https://github.com/heremaps/harp.gl#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/@here/harp-fetch/-/harp-fetch-0.11.0.tgz"
+    hash:
+      value: "8d0e0bdb523c7c4f306f676aac65aa6bcb95da1c"
+      algorithm: "SHA1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/heremaps/harp.gl.git"
+    revision: "ce42b2ce221de76b25ef8aea54f50ff007da2664"
+    path: "@here/harp-fetch"
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/heremaps/harp.gl.git"
+    revision: "ce42b2ce221de76b25ef8aea54f50ff007da2664"
     path: "@here/harp-fetch"
 - id: "NPM:@scope1:pkg1:1.0.0"
   purl: "pkg:npm/%40scope1/pkg1@1.0.0"

--- a/model/src/test/kotlin/IdentifierTest.kt
+++ b/model/src/test/kotlin/IdentifierTest.kt
@@ -81,8 +81,8 @@ class IdentifierTest : WordSpec({
             )
 
             ids.sorted() should containExactly(
-                Identifier("Maven:net.java.dev.jna:jna-platform:5.11.0"),
                 Identifier("Maven:net.java.dev.jna:jna-platform:5.6.0"),
+                Identifier("Maven:net.java.dev.jna:jna-platform:5.11.0"),
                 Identifier("Maven:net.java.dev.jna:jna-platform:NOT_A_VERSION"),
                 Identifier("Maven:org.springframework.boot:spring-boot"),
                 Identifier("Maven:org.springframework.boot:spring-boot-actuator")

--- a/model/src/test/kotlin/IdentifierTest.kt
+++ b/model/src/test/kotlin/IdentifierTest.kt
@@ -74,10 +74,16 @@ class IdentifierTest : WordSpec({
         "be sorted as expected" {
             val ids = listOf(
                 Identifier("Maven:org.springframework.boot:spring-boot-actuator"),
-                Identifier("Maven:org.springframework.boot:spring-boot")
+                Identifier("Maven:org.springframework.boot:spring-boot"),
+                Identifier("Maven:net.java.dev.jna:jna-platform:5.11.0"),
+                Identifier("Maven:net.java.dev.jna:jna-platform:5.6.0"),
+                Identifier("Maven:net.java.dev.jna:jna-platform:NOT_A_VERSION")
             )
 
             ids.sorted() should containExactly(
+                Identifier("Maven:net.java.dev.jna:jna-platform:5.11.0"),
+                Identifier("Maven:net.java.dev.jna:jna-platform:5.6.0"),
+                Identifier("Maven:net.java.dev.jna:jna-platform:NOT_A_VERSION"),
                 Identifier("Maven:org.springframework.boot:spring-boot"),
                 Identifier("Maven:org.springframework.boot:spring-boot-actuator")
             )


### PR DESCRIPTION
This way e.g. version "5.11.0" will come after "5.6.0" instead of now
before it.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>