### PR TITLE
ScannerConfiguration: Add option to provide detected license mappings

### DIFF
--- a/model/src/main/kotlin/LicenseFinding.kt
+++ b/model/src/main/kotlin/LicenseFinding.kt
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
+import org.ossreviewtoolkit.utils.spdx.isSpdxExpression
 import org.ossreviewtoolkit.utils.spdx.toSpdx
 
 /**
@@ -51,9 +52,41 @@ data class LicenseFinding(
 ) : Comparable<LicenseFinding> {
     companion object {
         private val COMPARATOR = compareBy<LicenseFinding>({ it.license.toString() }, { it.location })
+
+        /**
+         * Create a [LicenseFinding] with [detectedLicenseMapping]s applied.
+         */
+        fun createAndMap(
+            license: String,
+            location: TextLocation,
+            score: Float? = null,
+            detectedLicenseMapping: Map<String, String>
+        ): LicenseFinding = LicenseFinding(
+            license = if (license.isSpdxExpression() || detectedLicenseMapping.isEmpty()) {
+                license
+            } else {
+                license.applyDetectedLicenseMapping(detectedLicenseMapping)
+            }.toSpdx(),
+            location = location,
+            score = score
+        )
     }
 
     constructor(license: String, location: TextLocation, score: Float? = null) : this(license.toSpdx(), location, score)
 
     override fun compareTo(other: LicenseFinding) = COMPARATOR.compare(this, other)
+}
+
+/**
+ * Apply [detectedLicenseMapping] from the [org.ossreviewtoolkit.model.config.ScannerConfiguration] to any license
+ * String.
+ */
+private fun String.applyDetectedLicenseMapping(detectedLicenseMapping: Map<String, String>): String {
+    var result = this
+    detectedLicenseMapping.forEach { (from, to) ->
+        // Replace a license restricted by whitespace boundaries.
+        result = result.replace("""(?<!\S)${Regex.escape(from)}""".toRegex(), to)
+    }
+
+    return result
 }

--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 
 import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.utils.ort.storage.FileStorage
+import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 
 typealias ScannerOptions = Map<String, String>
 
