### PR TITLE
Gradle: Improve the detection of unresolvable configurations

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result-with-curations.yml
@@ -82,15 +82,6 @@ analyzer:
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
       homepage_url: ""
       scopes:
-      - name: "compile"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
       - name: "compileClasspath"
         dependencies:
         - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -109,15 +100,6 @@ analyzer:
             dependencies:
             - id: "Maven:org.apache.commons:commons-lang3:3.5"
           - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtime"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
       - name: "runtimeClasspath"
         dependencies:
         - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -127,25 +109,7 @@ analyzer:
             dependencies:
             - id: "Maven:org.apache.commons:commons-lang3:3.5"
           - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompile"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
       - name: "testCompileClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testRuntime"
         dependencies:
         - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
           linkage: "PROJECT_DYNAMIC"
@@ -179,12 +143,6 @@ analyzer:
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
       homepage_url: ""
       scopes:
-      - name: "compile"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
       - name: "compileClasspath"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -197,37 +155,13 @@ analyzer:
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
         - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtime"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
       - name: "runtimeClasspath"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
         - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompile"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
       - name: "testCompileClasspath"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testRuntime"
         dependencies:
         - id: "Maven:junit:junit:4.12"
           dependencies:
@@ -261,16 +195,6 @@ analyzer:
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
       homepage_url: ""
       scopes:
-      - name: "compile"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
       - name: "compileClasspath"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
@@ -291,16 +215,6 @@ analyzer:
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
             severity: "ERROR"
-      - name: "runtime"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
       - name: "runtimeClasspath"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
@@ -311,41 +225,7 @@ analyzer:
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
             severity: "ERROR"
-      - name: "testCompile"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
       - name: "testCompileClasspath"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testRuntime"
         dependencies:
         - id: "Unknown:junit:junit:4.12"
           issues:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-all-dependencies-expected-result.yml
@@ -82,15 +82,6 @@ analyzer:
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
       homepage_url: ""
       scopes:
-      - name: "compile"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
       - name: "compileClasspath"
         dependencies:
         - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -109,15 +100,6 @@ analyzer:
             dependencies:
             - id: "Maven:org.apache.commons:commons-lang3:3.5"
           - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtime"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
       - name: "runtimeClasspath"
         dependencies:
         - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -127,25 +109,7 @@ analyzer:
             dependencies:
             - id: "Maven:org.apache.commons:commons-lang3:3.5"
           - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompile"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
       - name: "testCompileClasspath"
-        dependencies:
-        - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-          linkage: "PROJECT_DYNAMIC"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-text:1.1"
-            dependencies:
-            - id: "Maven:org.apache.commons:commons-lang3:3.5"
-          - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testRuntime"
         dependencies:
         - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
           linkage: "PROJECT_DYNAMIC"
@@ -179,12 +143,6 @@ analyzer:
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
       homepage_url: ""
       scopes:
-      - name: "compile"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
       - name: "compileClasspath"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -197,37 +155,13 @@ analyzer:
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
         - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "runtime"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
       - name: "runtimeClasspath"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
         - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testCompile"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
       - name: "testCompileClasspath"
-        dependencies:
-        - id: "Maven:junit:junit:4.12"
-          dependencies:
-          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-        - id: "Maven:org.apache.commons:commons-text:1.1"
-          dependencies:
-          - id: "Maven:org.apache.commons:commons-lang3:3.5"
-        - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-      - name: "testRuntime"
         dependencies:
         - id: "Maven:junit:junit:4.12"
           dependencies:
@@ -261,16 +195,6 @@ analyzer:
         path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
       homepage_url: ""
       scopes:
-      - name: "compile"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
       - name: "compileClasspath"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
@@ -291,16 +215,6 @@ analyzer:
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
             severity: "ERROR"
-      - name: "runtime"
-        dependencies:
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
       - name: "runtimeClasspath"
         dependencies:
         - id: "Unknown:org.apache.commons:commons-text:1.1"
