### PR TITLE
GoMod/GoDep: Normalize package versions

### DIFF
--- a/advisor/src/funTest/kotlin/OsvFunTest.kt
+++ b/advisor/src/funTest/kotlin/OsvFunTest.kt
@@ -40,7 +40,7 @@ class OsvFunTest : StringSpec({
         val packages = listOf(
             "Crate::sys-info:0.7.0",
             "Gem::rack:2.0.4",
-            "Go::github.com/nats-io/nats-server/v2:2.1.0",
+            "Go::github.com/nats-io/nats-server/v2:v2.1.0",
             "Maven:com.jfinal:jfinal:1.4",
             "NPM::rebber:1.0.0",
             "NuGet::Microsoft.ChakraCore:1.10.0",

--- a/advisor/src/funTest/kotlin/OsvFunTest.kt
+++ b/advisor/src/funTest/kotlin/OsvFunTest.kt
@@ -40,7 +40,7 @@ class OsvFunTest : StringSpec({
         val packages = listOf(
             "Crate::sys-info:0.7.0",
             "Gem::rack:2.0.4",
-            "Go::github.com/nats-io/nats-server/v2:v2.1.0",
+            "Go::github.com/nats-io/nats-server/v2:2.1.0",
             "Maven:com.jfinal:jfinal:1.4",
             "NPM::rebber:1.0.0",
             "NuGet::Microsoft.ChakraCore:1.10.0",

--- a/analyzer/src/funTest/assets/projects/synthetic/glide-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/glide-expected-output.yml
@@ -18,13 +18,13 @@ project:
   scopes:
   - name: "default"
     dependencies:
-    - id: "Go::github.com/mattn/go-isatty:v0.0.12"
+    - id: "Go::github.com/mattn/go-isatty:0.0.12"
       linkage: "STATIC"
     - id: "Go::golang.org/x/sys:05986578812163b26672dabd9b425240ae2bb0ad"
       linkage: "STATIC"
 packages:
-- id: "Go::github.com/mattn/go-isatty:v0.0.12"
-  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.12"
+- id: "Go::github.com/mattn/go-isatty:0.0.12"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@0.0.12"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/godep-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/godep-expected-output.yml
@@ -18,17 +18,17 @@ project:
   scopes:
   - name: "default"
     dependencies:
-    - id: "Go::github.com/fatih/color:v1.9.0"
+    - id: "Go::github.com/fatih/color:1.9.0"
       linkage: "STATIC"
-    - id: "Go::github.com/mattn/go-colorable:v0.1.6"
+    - id: "Go::github.com/mattn/go-colorable:0.1.6"
       linkage: "STATIC"
-    - id: "Go::github.com/mattn/go-isatty:v0.0.12"
+    - id: "Go::github.com/mattn/go-isatty:0.0.12"
       linkage: "STATIC"
     - id: "Go::golang.org/x/sys:05986578812163b26672dabd9b425240ae2bb0ad"
       linkage: "STATIC"
 packages:
-- id: "Go::github.com/fatih/color:v1.9.0"
-  purl: "pkg:golang/github.com%2Ffatih%2Fcolor@v1.9.0"
+- id: "Go::github.com/fatih/color:1.9.0"
+  purl: "pkg:golang/github.com%2Ffatih%2Fcolor@1.9.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -53,8 +53,8 @@ packages:
     url: "https://github.com/fatih/color.git"
     revision: "daf2830f2741ebb735b21709a520c5f37d642d85"
     path: ""
-- id: "Go::github.com/mattn/go-colorable:v0.1.6"
-  purl: "pkg:golang/github.com%2Fmattn%2Fgo-colorable@v0.1.6"
+- id: "Go::github.com/mattn/go-colorable:0.1.6"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-colorable@0.1.6"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -79,8 +79,8 @@ packages:
     url: "https://github.com/mattn/go-colorable.git"
     revision: "68e95eba382c972aafde02ead2cd2426a8a92480"
     path: ""
-- id: "Go::github.com/mattn/go-isatty:v0.0.12"
-  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.12"
+- id: "Go::github.com/mattn/go-isatty:0.0.12"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@0.0.12"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/godeps-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/godeps-expected-output.yml
@@ -18,13 +18,13 @@ project:
   scopes:
   - name: "default"
     dependencies:
-    - id: "Go::github.com/mattn/go-isatty:v0.0.12"
+    - id: "Go::github.com/mattn/go-isatty:0.0.12"
       linkage: "STATIC"
     - id: "Go::golang.org/x/sys:8d3cce7afc34617998104db7c4b58c2de9e77215"
       linkage: "STATIC"
 packages:
-- id: "Go::github.com/mattn/go-isatty:v0.0.12"
-  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.12"
+- id: "Go::github.com/mattn/go-isatty:0.0.12"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@0.0.12"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
@@ -18,66 +18,66 @@ project:
   scopes:
   - name: "main"
     dependencies:
-    - id: "Go::github.com/fatih/color:v1.13.0"
+    - id: "Go::github.com/fatih/color:1.13.0"
       linkage: "PROJECT_STATIC"
       dependencies:
-      - id: "Go::github.com/mattn/go-colorable:v0.1.12"
+      - id: "Go::github.com/mattn/go-colorable:0.1.12"
         linkage: "PROJECT_STATIC"
         dependencies:
-        - id: "Go::github.com/mattn/go-isatty:v0.0.14"
+        - id: "Go::github.com/mattn/go-isatty:0.0.14"
           linkage: "PROJECT_STATIC"
           dependencies:
-          - id: "Go::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
+          - id: "Go::golang.org/x/sys:0.0.0-20220610221304-9f5ed59c137d"
             linkage: "PROJECT_STATIC"
-        - id: "Go::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
+        - id: "Go::golang.org/x/sys:0.0.0-20220610221304-9f5ed59c137d"
           linkage: "PROJECT_STATIC"
-      - id: "Go::github.com/mattn/go-isatty:v0.0.14"
+      - id: "Go::github.com/mattn/go-isatty:0.0.14"
         linkage: "PROJECT_STATIC"
         dependencies:
-        - id: "Go::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
+        - id: "Go::golang.org/x/sys:0.0.0-20220610221304-9f5ed59c137d"
           linkage: "PROJECT_STATIC"
-    - id: "Go::github.com/pborman/uuid:v1.2.1"
+    - id: "Go::github.com/pborman/uuid:1.2.1"
       linkage: "PROJECT_STATIC"
       dependencies:
-      - id: "Go::github.com/google/uuid:v1.0.0"
+      - id: "Go::github.com/google/uuid:1.0.0"
         linkage: "PROJECT_STATIC"
   - name: "vendor"
     dependencies:
-    - id: "Go::github.com/fatih/color:v1.13.0"
+    - id: "Go::github.com/fatih/color:1.13.0"
       linkage: "PROJECT_STATIC"
       dependencies:
-      - id: "Go::github.com/mattn/go-colorable:v0.1.12"
+      - id: "Go::github.com/mattn/go-colorable:0.1.12"
         linkage: "PROJECT_STATIC"
         dependencies:
-        - id: "Go::github.com/mattn/go-isatty:v0.0.14"
+        - id: "Go::github.com/mattn/go-isatty:0.0.14"
           linkage: "PROJECT_STATIC"
           dependencies:
-          - id: "Go::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
+          - id: "Go::golang.org/x/sys:0.0.0-20220610221304-9f5ed59c137d"
             linkage: "PROJECT_STATIC"
-        - id: "Go::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
+        - id: "Go::golang.org/x/sys:0.0.0-20220610221304-9f5ed59c137d"
           linkage: "PROJECT_STATIC"
-      - id: "Go::github.com/mattn/go-isatty:v0.0.14"
+      - id: "Go::github.com/mattn/go-isatty:0.0.14"
         linkage: "PROJECT_STATIC"
         dependencies:
-        - id: "Go::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
+        - id: "Go::golang.org/x/sys:0.0.0-20220610221304-9f5ed59c137d"
           linkage: "PROJECT_STATIC"
-    - id: "Go::github.com/pborman/uuid:v1.2.1"
+    - id: "Go::github.com/pborman/uuid:1.2.1"
       linkage: "PROJECT_STATIC"
       dependencies:
-      - id: "Go::github.com/google/uuid:v1.0.0"
+      - id: "Go::github.com/google/uuid:1.0.0"
         linkage: "PROJECT_STATIC"
-    - id: "Go::github.com/stretchr/testify:v1.7.2"
+    - id: "Go::github.com/stretchr/testify:1.7.2"
       linkage: "PROJECT_STATIC"
       dependencies:
-      - id: "Go::github.com/davecgh/go-spew:v1.1.0"
+      - id: "Go::github.com/davecgh/go-spew:1.1.0"
         linkage: "PROJECT_STATIC"
-      - id: "Go::github.com/pmezard/go-difflib:v1.0.0"
+      - id: "Go::github.com/pmezard/go-difflib:1.0.0"
         linkage: "PROJECT_STATIC"
-      - id: "Go::gopkg.in/yaml.v3:v3.0.1"
+      - id: "Go::gopkg.in/yaml.v3:3.0.1"
         linkage: "PROJECT_STATIC"
 packages:
-- id: "Go::github.com/davecgh/go-spew:v1.1.0"
-  purl: "pkg:golang/github.com%2Fdavecgh%2Fgo-spew@v1.1.0"
+- id: "Go::github.com/davecgh/go-spew:1.1.0"
+  purl: "pkg:golang/github.com%2Fdavecgh%2Fgo-spew@1.1.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -102,8 +102,8 @@ packages:
     url: "https://github.com/davecgh/go-spew.git"
     revision: "v1.1.0"
     path: ""
-- id: "Go::github.com/fatih/color:v1.13.0"
-  purl: "pkg:golang/github.com%2Ffatih%2Fcolor@v1.13.0"
+- id: "Go::github.com/fatih/color:1.13.0"
+  purl: "pkg:golang/github.com%2Ffatih%2Fcolor@1.13.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -128,8 +128,8 @@ packages:
     url: "https://github.com/fatih/color.git"
     revision: "v1.13.0"
     path: ""
-- id: "Go::github.com/google/uuid:v1.0.0"
-  purl: "pkg:golang/github.com%2Fgoogle%2Fuuid@v1.0.0"
+- id: "Go::github.com/google/uuid:1.0.0"
+  purl: "pkg:golang/github.com%2Fgoogle%2Fuuid@1.0.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -154,8 +154,8 @@ packages:
     url: "https://github.com/google/uuid.git"
     revision: "v1.0.0"
     path: ""
-- id: "Go::github.com/mattn/go-colorable:v0.1.12"
-  purl: "pkg:golang/github.com%2Fmattn%2Fgo-colorable@v0.1.12"
+- id: "Go::github.com/mattn/go-colorable:0.1.12"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-colorable@0.1.12"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -180,8 +180,8 @@ packages:
     url: "https://github.com/mattn/go-colorable.git"
     revision: "v0.1.12"
     path: ""
-- id: "Go::github.com/mattn/go-isatty:v0.0.14"
-  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.14"
+- id: "Go::github.com/mattn/go-isatty:0.0.14"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@0.0.14"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -206,8 +206,8 @@ packages:
     url: "https://github.com/mattn/go-isatty.git"
     revision: "v0.0.14"
     path: ""
-- id: "Go::github.com/pborman/uuid:v1.2.1"
-  purl: "pkg:golang/github.com%2Fpborman%2Fuuid@v1.2.1"
+- id: "Go::github.com/pborman/uuid:1.2.1"
+  purl: "pkg:golang/github.com%2Fpborman%2Fuuid@1.2.1"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -232,8 +232,8 @@ packages:
     url: "https://github.com/pborman/uuid.git"
     revision: "v1.2.1"
     path: ""
-- id: "Go::github.com/pmezard/go-difflib:v1.0.0"
-  purl: "pkg:golang/github.com%2Fpmezard%2Fgo-difflib@v1.0.0"
+- id: "Go::github.com/pmezard/go-difflib:1.0.0"
+  purl: "pkg:golang/github.com%2Fpmezard%2Fgo-difflib@1.0.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -258,8 +258,8 @@ packages:
     url: "https://github.com/pmezard/go-difflib.git"
     revision: "v1.0.0"
     path: ""
-- id: "Go::github.com/stretchr/testify:v1.7.2"
-  purl: "pkg:golang/github.com%2Fstretchr%2Ftestify@v1.7.2"
+- id: "Go::github.com/stretchr/testify:1.7.2"
+  purl: "pkg:golang/github.com%2Fstretchr%2Ftestify@1.7.2"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -284,8 +284,8 @@ packages:
     url: "https://github.com/stretchr/testify.git"
     revision: "v1.7.2"
     path: ""
-- id: "Go::golang.org/x/sys:v0.0.0-20220610221304-9f5ed59c137d"
-  purl: "pkg:golang/golang.org%2Fx%2Fsys@v0.0.0-20220610221304-9f5ed59c137d"
+- id: "Go::golang.org/x/sys:0.0.0-20220610221304-9f5ed59c137d"
+  purl: "pkg:golang/golang.org%2Fx%2Fsys@0.0.0-20220610221304-9f5ed59c137d"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -310,8 +310,8 @@ packages:
     url: ""
     revision: ""
     path: ""
-- id: "Go::gopkg.in/yaml.v3:v3.0.1"
-  purl: "pkg:golang/gopkg.in%2Fyaml.v3@v3.0.1"
+- id: "Go::gopkg.in/yaml.v3:3.0.1"
+  purl: "pkg:golang/gopkg.in%2Fyaml.v3@3.0.1"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-subpkg-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-subpkg-expected-output.yml
@@ -18,15 +18,15 @@ project:
   scopes:
   - name: "main"
     dependencies:
-    - id: "Go::github.com/fatih/color:v1.7.0"
+    - id: "Go::github.com/fatih/color:1.7.0"
       linkage: "PROJECT_STATIC"
   - name: "vendor"
     dependencies:
-    - id: "Go::github.com/fatih/color:v1.7.0"
+    - id: "Go::github.com/fatih/color:1.7.0"
       linkage: "PROJECT_STATIC"
 packages:
-- id: "Go::github.com/fatih/color:v1.7.0"
-  purl: "pkg:golang/github.com%2Ffatih%2Fcolor@v1.7.0"
+- id: "Go::github.com/fatih/color:1.7.0"
+  purl: "pkg:golang/github.com%2Ffatih%2Fcolor@1.7.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -51,8 +51,8 @@ packages:
     url: "https://github.com/fatih/color.git"
     revision: "v1.7.0"
     path: ""
-- id: "Go::github.com/mattn/go-colorable:v0.1.4"
-  purl: "pkg:golang/github.com%2Fmattn%2Fgo-colorable@v0.1.4"
+- id: "Go::github.com/mattn/go-colorable:0.1.4"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-colorable@0.1.4"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -77,8 +77,8 @@ packages:
     url: "https://github.com/mattn/go-colorable.git"
     revision: "v0.1.4"
     path: ""
-- id: "Go::github.com/mattn/go-isatty:v0.0.10"
-  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@v0.0.10"
+- id: "Go::github.com/mattn/go-isatty:0.0.10"
+  purl: "pkg:golang/github.com%2Fmattn%2Fgo-isatty@0.0.10"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -103,8 +103,8 @@ packages:
     url: "https://github.com/mattn/go-isatty.git"
     revision: "v0.0.10"
     path: ""
-- id: "Go::golang.org/x/sys:v0.0.0-20191008105621-543471e840be"
-  purl: "pkg:golang/golang.org%2Fx%2Fsys@v0.0.0-20191008105621-543471e840be"
+- id: "Go::golang.org/x/sys:0.0.0-20191008105621-543471e840be"
+  purl: "pkg:golang/golang.org%2Fx%2Fsys@0.0.0-20191008105621-543471e840be"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -27,6 +27,7 @@ import java.net.URI
 
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
+import org.ossreviewtoolkit.analyzer.managers.utils.normalizeModuleVersion
 import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Identifier
@@ -130,7 +131,7 @@ class GoDep(
             }
 
             val pkg = Package(
-                id = Identifier("Go", "", name, version),
+                id = Identifier("Go", "", name, normalizeModuleVersion(version)),
                 authors = sortedSetOf(),
                 declaredLicenses = sortedSetOf(),
                 description = "",

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -151,14 +151,7 @@ class GoMod(
 
         fun parseModuleEntry(entry: String): Identifier =
             entry.substringBefore('@').let { moduleName ->
-                val version = moduleInfo(moduleName).version
-
-                Identifier(
-                    type = managerName.takeIf { version.isBlank() } ?: "Go",
-                    namespace = "",
-                    name = moduleName,
-                    version = version
-                )
+                moduleInfo(moduleName).toId()
             }
 
         var graph = Graph()
@@ -208,6 +201,14 @@ class GoMod(
         @JsonProperty("Main")
         val main: Boolean = false
     )
+
+    private fun ModuleInfo.toId(): Identifier =
+        Identifier(
+            type = managerName.takeIf { version.isBlank() } ?: "Go",
+            namespace = "",
+            name = path,
+            version = version
+        )
 
     /**
      * Return the list of all modules contained in the dependency tree with resolved versions and the 'replace'

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -206,7 +206,9 @@ class GoMod(
             type = managerName.takeIf { version.isBlank() } ?: "Go",
             namespace = "",
             name = path,
-            version = version
+            // Strip any suffix starting with '+', because build metadata is not involved in version comparison, see
+            // https://go.dev/ref/mod#incompatible-versions.
+            version = version.removePrefix("v").substringBefore("+")
         )
 
     /**

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -145,8 +145,7 @@ class GoMod(
      * Return the module graph output from `go mod graph` with non-vendor dependencies removed.
      */
     private fun getModuleGraph(projectDir: File): Graph {
-        val moduleInfoForModuleName = getModuleInfos(projectDir).map { it.replace ?: it }
-            .associateBy({ it.path }, { it })
+        val moduleInfoForModuleName = getModuleInfos(projectDir).associateBy({ it.path }, { it })
 
         fun moduleInfo(moduleName: String): ModuleInfo = moduleInfoForModuleName.getValue(moduleName)
 
@@ -211,7 +210,8 @@ class GoMod(
     )
 
     /**
-     * Return the list of all modules contained in the dependency tree with resolved versions.
+     * Return the list of all modules contained in the dependency tree with resolved versions and the 'replace'
+     * directive applied.
      */
     private fun getModuleInfos(projectDir: File): List<ModuleInfo> {
         val list = run("list", "-m", "-json", "all", workingDir = projectDir)
@@ -229,7 +229,7 @@ class GoMod(
                 }
             }
 
-            return result
+            return result.map { it.replace ?: it }
         }
     }
 

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -29,6 +29,7 @@ import java.util.SortedSet
 
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
+import org.ossreviewtoolkit.analyzer.managers.utils.normalizeModuleVersion
 import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Hash
@@ -206,9 +207,7 @@ class GoMod(
             type = managerName.takeIf { version.isBlank() } ?: "Go",
             namespace = "",
             name = path,
-            // Strip any suffix starting with '+', because build metadata is not involved in version comparison, see
-            // https://go.dev/ref/mod#incompatible-versions.
-            version = version.removePrefix("v").substringBefore("+")
+            version = normalizeModuleVersion(version)
         )
 
     /**

--- a/analyzer/src/main/kotlin/managers/utils/GoSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/GoSupport.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 EPAM Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers.utils
+
+/**
+ * Return the given [moduleVersion] normalized to a Semver compliant version. The `v` prefix gets stripped and
+ * also any suffix starting with '+', because build metadata is not involved in version comparison according to
+ * https://go.dev/ref/mod#incompatible-versions.
+ */
+fun normalizeModuleVersion(moduleVersion: String): String =
+    moduleVersion.removePrefix("v").substringBefore("+")

--- a/analyzer/src/test/kotlin/managers/GoModTest.kt
+++ b/analyzer/src/test/kotlin/managers/GoModTest.kt
@@ -25,36 +25,41 @@ import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
-import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.VcsType
 
 class GoModTest : WordSpec({
     "toVcsInfo" should {
         "return the VCS type 'Git'" {
-            val id = Identifier("Go::github.com/chai2010/gettext-go:v1.0.0")
+            val moduleInfo = GoMod.ModuleInfo(
+                path = "github.com/chai2010/gettext-go",
+                version = "v1.0.0"
+            )
 
-            id.toVcsInfo().type shouldBe VcsType.GIT
+            moduleInfo.toVcsInfo().type shouldBe VcsType.GIT
         }
 
         "return the revision" {
-            val id = Identifier("Go::github.com/chai2010/gettext-go:v1.0.0")
+            val moduleInfo = GoMod.ModuleInfo(
+                path = "github.com/chai2010/gettext-go",
+                version = "v1.0.0"
+            )
 
-            id.toVcsInfo().revision shouldBe "v1.0.0"
+            moduleInfo.toVcsInfo().revision shouldBe "v1.0.0"
         }
 
         "return the VCS URL and path for a package from a single module repository" {
-            val id = Identifier("Go::github.com/chai2010/gettext-go:v1.0.0")
+            val moduleInfo = GoMod.ModuleInfo(path = "github.com/chai2010/gettext-go", version = "v1.0.0")
 
-            with(id.toVcsInfo()) {
+            with(moduleInfo.toVcsInfo()) {
                 path shouldBe ""
                 url shouldBe "https://github.com/chai2010/gettext-go.git"
             }
         }
 
         "return the VCS URL and path for a package from a mono repository" {
-            val id = Identifier("Go::github.com/Azure/go-autorest/autorest/date:v0.1.0")
+            val moduleInfo = GoMod.ModuleInfo(path = "github.com/Azure/go-autorest/autorest/date", version = "v0.1.0")
 
-            with(id.toVcsInfo()) {
+            with(moduleInfo.toVcsInfo()) {
                 path shouldBe "autorest/date"
                 url shouldBe "https://github.com/Azure/go-autorest.git"
             }
@@ -62,31 +67,41 @@ class GoModTest : WordSpec({
 
         "return the SHA1 from a 'pseudo version', when there is no known base version" {
             // See https://golang.org/ref/mod#pseudo-versions.
-            val id = Identifier("Go::github.com/example/project:v0.0.0-20191109021931-daa7c04131f5")
+            val moduleInfo = GoMod.ModuleInfo(
+                path = "github.com/example/project",
+                version = "v0.0.0-20191109021931-daa7c04131f5"
+            )
 
-            id.toVcsInfo().revision shouldBe "daa7c04131f5"
+            moduleInfo.toVcsInfo().revision shouldBe "daa7c04131f5"
         }
 
         "return the SHA1 from a 'pseudo version', when base version is a release version" {
             // See https://golang.org/ref/mod#pseudo-versions.
-            val id = Identifier(
-                "Go::github.com/example/project:v0.8.1-0.20171018195549-f15c970de5b7"
+            val moduleInfo = GoMod.ModuleInfo(
+                path = "github.com/example/project",
+                version = "v0.8.1-0.20171018195549-f15c970de5b7"
             )
 
-            id.toVcsInfo().revision shouldBe "f15c970de5b7"
+            moduleInfo.toVcsInfo().revision shouldBe "f15c970de5b7"
         }
 
         "return the SHA1 from a 'pseudo version', when base version is a pre-release version" {
             // See https://golang.org/ref/mod#pseudo-versions.
-            val id = Identifier("Go::github.com/example/project:v0.8.1-pre.0.20171018195549-f15c970de5b7")
+            val moduleInfo = GoMod.ModuleInfo(
+                path = "github.com/example/project",
+                version = "v0.8.1-pre.0.20171018195549-f15c970de5b7"
+            )
 
-            id.toVcsInfo().revision shouldBe "f15c970de5b7"
+            moduleInfo.toVcsInfo().revision shouldBe "f15c970de5b7"
         }
 
         "return the SHA1 for a version with a '+incompatible' suffix" {
-            val id = Identifier("Go::github.com/example/project:v43.3.0+incompatible")
+            val moduleInfo = GoMod.ModuleInfo(
+                path = "github.com/example/project",
+                version = "v43.3.0+incompatible"
+            )
 
-            id.toVcsInfo().revision shouldBe "v43.3.0"
+            moduleInfo.toVcsInfo().revision shouldBe "v43.3.0"
         }
     }
 


### PR DESCRIPTION
Map the Go package / module version strings to semver compatible version strings. See individual commits.
Note: A reason for doing so, besides consistency, is to allow for passing the version strings as-is to any third-party advisor backend API. OSV can handle the `v` prefixes, but maybe not all backends can.

Fixes #5532.

_edit: The change is breaking, because any ORT configuration which uses version strings for Go packages need to be adjusted._