### PR TITLE
ProcessCapture: Make `{stdout,stderr}File` private

### DIFF
--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -425,7 +425,7 @@ open class Npm(
 
     protected open fun getRemotePackageDetails(workingDir: File, packageName: String): JsonNode {
         val process = run(workingDir, "view", "--json", packageName)
-        return jsonMapper.readTree(process.stdoutFile)
+        return jsonMapper.readTree(process.stdout)
     }
 
     /**

--- a/analyzer/src/main/kotlin/managers/Pipenv.kt
+++ b/analyzer/src/main/kotlin/managers/Pipenv.kt
@@ -69,10 +69,8 @@ class Pipenv(
 
         log.info { "Generating '${requirementsFile.name}' file in '$workingDir' directory..." }
 
-        ProcessCapture(workingDir, command(), "lock", "--requirements")
-            .requireSuccess()
-            .stdoutFile
-            .copyTo(requirementsFile)
+        val requirements = ProcessCapture(workingDir, command(), "lock", "--requirements").requireSuccess().stdout
+        requirementsFile.writeText(requirements)
 
         return Pip(managerName, analysisRoot, analyzerConfig, repoConfig)
             .resolveDependencies(requirementsFile, labels)

--- a/analyzer/src/main/kotlin/managers/Yarn.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn.kt
@@ -69,6 +69,6 @@ class Yarn(
 
     override fun getRemotePackageDetails(workingDir: File, packageName: String): JsonNode {
         val process = run(workingDir, "info", "--json", packageName)
-        return jsonMapper.readTree(process.stdoutFile)["data"]
+        return jsonMapper.readTree(process.stdout)["data"]
     }
 }

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -114,14 +114,14 @@ class Askalono internal constructor(
             if (stderr.isNotBlank()) log.debug { stderr }
             if (isError) throw ScanException(errorMessage)
 
-            generateSummary(startTime, endTime, path, stdoutFile)
+            generateSummary(startTime, endTime, path, stdout)
         }
     }
 
-    private fun generateSummary(startTime: Instant, endTime: Instant, scanPath: File, resultFile: File): ScanSummary {
+    private fun generateSummary(startTime: Instant, endTime: Instant, scanPath: File, result: String): ScanSummary {
         val licenseFindings = sortedSetOf<LicenseFinding>()
 
-        resultFile.readLines().forEach { line ->
+        result.lines().forEach { line ->
             val root = jsonMapper.readTree(line)
             root["result"]?.let { result ->
                 val licenseFinding = LicenseFinding(

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -28,7 +28,7 @@ import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.model.readJsonFile
+import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.scanner.AbstractScannerFactory
 import org.ossreviewtoolkit.scanner.BuildConfig
 import org.ossreviewtoolkit.scanner.CommandLineScanner
@@ -97,15 +97,15 @@ class Licensee internal constructor(
             if (stderr.isNotBlank()) log.debug { stderr }
             if (isError) throw ScanException(errorMessage)
 
-            generateSummary(startTime, endTime, path, stdoutFile)
+            generateSummary(startTime, endTime, path, stdout)
         }
     }
 
-    private fun generateSummary(startTime: Instant, endTime: Instant, scanPath: File, resultFile: File): ScanSummary {
+    private fun generateSummary(startTime: Instant, endTime: Instant, scanPath: File, result: String): ScanSummary {
         val licenseFindings = sortedSetOf<LicenseFinding>()
 
-        val result = readJsonFile(resultFile)
-        val matchedFiles = result["matched_files"]
+        val json = jsonMapper.readTree(result)
+        val matchedFiles = json["matched_files"]
 
         matchedFiles.mapTo(licenseFindings) {
             val filePath = File(it["filename"].textValue())

--- a/utils/common/src/main/kotlin/ProcessCapture.kt
+++ b/utils/common/src/main/kotlin/ProcessCapture.kt
@@ -61,8 +61,8 @@ class ProcessCapture(vararg command: String, workingDir: File? = null, environme
     private val tempDir = createTempDirectory("$command-process").toFile().apply { deleteOnExit() }
     private val tempPrefix = command.first().substringAfterLast(File.separatorChar)
 
-    val stdoutFile = tempDir.resolve("$tempPrefix.stdout").apply { deleteOnExit() }
-    val stderrFile = tempDir.resolve("$tempPrefix.stderr").apply { deleteOnExit() }
+    private val stdoutFile = tempDir.resolve("$tempPrefix.stdout").apply { deleteOnExit() }
+    private val stderrFile = tempDir.resolve("$tempPrefix.stderr").apply { deleteOnExit() }
 
     /**
      * Get the standard output stream of the terminated process as a string.


### PR DESCRIPTION
The fact that `ProcessCapture` uses temporary files to work around the
64k buffering limit is an implementation detail that should not be
exposed to ease switching to another process builder alternative
eventually. Also see [1].

[1]: https://github.com/oss-review-toolkit/ort/issues/4668

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>