### PR TITLE
fossid-webapp: Improve FossID reporter error logging

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/Extensions.kt
+++ b/clients/fossid-webapp/src/main/kotlin/Extensions.kt
@@ -341,9 +341,15 @@ suspend fun FossIdRestService.generateReport(
         val fileName = if (reportType == ReportType.HTML_STATIC) {
             "fossid-$scanCode-report.html"
         } else {
-            response.headers()["Content-disposition"]?.split(';')?.firstNotNullOfOrNull {
+            val contentDisposition = response.headers()["Content-disposition"]
+
+            contentDisposition?.split(';')?.firstNotNullOfOrNull {
                 it.trim().withoutPrefix("filename=")?.removeSurrounding("\"")
-            } ?: return Result.failure(IllegalStateException("Cannot determine name of the report"))
+            } ?: return Result.failure<File>(IllegalStateException("Cannot determine name of the report")).also {
+                FossIdRestService.logger.error {
+                    "Cannot determine name of the report with raw headers '$contentDisposition'."
+                }
+            }
         }
 
         Result.success(


### PR DESCRIPTION
When the report cannot be generated, log the headers of the response
received from the FossID server for better error logging.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>
