### PR TITLE
NestedProvenanceScanResult: Pass `additionalData` to the merged results

### DIFF
--- a/scanner/src/main/kotlin/experimental/NestedProvenanceScanResult.kt
+++ b/scanner/src/main/kotlin/experimental/NestedProvenanceScanResult.kt
@@ -99,7 +99,8 @@ data class NestedProvenanceScanResult(
                     licenseFindings = licenseFindings,
                     copyrightFindings = copyrightFindings,
                     issues = issues
-                )
+                ),
+                additionalData = allScanResults.map { it.additionalData }.reduce { acc, map -> acc + map }
             )
         }
     }


### PR DESCRIPTION
This fixes a bug where `additionalData` were not in the OrtResults when
using the experimental scanners, despite being set by a scanner.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>
