### PR TITLE
VcsHost: Add special handling for Azure DevOps packages URLs

### DIFF
--- a/downloader/src/main/kotlin/VcsHost.kt
+++ b/downloader/src/main/kotlin/VcsHost.kt
@@ -96,6 +96,11 @@ enum class VcsHost(
             return "https://dev.azure.com/$userOrOrg/$team/_apis/git/repositories/$project/items" +
                     "?scopePath=/${vcsInfo.path}"
         }
+
+        /**
+         * Return whether [url] is a VCS URI for Azure DevOps. URIs referencing an artifacts feed are excluded.
+         */
+        override fun isApplicable(url: URI): Boolean = super.isApplicable(url) && url.host != "pkgs.$hostname"
     },
 
     /**

--- a/downloader/src/test/kotlin/VcsHostTest.kt
+++ b/downloader/src/test/kotlin/VcsHostTest.kt
@@ -82,6 +82,13 @@ class VcsHostTest : WordSpec({
             AZURE_DEVOPS.toRawDownloadUrl(projectUrl) shouldBe "https://dev.azure.com/oss-review-toolkit/kotlin-devs/" +
                     "_apis/git/repositories/ort/items?scopePath=/README.md"
         }
+
+        "not be applicable to a URL pointing to a package registry" {
+            val url = "https://pkgs.dev.azure.com/project/0123456789/_packaging/some-npm-registry/" +
+                    "npm/registry/apkg/-/apkg-1.2.3.tgz"
+
+            VcsHost.fromUrl(url) should beNull()
+        }
     }
 
     "The Bitbucket implementation" should {


### PR DESCRIPTION
Azure DevOps supports so-called artifact feeds [1]. URLs pointing to
such feeds are no VCS URLs and thus must not be modified. So, add an
isApplicable() implementation for AZURE_DEVOPS to ignore those URLs.

[1] https://docs.microsoft.com/en-us/azure/devops/artifacts/concepts/feeds?view=azure-devops

