### PR TITLE
Dockerfile: Avoid copying the distribution TAR by mounting it instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,7 +155,7 @@ RUN /opt/ort/bin/import_proxy_certs.sh && \
 ARG SCANCODE_VERSION
 RUN pip install --no-cache-dir scancode-toolkit==$SCANCODE_VERSION
 
-FROM run
+FROM run AS dist
 
 COPY --from=build /usr/local/src/ort/cli/build/distributions/ort-*.tar /opt/ort.tar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -157,13 +157,14 @@ RUN pip install --no-cache-dir scancode-toolkit==$SCANCODE_VERSION
 
 FROM run AS dist
 
-COPY --from=build /usr/local/src/ort/cli/build/distributions/ort-*.tar /opt/ort.tar
+ARG ORT_VERSION
+COPY --from=build /usr/local/src/ort/cli/build/distributions/ort-$ORT_VERSION.tar /opt/ort.tar
 
 RUN tar xf /opt/ort.tar -C /opt/ort --exclude="*.bat" --strip-components 1 && \
     rm /opt/ort.tar && \
     /opt/ort/bin/ort requirements
 
 COPY --from=build /usr/local/src/ort/helper-cli/build/scripts/orth /opt/ort/bin/
-COPY --from=build /usr/local/src/ort/helper-cli/build/libs/helper-cli-*.jar /opt/ort/lib/
+COPY --from=build /usr/local/src/ort/helper-cli/build/libs/helper-cli-$ORT_VERSION.jar /opt/ort/lib/
 
 ENTRYPOINT ["/opt/ort/bin/ort"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -158,10 +158,8 @@ RUN pip install --no-cache-dir scancode-toolkit==$SCANCODE_VERSION
 FROM run AS dist
 
 ARG ORT_VERSION
-COPY --from=build /usr/local/src/ort/cli/build/distributions/ort-$ORT_VERSION.tar /opt/ort.tar
-
-RUN tar xf /opt/ort.tar -C /opt/ort --exclude="*.bat" --strip-components 1 && \
-    rm /opt/ort.tar && \
+RUN --mount=type=bind,from=build,source=/usr/local/src/ort/cli/build/distributions/ort-$ORT_VERSION.tar,target=/opt/ort.tar \
+    tar xf /opt/ort.tar -C /opt/ort --exclude="*.bat" --strip-components 1 && \
     /opt/ort/bin/ort requirements
 
 COPY --from=build /usr/local/src/ort/helper-cli/build/scripts/orth /opt/ort/bin/


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.