### PR TITLE
clients/osv: Implement querying the OSV API

### DIFF
--- a/clients/osv/build.gradle.kts
+++ b/clients/osv/build.gradle.kts
@@ -27,9 +27,15 @@ plugins {
 }
 
 dependencies {
+    api(libs.retrofit)
+
     implementation(libs.kotlinxSerialization)
+    implementation(libs.retrofitConverterKotlinxSerialization)
+    implementation(libs.retrofitConverterScalars)
 
     testImplementation(libs.kotestAssertionsJson)
+
+    funTestImplementation(libs.kotestAssertionsJson)
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/clients/osv/build.gradle.kts
+++ b/clients/osv/build.gradle.kts
@@ -28,6 +28,8 @@ plugins {
 
 dependencies {
     implementation(libs.kotlinxSerialization)
+
+    testImplementation(libs.kotestAssertionsJson)
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/clients/osv/src/funTest/assets/vulnerabilities-by-commit-expected-result.json
+++ b/clients/osv/src/funTest/assets/vulnerabilities-by-commit-expected-result.json
@@ -1,0 +1,49 @@
+[
+    {
+        "schema_version": "1.2.0",
+        "id": "OSV-2020-484",
+        "modified": "2022-04-13T03:04:32.842142Z",
+        "published": "2020-07-01T00:00:12.297418Z",
+        "summary": "Heap-buffer-overflow in AAT::KerxSubTableFormat4<AAT::KerxSubTableHeader>::driver_context_t::transition",
+        "details": "OSS-Fuzz report: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=12532\n\n```\nCrash type: Heap-buffer-overflow READ 4\nCrash state:\nAAT::KerxSubTableFormat4<AAT::KerxSubTableHeader>::driver_context_t::transition\nvoid AAT::StateTableDriver<AAT::ExtendedTypes, AAT::KerxSubTableFormat4<AAT::Ker\nAAT::KerxSubTableFormat4<AAT::KerxSubTableHeader>::apply\n```\n",
+        "affected": [
+            {
+                "package": {
+                    "ecosystem": "OSS-Fuzz",
+                    "name": "harfbuzz",
+                    "purl": "pkg:generic/harfbuzz"
+                },
+                "ranges": [
+                    {
+                        "type": "GIT",
+                        "repo": "https://github.com/harfbuzz/harfbuzz.git",
+                        "events": [
+                            {
+                                "introduced": "4009a05ca7de21fff2176621597cd0cd01e9d80e"
+                            },
+                            {
+                                "fixed": "cc8e9a436fa408a1c63f4b9afb7643cea76a079c"
+                            }
+                        ]
+                    }
+                ],
+                "versions": [
+                    "2.2.0",
+                    "2.3.0"
+                ],
+                "ecosystem_specific": {
+                    "severity": "MEDIUM"
+                },
+                "database_specific": {
+                    "source": "https://github.com/google/oss-fuzz-vulns/blob/main/vulns/harfbuzz/OSV-2020-484.yaml"
+                }
+            }
+        ],
+        "references": [
+            {
+                "type": "REPORT",
+                "url": "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=12532"
+            }
+        ]
+    }
+]

--- a/clients/osv/src/funTest/assets/vulnerabilities-by-name-and-version-expected-result.json
+++ b/clients/osv/src/funTest/assets/vulnerabilities-by-name-and-version-expected-result.json
@@ -1,0 +1,602 @@
+[
+    {
+        "schema_version": "1.2.0",
+        "id": "PYSEC-2014-8",
+        "modified": "2021-07-05T00:01:22.043149Z",
+        "published": "2014-05-19T14:55:00Z",
+        "aliases": [
+            "CVE-2014-1402"
+        ],
+        "details": "The default configuration for bccache.FileSystemBytecodeCache in Jinja2 before 2.7.2 does not properly create temporary files, which allows local users to gain privileges via a crafted .cache file with a name starting with __jinja2_ in /tmp.",
+        "affected": [
+            {
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "jinja2",
+                    "purl": "pkg:pypi/jinja2"
+                },
+                "ranges": [
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [
+                            {
+                                "introduced": "0"
+                            },
+                            {
+                                "fixed": "2.7.2"
+                            }
+                        ]
+                    }
+                ],
+                "versions": [
+                    "2.0",
+                    "2.0rc1",
+                    "2.1",
+                    "2.1.1",
+                    "2.2",
+                    "2.2.1",
+                    "2.3",
+                    "2.3.1",
+                    "2.4",
+                    "2.4.1",
+                    "2.5",
+                    "2.5.1",
+                    "2.5.2",
+                    "2.5.3",
+                    "2.5.4",
+                    "2.5.5",
+                    "2.6",
+                    "2.7",
+                    "2.7.1"
+                ],
+                "database_specific": {
+                    "source": "https://github.com/pypa/advisory-database/blob/main/vulns/jinja2/PYSEC-2014-8.yaml"
+                }
+            }
+        ],
+        "references": [
+            {
+                "type": "WEB",
+                "url": "https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=734747"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "http://advisories.mageia.org/MGASA-2014-0028.html"
+            },
+            {
+                "type": "WEB",
+                "url": "http://jinja.pocoo.org/docs/changelog/"
+            },
+            {
+                "type": "WEB",
+                "url": "http://openwall.com/lists/oss-security/2014/01/10/3"
+            },
+            {
+                "type": "REPORT",
+                "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1051421"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "http://www.mandriva.com/security/advisories?name=MDVSA-2014:096"
+            },
+            {
+                "type": "WEB",
+                "url": "http://openwall.com/lists/oss-security/2014/01/10/2"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "http://secunia.com/advisories/59017"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "http://secunia.com/advisories/58918"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "http://secunia.com/advisories/60770"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "http://secunia.com/advisories/60738"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "http://secunia.com/advisories/56287"
+            },
+            {
+                "type": "WEB",
+                "url": "http://www.gentoo.org/security/en/glsa/glsa-201408-13.xml"
+            },
+            {
+                "type": "WEB",
+                "url": "https://oss.oracle.com/pipermail/el-errata/2014-June/004192.html"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "http://secunia.com/advisories/58783"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "http://rhn.redhat.com/errata/RHSA-2014-0748.html"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "http://rhn.redhat.com/errata/RHSA-2014-0747.html"
+            }
+        ]
+    },
+    {
+        "schema_version": "1.2.0",
+        "id": "PYSEC-2014-82",
+        "modified": "2021-08-27T03:22:05.027573Z",
+        "published": "2014-05-19T14:55:00Z",
+        "aliases": [
+            "CVE-2014-0012"
+        ],
+        "details": "FileSystemBytecodeCache in Jinja2 2.7.2 does not properly create temporary directories, which allows local users to gain privileges by pre-creating a temporary directory with a user's uid.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-1402.",
+        "affected": [
+            {
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "jinja2",
+                    "purl": "pkg:pypi/jinja2"
+                },
+                "ranges": [
+                    {
+                        "type": "GIT",
+                        "repo": "https://github.com/mitsuhiko/jinja2",
+                        "events": [
+                            {
+                                "introduced": "0"
+                            },
+                            {
+                                "fixed": "acb672b6a179567632e032f547582f30fa2f4aa7"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [
+                            {
+                                "introduced": "0"
+                            },
+                            {
+                                "fixed": "2.7.3"
+                            }
+                        ]
+                    }
+                ],
+                "versions": [
+                    "2.0",
+                    "2.0rc1",
+                    "2.1",
+                    "2.1.1",
+                    "2.2",
+                    "2.2.1",
+                    "2.3",
+                    "2.3.1",
+                    "2.4",
+                    "2.4.1",
+                    "2.5",
+                    "2.5.1",
+                    "2.5.2",
+                    "2.5.3",
+                    "2.5.4",
+                    "2.5.5",
+                    "2.6",
+                    "2.7",
+                    "2.7.1",
+                    "2.7.2"
+                ],
+                "database_specific": {
+                    "source": "https://github.com/pypa/advisory-database/blob/main/vulns/jinja2/PYSEC-2014-82.yaml"
+                }
+            }
+        ],
+        "references": [
+            {
+                "type": "REPORT",
+                "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1051421"
+            },
+            {
+                "type": "WEB",
+                "url": "https://github.com/mitsuhiko/jinja2/pull/292"
+            },
+            {
+                "type": "FIX",
+                "url": "https://github.com/mitsuhiko/jinja2/commit/acb672b6a179567632e032f547582f30fa2f4aa7"
+            },
+            {
+                "type": "WEB",
+                "url": "http://seclists.org/oss-sec/2014/q1/73"
+            },
+            {
+                "type": "WEB",
+                "url": "https://github.com/mitsuhiko/jinja2/pull/296"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "http://secunia.com/advisories/60738"
+            },
+            {
+                "type": "WEB",
+                "url": "http://www.gentoo.org/security/en/glsa/glsa-201408-13.xml"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "http://secunia.com/advisories/56328"
+            }
+        ]
+    },
+    {
+        "schema_version": "1.2.0",
+        "id": "PYSEC-2019-217",
+        "modified": "2021-11-22T04:57:52.862665Z",
+        "published": "2019-04-07T00:29:00Z",
+        "aliases": [
+            "CVE-2019-10906",
+            "GHSA-462w-v97r-4m45"
+        ],
+        "details": "In Pallets Jinja before 2.10.1, str.format_map allows a sandbox escape.",
+        "affected": [
+            {
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "jinja2",
+                    "purl": "pkg:pypi/jinja2"
+                },
+                "ranges": [
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [
+                            {
+                                "introduced": "0"
+                            },
+                            {
+                                "fixed": "2.10.1"
+                            }
+                        ]
+                    }
+                ],
+                "versions": [
+                    "2.0",
+                    "2.0rc1",
+                    "2.1",
+                    "2.1.1",
+                    "2.10",
+                    "2.2",
+                    "2.2.1",
+                    "2.3",
+                    "2.3.1",
+                    "2.4",
+                    "2.4.1",
+                    "2.5",
+                    "2.5.1",
+                    "2.5.2",
+                    "2.5.3",
+                    "2.5.4",
+                    "2.5.5",
+                    "2.6",
+                    "2.7",
+                    "2.7.1",
+                    "2.7.2",
+                    "2.7.3",
+                    "2.8",
+                    "2.8.1",
+                    "2.9",
+                    "2.9.1",
+                    "2.9.2",
+                    "2.9.3",
+                    "2.9.4",
+                    "2.9.5",
+                    "2.9.6"
+                ],
+                "database_specific": {
+                    "source": "https://github.com/pypa/advisory-database/blob/main/vulns/jinja2/PYSEC-2019-217.yaml"
+                }
+            }
+        ],
+        "references": [
+            {
+                "type": "ARTICLE",
+                "url": "https://palletsprojects.com/blog/jinja-2-10-1-released"
+            },
+            {
+                "type": "WEB",
+                "url": "https://lists.apache.org/thread.html/b2380d147b508bbcb90d2cad443c159e63e12555966ab4f320ee22da@%3Ccommits.airflow.apache.org%3E"
+            },
+            {
+                "type": "WEB",
+                "url": "https://lists.apache.org/thread.html/46c055e173b52d599c648a98199972dbd6a89d2b4c4647b0500f2284@%3Cdevnull.infra.apache.org%3E"
+            },
+            {
+                "type": "WEB",
+                "url": "https://lists.apache.org/thread.html/f0c4a03418bcfe70c539c5dbaf99c04c98da13bfa1d3266f08564316@%3Ccommits.airflow.apache.org%3E"
+            },
+            {
+                "type": "WEB",
+                "url": "https://lists.apache.org/thread.html/7f39f01392d320dfb48e4901db68daeece62fd60ef20955966739993@%3Ccommits.airflow.apache.org%3E"
+            },
+            {
+                "type": "WEB",
+                "url": "https://lists.apache.org/thread.html/57673a78c4d5c870d3f21465c7e2946b9f8285c7c57e54c2ae552f02@%3Ccommits.airflow.apache.org%3E"
+            },
+            {
+                "type": "WEB",
+                "url": "https://lists.apache.org/thread.html/320441dccbd9a545320f5f07306d711d4bbd31ba43dc9eebcfc602df@%3Cdevnull.infra.apache.org%3E"
+            },
+            {
+                "type": "WEB",
+                "url": "https://lists.apache.org/thread.html/2b52b9c8b9d6366a4f1b407a8bde6af28d9fc73fdb3b37695fd0d9ac@%3Cdevnull.infra.apache.org%3E"
+            },
+            {
+                "type": "WEB",
+                "url": "https://lists.apache.org/thread.html/09fc842ff444cd43d9d4c510756fec625ef8eb1175f14fd21de2605f@%3Cdevnull.infra.apache.org%3E"
+            },
+            {
+                "type": "WEB",
+                "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/QCDYIS254EJMBNWOG4S5QY6AOTOR4TZU/"
+            },
+            {
+                "type": "WEB",
+                "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DSW3QZMFVVR7YE3UT4YRQA272TYAL5AF/"
+            },
+            {
+                "type": "WEB",
+                "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TS7IVZAJBWOHNRDMFJDIZVFCMRP6YIUQ/"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "https://access.redhat.com/errata/RHSA-2019:1152"
+            },
+            {
+                "type": "WEB",
+                "url": "http://lists.opensuse.org/opensuse-security-announce/2019-05/msg00030.html"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "https://access.redhat.com/errata/RHSA-2019:1237"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "https://access.redhat.com/errata/RHSA-2019:1329"
+            },
+            {
+                "type": "WEB",
+                "url": "https://usn.ubuntu.com/4011-1/"
+            },
+            {
+                "type": "WEB",
+                "url": "https://usn.ubuntu.com/4011-2/"
+            },
+            {
+                "type": "WEB",
+                "url": "http://lists.opensuse.org/opensuse-security-announce/2019-06/msg00064.html"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "https://github.com/advisories/GHSA-462w-v97r-4m45"
+            }
+        ]
+    },
+    {
+        "schema_version": "1.2.0",
+        "id": "PYSEC-2019-220",
+        "modified": "2021-11-22T04:57:52.929678Z",
+        "published": "2019-04-08T13:29:00Z",
+        "aliases": [
+            "CVE-2016-10745",
+            "GHSA-hj2j-77xm-mc5v"
+        ],
+        "details": "In Pallets Jinja before 2.8.1, str.format allows a sandbox escape.",
+        "affected": [
+            {
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "jinja2",
+                    "purl": "pkg:pypi/jinja2"
+                },
+                "ranges": [
+                    {
+                        "type": "GIT",
+                        "repo": "https://github.com/pallets/jinja",
+                        "events": [
+                            {
+                                "introduced": "0"
+                            },
+                            {
+                                "fixed": "9b53045c34e61013dc8f09b7e52a555fa16bed16"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [
+                            {
+                                "introduced": "0"
+                            },
+                            {
+                                "fixed": "2.8.1"
+                            }
+                        ]
+                    }
+                ],
+                "versions": [
+                    "2.0",
+                    "2.0rc1",
+                    "2.1",
+                    "2.1.1",
+                    "2.2",
+                    "2.2.1",
+                    "2.3",
+                    "2.3.1",
+                    "2.4",
+                    "2.4.1",
+                    "2.5",
+                    "2.5.1",
+                    "2.5.2",
+                    "2.5.3",
+                    "2.5.4",
+                    "2.5.5",
+                    "2.6",
+                    "2.7",
+                    "2.7.1",
+                    "2.7.2",
+                    "2.7.3",
+                    "2.8"
+                ],
+                "database_specific": {
+                    "source": "https://github.com/pypa/advisory-database/blob/main/vulns/jinja2/PYSEC-2019-220.yaml"
+                }
+            }
+        ],
+        "references": [
+            {
+                "type": "ARTICLE",
+                "url": "https://palletsprojects.com/blog/jinja-281-released/"
+            },
+            {
+                "type": "FIX",
+                "url": "https://github.com/pallets/jinja/commit/9b53045c34e61013dc8f09b7e52a555fa16bed16"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "https://access.redhat.com/errata/RHSA-2019:1022"
+            },
+            {
+                "type": "WEB",
+                "url": "http://lists.opensuse.org/opensuse-security-announce/2019-05/msg00030.html"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "https://access.redhat.com/errata/RHSA-2019:1237"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "https://access.redhat.com/errata/RHSA-2019:1260"
+            },
+            {
+                "type": "WEB",
+                "url": "https://usn.ubuntu.com/4011-1/"
+            },
+            {
+                "type": "WEB",
+                "url": "https://usn.ubuntu.com/4011-2/"
+            },
+            {
+                "type": "WEB",
+                "url": "http://lists.opensuse.org/opensuse-security-announce/2019-06/msg00064.html"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "https://access.redhat.com/errata/RHSA-2019:3964"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "https://access.redhat.com/errata/RHSA-2019:4062"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "https://github.com/advisories/GHSA-hj2j-77xm-mc5v"
+            }
+        ]
+    },
+    {
+        "schema_version": "1.2.0",
+        "id": "PYSEC-2021-66",
+        "modified": "2021-03-22T16:34:00Z",
+        "published": "2021-02-01T20:15:00Z",
+        "aliases": [
+            "CVE-2020-28493",
+            "SNYK-PYTHON-JINJA2-1012994",
+            "GHSA-g3rq-g295-4j3m"
+        ],
+        "details": "This affects the package jinja2 from 0.0.0 and before 2.11.3. The ReDoS vulnerability is mainly due to the `_punctuation_re regex` operator and its use of multiple wildcards. The last wildcard is the most exploitable as it searches for trailing punctuation. This issue can be mitigated by Markdown to format user content instead of the urlize filter, or by implementing request timeouts and limiting process memory.",
+        "affected": [
+            {
+                "package": {
+                    "ecosystem": "PyPI",
+                    "name": "jinja2",
+                    "purl": "pkg:pypi/jinja2"
+                },
+                "ranges": [
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [
+                            {
+                                "introduced": "0"
+                            },
+                            {
+                                "fixed": "2.11.3"
+                            }
+                        ]
+                    }
+                ],
+                "versions": [
+                    "2.0rc1",
+                    "2.0",
+                    "2.1",
+                    "2.1.1",
+                    "2.2",
+                    "2.2.1",
+                    "2.3",
+                    "2.3.1",
+                    "2.4",
+                    "2.4.1",
+                    "2.5",
+                    "2.5.1",
+                    "2.5.2",
+                    "2.5.3",
+                    "2.5.4",
+                    "2.5.5",
+                    "2.6",
+                    "2.7",
+                    "2.7.1",
+                    "2.7.2",
+                    "2.7.3",
+                    "2.8",
+                    "2.8.1",
+                    "2.9",
+                    "2.9.1",
+                    "2.9.2",
+                    "2.9.3",
+                    "2.9.4",
+                    "2.9.5",
+                    "2.9.6",
+                    "2.10",
+                    "2.10.1",
+                    "2.10.2",
+                    "2.10.3",
+                    "2.11.0",
+                    "2.11.1",
+                    "2.11.2"
+                ],
+                "database_specific": {
+                    "source": "https://github.com/pypa/advisory-database/blob/main/vulns/jinja2/PYSEC-2021-66.yaml"
+                }
+            }
+        ],
+        "references": [
+            {
+                "type": "WEB",
+                "url": "https://github.com/pallets/jinja/blob/ab81fd9c277900c85da0c322a2ff9d68a235b2e6/src/jinja2/utils.py%23L20"
+            },
+            {
+                "type": "WEB",
+                "url": "https://github.com/pallets/jinja/pull/1343"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "https://snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994"
+            },
+            {
+                "type": "WEB",
+                "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PVAKCOO7VBVUBM3Q6CBBTPBFNP5NDXF4/"
+            },
+            {
+                "type": "ADVISORY",
+                "url": "https://github.com/advisories/GHSA-g3rq-g295-4j3m"
+            }
+        ]
+    }
+]

