### PR TITLE
Pub: Upgrade bootstrapped Flutter to version 3.0.0

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -71,7 +71,7 @@ private const val PUB_LOCK_FILE = "pubspec.lock"
 private val flutterCommand = if (Os.isWindows) "flutter.bat" else "flutter"
 private val dartCommand = if (Os.isWindows) "dart.bat" else "dart"
 
-private val flutterVersion = Os.env["FLUTTER_VERSION"] ?: "2.10.5-stable"
+private val flutterVersion = Os.env["FLUTTER_VERSION"] ?: "3.0.0-stable"
 private val flutterInstallDir = ortToolsDirectory.resolve("flutter-$flutterVersion")
 
 val flutterHome by lazy {


### PR DESCRIPTION
See: https://docs.flutter.dev/development/tools/sdk/release-notes/release-notes-3.0.0
