### PR TITLE
Npm: Disable audit submission during `npm ci` or `npm install`

### DIFF
--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -645,5 +645,5 @@ open class Npm(
     }
 
     protected open fun runInstall(workingDir: File) =
-        run(workingDir, if (hasLockFile(workingDir)) "ci" else "install", "--ignore-scripts")
+        run(workingDir, if (hasLockFile(workingDir)) "ci" else "install", "--ignore-scripts", "--no-audit")
 }


### PR DESCRIPTION
According to the documentation ([1] and [2]), NPM submits by default a
dependency description to the configured registry and asks for a report
of known vulnerabilities.
Since:
* ORT does not use this information (security analysis is done
separately by the Advisor)
* this auditing should be done regularly and not only at install time
this commit deactivates this option for now.

[1]: https://docs.npmjs.com/cli/v8/commands/npm-ci
[2]: https://docs.npmjs.com/cli/v8/commands/npm-audit

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
