### PR TITLE
model: Add a global typealias for options

### DIFF
--- a/advisor/src/main/kotlin/AdviceProviderFactory.kt
+++ b/advisor/src/main/kotlin/AdviceProviderFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Bosch.IO GmbH
+ * Copyright (C) 2020-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ package org.ossreviewtoolkit.advisor
 
 import java.util.ServiceLoader
 
-import org.ossreviewtoolkit.model.config.AdviceProviderOptions
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
+import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
@@ -59,7 +59,7 @@ abstract class AbstractAdviceProviderFactory<out T : AdviceProvider>(
      * Return a map with options for the [AdviceProvider] managed by this factory or an empty map if no options are
      * available.
      */
-    protected fun AdvisorConfiguration.providerOptions(): AdviceProviderOptions =
+    protected fun AdvisorConfiguration.providerOptions(): Options =
         options.orEmpty()[providerName].orEmpty()
 
     /**

--- a/model/src/main/kotlin/config/AdvisorConfiguration.kt
+++ b/model/src/main/kotlin/config/AdvisorConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Bosch.IO GmbH
+ * Copyright (C) 2020-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,13 +23,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
 /**
- * Type alias for a map with configuration options for a single _AdviceProvider_. In addition to the concrete
- * configuration classes for the providers shipped with ORT, [AdvisorConfiguration] holds a map with generic options
- * that can be used to configure external plugins via the ORT configuration.
- */
-typealias AdviceProviderOptions = Map<String, String>
-
-/**
  * The base configuration model of the advisor.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -44,7 +37,7 @@ data class AdvisorConfiguration(
      * this map offers a way for external advisor plugins to query configuration information.
      */
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-    val options: Map<String, AdviceProviderOptions>? = null
+    val options: Map<String, Options>? = null
 )
 
 /**

--- a/model/src/main/kotlin/config/AnalyzerConfiguration.kt
+++ b/model/src/main/kotlin/config/AnalyzerConfiguration.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
- * Copyright (C) 2020-2021 Bosch.IO GmbH
+ * Copyright (C) 2020-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,6 @@ package org.ossreviewtoolkit.model.config
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 
-typealias PackageManagerOptions = Map<String, String>
-
 @JsonIgnoreProperties(value = ["ignore_tool_versions"]) // Backwards compatibility.
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class AnalyzerConfiguration(
@@ -41,7 +39,7 @@ data class AnalyzerConfiguration(
      * Package manager specific configuration options. The key needs to match the name of the package manager class,
      * e.g. "NuGet" for the NuGet package manager. See the documentation of the respective class for available options.
      */
-    val options: Map<String, PackageManagerOptions>? = null,
+    val options: Map<String, Options>? = null,
 
     /**
      * Configuration of the SW360 package curation provider.

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -150,3 +150,8 @@ data class OrtConfiguration(
 internal data class OrtConfigurationWrapper(
     val ort: OrtConfiguration
 )
+
+/**
+ * A typealias for key-value pairs, used in several configuration classes.
+ */
+typealias Options = Map<String, String>

--- a/model/src/main/kotlin/config/ReporterConfiguration.kt
+++ b/model/src/main/kotlin/config/ReporterConfiguration.kt
@@ -22,13 +22,6 @@ package org.ossreviewtoolkit.model.config
 import com.fasterxml.jackson.annotation.JsonProperty
 
 /**
- * Type alias for a map with configuration options for a single _Reporter_. In addition to the concrete configuration
- * classes for the reporters shipped with ORT, [ReporterConfiguration] holds a map with generic options that can be used
- * to configure external plugins via the ORT configuration.
- */
-typealias ReporterOptions = Map<String, String>
-
-/**
  * The base configuration model of the reporter.
  */
 data class ReporterConfiguration(
@@ -37,5 +30,5 @@ data class ReporterConfiguration(
      * for the FossId reporter. See the documentation of the reporter for available options.
      */
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-    val options: Map<String, ReporterOptions>? = null
+    val options: Map<String, Options>? = null
 )

--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.utils.ort.storage.FileStorage
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
-
-typealias ScannerOptions = Map<String, String>
 
 /**
  * The configuration model of the scanner.
@@ -84,7 +82,7 @@ data class ScannerConfiguration(
      * for the ScanCode wrapper. See the documentation of the scanner for available options.
      */
     @JsonAlias("scanner")
-    val options: Map<String, ScannerOptions>? = null,
+    val options: Map<String, Options>? = null,
 
     /**
      * A map with the configurations of the scan result storages available. Based on this information the actual

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2021 HERE Europe B.V.
+ * Copyright (C) 2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +36,8 @@ import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.ScannerRun
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
+import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.model.config.ScannerOptions
 import org.ossreviewtoolkit.model.utils.filterByProject
 import org.ossreviewtoolkit.utils.ort.Environment
 import org.ossreviewtoolkit.utils.ort.log
@@ -156,7 +157,7 @@ fun scanOrtResult(
         "The package and project scanners need to refer to the same global scanner configuration."
     }
 
-    val filteredScannerOptions = mutableMapOf<String, ScannerOptions>()
+    val filteredScannerOptions = mutableMapOf<String, Options>()
 
     packageScanner?.scannerConfig?.options?.get(packageScanner.scannerName)?.let { packageScannerOptions ->
         val filteredPackageScannerOptions = packageScanner.filterSecretOptions(packageScannerOptions)
@@ -239,5 +240,5 @@ abstract class Scanner(
     /**
      * Filter the scanner-specific options to remove / obfuscate any secrets, like credentials.
      */
-    open fun filterSecretOptions(options: ScannerOptions) = options
+    open fun filterSecretOptions(options: Options) = options
 }

