### PR TITLE
Osv: Somewhat improve the mapping of the severity

### DIFF
--- a/advisor/build.gradle.kts
+++ b/advisor/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     api(project(":clients:github-graphql"))
     api(project(":model"))
 
+    implementation(libs.cvssCalculator)
     implementation(libs.kotlinxCoroutines)
     implementation(libs.ktorClientOkHttp)
 

--- a/advisor/src/funTest/assets/retrieve-package-findings-expected-result.json
+++ b/advisor/src/funTest/assets/retrieve-package-findings-expected-result.json
@@ -13,40 +13,40 @@
       "id" : "GHSA-ww39-953v-wcq6",
       "references" : [ {
         "url" : "https://nvd.nist.gov/vuln/detail/CVE-2020-28469",
-        "scoring_system" : "CVSS_V3",
-        "severity" : "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        "scoring_system" : "CVSS:3.1",
+        "severity" : "7.5"
       }, {
         "url" : "https://github.com/gulpjs/glob-parent/pull/36",
-        "scoring_system" : "CVSS_V3",
-        "severity" : "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        "scoring_system" : "CVSS:3.1",
+        "severity" : "7.5"
       }, {
         "url" : "https://github.com/gulpjs/glob-parent/blob/6ce8d11f2f1ed8e80a9526b1dc8cf3aa71f43474/index.js%23L9",
-        "scoring_system" : "CVSS_V3",
-        "severity" : "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        "scoring_system" : "CVSS:3.1",
+        "severity" : "7.5"
       }, {
         "url" : "https://github.com/gulpjs/glob-parent/releases/tag/v5.1.2",
-        "scoring_system" : "CVSS_V3",
-        "severity" : "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        "scoring_system" : "CVSS:3.1",
+        "severity" : "7.5"
       }, {
         "url" : "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWERGITHUBES128-1059093",
-        "scoring_system" : "CVSS_V3",
-        "severity" : "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        "scoring_system" : "CVSS:3.1",
+        "severity" : "7.5"
       }, {
         "url" : "https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1059092",
-        "scoring_system" : "CVSS_V3",
-        "severity" : "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        "scoring_system" : "CVSS:3.1",
+        "severity" : "7.5"
       }, {
         "url" : "https://snyk.io/vuln/SNYK-JS-GLOBPARENT-1016905",
-        "scoring_system" : "CVSS_V3",
-        "severity" : "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        "scoring_system" : "CVSS:3.1",
+        "severity" : "7.5"
       }, {
         "url" : "https://www.oracle.com/security-alerts/cpujan2022.html",
-        "scoring_system" : "CVSS_V3",
-        "severity" : "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        "scoring_system" : "CVSS:3.1",
+        "severity" : "7.5"
       }, {
         "url" : "https://github.com/gulpjs/glob-parent",
-        "scoring_system" : "CVSS_V3",
-        "severity" : "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        "scoring_system" : "CVSS:3.1",
+        "severity" : "7.5"
       } ]
     } ]
   } ]

--- a/advisor/src/main/kotlin/advisors/Osv.kt
+++ b/advisor/src/main/kotlin/advisors/Osv.kt
@@ -170,7 +170,7 @@ private fun createRequest(pkg: Package): VulnerabilitiesForPackageRequest? {
 private fun Vulnerability.toOrtVulnerability(): org.ossreviewtoolkit.model.Vulnerability {
     val (scoringSystem, severity) = severity.firstOrNull()?.let {
         it.type.name to it.score
-    } ?: null to null
+    } ?: (null to null)
 
     // TODO: Improve parsing the severity properties. Parse vectors, e.g. CVSS:3.1 and consider using the severity
     // in the database specific property as a fallback.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ clikt = "3.5.0"
 commonsCompress = "1.21"
 commonsEmail = "1.5"
 config4k = "0.4.2"
+cvssCalculator = "1.4.1"
 cyclonedx = "7.1.5"
 digraphParser = "1.0"
 diskLruCache = "2.0.2"
@@ -92,6 +93,7 @@ clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 commonsCompress = { module = "org.apache.commons:commons-compress", version.ref = "commonsCompress" }
 commonsEmail = { module = "org.apache.commons:commons-email", version.ref = "commonsEmail" }
 config4k = { module = "io.github.config4k:config4k", version.ref = "config4k" }
+cvssCalculator = { module = "us.springett:cvss-calculator", version.ref = "cvssCalculator"}
 cyclonedx = { module = "org.cyclonedx:cyclonedx-core-java", version.ref = "cyclonedx" }
 detektApi = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detektPlugin" }
 digraphParser = { module = "com.paypal.digraph:digraph-parser", version.ref = "digraphParser" }


### PR DESCRIPTION
ORT's data model for the severity of a vulnerability is quite generic.
The wide flexibiltiy it provides makes it unclear how to best map the
obtained values from the provider to that data model.

The use of `VulnerabilityReference.severity` in [1] indicates that a
float score value is a valid option. So, change the mapping to float for
now as that is easier to understand - even though this is a lossy
transformation.

In the longer run, ORT's vulnerability data model should be improved to
support vectors in a less generic stricter typed way.

[1] https://github.com/oss-review-toolkit/ort/blob/470e2f323b516389bd96a63a81c67b74891a36f8/model/src/main/kotlin/VulnerabilityReference.kt#L58-L63

This is part of #3599.
