### PR TITLE
Pip: Fix license detection for license containing separators

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -619,7 +619,7 @@ class Pip(
             *allPackages.map { it.name }.toTypedArray()
         ).requireSuccess().stdout
 
-        return output.normalizeLineBreaks().split("---\n").map { parsePipShowOutput(it) }
+        return output.normalizeLineBreaks().split("\n---\n").map { parsePipShowOutput(it) }
     }
 
     /**


### PR DESCRIPTION
For example the license of package kiwisolver contains `-` characters
https://github.com/nucleic/kiwi/blob/main/LICENSE

Signed-off-by: Stefano Bennati <stefano.bennati@here.com>

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
