### PR TITLE
LicenseFinding: Apply detected license mapping to valid SPDX expressions

### DIFF
--- a/model/src/main/kotlin/LicenseFinding.kt
+++ b/model/src/main/kotlin/LicenseFinding.kt
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
-import org.ossreviewtoolkit.utils.spdx.isSpdxExpression
 import org.ossreviewtoolkit.utils.spdx.toSpdx
 
 /**
@@ -62,7 +61,7 @@ data class LicenseFinding(
             score: Float? = null,
             detectedLicenseMapping: Map<String, String>
         ): LicenseFinding = LicenseFinding(
-            license = if (license.isSpdxExpression() || detectedLicenseMapping.isEmpty()) {
+            license = if (detectedLicenseMapping.isEmpty()) {
                 license
             } else {
                 license.applyDetectedLicenseMapping(detectedLicenseMapping)

--- a/model/src/test/kotlin/LicenseFindingTest.kt
+++ b/model/src/test/kotlin/LicenseFindingTest.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.model
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
+import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.toSpdx
 
 class LicenseFindingTest : WordSpec({
@@ -35,6 +36,19 @@ class LicenseFindingTest : WordSpec({
                 )
             ) shouldBe LicenseFinding(
                 license = "BSD-3-Clause".toSpdx(),
+                location = TextLocation(".", -1),
+            )
+        }
+
+        "apply the detected license mapping to a valid SPDX expression" {
+            LicenseFinding.createAndMap(
+                license = "LicenseRef-scancode-unknown",
+                location = TextLocation(".", -1),
+                detectedLicenseMapping = mapOf(
+                    "LicenseRef-scancode-unknown" to SpdxConstants.NOASSERTION,
+                )
+            ) shouldBe LicenseFinding(
+                license = SpdxConstants.NOASSERTION,
                 location = TextLocation(".", -1),
             )
         }


### PR DESCRIPTION
The functionality to map detected licenses can be used to map non-SPDX
licenses returned from scanners. However, it is also intended to be used
to map unwanted but valid licenses. Therefore, apply the mapping also to
valid SPDX expressions.

This is a fixup for https://github.com/oss-review-toolkit/ort/commit/0b8377dafdcae2cf48958876ff848c8c1d1b9d07.