### PR TITLE
fossid-webapp: Fix deserialization error on `deleteScan` response

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/EntityResponseBody.kt
+++ b/clients/fossid-webapp/src/main/kotlin/EntityResponseBody.kt
@@ -34,3 +34,5 @@ typealias MapResponseBody<T> = EntityResponseBody<Map<String, T>>
 typealias PolymorphicResponseBody<T> = EntityResponseBody<PolymorphicList<T>>
 
 class PolymorphicList<T>(data: List<T> = listOf()) : List<T> by data
+
+class PolymorphicInt(val value: Int?)

--- a/clients/fossid-webapp/src/main/kotlin/EntityResponseBody.kt
+++ b/clients/fossid-webapp/src/main/kotlin/EntityResponseBody.kt
@@ -23,7 +23,7 @@ class EntityResponseBody<T>(
     val operation: String? = null,
     val status: Int? = null,
     val message: String? = null,
-    val messageParameters: Array<String>? = null,
+    val messageParameters: Map<String, String> = emptyMap(),
     val error: String? = null,
 
     val data: T? = null

--- a/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
+++ b/clients/fossid-webapp/src/main/kotlin/FossIdRestService.kt
@@ -83,7 +83,7 @@ interface FossIdRestService {
          * A class to modify the standard Jackson deserialization to deal with inconsistencies in responses
          * sent by the FossID server.
          * FossID usually returns data as a List or Map, but in case of no entries it returns a Boolean (which is set to
-         * false). This custom deserializer streamLines the result:
+         * false). This custom deserializer streamlines the result:
          * - maps are converted to lists by ignoring the keys
          * - empty list is returned when the result is Boolean
          * - to address a FossID bug in get_all_scans operation, arrays are converted to list.

--- a/clients/fossid-webapp/src/test/assets/return-type/mappings/apiphp-delete_scan.json
+++ b/clients/fossid-webapp/src/test/assets/return-type/mappings/apiphp-delete_scan.json
@@ -1,0 +1,26 @@
+{
+  "id" : "d791fc9e-c440-4123-9267-72baab5019e9",
+  "name" : "apiphp",
+  "request" : {
+    "url" : "/api.php",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"action\":\"delete\",\"group\":\"scans\",\"data\":{\"username\":\"\",\"key\":\"\",\"scan_code\":\"semver4j_20201203_090342\",\"delete_identifications\":\"1\"}}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : true
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"operation\":\"scans_delete\",\"status\":\"0\",\"data\":[],\"error\":\"Classes.TableRepository.row_not_found\",\"message\":\"Row semver4j_20201203_090342 in table scans not found\",\"message_parameters\":{\"rowidentifier\":\"semver4j_20201203_090342\",\"table\":\"scans\"}}",
+    "headers" : {
+      "Content-Type" : "text/html; charset=UTF-8",
+      "Date" : "Thu, 15 Mar 2021 15:05:02 GMT",
+      "Server" : "Apache/2.4.38 (Debian)",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "d791fc9e-c440-4123-9267-72baab5019e9",
+  "persistent" : true,
+  "insertionIndex" : 10
+}

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientNewProjectTest.kt
@@ -136,7 +136,7 @@ class FossIdClientNewProjectTest : StringSpec({
         service.deleteScan("", "", SCAN_CODE).shouldNotBeNull().run {
             checkResponse("delete scan")
 
-            data shouldBe 2976
+            data?.value shouldBe 2976
             message shouldContain "has been deleted"
         }
     }

--- a/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
+++ b/clients/fossid-webapp/src/test/kotlin/FossIdClientReturnTypeTest.kt
@@ -30,6 +30,7 @@ import io.kotest.matchers.types.shouldBeTypeOf
 
 import org.ossreviewtoolkit.clients.fossid.FossIdRestService
 import org.ossreviewtoolkit.clients.fossid.checkResponse
+import org.ossreviewtoolkit.clients.fossid.deleteScan
 import org.ossreviewtoolkit.clients.fossid.listIdentifiedFiles
 import org.ossreviewtoolkit.clients.fossid.listIgnoredFiles
 import org.ossreviewtoolkit.clients.fossid.listMarkedAsIdentifiedFiles
@@ -194,6 +195,12 @@ class FossIdClientReturnTypeTest : StringSpec({
                     it.shouldBeTypeOf<String>()
                 }
             }
+        }
+    }
+
+    "When the scan to delete does not exist, no exception is thrown" {
+        service.deleteScan("", "", SCAN_CODE_1).shouldNotBeNull().run {
+            error shouldBe "Classes.TableRepository.row_not_found"
         }
     }
 })

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -48,6 +48,7 @@ import org.ossreviewtoolkit.clients.fossid.EntityResponseBody
 import org.ossreviewtoolkit.clients.fossid.FossIdRestService
 import org.ossreviewtoolkit.clients.fossid.FossIdServiceWithVersion
 import org.ossreviewtoolkit.clients.fossid.MapResponseBody
+import org.ossreviewtoolkit.clients.fossid.PolymorphicInt
 import org.ossreviewtoolkit.clients.fossid.PolymorphicList
 import org.ossreviewtoolkit.clients.fossid.PolymorphicResponseBody
 import org.ossreviewtoolkit.clients.fossid.checkDownloadStatus
@@ -1057,7 +1058,9 @@ private fun FossIdServiceWithVersion.expectCreateScan(
  * Prepare this service mock to expect a request to delete the scan with the given [scanCode].
  */
 private fun FossIdServiceWithVersion.expectDeleteScan(scanCode: String): FossIdServiceWithVersion {
-    coEvery { deleteScan(USER, API_KEY, scanCode) } returns EntityResponseBody(status = 1, data = 0)
+    coEvery {
+        deleteScan(USER, API_KEY, scanCode)
+    } returns EntityResponseBody(status = 1, data = PolymorphicInt(0))
     return this
 }
 


### PR DESCRIPTION
Please refer to individual commit messages for details.

This PR fixes the following exception:
```
Exception in thread "main" com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.lang.Integer` from Array value (token `JsonToken.START_ARRAY`)
 at [Source: (okhttp3.ResponseBody$BomAwareReader); line: 1, column: 49] (through reference chain: org.ossreviewtoolkit.clients.fossid.EntityResponseBody["data"]) 
```