### PR TITLE
ArchiveUtils: Do not follow links in `packZip()`

### DIFF
--- a/utils/common/src/main/kotlin/ArchiveUtils.kt
+++ b/utils/common/src/main/kotlin/ArchiveUtils.kt
@@ -202,16 +202,17 @@ fun File.packZip(
     ZipArchiveOutputStream(targetFile).use { output ->
         output.setLevel(Deflater.BEST_COMPRESSION)
 
-        walkTopDown()
-            .onEnter { directoryFilter(it) }
-            .filter { Files.isRegularFile(it.toPath()) && fileFilter(it) && it != targetFile }
-            .forEach { file ->
-                val packPath = prefix + file.toRelativeString(this)
-                val entry = ZipArchiveEntry(file, packPath)
-                output.putArchiveEntry(entry)
-                file.inputStream().use { input -> input.copyTo(output) }
-                output.closeArchiveEntry()
-            }
+        walkTopDown().onEnter {
+            directoryFilter(it)
+        }.filter {
+            Files.isRegularFile(it.toPath()) && fileFilter(it) && it != targetFile
+        }.forEach { file ->
+            val packPath = prefix + file.toRelativeString(this)
+            val entry = ZipArchiveEntry(file, packPath)
+            output.putArchiveEntry(entry)
+            file.inputStream().use { input -> input.copyTo(output) }
+            output.closeArchiveEntry()
+        }
     }
 
     return targetFile

--- a/utils/common/src/main/kotlin/ArchiveUtils.kt
+++ b/utils/common/src/main/kotlin/ArchiveUtils.kt
@@ -26,6 +26,7 @@ import java.io.File
 import java.io.IOException
 import java.io.InputStream
 import java.nio.file.Files
+import java.nio.file.LinkOption
 import java.util.zip.Deflater
 
 import kotlin.io.path.createTempDirectory
@@ -205,7 +206,7 @@ fun File.packZip(
         walkTopDown().onEnter {
             directoryFilter(it)
         }.filter {
-            Files.isRegularFile(it.toPath()) && fileFilter(it) && it != targetFile
+            Files.isRegularFile(it.toPath(), LinkOption.NOFOLLOW_LINKS) && fileFilter(it) && it != targetFile
         }.forEach { file ->
             val packPath = prefix + file.toRelativeString(this)
             val entry = ZipArchiveEntry(file, packPath)


### PR DESCRIPTION
This is a fixup for fe53333. Resolves #5376.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>