--- a/clients/osv/src/funTest/assets/vulnerability-by-id-expected-result.json
+++ b/clients/osv/src/funTest/assets/vulnerability-by-id-expected-result.json
@@ -1,0 +1,79 @@
+{
+    "schema_version": "1.2.0",
+    "id": "GHSA-xvch-5gv4-984h",
+    "modified": "2022-04-04T21:39:38Z",
+    "published": "2022-03-18T00:01:09Z",
+    "aliases": [
+        "CVE-2021-44906"
+    ],
+    "summary": "Prototype Pollution in minimist",
+    "details": "Minimist <=1.2.5 is vulnerable to Prototype Pollution via file index.js, function setKey() (lines 69-95).",
+    "severity": [
+        {
+            "type": "CVSS_V3",
+            "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        }
+    ],
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "minimist",
+                "purl": "pkg:npm/minimist"
+            },
+            "ranges": [
+                {
+                    "type": "SEMVER",
+                    "events": [
+                        {
+                            "introduced": "0"
+                        },
+                        {
+                            "fixed": "1.2.6"
+                        }
+                    ]
+                }
+            ],
+            "database_specific": {
+                "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2022/03/GHSA-xvch-5gv4-984h/GHSA-xvch-5gv4-984h.json"
+            }
+        }
+    ],
+    "references": [
+        {
+            "type": "ADVISORY",
+            "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-44906"
+        },
+        {
+            "type": "WEB",
+            "url": "https://github.com/substack/minimist/issues/164"
+        },
+        {
+            "type": "WEB",
+            "url": "https://github.com/Marynk/JavaScript-vulnerability-detection/blob/main/minimist%20PoC.zip"
+        },
+        {
+            "type": "WEB",
+            "url": "https://github.com/substack/minimist/blob/master/index.js#L69"
+        },
+        {
+            "type": "WEB",
+            "url": "https://snyk.io/vuln/SNYK-JS-MINIMIST-559764"
+        },
+        {
+            "type": "WEB",
+            "url": "https://stackoverflow.com/questions/8588563/adding-custom-properties-to-a-function/20278068#20278068"
+        },
+        {
+            "type": "PACKAGE",
+            "url": "https://github.com/substack/minimist"
+        }
+    ],
+    "database_specific": {
+        "github_reviewed": true,
+        "cwe_ids": [
+            "CWE-1321"
+        ],
+        "severity": "CRITICAL"
+    }
+}

