### PR TITLE
Introduce ORT result scanner infrastructure

### DIFF
--- a/scanner/src/main/kotlin/OrtResultScanner.kt
+++ b/scanner/src/main/kotlin/OrtResultScanner.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 Porsche AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package org.ossreviewtoolkit.scanner
+
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.ScanResult
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+
+/**
+ * A [Scanner] that operates on a complete [OrtResult]
+ */
+abstract class OrtResultScanner(
+    scannerName: String,
+    scannerConfig: ScannerConfiguration,
+    downloaderConfig: DownloaderConfiguration
+) : Scanner(scannerName, scannerConfig, downloaderConfig) {
+
+    /**
+     * This scanner operates on the level of a complete [OrtResult].
+     *
+     * Using it for package scanning is neither wanted nor supported and must be considered as an error.
+     */
+    final override suspend fun scanPackages(
+        packages: Set<org.ossreviewtoolkit.model.Package>,
+        labels: Map<String, String>
+    ): Map<org.ossreviewtoolkit.model.Package, List<ScanResult>> =
+        throw NotImplementedError("Not implemented on purpose")
+
+    /**
+     * Process a complete [OrtResult] and manage any scanning activities on projects and packages
+     * autonomous without any orchestration from ORT
+     */
+    abstract suspend fun scanOrtResult(
+        ortResult: OrtResult,
+        labels: Map<String, String>
+    ): Map<Package, List<ScanResult>>
+}


### PR DESCRIPTION
This pull request is meant to provide a functional overview of what changes in the ORT infrastrcture are required to allow the integration of ORT with the (commercial) BlackDuck tool as a backend scanner.

From a high-level perspective, we need an infrastructural way to integrate a scanner which is not working on a per-package level, like scancode does, but works on the level of an analyzer result.

We have built the Blackduck integration in a way that we organize all projects in an ORT analyzer result as projects grouped in a project group. A project group is a Blackduck-specific concept of a container grouping individual projects.

In order to make this logic work, we need to work on the level of an analyzer result which where we descend through the projects and its dependencies. 
We then build the Blackduck scan input per project, create the project groups and the projects in Blackduck, ship the dependencies and start the processing on Blackduck.
Once the scanning is complete (on Blackduck), we retrieve the results for all projects and create the ORT scan result in one step.

We are well aware of the on-going changes in ORT in the area of experimental scanner support (as discussed in the ORT developer meeting). Therefore we submit this pull request as a technology demo to show what support we need from the ORT infrastructure.

Once the additional infrastructure is in place, we're happy to supply another pull request to provide the Blackduck inegration