### PR TITLE
JSON Schemas: Use references in repository configuration schema

### DIFF
--- a/integrations/schemas/repository-configuration-schema.json
+++ b/integrations/schemas/repository-configuration-schema.json
@@ -153,7 +153,19 @@
         "packages": {
           "$ref": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/curations-schema.json"
         }
-      }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "license_findings"
+          ]
+        },
+        {
+          "required": [
+            "packages"
+          ]
+        }
+      ]
     },
     "package_configurations": {
       "type": "array",

--- a/integrations/schemas/repository-configuration-schema.json
+++ b/integrations/schemas/repository-configuration-schema.json
@@ -213,45 +213,6 @@
     }
   },
   "definitions": {
-    "vcsMatcher": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "revision": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        }
-      },
-      "anyOf": [
-        {
-          "required": [
-            "type"
-          ]
-        },
-        {
-          "required": [
-            "url"
-          ]
-        },
-        {
-          "required": [
-            "revision"
-          ]
-        },
-        {
-          "required": [
-            "path"
-          ]
-        }
-      ]
-    },
     "licenseFindingCurations": {
       "type": "object",
       "properties": {

--- a/integrations/schemas/repository-configuration-schema.json
+++ b/integrations/schemas/repository-configuration-schema.json
@@ -159,48 +159,7 @@
       "type": "array",
       "description": "A configuration for a specific package and provenance.",
       "items": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "source_artifact_url": {
-            "type": "string"
-          },
-          "vcs": {
-            "$ref": "#/definitions/vcsMatcher"
-          },
-          "license_finding_curations": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/licenseFindingCurations"
-            }
-          },
-          "path_excludes": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "pattern": {
-                  "type": "string"
-                },
-                "reason": {
-                  "$ref": "#/definitions/pathExcludeReason"
-                },
-                "comment": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "pattern",
-                "reason"
-              ]
-            }
-          }
-        },
-        "required": [
-          "id"
-        ]
+        "$ref": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/package-configuration-schema.json"
       }
     },
     "license_choices": {

--- a/integrations/schemas/repository-configuration-schema.json
+++ b/integrations/schemas/repository-configuration-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://oss-review-toolkit.org/.ort.yml",
   "title": "ORT repository configuration",
   "description": "The OSS-Review-Toolkit (ORT) provides a possibility to configure exclusions, resolutions and more in a file called `.ort.yml`. A full list of all available options can be found at https://github.com/oss-review-toolkit/ort/blob/main/docs/config-file-ort-yml.md.",
@@ -151,114 +151,9 @@
           }
         },
         "packages": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "curations": {
-                "type": "object",
-                "properties": {
-                  "comment": {
-                    "type": "string"
-                  },
-                  "authors": {
-                    "type": "array",
-                    "items": [
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "concluded_license": {
-                    "type": "string"
-                  },
-                  "cpe": {
-                    "type": "string"
-                  },
-                  "declared_license_mapping": {
-                    "type": "object"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "homepage_url": {
-                    "type": "string"
-                  },
-                  "purl": {
-                    "type": "string"
-                  },
-                  "binary_artifact": {
-                    "type": "object",
-                    "properties": {
-                      "url": {
-                        "type": "string"
-                      },
-                      "hash": {
-                        "type": "string"
-                      },
-                      "hash_algorithm": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "url",
-                      "hash",
-                      "hash_algorithm"
-                    ]
-                  },
-                  "source_artifact": {
-                    "type": "object",
-                    "properties": {
-                      "url": {
-                        "type": "string"
-                      },
-                      "hash": {
-                        "type": "string"
-                      },
-                      "hash_algorithm": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "url",
-                      "hash",
-                      "hash_algorithm"
-                    ]
-                  },
-                  "vcs": {
-                    "$ref": "#/definitions/vcsMatcher"
-                  },
-                  "is_meta_data_only": {
-                    "type": "boolean"
-                  },
-                  "is_modified": {
-                    "type": "boolean"
-                  }
-                }
-              }
-            },
-            "required": [
-              "id",
-              "curations"
-            ]
-          }
+          "$ref": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/curations-schema.json"
         }
-      },
-      "anyOf": [
-        {
-          "required": [
-            "license_findings"
-          ]
-        },
-        {
-          "required": [
-            "packages"
-          ]
-        }
-      ]
+      }
     },
     "package_configurations": {
       "type": "array",

--- a/model/src/test/kotlin/JsonSchemaTest.kt
+++ b/model/src/test/kotlin/JsonSchemaTest.kt
@@ -33,7 +33,7 @@ class JsonSchemaTest : StringSpec() {
     private val mapper = FileFormat.YAML.mapper
 
     private val repositoryConfigurationSchema = JsonSchemaFactory
-        .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4))
+        .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
         .objectMapper(mapper)
         .build()
         .getSchema(File("../integrations/schemas/repository-configuration-schema.json").toURI())


### PR DESCRIPTION
To test this, you can use this configuration in VSCode `settings.json`:

For the .ort.yml:
```json
  "yaml.schemas": {
    "file:///Users/marcel/work/oss/ort/integrations/schemas/repository-configuration-schema.json": "*.ort.yml"
  }
```

