### PR TITLE
fossid-webapp: Remove property `messageParameters`

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/EntityResponseBody.kt
+++ b/clients/fossid-webapp/src/main/kotlin/EntityResponseBody.kt
@@ -19,11 +19,13 @@
 
 package org.ossreviewtoolkit.clients.fossid
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 class EntityResponseBody<T>(
     val operation: String? = null,
     val status: Int? = null,
     val message: String? = null,
-    val messageParameters: Map<String, String> = emptyMap(),
     val error: String? = null,
 
     val data: T? = null


### PR DESCRIPTION
Commit https://github.com/bosch-io/oss-review-toolkit/commit/62d6ddf875784bcf7ad3b085c13601a7a52c6b63 wrongly changed the type of this property due to a
misinterpretation of a FossID changelog: Its type is in fact an array in
most of the responses, and an object in the response of `deleteScan` in
case the scan does not exist.
Ignore this parameter, as ORT does not use this property at all.