### PR TITLE
Prepare ort-config PackageConfigurationProvider

### DIFF
--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -290,7 +290,7 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate ORT re
         if (config.enableRepositoryPackageConfigurations) {
             packageConfigurations += repositoryPackageConfigurations
         } else if (repositoryPackageConfigurations.isNotEmpty()) {
-            log.warn { "Local package configurations were not applied because the feature is not enabled." }
+            log.info { "Local package configurations were not applied because the feature is not enabled." }
         }
 
         val packageConfigurationProvider = SimplePackageConfigurationProvider(packageConfigurations)

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -225,7 +225,7 @@ class ReporterCommand : CliktCommand(
         if (config.enableRepositoryPackageConfigurations) {
             packageConfigurations += repositoryPackageConfigurations
         } else if (repositoryPackageConfigurations.isNotEmpty()) {
-            log.warn { "Local package configurations were not applied because the feature is not enabled." }
+            log.info { "Local package configurations were not applied because the feature is not enabled." }
         }
 
         val packageConfigurationProvider = SimplePackageConfigurationProvider(packageConfigurations)

--- a/cli/src/main/kotlin/utils/PackageConfigurationOption.kt
+++ b/cli/src/main/kotlin/utils/PackageConfigurationOption.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +20,9 @@
 
 package org.ossreviewtoolkit.cli.utils
 
+import org.ossreviewtoolkit.model.utils.DirectoryPackageConfigurationProvider
+import org.ossreviewtoolkit.model.utils.FilePackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
-import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
 import org.ossreviewtoolkit.utils.core.ORT_PACKAGE_CONFIGURATIONS_DIRNAME
 import org.ossreviewtoolkit.utils.core.ortConfigDirectory
 
@@ -31,10 +33,10 @@ internal sealed class PackageConfigurationOption {
 
 internal fun PackageConfigurationOption?.createProvider(): PackageConfigurationProvider =
     when (this) {
-        is PackageConfigurationOption.Dir -> SimplePackageConfigurationProvider.forDirectory(value)
-        is PackageConfigurationOption.File -> SimplePackageConfigurationProvider.forFile(value)
+        is PackageConfigurationOption.Dir -> DirectoryPackageConfigurationProvider(value)
+        is PackageConfigurationOption.File -> FilePackageConfigurationProvider(value)
         null -> {
             val globalPackageConfigurations = ortConfigDirectory.resolve(ORT_PACKAGE_CONFIGURATIONS_DIRNAME)
-            SimplePackageConfigurationProvider.forDirectory(globalPackageConfigurations)
+            DirectoryPackageConfigurationProvider(globalPackageConfigurations)
         }
     }

--- a/helper-cli/src/main/kotlin/commands/GetPackageLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GetPackageLicensesCommand.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 HERE Europe B.V.
+ * Copyright (C) 2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,12 +89,11 @@ class GetPackageLicensesCommand : CliktCommand(
         val packageConfigurationProvider = packageConfigurationOption.createProvider()
 
         val result = scanResults.firstOrNull()?.let { scanResult ->
-            val packageConfiguration = packageConfigurationProvider.getPackageConfiguration(
-                packageId, scanResult.provenance
-            )
+            val packageConfigurations =
+                packageConfigurationProvider.getPackageConfigurations(packageId, scanResult.provenance)
 
-            val licenseFindingCurations = packageConfiguration?.licenseFindingCurations.orEmpty()
-            val pathExcludes = packageConfiguration?.pathExcludes.orEmpty()
+            val licenseFindingCurations = packageConfigurations.flatMap { it.licenseFindingCurations }
+            val pathExcludes = packageConfigurations.flatMap { it.pathExcludes }
 
             val nonExcludedLicenseFindings = scanResult.summary.licenseFindings.filter { licenseFinding ->
                 pathExcludes.none { it.matches(licenseFinding.location.path) }

--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -171,7 +172,7 @@ internal class ListLicensesCommand : CliktCommand(
             if (ortResult.isProject(packageId)) {
                 ortResult.getExcludes().paths
             } else {
-                packageConfigurationProvider.getPackageConfiguration(packageId, provenance)?.pathExcludes.orEmpty()
+                packageConfigurationProvider.getPackageConfigurations(packageId, provenance).flatMap { it.pathExcludes }
             }.any { it.matches(path) }
 
         val violatedRulesByLicense = ortResult.getViolatedRulesByLicense(packageId, offendingSeverity)

--- a/helper-cli/src/main/kotlin/common/PackageConfigurationOption.kt
+++ b/helper-cli/src/main/kotlin/common/PackageConfigurationOption.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +20,8 @@
 
 package org.ossreviewtoolkit.helper.common
 
+import org.ossreviewtoolkit.model.utils.DirectoryPackageConfigurationProvider
+import org.ossreviewtoolkit.model.utils.FilePackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
 
@@ -29,7 +32,7 @@ internal sealed class PackageConfigurationOption {
 
 internal fun PackageConfigurationOption?.createProvider(): PackageConfigurationProvider =
     when (this) {
-        is PackageConfigurationOption.Dir -> SimplePackageConfigurationProvider.forDirectory(value)
-        is PackageConfigurationOption.File -> SimplePackageConfigurationProvider.forFile(value)
+        is PackageConfigurationOption.Dir -> DirectoryPackageConfigurationProvider(value)
+        is PackageConfigurationOption.File -> FilePackageConfigurationProvider(value)
         null -> SimplePackageConfigurationProvider.EMPTY
     }

--- a/helper-cli/src/main/kotlin/common/PackageConfigurationOption.kt
+++ b/helper-cli/src/main/kotlin/common/PackageConfigurationOption.kt
@@ -23,7 +23,6 @@ package org.ossreviewtoolkit.helper.common
 import org.ossreviewtoolkit.model.utils.DirectoryPackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.FilePackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
-import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
 
 internal sealed class PackageConfigurationOption {
     data class Dir(val value: java.io.File) : PackageConfigurationOption()
@@ -34,5 +33,5 @@ internal fun PackageConfigurationOption?.createProvider(): PackageConfigurationP
     when (this) {
         is PackageConfigurationOption.Dir -> DirectoryPackageConfigurationProvider(value)
         is PackageConfigurationOption.File -> FilePackageConfigurationProvider(value)
-        null -> SimplePackageConfigurationProvider.EMPTY
+        null -> PackageConfigurationProvider.EMPTY
     }

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +64,6 @@ import org.ossreviewtoolkit.model.config.VulnerabilityResolution
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
-import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.createLicenseInfoResolver
 import org.ossreviewtoolkit.model.writeValue
 import org.ossreviewtoolkit.model.yamlMapper
@@ -229,7 +229,7 @@ internal fun OrtResult.processAllCopyrightStatements(
     omitExcluded: Boolean = true,
     copyrightGarbage: Set<String> = emptySet(),
     addAuthorsToCopyrights: Boolean = false,
-    packageConfigurationProvider: PackageConfigurationProvider = SimplePackageConfigurationProvider.EMPTY
+    packageConfigurationProvider: PackageConfigurationProvider = PackageConfigurationProvider.EMPTY
 ): List<ProcessedCopyrightStatement> {
     val result = mutableListOf<ProcessedCopyrightStatement>()
 

--- a/helper-cli/src/main/kotlin/common/Utils.kt
+++ b/helper-cli/src/main/kotlin/common/Utils.kt
@@ -293,7 +293,7 @@ internal fun OrtResult.getLicenseFindingsById(
         if (isProject(id)) {
             getLicenseFindingsCurations(id)
         } else {
-            packageConfigurationProvider.getPackageConfiguration(id, provenance)?.licenseFindingCurations.orEmpty()
+            packageConfigurationProvider.getPackageConfigurations(id, provenance).flatMap { it.licenseFindingCurations }
         }
 
     scanner?.results?.scanResults?.get(id)?.forEach { scanResult ->

--- a/model/src/main/kotlin/licenses/DefaultLicenseInfoProvider.kt
+++ b/model/src/main/kotlin/licenses/DefaultLicenseInfoProvider.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,10 +109,10 @@ class DefaultLicenseInfoProvider(
                 ortResult.repository.config.excludes.paths,
                 ortResult.repository.getRelativePath(project.vcsProcessed).orEmpty()
             )
-        } ?: packageConfigurationProvider.getPackageConfiguration(id, provenance).let { packageConfiguration ->
+        } ?: packageConfigurationProvider.getPackageConfigurations(id, provenance).let { packageConfigurations ->
             Triple(
-                packageConfiguration?.licenseFindingCurations.orEmpty(),
-                packageConfiguration?.pathExcludes.orEmpty(),
+                packageConfigurations.flatMap { it.licenseFindingCurations },
+                packageConfigurations.flatMap { it.pathExcludes },
                 ""
             )
         }

--- a/model/src/main/kotlin/utils/CompositePackageConfigurationProvider.kt
+++ b/model/src/main/kotlin/utils/CompositePackageConfigurationProvider.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.utils
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.config.PackageConfiguration
+
+/**
+ * A [PackageConfigurationProvider] that combines the provided [providers] into a single provider. The order of the
+ * [providers] determines the order in which they are queried when requesting a [PackageConfiguration] in
+ * [getPackageConfiguration].
+ */
+class CompositePackageConfigurationProvider(
+    private val providers: List<PackageConfigurationProvider>
+) : PackageConfigurationProvider {
+    constructor(vararg providers: PackageConfigurationProvider) : this(providers.asList())
+
+    override fun getPackageConfigurations(): List<PackageConfiguration> =
+        providers.flatMap { it.getPackageConfigurations() }
+
+    override fun getPackageConfiguration(packageId: Identifier, provenance: Provenance): PackageConfiguration? =
+        providers.firstNotNullOfOrNull { it.getPackageConfiguration(packageId, provenance) }
+}

--- a/model/src/main/kotlin/utils/CompositePackageConfigurationProvider.kt
+++ b/model/src/main/kotlin/utils/CompositePackageConfigurationProvider.kt
@@ -25,14 +25,13 @@ import org.ossreviewtoolkit.model.config.PackageConfiguration
 
 /**
  * A [PackageConfigurationProvider] that combines the provided [providers] into a single provider. The order of the
- * [providers] determines the order in which they are queried when requesting a [PackageConfiguration] in
- * [getPackageConfiguration].
+ * [providers] determines the order in which they are queried when calling [getPackageConfigurations].
  */
 class CompositePackageConfigurationProvider(
     private val providers: List<PackageConfigurationProvider>
 ) : PackageConfigurationProvider {
     constructor(vararg providers: PackageConfigurationProvider) : this(providers.asList())
 
-    override fun getPackageConfiguration(packageId: Identifier, provenance: Provenance): PackageConfiguration? =
-        providers.firstNotNullOfOrNull { it.getPackageConfiguration(packageId, provenance) }
+    override fun getPackageConfigurations(packageId: Identifier, provenance: Provenance): List<PackageConfiguration> =
+        providers.flatMap { it.getPackageConfigurations(packageId, provenance) }
 }

--- a/model/src/main/kotlin/utils/CompositePackageConfigurationProvider.kt
+++ b/model/src/main/kotlin/utils/CompositePackageConfigurationProvider.kt
@@ -33,9 +33,6 @@ class CompositePackageConfigurationProvider(
 ) : PackageConfigurationProvider {
     constructor(vararg providers: PackageConfigurationProvider) : this(providers.asList())
 
-    override fun getPackageConfigurations(): List<PackageConfiguration> =
-        providers.flatMap { it.getPackageConfigurations() }
-
     override fun getPackageConfiguration(packageId: Identifier, provenance: Provenance): PackageConfiguration? =
         providers.firstNotNullOfOrNull { it.getPackageConfiguration(packageId, provenance) }
 }

--- a/model/src/main/kotlin/utils/OrtResultExtensions.kt
+++ b/model/src/main/kotlin/utils/OrtResultExtensions.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +56,7 @@ fun OrtResult.collectDeclaredLicenses(omitExcluded: Boolean = false): Map<Identi
  * instead of calling this function multiple times for better performance.
  */
 fun OrtResult.createLicenseInfoResolver(
-    packageConfigurationProvider: PackageConfigurationProvider = SimplePackageConfigurationProvider.EMPTY,
+    packageConfigurationProvider: PackageConfigurationProvider = PackageConfigurationProvider.EMPTY,
     copyrightGarbage: CopyrightGarbage = CopyrightGarbage(),
     addAuthorsToCopyrights: Boolean = false,
     archiver: FileArchiver? = null

--- a/model/src/main/kotlin/utils/PackageConfigurationProvider.kt
+++ b/model/src/main/kotlin/utils/PackageConfigurationProvider.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,11 +28,6 @@ import org.ossreviewtoolkit.model.config.PackageConfiguration
  * A provider for [PackageConfiguration]s.
  */
 interface PackageConfigurationProvider {
-    /**
-     * Return all [PackageConfiguration]s of this provider.
-     */
-    fun getPackageConfigurations(): List<PackageConfiguration>
-
     /**
      * Return the first matching [PackageConfiguration] for the given [packageId] and [provenance] if any.
      */

--- a/model/src/main/kotlin/utils/PackageConfigurationProvider.kt
+++ b/model/src/main/kotlin/utils/PackageConfigurationProvider.kt
@@ -27,7 +27,15 @@ import org.ossreviewtoolkit.model.config.PackageConfiguration
 /**
  * A provider for [PackageConfiguration]s.
  */
-interface PackageConfigurationProvider {
+fun interface PackageConfigurationProvider {
+    companion object {
+        /**
+         * A provider that does not provide any curations.
+         */
+        @JvmField
+        val EMPTY = PackageConfigurationProvider { _, _ -> null }
+    }
+
     /**
      * Return the first matching [PackageConfiguration] for the given [packageId] and [provenance] if any.
      */

--- a/model/src/main/kotlin/utils/PackageConfigurationProvider.kt
+++ b/model/src/main/kotlin/utils/PackageConfigurationProvider.kt
@@ -33,11 +33,11 @@ fun interface PackageConfigurationProvider {
          * A provider that does not provide any curations.
          */
         @JvmField
-        val EMPTY = PackageConfigurationProvider { _, _ -> null }
+        val EMPTY = PackageConfigurationProvider { _, _ -> emptyList() }
     }
 
     /**
-     * Return the first matching [PackageConfiguration] for the given [packageId] and [provenance] if any.
+     * Return a list of [PackageConfiguration]s for the given [packageId] and [provenance].
      */
-    fun getPackageConfiguration(packageId: Identifier, provenance: Provenance): PackageConfiguration?
+    fun getPackageConfigurations(packageId: Identifier, provenance: Provenance): List<PackageConfiguration>
 }

--- a/model/src/main/kotlin/utils/SimplePackageConfigurationProvider.kt
+++ b/model/src/main/kotlin/utils/SimplePackageConfigurationProvider.kt
@@ -45,11 +45,8 @@ open class SimplePackageConfigurationProvider(
         configurationsById = configurations.groupByTo(HashMap()) { it.id }
     }
 
-    override fun getPackageConfiguration(packageId: Identifier, provenance: Provenance): PackageConfiguration? =
-        configurationsById[packageId]?.filter { it.matches(packageId, provenance) }?.let {
-            require(it.size <= 1) { "There must be at most one package configuration per Id and provenance." }
-            it.singleOrNull()
-        }
+    override fun getPackageConfigurations(packageId: Identifier, provenance: Provenance): List<PackageConfiguration> =
+        configurationsById[packageId]?.filter { it.matches(packageId, provenance) }.orEmpty()
 }
 
 /**

--- a/model/src/main/kotlin/utils/SimplePackageConfigurationProvider.kt
+++ b/model/src/main/kotlin/utils/SimplePackageConfigurationProvider.kt
@@ -37,14 +37,6 @@ import org.ossreviewtoolkit.model.readValue
 open class SimplePackageConfigurationProvider(
     configurations: Collection<PackageConfiguration>
 ) : PackageConfigurationProvider {
-    companion object {
-        /**
-         * A provider without any package configurations.
-         */
-        @JvmField
-        val EMPTY = SimplePackageConfigurationProvider(emptyList())
-   }
-
     private val configurationsById: Map<Identifier, List<PackageConfiguration>>
 
     init {

--- a/model/src/main/kotlin/utils/SimplePackageConfigurationProvider.kt
+++ b/model/src/main/kotlin/utils/SimplePackageConfigurationProvider.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,8 +80,6 @@ class SimplePackageConfigurationProvider(
 
         configurationsById = configurations.groupByTo(HashMap()) { it.id }
     }
-
-    override fun getPackageConfigurations() = configurationsById.values.flatten()
 
     override fun getPackageConfiguration(packageId: Identifier, provenance: Provenance): PackageConfiguration? =
         configurationsById[packageId]?.filter { it.matches(packageId, provenance) }?.let {

--- a/model/src/test/kotlin/licenses/DefaultLicenseInfoProviderTest.kt
+++ b/model/src/test/kotlin/licenses/DefaultLicenseInfoProviderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ package org.ossreviewtoolkit.model.licenses
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
-import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
+import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 
 class DefaultLicenseInfoProviderTest : WordSpec({
-    val defaultLicenseInfoProvider = DefaultLicenseInfoProvider(ortResult, SimplePackageConfigurationProvider.EMPTY)
+    val defaultLicenseInfoProvider = DefaultLicenseInfoProvider(ortResult, PackageConfigurationProvider.EMPTY)
 
     "declaredLicenseInfo" should {
         "contain author information for package" {

--- a/model/src/test/kotlin/licenses/LicenseViewTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseViewTest.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,14 +30,14 @@ import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.utils.FileArchiver
-import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
+import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.utils.test.createDefault
 import org.ossreviewtoolkit.utils.test.transformingCollectionMatcher
 
 class LicenseViewTest : WordSpec() {
     private val licenseInfoResolver = LicenseInfoResolver(
-        provider = DefaultLicenseInfoProvider(ortResult, SimplePackageConfigurationProvider.EMPTY),
+        provider = DefaultLicenseInfoProvider(ortResult, PackageConfigurationProvider.EMPTY),
         copyrightGarbage = CopyrightGarbage(),
         addAuthorsToCopyrights = false,
         archiver = FileArchiver.createDefault()

--- a/reporter/src/main/kotlin/ReporterInput.kt
+++ b/reporter/src/main/kotlin/ReporterInput.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +33,6 @@ import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.ResolutionProvider
-import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
 
 /**
  * A bundle of input to be used by [Reporter] implementations.
@@ -51,7 +51,7 @@ data class ReporterInput(
     /**
      * A [PackageConfigurationProvider], can be used to obtain [PackageConfiguration]s for packages.
      */
-    val packageConfigurationProvider: PackageConfigurationProvider = SimplePackageConfigurationProvider.EMPTY,
+    val packageConfigurationProvider: PackageConfigurationProvider = PackageConfigurationProvider.EMPTY,
 
     /**
      * A [ResolutionProvider], can be used to check which [OrtIssue]s and [RuleViolation]s are resolved.

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelMapper.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2021 HERE Europe B.V.
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -235,15 +235,16 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         if (input.ortResult.isProject(id)) {
             input.ortResult.repository.config.curations.licenseFindings
         } else {
-            input.packageConfigurationProvider.getPackageConfiguration(id, provenance)
-                ?.licenseFindingCurations.orEmpty()
+            input.packageConfigurationProvider.getPackageConfigurations(id, provenance)
+                .flatMap { it.licenseFindingCurations }
         }
 
     private fun getPathExcludes(id: Identifier, provenance: Provenance): List<PathExclude> =
         if (input.ortResult.isProject(id)) {
             input.ortResult.getExcludes().paths
         } else {
-            input.packageConfigurationProvider.getPackageConfiguration(id, provenance)?.pathExcludes.orEmpty()
+            input.packageConfigurationProvider.getPackageConfigurations(id, provenance)
+                .flatMap { it.pathExcludes }
         }
 
     private fun addProject(project: Project) {


### PR DESCRIPTION
Several refactorings to prepare the implementation of a `PackageConfigurationProvider` for the ort-config repository, see the commit messages for details.