### PR TITLE
AnalyzerCommand: Use the logger from the parent class

### DIFF
--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -244,7 +244,7 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
             if (config.enableRepositoryPackageCurations) {
                 add(SimplePackageCurationProvider(repositoryPackageCurations))
             } else if (repositoryPackageCurations.isNotEmpty()) {
-                log.warn {
+                this@AnalyzerCommand.log.warn {
                     "Existing package curations from '$ORT_REPO_CONFIG_FILENAME' are not applied because the feature " +
                             "is disabled."
                 }


### PR DESCRIPTION
Logging using `log` is only allowed on ORT classes.
