### PR TITLE
Evaluated model: Strip dependency trees

### DIFF
--- a/model/src/main/kotlin/DependencyGraphNavigator.kt
+++ b/model/src/main/kotlin/DependencyGraphNavigator.kt
@@ -150,6 +150,8 @@ private class DependencyRefCursor(
 
     override fun getStableReference(): DependencyNode = DependencyRefCursor(graph, initCurrent = current)
 
+    override fun getInternalId(): Any = current
+
     /**
      * Return a sequence of [DependencyNode]s that is implemented based on this instance. This sequence allows access
      * to the properties of the [DependencyReference]s passed to this instance, although each sequence element is a

--- a/model/src/main/kotlin/DependencyNode.kt
+++ b/model/src/main/kotlin/DependencyNode.kt
@@ -73,4 +73,13 @@ interface DependencyNode {
      */
     @JsonIgnore
     fun getStableReference(): DependencyNode = this
+
+    /**
+     * Return a unique ID for this [DependencyNode]. This ID can be used for instance during traversal of the
+     * dependency graph to detect nodes that have already been visited. As pointed out in the class comment, the
+     * reference to this [DependencyNode] itself is not suitable for this purpose. A concrete implementation
+     * typically returns a reference to an underlying node structure.
+     */
+    @JsonIgnore
+    fun getInternalId(): Any = this
 }

