### PR TITLE
GoMod: Drop the "all" scope, simplify and clean-up a bit

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
@@ -16,31 +16,6 @@ project:
     path: "<REPLACE_PATH>"
   homepage_url: ""
   scopes:
-  - name: "all"
-    dependencies:
-    - id: "GoMod::github.com/davecgh/go-spew:v1.1.0"
-      linkage: "PROJECT_STATIC"
-    - id: "GoMod::github.com/fatih/color:v1.13.0"
-      linkage: "PROJECT_STATIC"
-    - id: "GoMod::github.com/google/uuid:v1.0.0"
-      linkage: "PROJECT_STATIC"
-    - id: "GoMod::github.com/mattn/go-colorable:v0.1.12"
-      linkage: "PROJECT_STATIC"
-    - id: "GoMod::github.com/mattn/go-isatty:v0.0.14"
-      linkage: "PROJECT_STATIC"
-    - id: "GoMod::github.com/pborman/uuid:v1.2.1"
-      linkage: "PROJECT_STATIC"
-    - id: "GoMod::github.com/pmezard/go-difflib:v1.0.0"
-      linkage: "PROJECT_STATIC"
-    - id: "GoMod::github.com/stretchr/testify:v1.7.2"
-      linkage: "PROJECT_STATIC"
-    - id: "GoMod::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
-      linkage: "PROJECT_STATIC"
-    - id: "GoMod::gopkg.in/yaml.v3:v3.0.1"
-      linkage: "PROJECT_STATIC"
-      dependencies:
-      - id: "GoMod::gopkg.in/check.v1:v0.0.0-20161208181325-20d25e280405"
-        linkage: "PROJECT_STATIC"
   - name: "vendor"
     dependencies:
     - id: "GoMod::github.com/davecgh/go-spew:v1.1.0"
@@ -285,32 +260,6 @@ packages:
       algorithm: ""
   source_artifact:
     url: "https://proxy.golang.org/golang.org/x/sys/@v/v0.0.0-20220610221304-9f5ed59c137d.zip"
-    hash:
-      value: ""
-      algorithm: ""
-  vcs:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-  vcs_processed:
-    type: ""
-    url: ""
-    revision: ""
-    path: ""
-- id: "GoMod::gopkg.in/check.v1:v0.0.0-20161208181325-20d25e280405"
-  purl: "pkg:golang/gopkg.in%2Fcheck.v1@v0.0.0-20161208181325-20d25e280405"
-  declared_licenses: []
-  declared_licenses_processed: {}
-  description: ""
-  homepage_url: ""
-  binary_artifact:
-    url: ""
-    hash:
-      value: ""
-      algorithm: ""
-  source_artifact:
-    url: "https://proxy.golang.org/gopkg.in/check.v1/@v/v0.0.0-20161208181325-20d25e280405.zip"
     hash:
       value: ""
       algorithm: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-subpkg-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-subpkg-expected-output.yml
@@ -16,17 +16,6 @@ project:
     path: "<REPLACE_PATH>"
   homepage_url: ""
   scopes:
-  - name: "all"
-    dependencies:
-    - id: "GoMod::github.com/fatih/color:v1.7.0"
-      linkage: "PROJECT_STATIC"
-    - id: "GoMod::github.com/mattn/go-colorable:v0.1.4"
-      linkage: "PROJECT_STATIC"
-    - id: "GoMod::github.com/mattn/go-isatty:v0.0.10"
-      linkage: "PROJECT_STATIC"
-      dependencies:
-      - id: "GoMod::golang.org/x/sys:v0.0.0-20191008105621-543471e840be"
-        linkage: "PROJECT_STATIC"
   - name: "vendor"
     dependencies:
     - id: "GoMod::github.com/fatih/color:v1.7.0"

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -153,7 +153,7 @@ class GoMod(
             graph.addEdge(parent, child)
         }
 
