### PR TITLE
ClearlyDefinedPackageCurationProvider: Filter duplicate curations

### DIFF
--- a/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
@@ -172,6 +172,6 @@ class ClearlyDefinedPackageCurationProvider(
             }
         }
 
-        return curations
+        return curations.mapValues { (_, curations) -> curations.distinct() }
     }
 }

--- a/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
@@ -32,7 +32,6 @@ import org.ossreviewtoolkit.analyzer.PackageCurationProvider
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
 import org.ossreviewtoolkit.clients.clearlydefined.ComponentType
-import org.ossreviewtoolkit.clients.clearlydefined.ContributedCurations
 import org.ossreviewtoolkit.clients.clearlydefined.Coordinates
 import org.ossreviewtoolkit.clients.clearlydefined.SourceLocation
 import org.ossreviewtoolkit.model.Hash
@@ -109,9 +108,9 @@ class ClearlyDefinedPackageCurationProvider(
         }.toMap()
 
         val contributedCurations = runCatching {
-            mutableMapOf<Coordinates, ContributedCurations>().also {
+            buildMap {
                 coordinatesToIds.keys.chunked(BULK_REQUEST_SIZE).forEach { coordinates ->
-                    it += runBlocking(Dispatchers.IO) { service.getCurations(coordinates) }
+                    putAll(runBlocking(Dispatchers.IO) { service.getCurations(coordinates) })
                 }
             }
         }.onFailure { e ->


### PR DESCRIPTION
When requesting curations for a certain coordinate the ClearlyDefined
API [1] sometimes also return curations for other coordinates. For
example, the response for "maven/mavencentral/org.ow2.asm/asm/7.0" also
contains curations for other versions of the same package, but also for
other packages that start with "asm", like "asm-tree". This means, that
the same curations can be contained multiple times in a response, if
multiple coordinates are sent at once.

As a result, it can happen that ORT adds the same curation multiple
times to a package. To prevent this, filter duplicate curations before
returning the result.

[1]: https://api.clearlydefined.io/api-docs/#/curations/post_curations_