### PR TITLE
Add Analyzer for PNPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ ENV \
     GO_VERSION=1.18.3 \
     HASKELL_STACK_VERSION=2.1.3 \
     NPM_VERSION=8.5.0 \
+    PNPM_VERSION=7.8.0 \
     PYTHON_PIPENV_VERSION=2018.11.26 \
     PYTHON_POETRY_VERSION=1.1.13 \
     PYTHON_VIRTUALENV_VERSION=20.0.26 \
@@ -128,7 +129,7 @@ RUN /opt/ort/bin/import_proxy_certs.sh && \
     curl -ksS https://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo && \
     chmod a+x /usr/local/bin/repo && \
     # Install package managers (in versions known to work).
-    npm install --location=global npm@$NPM_VERSION bower@$BOWER_VERSION yarn@$YARN_VERSION && \
+    npm install --location=global npm@$NPM_VERSION bower@$BOWER_VERSION pnpm@$PNPM_VERSION yarn@$YARN_VERSION && \
     pip install --no-cache-dir wheel && \
     pip install --no-cache-dir conan==$CONAN_VERSION poetry==$PYTHON_POETRY_VERSION pipenv==$PYTHON_PIPENV_VERSION virtualenv==$PYTHON_VIRTUALENV_VERSION && \
     # Install golang in order to have `go mod` as package manager.

