### PR TITLE
Analyzer: Automatically determine package manager order

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -41,6 +41,7 @@ import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
+import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
@@ -204,6 +205,16 @@ abstract class PackageManager(
      * Optional mapping of found [definitionFiles] before dependency resolution.
      */
     open fun mapDefinitionFiles(definitionFiles: List<File>): List<File> = definitionFiles
+
+    /**
+     * Return if this package manager must run before or after certain other package managers. This can manually be
+     * configured by the user in [PackageManagerConfiguration.mustRunAfter], but in some cases it is possible to
+     * determine such dependencies automatically.
+     */
+    open fun findPackageManagerDependencies(
+        managedFiles: Map<PackageManager, List<File>>
+    ): PackageManagerDependencyResult =
+        PackageManagerDependencyResult(mustRunBefore = emptySet(), mustRunAfter = emptySet())
 
     /**
      * Optional step to run before dependency resolution, like checking for prerequisites.

--- a/analyzer/src/main/kotlin/PackageManagerDependencyResult.kt
+++ b/analyzer/src/main/kotlin/PackageManagerDependencyResult.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer
+
+data class PackageManagerDependencyResult(
+    /**
+     * The names of package managers that the package manager that provided this result must run before.
+     */
+    val mustRunBefore: Set<String>,
+
+    /**
+     * The names of package managers that the package manager that provided this result must run after.
+     */
+    val mustRunAfter: Set<String>
+)


### PR DESCRIPTION
This is the first step in generalizing the way that Pub uses to get Gradle and Cocoapods dependencies so that it can also be used for other package managers. To keep the diff small I will do it in several smaller PRs.
Please see the commit messages for details.