### PR TITLE
GoMod: Account for `go mod graph` not resolving module versions

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
@@ -22,29 +22,12 @@ project:
       linkage: "PROJECT_STATIC"
     - id: "GoMod::github.com/fatih/color:v1.13.0"
       linkage: "PROJECT_STATIC"
-      dependencies:
-      - id: "GoMod::github.com/mattn/go-colorable:v0.1.9"
-        linkage: "PROJECT_STATIC"
-        dependencies:
-        - id: "GoMod::github.com/mattn/go-isatty:v0.0.12"
-          linkage: "PROJECT_STATIC"
-          dependencies:
-          - id: "GoMod::golang.org/x/sys:v0.0.0-20200116001909-b77594299b42"
-            linkage: "PROJECT_STATIC"
-        - id: "GoMod::golang.org/x/sys:v0.0.0-20200223170610-d5e6a3e2c0ae"
-          linkage: "PROJECT_STATIC"
     - id: "GoMod::github.com/google/uuid:v1.0.0"
       linkage: "PROJECT_STATIC"
     - id: "GoMod::github.com/mattn/go-colorable:v0.1.12"
       linkage: "PROJECT_STATIC"
-      dependencies:
-      - id: "GoMod::golang.org/x/sys:v0.0.0-20210927094055-39ccf1dd6fa6"
-        linkage: "PROJECT_STATIC"
     - id: "GoMod::github.com/mattn/go-isatty:v0.0.14"
       linkage: "PROJECT_STATIC"
-      dependencies:
-      - id: "GoMod::golang.org/x/sys:v0.0.0-20210630005230-0f9fa26af87c"
-        linkage: "PROJECT_STATIC"
     - id: "GoMod::github.com/pborman/uuid:v1.2.1"
       linkage: "PROJECT_STATIC"
     - id: "GoMod::github.com/pmezard/go-difflib:v1.0.0"
@@ -159,32 +142,6 @@ packages:
     url: "https://github.com/google/uuid.git"
     revision: "v1.0.0"
     path: ""
-- id: "GoMod::github.com/mattn/go-colorable:v0.1.9"
-  purl: "pkg:golang/github.com%2Fmattn%2Fgo-colorable@v0.1.9"
-  declared_licenses: []
-  declared_licenses_processed: {}
-  description: ""
-  homepage_url: ""
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  vcs:
-    type: "Git"
-    url: "https://github.com/mattn/go-colorable.git"
-    revision: "v0.1.9"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/mattn/go-colorable.git"
-    revision: "v0.1.9"
-    path: ""
 - id: "GoMod::github.com/mattn/go-colorable:v0.1.12"
   purl: "pkg:golang/github.com%2Fmattn%2Fgo-colorable@v0.1.12"
   declared_licenses: []
@@ -210,32 +167,6 @@ packages:
     type: "Git"
     url: "https://github.com/mattn/go-colorable.git"
     revision: "v0.1.12"
-    path: ""
-- id: "GoMod::github.com/mattn/go-isatty:v0.0.12"
-  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.12"
-  declared_licenses: []
-  declared_licenses_processed: {}
-  description: ""
-  homepage_url: ""
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  vcs:
-    type: "Git"
-    url: "https://github.com/mattn/go-isatty.git"
-    revision: "v0.0.12"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/mattn/go-isatty.git"
-    revision: "v0.0.12"
     path: ""
 - id: "GoMod::github.com/mattn/go-isatty:v0.0.14"
   purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.14"
@@ -340,110 +271,6 @@ packages:
     type: "Git"
     url: "https://github.com/stretchr/testify.git"
     revision: "v1.7.2"
