### PR TITLE
AnalyzerConfiguration: Make the package managers case-insensitive

### DIFF
--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -150,7 +150,8 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
                     manager = manager,
                     definitionFiles = files,
                     labels = labels,
-                    mustRunAfter = config.packageManagers?.get(manager.managerName)?.mustRunAfter?.toSet().orEmpty(),
+                    mustRunAfter = config.getPackageManagerConfiguration(manager.managerName)?.mustRunAfter?.toSet()
+                        .orEmpty(),
                     finishedPackageManagersState = state.finishedPackageManagersState,
                     onResult = { result -> state.addResult(manager, result) }
                 )

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -197,7 +197,8 @@ private class AnalyzerState(curationProvider: PackageCurationProvider) {
                 result.dependencyGraph?.let {
                     builder.addDependencyGraph(manager.managerName, it).addPackages(result.sharedPackages)
                 }
-                _finishedPackageManagersState.value += manager.managerName
+                _finishedPackageManagersState.value = (_finishedPackageManagersState.value + manager.managerName)
+                    .toSortedSet(String.CASE_INSENSITIVE_ORDER)
             }
         }
     }

--- a/analyzer/src/main/kotlin/managers/DotNet.kt
+++ b/analyzer/src/main/kotlin/managers/DotNet.kt
@@ -65,7 +65,8 @@ class DotNet(
     }
 
     private val directDependenciesOnly =
-        analyzerConfig.packageManagers?.get(managerName)?.options?.get(OPTION_DIRECT_DEPENDENCIES_ONLY).toBoolean()
+        analyzerConfig.getPackageManagerConfiguration(managerName)?.options?.get(OPTION_DIRECT_DEPENDENCIES_ONLY)
+            .toBoolean()
 
     private val reader = DotNetPackageFileReader()
 

--- a/analyzer/src/main/kotlin/managers/NuGet.kt
+++ b/analyzer/src/main/kotlin/managers/NuGet.kt
@@ -64,7 +64,8 @@ class NuGet(
     }
 
     private val directDependenciesOnly =
-        analyzerConfig.packageManagers?.get(managerName)?.options?.get(OPTION_DIRECT_DEPENDENCIES_ONLY).toBoolean()
+        analyzerConfig.getPackageManagerConfiguration(managerName)?.options?.get(OPTION_DIRECT_DEPENDENCIES_ONLY)
+            .toBoolean()
 
     private val reader = NuGetPackageFileReader()
 

--- a/model/src/main/kotlin/config/AnalyzerConfiguration.kt
+++ b/model/src/main/kotlin/config/AnalyzerConfiguration.kt
@@ -57,4 +57,25 @@ data class AnalyzerConfiguration(
      * Configuration of the SW360 package curation provider.
      */
     val sw360Configuration: Sw360StorageConfiguration? = null
-)
+) {
+    /**
+     * A copy of [packageManagers] with case-insensitive keys.
+     */
+    private val packageManagersCaseInsensitive: Map<String, PackageManagerConfiguration>? =
+        packageManagers?.toSortedMap(String.CASE_INSENSITIVE_ORDER)
+
+    init {
+        val duplicatePackageManagers =
+            packageManagers?.keys.orEmpty() - packageManagersCaseInsensitive?.keys?.toSet().orEmpty()
+
+        require(duplicatePackageManagers.isEmpty()) {
+            "The following package managers have duplicate configuration: ${duplicatePackageManagers.joinToString()}."
+        }
+    }
+
+    /**
+     * Get a [PackageManagerConfiguration] from [packageManagers]. The difference to accessing the map directly is that
+     * [packageManager] can be case-insensitive.
+     */
+    fun getPackageManagerConfiguration(packageManager: String) = packageManagersCaseInsensitive?.get(packageManager)
+}

--- a/model/src/test/kotlin/config/AnalyzerConfigurationTest.kt
+++ b/model/src/test/kotlin/config/AnalyzerConfigurationTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.config
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.shouldNot
+
+class AnalyzerConfigurationTest : WordSpec({
+    "getPackageManagerConfiguration" should {
+        "be case-insensitive" {
+            val config = AnalyzerConfiguration(
+                packageManagers = mapOf(
+                    "Gradle" to PackageManagerConfiguration()
+                )
+            )
+
+            config.getPackageManagerConfiguration("Gradle") shouldNot beNull()
+            config.getPackageManagerConfiguration("gradle") shouldNot beNull()
+            config.getPackageManagerConfiguration("gRADLE") shouldNot beNull()
+        }
+    }
+
+    "AnalyzerConfiguration" should {
+        "throw an exception on duplicate package manager configuration" {
+            shouldThrow<IllegalArgumentException> {
+                AnalyzerConfiguration(
+                    packageManagers = mapOf(
+                        "Gradle" to PackageManagerConfiguration(),
+                        "gradle" to PackageManagerConfiguration()
+                    )
+                )
+            }
+        }
+    }
+})

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -61,6 +61,10 @@ class OrtConfigurationTest : WordSpec({
                             this shouldContainExactly mapOf("directDependenciesOnly" to "true")
                         }
                     }
+
+                    getPackageManagerConfiguration("gradle") shouldNotBeNull {
+                        this shouldBe get("Gradle")
+                    }
                 }
 
                 sw360Configuration shouldNotBeNull {


### PR DESCRIPTION
Make sure that package manager names used within `AnalyzerConfiguration` are case-insensitive. See the commit messages for details.