### PR TITLE
OsvApiClient: Revert a rename of the `Id` class

### DIFF
--- a/clients/osv/src/main/kotlin/OsvApiClient.kt
+++ b/clients/osv/src/main/kotlin/OsvApiClient.kt
@@ -115,11 +115,11 @@ data class VulnerabilitiesForPackageBatchResponse(
     @Serializable
     data class IdList(
         @SerialName("vulns")
-        val vulnerabilities: List<Vulnerability> = emptyList()
+        val vulnerabilities: List<Id> = emptyList()
     )
 
     @Serializable
-    data class Vulnerability(
+    data class Id(
         val id: String,
         @Serializable(InstantSerializer::class)
         val modified: Instant


### PR DESCRIPTION
The class has been renamed to `Vulnerability` recently by [1]. As there
is also a `Vulnerability` class in `Model.kt` undo the rename to avoid
confusion.

[1] 064c5898868e590b5fc736670bebea2a8f3ff95d