-        val vendorModules = getVendorModules(graph, projectDir, graph.projectId())
+        val vendorModules = getVendorModules(graph, projectDir)
         if (vendorModules.size < graph.size()) {
             log.debug { "Removing ${graph.size() - vendorModules.size} non-vendor modules from the dependency graph." }
 
@@ -184,8 +184,8 @@ class GoMod(
      * Return the subset of the modules in [graph] required for building and testing the main module. So, test
      * dependencies of dependencies are filtered out.
      */
-    private fun getVendorModules(graph: Graph, projectDir: File, projectId: Identifier): Set<Identifier> {
-        val vendorModuleNames = mutableSetOf(projectId.name)
+    private fun getVendorModules(graph: Graph, projectDir: File): Set<Identifier> {
+        val vendorModuleNames = mutableSetOf(graph.projectId().name)
 
         graph.nodes().chunked(WHY_CHUNK_SIZE).forEach { ids ->
             val moduleNames = ids.map { it.name }.toTypedArray()

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -190,8 +190,8 @@ class GoMod(
     }
 
     /**
-     * Determine the set of modules that are actually used by the [main module][projectId] by running the _go mod why_
-     * command repeatedly in [projectDir].
+     * Return the subset of the modules in [graph] required for building and testing the main module. So, test
+     * dependencies of dependencies are filtered out.
      */
     private fun getVendorModules(graph: Graph, projectDir: File, projectId: Identifier): Set<Identifier> {
         val vendorModuleNames = mutableSetOf(projectId.name)

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -160,15 +160,6 @@ class GoMod(
             graph = graph.subgraph(vendorModules)
         }
 
-        val referencedModules = graph.getTransitiveDependencies(graph.projectId())
-        if (referencedModules.size < graph.size()) {
-            log.debug {
-                "Removing ${graph.size() - referencedModules.size} unreferenced modules from the dependency graph."
-            }
-
-            graph = graph.subgraph(referencedModules)
-        }
-
         return graph
     }
 
@@ -327,25 +318,6 @@ private class Graph(private val nodeMap: MutableMap<Identifier, Set<Identifier>>
 
         val startNodes = dependencies(root)
         return startNodes.mapTo(sortedSetOf()) { getPackageReference(it, startNodes) }
-    }
-
-    /**
-     * Return all identifiers reachable from [root] including [root].
-     */
-    fun getTransitiveDependencies(root: Identifier): Set<Identifier> {
-        val queue = mutableListOf(root)
-        val result = mutableSetOf<Identifier>()
-
-        while (queue.isNotEmpty()) {
-            val id = queue.removeFirst()
-
-            if (id !in result) {
-                result += id
-                queue += dependencies(id)
-            }
-        }
-
-        return result
     }
 
     /**

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -99,9 +99,7 @@ class GoMod(
             val projectId = graph.projectId()
             val packageIds = graph.nodes() - projectId
             val packages = packageIds.mapTo(sortedSetOf()) { createPackage(it) }
-
             val projectVcs = processProjectVcs(projectDir)
-
             val scopes = sortedSetOf(
                 Scope(name = "vendor", dependencies = graph.toPackageReferenceForest(projectId))
             )

--- a/helper-cli/src/main/kotlin/commands/repoconfig/GenerateScopeExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/repoconfig/GenerateScopeExcludesCommand.kt
@@ -115,13 +115,6 @@ private fun getScopeExcludesForPackageManager(packageManagerName: String): List<
                 comment = "Packages for development only."
             )
         )
-        "GoMod" -> listOf(
-            ScopeExclude(
-                pattern = "all",
-                reason = ScopeExcludeReason.BUILD_DEPENDENCY_OF,
-                comment = "Packages to build all targets including tests only."
-            )
-        )
         "Gradle" -> listOf(
             ScopeExclude(
                 pattern = ".*AnnotationProcessor.*",


### PR DESCRIPTION
See individual commits.

Eliminate over-reporting of dependencies I discovered while investigating #5021.
