### PR TITLE
Analyzer: Close Response Body on failure

### DIFF
--- a/utils/core/src/main/kotlin/OkHttpClientHelper.kt
+++ b/utils/core/src/main/kotlin/OkHttpClientHelper.kt
@@ -241,6 +241,7 @@ fun OkHttpClient.download(url: String, acceptEncoding: String? = null): Result<P
         val body = response.body
 
         if (!response.isSuccessful || body == null) {
+            body?.close()
             throw HttpDownloadError(response.code, response.message)
         }
 


### PR DESCRIPTION
A Resource leak was partially fixed in
https://github.com/oss-review-toolkit/ort/issues/5240.
However the Response would still not be closed if unsuccessful, and the same warnings as in #5240 would appear if so.

By also closing (as recommended by OKHttp) before throwing the exception, it will not show the warn messages.
(and the potential resource leak).

Note: It can be argued it could be solved in less imperative ways by some overall refactoring,
but for a first PR I would like it to be as simple and straightforward as possible.

Signed-off-by: Josef Andersson <josef.andersson@gmail.com>