-    path: ""
-- id: "GoMod::golang.org/x/sys:v0.0.0-20200116001909-b77594299b42"
-  purl: "pkg:golang/golang.org%2Fx%2Fsys@v0.0.0-20200116001909-b77594299b42"
-  declared_licenses: []
-  declared_licenses_processed: {}
-  description: ""
-  homepage_url: ""
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://proxy.golang.org/golang.org/x/sys/@v/v0.0.0-20200116001909-b77594299b42.zip"
-    hash:
-      value: ""
-      algorithm: ""
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-- id: "GoMod::golang.org/x/sys:v0.0.0-20200223170610-d5e6a3e2c0ae"
-  purl: "pkg:golang/golang.org%2Fx%2Fsys@v0.0.0-20200223170610-d5e6a3e2c0ae"
-  declared_licenses: []
-  declared_licenses_processed: {}
-  description: ""
-  homepage_url: ""
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://proxy.golang.org/golang.org/x/sys/@v/v0.0.0-20200223170610-d5e6a3e2c0ae.zip"
-    hash:
-      value: ""
-      algorithm: ""
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-- id: "GoMod::golang.org/x/sys:v0.0.0-20210630005230-0f9fa26af87c"
-  purl: "pkg:golang/golang.org%2Fx%2Fsys@v0.0.0-20210630005230-0f9fa26af87c"
-  declared_licenses: []
-  declared_licenses_processed: {}
-  description: ""
-  homepage_url: ""
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://proxy.golang.org/golang.org/x/sys/@v/v0.0.0-20210630005230-0f9fa26af87c.zip"
-    hash:
-      value: ""
-      algorithm: ""
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-- id: "GoMod::golang.org/x/sys:v0.0.0-20210927094055-39ccf1dd6fa6"
-  purl: "pkg:golang/golang.org%2Fx%2Fsys@v0.0.0-20210927094055-39ccf1dd6fa6"
-  declared_licenses: []
-  declared_licenses_processed: {}
-  description: ""
-  homepage_url: ""
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://proxy.golang.org/golang.org/x/sys/@v/v0.0.0-20210927094055-39ccf1dd6fa6.zip"
-    hash:
-      value: ""
-      algorithm: ""
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: ""
-    url: ""
-    revision: ""
     path: ""
 - id: "GoMod::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
   purl: "pkg:golang/golang.org%2Fx%2Fsys@v0.0.0-20220610221304-9f5ed59c137d"

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-subpkg-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-subpkg-expected-output.yml
@@ -22,12 +22,6 @@ project:
       linkage: "PROJECT_STATIC"
     - id: "GoMod::github.com/mattn/go-colorable:v0.1.4"
       linkage: "PROJECT_STATIC"
-      dependencies:
-      - id: "GoMod::github.com/mattn/go-isatty:v0.0.8"
-        linkage: "PROJECT_STATIC"
-        dependencies:
-        - id: "GoMod::golang.org/x/sys:v0.0.0-20190222072716-a9d3bda3a223"
-          linkage: "PROJECT_STATIC"
     - id: "GoMod::github.com/mattn/go-isatty:v0.0.10"
       linkage: "PROJECT_STATIC"
       dependencies:
@@ -97,32 +91,6 @@ packages:
     url: "https://github.com/mattn/go-colorable.git"
     revision: "v0.1.4"
     path: ""
-- id: "GoMod::github.com/mattn/go-isatty:v0.0.8"
-  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.8"
-  declared_licenses: []
-  declared_licenses_processed: {}
-  description: ""
-  homepage_url: ""
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  vcs:
-    type: "Git"
-    url: "https://github.com/mattn/go-isatty.git"
-    revision: "v0.0.8"
-    path: ""
-  vcs_processed:
-    type: "Git"
-    url: "https://github.com/mattn/go-isatty.git"
-    revision: "v0.0.8"
-    path: ""
 - id: "GoMod::github.com/mattn/go-isatty:v0.0.10"
   purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.10"
   declared_licenses: []
@@ -148,32 +116,6 @@ packages:
     type: "Git"
     url: "https://github.com/mattn/go-isatty.git"
     revision: "v0.0.10"
-    path: ""
-- id: "GoMod::golang.org/x/sys:v0.0.0-20190222072716-a9d3bda3a223"
-  purl: "pkg:golang/golang.org%2Fx%2Fsys@v0.0.0-20190222072716-a9d3bda3a223"
-  declared_licenses: []
-  declared_licenses_processed: {}
-  description: ""
-  homepage_url: ""
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://proxy.golang.org/golang.org/x/sys/@v/v0.0.0-20190222072716-a9d3bda3a223.zip"
-    hash:
-      value: ""
-      algorithm: ""
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: ""
-    url: ""
-    revision: ""
     path: ""
 - id: "GoMod::golang.org/x/sys:v0.0.0-20191008105621-543471e840be"
   purl: "pkg:golang/golang.org%2Fx%2Fsys@v0.0.0-20191008105621-543471e840be"


### PR DESCRIPTION
The documentation [1] states that "Each vertex in the module graph
represents a specific version of a module. Each edge in the graph
represents a requirement on a minimum version of a dependency."

As ORT's dependency tree representation is about resolved version, not
about version requirements, using the graph as-is is wrong. Turn the
version requirements graph into a dependency graph with resolved version
by utilizing the command ´go list -m´, which outputs the resolved
version for each respective module [1][2].

[1] https://go.dev/ref/mod#go-mod-graph
[2] https://go.dev/ref/mod#minimal-version-selection

This fixes one of the issues outlined in #5021.