### PR TITLE
DeleteCommand: Remove hard coded database schema name

### DIFF
--- a/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
@@ -106,11 +106,12 @@ internal class DeleteCommand : CliktCommand(
             val ids = database.transaction {
                 // language=PostgreSQL
                 """
-                SELECT id
-                FROM scan_storage.scan_results
-                WHERE (scan_result -> 'summary' -> 'licenses')::jsonb @> '[{"license": "$license"}]'::jsonb
+                SELECT ${ScanResults.id.name}
+                FROM ${ScanResults.tableName}
+                WHERE (${ScanResults.scanResult.name} -> 'summary' -> 'licenses')::jsonb @>
+                    '[{"license": "$license"}]'::jsonb
                 """.trimIndent().execAndMap {
-                    it.getInt("id")
+                    it.getInt(ScanResults.id.name)
                 }
             }
 


### PR DESCRIPTION
Change the SELECT statement to retrieve stored scan results with a
specific license to use the configured schema name.

This is a fixup for 5cae85a7dbab35a20de26134f2cb0e13055a447a.
