### PR TITLE
README: Update a second reference to our Slack workspace

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,7 @@ Dockerfile
 
 # Ignore the Jenkinsfile to avoid that all layers are invalidated if the
 # Jenkinsfile is changed during development.
-integrations/Jenkinsfile
+integrations/jenkins/Jenkinsfile
 
 # Ignore the Git directory.
 .git/

--- a/README.md
+++ b/README.md
@@ -149,11 +149,11 @@ or
 ## Running on CI
 
 A basic ORT pipeline (using the _analyzer_, _scanner_ and _reporter_) can easily be run on
-[Jenkins CI](https://jenkins.io/) by using the [Jenkinsfile](./integrations/Jenkinsfile) in a (declarative)
-[pipeline](https://jenkins.io/doc/book/pipeline/) job. Please see the [Jenkinsfile](./integrations/Jenkinsfile) itself
-for documentation of the required Jenkins plugins. The job accepts various parameters that are translated to ORT command
-line arguments. Additionally, one can trigger a downstream job which e.g. further processes scan results. Note that it
-is the downstream job's responsibility to copy any artifacts it needs from the upstream job.
+[Jenkins CI](https://jenkins.io/) by using the [Jenkinsfile](./integrations/jenkins/Jenkinsfile) in a (declarative)
+[pipeline](https://jenkins.io/doc/book/pipeline/) job. Please see the [Jenkinsfile](./integrations/jenkins/Jenkinsfile)
+itself for documentation of the required Jenkins plugins. The job accepts various parameters that are translated to ORT
+command line arguments. Additionally, one can trigger a downstream job which e.g. further processes scan results. Note
+that it is the downstream job's responsibility to copy any artifacts it needs from the upstream job.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -773,7 +773,7 @@ via the green "Play" icon from the gutter as described above.
 All contributions are welcome. If you are interested in contributing, please read our
 [contributing guide](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md), and to get quick answers
 to any of your questions we recommend you
-[join our Slack community](https://join.slack.com/t/ort-talk/shared_invite/enQtMzk3MDU5Njk0Njc1LThiNmJmMjc5YWUxZTU4OGI5NmY3YTFlZWM5YTliZmY5ODc0MGMyOWIwYmRiZWFmNGMzOWY2NzVhYTI0NTJkNmY).
+[join our Slack community][2].
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ supported:
 
 If another package manager that is not part of the list above is used (or no package manager at all), the generic
 fallback to [SPDX documents](https://spdx.dev/specifications/) can be leveraged to describe
-[projects](./analyzer/src/funTest/assets/projects/synthetic/spdx/project-xyz-with-inline-packages.spdx.yml) or
+[projects](./analyzer/src/funTest/assets/projects/synthetic/spdx/inline-packages/project-xyz.spdx.yml) or
 [packages](./analyzer/src/funTest/assets/projects/synthetic/spdx/libs/curl/package.spdx.yml).
 
 <a name="downloader">&nbsp;</a>


### PR DESCRIPTION
This is a fixup for 470e2f3. Instead of hard-coding the updated link
also here, just refer to the link from the badge instead, so going
forward only a single link has to be maintained.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>