### PR TITLE
Add NOTICE file

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -24,6 +24,10 @@ Files: mlc_config.json
 Copyright: 2017-2020 HERE Europe B.V. <opensource@here.com>
 License: Apache-2.0
 
+Files: NOTICE
+Copyright: 2022 Bosch.IO GmbH <osm@bosch.com>
+License: Apache-2.0
+
 Files: */src/main/resources/*
 Copyright: 2017-2020 HERE Europe B.V. <opensource@here.com>
 License: Apache-2.0

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -98,6 +98,10 @@ Files: clients/github-graphql/src/main/assets/schema.docs.graphql
 Copyright: 2017 Gregor Martynus
 License: MIT
 
+Files: reporter/src/main/resources/prismjs/*
+Copyright: 2012 Lea Verou
+License: MIT
+
 Files: reporter/src/funTest/assets/sample.fossinfo.json
 Copyright: 2020-2021 Bosch Rexroth AG
 License: MIT

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,15 @@
+The ORT Project <https://oss-review-toolkit.org>
+
+Copyright (C) 2017-2022 HERE Europe B.V.
+Copyright (C) 2019 Verifa Oy.
+Copyright (C) 2019-2020 Bosch Software Innovations GmbH
+Copyright (C) 2020-2021 SCANOSS TECNOLOGIAS SL
+Copyright (C) 2020-2022 Bosch.IO GmbH
+Copyright (C) 2021 Alliander N.V.
+Copyright (C) 2021 Dr. Ing. h.c. F. Porsche AG
+Copyright (C) 2021 JetBrains s.r.o. and Kotlin Programming Language contributors
+Copyright (C) 2021 Sonatype, Inc.
+Copyright (C) 2021 TNG Technology Consulting GmbH
+Copyright (C) 2022 Eclypsium Inc.
+Copyright (C) 2022 EPAM Systems, Inc.
+Copyright (C) 2022 Google, LLC.


### PR DESCRIPTION
The copyright list for the NOTICE file was compiled with a combination of plain text search and manually from the [dep5](https://github.com/oss-review-toolkit/ort/blob/main/.reuse/dep5) file.

Command used for [ripgrep](https://github.com/BurntSushi/ripgrep):
```
rg --hidden --no-filename --no-line-number --iglob \!utils/spdx/src/main/resources/licenses/ 'Copyright \(C\)' | sort | uniq
```

I also tried to compile the list using ORT itself:
```
ort --info scan --package-types PROJECT -i ort/analyzer-result.yml -o ort/
```

This resulted in a list which is too large, and would require quite some exclusions in the `.ort.yml`.
```
❯ grep 'statement:' scan-result.yml | sort | uniq | wc -l
1746
```