### PR TITLE
LicenseFinding: Fix regex to replace the detected license finding

### DIFF
--- a/model/src/main/kotlin/LicenseFinding.kt
+++ b/model/src/main/kotlin/LicenseFinding.kt
@@ -83,8 +83,11 @@ data class LicenseFinding(
 private fun String.applyDetectedLicenseMapping(detectedLicenseMapping: Map<String, String>): String {
     var result = this
     detectedLicenseMapping.forEach { (from, to) ->
-        // Replace a license restricted by whitespace boundaries.
-        result = result.replace("""(?<!\S)${Regex.escape(from)}""".toRegex(), to)
+        val regex = """(^| |\()(${Regex.escape(from)})($| |\))""".toRegex()
+
+        result = regex.replace(result) {
+            "${it.groupValues[1]}${to}${it.groupValues[3]}"
+        }
     }
 
     return result

--- a/model/src/test/kotlin/LicenseFindingTest.kt
+++ b/model/src/test/kotlin/LicenseFindingTest.kt
@@ -40,6 +40,19 @@ class LicenseFindingTest : WordSpec({
             )
         }
 
+        "apply the detected license mapping if the mapping is wrapped in parentheses" {
+            LicenseFinding.createAndMap(
+                license = "(a)",
+                location = TextLocation(".", -1),
+                detectedLicenseMapping = mapOf(
+                    "(a)" to "b",
+                )
+            ) shouldBe LicenseFinding(
+                license = "b".toSpdx(),
+                location = TextLocation(".", -1),
+            )
+        }
+
         "apply the detected license mapping to a valid SPDX expression" {
             LicenseFinding.createAndMap(
                 license = "LicenseRef-scancode-unknown",
@@ -62,6 +75,19 @@ class LicenseFindingTest : WordSpec({
                 )
             ) shouldBe LicenseFinding(
                 license = "AGPL-1.0-or-later".toSpdx(),
+                location = TextLocation(".", -1),
+            )
+        }
+
+        "apply the detected license mapping only on word boundaries" {
+            LicenseFinding.createAndMap(
+                license = "LicenseRef-scancode-unknown-license-reference",
+                location = TextLocation(".", -1),
+                detectedLicenseMapping = mapOf(
+                    "LicenseRef-scancode-unknown" to SpdxConstants.NOASSERTION,
+                )
+            ) shouldBe LicenseFinding(
+                license = "LicenseRef-scancode-unknown-license-reference".toSpdx(),
                 location = TextLocation(".", -1),
             )
         }
@@ -97,6 +123,19 @@ class LicenseFindingTest : WordSpec({
                 )
             ) shouldBe LicenseFinding(
                 license = "(AGPL-1.0-or-later AND BSD-3-Clause) OR MIT".toSpdx(),
+                location = TextLocation(".", -1),
+            )
+        }
+
+        "apply the detected license mapping without removing necessary parentheses" {
+            LicenseFinding.createAndMap(
+                license = "(a OR b) AND c",
+                location = TextLocation(".", -1),
+                detectedLicenseMapping = mapOf(
+                    "a" to "d",
+                )
+            ) shouldBe LicenseFinding(
+                license = "(d OR b) AND c".toSpdx(),
                 location = TextLocation(".", -1),
             )
         }


### PR DESCRIPTION
The regex used before, using a negative lookbehind to determine the word
boundaries of a license, did not work in some cases, when special
characters are used in the license expression.
Replace this regex with another one that checks either for whitespaces
before and after the license expression or for the beginning or the end
of the string, respectively.