--- a/model/src/test/kotlin/DependencyGraphNavigatorTest.kt
+++ b/model/src/test/kotlin/DependencyGraphNavigatorTest.kt
@@ -20,9 +20,11 @@
 package org.ossreviewtoolkit.model
 
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.types.shouldBeTypeOf
 
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.utils.ort.Environment
+import org.ossreviewtoolkit.utils.test.readOrtResult
 
 class DependencyGraphNavigatorTest : AbstractDependencyNavigatorTest() {
     override val resultFileName = "src/test/assets/sbt-multi-project-example-graph.yml"
@@ -49,6 +51,17 @@ class DependencyGraphNavigatorTest : AbstractDependencyNavigatorTest() {
                 shouldThrow<IllegalArgumentException> {
                     DependencyGraphNavigator(result)
                 }
+            }
+        }
+
+        "getInternalId" should {
+            "return the underlying graph node" {
+                val result = readOrtResult(resultFileName)
+                val testProject = result.getProjects().first()
+
+                val node = navigator.directDependencies(testProject, "test").first()
+
+                node.getInternalId().shouldBeTypeOf<DependencyGraphNode>()
             }
         }
     }

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
@@ -1,0 +1,951 @@
+---
+path_excludes:
+- _id: 0
+  pattern: "sub/module/project/build.gradle"
+  reason: "EXAMPLE_OF"
+  comment: "The project is an example."
+- _id: 1
+  pattern: "**.java"
+  reason: "EXAMPLE_OF"
+  comment: "These are example files."
+scope_excludes:
+- _id: 0
+  pattern: "testCompile"
+  reason: "TEST_DEPENDENCY_OF"
+  comment: "The scope only contains test dependencies."
+copyrights:
+- _id: 0
+  statement: "Copyright (c) example authors."
+licenses:
+- _id: 0
+  id: "GPL-3.0-only WITH GCC-exception-3.1 AND CC-BY-NC-3.0"
+- _id: 1
+  id: "GPL-3.0-only WITH GCC-exception-3.1"
+- _id: 2
+  id: "CC-BY-NC-3.0"
+- _id: 3
+  id: "Apache-2.0"
+- _id: 4
+  id: "MIT"
+- _id: 5
+  id: "(GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause) OR MIT"
+- _id: 6
+  id: "LicenseRef-test-Apache-2.0-multi-line"
+- _id: 7
+  id: "LicenseRef-test-Apache-2.0-single-line"
+- _id: 8
+  id: "Eclipse Public License 1.0"
+- _id: 9
+  id: "EPL-1.0"
+- _id: 10
+  id: "GPL-2.0-only OR MIT"
+- _id: 11
+  id: "GPL-2.0-only"
+- _id: 12
+  id: "MPL 2.0 or EPL 1.0"
+- _id: 13
+  id: "MPL-2.0"
+- _id: 14
+  id: "Apache License, Version 2.0"
+- _id: 15
+  id: "New BSD License"
+- _id: 16
+  id: "BSD-3-Clause"
+scopes:
+- _id: 0
+  name: "compile"
+- _id: 1
+  name: "testCompile"
+  excludes:
+  - 0
+issue_resolutions: []
+issues:
+- _id: 0
+  timestamp: "1970-01-01T00:00:00Z"
+  type: "SCANNER"
+  source: "Dummy"
+  message: "DownloadException: No source artifact URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\n\
+    Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\
+    \ Please make sure the published POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
+  severity: "ERROR"
+  pkg: 0
+  scan_result: 0
+  how_to_fix: "Some how to fix text."
+scan_results:
+- _id: 0
+  provenance:
+    vcs_info:
+      type: "Git"
+      url: "https://github.com/oss-review-toolkit/ort.git"
+      revision: "master"
+      path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
+    resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+  scanner:
+    name: "FakeScanner"
+    version: "1.0"
+    configuration: ""
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "0000000000000000000000000000000000000000"
+  issues:
+  - 0
+- _id: 1
+  provenance:
+    vcs_info:
+      type: "Git"
+      url: "https://example.com/git"
+      revision: "master"
+      path: "project"
+    resolved_revision: "0000000000000000000000000000000000000000"
+  scanner:
+    name: "FakeScanner"
+    version: "1.0"
+    configuration: ""
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "0000000000000000000000000000000000000000"
+- _id: 2
+  provenance:
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+      hash:
+        value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+        algorithm: "SHA-1"
+  scanner:
+    name: "Dummy"
+    version: "1.0"
+    configuration: ""
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "0000000000000000000000000000000000000000"
+- _id: 3
+  provenance:
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+      hash:
+        value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+        algorithm: "SHA-1"
+  scanner:
+    name: "Dummy"
+    version: "1.0"
+    configuration: ""
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "0000000000000000000000000000000000000000"
+- _id: 4
+  provenance:
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+      hash:
+        value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+        algorithm: "SHA-1"
+  scanner:
+    name: "Dummy"
+    version: "1.0"
+    configuration: ""
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "0000000000000000000000000000000000000000"
+- _id: 5
+  provenance:
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+      hash:
+        value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+        algorithm: "SHA-1"
+  scanner:
+    name: "Dummy"
+    version: "1.0"
+    configuration: ""
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "0000000000000000000000000000000000000000"
+- _id: 6
+  provenance:
+    source_artifact:
+      url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+      hash:
+        value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+        algorithm: "SHA-1"
+  scanner:
+    name: "Dummy"
+    version: "1.0"
+    configuration: ""
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  package_verification_code: "0000000000000000000000000000000000000000"
+packages:
+- _id: 0
+  id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+  is_project: true
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+  declared_licenses_processed: {}
+  detected_licenses:
+  - 5
+  - 6
+  - 7
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/oss-review-toolkit/ort.git"
+    revision: "master"
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
+  paths: []
+  levels:
+  - 0
+  scan_results:
+  - 0
+  findings:
+  - type: "LICENSE"
+    license: 5
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp"
+    start_line: 1
+    end_line: 1
+    scan_result: 0
+  - type: "COPYRIGHT"
+    copyright: 0
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+    start_line: 20
+    end_line: 20
+    scan_result: 0
+  - type: "LICENSE"
+    license: 6
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+    start_line: 19
+    end_line: 20
+    scan_result: 0
+  - type: "COPYRIGHT"
+    copyright: 0
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+    start_line: 20
+    end_line: 20
+    scan_result: 0
+  - type: "LICENSE"
+    license: 7
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+    start_line: 19
+    end_line: 19
+    scan_result: 0
+  - type: "LICENSE"
+    license: 7
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+    start_line: 20
+    end_line: 20
+    scan_result: 0
+  is_excluded: false
+- _id: 1
+  id: "Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0"
+  is_project: true
+  definition_file_path: "project/build.gradle"
+  declared_licenses:
+  - 0
+  declared_licenses_processed:
+    spdx_expression: "GPL-3.0-only WITH GCC-exception-3.1 AND CC-BY-NC-3.0"
+    mapped_licenses:
+    - 1
+    - 2
+  detected_licenses:
+  - 3
+  - 4
+  detected_excluded_licenses:
+  - 4
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://example.com/git"
+    revision: "master"
+    path: "project"
+  paths: []
+  levels:
+  - 0
+  scan_results:
+  - 1
+  findings:
+  - type: "COPYRIGHT"
+    copyright: 0
+    path: "file.java"
+    start_line: 1
+    end_line: 1
+    scan_result: 1
+    path_excludes:
+    - 1
+  - type: "LICENSE"
+    license: 3
+    path: "file.java"
+    start_line: 1
+    end_line: 2
+    scan_result: 1
+    path_excludes:
+    - 1
+  - type: "LICENSE"
+    license: 3
+    path: "file.kt"
+    start_line: 1
+    end_line: 2
+    scan_result: 1
+  - type: "COPYRIGHT"
+    copyright: 0
+    path: "file1.java"
+    start_line: 1
+    end_line: 1
+    scan_result: 1
+    path_excludes:
+    - 1
+  - type: "LICENSE"
+    license: 4
+    path: "file1.java"
+    start_line: 1
+    end_line: 2
+    scan_result: 1
+    path_excludes:
+    - 1
+  - type: "LICENSE"
+    license: 4
+    path: "file2.java"
+    start_line: 1
+    end_line: 2
+    scan_result: 1
+    path_excludes:
+    - 1
+  is_excluded: true
+  path_excludes:
+  - 0
+- _id: 2
+  id: "Ant:junit:junit:4.12"
+  is_project: false
+  definition_file_path: ""
+  purl: "pkg:maven/junit/junit@4.12"
+  declared_licenses:
+  - 8
+  declared_licenses_processed:
+    spdx_expression: "EPL-1.0"
+    mapped_licenses:
+    - 9
+  description: "JUnit is a unit testing framework for Java, created by Erich Gamma\
+    \ and Kent Beck."
+  homepage_url: "http://junit.org"
+  binary_artifact:
+    url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
+    hash:
+      value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+      algorithm: "SHA-1"
+  source_artifact:
+    url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+    hash:
+      value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+      algorithm: "SHA-1"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  paths:
+  - 0
+  levels:
+  - 0
+  scopes:
+  - 1
+  scan_results:
+  - 2
+  is_excluded: true
+  scope_excludes:
+  - 0
+- _id: 3
+  id: "Maven:com.foobar:foobar:1.0"
+  is_project: false
+  definition_file_path: ""
+  purl: "pkg:maven/com.foobar/foobar@1.0"
+  declared_licenses:
+  - 10
+  declared_licenses_processed:
+    spdx_expression: "GPL-2.0-only OR MIT"
+    mapped_licenses:
+    - 11
+    - 4
+  concluded_license: "GPL-2.0-only OR MIT"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  curations:
+  - base: {}
+    curation:
+      comment: "Foobar is an imaginary dependency and offers a license choice"
+      concluded_license: "GPL-2.0-only OR MIT"
+  paths:
+  - 1
+  levels:
+  - 1
+  scopes:
+  - 1
+  is_excluded: true
+  scope_excludes:
+  - 0
+- _id: 4
+  id: "Maven:com.h2database:h2:1.4.200"
+  is_project: false
+  definition_file_path: ""
+  purl: "pkg:maven/com.h2database/h2@1.4.200"
+  declared_licenses:
+  - 12
+  declared_licenses_processed:
+    spdx_expression: "MPL-2.0 OR EPL-1.0"
+    mapped_licenses:
+    - 13
+    - 9
+  concluded_license: "MPL-2.0 OR EPL-1.0"
+  description: "H2 Database Engine"
+  homepage_url: "https://h2database.com"
+  binary_artifact:
+    url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200.jar"
+    hash:
+      value: "f7533fe7cb8e99c87a43d325a77b4b678ad9031a"
+      algorithm: "SHA-1"
+  source_artifact:
+    url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+    hash:
+      value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/h2database/h2database"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/h2database/h2database.git"
+    revision: ""
+    path: ""
+  curations:
+  - base: {}
+    curation:
+      comment: "H2 database offers a license choice"
+      concluded_license: "MPL-2.0 OR EPL-1.0"
+  paths:
+  - 2
+  levels:
+  - 1
+  scopes:
+  - 1
+  scan_results:
+  - 3
+  is_excluded: true
+  scope_excludes:
+  - 0
+- _id: 5
+  id: "Maven:org.apache.commons:commons-lang3:3.5"
+  is_project: false
+  definition_file_path: ""
+  purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
+  declared_licenses:
+  - 14
+  declared_licenses_processed:
+    spdx_expression: "Apache-2.0"
+    mapped_licenses:
+    - 3
+  description: "Apache Commons Lang, a package of Java utility classes for the\n \
+    \ classes that are in java.lang's hierarchy, or are considered to be so\n  standard\
+    \ as to justify existence in java.lang."
+  homepage_url: "http://commons.apache.org/proper/commons-lang/"
+  binary_artifact:
+    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
+    hash:
+      value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+      algorithm: "SHA-1"
+  source_artifact:
+    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+    hash:
+      value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+      algorithm: "SHA-1"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  paths:
+  - 3
+  - 4
+  levels:
+  - 1
+  - 2
+  scopes:
+  - 0
+  - 1
+  scan_results:
+  - 4
+  is_excluded: false
+- _id: 6
+  id: "Maven:org.apache.commons:commons-text:1.1"
+  is_project: false
+  definition_file_path: ""
+  purl: "pkg:maven/org.apache.commons/commons-text@1.1"
+  declared_licenses:
+  - 14
+  declared_licenses_processed:
+    spdx_expression: "Apache-2.0"
+    mapped_licenses:
+    - 3
+  description: "Apache Commons Text is a library focused on algorithms working on\
+    \ strings."
+  homepage_url: "http://commons.apache.org/proper/commons-text/"
+  binary_artifact:
+    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
+    hash:
+      value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+      algorithm: "SHA-1"
+  source_artifact:
+    url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+    hash:
+      value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+      algorithm: "SHA-1"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  paths:
+  - 5
+  - 6
+  levels:
+  - 0
+  - 1
+  scopes:
+  - 0
+  - 1
+  scan_results:
+  - 5
+  is_excluded: false
+- _id: 7
+  id: "Maven:org.example.test:example-component:1.11"
+  is_project: false
+  definition_file_path: ""
+  purl: "pkg:maven/org.example.test/example-component@1.11"
+  declared_licenses:
+  - 14
+  declared_licenses_processed:
+    spdx_expression: "Apache-2.0"
+    mapped_licenses:
+    - 3
+  description: "A test component with no specific functionality"
+  homepage_url: "http://example.org/test/component/"
+  binary_artifact:
+    url: "https://repo.maven.apache.org/maven2/org/example/test/component/1.11/test-component-1.11.jar"
+    hash:
+      value: "c446bf600f44b88af356c8a85eef4af822b06a4d"
+      algorithm: "SHA-1"
+  source_artifact:
+    url: "https://repo.maven.apache.org/maven2/org/example/test/component/1.11/test-component-1.11-sources.jar"
+    hash:
+      value: "f0880f7f0472bf120ada47beecadce4056fbd20a"
+      algorithm: "SHA-1"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  paths: []
+  is_excluded: true
+- _id: 8
+  id: "Maven:org.hamcrest:hamcrest-core:1.3"
+  is_project: false
+  definition_file_path: ""
+  purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
+  declared_licenses:
+  - 15
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped_licenses:
+    - 16
+  description: "This is the core API of hamcrest matcher framework to be used by third-party\
+    \ framework providers. This includes the a foundation set of matcher implementations\
+    \ for common operations."
+  homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
+  binary_artifact:
+    url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
+    hash:
+      value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+      algorithm: "SHA-1"
+  source_artifact:
+    url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+    hash:
+      value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+      algorithm: "SHA-1"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  paths:
+  - 7
+  levels:
+  - 1
+  scopes:
+  - 1
+  scan_results:
+  - 6
+  is_excluded: true
+  scope_excludes:
+  - 0
+- _id: 9
+  id: "Maven:org.example.test:component:1.11"
+  is_project: false
+  definition_file_path: ""
+  declared_licenses_processed: {}
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  paths:
+  - 8
+  - 9
+  levels:
+  - 0
+  scopes:
+  - 0
+  - 1
+  is_excluded: false
+paths:
+- _id: 0
+  pkg: 2
+  project: 0
+  scope: 1
+  path: []
+- _id: 1
+  pkg: 3
+  project: 0
+  scope: 1
+  path:
+  - 2
+- _id: 2
+  pkg: 4
+  project: 0
+  scope: 1
+  path:
+  - 2
+- _id: 3
+  pkg: 5
+  project: 0
+  scope: 0
+  path:
+  - 6
+- _id: 4
+  pkg: 5
+  project: 0
+  scope: 1
+  path:
+  - 9
+  - 6
+- _id: 5
+  pkg: 6
+  project: 0
+  scope: 0
+  path: []
+- _id: 6
+  pkg: 6
+  project: 0
+  scope: 1
+  path:
+  - 9
+- _id: 7
+  pkg: 8
+  project: 0
+  scope: 1
+  path:
+  - 2
+- _id: 8
+  pkg: 9
+  project: 0
+  scope: 0
+  path: []
+- _id: 9
+  pkg: 9
+  project: 0
+  scope: 1
+  path: []
+dependency_trees:
+- key: 0
+  pkg: 1
+  path_excludes:
+  - 0
+- key: 1
+  pkg: 0
+  children:
+  - key: 2
+    scope: 0
+    children:
+    - key: 3
+      linkage: "DYNAMIC"
+      pkg: 6
+      children:
+      - key: 4
+        linkage: "DYNAMIC"
+        pkg: 5
+    - key: 5
+      linkage: "DYNAMIC"
+      pkg: 9
+      children:
+      - key: 6
+        linkage: "DYNAMIC"
+        pkg: 6
+  - key: 7
+    scope: 1
+    scope_excludes:
+    - 0
+    children:
+    - key: 8
+      linkage: "DYNAMIC"
+      pkg: 2
+      children:
+      - key: 9
+        linkage: "DYNAMIC"
+        pkg: 3
+      - key: 10
+        linkage: "DYNAMIC"
+        pkg: 4
+      - key: 11
+        linkage: "DYNAMIC"
+        pkg: 8
+    - key: 12
+      linkage: "DYNAMIC"
+      pkg: 9
+      children:
+      - key: 13
+        linkage: "DYNAMIC"
+        pkg: 6
+        children:
+        - key: 14
+          linkage: "DYNAMIC"
+          pkg: 5
+rule_violation_resolutions:
+- _id: 0
+  message: "Apache-2.0 hint"
+  reason: "CANT_FIX_EXCEPTION"
+  comment: "Apache-2 is not an issue."
+rule_violations:
+- _id: 0
+  rule: "rule 1"
+  pkg: 2
+  license: 9
+  license_source: "DETECTED"
+  severity: "ERROR"
+  message: "EPL-1.0 error"
+  how_to_fix: "* *Step 1*\n* __Step 2__\n* ***Step 3***\n```\nSome long text verify\
+    \ that overflow:scroll is working as expected.\n```"
+- _id: 1
+  rule: "rule 2"
+  pkg: 6
+  license: 3
+  license_source: "DECLARED"
+  severity: "HINT"
+  message: "Apache-2.0 hint"
+  how_to_fix: "* *Step 1*\n* __Step 2__\n* ***Step 3***\n```\nSome long text verify\
+    \ that overflow:scroll is working as expected.\n```"
+  resolutions:
+  - 0
+- _id: 2
+  rule: "rule 3"
+  pkg: 8
+  license: 16
+  license_source: "CONCLUDED"
+  severity: "WARNING"
+  message: "BSD-3-Clause warning"
+  how_to_fix: "* *Step 1*\n* __Step 2__\n* ***Step 3***\n```\nSome long text verify\
+    \ that overflow:scroll is working as expected.\n```"
+vulnerabilities_resolutions: []
+vulnerabilities:
+- _id: 0
+  id: "VULCOID-VULNERABILITY_ID"
+  pkg: 2
+  references:
+  - url: "https://registry.vulnerability-url/"
+    scoring_system: "SCORING_SYSTEM_NAME"
+    severity: "ERROR"
+    severity_mapped: "UNKNOWN"
+  resolutions: []
+statistics:
+  repository_configuration:
+    path_excludes: 2
+    scope_excludes: 1
+    license_choices: 2
+    license_finding_curations: 0
+    issue_resolutions: 0
+    rule_violation_resolutions: 1
+    vulnerability_resolutions: 0
+  open_issues:
+    errors: 1
+    warnings: 0
+    hints: 0
+  open_rule_violations:
+    errors: 1
+    warnings: 1
+    hints: 0
+  open_vulnerabilities: 0
+  dependency_tree:
+    included_projects: 1
+    excluded_projects: 1
+    included_packages: 2
+    excludes_packages: 5
+    total_tree_depth: 3
+    included_tree_depth: 3
+    included_scopes:
+    - "compile"
+    excluded_scopes:
+    - "testCompile"
+  licenses:
+    declared:
+      Apache-2.0: 3
+      BSD-3-Clause: 1
+      CC-BY-NC-3.0: 1
+      EPL-1.0: 2
+      GPL-2.0-only: 1
+      GPL-3.0-only WITH GCC-exception-3.1: 1
+      MIT: 1
+      MPL-2.0: 1
+    detected:
+      Apache-2.0: 1
+      BSD-3-Clause: 1
+      GPL-2.0-only WITH Classpath-exception-2.0: 1
+      LicenseRef-test-Apache-2.0-multi-line: 1
+      LicenseRef-test-Apache-2.0-single-line: 1
+      MIT: 2
+repository:
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/oss-review-toolkit/ort.git"
+    revision: "master"
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
+  nested_repositories:
+    sub/module:
+      type: "Git"
+      url: "https://example.com/git"
+      revision: "master"
+      path: ""
+  config:
+    excludes:
+      paths:
+      - 0
+      - 1
+      scopes:
+      - 0
+    resolutions:
+      rule_violations:
+      - 0
+    license_choices:
+      repository_license_choices:
+      - given: "GPL-2.0-only OR MIT"
+        choice: "MIT"
+      package_license_choices:
+      - package_id: "Maven:com.h2database:h2:1.4.200"
+        license_choices:
+        - given: "MPL-2.0 OR EPL-1.0"
+          choice: "MPL-2.0"
+severe_issue_threshold: "WARNING"
+severe_rule_violation_threshold: "WARNING"
+repository_configuration: "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/project/build.gradle\"\
+  \n    reason: \"EXAMPLE_OF\"\n    comment: \"The project is an example.\"\n  - pattern:\
+  \ \"**.java\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"These are example files.\"\
+  \n  scopes:\n  - pattern: \"testCompile\"\n    reason: \"TEST_DEPENDENCY_OF\"\n\
+  \    comment: \"The scope only contains test dependencies.\"\nresolutions:\n  rule_violations:\n\
+  \  - message: \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment:\
+  \ \"Apache-2 is not an issue.\"\nlicense_choices:\n  repository_license_choices:\n\
+  \  - given: \"GPL-2.0-only OR MIT\"\n    choice: \"MIT\"\n  package_license_choices:\n\
+  \  - package_id: \"Maven:com.h2database:h2:1.4.200\"\n    license_choices:\n   \
+  \ - given: \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\n"
+labels:
+  job_parameters.JOB_PARAM_1: "label job param 1"
+  job_parameters.JOB_PARAM_2: "label job param 2"
+  process_parameters.PROCESS_PARAM_1: "label process param 1"
+  process_parameters.PROCESS_PARAM_2: "label process param 2"
+  OTHER: "label other"
+meta_data:
+  analyzer_start_time: "1970-01-01T00:00:00Z"

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-input.yml
@@ -1,0 +1,639 @@
+---
+repository:
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/oss-review-toolkit/ort.git"
+    revision: "master"
+    path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
+  nested_repositories:
+    sub/module:
+      type: "Git"
+      url: "https://example.com/git"
+      revision: "master"
+      path: ""
+  config:
+    excludes:
+      paths:
+      - pattern: "sub/module/project/build.gradle"
+        reason: "EXAMPLE_OF"
+        comment: "The project is an example."
+      - pattern: "**.java"
+        reason: "EXAMPLE_OF"
+        comment: "These are example files."
+      scopes:
+      - pattern: "testCompile"
+        reason: "TEST_DEPENDENCY_OF"
+        comment: "The scope only contains test dependencies."
+    resolutions:
+      rule_violations:
+      - message: "Apache-2.0 hint"
+        reason: "CANT_FIX_EXCEPTION"
+        comment: "Apache-2 is not an issue."
+    license_choices:
+      repository_license_choices:
+      - given: "GPL-2.0-only OR MIT"
+        choice: "MIT"
+      package_license_choices:
+        - package_id: "Maven:com.h2database:h2:1.4.200"
+          license_choices:
+            - given: "MPL-2.0 OR EPL-1.0"
+              choice: "MPL-2.0"
+analyzer:
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  environment:
+    ort_version: "72463cc"
+    java_version: "1.8.0_181"
+    os: "Linux"
+    variables: {}
+    tool_versions: {}
+  config:
+    allow_dynamic_versions: false
+  result:
+    projects:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+      declared_licenses: []
+      declared_licenses_processed: {}
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://github.com/oss-review-toolkit/ort.git"
+        revision: "master"
+        path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
+      homepage_url: ""
+      scopes:
+      - name: "compile"
+        dependencies:
+        - id: "Maven:org.example.test:component:1.11"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+        - id: "Maven:org.apache.commons:commons-text:1.1"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      - name: "testCompile"
+        dependencies:
+        - id: "Ant:junit:junit:4.12"
+          dependencies:
+          - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+          - id: "Maven:com.h2database:h2:1.4.200"
+          - id: "Maven:com.foobar:foobar:1.0"
+        - id: "Maven:org.example.test:component:1.11"
+          dependencies:
+          - id: "Maven:org.apache.commons:commons-text:1.1"
+            dependencies:
+            - id: "Maven:org.apache.commons:commons-lang3:3.5"
+    - id: "Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0"
+      definition_file_path: "project/build.gradle"
+      declared_licenses:
+      - "GPL-3.0-only WITH GCC-exception-3.1 AND CC-BY-NC-3.0"
+      vcs:
+        type: ""
+        url: ""
+        revision: ""
+        path: ""
+      vcs_processed:
+        type: "Git"
+        url: "https://example.com/git"
+        revision: "master"
+        path: "project"
+      homepage_url: ""
+      scopes: []
+    packages:
+    - package:
+        id: "Ant:junit:junit:4.12"
+        purl: "pkg:maven/junit/junit@4.12"
+        declared_licenses:
+        - "Eclipse Public License 1.0"
+        declared_licenses_processed:
+          spdx_expression: "EPL-1.0"
+          mapped:
+            Eclipse Public License 1.0: "EPL-1.0"
+        description: "JUnit is a unit testing framework for Java, created by Erich\
+          \ Gamma and Kent Beck."
+        homepage_url: "http://junit.org"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
+          hash:
+            value: "2973d150c0dc1fefe998f834810d68f278ea58ec"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+          hash:
+            value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+            algorithm: "SHA-1"
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.apache.commons:commons-lang3:3.5"
+        purl: "pkg:maven/org.apache.commons/commons-lang3@3.5"
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+        description: "Apache Commons Lang, a package of Java utility classes for the\n\
+          \  classes that are in java.lang's hierarchy, or are considered to be so\n\
+          \  standard as to justify existence in java.lang."
+        homepage_url: "http://commons.apache.org/proper/commons-lang/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
+          hash:
+            value: "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+          hash:
+            value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+            algorithm: "SHA-1"
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.apache.commons:commons-text:1.1"
+        purl: "pkg:maven/org.apache.commons/commons-text@1.1"
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+        description: "Apache Commons Text is a library focused on algorithms working\
+          \ on strings."
+        homepage_url: "http://commons.apache.org/proper/commons-text/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1.jar"
+          hash:
+            value: "c336bf600f44b88af356c8a85eef4af822b06a4d"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+          hash:
+            value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+            algorithm: "SHA-1"
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.example.test:example-component:1.11"
+        purl: "pkg:maven/org.example.test/example-component@1.11"
+        declared_licenses:
+        - "Apache License, Version 2.0"
+        declared_licenses_processed:
+          spdx_expression: "Apache-2.0"
+          mapped:
+            Apache License, Version 2.0: "Apache-2.0"
+        description: "A test component with no specific functionality"
+        homepage_url: "http://example.org/test/component/"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/example/test/component/1.11/test-component-1.11.jar"
+          hash:
+            value: "c446bf600f44b88af356c8a85eef4af822b06a4d"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/example/test/component/1.11/test-component-1.11-sources.jar"
+          hash:
+            value: "f0880f7f0472bf120ada47beecadce4056fbd20a"
+            algorithm: "SHA-1"
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:org.hamcrest:hamcrest-core:1.3"
+        purl: "pkg:maven/org.hamcrest/hamcrest-core@1.3"
+        declared_licenses:
+        - "New BSD License"
+        declared_licenses_processed:
+          spdx_expression: "BSD-3-Clause"
+          mapped:
+            New BSD License: "BSD-3-Clause"
+        description: "This is the core API of hamcrest matcher framework to be used\
+          \ by third-party framework providers. This includes the a foundation set\
+          \ of matcher implementations for common operations."
+        homepage_url: "https://github.com/hamcrest/JavaHamcrest/hamcrest-core"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
+          hash:
+            value: "42a25dc3219429f0e5d060061f71acb49bf010a0"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+          hash:
+            value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+            algorithm: "SHA-1"
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+      curations: []
+    - package:
+        id: "Maven:com.foobar:foobar:1.0"
+        purl: "pkg:maven/com.foobar/foobar@1.0"
+        authors:
+        - "Jane Doe"
+        declared_licenses:
+        - "GPL-2.0-only OR MIT"
+        declared_licenses_processed:
+          spdx_expression: "GPL-2.0-only OR MIT"
+          mapped:
+            GPL-2.0-only OR MIT: "GPL-2.0-only OR MIT"
+        concluded_license: "GPL-2.0-only OR MIT"
+        description: ""
+        homepage_url: ""
+        binary_artifact:
+          url: ""
+          hash:
+            value: ""
+            algorithm: ""
+        source_artifact:
+          url: ""
+          hash:
+            value: ""
+            algorithm: ""
+        vcs:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: ""
+          url: ""
+          revision: ""
+          path: ""
+      curations:
+      - base: { }
+        curation:
+          concluded_license: "GPL-2.0-only OR MIT"
+          comment: "Foobar is an imaginary dependency and offers a license choice"
+    - package:
+        id: "Maven:com.h2database:h2:1.4.200"
+        purl: "pkg:maven/com.h2database/h2@1.4.200"
+        authors:
+          - "Thomas Mueller"
+        declared_licenses:
+          - "MPL 2.0 or EPL 1.0"
+        declared_licenses_processed:
+          spdx_expression: "MPL-2.0 OR EPL-1.0"
+          mapped:
+            MPL 2.0 or EPL 1.0: "MPL-2.0 OR EPL-1.0"
+        concluded_license: "MPL-2.0 OR EPL-1.0"
+        description: "H2 Database Engine"
+        homepage_url: "https://h2database.com"
+        binary_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200.jar"
+          hash:
+            value: "f7533fe7cb8e99c87a43d325a77b4b678ad9031a"
+            algorithm: "SHA-1"
+        source_artifact:
+          url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+          hash:
+            value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+            algorithm: "SHA-1"
+        vcs:
+          type: "Git"
+          url: "https://github.com/h2database/h2database"
+          revision: ""
+          path: ""
+        vcs_processed:
+          type: "Git"
+          url: "https://github.com/h2database/h2database.git"
+          revision: ""
+          path: ""
+      curations:
+        - base: { }
+          curation:
+            concluded_license: "MPL-2.0 OR EPL-1.0"
+            comment: "H2 database offers a license choice"
+    has_issues: false
+scanner:
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  environment:
+    ort_version: "72463cc"
+    java_version: "1.8.0_181"
+    os: "Linux"
+    variables: {}
+    tool_versions: {}
+  config:
+    file_based_storage: null
+    postgres_storage: null
+    scanner: null
+  results:
+    scopes:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      scanned:
+      - "compile"
+      - "testCompile"
+      ignored: []
+    scan_results:
+    - id: "Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0"
+      results:
+      - provenance:
+          vcs_info:
+            type: "Git"
+            url: "https://github.com/oss-review-toolkit/ort.git"
+            revision: "master"
+            path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib"
+          resolved_revision: "3dcca3e6ee0dea120922f90495bf04b4e09ae455"
+        scanner:
+          name: "FakeScanner"
+          version: "1.0"
+          configuration: ""
+        summary:
+          start_time: "1970-01-01T00:00:00Z"
+          end_time: "1970-01-01T00:00:00Z"
+          package_verification_code: "0000000000000000000000000000000000000000"
+          licenses:
+          - license: "LicenseRef-test-Apache-2.0-multi-line"
+            location:
+              path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+              start_line: 19
+              end_line: 20
+          - license: "LicenseRef-test-Apache-2.0-single-line"
+            location:
+              path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+              start_line: 19
+              end_line: 19
+          - license: "LicenseRef-test-Apache-2.0-single-line"
+            location:
+              path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+              start_line: 20
+              end_line: 20
+          - license: "GPL-2.0-only WITH Classpath-exception-2.0 AND BSD-3-Clause OR MIT"
+            location:
+              path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/src/code.cpp"
+              start_line: 1
+              end_line: 1
+          copyrights:
+          - statement: "Copyright (c) example authors."
+            location:
+              path: "analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle"
+              start_line: 20
+              end_line: 20
+          issues:
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "Dummy"
+            message: "DownloadException: No source artifact URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\n\
+              Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.\
+              \ Please make sure the published POM file includes the SCM connection,\
+              \ see: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom"
+            severity: "ERROR"
+    - id: "Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0"
+      results:
+      - provenance:
+          vcs_info:
+            type: "Git"
+            url: "https://example.com/git"
+            revision: "master"
+            path: "project"
+          resolved_revision: "0000000000000000000000000000000000000000"
+        scanner:
+          name: "FakeScanner"
+          version: "1.0"
+          configuration: ""
+        summary:
+          start_time: "1970-01-01T00:00:00Z"
+          end_time: "1970-01-01T00:00:00Z"
+          package_verification_code: "0000000000000000000000000000000000000000"
+          licenses:
+          - license: "Apache-2.0"
+            location:
+              path: "file.java"
+              start_line: 1
+              end_line: 2
+          - license: "Apache-2.0"
+            location:
+              path: "file.kt"
+              start_line: 1
+              end_line: 2
+          - license: "MIT"
+            location:
+              path: "file1.java"
+              start_line: 1
+              end_line: 2
+          - license: "MIT"
+            location:
+              path: "file2.java"
+              start_line: 1
+              end_line: 2
+          copyrights:
+          - statement: "Copyright (c) example authors."
+            location:
+              path: "file.java"
+              start_line: 1
+              end_line: 1
+          - statement: "Copyright (c) example authors."
+            location:
+              path: "file1.java"
+              start_line: 1
+              end_line: 1
+    - id: "Ant:junit:junit:4.12"
+      results:
+      - provenance:
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12-sources.jar"
+            hash:
+              value: "a6c32b40bf3d76eca54e3c601e5d1470c86fcdfa"
+              algorithm: "SHA-1"
+        scanner:
+          name: "Dummy"
+          version: "1.0"
+          configuration: ""
+        summary:
+          start_time: "1970-01-01T00:00:00Z"
+          end_time: "1970-01-01T00:00:00Z"
+          package_verification_code: "0000000000000000000000000000000000000000"
+          licenses: []
+          copyrights: []
+    - id: "Maven:org.apache.commons:commons-lang3:3.5"
+      results:
+      - provenance:
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5-sources.jar"
+            hash:
+              value: "f7d878153e86a1cdddf6b37850e00a9f8bff726f"
+              algorithm: "SHA-1"
+        scanner:
+          name: "Dummy"
+          version: "1.0"
+          configuration: ""
+        summary:
+          start_time: "1970-01-01T00:00:00Z"
+          end_time: "1970-01-01T00:00:00Z"
+          package_verification_code: "0000000000000000000000000000000000000000"
+          licenses: []
+          copyrights: []
+    - id: "Maven:org.apache.commons:commons-text:1.1"
+      results:
+      - provenance:
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/1.1/commons-text-1.1-sources.jar"
+            hash:
+              value: "f0770f7f0472bf120ada47beecadce4056fbd20a"
+              algorithm: "SHA-1"
+        scanner:
+          name: "Dummy"
+          version: "1.0"
+          configuration: ""
+        summary:
+          start_time: "1970-01-01T00:00:00Z"
+          end_time: "1970-01-01T00:00:00Z"
+          package_verification_code: "0000000000000000000000000000000000000000"
+          licenses: []
+          copyrights: []
+    - id: "Maven:org.hamcrest:hamcrest-core:1.3"
+      results:
+      - provenance:
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+            hash:
+              value: "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"
+              algorithm: "SHA-1"
+        scanner:
+          name: "Dummy"
+          version: "1.0"
+          configuration: ""
+        summary:
+          start_time: "1970-01-01T00:00:00Z"
+          end_time: "1970-01-01T00:00:00Z"
+          package_verification_code: "0000000000000000000000000000000000000000"
+          licenses: []
+          copyrights: []
+    - id: "Maven:com.h2database:h2:1.4.200"
+      results:
+      - provenance:
+          source_artifact:
+            url: "https://repo.maven.apache.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200-sources.jar"
+            hash:
+              value: "3b5883b7a5a05b932c699760f0854ca565785a84"
+              algorithm: "SHA-1"
+        scanner:
+          name: "Dummy"
+          version: "1.0"
+          configuration: ""
+        summary:
+          start_time: "1970-01-01T00:00:00Z"
+          end_time: "1970-01-01T00:00:00Z"
+          package_verification_code: "0000000000000000000000000000000000000000"
+          licenses: [ ]
+          copyrights: [ ]
+    storage_stats:
+      num_reads: 5
+      num_hits: 0
+    has_issues: true
+advisor:
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  environment:
+    ort_version: "72463cc"
+    java_version: "1.8.0_181"
+    os: "Linux"
+    variables: {}
+    tool_versions: {}
+  config:
+    nexus_iq:
+      server_url: "https://rest-api-url-of-your-nexus-iq-server"
+      browse_url: "https://web-browsing-url-of-your-nexus-iq-server"
+      username: "username"
+    vulnerable_code:
+      server_url: "http://localhost:8000"
+  results:
+    advisor_results:
+      Ant:junit:junit:4.12:
+      - vulnerabilities:
+        - id: "VULCOID-VULNERABILITY_ID"
+          references:
+          - url: "https://registry.vulnerability-url/"
+            scoring_system: "SCORING_SYSTEM_NAME"
+            severity: "ERROR"
+        advisor:
+          name: "VulnerableCode"
+        summary:
+          start_time: "1970-01-01T00:00:00Z"
+          end_time: "1970-01-01T00:00:00Z"
+    has_issues: false
+evaluator:
+  start_time: "1970-01-01T00:00:00Z"
+  end_time: "1970-01-01T00:00:00Z"
+  violations:
+  - rule: "rule 1"
+    pkg: "Ant:junit:junit:4.12"
+    license: "EPL-1.0"
+    license_source: "DETECTED"
+    severity: "ERROR"
+    message: "EPL-1.0 error"
+    how_to_fix: "* *Step 1*\n* __Step 2__\n* ***Step 3***\n```\nSome long text verify\
+      \ that overflow:scroll is working as expected.\n```"
+  - rule: "rule 2"
+    pkg: "Maven:org.apache.commons:commons-text:1.1"
+    license: "Apache-2.0"
+    license_source: "DECLARED"
+    severity: "HINT"
+    message: "Apache-2.0 hint"
+    how_to_fix: "* *Step 1*\n* __Step 2__\n* ***Step 3***\n```\nSome long text verify\
+      \ that overflow:scroll is working as expected.\n```"
+  - rule: "rule 3"
+    pkg: "Maven:org.hamcrest:hamcrest-core:1.3"
+    license: "BSD-3-Clause"
+    license_source: "CONCLUDED"
+    severity: "WARNING"
+    message: "BSD-3-Clause warning"
+    how_to_fix: "* *Step 1*\n* __Step 2__\n* ***Step 3***\n```\nSome long text verify\
+      \ that overflow:scroll is working as expected.\n```"
+labels:
+  job_parameters.JOB_PARAM_1: "label job param 1"
+  job_parameters.JOB_PARAM_2: "label job param 2"
+  process_parameters.PROCESS_PARAM_1: "label process param 1"
+  process_parameters.PROCESS_PARAM_2: "label process param 2"
+  OTHER: "label other"

