### PR TITLE
.mailmap: Add Thomas' e-mail addresses

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -21,6 +21,8 @@ Sebastian Schuberth <sebastian.schuberth@bosch.io> <sebastian.schuberth@here.com
 Sebastian Schuberth <sebastian.schuberth@bosch.io> <sschuberth@gmail.com>
 Sebastian Schuberth <sebastian.schuberth@bosch.io> <sschuberth@users.noreply.github.com>
 Stephanie Neubauer  <Stephanie.Neubauer@bosch.io> <Stephanie.Neubauer@bosch-si.com>
+Thomas Steenbergen <thomas_steenbergen@epam.com> <thomas.steenbergen@here.com> 
+Thomas Steenbergen <thomas_steenbergen@epam.com> <opensource@steenbe.nl>
 Uwe Sander <uwe.sander@zeiss.com> <61053896+uszeiss@users.noreply.github.com>
 William Bartholomew <willbar@microsoft.com> <iamwillbar@github.com>
 Yann Jorelle <yann.jorelle@aalto.fi>


### PR DESCRIPTION
Add his new e-mail address at EPAM and also cover all his addresses
present in the Git log.