### PR TITLE
ScanCode: Support version parsing for ScanCode 31.0.0b4

### DIFF
--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -43,6 +43,7 @@ import org.ossreviewtoolkit.utils.common.isTrue
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.common.unpack
+import org.ossreviewtoolkit.utils.common.withoutPrefix
 import org.ossreviewtoolkit.utils.core.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.core.createOrtTempDir
 import org.ossreviewtoolkit.utils.core.log
@@ -141,8 +142,10 @@ class ScanCode internal constructor(
         // On first use, the output is prefixed by "Configuring ScanCode for first use...". The version string can be
         // something like:
         // ScanCode version 2.0.1.post1.fb67a181
-        val prefix = "ScanCode version "
-        return output.lineSequence().first { it.startsWith(prefix) }.substring(prefix.length)
+        // ScanCode version: 31.0.0b4
+        return output.lineSequence().firstNotNullOfOrNull { line ->
+            line.withoutPrefix("ScanCode version")?.removePrefix(":")?.trim()
+        }.orEmpty()
     }
 
     override fun bootstrap(): File {

--- a/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
@@ -119,4 +119,32 @@ class ScanCodeTest : WordSpec({
             }
         }
     }
+
+    "transformVersion" should {
+        val scanCode = ScanCode(
+            "ScanCode",
+            ScannerConfiguration(),
+            DownloaderConfiguration()
+        )
+
+        "work with a version output without a colon" {
+            scanCode.transformVersion(
+                """
+                    ScanCode version 30.0.1
+                    ScanCode Output Format version 1.0.0
+                    SPDX License list version 3.16
+                """.trimIndent()
+            ) shouldBe "30.0.1"
+        }
+
+        "work with a version output with a colon" {
+            scanCode.transformVersion(
+                """
+                    ScanCode version: 31.0.0b4
+                    ScanCode Output Format version: 2.0.0
+                    SPDX License list version: 3.16
+                """.trimIndent()
+            ) shouldBe "31.0.0b4"
+        }
+    }
 })


### PR DESCRIPTION
The version output of ScanCode 31.x adds a colon to the version
output, see [1]. Support the parsing of this new format.

[1]: https://github.com/nexB/scancode-toolkit/commit/b78b49f7d57d03938f973f0542a08417c84bb77e