--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ supported:
   * [NPM](https://www.npmjs.com/) (limitations:
     [no scope-specific registries](https://github.com/oss-review-toolkit/ort/issues/3741),
     [no peer dependencies](https://github.com/oss-review-toolkit/ort/issues/95))
+  * [PNPM](https://pnpm.io/) (limitations:
+    [no peer dependencies](https://github.com/oss-review-toolkit/ort/issues/95))
   * [Yarn 1](https://classic.yarnpkg.com/)
   * [Yarn 2+](https://next.yarnpkg.com/)
 * .NET

--- a/README.md
+++ b/README.md
@@ -337,7 +337,6 @@ supported:
 * JavaScript / Node.js
   * [Bower](https://bower.io/)
   * [NPM](https://www.npmjs.com/) (limitations:
-    [no scope-specific registries](https://github.com/oss-review-toolkit/ort/issues/3741),
     [no peer dependencies](https://github.com/oss-review-toolkit/ort/issues/95))
   * [PNPM](https://pnpm.io/) (limitations:
     [no peer dependencies](https://github.com/oss-review-toolkit/ort/issues/95))

--- a/analyzer/src/funTest/assets/projects/synthetic/pnpm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pnpm-expected-output.yml
@@ -1,0 +1,1135 @@
+---
+project:
+  id: "PNPM::pnpm-test:1.0.0"
+  definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
+  declared_licenses:
+  - "Apache-2.0"
+  declared_licenses_processed:
+    spdx_expression: "Apache-2.0"
+  vcs:
+    type: "Git"
+    url: "https://github.com/oss-review-toolkit/ort.git"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scopes:
+  - name: "dependencies"
+    dependencies:
+    - id: "NPM::cheerio:1.0.0-rc.1"
+      dependencies:
+      - id: "NPM::css-select:1.2.0"
+        dependencies:
+        - id: "NPM::boolbase:1.0.0"
+        - id: "NPM::css-what:2.1.3"
+        - id: "NPM::domutils:1.5.1"
+          dependencies:
+          - id: "NPM::dom-serializer:0.1.1"
+            dependencies:
+            - id: "NPM::domelementtype:1.3.1"
+            - id: "NPM::entities:1.1.2"
+          - id: "NPM::domelementtype:1.3.1"
+        - id: "NPM::nth-check:1.0.2"
+          dependencies:
+          - id: "NPM::boolbase:1.0.0"
+      - id: "NPM::dom-serializer:0.1.1"
+        dependencies:
+        - id: "NPM::domelementtype:1.3.1"
+        - id: "NPM::entities:1.1.2"
+      - id: "NPM::entities:1.1.2"
+      - id: "NPM::htmlparser2:3.10.1"
+        dependencies:
+        - id: "NPM::domelementtype:1.3.1"
+        - id: "NPM::domhandler:2.4.2"
+          dependencies:
+          - id: "NPM::domelementtype:1.3.1"
+        - id: "NPM::domutils:1.5.1"
+          dependencies:
+          - id: "NPM::dom-serializer:0.1.1"
+            dependencies:
+            - id: "NPM::domelementtype:1.3.1"
+            - id: "NPM::entities:1.1.2"
+          - id: "NPM::domelementtype:1.3.1"
+        - id: "NPM::entities:1.1.2"
+        - id: "NPM::inherits:2.0.4"
+        - id: "NPM::readable-stream:3.6.0"
+          dependencies:
+          - id: "NPM::inherits:2.0.4"
+          - id: "NPM::string_decoder:1.3.0"
+            dependencies:
+            - id: "NPM::safe-buffer:5.2.1"
+          - id: "NPM::util-deprecate:1.0.2"
+      - id: "NPM::lodash:4.17.21"
+      - id: "NPM::parse5:3.0.3"
+        dependencies:
+        - id: "NPM:@types:node:18.0.6"
+    - id: "NPM::long:3.2.0"
+    - id: "NPM::promise:7.3.1"
+      dependencies:
+      - id: "NPM::asap:2.0.6"
+  - name: "devDependencies"
+    dependencies:
+    - id: "NPM::cson:4.1.0"
+      dependencies:
+      - id: "NPM::coffee-script:1.12.7"
+      - id: "NPM::cson-parser:1.3.5"
+        dependencies:
+        - id: "NPM::coffee-script:1.12.7"
+      - id: "NPM::extract-opts:3.4.0"
+        dependencies:
+        - id: "NPM::eachr:3.3.0"
+          dependencies:
+          - id: "NPM::editions:2.3.1"
+            dependencies:
+            - id: "NPM::errlop:2.2.0"
+            - id: "NPM::semver:6.3.0"
+          - id: "NPM::typechecker:4.11.0"
+            dependencies:
+            - id: "NPM::editions:2.3.1"
+              dependencies:
+              - id: "NPM::errlop:2.2.0"
+              - id: "NPM::semver:6.3.0"
+        - id: "NPM::editions:2.3.1"
+          dependencies:
+          - id: "NPM::errlop:2.2.0"
+          - id: "NPM::semver:6.3.0"
+        - id: "NPM::typechecker:4.11.0"
+          dependencies:
+          - id: "NPM::editions:2.3.1"
+            dependencies:
+            - id: "NPM::errlop:2.2.0"
+            - id: "NPM::semver:6.3.0"
+      - id: "NPM::requirefresh:2.3.0"
+        dependencies:
+        - id: "NPM::editions:2.3.1"
+          dependencies:
+          - id: "NPM::errlop:2.2.0"
+          - id: "NPM::semver:6.3.0"
+      - id: "NPM::safefs:4.2.0"
+        dependencies:
+        - id: "NPM::editions:2.3.1"
+          dependencies:
+          - id: "NPM::errlop:2.2.0"
+          - id: "NPM::semver:6.3.0"
+        - id: "NPM::graceful-fs:4.2.10"
+packages:
+- id: "NPM::asap:2.0.6"
+  purl: "pkg:npm/asap@2.0.6"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "High-priority task queue for Node.js and browsers"
+  homepage_url: "https://github.com/kriskowal/asap#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
+    hash:
+      value: "e50347611d7e690943208bbdafebcbc2fb866d46"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/kriskowal/asap.git"
+    revision: "3e3d99381444379bb0483cb9216caa39ac67bebb"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/kriskowal/asap.git"
+    revision: "3e3d99381444379bb0483cb9216caa39ac67bebb"
+    path: ""
+- id: "NPM::boolbase:1.0.0"
+  purl: "pkg:npm/boolbase@1.0.0"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "ISC"
+  declared_licenses_processed:
+    spdx_expression: "ISC"
+  description: "two functions: One that returns true, one that returns false"
+  homepage_url: "https://github.com/fb55/boolbase"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
+    hash:
+      value: "68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/fb55/boolbase"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fb55/boolbase.git"
+    revision: ""
+    path: ""
+- id: "NPM::cheerio:1.0.0-rc.1"
+  purl: "pkg:npm/cheerio@1.0.0-rc.1"
+  authors:
+  - "Matt Mueller"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Tiny, fast, and elegant implementation of core jQuery designed specifically\
+    \ for the server"
+  homepage_url: "https://github.com/cheeriojs/cheerio#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.1.tgz"
+    hash:
+      value: "2af37339eab713ef6b72cde98cefa672b87641fe"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/cheeriojs/cheerio.git"
+    revision: "f21ffef971826d1ba64ccbdf96adbc44964d30c5"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/cheeriojs/cheerio.git"
+    revision: "f21ffef971826d1ba64ccbdf96adbc44964d30c5"
+    path: ""
+- id: "NPM::coffee-script:1.12.7"
+  purl: "pkg:npm/coffee-script@1.12.7"
+  authors:
+  - "Jeremy Ashkenas"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Unfancy JavaScript"
+  homepage_url: "http://coffeescript.org"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz"
+    hash:
+      value: "c05dae0cb79591d05b3070a8433a98c9a89ccc53"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/jashkenas/coffeescript.git"
+    revision: "492111ccfb9b703b49a443c1aa68fb41dc8a2271"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/jashkenas/coffeescript.git"
+    revision: "492111ccfb9b703b49a443c1aa68fb41dc8a2271"
+    path: ""
+- id: "NPM::cson:4.1.0"
+  purl: "pkg:npm/cson@4.1.0"
+  authors:
+  - "2012+ Bevry Pty Ltd"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "CoffeeScript-Object-Notation Parser. Same as JSON but for CoffeeScript\
+    \ objects."
+  homepage_url: "https://github.com/bevry/cson"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/cson/-/cson-4.1.0.tgz"
+    hash:
+      value: "b1075344fa9d9fe5cf88d80f21d9366296b865c7"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/bevry/cson.git"
+    revision: "0e913a90be66b2f29d2d75433b06ed52e83ba810"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/bevry/cson.git"
+    revision: "0e913a90be66b2f29d2d75433b06ed52e83ba810"
+    path: ""
+- id: "NPM::cson-parser:1.3.5"
+  purl: "pkg:npm/cson-parser@1.3.5"
+  authors:
+  - "Groupon"
+  declared_licenses:
+  - "BSD-3-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+  description: "Safe parsing of CSON files"
+  homepage_url: "https://github.com/groupon/cson-parser"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz"
+    hash:
+      value: "7ec675e039145533bf2a6a856073f1599d9c2d24"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+ssh://git@github.com/groupon/cson-parser.git"
+    revision: "fa37e04bc6c516eb76ef01df2d105a413c0253a0"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "ssh://git@github.com/groupon/cson-parser.git"
+    revision: "fa37e04bc6c516eb76ef01df2d105a413c0253a0"
+    path: ""
+- id: "NPM::css-select:1.2.0"
+  purl: "pkg:npm/css-select@1.2.0"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "BSD-like"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD-like: "BSD-3-Clause"
+  description: "a CSS selector compiler/engine"
+  homepage_url: "https://github.com/fb55/css-select#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz"
+    hash:
+      value: "2b3a110539c5355f1cd8d314623e870b121ec858"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/fb55/css-select.git"
+    revision: "09c405d8296bd97a660256604d8cdfb23fca47b6"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fb55/css-select.git"
+    revision: "09c405d8296bd97a660256604d8cdfb23fca47b6"
+    path: ""
+- id: "NPM::css-what:2.1.3"
+  purl: "pkg:npm/css-what@2.1.3"
+  authors:
+  - "Felix Böhm"
+  declared_licenses:
+  - "BSD-2-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-2-Clause"
+  description: "a CSS selector parser"
+  homepage_url: "https://github.com/fb55/css-what#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz"
+    hash:
+      value: "a6d7604573365fe74686c3f311c56513d88285f2"
+      algorithm: "SHA-1"
+  vcs:
+    type: ""
+    url: "git+https://github.com/fb55/css-what.git"
+    revision: "2db00ca221922c5b5131d798614aa043f2f6f80e"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fb55/css-what.git"
+    revision: "2db00ca221922c5b5131d798614aa043f2f6f80e"
+    path: ""
+- id: "NPM::dom-serializer:0.1.1"
+  purl: "pkg:npm/dom-serializer@0.1.1"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "render dom nodes to string"
+  homepage_url: "https://github.com/cheeriojs/dom-renderer#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz"
+    hash:
+      value: "1ec4059e284babed36eec2941d4a970a189ce7c0"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/cheeriojs/dom-renderer.git"
+    revision: "1b9eb87c621a184b97467b03600b50d08e5a5086"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/cheeriojs/dom-renderer.git"
+    revision: "1b9eb87c621a184b97467b03600b50d08e5a5086"
+    path: ""
+- id: "NPM::domelementtype:1.3.1"
+  purl: "pkg:npm/domelementtype@1.3.1"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "BSD-2-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-2-Clause"
+  description: "all the types of nodes in htmlparser2's dom"
+  homepage_url: "https://github.com/fb55/domelementtype#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz"
+    hash:
+      value: "d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/fb55/domelementtype.git"
+    revision: "19b2491101a4de3679b59db8eb7fdd9aa0fbc60b"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fb55/domelementtype.git"
+    revision: "19b2491101a4de3679b59db8eb7fdd9aa0fbc60b"
+    path: ""
+- id: "NPM::domhandler:2.4.2"
+  purl: "pkg:npm/domhandler@2.4.2"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "BSD-2-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-2-Clause"
+  description: "handler for htmlparser2 that turns pages into a dom"
+  homepage_url: "https://github.com/fb55/DomHandler#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz"
+    hash:
+      value: "8805097e933d65e85546f726d60f5eb88b44f803"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/fb55/DomHandler.git"
+    revision: "045bd8d634dca30192fbd23fee0c530adc9c6f52"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fb55/DomHandler.git"
+    revision: "045bd8d634dca30192fbd23fee0c530adc9c6f52"
+    path: ""
+- id: "NPM::domutils:1.5.1"
+  purl: "pkg:npm/domutils@1.5.1"
+  authors:
+  - "Felix Boehm"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: "utilities for working with htmlparser2's dom"
+  homepage_url: "https://github.com/FB55/domutils"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
+    hash:
+      value: "dcd8488a26f563d61079e48c9f7b7e32373682cf"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/FB55/domutils.git"
+    revision: "7d4bd16cd36ffce62362ef91616806ea27e30d95"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/FB55/domutils.git"
+    revision: "7d4bd16cd36ffce62362ef91616806ea27e30d95"
+    path: ""
+- id: "NPM::eachr:3.3.0"
+  purl: "pkg:npm/eachr@3.3.0"
+  authors:
+  - "2011+ Bevry Pty Ltd"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Give eachr an item to iterate (array, object or map) and an iterator,\
+    \ then in return eachr gives iterator the value and key of each item, and will\
+    \ stop if the iterator returned false."
+  homepage_url: "https://github.com/bevry/eachr"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/eachr/-/eachr-3.3.0.tgz"
+    hash:
+      value: "11f7287be7d31d6b99947fe0d8a79de99ac2a469"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/bevry/eachr.git"
+    revision: "0d1b43cc12c83f9ddb8d49a1acaf8718a026f863"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/bevry/eachr.git"
+    revision: "0d1b43cc12c83f9ddb8d49a1acaf8718a026f863"
+    path: ""
+- id: "NPM::editions:2.3.1"
+  purl: "pkg:npm/editions@2.3.1"
+  authors:
+  - "2016+ Bevry Pty Ltd"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Publish multiple editions for your JavaScript packages consistently\
+    \ and easily (e.g. source edition, esnext edition, es2015 edition)"
+  homepage_url: "https://github.com/bevry/editions"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz"
+    hash:
+      value: "3bc9962f1978e801312fbd0aebfed63b49bfe698"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/bevry/editions.git"
+    revision: "b03745b7cd5a09a6fb4984dcab9544f20a794078"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/bevry/editions.git"
+    revision: "b03745b7cd5a09a6fb4984dcab9544f20a794078"
+    path: ""
+- id: "NPM::entities:1.1.2"
+  purl: "pkg:npm/entities@1.1.2"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "BSD-2-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-2-Clause"
+  description: "Encode & decode XML/HTML entities with ease"
+  homepage_url: "https://github.com/fb55/entities#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz"
+    hash:
+      value: "bdfa735299664dfafd34529ed4f8522a275fea56"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/fb55/entities.git"
+    revision: "54a5717d85d886c4aafa2ac5ff83d8d3d730337c"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fb55/entities.git"
+    revision: "54a5717d85d886c4aafa2ac5ff83d8d3d730337c"
+    path: ""
+- id: "NPM::errlop:2.2.0"
+  purl: "pkg:npm/errlop@2.2.0"
+  authors:
+  - "2018+ Benjamin Lupton"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "An extended Error class that envelops a parent error, such that the\
+    \ stack trace contains the causation"
+  homepage_url: "https://github.com/bevry/errlop"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/errlop/-/errlop-2.2.0.tgz"
+    hash:
+      value: "1ff383f8f917ae328bebb802d6ca69666a42d21b"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/bevry/errlop.git"
+    revision: "df73707a467967d1da36176e9199f2c98a314220"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/bevry/errlop.git"
+    revision: "df73707a467967d1da36176e9199f2c98a314220"
+    path: ""
+- id: "NPM::extract-opts:3.4.0"
+  purl: "pkg:npm/extract-opts@3.4.0"
+  authors:
+  - "2013+ Bevry Pty Ltd"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Extract the options and callback from a function's arguments easily"
+  homepage_url: "https://github.com/bevry/extract-opts"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/extract-opts/-/extract-opts-3.4.0.tgz"
+    hash:
+      value: "ab07a7873896a1a7e350f27e2d52645c2ceba9ac"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/bevry/extract-opts.git"
+    revision: "be6ba5f1d865d3d547350fe3f379251792936ed8"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/bevry/extract-opts.git"
+    revision: "be6ba5f1d865d3d547350fe3f379251792936ed8"
+    path: ""
+- id: "NPM::graceful-fs:4.2.10"
+  purl: "pkg:npm/graceful-fs@4.2.10"
+  declared_licenses:
+  - "ISC"
+  declared_licenses_processed:
+    spdx_expression: "ISC"
+  description: "A drop-in replacement for fs, making various improvements."
+  homepage_url: "https://github.com/isaacs/node-graceful-fs#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz"
+    hash:
+      value: "147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/isaacs/node-graceful-fs.git"
+    revision: "1f19b0b467e4144260b397343cd60f37c5bdcfda"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/isaacs/node-graceful-fs.git"
+    revision: "1f19b0b467e4144260b397343cd60f37c5bdcfda"
+    path: ""
+- id: "NPM::htmlparser2:3.10.1"
+  purl: "pkg:npm/htmlparser2@3.10.1"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Fast & forgiving HTML/XML/RSS parser"
+  homepage_url: "https://github.com/fb55/htmlparser2#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz"
+    hash:
+      value: "bd679dc3f59897b6a34bb10749c855bb53a9392f"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/fb55/htmlparser2.git"
+    revision: "537bf2aeb56910d84d2c5aedb839dec678188a43"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fb55/htmlparser2.git"
+    revision: "537bf2aeb56910d84d2c5aedb839dec678188a43"
+    path: ""
+- id: "NPM::inherits:2.0.4"
+  purl: "pkg:npm/inherits@2.0.4"
+  declared_licenses:
+  - "ISC"
+  declared_licenses_processed:
+    spdx_expression: "ISC"
+  description: "Browser-friendly inheritance fully compatible with standard node.js\
+    \ inherits()"
+  homepage_url: "https://github.com/isaacs/inherits#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
+    hash:
+      value: "0fa2c64f932917c3433a0ded55363aae37416b7c"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/isaacs/inherits.git"
+    revision: "9a2c29400c6d491e0b7beefe0c32efa3b462545d"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/isaacs/inherits.git"
+    revision: "9a2c29400c6d491e0b7beefe0c32efa3b462545d"
+    path: ""
+- id: "NPM::lodash:4.17.21"
+  purl: "pkg:npm/lodash@4.17.21"
+  authors:
+  - "John-David Dalton"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Lodash modular utilities."
+  homepage_url: "https://lodash.com/"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
+    hash:
+      value: "679591c564c3bffaae8454cf0b3df370c3d6911c"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/lodash/lodash.git"
+    revision: "c6e281b878b315c7a10d90f9c2af4cdb112d9625"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/lodash/lodash.git"
+    revision: "c6e281b878b315c7a10d90f9c2af4cdb112d9625"
+    path: ""
+- id: "NPM::long:3.2.0"
+  purl: "pkg:npm/long@3.2.0"
+  authors:
+  - "Daniel Wirtz"
+  declared_licenses:
+  - "Apache-2.0"
+  declared_licenses_processed:
+    spdx_expression: "Apache-2.0"
+  description: "A Long class for representing a 64-bit two's-complement integer value."
+  homepage_url: "https://github.com/dcodeIO/long.js#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/long/-/long-3.2.0.tgz"
+    hash:
+      value: "d821b7138ca1cb581c172990ef14db200b5c474b"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/dcodeIO/long.js.git"
+    revision: "8cdc1f74ced4f771aa844f1cbc565b1d4c4451b8"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/dcodeIO/long.js.git"
+    revision: "8cdc1f74ced4f771aa844f1cbc565b1d4c4451b8"
+    path: ""
+- id: "NPM::nth-check:1.0.2"
+  purl: "pkg:npm/nth-check@1.0.2"
+  authors:
+  - "Felix Boehm"
+  declared_licenses:
+  - "BSD-2-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-2-Clause"
+  description: "performant nth-check parser & compiler"
+  homepage_url: "https://github.com/fb55/nth-check"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz"
+    hash:
+      value: "b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/fb55/nth-check.git"
+    revision: "03a02587bbd126fafc3d2331ffef6ea5cb2f9b66"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/fb55/nth-check.git"
+    revision: "03a02587bbd126fafc3d2331ffef6ea5cb2f9b66"
+    path: ""
+- id: "NPM::parse5:3.0.3"
+  purl: "pkg:npm/parse5@3.0.3"
+  authors:
+  - "Ivan Nikulin"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "HTML parsing/serialization toolset for Node.js. WHATWG HTML Living\
+    \ Standard (aka HTML5)-compliant."
+  homepage_url: "https://github.com/inikulin/parse5"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz"
+    hash:
+      value: "042f792ffdd36851551cf4e9e066b3874ab45b5c"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/inikulin/parse5.git"
+    revision: "723d782abee65aaab9c50f92e73ac2029ae853df"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/inikulin/parse5.git"
+    revision: "723d782abee65aaab9c50f92e73ac2029ae853df"
+    path: ""
+- id: "NPM::promise:7.3.1"
+  purl: "pkg:npm/promise@7.3.1"
+  authors:
+  - "ForbesLindesay"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Bare bones Promises/A+ implementation"
+  homepage_url: "https://github.com/then/promise#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz"
+    hash:
+      value: "064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/then/promise.git"
+    revision: "cebfa6049cc08843f428c6fc92dde918f8687e6d"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/then/promise.git"
+    revision: "cebfa6049cc08843f428c6fc92dde918f8687e6d"
+    path: ""
+- id: "NPM::readable-stream:3.6.0"
+  purl: "pkg:npm/readable-stream@3.6.0"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Streams3, a user-land copy of the stream library from Node.js"
+  homepage_url: "https://github.com/nodejs/readable-stream#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz"
+    hash:
+      value: "337bbda3adc0706bd3e024426a286d4b4b2c9198"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/nodejs/readable-stream.git"
+    revision: "bed7ffa274f5b9e6d0d5c22369e6fe825ded03d2"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/nodejs/readable-stream.git"
+    revision: "bed7ffa274f5b9e6d0d5c22369e6fe825ded03d2"
+    path: ""
+- id: "NPM::requirefresh:2.3.0"
+  purl: "pkg:npm/requirefresh@2.3.0"
+  authors:
+  - "2013+ Bevry Pty Ltd"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Require a file without adding it into the require cache"
+  homepage_url: "https://github.com/bevry/requirefresh"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/requirefresh/-/requirefresh-2.3.0.tgz"
+    hash:
+      value: "fb09387b57f5ed335ff4a4beea3d8c0bf2367306"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/bevry/requirefresh.git"
+    revision: "aecc77a6b41d1486ca63b317cb31dd07b4f56629"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/bevry/requirefresh.git"
+    revision: "aecc77a6b41d1486ca63b317cb31dd07b4f56629"
+    path: ""
+- id: "NPM::safe-buffer:5.2.1"
+  purl: "pkg:npm/safe-buffer@5.2.1"
+  authors:
+  - "Feross Aboukhadijeh"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Safer Node.js Buffer API"
+  homepage_url: "https://github.com/feross/safe-buffer"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
+    hash:
+      value: "1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/feross/safe-buffer.git"
+    revision: "89d3d5b4abd6308c6008499520373d204ada694b"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/feross/safe-buffer.git"
+    revision: "89d3d5b4abd6308c6008499520373d204ada694b"
+    path: ""
+- id: "NPM::safefs:4.2.0"
+  purl: "pkg:npm/safefs@4.2.0"
+  authors:
+  - "2013+ Bevry Pty Ltd"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Stop getting EMFILE errors! Open only as many files as the operating\
+    \ system supports."
+  homepage_url: "https://github.com/bevry/safefs"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/safefs/-/safefs-4.2.0.tgz"
+    hash:
+      value: "6d60d3aecc47c3d02b0ecf39ee0a3798cb363218"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/bevry/safefs.git"
+    revision: "f57353e1353147252e8c306eb5f06321631ea46a"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/bevry/safefs.git"
+    revision: "f57353e1353147252e8c306eb5f06321631ea46a"
+    path: ""
+- id: "NPM::semver:6.3.0"
+  purl: "pkg:npm/semver@6.3.0"
+  declared_licenses:
+  - "ISC"
+  declared_licenses_processed:
+    spdx_expression: "ISC"
+  description: "The semantic version parser used by npm."
+  homepage_url: "https://github.com/npm/node-semver#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
+    hash:
+      value: "ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/npm/node-semver.git"
+    revision: "0eeceecfba490d136eb3ccae3a8dc118a28565a0"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/npm/node-semver.git"
+    revision: "0eeceecfba490d136eb3ccae3a8dc118a28565a0"
+    path: ""
+- id: "NPM::string_decoder:1.3.0"
+  purl: "pkg:npm/string_decoder@1.3.0"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "The string_decoder module from Node core"
+  homepage_url: "https://github.com/nodejs/string_decoder"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+    hash:
+      value: "42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/nodejs/string_decoder.git"
+    revision: "60db81e031c126112039157ba9437484b1329dff"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/nodejs/string_decoder.git"
+    revision: "60db81e031c126112039157ba9437484b1329dff"
+    path: ""
+- id: "NPM::typechecker:4.11.0"
+  purl: "pkg:npm/typechecker@4.11.0"
+  authors:
+  - "2013+ Bevry Pty Ltd"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "Utilities to get and check variable types (isString, isPlainObject,\
+    \ isRegExp, etc)"
+  homepage_url: "https://github.com/bevry/typechecker"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/typechecker/-/typechecker-4.11.0.tgz"
+    hash:
+      value: "8219cd90d2f7b585a3f5af9c146c8a23891f1eac"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/bevry/typechecker.git"
+    revision: "3a3868d30834a52522ecb1032dc475af5e8ecc2c"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/bevry/typechecker.git"
+    revision: "3a3868d30834a52522ecb1032dc475af5e8ecc2c"
+    path: ""
+- id: "NPM::util-deprecate:1.0.2"
+  purl: "pkg:npm/util-deprecate@1.0.2"
+  authors:
+  - "Nathan Rajlich"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "The Node.js `util.deprecate()` function with browser support"
+  homepage_url: "https://github.com/TooTallNate/util-deprecate"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+    hash:
+      value: "450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "git://github.com/TooTallNate/util-deprecate.git"
+    revision: "475fb6857cd23fafff20c1be846c1350abf8e6d4"
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/TooTallNate/util-deprecate.git"
+    revision: "475fb6857cd23fafff20c1be846c1350abf8e6d4"
+    path: ""
+- id: "NPM:@types:node:18.0.6"
+  purl: "pkg:npm/%40types/node@18.0.6"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "TypeScript definitions for Node.js"
+  homepage_url: "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz"
+    hash:
+      value: "0ba49ac517ad69abe7a1508bc9b3a5483df9d5d7"
+      algorithm: "SHA-1"
+  vcs:
+    type: "Git"
+    url: "https://github.com/DefinitelyTyped/DefinitelyTyped.git"
+    revision: ""
+    path: "types/node"
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/DefinitelyTyped/DefinitelyTyped.git"
+    revision: ""
+    path: "types/node"

--- a/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces-expected-output.yml
@@ -1,0 +1,748 @@
+---
+projects:
+- id: "PNPM::pnpm-workspaces:1.0.1"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/package.json"
+  authors:
+  - "Marcel Bochtler"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scopes:
+  - name: "dependencies"
+    dependencies:
+    - id: "NPM::chalk:4.0.0"
+      dependencies:
+      - id: "NPM::ansi-styles:4.3.0"
+        dependencies:
+        - id: "NPM::color-convert:2.0.1"
+          dependencies:
+          - id: "NPM::color-name:1.1.4"
+      - id: "NPM::supports-color:7.2.0"
+        dependencies:
+        - id: "NPM::has-flag:4.0.0"
+    - id: "NPM::chalk:5.0.1"
+    - id: "NPM::is-even:1.0.0"
+      dependencies:
+      - id: "NPM::is-odd:0.1.2"
+        dependencies:
+        - id: "NPM::is-number:3.0.0"
+          dependencies:
+          - id: "NPM::kind-of:3.2.2"
+            dependencies:
+            - id: "NPM::is-buffer:1.1.6"
+    - id: "NPM::json-stable-stringify:1.0.1"
+      dependencies:
+      - id: "NPM::jsonify:0.0.0"
+    - id: "NPM::pnpm-workspaces:1.0.1"
+      dependencies:
+      - id: "NPM::json-stable-stringify:1.0.1"
+        dependencies:
+        - id: "NPM::jsonify:0.0.0"
+    - id: "NPM::sax:1.2.4"
+    - id: "NPM::testing-pnpm-package-a:1.0.2"
+      dependencies:
+      - id: "NPM::chalk:5.0.1"
+      - id: "NPM::is-even:1.0.0"
+        dependencies:
+        - id: "NPM::is-odd:0.1.2"
+          dependencies:
+          - id: "NPM::is-number:3.0.0"
+            dependencies:
+            - id: "NPM::kind-of:3.2.2"
+              dependencies:
+              - id: "NPM::is-buffer:1.1.6"
+      - id: "NPM::sax:1.2.4"
+  - name: "devDependencies"
+    dependencies:
+    - id: "NPM::require-uncached:2.0.0"
+      dependencies:
+      - id: "NPM::caller-path:0.1.0"
+        dependencies:
+        - id: "NPM::callsites:0.2.0"
+      - id: "NPM::resolve-from:1.0.1"
+packages:
+- package:
+    id: "NPM::ansi-styles:4.3.0"
+    purl: "pkg:npm/ansi-styles@4.3.0"
+    authors:
+    - "Sindre Sorhus"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "ANSI escape codes for styling strings in the terminal"
+    homepage_url: "https://github.com/chalk/ansi-styles#readme"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
+      hash:
+        value: "edd803628ae71c04c85ae7a0906edad34b648937"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git+https://github.com/chalk/ansi-styles.git"
+      revision: "2d02d5bd070f733179007f0904eb5fb41090395a"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/chalk/ansi-styles.git"
+      revision: "2d02d5bd070f733179007f0904eb5fb41090395a"
+      path: ""
+  curations: []
+- package:
+    id: "NPM::caller-path:0.1.0"
+    purl: "pkg:npm/caller-path@0.1.0"
+    authors:
+    - "Sindre Sorhus"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "Get the path of the caller module"
+    homepage_url: "https://github.com/sindresorhus/caller-path"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz"
+      hash:
+        value: "94085ef63581ecd3daa92444a8fe94e82577751f"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git://github.com/sindresorhus/caller-path"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/sindresorhus/caller-path.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "NPM::callsites:0.2.0"
+    purl: "pkg:npm/callsites@0.2.0"
+    authors:
+    - "Sindre Sorhus"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "Get callsites from the V8 stack trace API"
+    homepage_url: "https://github.com/sindresorhus/callsites"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
+      hash:
+        value: "afab96262910a7f33c19a5775825c69f34e350ca"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git://github.com/sindresorhus/callsites"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/sindresorhus/callsites.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "NPM::chalk:4.0.0"
+    purl: "pkg:npm/chalk@4.0.0"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "Terminal string styling done right"
+    homepage_url: "https://github.com/chalk/chalk#readme"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz"
+      hash:
+        value: "6e98081ed2d17faab615eb52ac66ec1fe6209e72"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git+https://github.com/chalk/chalk.git"
+      revision: "31fa94208034cb7581a81b06045ff2cf51057b40"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/chalk/chalk.git"
+      revision: "31fa94208034cb7581a81b06045ff2cf51057b40"
+      path: ""
+  curations: []
+- package:
+    id: "NPM::chalk:5.0.1"
+    purl: "pkg:npm/chalk@5.0.1"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "Terminal string styling done right"
+    homepage_url: "https://github.com/chalk/chalk#readme"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz"
+      hash:
+        value: "ca57d71e82bb534a296df63bbacc4a1c22b2a4b6"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git+https://github.com/chalk/chalk.git"
+      revision: "bccde97f8a1bb125d4fe99e8fd355182101ff4f2"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/chalk/chalk.git"
+      revision: "bccde97f8a1bb125d4fe99e8fd355182101ff4f2"
+      path: ""
+  curations: []
+- package:
+    id: "NPM::color-convert:2.0.1"
+    purl: "pkg:npm/color-convert@2.0.1"
+    authors:
+    - "Heather Arthur"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "Plain color conversion functions"
+    homepage_url: "https://github.com/Qix-/color-convert#readme"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
+      hash:
+        value: "72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git+https://github.com/Qix-/color-convert.git"
+      revision: "e1cb7846258e1d7aa25873814684d4fbbbca53ed"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/Qix-/color-convert.git"
+      revision: "e1cb7846258e1d7aa25873814684d4fbbbca53ed"
+      path: ""
+  curations: []
+- package:
+    id: "NPM::color-name:1.1.4"
+    purl: "pkg:npm/color-name@1.1.4"
+    authors:
+    - "DY"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "A list of color names and its values"
+    homepage_url: "https://github.com/colorjs/color-name"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+      hash:
+        value: "c2a09a87acbde69543de6f63fa3995c826c536a2"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git+ssh://git@github.com/colorjs/color-name.git"
+      revision: "4536ce5944f56659a2dfb2198eaf81b5ad5f2ad9"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "ssh://git@github.com/colorjs/color-name.git"
+      revision: "4536ce5944f56659a2dfb2198eaf81b5ad5f2ad9"
+      path: ""
+  curations: []
+- package:
+    id: "NPM::has-flag:4.0.0"
+    purl: "pkg:npm/has-flag@4.0.0"
+    authors:
+    - "Sindre Sorhus"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "Check if argv has a specific flag"
+    homepage_url: "https://github.com/sindresorhus/has-flag#readme"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
+      hash:
+        value: "944771fd9c81c81265c4d6941860da06bb59479b"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git+https://github.com/sindresorhus/has-flag.git"
+      revision: "474aa39afca7333d356c022fc5be4d31732bbba3"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/sindresorhus/has-flag.git"
+      revision: "474aa39afca7333d356c022fc5be4d31732bbba3"
+      path: ""
+  curations: []
+- package:
+    id: "NPM::is-buffer:1.1.6"
+    purl: "pkg:npm/is-buffer@1.1.6"
+    authors:
+    - "Feross Aboukhadijeh"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "Determine if an object is a Buffer"
+    homepage_url: "https://github.com/feross/is-buffer#readme"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
+      hash:
+        value: "efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git://github.com/feross/is-buffer.git"
+      revision: "1e84e7ee31cf6b660b12500f3111a05501da387f"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/feross/is-buffer.git"
+      revision: "1e84e7ee31cf6b660b12500f3111a05501da387f"
+      path: ""
+  curations: []
+- package:
+    id: "NPM::is-even:1.0.0"
+    purl: "pkg:npm/is-even@1.0.0"
+    authors:
+    - "Jon Schlinkert"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "Return true if the given number is even."
+    homepage_url: "https://github.com/jonschlinkert/is-even"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/is-even/-/is-even-1.0.0.tgz"
+      hash:
+        value: "76b5055fbad8d294a86b6a949015e1c97b717c06"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git+https://github.com/jonschlinkert/is-even.git"
+      revision: "e87c060bb1c3f5353cd49c45afbe98d1a6c22b89"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/jonschlinkert/is-even.git"
+      revision: "e87c060bb1c3f5353cd49c45afbe98d1a6c22b89"
+      path: ""
+  curations: []
+- package:
+    id: "NPM::is-number:3.0.0"
+    purl: "pkg:npm/is-number@3.0.0"
+    authors:
+    - "Jon Schlinkert"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "Returns true if the value is a number. comprehensive tests."
+    homepage_url: "https://github.com/jonschlinkert/is-number"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz"
+      hash:
+        value: "24fd6201a4782cf50561c810276afc7d12d71195"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git+https://github.com/jonschlinkert/is-number.git"
+      revision: "af885e2e890b9ef0875edd2b117305119ee5bdc5"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/jonschlinkert/is-number.git"
+      revision: "af885e2e890b9ef0875edd2b117305119ee5bdc5"
+      path: ""
+  curations: []
+- package:
+    id: "NPM::is-odd:0.1.2"
+    purl: "pkg:npm/is-odd@0.1.2"
+    authors:
+    - "Jon Schlinkert"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "Returns true if the given number is odd."
+    homepage_url: "https://github.com/jonschlinkert/is-odd"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/is-odd/-/is-odd-0.1.2.tgz"
+      hash:
+        value: "bc573b5ce371ef2aad6e6f49799b72bef13978a7"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git+https://github.com/jonschlinkert/is-odd.git"
+      revision: "59270f5a05b03bdeb0b06c95d922deb59ae31923"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/jonschlinkert/is-odd.git"
+      revision: "59270f5a05b03bdeb0b06c95d922deb59ae31923"
+      path: ""
+  curations: []
+- package:
+    id: "NPM::json-stable-stringify:1.0.1"
+    purl: "pkg:npm/json-stable-stringify@1.0.1"
+    authors:
+    - "James Halliday"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "deterministic JSON.stringify() with custom sorting to get deterministic\
+      \ hashes from stringified results"
+    homepage_url: "https://github.com/substack/json-stable-stringify"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+      hash:
+        value: "9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git://github.com/substack/json-stable-stringify.git"
+      revision: "4a3ac9cc006a91e64901f8ebe78d23bf9fc9fbd0"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/substack/json-stable-stringify.git"
+      revision: "4a3ac9cc006a91e64901f8ebe78d23bf9fc9fbd0"
+      path: ""
+  curations: []
+- package:
+    id: "NPM::jsonify:0.0.0"
+    purl: "pkg:npm/jsonify@0.0.0"
+    authors:
+    - "Douglas Crockford"
+    declared_licenses:
+    - "Public Domain"
+    declared_licenses_processed:
+      spdx_expression: "LicenseRef-scancode-public-domain-disclaimer"
+      mapped:
+        Public Domain: "LicenseRef-scancode-public-domain-disclaimer"
+    description: "JSON without touching any globals"
+    homepage_url: ""
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+      hash:
+        value: "2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git://github.com/substack/jsonify.git"
+      revision: ""
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/substack/jsonify.git"
+      revision: ""
+      path: ""
+  curations: []
+- package:
+    id: "NPM::kind-of:3.2.2"
+    purl: "pkg:npm/kind-of@3.2.2"
+    authors:
+    - "Jon Schlinkert"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "Get the native type of a value."
+    homepage_url: "https://github.com/jonschlinkert/kind-of"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+      hash:
+        value: "31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git+https://github.com/jonschlinkert/kind-of.git"
+      revision: "0ffe67cf12f5396047c1bacf04232b7deeb24063"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/jonschlinkert/kind-of.git"
+      revision: "0ffe67cf12f5396047c1bacf04232b7deeb24063"
+      path: ""
+  curations: []
+- package:
+    id: "NPM::pnpm-workspaces:1.0.1"
+    purl: "pkg:npm/pnpm-workspaces@1.0.1"
+    authors:
+    - "Marcel Bochtler"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "PNPM workspaces test"
+    homepage_url: ""
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    vcs:
+      type: "Git"
+      url: "<REPLACE_RAW_URL>"
+      revision: "<REPLACE_REVISION>"
+      path: "analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces"
+    vcs_processed:
+      type: "Git"
+      url: "<REPLACE_URL>"
+      revision: "<REPLACE_REVISION>"
+      path: "analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces"
+  curations: []
+- package:
+    id: "NPM::require-uncached:2.0.0"
+    purl: "pkg:npm/require-uncached@2.0.0"
+    authors:
+    - "Sindre Sorhus"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "Require a module bypassing the cache"
+    homepage_url: "https://github.com/sindresorhus/require-uncached#readme"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/require-uncached/-/require-uncached-2.0.0.tgz"
+      hash:
+        value: "ad54186d77fecf07b63d82f8dd7aad448863b06d"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git+https://github.com/sindresorhus/require-uncached.git"
+      revision: "c56e296e0028357629ea27c61c591c67e818db5f"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/sindresorhus/require-uncached.git"
+      revision: "c56e296e0028357629ea27c61c591c67e818db5f"
+      path: ""
+  curations: []
+- package:
+    id: "NPM::resolve-from:1.0.1"
+    purl: "pkg:npm/resolve-from@1.0.1"
+    authors:
+    - "Sindre Sorhus"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "Resolve the path of a module like require.resolve() but from a given\
+      \ path"
+    homepage_url: "https://github.com/sindresorhus/resolve-from"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
+      hash:
+        value: "26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "https://github.com/sindresorhus/resolve-from"
+      revision: "bae2cf1d66c616ad2eb27e0fe85a10ff0f2dfc92"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/sindresorhus/resolve-from.git"
+      revision: "bae2cf1d66c616ad2eb27e0fe85a10ff0f2dfc92"
+      path: ""
+  curations: []
+- package:
+    id: "NPM::sax:1.2.4"
+    purl: "pkg:npm/sax@1.2.4"
+    authors:
+    - "Isaac Z. Schlueter"
+    declared_licenses:
+    - "ISC"
+    declared_licenses_processed:
+      spdx_expression: "ISC"
+    description: "An evented streaming XML parser in JavaScript"
+    homepage_url: "https://github.com/isaacs/sax-js#readme"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
+      hash:
+        value: "2816234e2378bddc4e5354fab5caa895df7100d9"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git://github.com/isaacs/sax-js.git"
+      revision: "5aee2163d55cff24b817bbf550bac44841f9df45"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/isaacs/sax-js.git"
+      revision: "5aee2163d55cff24b817bbf550bac44841f9df45"
+      path: ""
+  curations: []
+- package:
+    id: "NPM::supports-color:7.2.0"
+    purl: "pkg:npm/supports-color@7.2.0"
+    authors:
+    - "Sindre Sorhus"
+    declared_licenses:
+    - "MIT"
+    declared_licenses_processed:
+      spdx_expression: "MIT"
+    description: "Detect whether a terminal supports color"
+    homepage_url: "https://github.com/chalk/supports-color#readme"
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
+      hash:
+        value: "1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+        algorithm: "SHA-1"
+    vcs:
+      type: "Git"
+      url: "git+https://github.com/chalk/supports-color.git"
+      revision: "c5edf46896d1fc1826cb1183a60d61eecb65d749"
+      path: ""
+    vcs_processed:
+      type: "Git"
+      url: "https://github.com/chalk/supports-color.git"
+      revision: "c5edf46896d1fc1826cb1183a60d61eecb65d749"
+      path: ""
+  curations: []
+- package:
+    id: "NPM::testing-pnpm-package-a:1.0.2"
+    purl: "pkg:npm/testing-pnpm-package-a@1.0.2"
+    authors:
+    - "Marcel Bochtler"
+    declared_licenses:
+    - "ISC"
+    declared_licenses_processed:
+      spdx_expression: "ISC"
+    description: ""
+    homepage_url: ""
+    binary_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    source_artifact:
+      url: ""
+      hash:
+        value: ""
+        algorithm: ""
+    vcs:
+      type: "Git"
+      url: "<REPLACE_RAW_URL>"
+      revision: "<REPLACE_REVISION>"
+      path: "analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/src/packages/package-a"
+    vcs_processed:
+      type: "Git"
+      url: "<REPLACE_URL>"
+      revision: "<REPLACE_REVISION>"
+      path: "analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/src/packages/package-a"
+  curations: []
+has_issues: false

--- a/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/package.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "pnpm-workspaces",
+  "version": "1.0.1",
+  "private": true,
+  "description": "PNPM workspaces test",
+  "author": "Marcel Bochtler",
+  "license": "MIT",
+  "main": "index.js",
+  "workspaces": [
+    "src/app",
+    "src/packages/**"
+  ],
+  "engines": {
+    "node": ">16.0.0",
+    "pnpm": ">=5"
+  },
+  "scripts": {},
+  "dependencies": {
+    "json-stable-stringify": "1.0.1",
+    "pnpm-workspaces": "link:"
+  }
+}

--- a/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/pnpm-lock.yaml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/pnpm-lock.yaml
@@ -1,0 +1,156 @@
+lockfileVersion: 5.4
+
+importers:
+
+  .:
+    specifiers:
+      json-stable-stringify: 1.0.1
+      pnpm-workspaces: 'link:'
+    dependencies:
+      json-stable-stringify: 1.0.1
+      pnpm-workspaces: 'link:'
+
+  src/app:
+    specifiers:
+      testing-pnpm-package-a: 1.0.2
+    dependencies:
+      testing-pnpm-package-a: link:../packages/package-a
+
+  src/packages/package-a:
+    specifiers:
+      chalk: 5.0.1
+      is-even: 1.0.0
+      require-uncached: 2.0.0
+      sax: 1.2.4
+    dependencies:
+      chalk: 5.0.1
+      is-even: 1.0.0
+    optionalDependencies:
+      sax: 1.2.4
+    devDependencies:
+      require-uncached: 2.0.0
+
+  src/packages/package-b:
+    specifiers:
+      chalk: 4.0.0
+    dependencies:
+      chalk: 4.0.0
+
+packages:
+
+  /ansi-styles/4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      color-convert: 2.0.1
+    dev: false
+
+  /caller-path/0.1.0:
+    resolution: {integrity: sha512-UJiE1otjXPF5/x+T3zTnSFiTOEmJoGTD9HmBoxnCUwho61a2eSNn/VwtwuIBDAo2SEOv1AJ7ARI5gCmohFLu/g==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      callsites: 0.2.0
+    dev: true
+
+  /callsites/0.2.0:
+    resolution: {integrity: sha512-Zv4Dns9IbXXmPkgRRUjAaJQgfN4xX5p6+RQFhWUqscdvvK2xK/ZL8b3IXIJsj+4sD+f24NwnWy2BY8AJ82JB0A==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /chalk/4.0.0:
+    resolution: {integrity: sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+    dev: false
+
+  /chalk/5.0.1:
+    resolution: {integrity: sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: false
+
+  /color-convert/2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+    dependencies:
+      color-name: 1.1.4
+    dev: false
+
+  /color-name/1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: false
+
+  /has-flag/4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /is-buffer/1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+    dev: false
+
+  /is-even/1.0.0:
+    resolution: {integrity: sha512-LEhnkAdJqic4Dbqn58A0y52IXoHWlsueqQkKfMfdEnIYG8A1sm/GHidKkS6yvXlMoRrkM34csHnXQtOqcb+Jzg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-odd: 0.1.2
+    dev: false
+
+  /is-number/3.0.0:
+    resolution: {integrity: sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      kind-of: 3.2.2
+    dev: false
+
+  /is-odd/0.1.2:
+    resolution: {integrity: sha512-Ri7C2K7o5IrUU9UEI8losXJCCD/UtsaIrkR5sxIcFg4xQ9cRJXlWA5DQvTE0yDc0krvSNLsRGXN11UPS6KyfBw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-number: 3.0.0
+    dev: false
+
+  /json-stable-stringify/1.0.1:
+    resolution: {integrity: sha512-i/J297TW6xyj7sDFa7AmBPkQvLIxWr2kKPWI26tXydnZrzVAocNqn5DMNT1Mzk0vit1V5UkRM7C1KdVNp7Lmcg==}
+    dependencies:
+      jsonify: 0.0.0
+    dev: false
+
+  /jsonify/0.0.0:
+    resolution: {integrity: sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==}
+    dev: false
+
+  /kind-of/3.2.2:
+    resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-buffer: 1.1.6
+    dev: false
+
+  /require-uncached/2.0.0:
+    resolution: {integrity: sha512-rPv1//BQwg4gzIbpJcKXWIfjDJEtgS8jzbsNoLcdVSE5FpBzKEKKuoG6MfCbLC28ZTv+qlQWC9/K7J5GBGPSMg==}
+    engines: {node: '>=0.10.0'}
+    deprecated: Renamed to `import-fresh`.
+    dependencies:
+      caller-path: 0.1.0
+      resolve-from: 1.0.1
+    dev: true
+
+  /resolve-from/1.0.1:
+    resolution: {integrity: sha512-kT10v4dhrlLNcnO084hEjvXCI1wUG9qZLoz2RogxqDQQYy7IxjI/iMUkOtQTNEh6rzHxvdQWHsJyel1pKOVCxg==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /sax/1.2.4:
+    resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /supports-color/7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: false

--- a/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/pnpm-workspace.yaml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'src/packages/**'
+  - 'src/app/**'

--- a/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/src/app/package.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/src/app/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "pnpm-app-example",
+  "version": "1.1.4",
+  "private": true,
+  "description": "",
+  "amdName": "app",
+  "source": "src/index.js",
+  "main": "dist/package-app.js",
+  "module": "dist/package-app.module.js",
+  "unpkg": "dist/package-app.umd.js",
+  "sideEffects": false,
+  "keywords": [],
+  "author": "DavidWells",
+  "license": "ISC",
+  "dependencies": {
+    "testing-pnpm-package-a": "1.0.2"
+  }
+}

--- a/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/src/packages/package-a/package.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/src/packages/package-a/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "testing-pnpm-package-a",
+  "version": "1.0.2",
+  "description": "",
+  "amdName": "packageA",
+  "source": "src/index.js",
+  "main": "dist/package-a.js",
+  "module": "dist/package-a.module.js",
+  "unpkg": "dist/package-a.umd.js",
+  "sideEffects": false,
+  "keywords": [],
+  "author": "Marcel Bochtler",
+  "license": "ISC",
+  "dependencies": {
+    "chalk": "5.0.1",
+    "is-even": "1.0.0"
+  },
+  "devDependencies": {
+    "require-uncached": "2.0.0"
+  },
+  "optionalDependencies": {
+    "sax": "1.2.4"
+  }
+}

--- a/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/src/packages/package-b/package.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/src/packages/package-b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "testing-pnpm-package-b",
+  "version": "1.0.2",
+  "description": "",
+  "amdName": "packageA",
+  "source": "src/index.js",
+  "main": "dist/package-b.js",
+  "module": "dist/package-b.module.js",
+  "unpkg": "dist/package-b.umd.js",
+  "sideEffects": false,
+  "keywords": [],
+  "author": "Marcel Bochtler",
+  "license": "ISC",
+  "dependencies": {
+    "chalk": "4.0.0"
+  }
+}

--- a/analyzer/src/funTest/assets/projects/synthetic/pnpm/package.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/pnpm/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "pnpm-test",
+  "version": "1.0.0",
+  "description": "PNPM project with pnpm-lock.yaml.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oss-review-toolkit/ort.git"
+  },
+  "license": "Apache-2.0",
+  "private": true,
+  "dependencies": {
+    "cheerio": "1.0.0-rc.1",
+    "long": "^3.2.0"
+  },
+  "devDependencies": {
+    "cson": "~4.1.0"
+  },
+  "optionalDependencies": {
+    "promise": "~7.3.1"
+  }
+}

--- a/analyzer/src/funTest/assets/projects/synthetic/pnpm/pnpm-lock.yaml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pnpm/pnpm-lock.yaml
@@ -1,0 +1,245 @@
+lockfileVersion: 5.4
+
+specifiers:
+  cheerio: 1.0.0-rc.1
+  cson: ~4.1.0
+  long: ^3.2.0
+  promise: ~7.3.1
+
+dependencies:
+  cheerio: 1.0.0-rc.1
+  long: 3.2.0
+
+optionalDependencies:
+  promise: 7.3.1
+
+devDependencies:
+  cson: 4.1.0
+
+packages:
+
+  /@types/node/18.0.6:
+    resolution: {integrity: sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==}
+    dev: false
+
+  /asap/2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+    dev: false
+    optional: true
+
+  /boolbase/1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+    dev: false
+
+  /cheerio/1.0.0-rc.1:
+    resolution: {integrity: sha512-f9fNo3JP239BmXoZM2afbybS8CSm9fPyrTSH1UbQCQaaMeL0bRfbpAvYMbKOvy0y9tSho/coEdwBvYWx8hemDg==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      css-select: 1.2.0
+      dom-serializer: 0.1.1
+      entities: 1.1.2
+      htmlparser2: 3.10.1
+      lodash: 4.17.21
+      parse5: 3.0.3
+    dev: false
+
+  /coffee-script/1.12.7:
+    resolution: {integrity: sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==}
+    engines: {node: '>=0.8.0'}
+    deprecated: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
+    hasBin: true
+    dev: true
+
+  /cson-parser/1.3.5:
+    resolution: {integrity: sha512-Pchz4dDkyafUL4V3xBuP9Os8Hu9VU96R+MxuTKh7NR+D866UiWrhBiSLbfuvwApEaJzpXhXTr3iPe4lFtXLzcQ==}
+    dependencies:
+      coffee-script: 1.12.7
+    dev: true
+
+  /cson/4.1.0:
+    resolution: {integrity: sha512-WJE4sajPn19i2NVs7PUjODPoEcwE7NEmVDsXYxyYca7UOcWcGIZM7xPtI0VQeOWxNbCLI+uvuP0BetJJfsspxQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+    dependencies:
+      coffee-script: 1.12.7
+      cson-parser: 1.3.5
+      extract-opts: 3.4.0
+      requirefresh: 2.3.0
+      safefs: 4.2.0
+    dev: true
+
+  /css-select/1.2.0:
+    resolution: {integrity: sha512-dUQOBoqdR7QwV90WysXPLXG5LO7nhYBgiWVfxF80DKPF8zx1t/pUd2FYy73emg3zrjtM6dzmYgbHKfV2rxiHQA==}
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 2.1.3
+      domutils: 1.5.1
+      nth-check: 1.0.2
+    dev: false
+
+  /css-what/2.1.3:
+    resolution: {integrity: sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==}
+    dev: false
+
+  /dom-serializer/0.1.1:
+    resolution: {integrity: sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==}
+    dependencies:
+      domelementtype: 1.3.1
+      entities: 1.1.2
+    dev: false
+
+  /domelementtype/1.3.1:
+    resolution: {integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==}
+    dev: false
+
+  /domhandler/2.4.2:
+    resolution: {integrity: sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==}
+    dependencies:
+      domelementtype: 1.3.1
+    dev: false
+
+  /domutils/1.5.1:
+    resolution: {integrity: sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==}
+    dependencies:
+      dom-serializer: 0.1.1
+      domelementtype: 1.3.1
+    dev: false
+
+  /domutils/1.7.0:
+    resolution: {integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==}
+    dependencies:
+      dom-serializer: 0.1.1
+      domelementtype: 1.3.1
+    dev: false
+
+  /eachr/3.3.0:
+    resolution: {integrity: sha512-yKWuGwOE283CTgbEuvqXXusLH4VBXnY2nZbDkeWev+cpAXY6zCIADSPLdvfkAROc0t8S4l07U1fateCdEDuuvg==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      editions: 2.3.1
+      typechecker: 4.11.0
+    dev: true
+
+  /editions/2.3.1:
+    resolution: {integrity: sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==}
+    engines: {node: '>=0.8'}
+    dependencies:
+      errlop: 2.2.0
+      semver: 6.3.0
+    dev: true
+
+  /entities/1.1.2:
+    resolution: {integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==}
+    dev: false
+
+  /errlop/2.2.0:
+    resolution: {integrity: sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw==}
+    engines: {node: '>=0.8'}
+    dev: true
+
+  /extract-opts/3.4.0:
+    resolution: {integrity: sha512-M7Y+1cJDkzOWqvGH5F/V2qgkD6+uitW3NV9rQGl+pLSVuXZ4IDDQgxxMeLPKcWUyfypBWczIILiroSuhXG7Ytg==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      eachr: 3.3.0
+      editions: 2.3.1
+      typechecker: 4.11.0
+    dev: true
+
+  /graceful-fs/4.2.10:
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
+    dev: true
+
+  /htmlparser2/3.10.1:
+    resolution: {integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==}
+    dependencies:
+      domelementtype: 1.3.1
+      domhandler: 2.4.2
+      domutils: 1.7.0
+      entities: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.0
+    dev: false
+
+  /inherits/2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: false
+
+  /lodash/4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: false
+
+  /long/3.2.0:
+    resolution: {integrity: sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==}
+    engines: {node: '>=0.6'}
+    dev: false
+
+  /nth-check/1.0.2:
+    resolution: {integrity: sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==}
+    dependencies:
+      boolbase: 1.0.0
+    dev: false
+
+  /parse5/3.0.3:
+    resolution: {integrity: sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==}
+    dependencies:
+      '@types/node': 18.0.6
+    dev: false
+
+  /promise/7.3.1:
+    resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
+    requiresBuild: true
+    dependencies:
+      asap: 2.0.6
+    dev: false
+    optional: true
+
+  /readable-stream/3.6.0:
+    resolution: {integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    dev: false
+
+  /requirefresh/2.3.0:
+    resolution: {integrity: sha512-oskKAg0pSlPnJAkFMrcqrHeCGzYunl4Hkl+N/NW3nnFWDHRg97yb475HtF5ax8LP9i8QvVkenVIhjNb+h+P7nA==}
+    engines: {node: '>=0.12'}
+    dependencies:
+      editions: 2.3.1
+    dev: true
+
+  /safe-buffer/5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: false
+
+  /safefs/4.2.0:
+    resolution: {integrity: sha512-1amPBO92jw/hWS+gH/u7z7EL7YxaJ8WecBQl49tMQ6Y6EQfndxNNKwlPqDOcwpUetdmK6nKLoVdjybVScRwq5A==}
+    engines: {node: '>=0.12'}
+    dependencies:
+      editions: 2.3.1
+      graceful-fs: 4.2.10
+    dev: true
+
+  /semver/6.3.0:
+    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
+    hasBin: true
+    dev: true
+
+  /string_decoder/1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
+
+  /typechecker/4.11.0:
+    resolution: {integrity: sha512-lz39Mc/d1UBcF/uQFL5P8L+oWdIn/stvkUgHf0tPRW4aEwGGErewNXo2Nb6We2WslWifn00rhcHbbRWRcTGhuw==}
+    engines: {node: '>=0.8'}
+    dependencies:
+      editions: 2.3.1
+    dev: true
+
+  /util-deprecate/1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: false

--- a/analyzer/src/funTest/kotlin/managers/PnpmFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PnpmFunTest.kt
@@ -41,6 +41,15 @@ class PnpmFunTest : WordSpec({
 
             result shouldBe expectedResult
         }
+
+        "resolve dependencies correctly in a workspaces project" {
+            val projectDir = File("src/funTest/assets/projects/synthetic/pnpm-workspaces").absoluteFile
+
+            val result = resolveMultipleDependencies(projectDir)
+            val expectedResult = getExpectedResult(projectDir, "pnpm-workspaces-expected-output.yml")
+
+            result shouldBe expectedResult
+        }
     }
 })
 
@@ -49,6 +58,13 @@ private fun resolveDependencies(projectDir: File): String {
     val result = createPnpm().resolveSingleProject(packageFile, resolveScopes = true)
 
     return result.toYaml()
+}
+
+private fun resolveMultipleDependencies(projectDir: File): String {
+    val packageFile = projectDir.resolve("package.json")
+    val result = createPnpm().collateMultipleProjects(packageFile)
+    // Remove the dependency graph and add scope information.
+    return result.withResolvedScopes().toYaml()
 }
 
 private fun createPnpm() = Pnpm("PNPM", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)

--- a/analyzer/src/funTest/kotlin/managers/PnpmFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PnpmFunTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2022 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import java.io.File
+
+import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
+import org.ossreviewtoolkit.utils.test.DEFAULT_ANALYZER_CONFIGURATION
+import org.ossreviewtoolkit.utils.test.DEFAULT_REPOSITORY_CONFIGURATION
+import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.patchExpectedResult
+
+class PnpmFunTest : WordSpec({
+    "Pnpm" should {
+        "resolve dependencies correctly in a simple project" {
+            val projectDir = File("src/funTest/assets/projects/synthetic/pnpm").absoluteFile
+
+            val result = resolveDependencies(projectDir)
+            val expectedResult = getExpectedResult(projectDir, "pnpm-expected-output.yml")
+
+            result shouldBe expectedResult
+        }
+    }
+})
+
+private fun resolveDependencies(projectDir: File): String {
+    val packageFile = projectDir.resolve("package.json")
+    val result = createPnpm().resolveSingleProject(packageFile, resolveScopes = true)
+
+    return result.toYaml()
+}
+
+private fun createPnpm() = Pnpm("PNPM", USER_DIR, DEFAULT_ANALYZER_CONFIGURATION, DEFAULT_REPOSITORY_CONFIGURATION)
+
+private fun getExpectedResult(projectDir: File, expectedResultTemplateFile: String): String {
+    val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
+    val vcsUrl = vcsDir.getRemoteUrl()
+    val vcsPath = vcsDir.getPathToRoot(projectDir)
+    val vcsRevision = vcsDir.getRevision()
+    val expectedOutputTemplate = projectDir.parentFile.resolve(expectedResultTemplateFile)
+
+    return patchExpectedResult(
+        result = expectedOutputTemplate,
+        definitionFilePath = "$vcsPath/package.json",
+        url = normalizeVcsUrl(vcsUrl),
+        revision = vcsRevision,
+        path = vcsPath,
+        custom = mapOf("<REPLACE_RAW_URL>" to vcsUrl)
+    )
+}

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -225,7 +225,6 @@ open class Npm(
         analyzerConfig.getPackageManagerConfiguration(managerName)?.options?.get(OPTION_LEGACY_PEER_DEPS)
             .toBoolean()
 
-    private val artifactoryApiPathPattern = Regex("(.*artifactory.*)(?:/api/npm/)(.*)")
     private val graphBuilder = DependencyGraphBuilder(NpmDependencyHandler(this))
 
     protected open fun hasLockFile(projectDir: File) = hasNpmLockFile(projectDir)

--- a/analyzer/src/main/kotlin/managers/Pnpm.kt
+++ b/analyzer/src/main/kotlin/managers/Pnpm.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2022 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers
+
+import com.fasterxml.jackson.databind.JsonNode
+
+import com.vdurmont.semver4j.Requirement
+
+import java.io.File
+
+import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
+import org.ossreviewtoolkit.analyzer.managers.utils.hasPnpmLockFile
+import org.ossreviewtoolkit.analyzer.managers.utils.mapDefinitionFilesForPnpm
+import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
+import org.ossreviewtoolkit.model.config.RepositoryConfiguration
+import org.ossreviewtoolkit.model.jsonMapper
+import org.ossreviewtoolkit.utils.common.Os
+import org.ossreviewtoolkit.utils.common.realFile
+
+/**
+ * The [fast, disk space efficient package manager](https://pnpm.io/).
+ */
+class Pnpm(
+    name: String,
+    analysisRoot: File,
+    analyzerConfig: AnalyzerConfiguration,
+    repoConfig: RepositoryConfiguration
+) : Npm(name, analysisRoot, analyzerConfig, repoConfig) {
+    class Factory : AbstractPackageManagerFactory<Pnpm>("PNPM") {
+        override val globsForDefinitionFiles = listOf("package.json", "pnpm-lock.yaml")
+
+        override fun create(
+            analysisRoot: File,
+            analyzerConfig: AnalyzerConfiguration,
+            repoConfig: RepositoryConfiguration
+        ) = Pnpm(managerName, analysisRoot, analyzerConfig, repoConfig)
+    }
+
+    /**
+     * PNPM symlinks workspace modules in the `node_modules` directory, which will result in cyclic symlinks of
+     * `node_module` directories. Limit the search depth to '2' in this case as all packages are in a direct
+     * subdirectory of the `node_modules` directory, thanks to the `--shamefully-hoist` install option.
+     */
+    override val modulesSearchDepth = 2
+
+    override fun hasLockFile(projectDir: File) = hasPnpmLockFile(projectDir)
+
+    override fun File.isWorkspaceDir() = realFile() in findWorkspaceSubmodules(analysisRoot)
+
+    override fun loadWorkspaceSubmodules(moduleDir: File): List<File> {
+        val process = run(moduleDir, "list", "--recursive", "--depth=-1", "--parseable")
+
+        return process.stdout.lines().filter { it.isNotEmpty() }.map { File(it) }
+    }
+
+    override fun command(workingDir: File?) = if (Os.isWindows) "pnpm.cmd" else "pnpm"
+
+    override fun getVersionRequirement(): Requirement = Requirement.buildNPM("5.* - 7.*")
+
+    override fun mapDefinitionFiles(definitionFiles: List<File>) = mapDefinitionFilesForPnpm(definitionFiles).toList()
+
+    override fun runInstall(workingDir: File) =
+        run(
+            "install",
+            "--ignore-pnpmfile",
+            "--ignore-scripts",
+            "--frozen-lockfile", // Use the existing lockfile instead of updating an outdated one.
+            "--shamefully-hoist", // Build a similar node_modules structure as NPM and Yarn does.
+            workingDir = workingDir
+        )
+
+    override fun beforeResolution(definitionFiles: List<File>) =
+        // We do not actually depend on any features specific to a PNPM version, but we still want to stick to a
+        // fixed major version to be sure to get consistent results.
+        checkVersion()
+
+    override fun getRemotePackageDetails(workingDir: File, packageName: String): JsonNode {
+        val process = run(workingDir, "view", "--json", packageName)
+
+        return jsonMapper.readTree(process.stdout)
+    }
+}

--- a/analyzer/src/main/kotlin/managers/utils/NpmDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NpmDependencyHandler.kt
@@ -47,7 +47,26 @@ data class NpmModuleInfo(
 
     /** A set with information about the modules this module depends on. */
     val dependencies: Set<NpmModuleInfo>
-)
+) {
+    /**
+     * [workingDir] and [packageFile] are not relevant when adding this [NpmModuleInfo] to the dependency graph.
+     * However, if these values differ the same dependencies are added as duplicates to the set which is used to create
+     * the dependency graph. Therefore, remove them from the equals check.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as NpmModuleInfo
+
+        if (id != other.id) return false
+        if (dependencies != other.dependencies) return false
+
+        return true
+    }
+
+    override fun hashCode() = 31 * id.hashCode() + dependencies.hashCode()
+}
 
 /**
  * A specialized [DependencyHandler] implementation for NPM.

--- a/analyzer/src/main/resources/META-INF/services/org.ossreviewtoolkit.analyzer.PackageManagerFactory
+++ b/analyzer/src/main/resources/META-INF/services/org.ossreviewtoolkit.analyzer.PackageManagerFactory
@@ -14,6 +14,7 @@ org.ossreviewtoolkit.analyzer.managers.Npm$Factory
 org.ossreviewtoolkit.analyzer.managers.NuGet$Factory
 org.ossreviewtoolkit.analyzer.managers.Pip$Factory
 org.ossreviewtoolkit.analyzer.managers.Pipenv$Factory
+org.ossreviewtoolkit.analyzer.managers.Pnpm$Factory
 org.ossreviewtoolkit.analyzer.managers.Poetry$Factory
 org.ossreviewtoolkit.analyzer.managers.Pub$Factory
 org.ossreviewtoolkit.analyzer.managers.Sbt$Factory

--- a/analyzer/src/test/kotlin/PackageManagerTest.kt
+++ b/analyzer/src/test/kotlin/PackageManagerTest.kt
@@ -51,9 +51,9 @@ class PackageManagerTest : WordSpec({
         "gradle-kotlin/build.gradle.kts",
         "maven/pom.xml",
 
-        // Note that the NPM and Yarn implementations share code. Internal logic decides dynamically whether to process
-        // "package.json" with NPM or Yarn.
-        "npm-and-yarn/package.json",
+        // Note that the NPM, PNPM and Yarn implementations share code. Internal logic decides dynamically whether to
+        // process "package.json" with NPM, PNPM or Yarn.
+        "npm-pnpm-and-yarn/package.json",
 
         "nuget/packages.config",
         "pip-requirements/requirements.txt",
@@ -112,13 +112,14 @@ class PackageManagerTest : WordSpec({
                     "gradle-kotlin/build.gradle.kts"
                 )
                 managedFilesByName["Maven"] should containExactlyInAnyOrder("maven/pom.xml")
-                managedFilesByName["NPM"] should containExactlyInAnyOrder("npm-and-yarn/package.json")
+                managedFilesByName["NPM"] should containExactlyInAnyOrder("npm-pnpm-and-yarn/package.json")
                 managedFilesByName["NuGet"] should containExactlyInAnyOrder("nuget/packages.config")
                 managedFilesByName["PIP"] should containExactlyInAnyOrder(
                     "pip-requirements/requirements.txt",
                     "pip-setup/setup.py"
                 )
                 managedFilesByName["Pipenv"] should containExactlyInAnyOrder("pipenv/Pipfile.lock")
+                managedFilesByName["PNPM"] should containExactlyInAnyOrder("npm-pnpm-and-yarn/package.json")
                 managedFilesByName["Poetry"] should containExactlyInAnyOrder("poetry/poetry.lock")
                 managedFilesByName["Pub"] should containExactlyInAnyOrder("pub/pubspec.yaml")
                 managedFilesByName["SBT"] should containExactlyInAnyOrder("sbt/build.sbt")
@@ -127,7 +128,7 @@ class PackageManagerTest : WordSpec({
                     "spdx-project/project.spdx.yml"
                 )
                 managedFilesByName["Stack"] should containExactlyInAnyOrder("stack/stack.yaml")
-                managedFilesByName["Yarn"] should containExactlyInAnyOrder("npm-and-yarn/package.json")
+                managedFilesByName["Yarn"] should containExactlyInAnyOrder("npm-pnpm-and-yarn/package.json")
             }
         }
 


### PR DESCRIPTION
This PR adds support for [PNPM](https://pnpm.io/).

The implementation is loosely based on #2128.
In contrast to #5594 it does not use `pnpm list` to avoid an out of memory issue for large projects, see: https://github.com/pnpm/pnpm/issues/3518.

This implementation relies on the `pnpm install` `--shamefully-hoist` option to create a similar `node_modules` directory structure as NPM and Yarn create it, and then reuses most of NPM's analyzer implementation.