--- a/clients/osv/src/funTest/kotlin/OsvServiceFunTest.kt
+++ b/clients/osv/src/funTest/kotlin/OsvServiceFunTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2022 EPAM Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.result.shouldBeSuccess
+import io.kotest.matchers.shouldBe
+
+import java.io.File
+
+import kotlinx.serialization.encodeToString
+
+import org.ossreviewtoolkit.clients.osv.OsvApiClient
+import org.ossreviewtoolkit.clients.osv.OsvService
+import org.ossreviewtoolkit.clients.osv.Package
+import org.ossreviewtoolkit.clients.osv.VulnerabilitiesForPackageRequest
+
+private val VULNERABILITY_FOR_PACKAGE_BY_COMMIT_REQUEST = VulnerabilitiesForPackageRequest(
+    commit = "6879efc2c1596d11a6a6ad296f80063b558d5e0f"
+)
+private val VULNERABILITY_FOR_PACKAGE_BY_NAME_AND_VERSION = VulnerabilitiesForPackageRequest(
+    pkg = Package(
+        name = "jinja2",
+        ecosystem = "PyPI"
+    ),
+    version = "2.4.1"
+)
+private val VULNERABILITY_FOR_PACKAGE_BY_INVALID_COMMIT_REQUEST = VulnerabilitiesForPackageRequest(
+    commit = "6879efc2c1596d11a6a6ad296f80063b558d5e0c"
+)
+
+class OsvServiceFunTest : StringSpec({
+    "getVulnerabilitiesForPackage() returns the expected vulnerability when queried by commit" {
+        val expectedResult = getAssetAsString("vulnerabilities-by-commit-expected-result.json")
+
+        val result = OsvService().getVulnerabilitiesForPackage(VULNERABILITY_FOR_PACKAGE_BY_COMMIT_REQUEST)
+
+        result.shouldBeSuccess {
+            JSON.encodeToString(it) shouldEqualJson expectedResult
+        }
+    }
+
+    "getVulnerabilitiesForPackage() returns the expected vulnerability when queried by name and version" {
+        val expectedResult = getAssetAsString("vulnerabilities-by-name-and-version-expected-result.json")
+
+        val result = OsvService().getVulnerabilitiesForPackage(VULNERABILITY_FOR_PACKAGE_BY_NAME_AND_VERSION)
+
+        result.shouldBeSuccess {
+            JSON.encodeToString(it) shouldEqualJson expectedResult
+        }
+    }
+
+    "getVulnerabilityIdsForPackages() return the vulnerability IDs for the given batch request" {
+        val requests = listOf(
+            VULNERABILITY_FOR_PACKAGE_BY_COMMIT_REQUEST,
+            VULNERABILITY_FOR_PACKAGE_BY_INVALID_COMMIT_REQUEST,
+            VULNERABILITY_FOR_PACKAGE_BY_NAME_AND_VERSION
+        )
+
+        val result = OsvService().getVulnerabilityIdsForPackages(requests)
+
+        result.shouldBeSuccess {
+            it shouldBe listOf(
+                listOf("OSV-2020-484"),
+                emptyList(),
+                listOf(
+                    "PYSEC-2014-8",
+                    "PYSEC-2014-82",
+                    "PYSEC-2019-217",
+                    "PYSEC-2019-220",
+                    "PYSEC-2021-66"
+                )
+            )
+        }
+    }
+
+    "getVulnerabilityForId() returns the expected vulnerability for the given ID" {
+        val expectedResult = getAssetAsString("vulnerability-by-id-expected-result.json")
+
+        val result = OsvService().getVulnerabilityForId("GHSA-xvch-5gv4-984h")
+
+        result.shouldBeSuccess {
+            JSON.encodeToString(it) shouldEqualJson expectedResult
+        }
+    }
+
+    "getVulnerabilitiesForIds() return the vulnerabilities for the given IDs" {
+        val ids = setOf("GHSA-xvch-5gv4-984h", "PYSEC-2014-82")
+
+        val result = OsvService().getVulnerabilitiesForIds(ids)
+
+        result.shouldBeSuccess {
+            it.map { it.id } shouldContainExactlyInAnyOrder ids
+        }
+    }
+})
+
+private val JSON = OsvApiClient.JSON
+
+private fun getAssetAsString(path: String): String = File("src/funTest/assets").resolve(path).readText()

