### PR TITLE
EvaluatedModelMapper: Drop an explicit variable type

### DIFF
--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelMapper.kt
@@ -212,15 +212,14 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
                 results.flatMap { result ->
                     result.vulnerabilities.map { vulnerability ->
                         val resolutions = addResolutions(vulnerability)
-                        val evaluatedReferences: List<EvaluatedVulnerabilityReference> =
-                            vulnerability.references.map {
-                                EvaluatedVulnerabilityReference(
-                                    it.url,
-                                    it.scoringSystem,
-                                    it.severity,
-                                    VulnerabilityReference.getSeverityString(it.scoringSystem, it.severity)
-                                )
-                            }
+                        val evaluatedReferences = vulnerability.references.map {
+                            EvaluatedVulnerabilityReference(
+                                it.url,
+                                it.scoringSystem,
+                                it.severity,
+                                VulnerabilityReference.getSeverityString(it.scoringSystem, it.severity)
+                            )
+                        }
 
                         vulnerabilities += EvaluatedVulnerability(
                             pkg = pkg,


### PR DESCRIPTION
Also reformat the code slightly for readability.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>