### PR TITLE
github/workflows: Upgrade deprecated upload-sarif action v1 to v2

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         arguments: --stacktrace detekt
     - name: Upload SARIF File
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v2
       if: ${{ always() }} # Upload even if the previous step failed.
       with:
         sarif_file: build/reports/detekt/detekt.sarif


### PR DESCRIPTION
See [1].

[1]: https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>