### PR TITLE
Analyzer: Log the repository configuration as YAML

### DIFF
--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -36,6 +36,7 @@ import org.ossreviewtoolkit.model.Repository
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.orEmpty
+import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
 import org.ossreviewtoolkit.utils.ort.Environment
@@ -59,7 +60,9 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
     ): ManagedFileInfo {
         require(absoluteProjectPath.isAbsolute)
 
-        log.debug { "Using the following configuration settings:\n$repositoryConfiguration" }
+        log.debug {
+            "Using the following configuration settings:\n${yamlMapper.writeValueAsString(repositoryConfiguration)}"
+        }
 
         // Associate files by the package manager factory that manages them.
         val factoryFiles = if (packageManagers.size == 1 && absoluteProjectPath.isFile) {


### PR DESCRIPTION
Log the repository configuration as YAML instead of using the generated
`toString()` function of the data class. This improves readability and
also equals the format that is used in the .ort.yml file.