### PR TITLE
fossid-webapp: Convert `isBlindAudit` from numeric String

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/model/Scan.kt
+++ b/clients/fossid-webapp/src/main/kotlin/model/Scan.kt
@@ -46,6 +46,7 @@ data class Scan(
      */
     val targetPath: String?,
 
+    @JsonDeserialize(using = IntBooleanDeserializer::class)
     val isBlindAudit: Boolean?,
 
     val filesNotScanned: String?,


### PR DESCRIPTION
The `isBlindAudit` property of a FossID `Scan` is either null, "0" or "1".
Therefore, it needs to be specially handled for deserialization.

This commit fixes an `InvalidFormatException` from Jackson that occurs
when deserializing archived scans.

