### PR TITLE
Osv: Avoid using `var` by using `let`

### DIFF
--- a/advisor/src/main/kotlin/advisors/Osv.kt
+++ b/advisor/src/main/kotlin/advisors/Osv.kt
@@ -200,8 +200,7 @@ private fun Vulnerability.toOrtVulnerability(): org.ossreviewtoolkit.model.Vulne
     }
 
     val references = references.mapNotNull { reference ->
-        var url = reference.url.trim()
-        url = url.takeUnless { it.startsWith("://") } ?: "https$url"
+        val url = reference.url.trim().let { if (it.startsWith("://")) "https$it" else it }
 
         url.toUri().onFailure {
             log.debug { "Could not parse reference URL for vulnerability '$id': ${it.message}." }


### PR DESCRIPTION
It is hard to track the current value of non-final `var`s, which is why
their use is discouraged. So use `let` instead.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>