### PR TITLE
FossId: Explicitly install the ORT authenticator

### DIFF
--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -76,6 +76,7 @@ import org.ossreviewtoolkit.scanner.experimental.ScanContext
 import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.common.toUri
+import org.ossreviewtoolkit.utils.ort.installAuthenticatorAndProxySelector
 import org.ossreviewtoolkit.utils.ort.log
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
@@ -230,6 +231,8 @@ class FossId internal constructor(
         packages: Set<Package>,
         labels: Map<String, String>
     ): Map<Package, List<ScanResult>> {
+        installAuthenticatorAndProxySelector()
+
         val (results, duration) = measureTimedValue {
             val results = mutableMapOf<Package, MutableList<ScanResult>>()
 


### PR DESCRIPTION
The authenticator is needed to add credentials to the Git URL passed
to FossID. Recent changes in the scanner infrastructure have obviously
caused that the ORT authenticator has not always been installed when a
new FossID scan is created. The scan then fails due to missing
credentials.
