### PR TITLE
Strip superfluous `requireSuccess()` calls

### DIFF
--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -144,7 +144,7 @@ class Conan(
             conanConfig?.also { configureRemoteAuthentication(it) }
 
             val jsonFile = createOrtTempDir().resolve("info.json")
-            run(workingDir, "info", ".", "--json", jsonFile.absolutePath, *DUMMY_COMPILER_SETTINGS).requireSuccess()
+            run(workingDir, "info", ".", "--json", jsonFile.absolutePath, *DUMMY_COMPILER_SETTINGS)
 
             val pkgInfos = jsonMapper.readTree(jsonFile)
             jsonFile.parentFile.safeDeleteRecursively(force = true)
@@ -304,7 +304,7 @@ class Conan(
     private fun inspectField(pkgName: String, workingDir: File, field: String): String =
         pkgInspectResults.getOrPut(pkgName) {
             val jsonFile = createOrtTempDir().resolve("inspect.json")
-            run(workingDir, "inspect", pkgName, "--json", jsonFile.absolutePath).requireSuccess()
+            run(workingDir, "inspect", pkgName, "--json", jsonFile.absolutePath)
             jsonMapper.readTree(jsonFile).also { jsonFile.parentFile.safeDeleteRecursively(force = true) }
         }.get(field).textValueOrEmpty()
 

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -153,7 +153,7 @@ class GoMod(
 
         var graph = Graph()
 
-        for (line in run("mod", "graph", workingDir = projectDir).requireSuccess().stdout.lines()) {
+        for (line in run("mod", "graph", workingDir = projectDir).stdout.lines()) {
             if (line.isBlank()) continue
 
             val columns = line.split(' ')
@@ -205,9 +205,7 @@ class GoMod(
             val moduleNames = ids.map { it.name }.toTypedArray()
             // Use the ´-m´ switch to use module names because the graph also uses module names, not package names.
             // This fixes the accidental dropping of some modules.
-            vendorModuleNames += parseWhyOutput(
-                run(projectDir, "mod", "why", "-m", "-vendor", *moduleNames).requireSuccess().stdout
-            )
+            vendorModuleNames += parseWhyOutput(run(projectDir, "mod", "why", "-m", "-vendor", *moduleNames).stdout)
         }
 
         return graph.nodes().filterTo(mutableSetOf()) { it.name in vendorModuleNames }


### PR DESCRIPTION
`run()` already calls `requireSuccess()` internally.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>