### PR TITLE
ArchiveUtils: Also do not follow symbolic links to directories

### DIFF
--- a/utils/common/src/main/kotlin/ArchiveUtils.kt
+++ b/utils/common/src/main/kotlin/ArchiveUtils.kt
@@ -204,7 +204,7 @@ fun File.packZip(
         output.setLevel(Deflater.BEST_COMPRESSION)
 
         walkTopDown().onEnter {
-            directoryFilter(it)
+            Files.isDirectory(it.toPath(), LinkOption.NOFOLLOW_LINKS) && directoryFilter(it)
         }.filter {
             Files.isRegularFile(it.toPath(), LinkOption.NOFOLLOW_LINKS) && fileFilter(it) && it != targetFile
         }.forEach { file ->


### PR DESCRIPTION
The fix in 3342e50 was incomplete in that only symbolic links to files
were not followed. Extend this to symbolic links to directories.

Resolves #5376, again.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>