### PR TITLE
Inline the `installAuthenticatorAndProxySelector()` helper function

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -90,8 +90,9 @@ import org.ossreviewtoolkit.utils.common.searchUpwardsForSubdirectory
 import org.ossreviewtoolkit.utils.common.withoutPrefix
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
+import org.ossreviewtoolkit.utils.ort.OrtAuthenticator
+import org.ossreviewtoolkit.utils.ort.OrtProxySelector
 import org.ossreviewtoolkit.utils.ort.ProcessedDeclaredLicense
-import org.ossreviewtoolkit.utils.ort.installAuthenticatorAndProxySelector
 import org.ossreviewtoolkit.utils.ort.log
 import org.ossreviewtoolkit.utils.ort.logOnce
 import org.ossreviewtoolkit.utils.ort.ortDataDirectory
@@ -356,7 +357,8 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
 
         return DefaultRepositorySystemSession(session).apply {
             setWorkspaceReader(skipDownloadWorkspaceReader)
-            installAuthenticatorAndProxySelector()
+            OrtAuthenticator.install()
+            OrtProxySelector.install()
             proxySelector = JreProxySelector()
         }
     }

--- a/downloader/src/main/kotlin/vcs/Subversion.kt
+++ b/downloader/src/main/kotlin/vcs/Subversion.kt
@@ -31,7 +31,8 @@ import org.ossreviewtoolkit.downloader.WorkingTree
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.common.collectMessages
-import org.ossreviewtoolkit.utils.ort.installAuthenticatorAndProxySelector
+import org.ossreviewtoolkit.utils.ort.OrtAuthenticator
+import org.ossreviewtoolkit.utils.ort.OrtProxySelector
 import org.ossreviewtoolkit.utils.ort.log
 import org.ossreviewtoolkit.utils.ort.requestPasswordAuthentication
 import org.ossreviewtoolkit.utils.ort.showStackTrace
@@ -245,7 +246,7 @@ private class OrtSVNAuthenticationManager : DefaultSVNAuthenticationManager(
     /* privateKey = */ null,
     /* passphrase = */ charArrayOf()
 ) {
-    private val ortProxySelector = installAuthenticatorAndProxySelector()
+    private val ortProxySelector = OrtProxySelector.install().also { OrtAuthenticator.install() }
 
     init {
         authenticationProvider = object : ISVNAuthenticationProvider {

--- a/utils/ort/src/main/kotlin/OkHttpClientHelper.kt
+++ b/utils/ort/src/main/kotlin/OkHttpClientHelper.kt
@@ -73,7 +73,8 @@ object OkHttpClientHelper {
     private val clients = ConcurrentHashMap<BuilderConfiguration, OkHttpClient>()
 
     private val defaultClient by lazy {
-        installAuthenticatorAndProxySelector()
+        OrtAuthenticator.install()
+        OrtProxySelector.install()
 
         if (log.delegate.isDebugEnabled) {
             // Allow to track down leaked connections.

--- a/utils/ort/src/main/kotlin/Utils.kt
+++ b/utils/ort/src/main/kotlin/Utils.kt
@@ -142,21 +142,12 @@ fun filterVersionNames(version: String, names: List<String>, project: String? = 
 }
 
 /**
- * Install both the [OrtAuthenticator] and the [OrtProxySelector] to handle proxy authentication. Return the
- * [OrtProxySelector] instance for further configuration.
- */
-fun installAuthenticatorAndProxySelector(): OrtProxySelector {
-    OrtAuthenticator.install()
-    return OrtProxySelector.install()
-}
-
-/**
- * Request a [PasswordAuthentication] object for the given [host], [port], and [scheme]. Call
- * [installAuthenticatorAndProxySelector] before to make sure that the [OrtAuthenticator] and the [OrtProxySelector]
- * are active.
+ * Request a [PasswordAuthentication] object for the given [host], [port], and [scheme]. Install the [OrtAuthenticator]
+ * and the [OrtProxySelector] beforehand to ensure they are active.
  */
 fun requestPasswordAuthentication(host: String, port: Int, scheme: String): PasswordAuthentication? {
-    installAuthenticatorAndProxySelector()
+    OrtAuthenticator.install()
+    OrtProxySelector.install()
 
     return Authenticator.requestPasswordAuthentication(
         /* host = */ host,
@@ -169,8 +160,8 @@ fun requestPasswordAuthentication(host: String, port: Int, scheme: String): Pass
 }
 
 /**
- * Request a [PasswordAuthentication] object for the given [uri]. Call [installAuthenticatorAndProxySelector] before
- * to make sure that the [OrtAuthenticator] and the [OrtProxySelector] are active.
+ * Request a [PasswordAuthentication] object for the given [uri]. Install the [OrtAuthenticator] and the
+ * [OrtProxySelector] beforehand to ensure they are active.
  */
 fun requestPasswordAuthentication(uri: URI): PasswordAuthentication? =
     requestPasswordAuthentication(uri.host, uri.port, uri.scheme)

--- a/utils/ort/src/test/kotlin/UtilsTest.kt
+++ b/utils/ort/src/test/kotlin/UtilsTest.kt
@@ -29,6 +29,7 @@ import io.kotest.matchers.shouldBe
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.verify
 
@@ -393,7 +394,8 @@ class UtilsTest : WordSpec({
             val port = 442
             val scheme = "https"
 
-            mockkStatic("org.ossreviewtoolkit.utils.ort.UtilsKt")
+            mockkObject(OrtAuthenticator)
+            mockkObject(OrtProxySelector)
             mockkStatic(Authenticator::class)
             val passwordAuth = mockk<PasswordAuthentication>()
 
@@ -404,7 +406,8 @@ class UtilsTest : WordSpec({
             requestPasswordAuthentication(host, port, scheme) shouldBe passwordAuth
 
             verify {
-                installAuthenticatorAndProxySelector()
+                OrtAuthenticator.install()
+                OrtProxySelector.install()
             }
         }
     }


### PR DESCRIPTION
Now that there is the more convenient `requestPasswordAuthentication()`
helper function, inline `installAuthenticatorAndProxySelector()` which
anyway had arbitrary semantics in returning just the proxy selector.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>