--- a/reporter/src/funTest/kotlin/reporters/evaluatedmodel/EvaluatedModelReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/evaluatedmodel/EvaluatedModelReporterFunTest.kt
@@ -54,6 +54,19 @@ class EvaluatedModelReporterFunTest : WordSpec({
             val options = mapOf(EvaluatedModelReporter.OPTION_OUTPUT_FILE_FORMATS to FileFormat.YAML.fileExtension)
             generateReport(ortResult, options) shouldBe expectedResult
         }
+
+        "support an option to deduplicate the dependency tree" {
+            val expectedResult = File(
+                "src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml"
+            ).readText()
+            val ortResult = readOrtResult("src/funTest/assets/evaluated-model-reporter-test-input.yml")
+
+            val options = mapOf(
+                EvaluatedModelReporter.OPTION_OUTPUT_FILE_FORMATS to FileFormat.YAML.fileExtension,
+                EvaluatedModelReporter.OPTION_DEDUPLICATE_DEPENDENCY_TREE to "True"
+            )
+            generateReport(ortResult, options).normalizeLineBreaks() shouldBe expectedResult
+        }
     }
 })
 

--- a/reporter/src/main/kotlin/reporters/WebAppReporter.kt
+++ b/reporter/src/main/kotlin/reporters/WebAppReporter.kt
@@ -33,7 +33,18 @@ import org.ossreviewtoolkit.reporter.reporters.evaluatedmodel.EvaluatedModel
 
 private const val PLACEHOLDER = "ORT_REPORT_DATA_PLACEHOLDER"
 