--- a/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
+++ b/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
@@ -42,8 +42,8 @@ import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerRun
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
+import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.model.config.ScannerOptions
 import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.scanner.TOOL_NAME
 import org.ossreviewtoolkit.utils.common.collectMessages
@@ -110,7 +110,7 @@ class ExperimentalScanner(
             storageStats = AccessStatistics() // TODO: Record access statistics.
         )
 
-        val filteredScannerOptions = mutableMapOf<String, ScannerOptions>()
+        val filteredScannerOptions = mutableMapOf<String, Options>()
 
         projectScannerWrappers.forEach { scannerWrapper ->
             scannerConfig.options?.get(scannerWrapper.name)?.let { options ->

--- a/scanner/src/main/kotlin/experimental/ScannerWrapper.kt
+++ b/scanner/src/main/kotlin/experimental/ScannerWrapper.kt
@@ -29,8 +29,8 @@ import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
+import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.model.config.ScannerOptions
 import org.ossreviewtoolkit.scanner.ScannerCriteria
 
 /**
@@ -73,7 +73,7 @@ sealed interface ScannerWrapper {
     /**
      * Filter the scanner-specific options to remove / obfuscate any secrets, like credentials.
      */
-    fun filterSecretOptions(options: ScannerOptions): ScannerOptions
+    fun filterSecretOptions(options: Options): Options
 }
 
 /**

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -64,8 +64,8 @@ import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
+import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.model.config.ScannerOptions
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.scanner.AbstractScannerFactory
 import org.ossreviewtoolkit.scanner.Scanner
@@ -198,7 +198,7 @@ class FossId internal constructor(
 
     override val configuration = ""
 
-    override fun filterSecretOptions(options: ScannerOptions) =
+    override fun filterSecretOptions(options: Options) =
         options.mapValues { (k, v) ->
             v.takeUnless { k in secretKeys }.orEmpty()
         }

--- a/scanner/src/test/kotlin/PathScannerTest.kt
+++ b/scanner/src/test/kotlin/PathScannerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Bosch.IO GmbH
+ * Copyright (C) 2020-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@ import io.kotest.matchers.shouldBe
 import java.io.File
 
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
+import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.model.config.ScannerOptions
 
 class PathScannerTest : WordSpec({
     "getScannerCriteria()" should {
@@ -87,7 +87,7 @@ private const val SCANNER_VERSION = "3.2.1.final"
 /**
  * Creates a [ScannerConfiguration] with the given properties for the test scanner.
  */
-private fun createScannerConfig(properties: ScannerOptions): ScannerConfiguration {
+private fun createScannerConfig(properties: Options): ScannerConfiguration {
     val options = mapOf(SCANNER_NAME to properties)
     return ScannerConfiguration(options = options)
 }

--- a/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
+++ b/scanner/src/test/kotlin/experimental/ExperimentalScannerTest.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2021 HERE Europe B.V.
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021-2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,8 +59,8 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.FileArchiverConfiguration
+import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.model.config.ScannerOptions
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.scanner.ScannerCriteria
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
@@ -796,7 +796,7 @@ private class FakePackageScannerWrapper(
     override fun scanPackage(pkg: Package, context: ScanContext): ScanResult =
         createScanResult(packageProvenanceResolver.resolveProvenance(pkg, sourceCodeOriginPriority), details)
 
-    override fun filterSecretOptions(options: ScannerOptions) = options
+    override fun filterSecretOptions(options: Options) = options
 }
 
 /**
@@ -810,7 +810,7 @@ private class FakeProvenanceScannerWrapper : ProvenanceScannerWrapper {
     override fun scanProvenance(provenance: KnownProvenance, context: ScanContext): ScanResult =
         createScanResult(provenance, details)
 
-    override fun filterSecretOptions(options: ScannerOptions) = options
+    override fun filterSecretOptions(options: Options) = options
 }
 
 /**
@@ -829,7 +829,7 @@ private class FakePathScannerWrapper : PathScannerWrapper {
         return createScanSummary(licenseFindings = licenseFindings)
     }
 
-    override fun filterSecretOptions(options: ScannerOptions) = options
+    override fun filterSecretOptions(options: Options) = options
 }
 
 /**


### PR DESCRIPTION
Replace the different typealiases for `Map<String, String>` used in
several configuration classes with one global typealias for options.