### PR TITLE
SpdxDocumentFile: Warn about artifact download locations that look like Git

### DIFF
--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -113,7 +113,16 @@ private fun SpdxPackage.getRemoteArtifact(): RemoteArtifact? =
     when {
         SpdxConstants.isNotPresent(downloadLocation) -> null
         SPDX_VCS_PREFIXES.any { (prefix, _) -> downloadLocation.startsWith(prefix) } -> null
-        else -> RemoteArtifact(downloadLocation, Hash.NONE)
+        else -> {
+            if (downloadLocation.endsWith(".git")) {
+                log.warn {
+                    "The download location $downloadLocation of SPDX package '$spdxId' looks like a Git repository " +
+                            "URL but it lacks the 'git+' prefix and thus will be treated as an artifact URL."
+                }
+            }
+
+            RemoteArtifact(downloadLocation, Hash.NONE)
+        }
     }
 
 /**


### PR DESCRIPTION
It is a common mistake by SPDX document authors to omit the VCS-specific
prefix in download locations that refer to VCS locations instead of
artifacts, so warn about this at least in the Git case.

[1]: https://spdx.github.io/spdx-spec/package-information/#77-package-download-location-field

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>