### PR TITLE
Gradle: Enable the JSON report for the `versions` plugin again

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,7 +95,7 @@ extensions.findByName("buildScan")?.withGroovyBuilder {
 
 tasks.named<DependencyUpdatesTask>("dependencyUpdates").configure {
     gradleReleaseChannel = "current"
-    outputFormatter = null
+    outputFormatter = "json"
 
     val nonFinalQualifiers = listOf(
         "alpha", "b", "beta", "cr", "dev", "ea", "eap", "m", "milestone", "pr", "preview", "rc", "\\d{14}"


### PR DESCRIPTION
This is a fixup for ab6ae6dd to enable at least the JSON report again as
the `version-catalog-update` plugin depends on it, see [1].

[1]: https://github.com/littlerobots/version-catalog-update-plugin/issues/59#issuecomment-1167333757

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>