### PR TITLE
FossId: Remove package filter options

### DIFF
--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -136,7 +136,6 @@ ort {
         namingVariableVar3 = "myUnit"
 
         waitForResult = "false"
-        packageNamespaceFilter = "myorg.myunit"
         addAuthenticationToUrl = "false"
 
         deltaScans = "true"

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -227,15 +227,6 @@ class FossId internal constructor(
         val (results, duration) = measureTimedValue {
             val results = mutableMapOf<Package, MutableList<ScanResult>>()
 
-            log.info {
-                if (config.packageNamespaceFilter.isEmpty()) "No package namespace filter is set."
-                else "Package namespace filter is '${config.packageNamespaceFilter}'."
-            }
-            log.info {
-                if (config.packageAuthorsFilter.isEmpty()) "No package authors filter is set."
-                else "Package authors filter is '${config.packageAuthorsFilter}'."
-            }
-
             fun addPackageWithSingleIssue(pkg: Package, issue: OrtIssue, provenance: Provenance) {
                 val time = Instant.now()
                 val summary = ScanSummary(time, time, "", sortedSetOf(), sortedSetOf(), listOf(issue))
@@ -244,8 +235,6 @@ class FossId internal constructor(
             }
 
             val filteredPackages = packages
-                .filter { config.packageNamespaceFilter.isEmpty() || it.id.namespace == config.packageNamespaceFilter }
-                .filter { config.packageAuthorsFilter.isEmpty() || config.packageAuthorsFilter in it.authors }
                 .partition { it.vcsProcessed.type == VcsType.GIT }
                 .let { (packagesInsideGit, packagesOutsideGit) ->
                     packagesOutsideGit.forEach {

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
@@ -31,22 +31,22 @@ import org.ossreviewtoolkit.utils.ort.log
  * * **"user":** The user to connect to the FossID server.
  * * **"apiKey":** The API key of the user which connects to the FossID server.
  * * **"waitForResult":** When set to false, ORT doesn't wait for repositories to be downloaded nor scans to be
- * completed. As a consequence, scan results won't be available in ORT result.
+ *   completed. As a consequence, scan results won't be available in ORT result.
  * * **"packageNamespaceFilter":** If this optional filter is set, only packages having an identifier in given namespace
- * will be scanned.
+ *   will be scanned.
  * * **"packageAuthorsFilter":** If this optional filter is set, only packages from a given author will be scanned.
  * * **"addAuthenticationToUrl":** When set, ORT will add credentials from its Authenticator to the URLs sent to FossID.
  * * **"deltaScans":** When set, ORT will create delta scans. When only changes in a repository need to be scanned,
- * delta scans reuse the identifications of latest scan on this repository to reduce the amount of findings. If
- * deltaScans is set and no scan exist yet, an initial scan called "origin" scan will be created.
+ *   delta scans reuse the identifications of latest scan on this repository to reduce the amount of findings. If
+ *   deltaScans is set and no scan exist yet, an initial scan called "origin" scan will be created.
  * * **"deltaScanLimit":** This setting can be used to limit the number of delta scans to keep for a given repository.
- * So if another delta scan is created, older delta scans are deleted until this number is reached. If unspecified, no
- * limit is enforced on the number of delta scans to keep. This property is evaluated only if *deltaScans* is enabled.
+ *   So if another delta scan is created, older delta scans are deleted until this number is reached. If unspecified, no
+ *   limit is enforced on the number of delta scans to keep. This property is evaluated only if *deltaScans* is enabled.
  *
  * Naming conventions options. If they are not set, default naming convention are used.
  * * **"namingProjectPattern":** A pattern for project names when projects are created on the FossID instance. Contains
- * variables prefixed by "$" e.g. "$Var1_$Var2". Variables are also passed as options and are prefixed by
- * [NAMING_CONVENTION_VARIABLE_PREFIX] e.g. namingVariableVar1 = "foo".
+ *   variables prefixed by "$" e.g. "$Var1_$Var2". Variables are also passed as options and are prefixed by
+ *   [NAMING_CONVENTION_VARIABLE_PREFIX] e.g. namingVariableVar1 = "foo".
  * * **"namingScanPattern":** A pattern for scan names when scans are created on the FossID instance.
  */
 internal data class FossIdConfig(

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
@@ -142,15 +142,15 @@ internal data class FossIdConfig(
             log.info { "waitForResult parameter is set to '$waitForResult'" }
 
             return FossIdConfig(
-                serverUrl,
-                user,
-                apiKey,
-                waitForResult,
-                addAuthenticationToUrl,
-                deltaScans,
-                deltaScanLimit,
-                timeout,
-                fossIdScannerOptions
+                serverUrl = serverUrl,
+                user = user,
+                apiKey = apiKey,
+                waitForResult = waitForResult,
+                addAuthenticationToUrl = addAuthenticationToUrl,
+                deltaScans = deltaScans,
+                deltaScanLimit = deltaScanLimit,
+                timeout = timeout,
+                options = fossIdScannerOptions
             )
         }
     }

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
@@ -32,9 +32,6 @@ import org.ossreviewtoolkit.utils.ort.log
  * * **"apiKey":** The API key of the user which connects to the FossID server.
  * * **"waitForResult":** When set to false, ORT does not wait for repositories to be downloaded nor scans to be
  *   completed. As a consequence, scan results won't be available in ORT result.
- * * **"packageNamespaceFilter":** If this optional filter is set, only packages having an identifier in given namespace
- *   will be scanned.
- * * **"packageAuthorsFilter":** If this optional filter is set, only packages from a given author will be scanned.
  * * **"addAuthenticationToUrl":** If set, ORT will add credentials from its Authenticator to the URLs sent to FossID.
  * * **"deltaScans":** If set, ORT will create delta scans. When only changes in a repository need to be scanned,
  *   delta scans reuse the identifications of the latest scan on this repository to reduce the amount of findings. If
@@ -62,12 +59,6 @@ internal data class FossIdConfig(
     /** Flag whether the scanner should wait for the completion of FossID scans. */
     val waitForResult: Boolean,
 
-    /** Filter for package namespaces (empty string if undefined). */
-    val packageNamespaceFilter: String,
-
-    /** Filter for package authors (empty string if undefined). */
-    val packageAuthorsFilter: String,
-
     /** Flag whether credentials should be passed to FossID in URLs. */
     val addAuthenticationToUrl: Boolean,
 
@@ -92,12 +83,6 @@ internal data class FossIdConfig(
 
         /** Name of the configuration property for the API key. */
         private const val API_KEY_PROPERTY = "apiKey"
-
-        /** Name of the configuration property for the packages namespace filter. */
-        private const val NAMESPACE_FILTER_PROPERTY = "packageNamespaceFilter"
-
-        /** Name of the configuration property for the packages authros filter. */
-        private const val AUTHORS_FILTER_PROPERTY = "packageAuthorsFilter"
 
         /** Name of the configuration property controlling that credentials are added to URLs. */
         private const val CREDENTIALS_IN_URL_PROPERTY = "addAuthenticationToUrl"
@@ -144,8 +129,6 @@ internal data class FossIdConfig(
                 ?: throw IllegalArgumentException("No FossID API Key configuration found.")
 
             val waitForResult = fossIdScannerOptions[WAIT_FOR_RESULT_PROPERTY]?.toBoolean() ?: true
-            val packageNamespaceFilter = fossIdScannerOptions[NAMESPACE_FILTER_PROPERTY].orEmpty()
-            val packageAuthorsFilter = fossIdScannerOptions[AUTHORS_FILTER_PROPERTY].orEmpty()
             val addAuthenticationToUrl = fossIdScannerOptions[CREDENTIALS_IN_URL_PROPERTY]?.toBoolean() ?: false
 
             val deltaScans = fossIdScannerOptions[DELTA_SCAN_PROPERTY]?.toBoolean() ?: false
@@ -163,8 +146,6 @@ internal data class FossIdConfig(
                 user,
                 apiKey,
                 waitForResult,
-                packageNamespaceFilter,
-                packageAuthorsFilter,
                 addAuthenticationToUrl,
                 deltaScans,
                 deltaScanLimit,

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
@@ -30,12 +30,12 @@ import org.ossreviewtoolkit.utils.ort.log
  * * **"serverUrl":** The URL of the FossID server.
  * * **"user":** The user to connect to the FossID server.
  * * **"apiKey":** The API key of the user which connects to the FossID server.
+ * * **"waitForResult":** When set to false, ORT doesn't wait for repositories to be downloaded nor scans to be
+ * completed. As a consequence, scan results won't be available in ORT result.
  * * **"packageNamespaceFilter":** If this optional filter is set, only packages having an identifier in given namespace
  * will be scanned.
  * * **"packageAuthorsFilter":** If this optional filter is set, only packages from a given author will be scanned.
  * * **"addAuthenticationToUrl":** When set, ORT will add credentials from its Authenticator to the URLs sent to FossID.
- * * **"waitForResult":** When set to false, ORT doesn't wait for repositories to be downloaded nor scans to be
- * completed. As a consequence, scan results won't be available in ORT result.
  * * **"deltaScans":** When set, ORT will create delta scans. When only changes in a repository need to be scanned,
  * delta scans reuse the identifications of latest scan on this repository to reduce the amount of findings. If
  * deltaScans is set and no scan exist yet, an initial scan called "origin" scan will be created.
@@ -53,11 +53,11 @@ internal data class FossIdConfig(
     /** The URL where the FossID service is running. */
     val serverUrl: String,
 
-    /** The API key to access the FossID server. */
-    val apiKey: String,
-
     /** The user to authenticate against the server. */
     val user: String,
+
+    /** The API key to access the FossID server. */
+    val apiKey: String,
 
     /** Flag whether the scanner should wait for the completion of FossID scans. */
     val waitForResult: Boolean,
@@ -87,11 +87,11 @@ internal data class FossIdConfig(
         /** Name of the configuration property for the server URL. */
         private const val SERVER_URL_PROPERTY = "serverUrl"
 
-        /** Name of the configuration property for the API key. */
-        private const val API_KEY_PROPERTY = "apiKey"
-
         /** Name of the configuration property for the user name. */
         private const val USER_PROPERTY = "user"
+
+        /** Name of the configuration property for the API key. */
+        private const val API_KEY_PROPERTY = "apiKey"
 
         /** Name of the configuration property for the packages namespace filter. */
         private const val NAMESPACE_FILTER_PROPERTY = "packageNamespaceFilter"
@@ -138,18 +138,18 @@ internal data class FossIdConfig(
 
             val serverUrl = fossIdScannerOptions[SERVER_URL_PROPERTY]
                 ?: throw IllegalArgumentException("No FossID server URL configuration found.")
-            val apiKey = fossIdScannerOptions[API_KEY_PROPERTY]
-                ?: throw IllegalArgumentException("No FossID API Key configuration found.")
             val user = fossIdScannerOptions[USER_PROPERTY]
                 ?: throw IllegalArgumentException("No FossID User configuration found.")
+            val apiKey = fossIdScannerOptions[API_KEY_PROPERTY]
+                ?: throw IllegalArgumentException("No FossID API Key configuration found.")
+
+            val waitForResult = fossIdScannerOptions[WAIT_FOR_RESULT_PROPERTY]?.toBoolean() ?: true
             val packageNamespaceFilter = fossIdScannerOptions[NAMESPACE_FILTER_PROPERTY].orEmpty()
             val packageAuthorsFilter = fossIdScannerOptions[AUTHORS_FILTER_PROPERTY].orEmpty()
             val addAuthenticationToUrl = fossIdScannerOptions[CREDENTIALS_IN_URL_PROPERTY]?.toBoolean() ?: false
-            val waitForResult = fossIdScannerOptions[WAIT_FOR_RESULT_PROPERTY]?.toBoolean() ?: true
+
             val deltaScans = fossIdScannerOptions[DELTA_SCAN_PROPERTY]?.toBoolean() ?: false
-
             val deltaScanLimit = fossIdScannerOptions[DELTA_SCAN_LIMIT_PROPERTY]?.toInt() ?: Int.MAX_VALUE
-
             val timeout = fossIdScannerOptions[TIMEOUT]?.toInt() ?: DEFAULT_TIMEOUT
 
             require(deltaScanLimit > 0) {
@@ -160,8 +160,8 @@ internal data class FossIdConfig(
 
             return FossIdConfig(
                 serverUrl,
-                apiKey,
                 user,
+                apiKey,
                 waitForResult,
                 packageNamespaceFilter,
                 packageAuthorsFilter,

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
@@ -30,20 +30,20 @@ import org.ossreviewtoolkit.utils.ort.log
  * * **"serverUrl":** The URL of the FossID server.
  * * **"user":** The user to connect to the FossID server.
  * * **"apiKey":** The API key of the user which connects to the FossID server.
- * * **"waitForResult":** When set to false, ORT doesn't wait for repositories to be downloaded nor scans to be
+ * * **"waitForResult":** When set to false, ORT does not wait for repositories to be downloaded nor scans to be
  *   completed. As a consequence, scan results won't be available in ORT result.
  * * **"packageNamespaceFilter":** If this optional filter is set, only packages having an identifier in given namespace
  *   will be scanned.
  * * **"packageAuthorsFilter":** If this optional filter is set, only packages from a given author will be scanned.
- * * **"addAuthenticationToUrl":** When set, ORT will add credentials from its Authenticator to the URLs sent to FossID.
- * * **"deltaScans":** When set, ORT will create delta scans. When only changes in a repository need to be scanned,
- *   delta scans reuse the identifications of latest scan on this repository to reduce the amount of findings. If
- *   deltaScans is set and no scan exist yet, an initial scan called "origin" scan will be created.
+ * * **"addAuthenticationToUrl":** If set, ORT will add credentials from its Authenticator to the URLs sent to FossID.
+ * * **"deltaScans":** If set, ORT will create delta scans. When only changes in a repository need to be scanned,
+ *   delta scans reuse the identifications of the latest scan on this repository to reduce the amount of findings. If
+ *   *deltaScans* is set and no scan exist yet, an initial scan called "origin" scan will be created.
  * * **"deltaScanLimit":** This setting can be used to limit the number of delta scans to keep for a given repository.
  *   So if another delta scan is created, older delta scans are deleted until this number is reached. If unspecified, no
  *   limit is enforced on the number of delta scans to keep. This property is evaluated only if *deltaScans* is enabled.
  *
- * Naming conventions options. If they are not set, default naming convention are used.
+ * Naming conventions options. If they are not set, default naming conventions are used.
  * * **"namingProjectPattern":** A pattern for project names when projects are created on the FossID instance. Contains
  *   variables prefixed by "$" e.g. "$Var1_$Var2". Variables are also passed as options and are prefixed by
  *   [NAMING_CONVENTION_VARIABLE_PREFIX] e.g. namingVariableVar1 = "foo".
@@ -87,7 +87,7 @@ internal data class FossIdConfig(
         /** Name of the configuration property for the server URL. */
         private const val SERVER_URL_PROPERTY = "serverUrl"
 
-        /** Name of the configuration property for the user name. */
+        /** Name of the configuration property for the username. */
         private const val USER_PROPERTY = "user"
 
         /** Name of the configuration property for the API key. */
@@ -121,7 +121,7 @@ internal data class FossIdConfig(
         private const val TIMEOUT = "timeout"
 
         /**
-         * The scanner options beginning with this prefix will be used to parametrize project and scan names.
+         * The scanner options beginning with this prefix will be used to parameterize project and scan names.
          */
         private const val NAMING_CONVENTION_VARIABLE_PREFIX = "namingVariable"
 

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
@@ -46,13 +46,13 @@ class FossIdConfigTest : WordSpec({
         "read all properties from the scanner configuration" {
             val options = mapOf(
                 "serverUrl" to SERVER_URL,
-                "apiKey" to API_KEY,
                 "user" to USER,
+                "apiKey" to API_KEY,
                 "waitForResult" to "false",
+                "addAuthenticationToUrl" to "false",
                 "deltaScans" to "true",
                 "deltaScanLimit" to "42",
-                "timeout" to "300",
-                "addAuthenticationToUrl" to "false"
+                "timeout" to "300"
             )
             val scannerConfig = options.toScannerConfig()
 
@@ -60,12 +60,12 @@ class FossIdConfigTest : WordSpec({
 
             fossIdConfig shouldBe FossIdConfig(
                 serverUrl = SERVER_URL,
-                apiKey = API_KEY,
                 user = USER,
+                apiKey = API_KEY,
                 waitForResult = false,
+                addAuthenticationToUrl = false,
                 deltaScans = true,
                 deltaScanLimit = 42,
-                addAuthenticationToUrl = false,
                 timeout = 300,
                 options = options
             )
@@ -74,8 +74,8 @@ class FossIdConfigTest : WordSpec({
         "set default values for optional properties" {
             val options = mapOf(
                 "serverUrl" to SERVER_URL,
-                "apiKey" to API_KEY,
-                "user" to USER
+                "user" to USER,
+                "apiKey" to API_KEY
             )
             val scannerConfig = options.toScannerConfig()
 
@@ -83,12 +83,12 @@ class FossIdConfigTest : WordSpec({
 
             fossIdConfig shouldBe FossIdConfig(
                 serverUrl = SERVER_URL,
-                apiKey = API_KEY,
                 user = USER,
+                apiKey = API_KEY,
                 waitForResult = true,
+                addAuthenticationToUrl = false,
                 deltaScans = false,
                 deltaScanLimit = Int.MAX_VALUE,
-                addAuthenticationToUrl = false,
                 timeout = 60,
                 options = options
             )
@@ -96,8 +96,8 @@ class FossIdConfigTest : WordSpec({
 
         "throw if the server URL is missing" {
             val scannerConfig = mapOf(
-                "apiKey" to API_KEY,
-                "user" to USER
+                "user" to USER,
+                "apiKey" to API_KEY
             ).toScannerConfig()
 
             shouldThrow<IllegalArgumentException> { FossIdConfig.create(scannerConfig) }
@@ -124,8 +124,8 @@ class FossIdConfigTest : WordSpec({
         "throw if the deltaScanLimit is invalid" {
             val scannerConfig = mapOf(
                 "serverUrl" to SERVER_URL,
-                "apiKey" to API_KEY,
                 "user" to USER,
+                "apiKey" to API_KEY,
                 "deltaScanLimit" to "0"
             ).toScannerConfig()
 
@@ -137,8 +137,8 @@ class FossIdConfigTest : WordSpec({
         "create a naming provider with a correct project naming convention" {
             val scannerConfig = mapOf(
                 "serverUrl" to SERVER_URL,
-                "apiKey" to API_KEY,
                 "user" to USER,
+                "apiKey" to API_KEY,
                 "namingProjectPattern" to "#projectName_\$Org_\$Unit",
                 "namingVariableOrg" to "TestOrganization",
                 "namingVariableUnit" to "TestUnit"
@@ -155,8 +155,8 @@ class FossIdConfigTest : WordSpec({
         "create a naming provider with a correct scan naming convention" {
             val scannerConfig = mapOf(
                 "serverUrl" to SERVER_URL,
-                "apiKey" to API_KEY,
                 "user" to USER,
+                "apiKey" to API_KEY,
                 "namingScanPattern" to "#projectName_\$Org_\$Unit_#deltaTag",
                 "namingVariableOrg" to "TestOrganization",
                 "namingVariableUnit" to "TestUnit"
@@ -182,8 +182,8 @@ class FossIdConfigTest : WordSpec({
                 val serverUrl = "http://localhost:${server.port()}"
                 val scannerConfig = mapOf(
                     "serverUrl" to serverUrl,
-                    "apiKey" to API_KEY,
-                    "user" to USER
+                    "user" to USER,
+                    "apiKey" to API_KEY
                 ).toScannerConfig()
 
                 server.stubFor(
@@ -207,8 +207,8 @@ class FossIdConfigTest : WordSpec({
 })
 
 private const val SERVER_URL = "https://www.example.org/fossid"
-private const val API_KEY = "test_api_key"
 private const val USER = "fossIdTestUser"
+private const val API_KEY = "test_api_key"
 
 /**
  * Return a [ScannerConfiguration] with this map as options for the FossID scanner.

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
@@ -48,8 +48,6 @@ class FossIdConfigTest : WordSpec({
                 "serverUrl" to SERVER_URL,
                 "apiKey" to API_KEY,
                 "user" to USER,
-                "packageNamespaceFilter" to NAMESPACE_FILTER,
-                "packageAuthorsFilter" to AUTHOR_FILTER,
                 "waitForResult" to "false",
                 "deltaScans" to "true",
                 "deltaScanLimit" to "42",
@@ -64,8 +62,6 @@ class FossIdConfigTest : WordSpec({
                 serverUrl = SERVER_URL,
                 apiKey = API_KEY,
                 user = USER,
-                packageAuthorsFilter = AUTHOR_FILTER,
-                packageNamespaceFilter = NAMESPACE_FILTER,
                 waitForResult = false,
                 deltaScans = true,
                 deltaScanLimit = 42,
@@ -89,8 +85,6 @@ class FossIdConfigTest : WordSpec({
                 serverUrl = SERVER_URL,
                 apiKey = API_KEY,
                 user = USER,
-                packageAuthorsFilter = "",
-                packageNamespaceFilter = "",
                 waitForResult = true,
                 deltaScans = false,
                 deltaScanLimit = Int.MAX_VALUE,
@@ -215,8 +209,6 @@ class FossIdConfigTest : WordSpec({
 private const val SERVER_URL = "https://www.example.org/fossid"
 private const val API_KEY = "test_api_key"
 private const val USER = "fossIdTestUser"
-private const val NAMESPACE_FILTER = "testFilterForNamespace"
-private const val AUTHOR_FILTER = "testFilterForAuthors"
 
 /**
  * Return a [ScannerConfiguration] with this map as options for the FossID scanner.

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -755,8 +755,14 @@ private fun createConfig(
 ): FossIdConfig {
     val config = FossIdConfig(
         "https://www.example.org/fossid",
-        USER, API_KEY, waitForResult, addAuthenticationToUrl = false,
-        deltaScans, deltaScanLimit, 60, emptyMap()
+        USER,
+        API_KEY,
+        waitForResult,
+        addAuthenticationToUrl = false,
+        deltaScans,
+        deltaScanLimit,
+        60,
+        emptyMap()
     )
 
     val namingProvider = createNamingProviderMock()
@@ -871,9 +877,16 @@ private fun textLocation(fileIndex: Int): TextLocation =
  */
 private fun createIdentifiedFile(index: Int): IdentifiedFile {
     val file = IdentifiedFile(
-        comment = null, identificationId = index, identificationCopyright = "copyright$index",
-        isDistributed = index, rowId = index, userName = "$USER$index", userSurname = null, userUsername = null
+        comment = null,
+        identificationId = index,
+        identificationCopyright = "copyright$index",
+        isDistributed = index,
+        rowId = index,
+        userName = "$USER$index",
+        userSurname = null,
+        userUsername = null
     )
+
     val license = org.ossreviewtoolkit.clients.fossid.model.identification.identifiedFiles.License(
         LicenseMatchType.SNIPPET,
         index,
@@ -883,6 +896,7 @@ private fun createIdentifiedFile(index: Int): IdentifiedFile {
         0,
         "name$index"
     )
+
     file.file = org.ossreviewtoolkit.clients.fossid.model.identification.identifiedFiles.File(
         "identified$index",
         "licenseIdentifier1",
@@ -898,6 +912,7 @@ private fun createIdentifiedFile(index: Int): IdentifiedFile {
         sha1 = null,
         sha256 = null
     )
+
     return file
 }
 
@@ -906,10 +921,15 @@ private fun createIdentifiedFile(index: Int): IdentifiedFile {
  */
 private fun createMarkedIdentifiedFile(index: Int): MarkedAsIdentifiedFile {
     val file = MarkedAsIdentifiedFile(
-        identificationId = index, identificationCopyright = "copyrightMarked$index",
-        isDistributed = index, rowId = index, comment = null
+        identificationId = index,
+        identificationCopyright = "copyrightMarked$index",
+        isDistributed = index,
+        rowId = index,
+        comment = null
     )
+
     val license = License(index, LicenseMatchType.FILE, index, index, index, index, "created$index", "updated$index")
+
     license.file = LicenseFile(
         "licenseMarkedIdentifier$index",
         licenseIncludeInReport = true,
@@ -918,6 +938,7 @@ private fun createMarkedIdentifiedFile(index: Int): MarkedAsIdentifiedFile {
         licenseIsSpdxStandard = true,
         licenseName = "test$index"
     )
+
     file.file = org.ossreviewtoolkit.clients.fossid.model.identification.markedAsIdentified.File(
         id = "marked$index",
         md5 = null,
@@ -927,6 +948,7 @@ private fun createMarkedIdentifiedFile(index: Int): MarkedAsIdentifiedFile {
         size = index,
         licenses = mutableMapOf(index to license)
     )
+
     return file
 }
 

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -754,15 +754,15 @@ private fun createConfig(
     deltaScanLimit: Int = Int.MAX_VALUE
 ): FossIdConfig {
     val config = FossIdConfig(
-        "https://www.example.org/fossid",
-        USER,
-        API_KEY,
-        waitForResult,
+        serverUrl = "https://www.example.org/fossid",
+        user = USER,
+        apiKey = API_KEY,
+        waitForResult = waitForResult,
         addAuthenticationToUrl = false,
-        deltaScans,
-        deltaScanLimit,
-        60,
-        emptyMap()
+        deltaScans = deltaScans,
+        deltaScanLimit = deltaScanLimit,
+        timeout = 60,
+        options = emptyMap()
     )
 
     val namingProvider = createNamingProviderMock()
@@ -888,18 +888,18 @@ private fun createIdentifiedFile(index: Int): IdentifiedFile {
     )
 
     val license = org.ossreviewtoolkit.clients.fossid.model.identification.identifiedFiles.License(
-        LicenseMatchType.SNIPPET,
-        index,
-        "lic$index",
-        0,
-        0,
-        0,
-        "name$index"
+        fileLicenseMatchType = LicenseMatchType.SNIPPET,
+        id = index,
+        identifier = "lic$index",
+        isFoss = 0,
+        isOsiApproved = 0,
+        isSpdxStandard = 0,
+        name = "name$index"
     )
 
     file.file = org.ossreviewtoolkit.clients.fossid.model.identification.identifiedFiles.File(
-        "identified$index",
-        "licenseIdentifier1",
+        id = "identified$index",
+        licenseIdentifier = "licenseIdentifier1",
         licenseIncludeInReport = false,
         licenseIsCopyleft = false,
         licenseIsFoss = true,
@@ -931,7 +931,7 @@ private fun createMarkedIdentifiedFile(index: Int): MarkedAsIdentifiedFile {
     val license = License(index, LicenseMatchType.FILE, index, index, index, index, "created$index", "updated$index")
 
     license.file = LicenseFile(
-        "licenseMarkedIdentifier$index",
+        licenseIdentifier = "licenseMarkedIdentifier$index",
         licenseIncludeInReport = true,
         licenseIsCopyleft = false,
         licenseIsFoss = true,

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -775,7 +775,7 @@ private fun createConfig(
 ): FossIdConfig {
     val config = FossIdConfig(
         "https://www.example.org/fossid",
-        API_KEY, USER, waitForResult, packageNamespaceFilter, packageAuthorsFilter, addAuthenticationToUrl = false,
+        USER, API_KEY, waitForResult, packageNamespaceFilter, packageAuthorsFilter, addAuthenticationToUrl = false,
         deltaScans, deltaScanLimit, 60, emptyMap()
     )
 

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -23,10 +23,8 @@ import io.kotest.assertions.fail
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAtLeastOne
-import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 
@@ -483,22 +481,6 @@ class FossIdTest : WordSpec({
             }
         }
 
-        "apply filters for namespaces and authors" {
-            val id1 = createIdentifier(1)
-            val pkg1 = createPackage(id1, createVcsInfo())
-
-            val ignoredAuthor = "hacker"
-            val pkgAuthors = setOf("foo", "bar", ignoredAuthor)
-            val id2 = createIdentifier(2).copy(namespace = "anotherNamespace")
-            val pkg2 = createPackage(id2, createVcsInfo("anotherProject"), authors = pkgAuthors)
-
-            val config = createConfig(packageNamespaceFilter = id1.namespace, packageAuthorsFilter = ignoredAuthor)
-            val fossId = createFossId(config)
-
-            val scannerRun = fossId.scan(listOf(pkg1, pkg2))
-            scannerRun.results.collectIssues().keys should beEmpty()
-        }
-
         "create a delta scan for an existing scan" {
             val projectCode = projectCode(PROJECT)
             val originCode = "originalScanCode"
@@ -768,14 +750,12 @@ private fun createFossId(config: FossIdConfig): FossId =
  */
 private fun createConfig(
     waitForResult: Boolean = true,
-    packageNamespaceFilter: String = "",
-    packageAuthorsFilter: String = "",
     deltaScans: Boolean = true,
     deltaScanLimit: Int = Int.MAX_VALUE
 ): FossIdConfig {
     val config = FossIdConfig(
         "https://www.example.org/fossid",
-        USER, API_KEY, waitForResult, packageNamespaceFilter, packageAuthorsFilter, addAuthenticationToUrl = false,
+        USER, API_KEY, waitForResult, addAuthenticationToUrl = false,
         deltaScans, deltaScanLimit, 60, emptyMap()
     )
 


### PR DESCRIPTION
Remove the unused package filter options and do some minor cleanup. See the commit messages for details.