### PR TITLE
scanoss: Replace the hard-coded "Blacklist" with a configurable one

### DIFF
--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -150,6 +150,15 @@ ort:
 
         timeout: 60
 
+      ScanOss:
+        ignoredFileSuffixes: >-
+          .1,.2,.3,.4,.5,.6,.7,.8,.9,.ac,.am,.bmp,.build,.cfg,.chm,.changelog,.class,.cmake,.conf,.config,.contributors,
+          .copying,.csproj,.css,.csv,.cvsignore,.dat,.data,.dtd,.dts,.dtsi,.eps,.geojson,.gif,.gitignore,.glif,.gmo,
+          .guess,.hex,.html,.htm,.ico,.in,.inc,.info,.ini,.ipynb,.jpg,.jpeg,.json,.license,.log,.m4,.map,.markdown,.md,
+          .md5,.mk,.makefile,.meta,.mxml,.notice,.out,.pdf,.pem,.phtml,.png,.po,.prefs,.properties,.readme,.result,.rst,
+          .scss,.sha,.sha1,.sha2,.sha256,.sln,.spec,.sub,.svg,.svn-base,.tab,.template,.test,.tex,.todo,.txt,.utf-8,
+          .version,.vim,.wav,.xht,.xhtml,.xml,.xpm,.xsd,.xul,.yaml,.yml
+
     storages:
       local:
         backend:

--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
@@ -20,7 +20,6 @@
 
 package org.ossreviewtoolkit.scanner.scanners.scanoss
 
-import com.scanoss.scanner.BlacklistRules
 import com.scanoss.scanner.Winnowing
 
 import java.io.File
