### PR TITLE
PackageCuration: Fix version range check for versions without a patch

### DIFF
--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -407,7 +407,22 @@ class PackageCurationTest : WordSpec({
             )
         }
     }
+
+    "isApplicable()" should {
+        "comply to the ivy version matchers specifications" {
+            packageCurationForVersion("[1.0.0,2.0.0]").isApplicable(identifierForVersion("1.0.0")) shouldBe true
+            packageCurationForVersion("[1.0.0,2.0.0]").isApplicable(identifierForVersion("1.23")) shouldBe true
+            packageCurationForVersion("[1.0,2.0]").isApplicable(identifierForVersion("1.23")) shouldBe true
+            packageCurationForVersion("1.+").isApplicable(identifierForVersion("1.23")) shouldBe true
+            packageCurationForVersion("]1.0,)").isApplicable(identifierForVersion("1.0")) shouldBe false
+        }
+    }
 })
+
+private fun packageCurationForVersion(version: String) =
+    PackageCuration(identifierForVersion(version), PackageCurationData())
+
+private fun identifierForVersion(version: String) = Identifier(type = "", namespace = "", name = "", version = version)
 
 private fun declaredLicenseMappingCuration(id: Identifier, vararg entries: Pair<String, String>): PackageCuration =
     PackageCuration(


### PR DESCRIPTION
Using `isSatisfiedBy(String)` defaults to `SemverType.STRICT`, which
doesn't allow versions without a patch. Specify the `SemverType`
explicitly to avoid this issue.

While at it, also print a warning if a version or a version range cannot
be parsed.
