### PR TITLE
SpdxDocumentFile: Determine VCS location from SPDX file by default

### DIFF
--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -276,10 +276,10 @@ class SpdxDocumentFile(
     private fun SpdxPackage.toPackage(definitionFile: File?, doc: SpdxResolvedDocument): Package {
         val packageDescription = description.takeUnless { it.isEmpty() } ?: summary
 
-        // If the VCS information cannot be determined from the VCS working tree itself, fall back to try getting it
-        // from the download location.
+        // If the VCS information cannot be determined from the download location,
+        // fall back to try getting it from the VCS working tree itself.
         val packageDir = definitionFile?.resolveSibling(packageFilename)
-        val vcs = packageDir?.let { VersionControlSystem.forDirectory(it)?.getInfo() } ?: getVcsInfo().orEmpty()
+        val vcs = getVcsInfo() ?: packageDir?.let { VersionControlSystem.forDirectory(it)?.getInfo() }.orEmpty()
 
         val generatedFromRelations = doc.relationships.filter {
             it.relationshipType == SpdxRelationship.Type.GENERATED_FROM


### PR DESCRIPTION
Refers-to: https://github.com/oss-review-toolkit/ort/issues/5483

Signed-off-by: Stefano Bennati <stefano.bennati@here.com>

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
