### PR TITLE
GoDepFunTest: Fix-up the expected result

### DIFF
--- a/analyzer/src/funTest/kotlin/managers/GoDepFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoDepFunTest.kt
@@ -32,6 +32,7 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
+import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
 import org.ossreviewtoolkit.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
@@ -45,7 +46,8 @@ class GoDepFunTest : WordSpec() {
     private val vcsRevision = vcsDir.getRevision()
 
     private val normalizedVcsUrl = normalizeVcsUrl(vcsUrl)
-    private val gitHubProject = normalizedVcsUrl.substringAfter("://").substringBefore(".git")
+    private val gitHubProject = normalizedVcsUrl.replaceCredentialsInUri()
+        .substringAfter("://").substringBefore(".git")
 
     init {
         "GoDep" should {


### PR DESCRIPTION
The tests fail on my machine because the string value assigned to
`gitHubProject` starts with "git@". On CI the tests succeed.

Strip the user from the VCS URL before mapping it to the project name,
to make that problem disappear.
