### PR TITLE
declared-license-mapping: Map `Go License` to `BSD-3-Clause`

### DIFF
--- a/utils/spdx/src/main/resources/declared-license-mapping.yml
+++ b/utils/spdx/src/main/resources/declared-license-mapping.yml
@@ -287,6 +287,7 @@
 "GWT Terms": Apache-2.0 AND BSD-3-Clause AND CC0-1.0 AND EPL-1.0 AND LGPL-2.1-only AND MPL-1.1
 "General Public License (GPL)": GPL-2.0-or-later
 "General Public License 2.0 (GPL)": GPL-2.0-only
+"Go license": BSD-3-Clause
 "Google Maps Platform Terms of Service": LicenseRef-ort-google-maps-tos
 "HERE Proprietary License": LicenseRef-scancode-here-proprietary
 "HSQLDB License": BSD-3-Clause


### PR DESCRIPTION
Found in [1].

[1]: https://repo1.maven.org/maven2/com/google/re2j/re2j/1.7/re2j-1.7.pom

