### PR TITLE
GoMod: Handle the replace directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,8 +326,7 @@ supported:
   * [dep](https://golang.github.io/dep/)
   * [Glide](https://github.com/Masterminds/glide)
   * [Godep](https://github.com/tools/godep)
-  * [GoMod](https://github.com/golang/go/wiki/Modules) (limitations:
-    [no `replace` directive](https://github.com/oss-review-toolkit/ort/issues/4445))
+  * [GoMod](https://github.com/golang/go/wiki/Modules)
 * Haskell
   * [Stack](https://haskellstack.org/)
 * Java

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod/go.mod
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/fatih/color v1.13.0
 	github.com/pborman/uuid v1.2.1
-	github.com/stretchr/testify v1.7.2
+	github.com/stretchr/testify v1.7.1
 )
 
 require (
@@ -17,3 +17,5 @@ require (
 	golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.7.2

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -171,7 +171,9 @@ class GoMod(
 
         val list = run("list", "-m", "all", workingDir = projectDir)
         list.stdout.lines().forEach { line ->
-            val columns = line.split(' ')
+            // For replaced modules the line is formatted as "${orig-module} => ${replaced-module}", see also
+            // https://go.dev/ref/mod#go-mod-file-replace.
+            val columns = line.substringAfterLast(" => ").split(' ')
             if (columns.size != 2) return@forEach
 
             result += Identifier(type = managerName, namespace = "", name = columns[0], version = columns[1])


### PR DESCRIPTION
Extend the logic for parsing the output for `go list -m all` to properly
handle lines for replaced modules [1]. Adjust the test asset to cover a
replacement. Also remove the mention of this limitation from the
documentation as replacements are now properly handled.

[1] https://go.dev/ref/mod#go-mod-file-replace

Fixes #4445.