### PR TITLE
AnalyzerResultBuilder: Fix a problem with results without dependencies

### DIFF
--- a/analyzer/src/main/kotlin/AnalyzerResultBuilder.kt
+++ b/analyzer/src/main/kotlin/AnalyzerResultBuilder.kt
@@ -123,6 +123,8 @@ class AnalyzerResultBuilder(private val curationProvider: PackageCurationProvide
 }
 
 private fun AnalyzerResult.resolvePackageManagerDependencies(): AnalyzerResult {
+    if (dependencyGraphs.isEmpty()) return this
+
     val handler = PackageManagerDependencyHandler(this)
     val navigator = DependencyGraphNavigator(dependencyGraphs)
 

--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
@@ -369,6 +370,13 @@ class AnalyzerResultBuilderTest : WordSpec() {
                         )
                     }
                 }
+            }
+
+            "handle a result without dependencies" {
+                val emptyResult = AnalyzerResultBuilder().build()
+
+                emptyResult.projects should beEmpty()
+                emptyResult.packages should beEmpty()
             }
         }
     }


### PR DESCRIPTION
This fixes a problem introduced by 7088e06a to support references
between different package managers. The corner case that a result does
not contain any dependencies caused an exception when navigating over
the dependency graph.

Resolves #5557.

Signed-off-by: Oliver Heger <oliver.heger@bosch.io>
