### PR TITLE
Pub: Upgrade bootstrapped Flutter version to 3.0.1

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -71,7 +71,7 @@ private const val PUB_LOCK_FILE = "pubspec.lock"
 private val flutterCommand = if (Os.isWindows) "flutter.bat" else "flutter"
 private val dartCommand = if (Os.isWindows) "dart.bat" else "dart"
 
-private val flutterVersion = Os.env["FLUTTER_VERSION"] ?: "3.0.0-stable"
+private val flutterVersion = Os.env["FLUTTER_VERSION"] ?: "3.0.1-stable"
 private val flutterInstallDir = ortToolsDirectory.resolve("flutter-$flutterVersion")
 
 val flutterHome by lazy {


### PR DESCRIPTION
No release notes are published for this minor update.