### PR TITLE
Codecov: Enable carry foward of partial coverage information

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,3 +6,6 @@ coverage:
     project:
       default:
         threshold: 0.1%
+flag_management:
+  default_rules:
+    carryforward: true


### PR DESCRIPTION
For details see [1]. This should help getting coverage right if not all
tests are run.

[1]: https://docs.codecov.com/docs/carryforward-flags

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>