### PR TITLE
clients/osv: Make the `ranges` property optional

### DIFF
--- a/clients/osv/src/main/kotlin/Model.kt
+++ b/clients/osv/src/main/kotlin/Model.kt
@@ -61,7 +61,7 @@ data class Vulnerability(
 data class Affected(
     @SerialName("package")
     val pkg: Package,
-    val ranges: List<Range>,
+    val ranges: List<Range> = emptyList(),
     val versions: List<String> = emptyList(),
     @SerialName("ecosystem_specific")
     val ecosystemSpecific: JsonObject? = null,


### PR DESCRIPTION
It was mandatory by accident, see [1] and also [2].

[1] https://github.com/ossf/osv-schema/blob/main/validation/schema.json
[2] https://github.com/google/osv.dev/issues/502#issuecomment-1182696991

Part of #3599.