@@ -95,8 +94,7 @@ class ScanOss internal constructor(
 
         val wfpString = buildString {
             path.walk()
-                // TODO: Consider not applying the (somewhat arbitrary) blacklist.
-                .filter { !it.isDirectory && !BlacklistRules.hasBlacklistedExt(it.name) }
+                .filter { it.isFile && config.ignoredFileSuffixes.none { suffix -> it.name.endsWith(suffix) } }
                 .forEach {
                     logger.info { "Computing fingerprint for file ${it.absolutePath}..." }
                     append(createWfpForFile(it.path))

--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOssConfig.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOssConfig.kt
@@ -47,7 +47,7 @@ internal data class ScanOssConfig(
         const val IGNORED_FILE_SUFFIXES_PROPERTY = "ignoredFileSuffixes"
 
         /** The default API URL to use. */
-        private const val DEFAULT_API_URL = "https://osskb.org/api/"
+        internal const val DEFAULT_API_URL = "https://osskb.org/api/"
 
         /** The default list of ignored file extension. */
         private val DEFAULT_IGNORED_FILE_EXTENSIONS = listOf(
@@ -66,7 +66,7 @@ internal data class ScanOssConfig(
         )
 
         /** The default list of ignored file suffixes. */
-        private val DEFAULT_IGNORED_FILE_SUFFIXES = DEFAULT_IGNORED_FILE_EXTENSIONS + listOf(
+        internal val DEFAULT_IGNORED_FILE_SUFFIXES = DEFAULT_IGNORED_FILE_EXTENSIONS + listOf(
             "-doc", "authors", "changelog", "config", "copying", "ignore", "license", "licenses", "manifest", "news",
             "notice", "readme", "sqlite", "sqlite3", "swiftdoc", "texidoc", "todo", "version"
         )

--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOssConfig.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOssConfig.kt
@@ -31,7 +31,10 @@ internal data class ScanOssConfig(
     val apiUrl: String,
 
     /** API Key required to authenticate with the ScanOSS server. */
-    val apiKey: String
+    val apiKey: String,
+
+    /** A list of suffixes of files to be ignored during the scan. */
+    val ignoredFileSuffixes: List<String>
 ) {
     companion object {
         /** Name of the configuration property for the API URL. */
@@ -40,6 +43,31 @@ internal data class ScanOssConfig(
         /** Name of the configuration property for the API key. */
         const val API_KEY_PROPERTY = "apiKey"
 
+        /** Name of the configuration property for the list of ignored file suffixes. */
+        const val IGNORED_FILE_SUFFIXES_PROPERTY = "ignoredFileSuffixes"
+
+        /** The default list of ignored file extension. */
+        private val DEFAULT_IGNORED_FILE_EXTENSIONS = listOf(
+            ".1", ".2", ".3", ".4", ".5", ".6", ".7", ".8", ".9", ".ac", ".adoc", ".am", ".asciidoc", ".bmp", ".build",
+            ".c9", ".c9revisions", ".cache", ".cfg", ".chm", ".class", ".cmake", ".cnf", ".conf", ".config",
+            ".contributors", ".copying", ".cover", ".coverage", ".crt", ".csproj", ".css", ".csv", ".dat", ".data",
+            ".doc", ".docx", ".dotcover", ".dtd", ".dts", ".dtsi", ".dump", ".editorconfig", ".egg", ".eot", ".eps",
+            ".gdoc", ".gem", ".geojson", ".gif", ".glif", ".gml", ".gmo", ".gradle", ".guess", ".hex", ".htm", ".html",
+            ".ico", ".iml", ".in", ".inc", ".info", ".ini", ".ipynb", ".iws", ".jpeg", ".jpg", ".json", ".jsonld",
+            ".lcov", ".lock", ".log", ".lst", ".m4", ".manifest", ".map", ".markdown", ".md", ".md5", ".meta", ".mk",
+            ".mxml", ".o", ".otf", ".out", ".pbtxt", ".pdb", ".pdf", ".pem", ".phtml", ".pickle", ".pid", ".plist",
+            ".plt", ".png", ".po", ".pot", ".ppt", ".prefs", ".properties", ".pyc", ".qdoc", ".result", ".rgb", ".rst",
+            ".scss", ".sha", ".sha1", ".sha2", ".sha256", ".sln", ".spec", ".sql", ".sub", ".svg", ".svn-base", ".tab",
+            ".template", ".test", ".tex", ".tiff", ".toml", ".ttf", ".txt", ".utf-8", ".vim", ".wav", ".wfp", ".whl",
+            ".woff", ".xht", ".xhtml", ".xls", ".xlsx", ".xml", ".xpm", ".xsd", ".xul", ".yaml", ".yml"
+        )
+
+        /** The default list of ignored file suffixes. */
+        private val DEFAULT_IGNORED_FILE_SUFFIXES = DEFAULT_IGNORED_FILE_EXTENSIONS + listOf(
+            "-doc", "authors", "changelog", "config", "copying", "ignore", "license", "licenses", "manifest", "news",
+            "notice", "readme", "sqlite", "sqlite3", "swiftdoc", "texidoc", "todo", "version"
+        )
+
         fun create(scannerConfig: ScannerConfiguration): ScanOssConfig {
             val scanOssIdScannerOptions = scannerConfig.options?.get("ScanOss")
 
@@ -47,8 +75,12 @@ internal data class ScanOssConfig(
 
             val apiURL = scanOssIdScannerOptions[API_URL_PROPERTY] ?: "https://osskb.org/api/"
             val apiKey = scanOssIdScannerOptions[API_KEY_PROPERTY].orEmpty()
+            val ignoredFileSuffixes = scanOssIdScannerOptions[IGNORED_FILE_SUFFIXES_PROPERTY]
+                ?.split(',')
+                ?.map { it.trim() }
+                ?: DEFAULT_IGNORED_FILE_SUFFIXES
 
-            return ScanOssConfig(apiURL, apiKey)
+            return ScanOssConfig(apiURL, apiKey, ignoredFileSuffixes)
         }
     }
 }

--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOssConfig.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOssConfig.kt
@@ -46,6 +46,9 @@ internal data class ScanOssConfig(
         /** Name of the configuration property for the list of ignored file suffixes. */
         const val IGNORED_FILE_SUFFIXES_PROPERTY = "ignoredFileSuffixes"
 
+        /** The default API URL to use. */
+        private const val DEFAULT_API_URL = "https://osskb.org/api/"
+
         /** The default list of ignored file extension. */
         private val DEFAULT_IGNORED_FILE_EXTENSIONS = listOf(
             ".1", ".2", ".3", ".4", ".5", ".6", ".7", ".8", ".9", ".ac", ".adoc", ".am", ".asciidoc", ".bmp", ".build",
@@ -73,7 +76,7 @@ internal data class ScanOssConfig(
 
             requireNotNull(scanOssIdScannerOptions) { "No ScanOSS Scanner configuration found." }
 
-            val apiURL = scanOssIdScannerOptions[API_URL_PROPERTY] ?: "https://osskb.org/api/"
+            val apiURL = scanOssIdScannerOptions[API_URL_PROPERTY] ?: DEFAULT_API_URL
             val apiKey = scanOssIdScannerOptions[API_KEY_PROPERTY].orEmpty()
             val ignoredFileSuffixes = scanOssIdScannerOptions[IGNORED_FILE_SUFFIXES_PROPERTY]
                 ?.split(',')

--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOssConfig.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOssConfig.kt
@@ -72,13 +72,11 @@ internal data class ScanOssConfig(
         )
 
         fun create(scannerConfig: ScannerConfiguration): ScanOssConfig {
-            val scanOssIdScannerOptions = scannerConfig.options?.get("ScanOss")
+            val scanOssOptions = scannerConfig.options?.get("ScanOss")
 
-            requireNotNull(scanOssIdScannerOptions) { "No ScanOSS Scanner configuration found." }
-
-            val apiURL = scanOssIdScannerOptions[API_URL_PROPERTY] ?: DEFAULT_API_URL
-            val apiKey = scanOssIdScannerOptions[API_KEY_PROPERTY].orEmpty()
-            val ignoredFileSuffixes = scanOssIdScannerOptions[IGNORED_FILE_SUFFIXES_PROPERTY]
+            val apiURL = scanOssOptions?.get(API_URL_PROPERTY) ?: DEFAULT_API_URL
+            val apiKey = scanOssOptions?.get(API_KEY_PROPERTY).orEmpty()
+            val ignoredFileSuffixes = scanOssOptions?.get(IGNORED_FILE_SUFFIXES_PROPERTY)
                 ?.split(',')
                 ?.map { it.trim() }
                 ?: DEFAULT_IGNORED_FILE_SUFFIXES

--- a/scanner/src/test/kotlin/scanners/scanoss/ScanOssConfigTest.kt
+++ b/scanner/src/test/kotlin/scanners/scanoss/ScanOssConfigTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.scanoss
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.beEmpty
+
+import org.ossreviewtoolkit.model.config.ScannerConfiguration
+
+class ScanOssConfigTest : StringSpec({
+    "Default values are used" {
+        with(ScanOssConfig.create(ScannerConfiguration())) {
+            apiUrl shouldBe ScanOssConfig.DEFAULT_API_URL
+            apiKey should beEmpty()
+            ignoredFileSuffixes shouldBe ScanOssConfig.DEFAULT_IGNORED_FILE_SUFFIXES
+        }
+    }
+
+    "Default values can be overridden" {
+        val scanOssOptions = mapOf(
+            ScanOssConfig.API_URL_PROPERTY to "url",
+            ScanOssConfig.API_KEY_PROPERTY to "key",
+            ScanOssConfig.IGNORED_FILE_SUFFIXES_PROPERTY to ".ext, -suffix"
+        )
+
+        val config = ScannerConfiguration(options = mapOf("ScanOss" to scanOssOptions))
+
+        with(ScanOssConfig.create(config)) {
+            apiUrl shouldBe "url"
+            apiKey shouldBe "key"
+            ignoredFileSuffixes shouldBe listOf(".ext", "-suffix")
+        }
+    }
+})


### PR DESCRIPTION
For reference, the original hard-coded values from the ScanOss library's
`BlacklistRules` [1] are used.

This is a step towards getting rid of the dependency on the deprecated
ScanOss Java library in favor of only using ORT's own client library.

[1]: https://github.com/scanoss/scanner.java/blob/350c211/src/main/java/com/scanoss/scanner/BlacklistRules.java#L32-L40

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>