--- a/clients/osv/src/main/kotlin/OsvApiClient.kt
+++ b/clients/osv/src/main/kotlin/OsvApiClient.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2022 EPAM Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.clients.osv
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+
+import java.util.concurrent.Executors
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+import okhttp3.Dispatcher
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+/**
+ * A rest API client for the Google Open Source Vulnerabilities API (OSV.dev), see https://osv.dev/.
+ */
+interface OsvApiClient {
+    companion object {
+        const val SERVER_URL_PRODUCTION = "https://api.osv.dev"
+        const val SERVER_URL_STAGING = "https://api-staging.osv.dev"
+        const val BATCH_REQUEST_MAX_SIZE = 1000
+
+        val JSON = Json.Default
+
+        fun create(serverUrl: String = SERVER_URL_PRODUCTION, client: OkHttpClient? = null): OsvApiClient {
+            val converterFactory = JSON.asConverterFactory(contentType = "application/json".toMediaType())
+
+            return Retrofit.Builder()
+                .apply { client(client ?: defaultHttpClient()) }
+                .baseUrl(serverUrl)
+                .addConverterFactory(converterFactory)
+                .build()
+                .create(OsvApiClient::class.java)
+        }
+    }
+
+    /**
+     * Get the vulnerabilities for the package matched by the given [request].
+     */
+    @POST("v1/query")
+    fun getVulnerabilitiesForPackage(
+        @Body request: VulnerabilitiesForPackageRequest
+    ): Call<VulnerabilitiesForPackageResponse>
+
+    /**
+     * Get the identifiers of the vulnerabilities for the packages matched by the respective given [request].
+     * The amount of requests contained in the give [batch request][request] must not exceed [BATCH_REQUEST_MAX_SIZE].
+     */
+    @POST("v1/querybatch")
+    fun getVulnerabilityIdsForPackages(
+        @Body request: VulnerabilitiesForPackageBatchRequest
+    ): Call<VulnerabilitiesForPackageBatchResponse>
+
+    /**
+     * Return the vulnerability denoted by the given [id].
+     */
+    @GET("v1/vulns/{id}")
+    fun getVulnerabilityForId(@Path("id") id: String): Call<Vulnerability>
+}
+
+@Serializable
+data class VulnerabilitiesForPackageRequest private constructor(
+    val commit: String? = null,
+    @SerialName("package")
+    val pkg: Package? = null,
+    val version: String? = null
+) {
+    constructor(commit: String, pkg: Package? = null) : this(commit = commit, pkg = pkg, version = null)
+    constructor(pkg: Package, version: String) : this(commit = null, pkg = pkg, version = version)
+}
+
+@Serializable
+data class VulnerabilitiesForPackageResponse(
+    @SerialName("vulns")
+    val vulnerabilities: List<Vulnerability>
+)
+
+@Serializable
+data class VulnerabilitiesForPackageBatchRequest(
+    val queries: List<VulnerabilitiesForPackageRequest>
+)
+
+@Serializable
+data class VulnerabilitiesForPackageBatchResponse(
+    val results: List<IdList>,
+) {
+    @Serializable
+    data class IdList(
+        @SerialName("vulns")
+        val vulnerabilities: List<Id> = emptyList()
+    )
+
+    @Serializable
+    data class Id(
+        val id: String
+    )
+}
+
+private fun defaultHttpClient(): OkHttpClient {
+    // Experimentally determined value to speed-up execution time of 1000 single vulnerability-by-id requests.
+    val n = 100
+    val dispatcher = Dispatcher(Executors.newFixedThreadPool(n)).apply {
+        maxRequests = n
+        maxRequestsPerHost = n
+    }
+
+    return OkHttpClient.Builder().dispatcher(dispatcher).build()
+}