@@ -311,41 +225,7 @@ analyzer:
               \ dependency org.apache.commons:commons-text:1.1 because no repositories\
               \ are defined."
             severity: "ERROR"
-      - name: "testCompile"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
       - name: "testCompileClasspath"
-        dependencies:
-        - id: "Unknown:junit:junit:4.12"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency junit:junit:4.12 because no repositories are defined."
-            severity: "ERROR"
-        - id: "Unknown:org.apache.commons:commons-text:1.1"
-          issues:
-          - timestamp: "1970-01-01T00:00:00Z"
-            source: "Gradle"
-            message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-              \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-              \ are defined."
-            severity: "ERROR"
-      - name: "testRuntime"
         dependencies:
         - id: "Unknown:junit:junit:4.12"
           issues:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-bom-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-bom-expected-output.yml
@@ -19,9 +19,6 @@ project:
   - name: "compileClasspath"
     dependencies:
     - id: "Maven:com.fasterxml.jackson.core:jackson-core:2.12.2"
-  - name: "default"
-    dependencies:
-    - id: "Maven:com.fasterxml.jackson.core:jackson-core:2.12.2"
   - name: "runtimeClasspath"
     dependencies:
     - id: "Maven:com.fasterxml.jackson.core:jackson-core:2.12.2"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -16,15 +16,6 @@ project:
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/app"
   homepage_url: ""
   scopes:
-  - name: "compile"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
   - name: "compileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -43,15 +34,6 @@ project:
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.5"
       - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
   - name: "runtimeClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -61,25 +43,7 @@ project:
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.5"
       - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompile"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
   - name: "testCompileClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testRuntime"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       linkage: "PROJECT_DYNAMIC"

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -16,16 +16,6 @@ project:
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
   homepage_url: ""
   scopes:
-  - name: "compile"
-    dependencies:
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
   - name: "compileClasspath"
     dependencies:
     - id: "Unknown:org.apache.commons:commons-text:1.1"
@@ -46,16 +36,6 @@ project:
           \ dependency org.apache.commons:commons-text:1.1 because no repositories\
           \ are defined."
         severity: "ERROR"
-  - name: "runtime"
-    dependencies:
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
   - name: "runtimeClasspath"
     dependencies:
     - id: "Unknown:org.apache.commons:commons-text:1.1"
@@ -66,41 +46,7 @@ project:
           \ dependency org.apache.commons:commons-text:1.1 because no repositories\
           \ are defined."
         severity: "ERROR"
-  - name: "testCompile"
-    dependencies:
-    - id: "Unknown:junit:junit:4.12"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency junit:junit:4.12 because no repositories are defined."
-        severity: "ERROR"
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
   - name: "testCompileClasspath"
-    dependencies:
-    - id: "Unknown:junit:junit:4.12"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency junit:junit:4.12 because no repositories are defined."
-        severity: "ERROR"
-    - id: "Unknown:org.apache.commons:commons-text:1.1"
-      issues:
-      - timestamp: "1970-01-01T00:00:00Z"
-        source: "Gradle"
-        message: "Unresolved: ModuleVersionNotFoundException: Cannot resolve external\
-          \ dependency org.apache.commons:commons-text:1.1 because no repositories\
-          \ are defined."
-        severity: "ERROR"
-  - name: "testRuntime"
     dependencies:
     - id: "Unknown:junit:junit:4.12"
       issues:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -16,12 +16,6 @@ project:
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
   homepage_url: ""
   scopes:
-  - name: "compile"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
   - name: "compileClasspath"
     dependencies:
     - id: "Maven:org.apache.commons:commons-text:1.1"
@@ -34,37 +28,13 @@ project:
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.5"
     - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtime"
-    dependencies:
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
   - name: "runtimeClasspath"
     dependencies:
     - id: "Maven:org.apache.commons:commons-text:1.1"
       dependencies:
       - id: "Maven:org.apache.commons:commons-lang3:3.5"
     - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompile"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
   - name: "testCompileClasspath"
