### PR TITLE
Schemas: Add JSON schema for curations

### DIFF
--- a/integrations/schemas/curations-schema.json
+++ b/integrations/schemas/curations-schema.json
@@ -1,0 +1,188 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://oss-review-toolkit.org/curations.yml",
+  "title": "ORT curations",
+  "description": "The OSS-Review-Toolkit (ORT) provides a possibility to correct metadata and set the concluded license for a specific packages (dependencies) in curation files. A full list of all available options can be found at https://github.com/oss-review-toolkit/ort/blob/main/docs/config-file-curations-yml.md.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "curations": {
+        "type": "object",
+        "properties": {
+          "comment": {
+            "type": "string"
+          },
+          "authors": {
+            "type": "array",
+            "items": [
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "concluded_license": {
+            "type": "string"
+          },
+          "cpe": {
+            "type": "string"
+          },
+          "declared_license_mapping": {
+            "type": "object"
+          },
+          "description": {
+            "type": "string"
+          },
+          "homepage_url": {
+            "type": "string"
+          },
+          "purl": {
+            "type": "string"
+          },
+          "binary_artifact": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              },
+              "hash": {
+                "$ref": "#/definitions/hash"
+              },
+              "hash_algorithm": {
+                "type": "string"
+              }
+            },
+            "if": {
+              "properties": {
+                "hash": {
+                  "type": "object"
+                }
+              }
+            },
+            "then": {
+              "required": [
+                "hash"
+              ]
+            },
+            "else": {
+              "required": [
+                "hash",
+                "hash_algorithm"
+              ]
+            },
+            "required": [
+              "url"
+            ]
+          },
+          "source_artifact": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              },
+              "hash": {
+                "$ref": "#/definitions/hash"
+              },
+              "hash_algorithm": {
+                "type": "string"
+              }
+            },
+            "if": {
+              "properties": {
+                "hash": {
+                  "type": "object"
+                }
+              }
+            },
+            "then": {
+              "required": [
+                "hash"
+              ]
+            },
+            "else": {
+              "required": [
+                "hash",
+                "hash_algorithm"
+              ]
+            },
+            "required": [
+              "url"
+            ]
+          },
+          "vcs": {
+            "$ref": "#/definitions/vcsMatcher"
+          },
+          "is_meta_data_only": {
+            "type": "boolean"
+          },
+          "is_modified": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "required": [
+      "id",
+      "curations"
+    ]
+  },
+  "definitions": {
+    "vcsMatcher": {
+      "anyOf": [
+        {
+          "required": [
+            "type"
+          ]
+        },
+        {
+          "required": [
+            "url"
+          ]
+        },
+        {
+          "required": [
+            "revision"
+          ]
+        },
+        {
+          "required": [
+            "path"
+          ]
+        }
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "revision": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "hash": {
+      "type": ["string", "object"],
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "algorithm": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value",
+        "algorithm"
+      ]
+    }
+  }
+}

--- a/model/src/test/assets/package-configuration.yml
+++ b/model/src/test/assets/package-configuration.yml
@@ -1,0 +1,14 @@
+id: "Pip::example-package:0.0.1"
+source_artifact_url: "https://some-host/some-file-path.tgz"
+path_excludes:
+- pattern: "docs/**"
+  reason: "DOCUMENTATION_OF"
+  comment: "This directory contains documentation which is not distributed."
+license_finding_curations:
+- path: "src/**.cpp"
+  start_lines: "3"
+  line_count: 11
+  detected_license: "GPL-2.0-only"
+  reason: "CODE"
+  comment: "The scanner matches a variable named `gpl`."
+  concluded_license: "Apache-2.0"

--- a/model/src/test/kotlin/JsonSchemaTest.kt
+++ b/model/src/test/kotlin/JsonSchemaTest.kt
@@ -47,7 +47,7 @@ class JsonSchemaTest : StringSpec() {
             errors should beEmpty()
         }
 
-        ".ort.yml examples validates successfully" {
+        ".ort.yml examples validate successfully" {
             val examplesDir = File("../examples")
             val exampleFiles =
                 examplesDir.walk().filterTo(mutableListOf()) { it.isFile && it.name.endsWith(".ort.yml") }

--- a/model/src/test/kotlin/JsonSchemaTest.kt
+++ b/model/src/test/kotlin/JsonSchemaTest.kt
@@ -60,6 +60,19 @@ class JsonSchemaTest : StringSpec() {
                 errors should beEmpty()
             }
         }
+
+        "curation.yml example validates successfully" {
+            val curationsSchema = JsonSchemaFactory
+                .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
+                .objectMapper(mapper)
+                .build()
+                .getSchema(File("../integrations/schemas/curations-schema.json").toURI())
+            val curationsExample = File("../examples/curations.yml").toJsonNode()
+
+            val errors = curationsSchema.validate(curationsExample)
+
+            errors should beEmpty()
+        }
     }
 
     private fun File.toJsonNode() = mapper.readTree(inputStream())

--- a/model/src/test/kotlin/JsonSchemaTest.kt
+++ b/model/src/test/kotlin/JsonSchemaTest.kt
@@ -32,7 +32,7 @@ import java.io.File
 class JsonSchemaTest : StringSpec() {
     private val mapper = FileFormat.YAML.mapper
 
-    private val schema = JsonSchemaFactory
+    private val repositoryConfigurationSchema = JsonSchemaFactory
         .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4))
         .objectMapper(mapper)
         .build()
@@ -42,7 +42,7 @@ class JsonSchemaTest : StringSpec() {
         ".ort.yml validates successfully" {
             val repositoryConfiguration = File("../.ort.yml").toJsonNode()
 
-            val errors = schema.validate(repositoryConfiguration)
+            val errors = repositoryConfigurationSchema.validate(repositoryConfiguration)
 
             errors should beEmpty()
         }
@@ -55,7 +55,7 @@ class JsonSchemaTest : StringSpec() {
             exampleFiles.forAll {
                 val repositoryConfiguration = it.toJsonNode()
 
-                val errors = schema.validate(repositoryConfiguration)
+                val errors = repositoryConfigurationSchema.validate(repositoryConfiguration)
 
                 errors should beEmpty()
             }

--- a/model/src/test/kotlin/JsonSchemaTest.kt
+++ b/model/src/test/kotlin/JsonSchemaTest.kt
@@ -73,6 +73,19 @@ class JsonSchemaTest : StringSpec() {
 
             errors should beEmpty()
         }
+
+        "package-configuration.yml validates successfully" {
+            val packageConfigurationSchema = JsonSchemaFactory
+                .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4))
+                .objectMapper(mapper)
+                .build()
+                .getSchema(File("../integrations/schemas/package-configuration-schema.json").toURI())
+            val packageConfiguration = File("src/test/assets/package-configuration.yml").toJsonNode()
+
+            val errors = packageConfigurationSchema.validate(packageConfiguration)
+
+            errors should beEmpty()
+        }
     }
 
     private fun File.toJsonNode() = mapper.readTree(inputStream())


### PR DESCRIPTION
Moving this from https://github.com/oss-review-toolkit/ort/pull/5395 to a separate PR, as the test won't pass without this being merged first.

This can be tested with this setting in VSCode:
```json
  "yaml.schemas": {
    "file:///Users/marcel/work/oss/ort/integrations/schemas/curations-schema.json": "*.yml"
  }
```
