### PR TITLE
PostresStorage: Make the number of storage threads configurable

### DIFF
--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -394,7 +394,8 @@ private fun createFileBasedStorage(config: FileBasedStorageConfiguration) =
 private fun createPostgresStorage(config: PostgresStorageConfiguration) =
     when (config.type) {
         StorageType.PACKAGE_BASED -> PostgresStorage(
-            DatabaseUtils.createHikariDataSource(config = config, applicationNameSuffix = TOOL_NAME)
+            DatabaseUtils.createHikariDataSource(config = config, applicationNameSuffix = TOOL_NAME),
+            config.parallelTransactions
         )
         StorageType.PROVENANCE_BASED -> ProvenanceBasedPostgresStorage(
             DatabaseUtils.createHikariDataSource(config = config, applicationNameSuffix = TOOL_NAME)

--- a/model/src/main/kotlin/config/ScanStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/ScanStorageConfiguration.kt
@@ -119,6 +119,11 @@ data class PostgresStorageConfiguration(
     val sslrootcert: String? = null,
 
     /**
+     * The number of parallel transactions to use for the storage dispatcher.
+     */
+    val parallelTransactions: Int = 5,
+
+    /**
      * The way that scan results are stored, defaults to [StorageType.PACKAGE_BASED].
      */
     val type: StorageType = StorageType.PACKAGE_BASED

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -99,6 +99,7 @@ ort {
         sslcert = /defaultdir/postgresql.crt
         sslkey = /defaultdir/postgresql.pk8
         sslrootcert = /defaultdir/root.crt
+        parallelTransactions = 5
       }
     }
 

--- a/scanner/src/funTest/kotlin/storages/PostgresStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/PostgresStorageFunTest.kt
@@ -24,5 +24,5 @@ import org.ossreviewtoolkit.utils.test.PostgresListener
 private val postgresListener = PostgresListener()
 
 class PostgresStorageFunTest : AbstractStorageFunTest(postgresListener) {
-    override fun createStorage() = PostgresStorage(postgresListener.dataSource)
+    override fun createStorage() = PostgresStorage(dataSource = postgresListener.dataSource, parallelTransactions = 5)
 }

--- a/scanner/src/main/kotlin/PathScanner.kt
+++ b/scanner/src/main/kotlin/PathScanner.kt
@@ -71,11 +71,6 @@ abstract class PathScanner(
 ) : Scanner(name, scannerConfig, downloaderConfig) {
     companion object {
         /**
-         * The number of threads to use for the storage dispatcher.
-         */
-        const val NUM_STORAGE_THREADS = 5
-
-        /**
          * The name of the property defining the regular expression for the scanner name as part of [ScannerCriteria].
          */
         const val PROP_CRITERIA_NAME = "regScannerName"

--- a/scanner/src/main/kotlin/ScanResultsStorage.kt
+++ b/scanner/src/main/kotlin/ScanResultsStorage.kt
@@ -152,15 +152,15 @@ abstract class ScanResultsStorage : PackageBasedScanStorage {
             val dataSource = DatabaseUtils.createHikariDataSource(
                 config = config,
                 applicationNameSuffix = TOOL_NAME,
-                // Use a value slightly higher than the number of threads accessing the storage.
-                maxPoolSize = PathScanner.NUM_STORAGE_THREADS + 3
+                // Use a value slightly higher than the number of transactions accessing the storage.
+                maxPoolSize = config.parallelTransactions + 3
             )
 
             log.info {
                 "Using Postgres storage with URL '${config.url}' and schema '${config.schema}'."
             }
 
-            return PostgresStorage(dataSource)
+            return PostgresStorage(dataSource, config.parallelTransactions)
         }
 
         /**


### PR DESCRIPTION
The database pool size is implicitly configured by the number of storage
threads. Before, this value was hard-coded to 5 threads. As this might
not fit the user's database setup, make the value
configurable.

