### PR TITLE
Schemas: Add JSON schema for resolutions

### DIFF
--- a/integrations/schemas/resolutions-schema.json
+++ b/integrations/schemas/resolutions-schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://oss-review-toolkit.org/resolutions.yml",
+  "title": "ORT resolutions",
+  "description": "The OSS-Review-Toolkit (ORT) provides a possibility to resolve issues, rule violations and security vulnerabilities in a resolutions file. A full list of all available options can be found at https://github.com/oss-review-toolkit/ort/blob/main/docs/config-file-resolutions-yml.md.",
+  "type": "object",
+  "properties": {
+    "issues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "reason": {
+            "$ref": "#/definitions/issueResolutionReason"
+          },
+          "comment": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message",
+          "reason"
+        ]
+      }
+    },
+    "rule_violations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "reason": {
+            "$ref": "#/definitions/ruleViolationResolutionReason"
+          },
+          "comment": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message",
+          "reason"
+        ]
+      }
+    },
+    "vulnerabilities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "reason": {
+            "$ref": "#/definitions/vulnerabilityResolutionReason"
+          },
+          "comment": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "reason"
+        ]
+      }
+    }
+  },
+  "anyOf": [
+    {
+      "required": [
+        "issues"
+      ]
+    },
+    {
+      "required": [
+        "rule_violations"
+      ]
+    },
+    {
+      "required": [
+        "vulnerabilities"
+      ]
+    }
+  ],
+  "definitions": {
+    "issueResolutionReason": {
+      "enum": [
+        "BUILD_TOOL_ISSUE",
+        "CANT_FIX_ISSUE",
+        "SCANNER_ISSUE"
+      ]
+    },
+    "ruleViolationResolutionReason": {
+      "enum": [
+        "CANT_FIX_EXCEPTION",
+        "DYNAMIC_LINKAGE_EXCEPTION",
+        "EXAMPLE_OF_EXCEPTION",
+        "LICENSE_ACQUIRED_EXCEPTION",
+        "NOT_MODIFIED_EXCEPTION",
+        "PATENT_GRANT_EXCEPTION"
+      ]
+    },
+    "vulnerabilityResolutionReason": {
+      "enum": [
+        "CANT_FIX_VULNERABILITY",
+        "INEFFECTIVE_VULNERABILITY",
+        "INVALID_MATCH_VULNERABILITY",
+        "MITIGATED_VULNERABILITY",
+        "WILL_NOT_FIX_VULNERABILITY",
+        "WORKAROUND_FOR_VULNERABILITY"
+      ]
+    }
+  }
+}

--- a/model/src/test/kotlin/JsonSchemaTest.kt
+++ b/model/src/test/kotlin/JsonSchemaTest.kt
@@ -86,6 +86,19 @@ class JsonSchemaTest : StringSpec() {
 
             errors should beEmpty()
         }
+
+        "resolutions.yml example validates successfully" {
+            val curationsSchema = JsonSchemaFactory
+                .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
+                .objectMapper(mapper)
+                .build()
+                .getSchema(File("../integrations/schemas/resolutions-schema.json").toURI())
+            val curationsExample = File("../examples/resolutions.yml").toJsonNode()
+
+            val errors = curationsSchema.validate(curationsExample)
+
+            errors should beEmpty()
+        }
     }
 
     private fun File.toJsonNode() = mapper.readTree(inputStream())


### PR DESCRIPTION
Taken from the repository configuration schema. The resolutions schema
in the .ort.yml schema will be replaced with a reference in a follow-up
commit.