### PR TITLE
GenerateScopeExcludesCommand: Add the 'vendor' scope for GoMod

### DIFF
--- a/helper-cli/src/main/kotlin/commands/repoconfig/GenerateScopeExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/repoconfig/GenerateScopeExcludesCommand.kt
@@ -115,6 +115,13 @@ private fun getScopeExcludesForPackageManager(packageManagerName: String): List<
                 comment = "Packages for development only."
             )
         )
+        "GoMod" -> listOf(
+            ScopeExclude(
+                pattern = "vendor",
+                reason = ScopeExcludeReason.DEV_DEPENDENCY_OF,
+                comment = "Packages to build and test the main module."
+            )
+        )
         "Gradle" -> listOf(
             ScopeExclude(
                 pattern = ".*AnnotationProcessor.*",


### PR DESCRIPTION
The 'vendor' scope contains all modules needed for building and testing
the main module while the 'main' scope contains only the main module
dependencies. So, only 'main' should not be excluded.

