### PR TITLE
Extensions: Add backwards compatibilites for renamed 'Go' packages

### DIFF
--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -157,7 +157,7 @@ fun Identifier.getPurlType() =
         "composer" -> PurlType.COMPOSER
         "conan" -> PurlType.CONAN
         "crate" -> PurlType.CARGO
-        "go" -> PurlType.GOLANG
+        "go" /* backwards compatibility: */, "godep", "gomod" -> PurlType.GOLANG
         "gem" -> PurlType.GEM
         "maven" -> PurlType.MAVEN
         "npm" -> PurlType.NPM


### PR DESCRIPTION
As of [1] Go packages use "Go" as value for `Identifier.type`. So, add
entries for backwards compatibility with old analyzer results. Note that
the entries are only ok for packages, but invalid for projects.

[1] https://github.com/oss-review-toolkit/ort/pull/5546

Note: This change was requested https://github.com/oss-review-toolkit/ort/pull/5546#discussion_r923048309. Personally I'd have the tendency to not merge it.