### PR TITLE
DependencyGraphBuilder: Handle cyclic dependencies

### DIFF
--- a/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
@@ -363,6 +363,13 @@ class DependencyGraphBuilder<D>(
         }
 
         val fragmentMapping = referenceMappings[index.fragment]
+        if (index.root in fragmentMapping) {
+            // If this point is reached, the package has already been inserted when processing its dependencies.
+            // This means that there is a cyclic dependency. To handle this case correctly, the insert operation has
+            // to be started anew.
+            return addDependencyToGraph(scopeName, dependency, transitive)
+        }
+
         val ref = DependencyReference(
             pkg = index.root,
             fragment = index.fragment,


### PR DESCRIPTION
If a dependency to a package was added to the builder which contains
another reference to this package in its dependencies, the builder
created multiple DependencyReference objects with the same index and
fragment. This caused a corrupted dependency graph which could not be
deserialized. Fix this by checking the fragment again before creating
a new DependencyReference.

Note that this issue was encountered with a real Gradle project where
the analyzer actually produced such cyclic dependencies.