@@ -50,6 +51,33 @@ data class ScannerConfiguration(
      * Create archives for packages that have a stored scan result but no license archive yet.
      */
     val createMissingArchives: Boolean = false,
+
+    /**
+     * Mappings from licenses returned by the scanner to valid SPDX licenses. Note that these mappings are only applied
+     * in new scans, stored scan results are not affected.
+     */
+    val detectedLicenseMapping: Map<String, String> = mapOf(
+        // https://scancode-licensedb.aboutcode.org/?search=generic
+        "LicenseRef-scancode-agpl-generic-additional-terms" to SpdxConstants.NOASSERTION,
+        "LicenseRef-scancode-generic-cla" to SpdxConstants.NOASSERTION,
+        "LicenseRef-scancode-generic-exception" to SpdxConstants.NOASSERTION,
+        "LicenseRef-scancode-generic-export-compliance" to SpdxConstants.NOASSERTION,
+        "LicenseRef-scancode-generic-tos" to SpdxConstants.NOASSERTION,
+        "LicenseRef-scancode-generic-trademark" to SpdxConstants.NOASSERTION,
+        "LicenseRef-scancode-gpl-generic-additional-terms" to SpdxConstants.NOASSERTION,
+        "LicenseRef-scancode-patent-disclaimer" to SpdxConstants.NOASSERTION,
+        "LicenseRef-scancode-warranty-disclaimer" to SpdxConstants.NOASSERTION,
+
+        // https://scancode-licensedb.aboutcode.org/?search=other
+        "LicenseRef-scancode-other-copyleft" to SpdxConstants.NOASSERTION,
+        "LicenseRef-scancode-other-permissive" to SpdxConstants.NOASSERTION,
+
+        // https://scancode-licensedb.aboutcode.org/?search=unknown
+        "LicenseRef-scancode-free-unknown" to SpdxConstants.NOASSERTION,
+        "LicenseRef-scancode-unknown" to SpdxConstants.NOASSERTION,
+        "LicenseRef-scancode-unknown-license-reference" to SpdxConstants.NOASSERTION,
+        "LicenseRef-scancode-unknown-spdx" to SpdxConstants.NOASSERTION
+    ),
 
     /**
      * Scanner specific configuration options. The key needs to match the name of the scanner class, e.g. "ScanCode"

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -104,6 +104,13 @@ ort {
 
     createMissingArchives = false
 
+    # Map scanner license findings to valid SPDX licenses. Note that these mappings are only applied in new scans,
+    # stored scan results are not affected.
+    detectedLicenseMapping {
+      "BSD (Three Clause License)" = "BSD-3-clause",
+      "LicenseRef-scancode-generic-cla" = "NOASSERTION"
+    }
+
     options {
       # A map of maps from scanner class names to scanner-specific key-value pairs.
       # At the example of applying custom options for ScanCode, this would look like:

--- a/model/src/test/kotlin/LicenseFindingTest.kt
+++ b/model/src/test/kotlin/LicenseFindingTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2022 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.utils.spdx.toSpdx
+
+class LicenseFindingTest : WordSpec({
+    "createAndMap()" should {
+        "apply the detected license mapping to simple SPDX expressions" {
+            LicenseFinding.createAndMap(
+                license = "BSD (3-Clause)",
+                location = TextLocation(".", -1),
+                detectedLicenseMapping = mapOf(
+                    "BSD (3-Clause)" to "BSD-3-Clause",
+                )
+            ) shouldBe LicenseFinding(
+                license = "BSD-3-Clause".toSpdx(),
+                location = TextLocation(".", -1),
+            )
+        }
+
+        "apply the detected license mapping only to full SPDX expressions" {
+            LicenseFinding.createAndMap(
+                license = "AGPL-1.0-or-later",
+                location = TextLocation(".", -1),
+                detectedLicenseMapping = mapOf(
+                    "GPL-1.0-or-later" to "GPL-1.0-only",
+                )
+            ) shouldBe LicenseFinding(
+                license = "AGPL-1.0-or-later".toSpdx(),
+                location = TextLocation(".", -1),
+            )
+        }
+
+        "apply the detected license mapping to non-parsable SPDX licenses" {
+            LicenseFinding.createAndMap(
+                license = "[template] Commercial License OR Commercial [template] License OR " +
+                    "Commercial License [template] OR (example) test license OR " +
+                    "test (example) license OR test license (example)",
+                location = TextLocation(".", -1),
+                detectedLicenseMapping = mapOf(
+                    "[template] Commercial License" to "LicenseRef-scancode-proprietary-license",
+                    "Commercial [template] License" to "LicenseRef-scancode-proprietary-license",
+                    "Commercial License [template]" to "LicenseRef-scancode-proprietary-license",
+                    "(example) test license" to "LicenseRef-scancode-proprietary-license",
+                    "test (example) license" to "LicenseRef-scancode-proprietary-license",
+                    "test license (example)" to "LicenseRef-scancode-proprietary-license",
+                )
+            ) shouldBe LicenseFinding(
+                license = "LicenseRef-scancode-proprietary-license OR LicenseRef-scancode-proprietary-license OR " +
+                    "LicenseRef-scancode-proprietary-license OR LicenseRef-scancode-proprietary-license OR " +
+                    "LicenseRef-scancode-proprietary-license OR LicenseRef-scancode-proprietary-license",
+                location = TextLocation(".", -1),
+            )
+        }
+
+        "apply the detected license mapping to complex SPDX expressions" {
+            LicenseFinding.createAndMap(
+                license = "(AGPL-1.0-or-later AND BSD (3-Clause)) OR MIT",
+                location = TextLocation(".", -1),
+                detectedLicenseMapping = mapOf(
+                    "BSD (3-Clause)" to "BSD-3-Clause",
+                )
+            ) shouldBe LicenseFinding(
+                license = "(AGPL-1.0-or-later AND BSD-3-Clause) OR MIT".toSpdx(),
+                location = TextLocation(".", -1),
+            )
+        }
+
+        "apply the detected license mapping to multiple SPDX expressions" {
+            LicenseFinding.createAndMap(
+                license = "AGPL-1.0-or-later OR BSD (3-Clause) OR BSD (2-Clause)",
+                location = TextLocation(".", -1),
+                detectedLicenseMapping = mapOf(
+                    "BSD (3-Clause)" to "BSD-3-Clause",
+                    "BSD (2-Clause)" to "BSD-2-Clause",
+                )
+            ) shouldBe LicenseFinding(
+                license = "AGPL-1.0-or-later OR BSD-3-Clause OR BSD-2-Clause".toSpdx(),
+                location = TextLocation(".", -1),
+            )
+        }
+    }
+})

--- a/scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
@@ -205,6 +205,22 @@ scanner:
   config:
     skip_concluded: false
     create_missing_archives: false
+    detected_license_mapping:
+      LicenseRef-scancode-agpl-generic-additional-terms: "NOASSERTION"
+      LicenseRef-scancode-generic-cla: "NOASSERTION"
+      LicenseRef-scancode-generic-exception: "NOASSERTION"
+      LicenseRef-scancode-generic-export-compliance: "NOASSERTION"
+      LicenseRef-scancode-generic-tos: "NOASSERTION"
+      LicenseRef-scancode-generic-trademark: "NOASSERTION"
+      LicenseRef-scancode-gpl-generic-additional-terms: "NOASSERTION"
+      LicenseRef-scancode-patent-disclaimer: "NOASSERTION"
+      LicenseRef-scancode-warranty-disclaimer: "NOASSERTION"
+      LicenseRef-scancode-other-copyleft: "NOASSERTION"
+      LicenseRef-scancode-other-permissive: "NOASSERTION"
+      LicenseRef-scancode-free-unknown: "NOASSERTION"
+      LicenseRef-scancode-unknown: "NOASSERTION"
+      LicenseRef-scancode-unknown-license-reference: "NOASSERTION"
+      LicenseRef-scancode-unknown-spdx: "NOASSERTION"
     ignore_patterns:
     - "**/*.ort.yml"
     - "**/*.spdx.yml"

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -124,14 +124,15 @@ class Askalono internal constructor(
         result.lines().forEach { line ->
             val root = jsonMapper.readTree(line)
             root["result"]?.let { result ->
-                val licenseFinding = LicenseFinding(
+                val licenseFinding = LicenseFinding.createAndMap(
                     license = result["license"]["name"].textValue(),
                     location = TextLocation(
                         // Turn absolute paths in the native result into relative paths to not expose any information.
                         relativizePath(scanPath, File(root["path"].textValue())),
                         TextLocation.UNKNOWN_LINE
                     ),
-                    score = result["score"].floatValue()
+                    score = result["score"].floatValue(),
+                    detectedLicenseMapping = scannerConfig.detectedLicenseMapping
                 )
 
                 licenseFindings += licenseFinding

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -138,14 +138,15 @@ class BoyterLc internal constructor(
         result.flatMapTo(licenseFindings) { file ->
             val filePath = File(file["Directory"].textValue(), file["Filename"].textValue())
             file["LicenseGuesses"].map {
-                LicenseFinding(
+                LicenseFinding.createAndMap(
                     license = it["LicenseId"].textValue(),
                     location = TextLocation(
                         // Turn absolute paths in the native result into relative paths to not expose any information.
                         relativizePath(scanPath, filePath),
                         TextLocation.UNKNOWN_LINE
                     ),
-                    score = it["Percentage"].floatValue()
+                    score = it["Percentage"].floatValue(),
+                    detectedLicenseMapping = scannerConfig.detectedLicenseMapping
                 )
             }
         }

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -109,14 +109,15 @@ class Licensee internal constructor(
 
         matchedFiles.mapTo(licenseFindings) {
             val filePath = File(it["filename"].textValue())
-            LicenseFinding(
+            LicenseFinding.createAndMap(
                 license = it["matched_license"].textValue(),
                 location = TextLocation(
                     // The path is already relative.
                     filePath.path,
                     TextLocation.UNKNOWN_LINE
                 ),
-                score = it["matcher"]["confidence"].floatValue()
+                score = it["matcher"]["confidence"].floatValue(),
+                detectedLicenseMapping = scannerConfig.detectedLicenseMapping
             )
         }
 

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -723,7 +723,7 @@ class FossId internal constructor(
 
         val (licenseFindings, copyrightFindings) = rawResults.markedAsIdentifiedFiles.ifEmpty {
             rawResults.identifiedFiles
-        }.mapSummary(ignoredFiles, issues)
+        }.mapSummary(ignoredFiles, issues, scannerConfig.detectedLicenseMapping)
 
         val summary = ScanSummary(
             startTime = startTime,

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdScanResults.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdScanResults.kt
@@ -31,56 +31,6 @@ import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.utils.common.collectMessages
 
 /**
- * Collection of problematic FossID license expressions. Compiled from FossID's list of licenses. May be updated if
- * FossID adds new licenses.
- */
-private val fossIdLicenseMappings = mapOf(
-    "BSD (Three Clause License)" to "BSD-3-clause",
-    "BSD-Acknowledgment-(Carrot2)" to "LicenseRef-scancode-bsd-ack-carrot2",
-    "Freeware-Public-(FPL)" to "LicenseRef-scancode-fpl",
-    "MediaInfo(Lib)" to "LicenseRef-scancode-mediainfo-lib",
-    "Oracle-Master-Agreement-(OMA)" to "LicenseRef-scancode-oracle-master-agreement",
-    "Things-I-Made-(TIM)-Public" to "LicenseRef-scancode-things-i-made-public-license",
-    "X11-Style-(Adobe)" to "LicenseRef-scancode-x11-adobe",
-    "X11-Style-(Adobe-DEC)" to "LicenseRef-scancode-x11-adobe-dec",
-    "X11-Style-(Bitstream-Charter)" to "LicenseRef-scancode-x11-bitstream",
-    "X11-Style-(DEC-1)" to "LicenseRef-scancode-x11-dec1",
-    "X11-Style-(DEC-2)" to "LicenseRef-scancode-x11-dec2",
-    "X11-Style-(DSC-Technologies)" to "LicenseRef-scancode-x11-dsc",
-    "X11-Style-(David-R.-Hanson)" to "LicenseRef-scancode-x11-hanson",
-    "X11-Style-(Keith-Packard)" to "HPND-sell-variant",
-    "X11-Style-(Lucent)" to "LicenseRef-scancode-x11-lucent",
-    "X11-Style-(OAR)" to "LicenseRef-scancode-x11-oar",
-    "X11-Style-(Open-Group)" to "MIT-open-group",
-    "X11-Style-(Quarterdeck)" to "LicenseRef-scancode-x11-quarterdeck",
-    "X11-Style-(Realmode)" to "LicenseRef-scancode-x11-realmode",
-    "X11-Style-(Silicon-Graphics)" to "LicenseRef-scancode-x11-sg",
-    "X11-Style-(Tektronix)" to "LicenseRef-scancode-x11-tektronix",
-    "u_Agere-BSD" to "LicenseRef-scancode-agere-bsd",
-    "u_BSD-3-Clause-Sun" to "LicenseRef-scancode-bsd-3-clause-sun",
-    "u_CC-BY-2.0-UK" to "LicenseRef-scancode-cc-by-2.0-uk",
-    "u_GLUT-License" to "LicenseRef-scancode-glut",
-    "u_HACOS-1.2" to "LicenseRef-scancode-hacos-1.2",
-    "u_Jscheme-License" to "LicenseRef-scancode-jscheme",
-    "u_MongoDB-SSPL-1.0" to "SSPL-1.0",
-    "u_Philips-Proprietary-Notice-2000" to "LicenseRef-scancode-philips-proprietary-notice-2000",
-    "u_Sun-BCL-11-plus-6" to "LicenseRef-scancode-sun-bcl-11-06",
-    "u_Sun-Communications-API" to "LicenseRef-scancode-sun-communications-api",
-    "u_Sun-EJB-Specification-3.0" to "LicenseRef-scancode-sun-ejb-spec-3.0",
-    "u_Sun-Entitlement-3-plus-15" to "LicenseRef-scancode-sun-entitlement-03-15",
-    "u_Sun-Entitlement-JAF" to "LicenseRef-scancode-sun-entitlement-jaf",
-    "u_Sun-Java-Web-Services-Developer-Pack-1.6" to "Xerox",
-    "u_Sun-JavaMail" to "LicenseRef-scancode-sun-javamail",
-    "u_Sun-Project-X" to "LicenseRef-scancode-sun-project-x",
-    "u_Taligent-JDK-Proprietary-Notice" to "LicenseRef-scancode-taligent-jdk",
-    "u_Trolltech-GPL-Exception-1.2" to "LicenseRef-scancode-trolltech-gpl-exception-1.2",
-    "u_Vuforia-2013-07-29" to "LicenseRef-scancode-vuforia-2013-07-29",
-    "u_Xerox" to "Xerox",
-    "u_nexB-EULA-for-SaaS-1.1.0" to "LicenseRef-scancode-nexb-eula-saas-1.1.0",
-    "u_nexB-SSLA-1.1.0" to "LicenseRef-scancode-nexb-ssla-1.1.0"
-)
-
-/**
  * A data class to hold FossID raw results.
  */
 internal data class RawResults(
@@ -115,16 +65,14 @@ internal fun <T : Summarizable> List<T>.mapSummary(
         val location = TextLocation(summary.path, TextLocation.UNKNOWN_LINE, TextLocation.UNKNOWN_LINE)
 
         summary.licences.forEach {
-            val license = fossIdLicenseMappings[it.identifier] ?: it.identifier
-
             runCatching {
-                LicenseFinding.createAndMap(license, location, detectedLicenseMapping = detectedLicenseMapping)
+                LicenseFinding.createAndMap(it.identifier, location, detectedLicenseMapping = detectedLicenseMapping)
             }.onSuccess { licenseFinding ->
                 licenseFindings += licenseFinding.copy(license = licenseFinding.license.normalize())
             }.onFailure { spdxException ->
                 issues += createAndLogIssue(
                     source = "FossId",
-                    message = "Failed to parse license '$license' as an SPDX expression: " +
+                    message = "Failed to parse license '${it.identifier}' as an SPDX expression: " +
                             spdxException.collectMessages()
                 )
             }

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -197,7 +197,14 @@ class ScanCode internal constructor(
         resultFile.parentFile.safeDeleteRecursively(force = true)
 
         val parseLicenseExpressions = scanCodeConfiguration["parseLicenseExpressions"].isTrue()
-        val summary = generateSummary(startTime, endTime, path, result, parseLicenseExpressions)
+        val summary = generateSummary(
+            startTime,
+            endTime,
+            path,
+            result,
+            scannerConfig.detectedLicenseMapping,
+            parseLicenseExpressions
+        )
 
         val issues = summary.issues.toMutableList()
 

--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
@@ -119,7 +119,13 @@ class ScanOss internal constructor(
         }.toMap()
 
         val endTime = Instant.now()
-        return generateSummary(startTime, endTime, path, resolvedResponse)
+        return generateSummary(
+            startTime,
+            endTime,
+            path,
+            resolvedResponse,
+            scannerConfig.detectedLicenseMapping
+        )
     }
 
     internal fun generateRandomUUID() = UUID.randomUUID()

--- a/scanner/src/test/kotlin/scanners/scancode/ScanCodeResultParserTest.kt
+++ b/scanner/src/test/kotlin/scanners/scancode/ScanCodeResultParserTest.kt
@@ -432,7 +432,7 @@ class ScanCodeResultParserTest : FreeSpec({
                         score = 100.0f
                     ),
                     LicenseFinding(
-                        license = "NOASSERTION",
+                        license = "LicenseRef-scancode-free-unknown",
                         location = TextLocation(
                             path = "Downloads/wasi-0.10.2+wasi-snapshot-preview1/ORG_CODE_OF_CONDUCT.md",
                             startLine = 106,
@@ -441,7 +441,7 @@ class ScanCodeResultParserTest : FreeSpec({
                         score = 50.0f
                     ),
                     LicenseFinding(
-                        license = "NOASSERTION",
+                        license = "LicenseRef-scancode-unknown-license-reference",
                         location = TextLocation("Downloads/wasi-0.10.2+wasi-snapshot-preview1/README.md", 88, 88),
                         score = 100.0f
                     ),

--- a/scanner/src/test/kotlin/scanners/scanoss/ScanOssResultParserTest.kt
+++ b/scanner/src/test/kotlin/scanners/scanoss/ScanOssResultParserTest.kt
@@ -45,7 +45,7 @@ class ScanOssResultParserTest : WordSpec({
             }
 
             val time = Instant.now()
-            val summary = generateSummary(time, time, SpdxConstants.NONE, result)
+            val summary = generateSummary(time, time, SpdxConstants.NONE, result, emptyMap())
 
             summary.licenses.map { it.toString() } should containExactlyInAnyOrder(
                 "Apache-2.0",


### PR DESCRIPTION
Scanners might return invalid SPDX license expressions. This causes
issues when reading the scanner results. Provide an option that users
can map detected licenses in the scanner configuration.

This functionality is not limited to invalid SPDX expressions. The user
can also map unwanted licenses, like `LicenseRef-scancode-unknown` to
`NOASSERTION`.

The mapping is being done when creating the LicenseFinding after
receiving the results from the scanners. This has the advantage that
internally, ORT handles only valid SPDX expressions. The disadvantage
of that approach is, that mapped licenses are stored in the
ScanResultStorage which might become invalid when the detected license
mapping in the scanner configuration is changed.

Resolves https://github.com/oss-review-toolkit/ort/issues/5345.

This PR removes some hard coded license mappings to make them user configurable, this is the configuration to reproduce the previous behavior:
```
ort {
  scanner {
    detectedLicenseMapping {
      # https://scancode-licensedb.aboutcode.org/?search=generic
      "LicenseRef-scancode-agpl-generic-additional-terms" = "NOASSERTION"
      "LicenseRef-scancode-generic-cla" = "NOASSERTION"
      "LicenseRef-scancode-generic-exception" = "NOASSERTION"
      "LicenseRef-scancode-generic-export-compliance" = "NOASSERTION"
      "LicenseRef-scancode-generic-tos" = "NOASSERTION"
      "LicenseRef-scancode-generic-trademark" = "NOASSERTION"
      "LicenseRef-scancode-gpl-generic-additional-terms" = "NOASSERTION"
      "LicenseRef-scancode-patent-disclaimer" = "NOASSERTION"
      "LicenseRef-scancode-warranty-disclaimer" = "NOASSERTION"

      # https://scancode-licensedb.aboutcode.org/?search=other
      "LicenseRef-scancode-other-copyleft" = "NOASSERTION"
      "LicenseRef-scancode-other-permissive" = "NOASSERTION"

      # https://scancode-licensedb.aboutcode.org/?search=unknown
      "LicenseRef-scancode-free-unknown" = "NOASSERTION"
      "LicenseRef-scancode-unknown" = "NOASSERTION"
      "LicenseRef-scancode-unknown-license-reference" = "NOASSERTION"
      "LicenseRef-scancode-unknown-spdx" = "NOASSERTION"

      # FossID
      "BSD (Three Clause License)" = "BSD-3-clause"
      "BSD-Acknowledgment-(Carrot2)" = "LicenseRef-scancode-bsd-ack-carrot2"
      "Freeware-Public-(FPL)" = "LicenseRef-scancode-fpl"
      "MediaInfo(Lib)" = "LicenseRef-scancode-mediainfo-lib"
      "Oracle-Master-Agreement-(OMA)" = "LicenseRef-scancode-oracle-master-agreement"
      "Things-I-Made-(TIM)-Public" = "LicenseRef-scancode-things-i-made-public-license"
      "X11-Style-(Adobe)" = "LicenseRef-scancode-x11-adobe"
      "X11-Style-(Adobe-DEC)" = "LicenseRef-scancode-x11-adobe-dec"
      "X11-Style-(Bitstream-Charter)" = "LicenseRef-scancode-x11-bitstream"
      "X11-Style-(DEC-1)" = "LicenseRef-scancode-x11-dec1"
      "X11-Style-(DEC-2)" = "LicenseRef-scancode-x11-dec2"
      "X11-Style-(DSC-Technologies)" = "LicenseRef-scancode-x11-dsc"
      "X11-Style-(David-R.-Hanson)" = "LicenseRef-scancode-x11-hanson"
      "X11-Style-(Keith-Packard)" = "HPND-sell-variant"
      "X11-Style-(Lucent)" = "LicenseRef-scancode-x11-lucent"
      "X11-Style-(OAR)" = "LicenseRef-scancode-x11-oar"
      "X11-Style-(Open-Group)" = "MIT-open-group"
      "X11-Style-(Quarterdeck)" = "LicenseRef-scancode-x11-quarterdeck"
      "X11-Style-(Realmode)" = "LicenseRef-scancode-x11-realmode"
      "X11-Style-(Silicon-Graphics)" = "LicenseRef-scancode-x11-sg"
      "X11-Style-(Tektronix)" = "LicenseRef-scancode-x11-tektronix"
      "u_Agere-BSD" = "LicenseRef-scancode-agere-bsd"
      "u_BSD-3-Clause-Sun" = "LicenseRef-scancode-bsd-3-clause-sun"
      "u_CC-BY-2.0-UK" = "LicenseRef-scancode-cc-by-2.0-uk"
      "u_GLUT-License" = "LicenseRef-scancode-glut"
      "u_HACOS-1.2" = "LicenseRef-scancode-hacos-1.2"
      "u_Jscheme-License" = "LicenseRef-scancode-jscheme"
      "u_MongoDB-SSPL-1.0" = "SSPL-1.0"
      "u_Philips-Proprietary-Notice-2000" = "LicenseRef-scancode-philips-proprietary-notice-2000"
      "u_Sun-BCL-11-plus-6" = "LicenseRef-scancode-sun-bcl-11-06"
      "u_Sun-Communications-API" = "LicenseRef-scancode-sun-communications-api"
      "u_Sun-EJB-Specification-3.0" = "LicenseRef-scancode-sun-ejb-spec-3.0"
      "u_Sun-Entitlement-3-plus-15" = "LicenseRef-scancode-sun-entitlement-03-15"
      "u_Sun-Entitlement-JAF" = "LicenseRef-scancode-sun-entitlement-jaf"
      "u_Sun-Java-Web-Services-Developer-Pack-1.6" = "Xerox"
      "u_Sun-JavaMail" = "LicenseRef-scancode-sun-javamail"
      "u_Sun-Project-X" = "LicenseRef-scancode-sun-project-x"
      "u_Taligent-JDK-Proprietary-Notice" = "LicenseRef-scancode-taligent-jdk"
      "u_Trolltech-GPL-Exception-1.2" = "LicenseRef-scancode-trolltech-gpl-exception-1.2"
      "u_Vuforia-2013-07-29" = "LicenseRef-scancode-vuforia-2013-07-29"
      "u_Xerox" = "Xerox"
      "u_nexB-EULA-for-SaaS-1.1.0" = "LicenseRef-scancode-nexb-eula-saas-1.1.0"
      "u_nexB-SSLA-1.1.0" = "LicenseRef-scancode-nexb-ssla-1.1.0"
    }
  }
}
```