### PR TITLE
Remove the `NoDockerTag` for running Analyzer funTests outside of Docker

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -117,31 +117,8 @@ jobs:
     - name: Validate Batect wrapper scripts
       uses: batect/batect-wrapper-validation-action@v0
     - name: Run functional tests
-      run: ./batect --enable-buildkit --config-var gradle_console=plain funTest -- jacocoFunTestReport -Dkotest.tags=!NoDockerTag -p analyzer
+      run: ./batect --enable-buildkit --config-var gradle_console=plain funTest -- jacocoFunTestReport -p analyzer
     - name: Upload code coverage data
       uses: codecov/codecov-action@v2
       with:
         flags: funTest-analyzer-docker
-  funTest-analyzer-no-docker:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v3
-      with:
-        submodules: recursive
-    - name: Setup Java
-      uses: actions/setup-java@v2
-      with:
-        distribution: temurin
-        java-version: 11
-        cache: gradle
-    - name: Run functional tests
-      uses: burrunan/gradle-cache-action@v1
-      with:
-        job-id: funTest-analyzer-no-docker
-        arguments: :analyzer:funTest :analyzer:jacocoFunTestReport -Dkotest.tags=NoDockerTag
-    - name: Upload code coverage data
-      uses: codecov/codecov-action@v2
-      with:
-        flags: funTest-analyzer-no-docker

--- a/analyzer/src/funTest/kotlin/managers/PubFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PubFunTest.kt
@@ -38,7 +38,6 @@ import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
 import org.ossreviewtoolkit.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
-import org.ossreviewtoolkit.utils.test.NoDockerTag
 import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
@@ -96,7 +95,7 @@ class PubFunTest : WordSpec() {
                 result.toYaml() shouldBe expectedResult
             }
 
-            "resolve dependencies for a project with Flutter, Android and Cocoapods".config(tags = setOf(NoDockerTag)) {
+            "resolve dependencies for a project with Flutter, Android and Cocoapods" {
                 val workingDir = projectsDir.resolve("flutter-project-with-android-and-cocoapods")
                 val expectedResultFile =
                     projectsDir.parentFile.resolve("pub-expected-output-with-flutter-android-and-cocoapods.yml")

--- a/utils/test/src/main/kotlin/TestTags.kt
+++ b/utils/test/src/main/kotlin/TestTags.kt
@@ -25,6 +25,4 @@ object AndroidTag : Tag()
 
 object ExpensiveTag : Tag()
 
-object NoDockerTag : Tag()
-
 object ScanCodeTag : Tag()


### PR DESCRIPTION
The only Analyzer funTest that was not running in Docker so far was the
`PubFunTest`, but as of https://github.com/oss-review-toolkit/ort/commit/16f029416a79e9a64e7f8a2ded1f425b25daccd9 this works.