--- a/clients/osv/src/main/kotlin/OsvService.kt
+++ b/clients/osv/src/main/kotlin/OsvService.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2022 EPAM Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.clients.osv
+
+import java.io.IOException
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicReference
+
+import okhttp3.OkHttpClient
+
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+/**
+ * This class wraps the OSV Rest API client in order to make its use simpler and less error-prone.
+ */
+class OsvService(serverUrl: String = OsvApiClient.SERVER_URL_PRODUCTION, httpClient: OkHttpClient? = null) {
+    private val client = OsvApiClient.create(serverUrl, httpClient)
+
+    /**
+     * Get the vulnerabilities for the package matching the given [request].
+     */
+    fun getVulnerabilitiesForPackage(
+        request: VulnerabilitiesForPackageRequest
+    ): Result<List<Vulnerability>> {
+        val response = client.getVulnerabilitiesForPackage(request).execute()
+
+        return when (response.isSuccessful) {
+            true -> Result.success(response.body()!!.vulnerabilities)
+            else -> Result.failure(IOException(response.message()))
+        }
+    }
+
+    /**
+     * Return the vulnerability IDs for the respective package matched by the given [requests].
+     */
+    fun getVulnerabilityIdsForPackages(
+        requests: List<VulnerabilitiesForPackageRequest>
+    ): Result<List<List<String>>> {
+        if (requests.isEmpty()) return Result.success(emptyList())
+
+        val result = mutableListOf<MutableList<String>>()
+
+        requests.chunked(OsvApiClient.BATCH_REQUEST_MAX_SIZE).forEach { requestsChunk ->
+            val batchRequest = VulnerabilitiesForPackageBatchRequest(requestsChunk)
+            val response = client.getVulnerabilityIdsForPackages(batchRequest).execute()
+
+            if (!response.isSuccessful) return Result.failure(IOException(response.message()))
+
+            result += response.body()!!.results.map { batchResponse ->
+                batchResponse.vulnerabilities.mapTo(mutableListOf()) { it.id }
+            }
+        }
+
+        return Result.success(result)
+    }
+
+    /**
+     * Return the vulnerability denoted by the given [id].
+     */
+    fun getVulnerabilityForId(id: String): Result<Vulnerability> {
+        val response = client.getVulnerabilityForId(id).execute()
+
+        return when (response.isSuccessful) {
+            true -> Result.success(response.body()!!)
+            else -> Result.failure(IOException(response.message()))
+        }
+    }
+
+    /**
+     * Return the vulnerabilities denoted by the given [ids].
+     *
+     * This executes a separate request for each given identifier since a batch request is not available.
+     * It's been considered to add a batch API in the future, see
+     * https://github.com/google/osv.dev/issues/466#issuecomment-1163337495.
+     */
+    fun getVulnerabilitiesForIds(ids: Set<String>): Result<List<Vulnerability>> {
+        val result = ConcurrentLinkedQueue<Vulnerability>()
+        val failureThrowable = AtomicReference<Throwable?>(null)
+        val latch = CountDownLatch(ids.size)
+
+        ids.forEach { id ->
+            client.getVulnerabilityForId(id).enqueue(object : Callback<Vulnerability> {
+                override fun onResponse(call: Call<Vulnerability>, response: Response<Vulnerability>) {
+                    response.body()?.let { result += it }
+                    latch.countDown()
+                }
+
+                override fun onFailure(call: Call<Vulnerability>, t: Throwable) {
+                    failureThrowable.set(t)
+                    latch.countDown()
+                }
+            })
+        }
+
+        latch.await()
+
+        return failureThrowable.get()?.let { Result.failure(it) }
+            ?: Result.success(result.toList())
+    }
+}

