### PR TITLE
fossid-webapp: Add a property to keep failed scans

### DIFF
--- a/model/src/main/resources/reference.conf
+++ b/model/src/main/resources/reference.conf
@@ -172,6 +172,7 @@ ort {
         waitForResult = false
         addAuthenticationToUrl = false
 
+        keepFailedScans = false
         deltaScans = true
         deltaScanLimit = 10
         timeout = 60

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -342,9 +342,11 @@ class FossId internal constructor(
                     val scanResult = ScanResult(provenance, details, summary)
                     results.getOrPut(pkg) { mutableListOf() } += scanResult
 
-                    createdScans.forEach { code ->
-                        log.warn { "Deleting scan '$code' during exception cleanup." }
-                        deleteScan(code)
+                    if (!config.keepFailedScans) {
+                        createdScans.forEach { code ->
+                            log.warn { "Deleting scan '$code' during exception cleanup." }
+                            deleteScan(code)
+                        }
                     }
                 }
             }

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
@@ -62,6 +62,9 @@ internal data class FossIdConfig(
     /** Flag whether credentials should be passed to FossID in URLs. */
     val addAuthenticationToUrl: Boolean,
 
+    /** Flag whether failed scans should be kept. */
+    val keepFailedScans: Boolean,
+
     /** Flag whether delta scans should be triggered. */
     val deltaScans: Boolean,
 
@@ -95,6 +98,9 @@ internal data class FossIdConfig(
 
         /** Name of the configuration property defining the naming convention for scans. */
         private const val NAMING_SCAN_PATTERN_PROPERTY = "namingScanPattern"
+
+        /** Name of the configuration property defining wether to keep failed scans. */
+        private const val KEEP_FAILED_SCANS_PROPERTY = "keepFailedScans"
 
         /** Name of the configuration property controlling whether delta scans are to be created. */
         private const val DELTA_SCAN_PROPERTY = "deltaScans"
@@ -131,6 +137,7 @@ internal data class FossIdConfig(
             val waitForResult = fossIdScannerOptions[WAIT_FOR_RESULT_PROPERTY]?.toBoolean() ?: true
             val addAuthenticationToUrl = fossIdScannerOptions[CREDENTIALS_IN_URL_PROPERTY]?.toBoolean() ?: false
 
+            val keepFailedScans = fossIdScannerOptions[KEEP_FAILED_SCANS_PROPERTY]?.toBoolean() ?: false
             val deltaScans = fossIdScannerOptions[DELTA_SCAN_PROPERTY]?.toBoolean() ?: false
             val deltaScanLimit = fossIdScannerOptions[DELTA_SCAN_LIMIT_PROPERTY]?.toInt() ?: Int.MAX_VALUE
             val timeout = fossIdScannerOptions[TIMEOUT]?.toInt() ?: DEFAULT_TIMEOUT
@@ -147,6 +154,7 @@ internal data class FossIdConfig(
                 apiKey = apiKey,
                 waitForResult = waitForResult,
                 addAuthenticationToUrl = addAuthenticationToUrl,
+                keepFailedScans = keepFailedScans,
                 deltaScans = deltaScans,
                 deltaScanLimit = deltaScanLimit,
                 timeout = timeout,

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
@@ -50,6 +50,7 @@ class FossIdConfigTest : WordSpec({
                 "apiKey" to API_KEY,
                 "waitForResult" to "false",
                 "addAuthenticationToUrl" to "false",
+                "keepFailedScans" to "true",
                 "deltaScans" to "true",
                 "deltaScanLimit" to "42",
                 "timeout" to "300"
@@ -64,6 +65,7 @@ class FossIdConfigTest : WordSpec({
                 apiKey = API_KEY,
                 waitForResult = false,
                 addAuthenticationToUrl = false,
+                keepFailedScans = true,
                 deltaScans = true,
                 deltaScanLimit = 42,
                 timeout = 300,
@@ -87,6 +89,7 @@ class FossIdConfigTest : WordSpec({
                 apiKey = API_KEY,
                 waitForResult = true,
                 addAuthenticationToUrl = false,
+                keepFailedScans = false,
                 deltaScans = false,
                 deltaScanLimit = Int.MAX_VALUE,
                 timeout = 60,

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -760,6 +760,7 @@ private fun createConfig(
         apiKey = API_KEY,
         waitForResult = waitForResult,
         addAuthenticationToUrl = false,
+        keepFailedScans = false,
         deltaScans = deltaScans,
         deltaScanLimit = deltaScanLimit,
         timeout = 60,


### PR DESCRIPTION
When there is an error during a FossID scan, the default behavior is to
delete the scan to avoid cluttering the FossID instance. While useful,
this makes error analysis of runs difficult. Therefore, this commit adds
an option to keep failed scans.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>