+/**
+ * A [Reporter] that generates a web application that allows browsing an ORT result interactively.
+ *
+ * This reporter supports the following options:
+ * - *deduplicateDependencyTree*: Controls whether subtrees occurring multiple times in the dependency tree are
+ *   stripped.
+ */
 class WebAppReporter : Reporter {
+    companion object {
+        const val OPTION_DEDUPLICATE_DEPENDENCY_TREE = "deduplicateDependencyTree"
+    }
+
     override val reporterName = "WebApp"
 
     private val reportFilename = "scan-report-web-app.html"
@@ -44,7 +55,7 @@ class WebAppReporter : Reporter {
         options: Map<String, String>
     ): List<File> {
         val template = javaClass.getResource("/scan-report-template.html").readText()
-        val evaluatedModel = EvaluatedModel.create(input)
+        val evaluatedModel = EvaluatedModel.create(input, options[OPTION_DEDUPLICATE_DEPENDENCY_TREE].toBoolean())
 
         val index = template.indexOf(PLACEHOLDER)
         val prefix = template.substring(0, index)

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModel.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModel.kt
@@ -148,7 +148,8 @@ data class EvaluatedModel(
             YAMLMapper().apply(mapperConfig).registerModule(IntIdModule(INT_ID_TYPES))
         }
 
-        fun create(input: ReporterInput): EvaluatedModel = EvaluatedModelMapper(input).build()
+        fun create(input: ReporterInput, deduplicateDependencyTree: Boolean = false): EvaluatedModel =
+            EvaluatedModelMapper(input).build(deduplicateDependencyTree)
     }
 
     /**

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelReporter.kt
@@ -32,10 +32,14 @@ import org.ossreviewtoolkit.reporter.ReporterInput
  *
  * This reporter supports the following options:
  * - *output.file.formats*: The list of [FileFormat]s to generate, defaults to [FileFormat.JSON].
+ * - *deduplicateDependencyTree*: Controls whether subtrees occurring multiple times in the dependency tree are
+ *   stripped.
  */
 class EvaluatedModelReporter : Reporter {
     companion object {
         const val OPTION_OUTPUT_FILE_FORMATS = "output.file.formats"
+
+        const val OPTION_DEDUPLICATE_DEPENDENCY_TREE = "deduplicateDependencyTree"
     }
 
     override val reporterName = "EvaluatedModel"
@@ -45,7 +49,9 @@ class EvaluatedModelReporter : Reporter {
         outputDir: File,
         options: Map<String, String>
     ): List<File> {
-        val evaluatedModel = measureTimedValue { EvaluatedModel.create(input) }
+        val evaluatedModel = measureTimedValue {
+            EvaluatedModel.create(input, options[OPTION_DEDUPLICATE_DEPENDENCY_TREE].toBoolean())
+        }
 
         val outputFiles = mutableListOf<File>()
         val outputFileFormats = options[OPTION_OUTPUT_FILE_FORMATS]


### PR DESCRIPTION
This PR addresses a problem with out-of-memory errors we face during report generation for large projects: For complex dependency graphs, the generation of the evaluated model for the WebApp reporter consumes a huge amount of memory, since the condensed graph gets unwrapped again.

The reporters dealing with the evaluated model now accept a new _deduplicateDependencyTree_ parameter. When set to *true* (the default is *false*) the dependency tree does no longer contain duplicate subtrees; when a duplicate subtree occurs, only the root node is inserted. This is similar to the way dependency trees are displayed by Gradle.