### PR TITLE
Git: Do not initialize submodules again in the fallback

### DIFF
--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -233,7 +233,7 @@ class Git : VersionControlSystem(), CommandLineTool {
             workingTree.runGit("submodule", "update", "--init", "--recursive", "--depth", "$GIT_HISTORY_DEPTH")
         }.recover {
             // As Git's dumb HTTP transport does not support shallow capabilities, also try to not limit the depth.
-            workingTree.runGit("submodule", "update", "--init", "--recursive")
+            workingTree.runGit("submodule", "update", "--recursive")
         }
     }
 


### PR DESCRIPTION
It's very likely not the init-step that fails, but the cloning, so do
not initialize submodules again when (re-)trying to clone them without
limiting the depth. This should avoid Git warnings like

   warning: 21f92cc4870a08c9ff1a4f7d7e03b5539fca51fb:.gitmodules,
   multiple configurations found for 'submodule.sdk.path'. Skipping
   second one!

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>