--- a/clients/osv/src/test/kotlin/ModelTest.kt
+++ b/clients/osv/src/test/kotlin/ModelTest.kt
@@ -19,17 +19,15 @@
 
 package org.ossreviewtoolkit.clients.osv
 
+import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.inspectors.forAll
-import io.kotest.matchers.shouldBe
 
 import java.io.File
 
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 class ModelTest : StringSpec({
     "Deserializing and serializing any vulnerability is idempotent for all official examples" {
@@ -38,7 +36,7 @@ class ModelTest : StringSpec({
 
             val serializedVulnerabilityJson = JSON.encodeToString(vulnerability)
 
-            normalizeJson(serializedVulnerabilityJson) shouldBe normalizeJson(vulnerabilityJson)
+            serializedVulnerabilityJson shouldEqualJson vulnerabilityJson
         }
     }
 })
@@ -47,18 +45,3 @@ private val JSON = Json {}
 
 private fun getVulnerabilityExamplesJson(): List<String> =
     (1..7).map { i -> File("src/test/assets/vulnerability/examples/$i.json").readText() }
-
-private fun normalizeJson(value: String): String {
-    val json = Json { prettyPrint = true }
-    val rootNode = json.decodeFromString<JsonElement>(value)
-
-    return json.encodeToString(rootNode.sortProperties())
-}
-
-private fun JsonElement.sortProperties(): JsonElement =
-    when (this) {
-        is JsonObject -> JsonObject(
-            entries.map { it.key to it.value.sortProperties() }.sortedBy { it.first }.toMap()
-        )
-        else -> this
-    }

--- a/clients/osv/src/test/kotlin/ModelTest.kt
+++ b/clients/osv/src/test/kotlin/ModelTest.kt
@@ -41,7 +41,7 @@ class ModelTest : StringSpec({
     }
 })
 
-private val JSON = Json {}
+private val JSON = Json.Default
 
 private fun getVulnerabilityExamplesJson(): List<String> =
     (1..7).map { i -> File("src/test/assets/vulnerability/examples/$i.json").readText() }


### PR DESCRIPTION
Add a retrofit based REST API client and a wrapper for simplicity and
information hiding. The implementation is based on [1], even though it
has some inconsistencies with the real behavior, see [2].

[1] https://osv.dev/docs/
[2] https://github.com/google/osv.dev/issues/466

This is an enabler for #3599.

