### PR TITLE
GoMod: Distinguish main module from development-only dependencies

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
@@ -16,6 +16,20 @@ project:
     path: "<REPLACE_PATH>"
   homepage_url: ""
   scopes:
+  - name: "main"
+    dependencies:
+    - id: "GoMod::github.com/fatih/color:v1.13.0"
+      linkage: "PROJECT_STATIC"
+    - id: "GoMod::github.com/google/uuid:v1.0.0"
+      linkage: "PROJECT_STATIC"
+    - id: "GoMod::github.com/mattn/go-colorable:v0.1.12"
+      linkage: "PROJECT_STATIC"
+    - id: "GoMod::github.com/mattn/go-isatty:v0.0.14"
+      linkage: "PROJECT_STATIC"
+    - id: "GoMod::github.com/pborman/uuid:v1.2.1"
+      linkage: "PROJECT_STATIC"
+    - id: "GoMod::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
+      linkage: "PROJECT_STATIC"
   - name: "vendor"
     dependencies:
     - id: "GoMod::github.com/davecgh/go-spew:v1.1.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-subpkg-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-subpkg-expected-output.yml
@@ -16,6 +16,17 @@ project:
     path: "<REPLACE_PATH>"
   homepage_url: ""
   scopes:
+  - name: "main"
+    dependencies:
+    - id: "GoMod::github.com/fatih/color:v1.7.0"
+      linkage: "PROJECT_STATIC"
+    - id: "GoMod::github.com/mattn/go-colorable:v0.1.4"
+      linkage: "PROJECT_STATIC"
+    - id: "GoMod::github.com/mattn/go-isatty:v0.0.10"
+      linkage: "PROJECT_STATIC"
+      dependencies:
+      - id: "GoMod::golang.org/x/sys:v0.0.0-20191008105621-543471e840be"
+        linkage: "PROJECT_STATIC"
   - name: "vendor"
     dependencies:
     - id: "GoMod::github.com/fatih/color:v1.7.0"

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -96,8 +96,20 @@ class GoMod(
             val packageIds = graph.nodes() - projectId
             val packages = packageIds.mapTo(sortedSetOf()) { createPackage(it) }
             val projectVcs = processProjectVcs(projectDir)
+
+            val dependenciesScopePackageIds = getTransitiveMainModuleDependencies(projectDir).let { moduleNames ->
+                graph.nodes().filterTo(mutableSetOf()) { it.name in moduleNames }
+            }
+
             val scopes = sortedSetOf(
-                Scope(name = "vendor", dependencies = graph.toPackageReferenceForest(projectId))
+                Scope(
+                    name = "main",
+                    dependencies = graph.subgraph(dependenciesScopePackageIds).toPackageReferenceForest(projectId)
+                ),
+                Scope(
+                    name = "vendor",
+                    dependencies = graph.toPackageReferenceForest(projectId)
+                )
             )
 
             return listOf(
@@ -197,6 +209,26 @@ class GoMod(
         }
 
         return graph.nodes().filterTo(mutableSetOf()) { it.name in vendorModuleNames }
+    }
+
+    /**
+     * Return the module names of all transitive main module dependencies. This excludes test-only dependencies.
+     */
+    private fun getTransitiveMainModuleDependencies(projectDir: File): Set<String> {
+        val result = mutableSetOf<String>()
+
+        val list = run(
+            "list", "-deps", "-f", "{{with .Module}}{{.Path}} {{.Version}}{{end}}", "./...", workingDir = projectDir
+        )
+
+        list.stdout.lines().forEach { line ->
+            val columns = line.split(' ')
+            if (columns.size != 2) return@forEach
+
+            result += columns[0]
+        }
+
+        return result
     }
 
     private fun createPackage(id: Identifier): Package {


### PR DESCRIPTION
See individual commits.

These are improvements on top of recent work done for fixing #5021.