### PR TITLE
SpdxDocumentFile: Improve error handling

### DIFF
--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Bosch.IO GmbH
+ * Copyright (C) 2020-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -414,10 +414,12 @@ class SpdxDocumentFile(
         }
 
     override fun mapDefinitionFiles(definitionFiles: List<File>): List<File> =
-        definitionFiles.associateWith(spdxDocumentCache::load).filter { (_, spdxDocument) ->
+        definitionFiles.associateWith {
+            spdxDocumentCache.load(it).getOrNull()
+        }.filter { (_, spdxDocument) ->
             // Distinguish whether we have a project-style SPDX document that describes a project and its dependencies,
             // or a package-style SPDX document that describes a single (dependency-)package.
-            spdxDocument.isProject()
+            spdxDocument?.isProject() == true
         }.keys.also { remainingFiles ->
             if (remainingFiles.isEmpty()) return definitionFiles
 
@@ -432,6 +434,7 @@ class SpdxDocumentFile(
 
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {
         val transitiveDocument = SpdxResolvedDocument.load(spdxDocumentCache, definitionFile, managerName)
+
         val spdxDocument = transitiveDocument.rootDocument.document
 
         val packages = mutableSetOf<Package>()

--- a/analyzer/src/main/kotlin/managers/utils/SpdxDocumentCache.kt
+++ b/analyzer/src/main/kotlin/managers/utils/SpdxDocumentCache.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,16 +37,16 @@ import org.ossreviewtoolkit.utils.spdx.model.SpdxDocument
  */
 internal class SpdxDocumentCache {
     /** A cache for the documents that have already been loaded. */
-    private val documentCache = mutableMapOf<File, SpdxDocument>()
+    private val documentCache = mutableMapOf<File, Result<SpdxDocument>>()
 
     /**
      * Load the given [file] and parse it to an [SpdxDocument]. Cache the resulting document in case the file is
      * queried again.
      */
-    fun load(file: File): SpdxDocument =
+    fun load(file: File): Result<SpdxDocument> =
         documentCache.getOrPut(file) {
             log.info { "Loading SpdxDocument from '$file'." }
 
-            SpdxModelMapper.read(file)
+            runCatching { SpdxModelMapper.read(file) }
         }
 }

--- a/analyzer/src/test/kotlin/managers/utils/SpdxDocumentCacheTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/SpdxDocumentCacheTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ class SpdxDocumentCacheTest : WordSpec({
         "return a parsed document" {
             val loader = SpdxDocumentCache()
 
-            val document = loader.load(TEST_DOCUMENT)
+            val document = loader.load(TEST_DOCUMENT).getOrThrow()
 
             document.spdxId shouldBe "SPDXRef-DOCUMENT"
             document.name shouldBe "xyz-0.1.0"
@@ -40,8 +40,8 @@ class SpdxDocumentCacheTest : WordSpec({
         "return a document from the cache" {
             val loader = SpdxDocumentCache()
 
-            val document1 = loader.load(TEST_DOCUMENT)
-            val document2 = loader.load(TEST_DOCUMENT)
+            val document1 = loader.load(TEST_DOCUMENT).getOrThrow()
+            val document2 = loader.load(TEST_DOCUMENT).getOrThrow()
 
             document1 should beTheSameInstanceAs(document2)
         }

--- a/analyzer/src/test/kotlin/managers/utils/SpdxResolvedDocumentTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/SpdxResolvedDocumentTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
         "load" should {
             "use the given loader to load a root document" {
                 val loader = SpdxDocumentCache()
-                val root = loader.load(BASE_DOCUMENT_FILE)
+                val root = loader.load(BASE_DOCUMENT_FILE).getOrThrow()
 
                 val resolvedDoc = SpdxResolvedDocument.load(loader, BASE_DOCUMENT_FILE, MANAGER_NAME)
 
@@ -539,7 +539,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
         "ResolvedSpdxDocument" should {
             "return null for the definition file if it was resolved via an URI" {
                 val resolvedDocument = ResolvedSpdxDocument(
-                    SpdxDocumentCache().load(BASE_DOCUMENT_FILE),
+                    SpdxDocumentCache().load(BASE_DOCUMENT_FILE).getOrThrow(),
                     URI("https://www.example.org/spdx/package.spdx.yml")
                 )
 
@@ -548,7 +548,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
 
             "return the definition file if available" {
                 val resolvedDocument = ResolvedSpdxDocument(
-                    SpdxDocumentCache().load(BASE_DOCUMENT_FILE),
+                    SpdxDocumentCache().load(BASE_DOCUMENT_FILE).getOrThrow(),
                     BASE_DOCUMENT_FILE.toURI()
                 )
 
@@ -557,7 +557,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
 
             "return the definition file for a relative URI" {
                 val resolvedDocument = ResolvedSpdxDocument(
-                    SpdxDocumentCache().load(BASE_DOCUMENT_FILE),
+                    SpdxDocumentCache().load(BASE_DOCUMENT_FILE).getOrThrow(),
                     URI("src/funTest/assets/projects/synthetic/spdx/project-xyz-with-inline-packages.spdx.yml")
                 )
 
@@ -566,7 +566,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
 
             "return a normalized definition file" {
                 val resolvedDocument = ResolvedSpdxDocument(
-                    SpdxDocumentCache().load(BASE_DOCUMENT_FILE),
+                    SpdxDocumentCache().load(BASE_DOCUMENT_FILE).getOrThrow(),
                     URI(
                         "../analyzer/src/funTest/assets/projects/synthetic/spdx/" +
                             "project-xyz-with-inline-packages.spdx.yml"
@@ -579,7 +579,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
             "return null if the file does not exist" {
                 val nonExistingFile = File("non/existing/file.spdx.yml")
                 val resolvedDocument = ResolvedSpdxDocument(
-                    SpdxDocumentCache().load(BASE_DOCUMENT_FILE),
+                    SpdxDocumentCache().load(BASE_DOCUMENT_FILE).getOrThrow(),
                     nonExistingFile.toURI()
                 )
 


### PR DESCRIPTION
Do not crash in `mapDefinitionFiles()` if an SPDX document cannot be
parsed, and while at it also improve the error reporting for unparseable
SPDX documents.