### PR TITLE
Pub: Upgrade bootstrapped Flutter version to 3.0.5

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -74,7 +74,7 @@ private const val PUB_LOCK_FILE = "pubspec.lock"
 private val flutterCommand = if (Os.isWindows) "flutter.bat" else "flutter"
 private val dartCommand = if (Os.isWindows) "dart.bat" else "dart"
 
-private val flutterVersion = Os.env["FLUTTER_VERSION"] ?: "3.0.3-stable"
+private val flutterVersion = Os.env["FLUTTER_VERSION"] ?: "3.0.5-stable"
 private val flutterInstallDir = ortToolsDirectory.resolve("flutter-$flutterVersion")
 
 val flutterHome by lazy {


### PR DESCRIPTION
See: https://github.com/flutter/flutter/wiki/Hotfixes-to-the-Stable-Channel#305-july-13-2022
