### PR TITLE
github/workflows: Set codecov flags according to job names

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,6 +64,8 @@ jobs:
         arguments: test jacocoTestReport -x :reporter-web-app:yarnBuild
     - name: Upload code coverage data
       uses: codecov/codecov-action@v2
+      with:
+        flags: test
   funTest-non-analyzer:
     needs: build-reporter-web-app
     runs-on: ubuntu-latest
@@ -97,6 +99,8 @@ jobs:
         arguments: funTest jacocoFunTestReport -x :analyzer:funTest
     - name: Upload code coverage data
       uses: codecov/codecov-action@v2
+      with:
+        flags: funTest-non-analyzer
   funTest-analyzer-docker:
     runs-on: ubuntu-latest
     steps:
@@ -116,6 +120,8 @@ jobs:
       run: ./batect --enable-buildkit --config-var gradle_console=plain funTest -- jacocoFunTestReport -Dkotest.tags=!NoDockerTag -p analyzer
     - name: Upload code coverage data
       uses: codecov/codecov-action@v2
+      with:
+        flags: funTest-analyzer-docker
   funTest-analyzer-no-docker:
     needs: build
     runs-on: ubuntu-latest
@@ -137,3 +143,5 @@ jobs:
         arguments: :analyzer:funTest :analyzer:jacocoFunTestReport -Dkotest.tags=NoDockerTag
     - name: Upload code coverage data
       uses: codecov/codecov-action@v2
+      with:
+        flags: funTest-analyzer-no-docker


### PR DESCRIPTION
This helps to understand where which coverage information comes from.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>