### PR TITLE
package-configuration-schema: Update schema version to draft-07

### DIFF
--- a/integrations/schemas/package-configuration-schema.json
+++ b/integrations/schemas/package-configuration-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://oss-review-toolkit.org/package-configuration.yml",
   "title": "ORT package configuration",
   "description": "The OSS-Review-Toolkit (ORT) provides a possibility to define path excludes and license finding curations for a specific package (dependency) and provenance in a package configuration file. A full list of all available options can be found at https://github.com/oss-review-toolkit/ort/blob/main/docs/config-file-package-configuration-yml.md.",

--- a/model/src/test/kotlin/JsonSchemaTest.kt
+++ b/model/src/test/kotlin/JsonSchemaTest.kt
@@ -76,7 +76,7 @@ class JsonSchemaTest : StringSpec() {
 
         "package-configuration.yml validates successfully" {
             val packageConfigurationSchema = JsonSchemaFactory
-                .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4))
+                .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
                 .objectMapper(mapper)
                 .build()
                 .getSchema(File("../integrations/schemas/package-configuration-schema.json").toURI())


### PR DESCRIPTION
This schema will be referenced from the repository-configuration schema
which requires version draft-07. Use this version consistently.

This is split from https://github.com/oss-review-toolkit/ort/pull/5395 as it has to be merged to master before the tests will succeeed in https://github.com/oss-review-toolkit/ort/pull/5395.
