### PR TITLE
model: Allow to enable and disable package managers in the configuration

### DIFF
--- a/cli/src/funTest/kotlin/OrtMainFunTest.kt
+++ b/cli/src/funTest/kotlin/OrtMainFunTest.kt
@@ -65,7 +65,7 @@ class OrtMainFunTest : StringSpec() {
             )
             val iterator = stdout.iterator()
             while (iterator.hasNext()) {
-                if (iterator.next() == "The following package managers are activated:") break
+                if (iterator.next() == "The following package managers are enabled:") break
             }
 
             iterator.hasNext() shouldBe true
@@ -83,7 +83,7 @@ class OrtMainFunTest : StringSpec() {
             )
             val iterator = stdout.iterator()
             while (iterator.hasNext()) {
-                if (iterator.next() == "The following package managers are activated:") break
+                if (iterator.next() == "The following package managers are enabled:") break
             }
 
             iterator.hasNext() shouldBe true

--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -28,6 +28,7 @@ import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.parameters.options.associate
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.deprecated
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
@@ -159,7 +160,11 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
     ).convert { name ->
         allPackageManagersByName[name]
             ?: throw BadParameterValue("Package managers must be one or more of ${allPackageManagersByName.keys}.")
-    }.split(",")
+    }.split(",").deprecated(
+        message = "--package-managers is deprecated, use -P ort.analyzer.enabledPackageManagers=... on the ort " +
+                "command instead.",
+        tagValue = "use -P ort.analyzer.enabledPackageManagers=... on the ort command instead"
+    )
 
     private val deactivatedPackageManagers by option(
         "--not-package-managers", "-n",
@@ -169,7 +174,11 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
     ).convert { name ->
         allPackageManagersByName[name]
             ?: throw BadParameterValue("Package managers must be one or more of ${allPackageManagersByName.keys}.")
-    }.split(",")
+    }.split(",").deprecated(
+        message = "--not-package-managers is deprecated, use -P ort.analyzer.disabledPackageManagers=... on the ort " +
+                "command instead.",
+        tagValue = "use -P ort.analyzer.disabledPackageManagers=... on the ort command instead"
+    )
 
     private val globalOptionsForSubcommands by requireObject<GlobalOptions>()
 

--- a/model/src/main/kotlin/config/AnalyzerConfiguration.kt
+++ b/model/src/main/kotlin/config/AnalyzerConfiguration.kt
@@ -36,6 +36,18 @@ data class AnalyzerConfiguration(
     val allowDynamicVersions: Boolean = false,
 
     /**
+     * A list of the case-insensitive names of package managers that are enabled. Disabling a package manager in
+     * [disabledPackageManagers] overrides enabling it here.
+     */
+    val enabledPackageManagers: List<String>? = null,
+
+    /**
+     * A list of the case-insensitive names of package managers that are disabled. Disabling a package manager in this
+     * list overrides [enabledPackageManagers].
+     */
+    val disabledPackageManagers: List<String>? = null,
+
+    /**
      * Package manager specific configuration options. The key needs to match the name of the package manager class,
      * e.g. "NuGet" for the NuGet package manager. See the documentation of the respective class for available options.
      */

--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -16,6 +16,13 @@ ort {
   analyzer {
     allowDynamicVersions = true
 
+    # A list of enabled package managers.
+    enabledPackageManagers = [DotNet, Gradle]
+
+    # A list of disabled package managers. Disabling a package manager here overrides enabling it in
+    # `enabledPackageManagers`.
+    disabledPackageManagers = [Maven, NPM]
+
     options {
       # A map of maps from package manager class names to package manager-specific key-value pairs.
       # At the example of applying custom options for DotNet, this would look like:


### PR DESCRIPTION
Allow to enable and disable specific package managers in the analyzer
configuration. This can still be overridden by the respective command
line options of the analyzer command.

The refactoring in this change is also a preparation for adding more
package manager specific configuration options later on.