-    dependencies:
-    - id: "Maven:junit:junit:4.12"
-      dependencies:
-      - id: "Maven:org.hamcrest:hamcrest-core:1.3"
-    - id: "Maven:org.apache.commons:commons-text:1.1"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-lang3:3.5"
-    - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testRuntime"
     dependencies:
     - id: "Maven:junit:junit:4.12"
       dependencies:

--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
@@ -16,15 +16,6 @@ project:
     path: "analyzer/src/funTest/assets/projects/synthetic/gradle-library/app"
   homepage_url: ""
   scopes:
-  - name: "compile"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
   - name: "compileClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
@@ -42,25 +33,7 @@ project:
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.5"
       - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "runtime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
   - name: "runtimeClasspath"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
-  - name: "testCompile"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
       linkage: "PROJECT_DYNAMIC"
@@ -77,15 +50,6 @@ project:
       - id: "Maven:org.apache.commons:commons-text:1.1"
         dependencies:
         - id: "Maven:org.apache.commons:commons-lang3:3.5"
-  - name: "testRuntime"
-    dependencies:
-    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
-      linkage: "PROJECT_DYNAMIC"
-      dependencies:
-      - id: "Maven:org.apache.commons:commons-text:1.1"
-        dependencies:
-        - id: "Maven:org.apache.commons:commons-lang3:3.5"
-      - id: "Maven:org.apache.struts:struts2-assembly:2.5.14.1"
   - name: "testRuntimeClasspath"
     dependencies:
     - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"

--- a/analyzer/src/main/resources/scripts/init.gradle
+++ b/analyzer/src/main/resources/scripts/init.gradle
@@ -168,9 +168,7 @@ class AbstractDependencyTreePlugin<T> implements Plugin<T> {
             }
 
             List<Configuration> configurations = project.configurations.findResults { configuration ->
-                // For versions of Gradle before the "canBeResolved" property was introduced, consider any
-                // configuration to be resolvable.
-                if (!configuration.hasProperty('canBeResolved') || configuration.canBeResolved) {
+                if (canBeResolved(configuration)) {
                     ResolutionResult result = configuration.getIncoming().getResolutionResult()
                     Set<ResolvedArtifact> resolvedArtifacts = []
 
@@ -351,6 +349,20 @@ class AbstractDependencyTreePlugin<T> implements Plugin<T> {
                 return dependencyFromDisplayName(dependencyResult.requested.displayName, [],
                         "Unknown result type: ${dependencyResult.getClass().simpleName}", null)
             }
+        }
+
+        private static boolean canBeResolved(org.gradle.api.artifacts.Configuration configuration) {
+            // The canBeResolved property is available since Gradle 3.3.
+            boolean canBeResolved = !configuration.hasProperty('canBeResolved') || configuration.canBeResolved
+
+            // The function getResolutionAlternatives() which belongs to the DeprecatableConfiguration class is
+            // available since Gradle 6.0.
+            boolean isDeprecatedForResolving = false
+            if (configuration.metaClass.respondsTo(configuration, 'getResolutionAlternatives')) {
+                isDeprecatedForResolving = configuration.getResolutionAlternatives() != null
+            }
+
+            return canBeResolved && !isDeprecatedForResolving
         }
 
         private static String collectCauses(Throwable throwable) {


### PR DESCRIPTION
Align the logic to detect unresolvable configurations with the logic
used by Gradle [1]. This prevents ORT from trying to resolve some
configurations that shall not be resolved, for example the "default"
configuration in many projects, and thereby avoids issues during the
resolution which are impossible to resolve. For example, in such
configurations Gradle can sometimes not determine the correct variant of
a dependency.

[1]: https://github.com/gradle/gradle/blob/0109a3c028c6ac8c6040c5dfcbdec2e5a9c51539/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/ConfigurationDetails.java#L40-L43