### PR TITLE
Use "Go" as value for `Identifier.type` for all Go packages

### DIFF
--- a/advisor/src/funTest/kotlin/OsvFunTest.kt
+++ b/advisor/src/funTest/kotlin/OsvFunTest.kt
@@ -42,7 +42,6 @@ class OsvFunTest : StringSpec({
             "Maven:com.jfinal:jfinal:1.4",
             "NPM::rebber:1.0.0",
             "Go::github.com/nats-io/nats-server/v2:v2.1.0",
-            "GoDep::github.com/nats-io/nats-server/v2:v2.1.0",
             "Crate::sys-info:0.7.0",
             "NuGet::Microsoft.ChakraCore:1.10.0"
             // TODO: Add an identifier for a composer package after https://github.com/google/osv.dev/issues/497 got

--- a/advisor/src/funTest/kotlin/OsvFunTest.kt
+++ b/advisor/src/funTest/kotlin/OsvFunTest.kt
@@ -41,7 +41,7 @@ class OsvFunTest : StringSpec({
             "PyPI::Plone:3.2",
             "Maven:com.jfinal:jfinal:1.4",
             "NPM::rebber:1.0.0",
-            "GoMod::github.com/nats-io/nats-server/v2:v2.1.0",
+            "Go::github.com/nats-io/nats-server/v2:v2.1.0",
             "GoDep::github.com/nats-io/nats-server/v2:v2.1.0",
             "Crate::sys-info:0.7.0",
             "NuGet::Microsoft.ChakraCore:1.10.0"

--- a/advisor/src/main/kotlin/advisors/Osv.kt
+++ b/advisor/src/main/kotlin/advisors/Osv.kt
@@ -143,8 +143,6 @@ private fun createRequest(pkg: Package): VulnerabilitiesForPackageRequest? {
         "Bower" -> null
         "Composer" -> Ecosystem.PACKAGIST
         "Crate" -> Ecosystem.CRATES_IO
-        // TODO: The entries for Go should be merged, see https://github.com/oss-review-toolkit/ort/issues/5533.
-        "GoDep" -> Ecosystem.GO
         "Go" -> Ecosystem.GO
         "NPM" -> Ecosystem.NPM
         "NuGet" -> Ecosystem.NUGET

--- a/advisor/src/main/kotlin/advisors/Osv.kt
+++ b/advisor/src/main/kotlin/advisors/Osv.kt
@@ -145,7 +145,7 @@ private fun createRequest(pkg: Package): VulnerabilitiesForPackageRequest? {
         "Crate" -> Ecosystem.CRATES_IO
         // TODO: The entries for Go should be merged, see https://github.com/oss-review-toolkit/ort/issues/5533.
         "GoDep" -> Ecosystem.GO
-        "GoMod" -> Ecosystem.GO
+        "Go" -> Ecosystem.GO
         "NPM" -> Ecosystem.NPM
         "NuGet" -> Ecosystem.NUGET
         "Maven" -> Ecosystem.MAVEN

--- a/analyzer/src/funTest/assets/projects/synthetic/glide-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/glide-expected-output.yml
@@ -18,12 +18,12 @@ project:
   scopes:
   - name: "default"
     dependencies:
-    - id: "GoDep::github.com/mattn/go-isatty:v0.0.12"
+    - id: "Go::github.com/mattn/go-isatty:v0.0.12"
       linkage: "STATIC"
-    - id: "GoDep::golang.org/x/sys:05986578812163b26672dabd9b425240ae2bb0ad"
+    - id: "Go::golang.org/x/sys:05986578812163b26672dabd9b425240ae2bb0ad"
       linkage: "STATIC"
 packages:
-- id: "GoDep::github.com/mattn/go-isatty:v0.0.12"
+- id: "Go::github.com/mattn/go-isatty:v0.0.12"
   purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.12"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -49,7 +49,7 @@ packages:
     url: "https://github.com/mattn/go-isatty.git"
     revision: "7b513a986450394f7bbf1476909911b3aa3a55ce"
     path: ""
-- id: "GoDep::golang.org/x/sys:05986578812163b26672dabd9b425240ae2bb0ad"
+- id: "Go::golang.org/x/sys:05986578812163b26672dabd9b425240ae2bb0ad"
   purl: "pkg:golang/golang.org%2Fx%2Fsys@05986578812163b26672dabd9b425240ae2bb0ad"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/godep-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/godep-expected-output.yml
@@ -18,16 +18,16 @@ project:
   scopes:
   - name: "default"
     dependencies:
-    - id: "GoDep::github.com/fatih/color:v1.9.0"
+    - id: "Go::github.com/fatih/color:v1.9.0"
       linkage: "STATIC"
-    - id: "GoDep::github.com/mattn/go-colorable:v0.1.6"
+    - id: "Go::github.com/mattn/go-colorable:v0.1.6"
       linkage: "STATIC"
-    - id: "GoDep::github.com/mattn/go-isatty:v0.0.12"
+    - id: "Go::github.com/mattn/go-isatty:v0.0.12"
       linkage: "STATIC"
-    - id: "GoDep::golang.org/x/sys:05986578812163b26672dabd9b425240ae2bb0ad"
+    - id: "Go::golang.org/x/sys:05986578812163b26672dabd9b425240ae2bb0ad"
       linkage: "STATIC"
 packages:
-- id: "GoDep::github.com/fatih/color:v1.9.0"
+- id: "Go::github.com/fatih/color:v1.9.0"
   purl: "pkg:golang/github.com%2Ffatih%2Fcolor@v1.9.0"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -53,7 +53,7 @@ packages:
     url: "https://github.com/fatih/color.git"
     revision: "daf2830f2741ebb735b21709a520c5f37d642d85"
     path: ""
-- id: "GoDep::github.com/mattn/go-colorable:v0.1.6"
+- id: "Go::github.com/mattn/go-colorable:v0.1.6"
   purl: "pkg:golang/github.com%2Fmattn%2Fgo-colorable@v0.1.6"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -79,7 +79,7 @@ packages:
     url: "https://github.com/mattn/go-colorable.git"
     revision: "68e95eba382c972aafde02ead2cd2426a8a92480"
     path: ""
-- id: "GoDep::github.com/mattn/go-isatty:v0.0.12"
+- id: "Go::github.com/mattn/go-isatty:v0.0.12"
   purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.12"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -105,7 +105,7 @@ packages:
     url: "https://github.com/mattn/go-isatty.git"
     revision: "7b513a986450394f7bbf1476909911b3aa3a55ce"
     path: ""
-- id: "GoDep::golang.org/x/sys:05986578812163b26672dabd9b425240ae2bb0ad"
+- id: "Go::golang.org/x/sys:05986578812163b26672dabd9b425240ae2bb0ad"
   purl: "pkg:golang/golang.org%2Fx%2Fsys@05986578812163b26672dabd9b425240ae2bb0ad"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/godeps-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/godeps-expected-output.yml
@@ -18,12 +18,12 @@ project:
   scopes:
   - name: "default"
     dependencies:
-    - id: "GoDep::github.com/mattn/go-isatty:v0.0.12"
+    - id: "Go::github.com/mattn/go-isatty:v0.0.12"
       linkage: "STATIC"
-    - id: "GoDep::golang.org/x/sys:8d3cce7afc34617998104db7c4b58c2de9e77215"
+    - id: "Go::golang.org/x/sys:8d3cce7afc34617998104db7c4b58c2de9e77215"
       linkage: "STATIC"
 packages:
-- id: "GoDep::github.com/mattn/go-isatty:v0.0.12"
+- id: "Go::github.com/mattn/go-isatty:v0.0.12"
   purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.12"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -49,7 +49,7 @@ packages:
     url: "https://github.com/mattn/go-isatty.git"
     revision: "7b513a986450394f7bbf1476909911b3aa3a55ce"
     path: ""
-- id: "GoDep::golang.org/x/sys:8d3cce7afc34617998104db7c4b58c2de9e77215"
+- id: "Go::golang.org/x/sys:8d3cce7afc34617998104db7c4b58c2de9e77215"
   purl: "pkg:golang/golang.org%2Fx%2Fsys@8d3cce7afc34617998104db7c4b58c2de9e77215"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
@@ -18,65 +18,65 @@ project:
   scopes:
   - name: "main"
     dependencies:
-    - id: "GoMod::github.com/fatih/color:v1.13.0"
+    - id: "Go::github.com/fatih/color:v1.13.0"
       linkage: "PROJECT_STATIC"
       dependencies:
-      - id: "GoMod::github.com/mattn/go-colorable:v0.1.12"
+      - id: "Go::github.com/mattn/go-colorable:v0.1.12"
         linkage: "PROJECT_STATIC"
         dependencies:
-        - id: "GoMod::github.com/mattn/go-isatty:v0.0.14"
+        - id: "Go::github.com/mattn/go-isatty:v0.0.14"
           linkage: "PROJECT_STATIC"
           dependencies:
-          - id: "GoMod::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
+          - id: "Go::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
             linkage: "PROJECT_STATIC"
-        - id: "GoMod::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
+        - id: "Go::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
           linkage: "PROJECT_STATIC"
-      - id: "GoMod::github.com/mattn/go-isatty:v0.0.14"
+      - id: "Go::github.com/mattn/go-isatty:v0.0.14"
         linkage: "PROJECT_STATIC"
         dependencies:
-        - id: "GoMod::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
+        - id: "Go::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
           linkage: "PROJECT_STATIC"
-    - id: "GoMod::github.com/pborman/uuid:v1.2.1"
+    - id: "Go::github.com/pborman/uuid:v1.2.1"
       linkage: "PROJECT_STATIC"
       dependencies:
-      - id: "GoMod::github.com/google/uuid:v1.0.0"
+      - id: "Go::github.com/google/uuid:v1.0.0"
         linkage: "PROJECT_STATIC"
   - name: "vendor"
     dependencies:
-    - id: "GoMod::github.com/fatih/color:v1.13.0"
+    - id: "Go::github.com/fatih/color:v1.13.0"
       linkage: "PROJECT_STATIC"
       dependencies:
-      - id: "GoMod::github.com/mattn/go-colorable:v0.1.12"
+      - id: "Go::github.com/mattn/go-colorable:v0.1.12"
         linkage: "PROJECT_STATIC"
         dependencies:
-        - id: "GoMod::github.com/mattn/go-isatty:v0.0.14"
+        - id: "Go::github.com/mattn/go-isatty:v0.0.14"
           linkage: "PROJECT_STATIC"
           dependencies:
-          - id: "GoMod::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
+          - id: "Go::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
             linkage: "PROJECT_STATIC"
-        - id: "GoMod::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
+        - id: "Go::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
           linkage: "PROJECT_STATIC"
-      - id: "GoMod::github.com/mattn/go-isatty:v0.0.14"
+      - id: "Go::github.com/mattn/go-isatty:v0.0.14"
         linkage: "PROJECT_STATIC"
         dependencies:
-        - id: "GoMod::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
+        - id: "Go::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
           linkage: "PROJECT_STATIC"
-    - id: "GoMod::github.com/pborman/uuid:v1.2.1"
+    - id: "Go::github.com/pborman/uuid:v1.2.1"
       linkage: "PROJECT_STATIC"
       dependencies:
-      - id: "GoMod::github.com/google/uuid:v1.0.0"
+      - id: "Go::github.com/google/uuid:v1.0.0"
         linkage: "PROJECT_STATIC"
-    - id: "GoMod::github.com/stretchr/testify:v1.7.2"
+    - id: "Go::github.com/stretchr/testify:v1.7.2"
       linkage: "PROJECT_STATIC"
       dependencies:
-      - id: "GoMod::github.com/davecgh/go-spew:v1.1.0"
+      - id: "Go::github.com/davecgh/go-spew:v1.1.0"
         linkage: "PROJECT_STATIC"
-      - id: "GoMod::github.com/pmezard/go-difflib:v1.0.0"
+      - id: "Go::github.com/pmezard/go-difflib:v1.0.0"
         linkage: "PROJECT_STATIC"
-      - id: "GoMod::gopkg.in/yaml.v3:v3.0.1"
+      - id: "Go::gopkg.in/yaml.v3:v3.0.1"
         linkage: "PROJECT_STATIC"
 packages:
-- id: "GoMod::github.com/davecgh/go-spew:v1.1.0"
+- id: "Go::github.com/davecgh/go-spew:v1.1.0"
   purl: "pkg:golang/github.com%2Fdavecgh%2Fgo-spew@v1.1.0"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -102,7 +102,7 @@ packages:
     url: "https://github.com/davecgh/go-spew.git"
     revision: "v1.1.0"
     path: ""
-- id: "GoMod::github.com/fatih/color:v1.13.0"
+- id: "Go::github.com/fatih/color:v1.13.0"
   purl: "pkg:golang/github.com%2Ffatih%2Fcolor@v1.13.0"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -128,7 +128,7 @@ packages:
     url: "https://github.com/fatih/color.git"
     revision: "v1.13.0"
     path: ""
-- id: "GoMod::github.com/google/uuid:v1.0.0"
+- id: "Go::github.com/google/uuid:v1.0.0"
   purl: "pkg:golang/github.com%2Fgoogle%2Fuuid@v1.0.0"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -154,7 +154,7 @@ packages:
     url: "https://github.com/google/uuid.git"
     revision: "v1.0.0"
     path: ""
-- id: "GoMod::github.com/mattn/go-colorable:v0.1.12"
+- id: "Go::github.com/mattn/go-colorable:v0.1.12"
   purl: "pkg:golang/github.com%2Fmattn%2Fgo-colorable@v0.1.12"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -180,7 +180,7 @@ packages:
     url: "https://github.com/mattn/go-colorable.git"
     revision: "v0.1.12"
     path: ""
-- id: "GoMod::github.com/mattn/go-isatty:v0.0.14"
+- id: "Go::github.com/mattn/go-isatty:v0.0.14"
   purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.14"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -206,7 +206,7 @@ packages:
     url: "https://github.com/mattn/go-isatty.git"
     revision: "v0.0.14"
     path: ""
-- id: "GoMod::github.com/pborman/uuid:v1.2.1"
+- id: "Go::github.com/pborman/uuid:v1.2.1"
   purl: "pkg:golang/github.com%2Fpborman%2Fuuid@v1.2.1"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -232,7 +232,7 @@ packages:
     url: "https://github.com/pborman/uuid.git"
     revision: "v1.2.1"
     path: ""
-- id: "GoMod::github.com/pmezard/go-difflib:v1.0.0"
+- id: "Go::github.com/pmezard/go-difflib:v1.0.0"
   purl: "pkg:golang/github.com%2Fpmezard%2Fgo-difflib@v1.0.0"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -258,7 +258,7 @@ packages:
     url: "https://github.com/pmezard/go-difflib.git"
     revision: "v1.0.0"
     path: ""
-- id: "GoMod::github.com/stretchr/testify:v1.7.2"
+- id: "Go::github.com/stretchr/testify:v1.7.2"
   purl: "pkg:golang/github.com%2Fstretchr%2Ftestify@v1.7.2"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -284,7 +284,7 @@ packages:
     url: "https://github.com/stretchr/testify.git"
     revision: "v1.7.2"
     path: ""
-- id: "GoMod::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
+- id: "Go::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
   purl: "pkg:golang/golang.org%2Fx%2Fsys@v0.0.0-20220610221304-9f5ed59c137d"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -310,7 +310,7 @@ packages:
     url: ""
     revision: ""
     path: ""
-- id: "GoMod::gopkg.in/yaml.v3:v3.0.1"
+- id: "Go::gopkg.in/yaml.v3:v3.0.1"
   purl: "pkg:golang/gopkg.in%2Fyaml.v3@v3.0.1"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-subpkg-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-subpkg-expected-output.yml
@@ -18,14 +18,14 @@ project:
   scopes:
   - name: "main"
     dependencies:
-    - id: "GoMod::github.com/fatih/color:v1.7.0"
+    - id: "Go::github.com/fatih/color:v1.7.0"
       linkage: "PROJECT_STATIC"
   - name: "vendor"
     dependencies:
-    - id: "GoMod::github.com/fatih/color:v1.7.0"
+    - id: "Go::github.com/fatih/color:v1.7.0"
       linkage: "PROJECT_STATIC"
 packages:
-- id: "GoMod::github.com/fatih/color:v1.7.0"
+- id: "Go::github.com/fatih/color:v1.7.0"
   purl: "pkg:golang/github.com%2Ffatih%2Fcolor@v1.7.0"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -51,7 +51,7 @@ packages:
     url: "https://github.com/fatih/color.git"
     revision: "v1.7.0"
     path: ""
-- id: "GoMod::github.com/mattn/go-colorable:v0.1.4"
+- id: "Go::github.com/mattn/go-colorable:v0.1.4"
   purl: "pkg:golang/github.com%2Fmattn%2Fgo-colorable@v0.1.4"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -77,7 +77,7 @@ packages:
     url: "https://github.com/mattn/go-colorable.git"
     revision: "v0.1.4"
     path: ""
-- id: "GoMod::github.com/mattn/go-isatty:v0.0.10"
+- id: "Go::github.com/mattn/go-isatty:v0.0.10"
   purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.10"
   declared_licenses: []
   declared_licenses_processed: {}
@@ -103,7 +103,7 @@ packages:
     url: "https://github.com/mattn/go-isatty.git"
     revision: "v0.0.10"
     path: ""
-- id: "GoMod::golang.org/x/sys:v0.0.0-20191008105621-543471e840be"
+- id: "Go::golang.org/x/sys:v0.0.0-20191008105621-543471e840be"
   purl: "pkg:golang/golang.org%2Fx%2Fsys@v0.0.0-20191008105621-543471e840be"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -130,7 +130,7 @@ class GoDep(
             }
 
             val pkg = Package(
-                id = Identifier(managerName, "", name, version),
+                id = Identifier("Go", "", name, version),
                 authors = sortedSetOf(),
                 declaredLicenses = sortedSetOf(),
                 description = "",

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -272,7 +272,7 @@ class GoMod(
         val vcsInfo = id.toVcsInfo().takeUnless { it.type == VcsType.UNKNOWN }.orEmpty()
 
         return Package(
-            id = Identifier(managerName, "", id.name, id.version),
+            id = id,
             authors = sortedSetOf(), // Go mod doesn't support author information.
             declaredLicenses = sortedSetOf(), // Go mod doesn't support declared licenses.
             description = "",

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -152,11 +152,13 @@ class GoMod(
 
         fun parseModuleEntry(entry: String): Identifier =
             entry.substringBefore('@').let { moduleName ->
+                val version = moduleInfo(moduleName).version
+
                 Identifier(
-                    type = managerName,
+                    type = managerName.takeIf { version.isBlank() } ?: "Go",
                     namespace = "",
                     name = moduleName,
-                    version = moduleInfo(moduleName).version
+                    version = version
                 )
             }
 

--- a/analyzer/src/test/kotlin/managers/GoModTest.kt
+++ b/analyzer/src/test/kotlin/managers/GoModTest.kt
@@ -31,19 +31,19 @@ import org.ossreviewtoolkit.model.VcsType
 class GoModTest : WordSpec({
     "toVcsInfo" should {
         "return the VCS type 'Git'" {
-            val id = Identifier("GoMod::github.com/chai2010/gettext-go:v1.0.0")
+            val id = Identifier("Go::github.com/chai2010/gettext-go:v1.0.0")
 
             id.toVcsInfo().type shouldBe VcsType.GIT
         }
 
         "return the revision" {
-            val id = Identifier("GoMod::github.com/chai2010/gettext-go:v1.0.0")
+            val id = Identifier("Go::github.com/chai2010/gettext-go:v1.0.0")
 
             id.toVcsInfo().revision shouldBe "v1.0.0"
         }
 
         "return the VCS URL and path for a package from a single module repository" {
-            val id = Identifier("GoMod::github.com/chai2010/gettext-go:v1.0.0")
+            val id = Identifier("Go::github.com/chai2010/gettext-go:v1.0.0")
 
             with(id.toVcsInfo()) {
                 path shouldBe ""
@@ -52,7 +52,7 @@ class GoModTest : WordSpec({
         }
 
         "return the VCS URL and path for a package from a mono repository" {
-            val id = Identifier("GoMod::github.com/Azure/go-autorest/autorest/date:v0.1.0")
+            val id = Identifier("Go::github.com/Azure/go-autorest/autorest/date:v0.1.0")
 
             with(id.toVcsInfo()) {
                 path shouldBe "autorest/date"
@@ -62,7 +62,7 @@ class GoModTest : WordSpec({
 
         "return the SHA1 from a 'pseudo version', when there is no known base version" {
             // See https://golang.org/ref/mod#pseudo-versions.
-            val id = Identifier("GoMod::github.com/example/project:v0.0.0-20191109021931-daa7c04131f5")
+            val id = Identifier("Go::github.com/example/project:v0.0.0-20191109021931-daa7c04131f5")
 
             id.toVcsInfo().revision shouldBe "daa7c04131f5"
         }
@@ -70,7 +70,7 @@ class GoModTest : WordSpec({
         "return the SHA1 from a 'pseudo version', when base version is a release version" {
             // See https://golang.org/ref/mod#pseudo-versions.
             val id = Identifier(
-                "GoMod::github.com/example/project:v0.8.1-0.20171018195549-f15c970de5b7"
+                "Go::github.com/example/project:v0.8.1-0.20171018195549-f15c970de5b7"
             )
 
             id.toVcsInfo().revision shouldBe "f15c970de5b7"
@@ -78,13 +78,13 @@ class GoModTest : WordSpec({
 
         "return the SHA1 from a 'pseudo version', when base version is a pre-release version" {
             // See https://golang.org/ref/mod#pseudo-versions.
-            val id = Identifier("GoMod::github.com/example/project:v0.8.1-pre.0.20171018195549-f15c970de5b7")
+            val id = Identifier("Go::github.com/example/project:v0.8.1-pre.0.20171018195549-f15c970de5b7")
 
             id.toVcsInfo().revision shouldBe "f15c970de5b7"
         }
 
         "return the SHA1 for a version with a '+incompatible' suffix" {
-            val id = Identifier("GoMod::github.com/example/project:v43.3.0+incompatible")
+            val id = Identifier("Go::github.com/example/project:v43.3.0+incompatible")
 
             id.toVcsInfo().revision shouldBe "v43.3.0"
         }

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -157,7 +157,7 @@ fun Identifier.getPurlType() =
         "composer" -> PurlType.COMPOSER
         "conan" -> PurlType.CONAN
         "crate" -> PurlType.CARGO
-        "godep", "gomod" -> PurlType.GOLANG
+        "godep", "go" -> PurlType.GOLANG
         "gem" -> PurlType.GEM
         "maven" -> PurlType.MAVEN
         "npm" -> PurlType.NPM

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -157,7 +157,7 @@ fun Identifier.getPurlType() =
         "composer" -> PurlType.COMPOSER
         "conan" -> PurlType.CONAN
         "crate" -> PurlType.CARGO
-        "godep", "go" -> PurlType.GOLANG
+        "go" -> PurlType.GOLANG
         "gem" -> PurlType.GEM
         "maven" -> PurlType.MAVEN
         "npm" -> PurlType.NPM


### PR DESCRIPTION
See individual commits.

Note: The label "breaking" has been set because any ORT configuration referring to Go packages by ID need alignment, like e.g. curations for Go packages. See also https://github.com/oss-review-toolkit/ort-config/pull/43.

Fixes #5533.