### PR TITLE
Rename the `log` extension property to `logger`

### DIFF
--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
 import org.ossreviewtoolkit.utils.ort.Environment
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * The class to manage [AdviceProvider]s. It invokes the configured providers and adds their findings to the current
@@ -59,7 +59,7 @@ class Advisor(
         val startTime = Instant.now()
 
         if (ortResult.analyzer == null) {
-            log.warn {
+            logger.warn {
                 "Cannot run the advisor as the provided ORT result does not contain an analyzer result. " +
                         "No result will be added."
             }
@@ -71,7 +71,7 @@ class Advisor(
 
         val packages = ortResult.getPackages(skipExcluded).map { it.pkg }
         if (packages.isEmpty()) {
-            log.info { "There are no packages to give advice for." }
+            logger.info { "There are no packages to give advice for." }
         } else {
             val providers = providerFactories.map { it.create(config) }
 
@@ -80,13 +80,13 @@ class Advisor(
                     async {
                         val providerResults = provider.retrievePackageFindings(packages)
 
-                        this@Advisor.log.info {
+                        this@Advisor.logger.info {
                             "Found ${providerResults.values.flatten().distinct().size} distinct vulnerabilities via " +
                                 "${provider.providerName}. "
                         }
 
                         providerResults.filter { it.value.isNotEmpty() }.keys.takeIf { it.isNotEmpty() }?.let { pkgs ->
-                            this@Advisor.log.debug {
+                            this@Advisor.logger.debug {
                                 "Affected packages:\n\n${pkgs.joinToString("\n") { it.id.toCoordinates() }}\n"
                             }
                         }

--- a/advisor/src/main/kotlin/advisors/GitHubDefects.kt
+++ b/advisor/src/main/kotlin/advisors/GitHubDefects.kt
@@ -54,7 +54,7 @@ import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.ort.filterVersionNames
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 /**
@@ -153,7 +153,7 @@ class GitHubDefects(name: String, gitHubConfiguration: GitHubDefectsConfiguratio
      * GitHub repository  for the necessary information.
      */
     private suspend fun findDefectsForGitHubPackage(pkg: GitHubPackage): List<AdvisorResult> {
-        log.info { "Finding defects for package '${pkg.pkg.id.toCoordinates()}'." }
+        logger.info { "Finding defects for package '${pkg.pkg.id.toCoordinates()}'." }
 
         val startTime = Instant.now()
         val ortIssues = mutableListOf<OrtIssue>()
@@ -175,18 +175,18 @@ class GitHubDefects(name: String, gitHubConfiguration: GitHubDefectsConfiguratio
             "releases"
         )
 
-        log.debug { "Found ${releases.size} releases for package '${pkg.pkg.id.toCoordinates()}'." }
+        logger.debug { "Found ${releases.size} releases for package '${pkg.pkg.id.toCoordinates()}'." }
 
         val issues = handleError(
             fetchAll(maxDefects) { service.repositoryIssues(pkg.repoOwner, pkg.repoName, it) },
             "issues"
         )
 
-        log.debug { "Found ${issues.size} issues for package '${pkg.pkg.id.toCoordinates()}'." }
+        logger.debug { "Found ${issues.size} issues for package '${pkg.pkg.id.toCoordinates()}'." }
 
         val defects = if (ortIssues.isEmpty()) {
             issuesForRelease(pkg, issues.applyLabelFilters(), releases, ortIssues).also {
-                log.debug { "Found ${it.size} defects for package '${pkg.pkg.id.toCoordinates()}'." }
+                logger.debug { "Found ${it.size} defects for package '${pkg.pkg.id.toCoordinates()}'." }
             }
         } else {
             emptyList()
@@ -222,7 +222,7 @@ class GitHubDefects(name: String, gitHubConfiguration: GitHubDefectsConfiguratio
                 )
             }
 
-        log.debug { "Assuming release date $releaseDate for package '${pkg.pkg.id.toCoordinates()}'." }
+        logger.debug { "Assuming release date $releaseDate for package '${pkg.pkg.id.toCoordinates()}'." }
         return issues.filter { it.closedAfter(releaseDate) }.map { it.toDefect(releases) }
     }
 

--- a/advisor/src/main/kotlin/advisors/NexusIq.kt
+++ b/advisor/src/main/kotlin/advisors/NexusIq.kt
@@ -40,7 +40,7 @@ import org.ossreviewtoolkit.model.utils.getPurlType
 import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 import retrofit2.HttpException
 
@@ -137,7 +137,7 @@ class NexusIq(name: String, private val nexusIqConfig: NexusIqConfiguration) : A
         components: List<NexusIqService.Component>
     ): NexusIqService.ComponentDetailsWrapper =
         try {
-            log.debug { "Querying component details from ${nexusIqConfig.serverUrl}." }
+            logger.debug { "Querying component details from ${nexusIqConfig.serverUrl}." }
             service.getComponentDetails(NexusIqService.ComponentsWrapper(components))
         } catch (e: HttpException) {
             throw IOException(e)

--- a/advisor/src/main/kotlin/advisors/OssIndex.kt
+++ b/advisor/src/main/kotlin/advisors/OssIndex.kt
@@ -37,7 +37,7 @@ import org.ossreviewtoolkit.model.config.AdvisorConfiguration
 import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 import retrofit2.HttpException
 
@@ -127,7 +127,7 @@ class OssIndex(name: String, serverUrl: String = OssIndexService.DEFAULT_BASE_UR
         coordinates: List<String>
     ): List<OssIndexService.ComponentReport> =
         try {
-            log.debug { "Querying component report from ${OssIndexService.DEFAULT_BASE_URL}." }
+            logger.debug { "Querying component report from ${OssIndexService.DEFAULT_BASE_URL}." }
             service.getComponentReport(OssIndexService.ComponentReportRequest(coordinates))
         } catch (e: HttpException) {
             throw IOException(e)

--- a/advisor/src/main/kotlin/advisors/Osv.kt
+++ b/advisor/src/main/kotlin/advisors/Osv.kt
@@ -44,7 +44,7 @@ import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.common.toUri
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 import us.springett.cvss.Cvss
 
@@ -107,7 +107,7 @@ class Osv(name: String, advisorConfiguration: AdvisorConfiguration) : AdviceProv
                 requests[i].first.id to vulnerabilities
             }
         }.onFailure {
-            log.error {
+            logger.error {
                 "Requesting vulnerabilities IDs for packages failed: ${result.exceptionOrNull()!!.collectMessages()}"
             }
         }
@@ -119,7 +119,7 @@ class Osv(name: String, advisorConfiguration: AdvisorConfiguration) : AdviceProv
         val result = service.getVulnerabilitiesForIds(ids)
 
         return result.getOrElse {
-            log.error {
+            logger.error {
                 "Requesting vulnerabilities IDs for packages failed: ${result.exceptionOrNull()!!.collectMessages()}"
             }
             emptyList()
@@ -176,7 +176,7 @@ private fun Vulnerability.toOrtVulnerability(): org.ossreviewtoolkit.model.Vulne
             // Work around for https://github.com/stevespringett/cvss-calculator/issues/56.
             it.score.substringBefore("/") to "${cvss.calculateScore().baseScore}"
         } ?: run {
-            log.debug { "Could not parse CVSS vector '${it.score}'." }
+            logger.debug { "Could not parse CVSS vector '${it.score}'." }
             null to it.score
         }
     } ?: (null to null)
@@ -195,7 +195,7 @@ private fun Vulnerability.toOrtVulnerability(): org.ossreviewtoolkit.model.Vulne
         val url = reference.url.trim().let { if (it.startsWith("://")) "https$it" else it }
 
         url.toUri().onFailure {
-            log.debug { "Could not parse reference URL for vulnerability '$id': ${it.message}." }
+            logger.debug { "Could not parse reference URL for vulnerability '$id': ${it.message}." }
         }.map {
             VulnerabilityReference(
                 url = it,

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -48,7 +48,7 @@ import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
 import org.ossreviewtoolkit.utils.ort.Environment
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * The class to run the analysis. The signatures of public functions in this class define the library API.
@@ -68,7 +68,7 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
     ): ManagedFileInfo {
         require(absoluteProjectPath.isAbsolute)
 
-        log.debug {
+        logger.debug {
             "Using the following configuration settings:\n${yamlMapper.writeValueAsString(repositoryConfiguration)}"
         }
 
@@ -183,7 +183,7 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
                 val managerForName = allPackageManagers[name]
 
                 if (managerForName == null) {
-                    log.debug {
+                    logger.debug {
                         "Ignoring that ${packageManager.managerName} must run after $name, because there are no " +
                                 "definition files for $name."
                     }
@@ -196,7 +196,7 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
                 val managerForName = allPackageManagers[name]
 
                 if (managerForName == null) {
-                    log.debug {
+                    logger.debug {
                         "Ignoring that ${packageManager.managerName} must run before $name, because there are no " +
                                 "definition files for $name."
                     }
@@ -290,7 +290,7 @@ private class PackageManagerRunner(
      */
     suspend fun start() {
         if (mustRunAfter.isNotEmpty()) {
-            manager.log.info {
+            manager.logger.info {
                 "Waiting for the following package managers to complete: ${mustRunAfter.joinToString()}."
             }
 
@@ -298,7 +298,7 @@ private class PackageManagerRunner(
                 val remaining = mustRunAfter - finishedPackageManagers
 
                 if (remaining.isNotEmpty()) {
-                    manager.log.info {
+                    manager.logger.info {
                         "Still waiting for the following package managers to complete: ${remaining.joinToString()}."
                     }
                 }
@@ -311,12 +311,12 @@ private class PackageManagerRunner(
     }
 
     private suspend fun run() {
-        manager.log.info { "Starting analysis." }
+        manager.logger.info { "Starting analysis." }
 
         withContext(Dispatchers.IO) {
             val result = manager.resolveDependencies(definitionFiles, labels)
 
-            manager.log.info { "Finished analysis." }
+            manager.logger.info { "Finished analysis." }
 
             onResult(result)
         }

--- a/analyzer/src/main/kotlin/AnalyzerResultBuilder.kt
+++ b/analyzer/src/main/kotlin/AnalyzerResultBuilder.kt
@@ -36,7 +36,7 @@ import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.model.utils.DependencyGraphBuilder
 import org.ossreviewtoolkit.model.utils.convertToDependencyGraph
 import org.ossreviewtoolkit.utils.common.getDuplicates
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 class AnalyzerResultBuilder(private val curationProvider: PackageCurationProvider = PackageCurationProvider.EMPTY) {
     private val projects = sortedSetOf<Project>()
@@ -97,11 +97,11 @@ class AnalyzerResultBuilder(private val curationProvider: PackageCurationProvide
     fun addPackages(packageSet: Set<Package>): AnalyzerResultBuilder {
         val (curations, duration) = measureTimedValue { curationProvider.getCurationsFor(packageSet.map { it.id }) }
 
-        log.info { "Getting package curations took $duration." }
+        logger.info { "Getting package curations took $duration." }
 
         packages += packageSet.map { pkg ->
             curations[pkg.id].orEmpty().fold(pkg.toCuratedPackage()) { cur, packageCuration ->
-                log.debug {
+                logger.debug {
                     "Applying curation '$packageCuration' to package '${pkg.id.toCoordinates()}'."
                 }
 

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -49,7 +49,7 @@ import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.isSymbolicLink
 import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
@@ -110,7 +110,7 @@ abstract class PackageManager(
                 object : SimpleFileVisitor<Path>() {
                     override fun preVisitDirectory(dir: Path, attributes: BasicFileAttributes): FileVisitResult {
                         if (IGNORED_DIRECTORY_MATCHERS.any { it.matches(dir) }) {
-                            PackageManager.log.info {
+                            PackageManager.logger.info {
                                 "Not analyzing directory '$dir' as it is hard-coded to be ignored."
                             }
 
@@ -122,7 +122,7 @@ abstract class PackageManager(
                         // Note that although FileVisitOption.FOLLOW_LINKS is not set, this would still follow junctions
                         // on Windows, so do a better check here.
                         if (dirAsFile.isSymbolicLink()) {
-                            PackageManager.log.info { "Not following symbolic link to directory '$dir'." }
+                            PackageManager.logger.info { "Not following symbolic link to directory '$dir'." }
                             return FileVisitResult.SKIP_SUBTREE
                         }
 
@@ -257,7 +257,7 @@ abstract class PackageManager(
         definitionFiles.forEach { definitionFile ->
             val relativePath = definitionFile.relativeTo(analysisRoot).invariantSeparatorsPath.ifEmpty { "." }
 
-            log.info { "Resolving $managerName dependencies for path '$relativePath'..." }
+            logger.info { "Resolving $managerName dependencies for path '$relativePath'..." }
 
             val duration = measureTime {
                 runCatching {
@@ -292,7 +292,7 @@ abstract class PackageManager(
                 }
             }
 
-            log.info { "Resolving $managerName dependencies for path '$relativePath' took $duration." }
+            logger.info { "Resolving $managerName dependencies for path '$relativePath' took $duration." }
         }
 
         afterResolution(definitionFiles)
@@ -331,10 +331,13 @@ abstract class PackageManager(
                 projectResult.takeIf { projectReferences.isEmpty() }
                     ?: projectResult.copy(packages = (projectResult.packages - projectReferences).toSortedSet())
                         .also {
-                            this@PackageManager.log.info {
+                            this@PackageManager.logger.info {
                                 "Removing ${projectReferences.size} packages that are projects."
                             }
-                            this@PackageManager.log.debug { projectReferences.joinToString { it.id.toCoordinates() } }
+
+                            this@PackageManager.logger.debug {
+                                projectReferences.joinToString { it.id.toCoordinates() }
+                            }
                         }
             }
         }

--- a/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
@@ -44,7 +44,7 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.utils.toClearlyDefinedTypeAndProvider
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.spdx.toSpdx
@@ -121,7 +121,7 @@ class ClearlyDefinedPackageCurationProvider(
                     if (e.code() != HttpURLConnection.HTTP_NOT_FOUND) {
                         e.showStackTrace()
 
-                        log.warn {
+                        logger.warn {
                             val message = e.response()?.errorBody()?.string() ?: e.collectMessages()
                             "Getting curations failed with code ${e.code()}: $message"
                         }
@@ -130,12 +130,12 @@ class ClearlyDefinedPackageCurationProvider(
 
                 is JsonMappingException -> {
                     e.showStackTrace()
-                    log.warn { "Deserializing the curations failed: ${e.collectMessages()}" }
+                    logger.warn { "Deserializing the curations failed: ${e.collectMessages()}" }
                 }
 
                 else -> {
                     e.showStackTrace()
-                    log.warn { "Querying curations failed: ${e.collectMessages()}" }
+                    logger.warn { "Querying curations failed: ${e.collectMessages()}" }
                 }
             }
         }.getOrNull() ?: return emptyMap()

--- a/analyzer/src/main/kotlin/curation/FilePackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/FilePackageCurationProvider.kt
@@ -27,7 +27,7 @@ import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.readValueOrDefault
 import org.ossreviewtoolkit.utils.common.getDuplicates
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * A [PackageCurationProvider] that loads [PackageCuration]s from all given curation files. Supports all file formats
@@ -54,7 +54,7 @@ class FilePackageCurationProvider(
                 val curations = runCatching {
                     curationFile.readValueOrDefault(emptyList<PackageCuration>())
                 }.onFailure {
-                    log.warn { "Failed parsing package curation from '${curationFile.absoluteFile}'." }
+                    logger.warn { "Failed parsing package curation from '${curationFile.absoluteFile}'." }
                 }.getOrThrow()
 
                 curations.mapTo(allCurations) { it to curationFile }

--- a/analyzer/src/main/kotlin/curation/OrtConfigPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/OrtConfigPackageCurationProvider.kt
@@ -32,7 +32,7 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.common.encodeOr
 import org.ossreviewtoolkit.utils.common.safeMkdirs
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.ortDataDirectory
 
 private const val ORT_CONFIG_REPOSITORY_BRANCH = "main"
@@ -60,7 +60,7 @@ open class OrtConfigPackageCurationProvider : PackageCurationProvider {
             runCatching {
                 yamlMapper.readValue<List<PackageCuration>>(file).filter { it.isApplicable(pkgId) }
             }.onFailure {
-                log.warn { "Failed parsing package curation from '${file.absolutePath}'." }
+                logger.warn { "Failed parsing package curation from '${file.absolutePath}'." }
             }.getOrThrow()
         } else {
             emptyList()

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -60,7 +60,7 @@ import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.textValueOrEmpty
 import org.ossreviewtoolkit.utils.ort.HttpDownloadError
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 /**
@@ -125,7 +125,7 @@ class Bundler(
         }
 
         if (bundlerGems.containsAll(HELPER_SCRIPT_DEPENDENCIES)) {
-            log.info { "Already installed the ${HELPER_SCRIPT_DEPENDENCIES.joinToString()} gem(s)." }
+            logger.info { "Already installed the ${HELPER_SCRIPT_DEPENDENCIES.joinToString()} gem(s)." }
         } else {
             // Install the Gems the helper scripts depend on.
             val duration = measureTime {
@@ -137,7 +137,7 @@ class Bundler(
                 )
             }
 
-            log.info { "Installing the ${HELPER_SCRIPT_DEPENDENCIES.joinToString()} gem(s) took $duration." }
+            logger.info { "Installing the ${HELPER_SCRIPT_DEPENDENCIES.joinToString()} gem(s) took $duration." }
         }
     }
 
@@ -184,7 +184,7 @@ class Bundler(
         workingDir: File, projectId: Identifier, groupName: String, dependencyList: List<String>,
         scopes: MutableSet<Scope>, gemSpecs: MutableMap<String, GemSpec>, issues: MutableList<OrtIssue>
     ) {
-        log.debug {
+        logger.debug {
             "Parsing scope '$groupName' with top-level dependencies $dependencyList for project " +
                     "'${projectId.toCoordinates()}' in '$workingDir'."
         }
@@ -202,7 +202,7 @@ class Bundler(
         workingDir: File, projectId: Identifier, gemName: String, gemSpecs: MutableMap<String, GemSpec>,
         scopeDependencies: MutableSet<PackageReference>, issues: MutableList<OrtIssue>
     ) {
-        log.debug { "Parsing dependency '$gemName'." }
+        logger.debug { "Parsing dependency '$gemName'." }
 
         runCatching {
             val gemSpec = gemSpecs.getValue(gemName)
@@ -299,12 +299,12 @@ class Bundler(
             GemSpec.createFromGem(yamlMapper.readTree(it))
         }.onFailure {
             val error = (it as? HttpDownloadError) ?: run {
-                log.warn { "Unable to retrieve metadata for gem '$name' from RubyGems: ${it.message}" }
+                logger.warn { "Unable to retrieve metadata for gem '$name' from RubyGems: ${it.message}" }
                 return null
             }
 
             when (error.code) {
-                HttpURLConnection.HTTP_NOT_FOUND -> log.info { "Gem '$name' was not found on RubyGems." }
+                HttpURLConnection.HTTP_NOT_FOUND -> logger.info { "Gem '$name' was not found on RubyGems." }
 
                 OkHttpClientHelper.HTTP_TOO_MANY_REQUESTS -> {
                     throw IOException(

--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -51,7 +51,7 @@ import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.textValueOrEmpty
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.ort.ProcessedDeclaredLicense
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxOperator
 
@@ -99,7 +99,7 @@ class Cargo(
 
     private fun readHashes(lockfile: File): Map<String, String> {
         if (!lockfile.isFile) {
-            log.debug { "Cannot determine the hashes of remote artifacts because the Cargo lockfile is missing." }
+            logger.debug { "Cannot determine the hashes of remote artifacts because the Cargo lockfile is missing." }
             return emptyMap()
         }
 

--- a/analyzer/src/main/kotlin/managers/CocoaPods.kt
+++ b/analyzer/src/main/kotlin/managers/CocoaPods.kt
@@ -56,7 +56,7 @@ import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.stashDirectories
 import org.ossreviewtoolkit.utils.common.textValueOrEmpty
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * The [CocoaPods](https://cocoapods.org/) package manager for Objective-C.
@@ -170,7 +170,7 @@ class CocoaPods(
 
     private fun getPackage(id: Identifier, workingDir: File): Package {
         val podspec = getPodspec(id, workingDir) ?: run {
-            log.warn { "Could not find a '.podspec' file for package '${id.toCoordinates()}'." }
+            logger.warn { "Could not find a '.podspec' file for package '${id.toCoordinates()}'." }
 
             return Package.EMPTY.copy(id = id)
         }

--- a/analyzer/src/main/kotlin/managers/Composer.kt
+++ b/analyzer/src/main/kotlin/managers/Composer.kt
@@ -53,7 +53,7 @@ import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.fieldNamesOrEmpty
 import org.ossreviewtoolkit.utils.common.stashDirectories
 import org.ossreviewtoolkit.utils.common.textValueOrEmpty
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 const val COMPOSER_PHAR_BINARY = "composer.phar"
@@ -129,7 +129,7 @@ class Composer(
 
                 val lockFile = workingDir.resolve(COMPOSER_LOCK_FILE)
 
-                log.info { "Reading '$lockFile'..." }
+                logger.info { "Reading '$lockFile'..." }
 
                 val json = jsonMapper.readTree(lockFile)
                 val packages = parseInstalledPackages(json)
@@ -152,7 +152,7 @@ class Composer(
                 Pair(emptyMap(), sortedSetOf())
             }
 
-            log.info { "Reading ${definitionFile.name} file in $workingDir..." }
+            logger.info { "Reading ${definitionFile.name} file in $workingDir..." }
 
             val project = parseProject(definitionFile, scopes)
 
@@ -187,7 +187,7 @@ class Composer(
                 ?: throw IOException("Could not find package info for $packageName")
 
             if (packageName in dependencyBranch) {
-                log.debug {
+                logger.debug {
                     "Not adding circular dependency '$packageName' to the tree, it is already on this branch of the " +
                             "dependency tree: ${dependencyBranch.joinToString(" -> ")}."
                 }
@@ -254,7 +254,7 @@ class Composer(
                 // Just warn if the version is missing as Composer itself declares it as optional, see
                 // https://getcomposer.org/doc/04-schema.md#version.
                 if (version.isEmpty()) {
-                    log.warn { "No version information found for package $rawName." }
+                    logger.warn { "No version information found for package $rawName." }
                 }
 
                 packages[rawName] = Package(

--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -55,7 +55,7 @@ import org.ossreviewtoolkit.utils.common.stashDirectories
 import org.ossreviewtoolkit.utils.common.textValueOrEmpty
 import org.ossreviewtoolkit.utils.common.toUri
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.requestPasswordAuthentication
 
 /**
@@ -193,7 +193,7 @@ class Conan(
         // List configured remotes in "remotes.txt" format.
         val remoteList = run("remote", "list", "--raw")
         if (remoteList.isError) {
-            log.warn { "Failed to list remotes." }
+            logger.warn { "Failed to list remotes." }
             return
         }
 
@@ -212,7 +212,7 @@ class Conan(
             val remoteUrl = wordIterator.next()
 
             remoteUrl.toUri().onSuccess { uri ->
-                log.info { "Found remote '$remoteName' pointing to URL $remoteUrl." }
+                logger.info { "Found remote '$remoteName' pointing to URL $remoteUrl." }
 
                 // Request authentication for the extracted remote URL.
                 val auth = requestPasswordAuthentication(uri)
@@ -221,11 +221,11 @@ class Conan(
                     // Configure Conan's authentication based on ORT's authentication for the remote.
                     val userAuth = run("user", "-r", remoteName, "-p", String(auth.password), auth.userName)
                     if (userAuth.isError) {
-                        log.error { "Failed to configure user authentication for remote '$remoteName'." }
+                        logger.error { "Failed to configure user authentication for remote '$remoteName'." }
                     }
                 }
             }.onFailure {
-                log.warn { "The remote '$remoteName' points to invalid URL $remoteUrl." }
+                logger.warn { "The remote '$remoteName' points to invalid URL $remoteUrl." }
             }
         }
     }
@@ -244,7 +244,7 @@ class Conan(
         pkg[scopeName]?.forEach { childNode ->
             val childRef = childNode.textValueOrEmpty()
             pkgInfos.find { it["reference"].textValueOrEmpty() == childRef }?.let { pkgInfo ->
-                log.debug { "Found child '$childRef'." }
+                logger.debug { "Found child '$childRef'." }
 
                 val id = parsePackageId(pkgInfo, workingDir)
                 val dependencies = parseDependencyTree(pkgInfos, pkgInfo, SCOPE_NAME_DEPENDENCIES, workingDir) +

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -52,7 +52,7 @@ import org.ossreviewtoolkit.utils.common.safeCopyRecursively
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.common.toUri
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 /**
@@ -101,7 +101,7 @@ class GoDep(
         val workingDir = setUpWorkspace(projectDir, projectVcs, gopath)
 
         GO_LEGACY_MANIFESTS[definitionFile.name]?.let { lockfileName ->
-            log.debug { "Importing legacy manifest file at '$definitionFile'." }
+            logger.debug { "Importing legacy manifest file at '$definitionFile'." }
             importLegacyManifest(lockfileName, workingDir, gopath)
         }
 
@@ -208,7 +208,7 @@ class GoDep(
     private fun setUpWorkspace(projectDir: File, vcs: VcsInfo, gopath: File): File {
         val destination = deduceImportPath(projectDir, vcs, gopath)
 
-        log.debug { "Copying $projectDir to temporary directory $destination" }
+        logger.debug { "Copying $projectDir to temporary directory $destination" }
 
         projectDir.safeCopyRecursively(destination)
 
@@ -229,14 +229,14 @@ class GoDep(
                 "No lockfile found in ${workingDir.invariantSeparatorsPath}, dependency versions are unstable."
             }
 
-            log.debug { "Running 'dep ensure' to generate missing lockfile in $workingDir" }
+            logger.debug { "Running 'dep ensure' to generate missing lockfile in $workingDir" }
 
             run("ensure", workingDir = workingDir, environment = mapOf("GOPATH" to gopath.path))
         }
 
         val entries = Toml().read(lockfile).toMap()["projects"]
         if (entries == null) {
-            log.warn { "${lockfile.name} is missing any [[projects]] entries" }
+            logger.warn { "${lockfile.name} is missing any [[projects]] entries" }
             return emptyList()
         }
 
@@ -248,7 +248,7 @@ class GoDep(
             val revision = project["revision"]
 
             if (name !is String || revision !is String) {
-                log.warn { "Invalid [[projects]] entry in $lockfile: $entry" }
+                logger.warn { "Invalid [[projects]] entry in $lockfile: $entry" }
                 continue
             }
 

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -51,7 +51,7 @@ import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.stashDirectories
 import org.ossreviewtoolkit.utils.common.withoutSuffix
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * The [Go Modules](https://github.com/golang/go/wiki/Modules) package manager for Go.
@@ -167,7 +167,10 @@ class GoMod(
             val child = parseModuleEntry(columns[1])
 
             if (moduleInfo(parent.name).main && moduleInfo(child.name).indirect) {
-                log.debug { "Module '${child.name}' is an indirect dependency of '${parent.name}. Skip adding edge." }
+                logger.debug {
+                    "Module '${child.name}' is an indirect dependency of '${parent.name}. Skip adding edge."
+                }
+
                 return@forEach
             }
 
@@ -176,7 +179,9 @@ class GoMod(
 
         val vendorModules = getVendorModules(graph, projectDir)
         if (vendorModules.size < graph.size()) {
-            log.debug { "Removing ${graph.size() - vendorModules.size} non-vendor modules from the dependency graph." }
+            logger.debug {
+                "Removing ${graph.size() - vendorModules.size} non-vendor modules from the dependency graph."
+            }
 
             graph = graph.subgraph(vendorModules)
         }

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -55,7 +55,7 @@ import org.ossreviewtoolkit.model.utils.DependencyGraphBuilder
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.temporaryProperties
 import org.ossreviewtoolkit.utils.ort.createOrtTempFile
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 private val GRADLE_USER_HOME = Os.env["GRADLE_USER_HOME"]?.let { File(it) } ?: Os.userHomeDirectory.resolve(".gradle")
 
@@ -110,13 +110,13 @@ class Gradle(
             val artifactCoordinate = "${artifact.identifier()}:${artifact.classifier}:${artifact.extension}"
 
             if (artifactFiles.size > 1) {
-                log.debug { "Multiple Gradle cache entries matching '$artifactCoordinate' found: $artifactFiles" }
+                logger.debug { "Multiple Gradle cache entries matching '$artifactCoordinate' found: $artifactFiles" }
             }
 
             // Return the most recent file, if any, as that is most likely the correct one, e.g. in case of a silent
             // update of an already published artifact.
             return artifactFiles.firstOrNull()?.also { artifactFile ->
-                log.debug { "Using Gradle cache entry at '$artifactFile' for artifact '$artifactCoordinate'." }
+                logger.debug { "Using Gradle cache entry at '$artifactFile' for artifact '$artifactCoordinate'." }
             }
         }
 
@@ -204,21 +204,21 @@ class Gradle(
                     .get()
 
                 if (stdout.size() > 0) {
-                    log.debug {
+                    logger.debug {
                         "Analyzing the project in '$projectDir' produced the following standard output:\n" +
                                 stdout.toString().prependIndent("\t")
                     }
                 }
 
                 if (stderr.size() > 0) {
-                    log.warn {
+                    logger.warn {
                         "Analyzing the project in '$projectDir' produced the following error output:\n" +
                                 stderr.toString().prependIndent("\t")
                     }
                 }
 
                 if (!initScriptFile.delete()) {
-                    log.warn { "Init script file '$initScriptFile' could not be deleted." }
+                    logger.warn { "Init script file '$initScriptFile' could not be deleted." }
                 }
 
                 val repositories = dependencyTreeModel.repositories.map {
@@ -228,7 +228,7 @@ class Gradle(
 
                 dependencyHandler.repositories = repositories
 
-                log.debug {
+                logger.debug {
                     val projectName = dependencyTreeModel.name
                     "The Gradle project '$projectName' uses the following Maven repositories: $repositories"
                 }

--- a/analyzer/src/main/kotlin/managers/Pipenv.kt
+++ b/analyzer/src/main/kotlin/managers/Pipenv.kt
@@ -30,7 +30,7 @@ import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.ProcessCapture
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 class Pipenv(
     name: String,
@@ -67,7 +67,7 @@ class Pipenv(
         val workingDir = definitionFile.parentFile
         val requirementsFile = workingDir.resolve("requirements-from-pipenv.txt")
 
-        log.info { "Generating '${requirementsFile.name}' file in '$workingDir' directory..." }
+        logger.info { "Generating '${requirementsFile.name}' file in '$workingDir' directory..." }
 
         val requirements = ProcessCapture(workingDir, command(), "lock", "--requirements").requireSuccess().stdout
         requirementsFile.writeText(requirements)

--- a/analyzer/src/main/kotlin/managers/Poetry.kt
+++ b/analyzer/src/main/kotlin/managers/Poetry.kt
@@ -28,7 +28,7 @@ import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.ProcessCapture
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * [Poetry](https://python-poetry.org/) package manager for Python.
@@ -59,7 +59,7 @@ class Poetry(
         val workingDir = definitionFile.parentFile
         val requirementsFile = workingDir.resolve("requirements-from-poetry.txt")
 
-        log.info { "Generating '${requirementsFile.name}' file in '$workingDir' directory..." }
+        logger.info { "Generating '${requirementsFile.name}' file in '$workingDir' directory..." }
 
         val req = ProcessCapture(workingDir, command(), "export", "--without-hashes", "--format=requirements.txt")
             .requireSuccess().stdout

--- a/analyzer/src/main/kotlin/managers/Sbt.kt
+++ b/analyzer/src/main/kotlin/managers/Sbt.kt
@@ -40,7 +40,7 @@ import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.common.searchUpwardsForSubdirectory
 import org.ossreviewtoolkit.utils.common.suppressInput
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * The [SBT](https://www.scala-sbt.org/) package manager for Scala.
@@ -112,7 +112,7 @@ class Sbt(
         }
 
         if (versions.isEmpty()) {
-            log.warn { "No version match found in output:\n$output" }
+            logger.warn { "No version match found in output:\n$output" }
         }
 
         return checkForSameSbtVersion(versions)
@@ -127,7 +127,7 @@ class Sbt(
     private fun checkForSameSbtVersion(versions: List<Semver>): String {
         val uniqueVersions = versions.toSortedSet()
         if (uniqueVersions.size > 1) {
-            log.warn { "Different sbt versions used in the same project: $uniqueVersions" }
+            logger.warn { "Different sbt versions used in the same project: $uniqueVersions" }
         }
 
         return uniqueVersions.firstOrNull()?.toString().orEmpty()
@@ -139,7 +139,7 @@ class Sbt(
         // definition file paths.
         val workingDir = getCommonFileParent(definitionFiles) ?: analysisRoot
 
-        log.info { "Determined '$workingDir' as the $managerName project root directory." }
+        logger.info { "Determined '$workingDir' as the $managerName project root directory." }
 
         fun runSbt(vararg command: String) =
             suppressInput {
@@ -152,7 +152,7 @@ class Sbt(
         }
 
         if (internalProjectNames.isEmpty()) {
-            log.warn { "No SBT project found inside the '$workingDir' directory." }
+            logger.warn { "No SBT project found inside the '$workingDir' directory." }
         }
 
         // Generate the POM files. Note that a single run of makePom might create multiple POM files in case of
@@ -163,7 +163,7 @@ class Sbt(
         }
 
         if (pomFiles.isEmpty()) {
-            log.warn { "No generated POM files found inside the '$workingDir' directory." }
+            logger.warn { "No generated POM files found inside the '$workingDir' directory." }
         }
 
         return pomFiles.distinct().map { moveGeneratedPom(it) }
@@ -175,7 +175,7 @@ class Sbt(
         // definition file paths.
         val workingDir = getCommonFileParent(definitionFiles) ?: analysisRoot
 
-        log.info { "Determined '$workingDir' as the $managerName project root directory." }
+        logger.info { "Determined '$workingDir' as the $managerName project root directory." }
 
         // Determine the SBT version(s) being used.
         val rootPropertiesFile = workingDir.resolve("project").resolve("build.properties")
@@ -225,7 +225,7 @@ private fun moveGeneratedPom(pomFile: File): File {
     val targetFile = targetDirParent.resolve(targetFilename)
 
     if (runCatching { pomFile.toPath().moveTo(targetFile.toPath(), StandardCopyOption.ATOMIC_MOVE) }.isFailure) {
-        Sbt.log.error { "Moving '${pomFile.absolutePath}' to '${targetFile.absolutePath}' failed." }
+        Sbt.logger.error { "Moving '${pomFile.absolutePath}' to '${targetFile.absolutePath}' failed." }
         return pomFile
     }
 

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -51,7 +51,7 @@ import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.utils.common.getQueryParameters
 import org.ossreviewtoolkit.utils.common.toUri
 import org.ossreviewtoolkit.utils.common.withoutPrefix
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.spdx.model.SpdxDocument
@@ -131,7 +131,7 @@ private fun SpdxPackage.getRemoteArtifact(): RemoteArtifact? =
         SPDX_VCS_PREFIXES.any { (prefix, _) -> downloadLocation.startsWith(prefix) } -> null
         else -> {
             if (downloadLocation.endsWith(".git")) {
-                log.warn {
+                logger.warn {
                     "The download location $downloadLocation of SPDX package '$spdxId' looks like a Git repository " +
                             "URL but it lacks the 'git+' prefix and thus will be treated as an artifact URL."
                 }
@@ -471,7 +471,7 @@ class SpdxDocumentFile(
 
             val discardedFiles = definitionFiles - remainingFiles
             if (discardedFiles.isNotEmpty()) {
-                log.info {
+                logger.info {
                     "Discarded the following ${discardedFiles.size} non-project SPDX files: " +
                             discardedFiles.joinToString { "'$it'" }
                 }
@@ -494,7 +494,7 @@ class SpdxDocumentFile(
             }
         }
 
-        log.info {
+        logger.info {
             "File '$definitionFile' contains SPDX document '${spdxDocument.name}' which describes project " +
                     "'${projectPackage.name}'."
         }

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -48,7 +48,7 @@ import org.ossreviewtoolkit.utils.common.ProcessCapture
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.common.unquote
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * The [Stack](https://haskellstack.org/) package manager for Haskell.
@@ -121,7 +121,7 @@ class Stack(
                 dependencies.getOrPut(parent) { mutableListOf() } += child
             }
 
-            log.debug { "Parsed ${dependencies.size} dependency relations from graph." }
+            logger.debug { "Parsed ${dependencies.size} dependency relations from graph." }
 
             return dependencies
         }
@@ -131,7 +131,7 @@ class Stack(
             return dependencies.lines().associate {
                 Pair(it.substringBefore(' '), it.substringAfter(' '))
             }.also {
-                log.debug { "Parsed ${it.size} dependency versions from list." }
+                logger.debug { "Parsed ${it.size} dependency versions from list." }
             }
         }
 
@@ -205,7 +205,7 @@ class Stack(
 
                 buildDependencyTree(childName, allPackages, childMap, versionMap, packageRef.dependencies)
             }
-        } ?: log.debug { "No dependencies found for '$parentName'." }
+        } ?: logger.debug { "No dependencies found for '$parentName'." }
     }
 
     private fun getPackageUrl(name: String, version: String) =
@@ -215,7 +215,7 @@ class Stack(
         val url = "${getPackageUrl(pkgId.name, pkgId.version)}/src/${pkgId.name}.cabal"
 
         return OkHttpClientHelper.downloadText(url).onFailure {
-            log.warn { "Unable to retrieve Hackage metadata for package '${pkgId.toCoordinates()}'." }
+            logger.warn { "Unable to retrieve Hackage metadata for package '${pkgId.toCoordinates()}'." }
         }.getOrNull()
     }
 

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -32,7 +32,7 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.utils.parseRepoManifestPath
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * A fake [PackageManager] for projects that do not use any of the known package managers, or no package manager at all.
@@ -69,7 +69,7 @@ class Unmanaged(
             vcsInfo == VcsInfo.EMPTY -> {
                 // This seems to be an analysis of a local directory that is not under version control, i.e. that is not
                 // a VCS working tree. In this case we have no chance to get a version.
-                log.warn {
+                logger.warn {
                     "Analysis of local directory '$definitionFile' which is not under version control will produce " +
                             "non-cacheable results as no version for the cache key can be determined."
                 }

--- a/analyzer/src/main/kotlin/managers/Yarn.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn.kt
@@ -32,7 +32,7 @@ import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.utils.common.Os
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * The [Yarn](https://classic.yarnpkg.com/) package manager for JavaScript.
@@ -71,7 +71,7 @@ class Yarn(
     override fun getRemotePackageDetails(workingDir: File, packageName: String): JsonNode {
         val process = run(workingDir, "info", "--json", packageName)
         return jsonMapper.readTree(process.stdout)["data"] ?: jsonMapper.readTree(process.stderr)["data"].also {
-            log.warn { "Error running '${process.commandLine}' in directory $workingDir: $it" }
+            logger.warn { "Error running '${process.commandLine}' in directory $workingDir: $it" }
         }
     }
 }

--- a/analyzer/src/main/kotlin/managers/utils/MavenDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenDependencyHandler.kt
@@ -31,7 +31,7 @@ import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.model.utils.DependencyHandler
 import org.ossreviewtoolkit.utils.common.collectMessages
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 /**
@@ -75,7 +75,7 @@ class MavenDependencyHandler(
         }
 
         if (childrenWithoutToolDependencies.size < dependency.children.size) {
-            log.info { "Omitting the Java < 1.9 system dependency on 'tools.jar'." }
+            logger.info { "Omitting the Java < 1.9 system dependency on 'tools.jar'." }
         }
 
         return childrenWithoutToolDependencies

--- a/analyzer/src/main/kotlin/managers/utils/MavenLogger.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenLogger.kt
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.Level
 import org.codehaus.plexus.logging.AbstractLogger
 import org.codehaus.plexus.logging.Logger
 
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * Map a Log4j2 Level to a Plexus Logger level.
@@ -48,13 +48,13 @@ private fun toPlexusLoggerLevel(level: Level) =
 class MavenLogger(level: Level) : AbstractLogger(toPlexusLoggerLevel(level), "MavenLogger") {
     override fun getChildLogger(name: String?) = this
 
-    override fun debug(message: String, throwable: Throwable?) = log.debug(message, throwable)
+    override fun debug(message: String, throwable: Throwable?) = logger.debug(message, throwable)
 
-    override fun error(message: String, throwable: Throwable?) = log.error(message, throwable)
+    override fun error(message: String, throwable: Throwable?) = logger.error(message, throwable)
 
-    override fun fatalError(message: String, throwable: Throwable?) = log.error(message, throwable)
+    override fun fatalError(message: String, throwable: Throwable?) = logger.error(message, throwable)
 
-    override fun info(message: String, throwable: Throwable?) = log.info(message, throwable)
+    override fun info(message: String, throwable: Throwable?) = logger.info(message, throwable)
 
-    override fun warn(message: String, throwable: Throwable?) = log.warn(message, throwable)
+    override fun warn(message: String, throwable: Throwable?) = logger.warn(message, throwable)
 }

--- a/analyzer/src/main/kotlin/managers/utils/NodeSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NodeSupport.kt
@@ -32,7 +32,7 @@ import org.ossreviewtoolkit.analyzer.managers.Yarn2
 import org.ossreviewtoolkit.model.readTree
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.toUri
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 /**
@@ -160,7 +160,7 @@ private fun isYarnWorkspaceRoot(definitionFile: File) =
     } catch (e: JsonProcessingException) {
         e.showStackTrace()
 
-        NodeSupport.log.error {
+        NodeSupport.logger.error {
             "Could not parse '${definitionFile.invariantSeparatorsPath}': ${e.collectMessages()}"
         }
 
@@ -197,7 +197,7 @@ private fun getWorkspaceMatchers(definitionFile: File): List<PathMatcher> {
     } catch (e: JsonProcessingException) {
         e.showStackTrace()
 
-        NodeSupport.log.error {
+        NodeSupport.logger.error {
             "Could not parse '${definitionFile.invariantSeparatorsPath}': ${e.collectMessages()}"
         }
 

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -68,7 +68,7 @@ import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.searchUpwardsForFile
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.ort.await
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 internal const val OPTION_DIRECT_DEPENDENCIES_ONLY = "directDependenciesOnly"
 
@@ -137,9 +137,9 @@ class NuGetSupport(serviceIndexUrls: List<String> = listOf(DEFAULT_SERVICE_INDEX
 
         val response = client.newCall(request).await()
         if (response.cacheResponse != null) {
-            log.debug { "Retrieved '$url' response from local cache." }
+            logger.debug { "Retrieved '$url' response from local cache." }
         } else {
-            log.debug { "Retrieved '$url' response from remote server." }
+            logger.debug { "Retrieved '$url' response from remote server." }
         }
 
         val body = response.body?.string()?.takeIf { response.isSuccessful }
@@ -246,7 +246,7 @@ class NuGetSupport(serviceIndexUrls: List<String> = listOf(DEFAULT_SERVICE_INDEX
                         recursive = true
                     )
                 } else {
-                    log.debug {
+                    logger.debug {
                         "Truncating dependencies for '${id.toCoordinates()}' which were already determined."
                     }
                 }
@@ -395,7 +395,7 @@ class NuGetConfigFileReader {
 
         if (locals.isNotEmpty()) {
             // TODO: Handle local package sources.
-            log.warn { "Ignoring local NuGet package sources $locals." }
+            logger.warn { "Ignoring local NuGet package sources $locals." }
         }
 
         return remotes

--- a/analyzer/src/main/kotlin/managers/utils/PackageManagerDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/utils/PackageManagerDependencyHandler.kt
@@ -35,7 +35,7 @@ import org.ossreviewtoolkit.model.PackageReference
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.utils.DependencyHandler
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 private const val TYPE = "PackageManagerDependency"
 
@@ -121,7 +121,7 @@ private data class PackageManagerDependency(
     fun findProjects(analyzerResult: AnalyzerResult): List<Project> =
         analyzerResult.projects.filter { it.definitionFilePath == definitionFile }.also { projects ->
             if (projects.isEmpty()) {
-                log.warn { "Could not find any project for definition file '$definitionFile'." }
+                logger.warn { "Could not find any project for definition file '$definitionFile'." }
             }
 
             projects.forEach { verify(it) }
@@ -148,7 +148,7 @@ private data class PackageManagerDependency(
         }
 
         if (scope !in project.scopeNames.orEmpty()) {
-            log.warn {
+            logger.warn {
                 "The project '${project.id.toCoordinates()}' from definition file '$definitionFile' does not contain " +
                         "the requested scope '$scope'."
             }

--- a/analyzer/src/main/kotlin/managers/utils/PubCacheReader.kt
+++ b/analyzer/src/main/kotlin/managers/utils/PubCacheReader.kt
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.isSymbolicLink
 import org.ossreviewtoolkit.utils.common.textValueOrEmpty
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * A reader for the Pub cache directory. It looks for files in the ".pub-cache" directory in the user's home
@@ -95,7 +95,7 @@ internal class PubCacheReader {
 
             "git/$projectName-$resolvedRef"
         } else {
-            log.error { "Could not find projectRoot of '$packageName'." }
+            logger.error { "Could not find projectRoot of '$packageName'." }
 
             // Unsupported type.
             return null

--- a/analyzer/src/main/kotlin/managers/utils/SpdxDocumentCache.kt
+++ b/analyzer/src/main/kotlin/managers/utils/SpdxDocumentCache.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.analyzer.managers.utils
 import java.io.File
 
 import org.ossreviewtoolkit.analyzer.managers.SpdxDocumentFile
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.spdx.SpdxModelMapper
 import org.ossreviewtoolkit.utils.spdx.model.SpdxDocument
 
@@ -45,7 +45,7 @@ internal class SpdxDocumentCache {
      */
     fun load(file: File): Result<SpdxDocument> =
         documentCache.getOrPut(file) {
-            log.info { "Loading SpdxDocument from '$file'." }
+            logger.info { "Loading SpdxDocument from '$file'." }
 
             runCatching { SpdxModelMapper.read(file) }
         }

--- a/analyzer/src/main/kotlin/managers/utils/SpdxResolvedDocument.kt
+++ b/analyzer/src/main/kotlin/managers/utils/SpdxResolvedDocument.kt
@@ -34,7 +34,7 @@ import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.ort.addBasicAuthorization
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 import org.ossreviewtoolkit.utils.ort.downloadFile
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.requestPasswordAuthentication
 import org.ossreviewtoolkit.utils.spdx.model.SpdxDocument
 import org.ossreviewtoolkit.utils.spdx.model.SpdxExternalDocumentReference
@@ -333,7 +333,7 @@ private fun SpdxExternalDocumentReference.resolveFromDownload(
     baseUri: URI,
     managerName: String
 ): ResolutionResult {
-    log.info { "Downloading SPDX document from $uri (referred from $baseUri as part of '$externalDocumentId')." }
+    logger.info { "Downloading SPDX document from $uri (referred from $baseUri as part of '$externalDocumentId')." }
 
     val tempDir = createOrtTempDir()
     return try {

--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -52,7 +52,7 @@ import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_DIR_ENV_NAME
 import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_DATA_DIR_ENV_NAME
 import org.ossreviewtoolkit.utils.ort.ORT_NAME
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 import org.ossreviewtoolkit.utils.ort.ortDataDirectory
 import org.ossreviewtoolkit.utils.ort.printStackTrace
@@ -173,7 +173,7 @@ class OrtMain : CliktCommand(name = ORT_NAME, invokeWithoutSubcommand = true) {
     override fun run() {
         Configurator.setRootLevel(logLevel)
 
-        log.debug { "Used command line arguments: ${currentContext.originalArgv}" }
+        logger.debug { "Used command line arguments: ${currentContext.originalArgv}" }
 
         // Make the parameter globally available.
         printStackTrace = stacktrace

--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -64,7 +64,7 @@ import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CURATIONS_DIRNAME
 import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CURATIONS_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
 private val allPackageManagersByName = PackageManager.ALL.associateBy { it.managerName }
@@ -244,7 +244,7 @@ class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine depende
             if (config.enableRepositoryPackageCurations) {
                 add(SimplePackageCurationProvider(repositoryPackageCurations))
             } else if (repositoryPackageCurations.isNotEmpty()) {
-                this@AnalyzerCommand.log.warn {
+                this@AnalyzerCommand.logger.warn {
                     "Existing package curations from '$ORT_REPO_CONFIG_FILENAME' are not applied because the feature " +
                             "is disabled."
                 }

--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -71,7 +71,7 @@ import org.ossreviewtoolkit.utils.common.packZip
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_LICENSE_CLASSIFICATIONS_FILENAME
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.ossreviewtoolkit.utils.spdx.model.SpdxLicenseChoice
@@ -188,7 +188,7 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
         }
 
         if (failureMessages.isNotEmpty()) {
-            log.error {
+            logger.error {
                 "The following failure(s) occurred:\n" + failureMessages.joinToString("\n--\n")
             }
 
@@ -206,7 +206,7 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
         val analyzerResult = ortResult.analyzer?.result
 
         if (analyzerResult == null) {
-            log.warn {
+            logger.warn {
                 "Cannot run the downloader as the provided ORT result file '${ortFile.canonicalPath}' does " +
                         "not contain an analyzer result. Nothing will be downloaded."
             }
@@ -224,7 +224,7 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
             }
         }
 
-        log.info { "Found ${packages.size} package(s)." }
+        logger.info { "Found ${packages.size} package(s)." }
 
         packageIds?.also {
             val originalCount = packages.size
@@ -234,7 +234,7 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
 
             if (isModified) {
                 val diffCount = originalCount - packages.size
-                log.info { "Removed $diffCount package(s) which do not match the specified id pattern." }
+                logger.info { "Removed $diffCount package(s) which do not match the specified id pattern." }
             }
         }
 
@@ -259,11 +259,11 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
 
             if (isModified) {
                 val diffCount = originalCount - packages.size
-                log.info { "Removed $diffCount package(s) which do not match the specified license classification." }
+                logger.info { "Removed $diffCount package(s) which do not match the specified license classification." }
             }
         }
 
-        log.info { "Downloading ${packages.size} package(s)." }
+        logger.info { "Downloading ${packages.size} package(s)." }
 
         val packageDownloadDirs = packages.associateWith { outputDir.resolve(it.id.toPath()) }
 
@@ -274,7 +274,7 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
                 if (archiveMode == ArchiveMode.ENTITY) {
                     val zipFile = outputDir.resolve("${pkg.id.toPath("-")}.zip")
 
-                    log.info { "Archiving directory '$dir' to '$zipFile'." }
+                    logger.info { "Archiving directory '$dir' to '$zipFile'." }
                     val result = runCatching {
                         dir.packZip(
                             zipFile,
@@ -283,7 +283,7 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
                     }
 
                     result.exceptionOrNull()?.let {
-                        log.error { "Could not archive '$dir': ${it.collectMessages()}" }
+                        logger.error { "Could not archive '$dir': ${it.collectMessages()}" }
                     }
 
                     dir.safeDeleteRecursively(baseDirectory = outputDir)
@@ -295,18 +295,18 @@ class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source c
                         e.collectMessages()
                 failureMessages += failureMessage
 
-                log.error { failureMessage }
+                logger.error { failureMessage }
             }
         }
 
         if (archiveMode == ArchiveMode.BUNDLE) {
             val zipFile = outputDir.resolve("archive.zip")
 
-            log.info { "Archiving directory '$outputDir' to '$zipFile'." }
+            logger.info { "Archiving directory '$outputDir' to '$zipFile'." }
             val result = runCatching { outputDir.packZip(zipFile) }
 
             result.exceptionOrNull()?.let {
-                log.error { "Could not archive '$outputDir': ${it.collectMessages()}" }
+                logger.error { "Could not archive '$outputDir': ${it.collectMessages()}" }
             }
 
             packageDownloadDirs.forEach { (_, dir) ->

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -78,7 +78,7 @@ import org.ossreviewtoolkit.utils.ort.ORT_EVALUATOR_RULES_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_LICENSE_CLASSIFICATIONS_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
 class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate ORT result files against policy rules.") {
@@ -291,7 +291,7 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate ORT re
             )
         } else {
             if (ortResultInput.repository.config.packageConfigurations.isNotEmpty()) {
-                log.info { "Local package configurations were not applied because the feature is not enabled." }
+                logger.info { "Local package configurations were not applied because the feature is not enabled." }
             }
 
             packageConfigurationOption.createProvider()
@@ -314,7 +314,7 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate ORT re
 
         val (evaluatorRun, duration) = measureTimedValue { evaluator.run(script) }
 
-        log.info { "Executed the evaluator in $duration." }
+        logger.info { "Executed the evaluator in $duration." }
 
         evaluatorRun.violations.forEach { violation ->
             println(violation.format())

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -77,7 +77,7 @@ import org.ossreviewtoolkit.utils.ort.ORT_HOW_TO_FIX_TEXT_PROVIDER_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_LICENSE_CLASSIFICATIONS_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
@@ -226,7 +226,7 @@ class ReporterCommand : CliktCommand(
             )
         } else {
             if (ortResult.repository.config.packageConfigurations.isNotEmpty()) {
-                log.info { "Local package configurations were not applied because the feature is not enabled." }
+                logger.info { "Local package configurations were not applied because the feature is not enabled." }
             }
 
             packageConfigurationOption.createProvider()
@@ -302,7 +302,7 @@ class ReporterCommand : CliktCommand(
             }.onFailure { e ->
                 e.showStackTrace()
 
-                log.error {
+                logger.error {
                     "Could not create '$name' report in ${timedValue.duration}: ${e.collectMessages()}"
                 }
 

--- a/cli/src/main/kotlin/commands/RequirementsCommand.kt
+++ b/cli/src/main/kotlin/commands/RequirementsCommand.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.Scanner
 import org.ossreviewtoolkit.utils.common.CommandLineTool
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.spdx.scanCodeLicenseTextDir
 
 import org.reflections.Reflections
@@ -54,13 +54,13 @@ class RequirementsCommand : CliktCommand(help = "Check for the command line tool
                 var category = "Other tool"
                 val instance = when {
                     kotlinObject != null -> {
-                        log.debug { "$it is a Kotlin object." }
+                        logger.debug { "$it is a Kotlin object." }
                         kotlinObject
                     }
 
                     PackageManager::class.java.isAssignableFrom(it) -> {
                         category = "PackageManager"
-                        log.debug { "$it is a $category." }
+                        logger.debug { "$it is a $category." }
                         it.getDeclaredConstructor(
                             String::class.java,
                             File::class.java,
@@ -76,7 +76,7 @@ class RequirementsCommand : CliktCommand(help = "Check for the command line tool
 
                     Scanner::class.java.isAssignableFrom(it) -> {
                         category = "Scanner"
-                        log.debug { "$it is a $category." }
+                        logger.debug { "$it is a $category." }
                         it.getDeclaredConstructor(
                             String::class.java,
                             ScannerConfiguration::class.java,
@@ -86,12 +86,12 @@ class RequirementsCommand : CliktCommand(help = "Check for the command line tool
 
                     VersionControlSystem::class.java.isAssignableFrom(it) -> {
                         category = "VersionControlSystem"
-                        log.debug { "$it is a $category." }
+                        logger.debug { "$it is a $category." }
                         it.getDeclaredConstructor().newInstance()
                     }
 
                     else -> {
-                        log.debug { "Trying to instantiate $it without any arguments." }
+                        logger.debug { "Trying to instantiate $it without any arguments." }
                         it.getDeclaredConstructor().newInstance()
                     }
                 }
@@ -100,7 +100,7 @@ class RequirementsCommand : CliktCommand(help = "Check for the command line tool
                     allTools.getOrPut(category) { mutableListOf() } += instance
                 }
             }.onFailure { e ->
-                log.error { "There was an error instantiating $it: $e." }
+                logger.error { "There was an error instantiating $it: $e." }
                 throw ProgramResult(1)
             }
         }

--- a/cli/src/main/kotlin/commands/UploadCurationsCommand.kt
+++ b/cli/src/main/kotlin/commands/UploadCurationsCommand.kt
@@ -55,7 +55,7 @@ import org.ossreviewtoolkit.model.utils.toClearlyDefinedCoordinates
 import org.ossreviewtoolkit.model.utils.toClearlyDefinedSourceLocation
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 import retrofit2.HttpException
 
@@ -87,7 +87,7 @@ class UploadCurationsCommand : CliktCommand(
                 val errorResponse = jsonMapper.readValue<ErrorResponse>(it.string())
                 val innerError = errorResponse.error.innererror
 
-                log.debug { innerError.stack }
+                logger.debug { innerError.stack }
 
                 "The HTTP service call failed with: ${innerError.message}"
             } ?: "The HTTP service call failed with code ${e.code()}: ${e.message()}"
@@ -115,7 +115,7 @@ class UploadCurationsCommand : CliktCommand(
         val definitions = service.call { getDefinitions(curationsToCoordinates.values) }
 
         val curationsByHarvestStatus = curations.groupBy { curation ->
-            definitions[curationsToCoordinates[curation]]?.getHarvestStatus() ?: log.warn {
+            definitions[curationsToCoordinates[curation]]?.getHarvestStatus() ?: logger.warn {
                 "No definition data available for package '${curation.id.toCoordinates()}', cannot request a harvest " +
                         "or upload curations for it."
             }

--- a/cli/src/main/kotlin/commands/UploadResultToSw360Command.kt
+++ b/cli/src/main/kotlin/commands/UploadResultToSw360Command.kt
@@ -55,7 +55,7 @@ import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.common.packZip
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 class UploadResultToSw360Command : CliktCommand(
     name = "upload-result-to-sw360",
@@ -123,12 +123,12 @@ class UploadResultToSw360Command : CliktCommand(
                         )
 
                         if (uploadResult.isSuccess) {
-                            log.info {
+                            logger.info {
                                 "Successfully uploaded source attachment '${zipFile.name}' to release " +
                                         "${release.id}:${release.name}"
                             }
                         } else {
-                            log.error { "Could not upload source attachment: " + uploadResult.failedUploads() }
+                            logger.error { "Could not upload source attachment: " + uploadResult.failedUploads() }
                         }
                     } finally {
                         tempDirectory.safeDeleteRecursively(force = true)
@@ -156,10 +156,10 @@ class UploadResultToSw360Command : CliktCommand(
 
         return try {
             client.createProject(sw360Project)?.also {
-                log.debug { "Project '${it.name}-${it.version}' created in SW360." }
+                logger.debug { "Project '${it.name}-${it.version}' created in SW360." }
             }
         } catch (e: SW360ClientException) {
-            log.error {
+            logger.error {
                 "Could not create the project '${project.id.toCoordinates()}' in SW360: " + e.collectMessages()
             }
 
@@ -173,7 +173,7 @@ class UploadResultToSw360Command : CliktCommand(
 
         val unmappedLicenses = pkg.declaredLicensesProcessed.unmapped.toSortedSet()
         if (unmappedLicenses.isNotEmpty()) {
-            log.warn {
+            logger.warn {
                 "The following licenses could not be mapped in order to create a SW360 release: $unmappedLicenses"
             }
         }
@@ -185,10 +185,10 @@ class UploadResultToSw360Command : CliktCommand(
 
         return try {
             client.createRelease(sw360Release)?.also {
-                log.debug { "Release '${it.name}-${it.version}' created in SW360." }
+                logger.debug { "Release '${it.name}-${it.version}' created in SW360." }
             }
         } catch (e: SW360ClientException) {
-            log.error {
+            logger.error {
                 "Could not create the release for '${pkg.id.toCoordinates()}' in SW360: " + e.collectMessages()
             }
 

--- a/cli/src/main/kotlin/utils/Extensions.kt
+++ b/cli/src/main/kotlin/utils/Extensions.kt
@@ -32,7 +32,7 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.writeValue
 import org.ossreviewtoolkit.utils.common.formatSizeInMib
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 fun <T : GroupableOption> T.group(name: String): T = apply { groupName = name }
 
@@ -46,11 +46,11 @@ fun <T : GroupableOption> T.configurationGroup(): T = group(OPTION_GROUP_CONFIGU
  * Read [ortFile] into an [OrtResult] and return it.
  */
 fun CliktCommand.readOrtResult(ortFile: File): OrtResult {
-    log.debug { "Input ORT result file has SHA-1 hash ${HashAlgorithm.SHA1.calculate(ortFile)}." }
+    logger.debug { "Input ORT result file has SHA-1 hash ${HashAlgorithm.SHA1.calculate(ortFile)}." }
 
     val (ortResult, duration) = measureTimedValue { ortFile.readValue<OrtResult>() }
 
-    log.info { "Read ORT result from '${ortFile.name}' (${ortFile.formatSizeInMib}) in $duration." }
+    logger.info { "Read ORT result from '${ortFile.name}' (${ortFile.formatSizeInMib}) in $duration." }
 
     return ortResult
 }
@@ -63,8 +63,8 @@ fun CliktCommand.writeOrtResult(ortResult: OrtResult, outputFiles: Collection<Fi
         println("Writing $resultName result to '$file'.")
         val duration = measureTime { file.writeValue(ortResult) }
 
-        log.info { "Wrote ORT result to '${file.name}' (${file.formatSizeInMib}) in $duration." }
+        logger.info { "Wrote ORT result to '${file.name}' (${file.formatSizeInMib}) in $duration." }
 
-        log.debug { "Output ORT result file has SHA-1 hash ${HashAlgorithm.SHA1.calculate(file)}." }
+        logger.debug { "Output ORT result file has SHA-1 hash ${HashAlgorithm.SHA1.calculate(file)}." }
     }
 }

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -34,7 +34,7 @@ import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.uppercaseFirstChar
 import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 abstract class VersionControlSystem {
@@ -115,7 +115,7 @@ abstract class VersionControlSystem {
                     } catch (e: IOException) {
                         e.showStackTrace()
 
-                        log.debug {
+                        logger.debug {
                             "Exception while validating ${it.vcsType} working tree, treating it as non-applicable: " +
                                     e.collectMessages()
                         }
@@ -236,7 +236,7 @@ abstract class VersionControlSystem {
         val results = mutableListOf<Result<String>>()
 
         for ((index, revision) in revisionCandidates.withIndex()) {
-            log.info { "Trying revision candidate '$revision' (${index + 1} of ${revisionCandidates.size})..." }
+            logger.info { "Trying revision candidate '$revision' (${index + 1} of ${revisionCandidates.size})..." }
             results += updateWorkingTree(workingTree, revision, pkg.vcsProcessed.path, recursive)
             if (results.last().isSuccess) break
         }
@@ -254,7 +254,7 @@ abstract class VersionControlSystem {
             }
         }
 
-        log.info {
+        logger.info {
             "Successfully downloaded revision $workingTreeRevision for package '${pkg.id.toCoordinates()}.'."
         }
 
@@ -289,14 +289,14 @@ abstract class VersionControlSystem {
             pkg.vcsProcessed.revision.also {
                 if (it.isNotBlank() && (allowMovingRevisions || isFixedRevision(workingTree, it))) {
                     if (revisionCandidates.add(it)) {
-                        log.info {
+                        logger.info {
                             "Adding $type revision '$it' (taken from package metadata) as a candidate."
                         }
                     }
                 }
             }
         }.onFailure {
-            log.info {
+            logger.info {
                 "Metadata has invalid $type revision '${pkg.vcsProcessed.revision}': ${it.collectMessages()}"
             }
 
@@ -307,14 +307,14 @@ abstract class VersionControlSystem {
             runCatching {
                 workingTree.guessRevisionName(project, version).also {
                     if (revisionCandidates.add(it)) {
-                        log.info {
+                        logger.info {
                             "Adding $type revision '$it' (guessed from package '$project' and version '$version') as " +
                                     "a candidate."
                         }
                     }
                 }
             }.onFailure {
-                log.info {
+                logger.info {
                     "No $type revision for package '$project' and version '$version' found: " +
                             it.collectMessages()
                 }

--- a/downloader/src/main/kotlin/vcs/GitRepo.kt
+++ b/downloader/src/main/kotlin/vcs/GitRepo.kt
@@ -40,7 +40,7 @@ import org.ossreviewtoolkit.utils.common.isSymbolicLink
 import org.ossreviewtoolkit.utils.common.realFile
 import org.ossreviewtoolkit.utils.common.searchUpwardsForSubdirectory
 import org.ossreviewtoolkit.utils.common.withoutPrefix
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 /**
@@ -154,7 +154,7 @@ class GitRepo : VersionControlSystem(), CommandLineTool {
             manifestPath?.let { listOf("-m", it) }
         ).flatten()
 
-        log.info {
+        logger.info {
             val revisionDetails = manifestRevision?.let { " with revision '$it'" }.orEmpty()
             val pathDetails = manifestPath?.let { " using manifest '$it'" }.orEmpty()
             "Initializing git-repo from $repoUrl$revisionDetails$pathDetails."
@@ -203,11 +203,11 @@ class GitRepo : VersionControlSystem(), CommandLineTool {
 
             runRepo(workingTree.workingDir, *syncArgs.toTypedArray())
 
-            log.debug { runRepo(workingTree.workingDir, "info").stdout }
+            logger.debug { runRepo(workingTree.workingDir, "info").stdout }
         }.onFailure { e ->
             e.showStackTrace()
 
-            log.warn {
+            logger.warn {
                 val revisionDetails = manifestRevision?.let { " to revision '$it'" }.orEmpty()
                 val pathDetails = manifestPath?.let { " using manifest '$it'" }.orEmpty()
                 "Failed to sync the working tree$revisionDetails$pathDetails: ${e.collectMessages()}"

--- a/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
+++ b/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
@@ -32,7 +32,7 @@ import org.eclipse.jgit.submodule.SubmoduleWalk
 import org.ossreviewtoolkit.downloader.WorkingTree
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 private fun findGitOrSubmoduleDir(workingDirOrFile: File): Repository {
     val workingDir = (workingDirOrFile.takeIf { it.isDirectory } ?: workingDirOrFile.parentFile).absoluteFile
@@ -66,7 +66,10 @@ open class GitWorkingTree(workingDir: File, vcsType: VcsType) : WorkingTree(work
                     paths += path
 
                     if (walk.repository == null) {
-                        log.info { "Git submodule at '$path' not initialized. Cannot recursively list its submodules." }
+                        logger.info {
+                            "Git submodule at '$path' not initialized. Cannot recursively list its submodules."
+                        }
+
                         continue
                     }
 

--- a/downloader/src/main/kotlin/vcs/Mercurial.kt
+++ b/downloader/src/main/kotlin/vcs/Mercurial.kt
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.ProcessCapture
 import org.ossreviewtoolkit.utils.common.collectMessages
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 const val MERCURIAL_LARGE_FILES_EXTENSION = "largefiles = "
@@ -117,7 +117,7 @@ class Mercurial : VersionControlSystem(), CommandLineTool {
         )
 
         if (MERCURIAL_SPARSE_EXTENSION in extensionsList) {
-            log.info { "Configuring Mercurial to do sparse checkout of path '${vcs.path}'." }
+            logger.info { "Configuring Mercurial to do sparse checkout of path '${vcs.path}'." }
 
             // Mercurial does not accept absolute paths.
             val globPatterns = getSparseCheckoutGlobPatterns() + "${vcs.path}/**"
@@ -142,7 +142,7 @@ class Mercurial : VersionControlSystem(), CommandLineTool {
         }.onFailure {
             it.showStackTrace()
 
-            log.warn { "Failed to update $type working tree to revision '$revision': ${it.collectMessages()}" }
+            logger.warn { "Failed to update $type working tree to revision '$revision': ${it.collectMessages()}" }
         }.map {
             revision
         }

--- a/downloader/src/main/kotlin/vcs/Subversion.kt
+++ b/downloader/src/main/kotlin/vcs/Subversion.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.ort.OrtAuthenticator
 import org.ossreviewtoolkit.utils.ort.OrtProxySelector
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.requestPasswordAuthentication
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
@@ -112,7 +112,7 @@ class Subversion : VersionControlSystem() {
                 } catch (e: SVNException) {
                     e.showStackTrace()
 
-                    log.info { "Unable to list remote refs for $type repository at $remoteUrl." }
+                    logger.info { "Unable to list remote refs for $type repository at $remoteUrl." }
                 }
 
                 return refs
@@ -134,7 +134,7 @@ class Subversion : VersionControlSystem() {
         } catch (e: SVNException) {
             e.showStackTrace()
 
-            log.debug {
+            logger.debug {
                 "An exception was thrown when checking $vcsUrl for a $type repository: ${e.collectMessages()}"
             }
 
@@ -229,7 +229,7 @@ class Subversion : VersionControlSystem() {
         }.onFailure {
             it.showStackTrace()
 
-            log.warn {
+            logger.warn {
                 "Failed to update the $type working tree at '${workingTree.workingDir}' to revision '$revision':\n" +
                         it.collectMessages()
             }

--- a/evaluator/src/main/kotlin/Rule.kt
+++ b/evaluator/src/main/kotlin/Rule.kt
@@ -25,7 +25,7 @@ import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.Severity
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
 
 /**
@@ -65,8 +65,8 @@ abstract class Rule(
      */
     private fun matches() = matchers.all { matcher ->
         matcher.matches().also { matches ->
-            log.info { "\t${matcher.description} == $matches" }
-            if (!matches) log.info { "\tRule skipped." }
+            logger.info { "\t${matcher.description} == $matches" }
+            if (!matches) logger.info { "\tRule skipped." }
         }
     }
 
@@ -75,13 +75,13 @@ abstract class Rule(
      * rule are added to the [ruleSet]. To add custom behavior if the rule matches override [runInternal].
      */
     fun evaluate() {
-        log.info { description }
+        logger.info { description }
 
         if (matches()) {
             ruleSet.violations += violations
 
             if (violations.isNotEmpty()) {
-                log.info {
+                logger.info {
                     "\tFound violations:\n\t\t${violations.joinToString("\n\t\t") { "${it.severity}: ${it.message}" }}"
                 }
             }

--- a/evaluator/src/main/kotlin/RuleSet.kt
+++ b/evaluator/src/main/kotlin/RuleSet.kt
@@ -28,7 +28,7 @@ import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.model.utils.ResolutionProvider
 import org.ossreviewtoolkit.model.utils.createLicenseInfoResolver
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * A set of evaluator [Rule]s, using an [ortResult] as input.
@@ -86,7 +86,7 @@ class RuleSet(
             visitedPackages: MutableSet<DependencyNode>
         ) {
             if (node in visitedPackages) {
-                log.debug { "Skipping rule $name for already visited dependency ${node.id.toCoordinates()}." }
+                logger.debug { "Skipping rule $name for already visited dependency ${node.id.toCoordinates()}." }
                 return
             }
 
@@ -96,7 +96,7 @@ class RuleSet(
                 ?: ortResult.getProject(node.id)?.toPackage()?.toCuratedPackage()
 
             if (curatedPackage == null) {
-                log.warn { "Could not find package for dependency ${node.id.toCoordinates()}, skipping rule $name." }
+                logger.warn { "Could not find package for dependency ${node.id.toCoordinates()}, skipping rule $name." }
             } else {
                 val resolvedLicenseInfo = licenseInfoResolver.resolveLicenseInfo(curatedPackage.pkg.id)
 

--- a/helper-cli/src/main/kotlin/commands/ListStoredScanResultsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListStoredScanResultsCommand.kt
@@ -34,7 +34,7 @@ import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
 internal class ListStoredScanResultsCommand : CliktCommand(
@@ -67,7 +67,7 @@ internal class ListStoredScanResultsCommand : CliktCommand(
         println("Searching for scan results of '${packageId.toCoordinates()}' in ${ScanResultsStorage.storage.name}.")
 
         val scanResults = ScanResultsStorage.storage.read(packageId).getOrElse {
-            log.error { "Could not read scan results: ${it.message}" }
+            logger.error { "Could not read scan results: ${it.message}" }
             throw ProgramResult(1)
         }
 

--- a/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/scanstorage/DeleteCommand.kt
@@ -49,7 +49,7 @@ import org.ossreviewtoolkit.model.utils.rawParam
 import org.ossreviewtoolkit.scanner.storages.utils.ScanResults
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
 internal class DeleteCommand : CliktCommand(
@@ -139,10 +139,10 @@ internal class DeleteCommand : CliktCommand(
 
             println("Would delete $count scan result(s).")
 
-            if (log.delegate.isDebugEnabled) {
+            if (logger.delegate.isDebugEnabled) {
                 database.transaction {
                     ScanResults.slice(ScanResults.identifier).select { condition }
-                        .forEach(this@DeleteCommand.log::debug)
+                        .forEach(this@DeleteCommand.logger::debug)
                 }
             }
         } else {
@@ -158,7 +158,7 @@ internal class DeleteCommand : CliktCommand(
         val storageConfig = config.scanner.storages?.get("postgresStorage") as? PostgresStorageConfiguration
             ?: throw IllegalArgumentException("postgresStorage not configured.")
 
-        log.info {
+        logger.info {
             "Using Postgres storage with URL '${storageConfig.connection.url}' and schema " +
                     "'${storageConfig.connection.schema}'."
         }

--- a/model/src/main/kotlin/OrtIssue.kt
+++ b/model/src/main/kotlin/OrtIssue.kt
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import java.time.Instant
 
 import org.ossreviewtoolkit.utils.common.normalizeLineBreaks
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * An issue that occurred while executing ORT.
@@ -76,6 +76,6 @@ inline fun <reified T : Any> T.createAndLogIssue(
 ): OrtIssue {
     val issue = severity?.let { OrtIssue(source = source, message = message, severity = it) }
         ?: OrtIssue(source = source, message = message)
-    log.log(issue.severity.toLog4jLevel()) { message }
+    logger.log(issue.severity.toLog4jLevel()) { message }
     return issue
 }

--- a/model/src/main/kotlin/PackageCuration.kt
+++ b/model/src/main/kotlin/PackageCuration.kt
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.vdurmont.semver4j.Requirement
 import com.vdurmont.semver4j.Semver
 
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 /**
@@ -67,7 +67,7 @@ data class PackageCuration(
             //       https://github.com/vdurmont/semver4j/issues/67.
             Requirement.buildIvy(id.version).isSatisfiedBy(Semver(pkgId.version, Semver.SemverType.LOOSE))
         }.onFailure {
-            log.warn {
+            logger.warn {
                 "Failed to check if package curation version '${id.version}' is applicable to package version " +
                         "'${pkgId.version}' of package '${pkgId.toCoordinates()}'."
             }

--- a/model/src/main/kotlin/config/FileArchiverConfiguration.kt
+++ b/model/src/main/kotlin/config/FileArchiverConfiguration.kt
@@ -28,7 +28,7 @@ import org.ossreviewtoolkit.model.utils.DatabaseUtils
 import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.model.utils.FileArchiverFileStorage
 import org.ossreviewtoolkit.model.utils.PostgresFileArchiverStorage
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.storage.FileStorage
 import org.ossreviewtoolkit.utils.ort.storage.LocalFileStorage
 
@@ -56,7 +56,7 @@ data class FileArchiverConfiguration(
 ) {
     init {
         if (fileStorage != null && postgresStorage != null) {
-            log.warn {
+            logger.warn {
                 "'fileStorage' and 'postgresStorage' are both configured but only one storage can be used. Using " +
                         "'fileStorage'."
             }

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -28,7 +28,7 @@ import com.sksamuel.hoplite.fp.getOrElse
 import java.io.File
 
 import org.ossreviewtoolkit.model.Severity
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * The configuration model for all ORT components.
@@ -111,7 +111,7 @@ data class OrtConfiguration(
         fun load(args: Map<String, String>? = null, file: File? = null): OrtConfiguration {
             val sources = listOfNotNull(
                 args?.filterKeys { it.startsWith("ort.") }?.takeUnless { it.isEmpty() }?.let {
-                    log.info {
+                    logger.info {
                         val argsList = it.map { (k, v) -> "\t$k=$v" }
                         "Using ORT configuration arguments:\n" + argsList.joinToString("\n")
                     }
@@ -119,7 +119,7 @@ data class OrtConfiguration(
                     PropertySource.map(it)
                 },
                 file?.takeIf { it.isFile }?.let {
-                    log.info { "Using ORT configuration file '$it'." }
+                    logger.info { "Using ORT configuration file '$it'." }
                     PropertySource.file(it)
                 }
             )

--- a/model/src/main/kotlin/config/ProvenanceStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/ProvenanceStorageConfiguration.kt
@@ -19,7 +19,7 @@
 
 package org.ossreviewtoolkit.model.config
 
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * Configuration of the storage to use for provenance information.
@@ -37,7 +37,7 @@ data class ProvenanceStorageConfiguration(
 ) {
     init {
         if (fileStorage != null && postgresStorage != null) {
-            log.warn {
+            logger.warn {
                 "'fileStorage' and 'postgresStorage' are both configured but only one storage can be used. Using " +
                         "'fileStorage'."
             }

--- a/model/src/main/kotlin/utils/DatabaseUtils.kt
+++ b/model/src/main/kotlin/utils/DatabaseUtils.kt
@@ -35,7 +35,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 
 import org.ossreviewtoolkit.model.config.PostgresConnection
 import org.ossreviewtoolkit.utils.ort.ORT_FULL_NAME
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 object DatabaseUtils {
     /**
@@ -99,7 +99,7 @@ object DatabaseUtils {
             if (resultSet.next()) {
                 val clientEncoding = resultSet.getString(1)
                 if (clientEncoding != expectedEncoding) {
-                    DatabaseUtils.log.warn {
+                    DatabaseUtils.logger.warn {
                         "The database's client_encoding is '$clientEncoding' but should be '$expectedEncoding'."
                     }
                 }

--- a/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
@@ -31,7 +31,7 @@ import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.RootDependencyIndex
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * Internal class to represent the result of a search in the dependency graph. The outcome of the search
@@ -185,7 +185,7 @@ class DependencyGraphBuilder<D>(
         val edgesToRemove = edges - edgesToKeep
 
         edgesToRemove.forEach {
-            this@DependencyGraphBuilder.log.warn { "Removing edge '${it.from} -> ${it.to}' to break a cycle." }
+            this@DependencyGraphBuilder.logger.warn { "Removing edge '${it.from} -> ${it.to}' to break a cycle." }
         }
 
         return filter { it in edgesToKeep }

--- a/model/src/main/kotlin/utils/FileArchiver.kt
+++ b/model/src/main/kotlin/utils/FileArchiver.kt
@@ -31,7 +31,7 @@ import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.packZip
 import org.ossreviewtoolkit.utils.common.unpackZip
 import org.ossreviewtoolkit.utils.ort.createOrtTempFile
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.ortDataDirectory
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.ossreviewtoolkit.utils.ort.storage.FileStorage
@@ -82,7 +82,7 @@ class FileArchiver(
      * Archive all files in [directory] matching any of the configured patterns in the [storage].
      */
     fun archive(directory: File, provenance: KnownProvenance) {
-        log.info { "Archiving files matching ${matcher.patterns} from '$directory'..." }
+        logger.info { "Archiving files matching ${matcher.patterns} from '$directory'..." }
 
         val zipFile = createOrtTempFile(suffix = ".zip")
 
@@ -91,7 +91,7 @@ class FileArchiver(
                 val relativePath = file.relativeTo(directory).invariantSeparatorsPath
 
                 matcher.matches(relativePath).also { result ->
-                    log.debug {
+                    logger.debug {
                         if (result) {
                             "Adding '$relativePath' to archive."
                         } else {
@@ -102,11 +102,11 @@ class FileArchiver(
             }
         }
 
-        log.info { "Archived directory '$directory' in $zipDuration." }
+        logger.info { "Archived directory '$directory' in $zipDuration." }
 
         val writeDuration = measureTime { storage.addArchive(provenance, zipFile) }
 
-        log.info { "Wrote archive of directory '$directory' to storage in $writeDuration." }
+        logger.info { "Wrote archive of directory '$directory' to storage in $writeDuration." }
 
         zipFile.delete()
     }
@@ -117,20 +117,20 @@ class FileArchiver(
     fun unarchive(directory: File, provenance: KnownProvenance): Boolean {
         val (zipFile, readDuration) = measureTimedValue { storage.getArchive(provenance) }
 
-        log.info { "Read archive of directory '$directory' from storage in $readDuration." }
+        logger.info { "Read archive of directory '$directory' from storage in $readDuration." }
 
         if (zipFile == null) return false
 
         return try {
             val unzipDuration = measureTime { zipFile.unpackZip(directory) }
 
-            log.info { "Unarchived directory '$directory' in $unzipDuration." }
+            logger.info { "Unarchived directory '$directory' in $unzipDuration." }
 
             true
         } catch (e: IOException) {
             e.showStackTrace()
 
-            log.error { "Could not extract ${zipFile.absolutePath}: ${e.collectMessages()}" }
+            logger.error { "Could not extract ${zipFile.absolutePath}: ${e.collectMessages()}" }
 
             false
         } finally {

--- a/model/src/main/kotlin/utils/FileArchiverFileStorage.kt
+++ b/model/src/main/kotlin/utils/FileArchiverFileStorage.kt
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.encodeHex
 import org.ossreviewtoolkit.utils.ort.createOrtTempFile
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.storage.FileStorage
 
 /**
@@ -65,7 +65,7 @@ class FileArchiverFileStorage(
 
             zipFile
         } catch (e: IOException) {
-            log.error { "Could not unarchive from $archivePath: ${e.collectMessages()}" }
+            logger.error { "Could not unarchive from $archivePath: ${e.collectMessages()}" }
 
             null
         }

--- a/model/src/main/kotlin/utils/PostgresFileArchiverStorage.kt
+++ b/model/src/main/kotlin/utils/PostgresFileArchiverStorage.kt
@@ -42,7 +42,7 @@ import org.ossreviewtoolkit.model.utils.DatabaseUtils.checkDatabaseEncoding
 import org.ossreviewtoolkit.model.utils.DatabaseUtils.tableExists
 import org.ossreviewtoolkit.model.utils.DatabaseUtils.transaction
 import org.ossreviewtoolkit.utils.ort.createOrtTempFile
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * A PostgreSQL based storage for archive files.
@@ -86,7 +86,7 @@ class PostgresFileArchiverStorage(
                     // The exception can happen when an archive with the same provenance has been inserted in parallel.
                     // That race condition is possible because [java.sql.Connection.TRANSACTION_READ_COMMITTED] is used
                     // as transaction isolation level (by default).
-                    log.warn(e) { "Could not insert archive for '${provenance.storageKey()}'." }
+                    logger.warn(e) { "Could not insert archive for '${provenance.storageKey()}'." }
                 }
             }
         }

--- a/notifier/src/main/kotlin/modules/JiraNotifier.kt
+++ b/notifier/src/main/kotlin/modules/JiraNotifier.kt
@@ -31,7 +31,7 @@ import java.net.URI
 
 import org.ossreviewtoolkit.model.config.JiraConfiguration
 import org.ossreviewtoolkit.utils.common.collectMessages
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 class JiraNotifier(private val restClient: JiraRestClient) {
     constructor(config: JiraConfiguration) : this(
@@ -58,7 +58,7 @@ class JiraNotifier(private val restClient: JiraRestClient) {
         return runCatching {
             restClient.issueClient.updateIssue(issueKey, input)
         }.onFailure {
-            log.error {
+            logger.error {
                 "Could not set the assignee to '$assignee' for issue '$issueKey': ${it.collectMessages()}"
             }
         }.isSuccess
@@ -75,7 +75,7 @@ class JiraNotifier(private val restClient: JiraRestClient) {
             val transition = possibleTransitions.single { it.name == state }
             restClient.issueClient.transition(issue, TransitionInput(transition.id)).claim()
         }.onFailure {
-            log.error {
+            logger.error {
                 "The transition to state '$state' for the issue '$issueKey' is not possible: " +
                         it.collectMessages()
             }
@@ -89,7 +89,7 @@ class JiraNotifier(private val restClient: JiraRestClient) {
         return runCatching {
             restClient.issueClient.getIssue(issueKey).claim()
         }.onFailure {
-            log.error {
+            logger.error {
                 "Could not retrieve the issue with the key '$issueKey' due to: ${it.collectMessages()}"
             }
         }.getOrNull()
@@ -152,7 +152,7 @@ class JiraNotifier(private val restClient: JiraRestClient) {
                     val comment = "$summary\n$description"
 
                     if (comment in issue.comments.mapNotNull { it.body }) {
-                        log.debug {
+                        logger.debug {
                             "The comment for the issue '$summary' already exists, therefore no new one will be added."
                         }
 
@@ -162,13 +162,13 @@ class JiraNotifier(private val restClient: JiraRestClient) {
                     return runCatching {
                         restClient.issueClient.addComment(issue.commentsUri, Comment.valueOf(comment)).claim()
                     }.map { issue }.onFailure {
-                        log.error {
+                        logger.error {
                             "The comment for the issue '${issue.key} could not be added: " +
                                     it.collectMessages()
                         }
                     }
                 } else if (searchResult.total > 1) {
-                    log.debug { "There are more than 1 duplicate issues of '$summary', which is not supported yet." }
+                    logger.debug { "There are more than 1 duplicate issues of '$summary', which is not supported yet." }
 
                     return Result.failure(
                         IllegalArgumentException(
@@ -180,10 +180,10 @@ class JiraNotifier(private val restClient: JiraRestClient) {
 
             return runCatching {
                 restClient.issueClient.createIssue(issueInput).claim().also {
-                    log.info { "Issue ${it.key} created." }
+                    logger.info { "Issue ${it.key} created." }
                 }
             }.onFailure {
-                log.error {
+                logger.error {
                     "The issue for the project '$projectKey' could not be created: " +
                             it.collectMessages()
                 }

--- a/reporter/src/main/kotlin/reporters/OpossumReporter.kt
+++ b/reporter/src/main/kotlin/reporters/OpossumReporter.kt
@@ -52,7 +52,7 @@ import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.reporters.OpossumReporter.OpossumInput
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxLicense
 import org.ossreviewtoolkit.utils.spdx.getLicenseText
@@ -298,7 +298,7 @@ class OpossumReporter : Reporter {
             }
 
             paths.forEach { path ->
-                log.debug { "add signal ${signal.id} of source ${signal.source} to $path" }
+                logger.debug { "add signal ${signal.id} of source ${signal.source} to $path" }
                 resources.addResource(path)
                 pathToSignal.getOrPut(resolvePath(path)) { sortedSetOf() } += uuidOfSignal
             }
@@ -322,7 +322,7 @@ class OpossumReporter : Reporter {
             level: Int = 1
         ) {
             val dependencyId = dependency.id
-            log.debug { "$relRoot - ${dependencyId.toCoordinates()} - Dependency" }
+            logger.debug { "$relRoot - ${dependencyId.toCoordinates()} - Dependency" }
             val dependencyPath =
                 resolvePath(listOf(relRoot, dependencyId.namespace, "${dependencyId.name}@${dependencyId.version}"))
 
@@ -347,12 +347,12 @@ class OpossumReporter : Reporter {
             relRoot: String = "/"
         ) {
             val name = scope.name
-            log.debug { "$relRoot - $name - DependencyScope" }
+            logger.debug { "$relRoot - $name - DependencyScope" }
 
             val rootForScope = resolvePath(relRoot, name)
             if (scope.dependencies.isNotEmpty()) addAttributionBreakpoint(rootForScope)
             scope.dependencies.forEachIndexed { index, dependency ->
-                log.debug { "scope -> dependency ${index + 1} of ${scope.dependencies.size}" }
+                logger.debug { "scope -> dependency ${index + 1} of ${scope.dependencies.size}" }
                 addDependency(dependency, curatedPackages, rootForScope)
             }
         }
@@ -375,7 +375,7 @@ class OpossumReporter : Reporter {
         ) {
             val projectId = project.id
             val definitionFilePath = resolvePath(relRoot, project.definitionFilePath)
-            log.debug { "$definitionFilePath - $projectId - Project" }
+            logger.debug { "$definitionFilePath - $projectId - Project" }
             val projectRoot = getRootForProject(project, relRoot)
             addPackageRoot(projectId, projectRoot, 0, project.toPackage().vcsProcessed)
             addFileWithChildren(definitionFilePath)
@@ -395,7 +395,7 @@ class OpossumReporter : Reporter {
             project.scopes
                 .filterNot { it.name in excludedScopes }
                 .forEachIndexed { index, scope ->
-                    log.debug { "analyzerResultProject -> scope ${index + 1} of ${project.scopes.size}" }
+                    logger.debug { "analyzerResultProject -> scope ${index + 1} of ${project.scopes.size}" }
                     addDependencyScope(scope, curatedPackages, definitionFilePath)
                 }
         }
@@ -404,11 +404,11 @@ class OpossumReporter : Reporter {
             val scanner = "${result.scanner.name}@${result.scanner.version}"
             val roots = packageToRoot[id]
             if (roots == null) {
-                log.info { "No root for $id from $scanner" }
+                logger.info { "No root for $id from $scanner" }
                 return
             }
 
-            log.debug { "add scanner results for $id from $scanner to ${roots.size} roots" }
+            logger.debug { "add scanner results for $id from $scanner to ${roots.size} roots" }
 
             val licenseFindings = result.summary.licenseFindings
             val copyrightFindings = result.summary.copyrightFindings
@@ -477,7 +477,7 @@ class OpossumReporter : Reporter {
         fun addIssue(issue: OrtIssue, id: Identifier, source: String) {
             val roots = packageToRoot[id]
             val paths = if (roots.isNullOrEmpty()) {
-                log.info { "No root for $id" }
+                logger.info { "No root for $id" }
                 mutableSetOf("/")
             } else {
                 roots.keys
@@ -497,7 +497,7 @@ class OpossumReporter : Reporter {
             }
 
             if (rootlessPackages.isNotEmpty()) {
-                log.warn { "There are ${rootlessPackages.size} packages that had no root." }
+                logger.warn { "There are ${rootlessPackages.size} packages that had no root." }
             }
         }
     }
@@ -535,7 +535,7 @@ class OpossumReporter : Reporter {
         val analyzerResultProjects = analyzerResult.projects
         val analyzerResultPackages = analyzerResult.packages
         analyzerResultProjects.forEachIndexed { index, project ->
-            log.debug { "analyzerResultProject ${index + 1} of ${analyzerResultProjects.size}" }
+            logger.debug { "analyzerResultProject ${index + 1} of ${analyzerResultProjects.size}" }
             opossumInput.addProject(project, analyzerResultPackages, excludedScopes)
         }
         if (excludedScopes.isEmpty()) {
@@ -554,7 +554,7 @@ class OpossumReporter : Reporter {
 
         val scannerResults = ortResult.scanner?.results?.scanResults ?: return OpossumInput()
         scannerResults.entries.forEachIndexed { index, entry ->
-            log.debug { "scannerResult ${index + 1} of ${scannerResults.entries.size}" }
+            logger.debug { "scannerResult ${index + 1} of ${scannerResults.entries.size}" }
             opossumInput.addScannerResults(entry.key, entry.value, maxDepth)
         }
 

--- a/reporter/src/main/kotlin/reporters/fossid/FossIdReporter.kt
+++ b/reporter/src/main/kotlin/reporters/fossid/FossIdReporter.kt
@@ -34,7 +34,7 @@ import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.collectMessages
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 class FossIdReporter : Reporter {
@@ -95,11 +95,11 @@ class FossIdReporter : Reporter {
             input.ortResult.scanner?.results?.scanResults?.values?.flatten()?.mapNotNull { result ->
                 result.additionalData[SCAN_CODE_KEY]?.let { scanCode ->
                     async {
-                        this@FossIdReporter.log.info { "Generating report for scan $scanCode." }
+                        this@FossIdReporter.logger.info { "Generating report for scan $scanCode." }
                         service.generateReport(user, apiKey, scanCode, reportType, selectionType, outputDir)
                             .onFailure {
                                 it.showStackTrace()
-                                this@FossIdReporter.log.info {
+                                this@FossIdReporter.logger.info {
                                     "Error during report generation: ${it.collectMessages()}."
                                 }
                             }.getOrNull()

--- a/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
@@ -55,7 +55,7 @@ import org.ossreviewtoolkit.model.licenses.filterExcluded
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.expandTilde
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.model.SpdxLicenseChoice
 
@@ -87,7 +87,7 @@ class FreemarkerTemplateProcessor(
         }
 
         if (projectTypesAsPackages.isNotEmpty()) {
-            log.info {
+            logger.info {
                 "Handling ${projectTypesAsPackages.size} projects of types $projectTypesAsPackages as packages."
             }
         }
@@ -160,7 +160,7 @@ class FreemarkerTemplateProcessor(
         templateIds.forEach { id ->
             val outputFile = outputDir.resolve("$filePrefix$id$fileExtensionWithDot")
 
-            log.info { "Generating output file '$outputFile' using template id '$id'." }
+            logger.info { "Generating output file '$outputFile' using template id '$id'." }
 
             val template = freemarkerConfig.getTemplate("$id.ftl")
             outputFile.writer().use { template.process(dataModel, it) }
@@ -171,7 +171,7 @@ class FreemarkerTemplateProcessor(
         templateFiles.forEach { file ->
             val outputFile = outputDir.resolve("$filePrefix${file.nameWithoutExtension}$fileExtensionWithDot")
 
-            log.info { "Generating output file '$outputFile' using template file '${file.absolutePath}'." }
+            logger.info { "Generating output file '$outputFile' using template file '${file.absolutePath}'." }
 
             val template = freemarkerConfig.run {
                 setDirectoryForTemplateLoading(file.parentFile)
@@ -409,7 +409,7 @@ class FreemarkerTemplateProcessor(
          */
         fun getPackage(id: Identifier): Package =
             input.ortResult.getPackage(id)?.pkg
-                ?: Package.EMPTY.also { log.warn { "Could not resolve package '${id.toCoordinates()}'." } }
+                ?: Package.EMPTY.also { logger.warn { "Could not resolve package '${id.toCoordinates()}'." } }
     }
 }
 

--- a/reporter/src/main/kotlin/reporters/gitlab/GitLabLicenseModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/gitlab/GitLabLicenseModelMapper.kt
@@ -24,7 +24,7 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.reporter.reporters.gitlab.GitLabLicenseModel.Dependency
 import org.ossreviewtoolkit.reporter.reporters.gitlab.GitLabLicenseModel.License
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.spdx.SpdxLicense
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseIdExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseWithExceptionExpression
@@ -119,6 +119,6 @@ private fun Identifier.toPackageManagerName(): String =
         "PIP" -> "pip"
         "Yarn" -> "yarn"
         else -> type.lowercase().also {
-            log.info { "No mapping defined for package manager '$type', guessing '$it'." }
+            logger.info { "No mapping defined for package manager '$type', guessing '$it'." }
         }
     }

--- a/scanner/src/main/kotlin/CommandLineScanner.kt
+++ b/scanner/src/main/kotlin/CommandLineScanner.kt
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.Os
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * A [PathScanner] that is executed as a [CommandLineTool] on the local machine.
@@ -48,14 +48,14 @@ abstract class CommandLineScanner(
         Os.getPathFromEnvironment(scannerExe)?.parentFile?.also {
             val actualVersion = getVersion(it)
             if (actualVersion != expectedVersion) {
-                log.warn {
+                logger.warn {
                     "ORT is currently tested with $name version $expectedVersion, but you are using version " +
                             "$actualVersion. This could lead to problems with parsing the $name output."
                 }
             }
         } ?: run {
             if (scannerExe.isNotEmpty()) {
-                log.info {
+                logger.info {
                     "Bootstrapping scanner '$scannerName' as expected version $expectedVersion was not found in PATH."
                 }
 
@@ -71,11 +71,11 @@ abstract class CommandLineScanner(
                     }
                 }
 
-                log.info { "Bootstrapped scanner '$scannerName' version $expectedVersion in $duration." }
+                logger.info { "Bootstrapped scanner '$scannerName' version $expectedVersion in $duration." }
 
                 bootstrapDirectory
             } else {
-                log.info { "Skipping to bootstrap scanner '$scannerName' as it has no executable." }
+                logger.info { "Skipping to bootstrap scanner '$scannerName' as it has no executable." }
 
                 File("")
             }

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -40,7 +40,7 @@ import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.model.utils.filterByProject
 import org.ossreviewtoolkit.utils.ort.Environment
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 const val TOOL_NAME = "scanner"
 
@@ -49,7 +49,7 @@ private fun removeConcludedPackages(packages: Set<Package>, scanner: Scanner): S
         // Remove all packages that have a concluded license and authors set.
         ?: packages.partition { it.concludedLicense != null && it.authors.isNotEmpty() }.let { (skip, keep) ->
             if (skip.isNotEmpty()) {
-                scanner.log.debug { "Not scanning the following packages with concluded licenses: $skip" }
+                scanner.logger.debug { "Not scanning the following packages with concluded licenses: $skip" }
             }
 
             keep.toSet()
@@ -92,7 +92,7 @@ fun scanOrtResult(
     }
 
     if (ortResult.analyzer == null) {
-        Scanner.log.warn {
+        Scanner.logger.warn {
             "Cannot run the scanner as the provided ORT result does not contain an analyzer result. " +
                     "No result will be added."
         }

--- a/scanner/src/main/kotlin/experimental/FileBasedNestedProvenanceStorage.kt
+++ b/scanner/src/main/kotlin/experimental/FileBasedNestedProvenanceStorage.kt
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.fileSystemEncode
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.ossreviewtoolkit.utils.ort.storage.FileStorage
 
@@ -51,7 +51,7 @@ class FileBasedNestedProvenanceStorage(private val backend: FileStorage) : Neste
                     emptyList()
                 }
                 else -> {
-                    log.info {
+                    logger.info {
                         "Could not read resolved nested provenances for '$root' from path '$path': " +
                                 it.collectMessages()
                     }
@@ -73,13 +73,13 @@ class FileBasedNestedProvenanceStorage(private val backend: FileStorage) : Neste
 
         runCatching {
             backend.write(path, input)
-            log.debug { "Stored resolved nested provenance for '$root' at path '$path'." }
+            logger.debug { "Stored resolved nested provenance for '$root' at path '$path'." }
         }.onFailure {
             when (it) {
                 is IllegalArgumentException, is IOException -> {
                     it.showStackTrace()
 
-                    log.warn {
+                    logger.warn {
                         "Could not store resolved nested provenance for '$root' at path '$path': " +
                                 it.collectMessages()
                     }

--- a/scanner/src/main/kotlin/experimental/FileBasedPackageProvenanceStorage.kt
+++ b/scanner/src/main/kotlin/experimental/FileBasedPackageProvenanceStorage.kt
@@ -31,7 +31,7 @@ import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.common.collectMessages
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.ossreviewtoolkit.utils.ort.storage.FileStorage
 
@@ -56,7 +56,7 @@ class FileBasedPackageProvenanceStorage(val backend: FileStorage) : PackageProve
                     emptyList()
                 }
                 else -> {
-                    log.info {
+                    logger.info {
                         "Could not read resolved provenances for '${id.toCoordinates()}' from path '$path': " +
                                 it.collectMessages()
                     }
@@ -93,13 +93,13 @@ class FileBasedPackageProvenanceStorage(val backend: FileStorage) : PackageProve
 
         runCatching {
             backend.write(path, input)
-            log.debug { "Stored resolved provenances for '${id.toCoordinates()}' at path '$path'." }
+            logger.debug { "Stored resolved provenances for '${id.toCoordinates()}' at path '$path'." }
         }.onFailure {
             when (it) {
                 is IllegalArgumentException, is IOException -> {
                     it.showStackTrace()
 
-                    log.warn {
+                    logger.warn {
                         "Could not store resolved provenances for '${id.toCoordinates()}' at path '$path': " +
                                 it.collectMessages()
                     }

--- a/scanner/src/main/kotlin/experimental/NestedProvenanceResolver.kt
+++ b/scanner/src/main/kotlin/experimental/NestedProvenanceResolver.kt
@@ -26,7 +26,7 @@ import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * The [NestedProvenanceResolver] provides a function to resolve nested provenances.
@@ -59,19 +59,19 @@ class DefaultNestedProvenanceResolver(
 
         if (storedResult != null) {
             if (storedResult.hasOnlyFixedRevisions) {
-                log.info {
+                logger.info {
                     "Found a stored nested provenance for $provenance with only fixed revisions, skipping resolution."
                 }
 
                 return storedResult.nestedProvenance
             } else {
-                log.info {
+                logger.info {
                     "Found a stored nested provenance for $provenance with at least one non-fixed revision, " +
                             "restarting resolution."
                 }
             }
         } else {
-            log.info {
+            logger.info {
                 "Could not find a stored nested provenance for $provenance, attempting resolution."
             }
         }

--- a/scanner/src/main/kotlin/experimental/ProvenanceBasedFileStorage.kt
+++ b/scanner/src/main/kotlin/experimental/ProvenanceBasedFileStorage.kt
@@ -32,7 +32,7 @@ import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.fileSystemEncode
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.ossreviewtoolkit.utils.ort.storage.FileStorage
 
@@ -57,7 +57,7 @@ class ProvenanceBasedFileStorage(private val backend: FileStorage) : ProvenanceB
                     emptyList()
                 }
                 else -> {
-                    log.info {
+                    logger.info {
                         "Could not read scan results for '$provenance' from path '$path': " +
                                 it.collectMessages()
                     }
@@ -94,13 +94,13 @@ class ProvenanceBasedFileStorage(private val backend: FileStorage) : ProvenanceB
 
         runCatching {
             backend.write(path, input)
-            log.debug { "Stored scan result for '$provenance' at path '$path'." }
+            logger.debug { "Stored scan result for '$provenance' at path '$path'." }
         }.onFailure {
             when (it) {
                 is IllegalArgumentException, is IOException -> {
                     it.showStackTrace()
 
-                    log.warn {
+                    logger.warn {
                         "Could not store scan result for '$provenance' at path '$path': ${it.collectMessages()}"
                     }
                 }

--- a/scanner/src/main/kotlin/experimental/ProvenanceBasedPostgresStorage.kt
+++ b/scanner/src/main/kotlin/experimental/ProvenanceBasedPostgresStorage.kt
@@ -43,7 +43,7 @@ import org.ossreviewtoolkit.model.utils.DatabaseUtils.tableExists
 import org.ossreviewtoolkit.model.utils.DatabaseUtils.transaction
 import org.ossreviewtoolkit.scanner.storages.utils.jsonb
 import org.ossreviewtoolkit.utils.common.collectMessages
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 class ProvenanceBasedPostgresStorage(
@@ -115,7 +115,7 @@ class ProvenanceBasedPostgresStorage(
         } catch (e: SQLException) {
             e.showStackTrace()
 
-            log.error { "Could not read scan results: ${e.collectMessages()}" }
+            logger.error { "Could not read scan results: ${e.collectMessages()}" }
 
             throw ScanStorageException(e)
         }
@@ -158,7 +158,7 @@ class ProvenanceBasedPostgresStorage(
         } catch (e: SQLException) {
             e.showStackTrace()
 
-            log.error { "Could not write scan result: ${e.collectMessages()}" }
+            logger.error { "Could not write scan result: ${e.collectMessages()}" }
 
             throw ScanStorageException(e)
         }

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -40,7 +40,7 @@ import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.ProcessCapture
 import org.ossreviewtoolkit.utils.common.unpackZip
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.ortToolsDirectory
 import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 
@@ -76,7 +76,7 @@ class Askalono internal constructor(
         val unpackDir = ortToolsDirectory.resolve(name).resolve(expectedVersion)
 
         if (unpackDir.resolve(command()).isFile) {
-            log.info { "Skipping to bootstrap $name as it was found in $unpackDir." }
+            logger.info { "Skipping to bootstrap $name as it was found in $unpackDir." }
             return unpackDir
         }
 
@@ -90,10 +90,10 @@ class Askalono internal constructor(
         val archive = "askalono-$platform.zip"
         val url = "https://github.com/amzn/askalono/releases/download/$expectedVersion/$archive"
 
-        log.info { "Downloading $scannerName from $url... " }
+        logger.info { "Downloading $scannerName from $url... " }
         val (_, body) = OkHttpClientHelper.download(url).getOrThrow()
 
-        log.info { "Unpacking '$archive' to '$unpackDir'... " }
+        logger.info { "Unpacking '$archive' to '$unpackDir'... " }
         body.bytes().unpackZip(unpackDir)
 
         return unpackDir
@@ -111,7 +111,7 @@ class Askalono internal constructor(
         val endTime = Instant.now()
 
         return with(process) {
-            if (stderr.isNotBlank()) log.debug { stderr }
+            if (stderr.isNotBlank()) logger.debug { stderr }
             if (isError) throw ScanException(errorMessage)
 
             generateSummary(startTime, endTime, path, stdout)

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -42,7 +42,7 @@ import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.common.unpackZip
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.ortToolsDirectory
 import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 
@@ -85,7 +85,7 @@ class BoyterLc internal constructor(
         val unpackDir = ortToolsDirectory.resolve(name).resolve(expectedVersion)
 
         if (unpackDir.resolve(command()).isFile) {
-            log.info { "Skipping to bootstrap $name as it was found in $unpackDir." }
+            logger.info { "Skipping to bootstrap $name as it was found in $unpackDir." }
             return unpackDir
         }
 
@@ -99,10 +99,10 @@ class BoyterLc internal constructor(
         val archive = "lc-$expectedVersion-$platform.zip"
         val url = "https://github.com/boyter/lc/releases/download/v$expectedVersion/$archive"
 
-        log.info { "Downloading $scannerName from $url... " }
+        logger.info { "Downloading $scannerName from $url... " }
         val (_, body) = OkHttpClientHelper.download(url).getOrThrow()
 
-        log.info { "Unpacking '$archive' to '$unpackDir'... " }
+        logger.info { "Unpacking '$archive' to '$unpackDir'... " }
         body.bytes().unpackZip(unpackDir)
 
         return unpackDir
@@ -122,7 +122,7 @@ class BoyterLc internal constructor(
         val endTime = Instant.now()
 
         return with(process) {
-            if (stderr.isNotBlank()) log.debug { stderr }
+            if (stderr.isNotBlank()) logger.debug { stderr }
             if (isError) throw ScanException(errorMessage)
 
             generateSummary(startTime, endTime, path, resultFile).also {

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -38,7 +38,7 @@ import org.ossreviewtoolkit.scanner.experimental.PathScannerWrapper
 import org.ossreviewtoolkit.scanner.experimental.ScanContext
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.ProcessCapture
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.spdx.calculatePackageVerificationCode
 
 class Licensee internal constructor(
@@ -94,7 +94,7 @@ class Licensee internal constructor(
         val endTime = Instant.now()
 
         return with(process) {
-            if (stderr.isNotBlank()) log.debug { stderr }
+            if (stderr.isNotBlank()) logger.debug { stderr }
             if (isError) throw ScanException(errorMessage)
 
             generateSummary(startTime, endTime, path, stdout)

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
@@ -20,7 +20,7 @@
 package org.ossreviewtoolkit.scanner.scanners.fossid
 
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * A data class that holds the configuration options supported by the [FossId] scanner. An instance of this class is
@@ -146,7 +146,7 @@ internal data class FossIdConfig(
                 "deltaScanLimit must be > 0, current value is $deltaScanLimit."
             }
 
-            log.info { "waitForResult parameter is set to '$waitForResult'" }
+            logger.info { "waitForResult parameter is set to '$waitForResult'" }
 
             return FossIdConfig(
                 serverUrl = serverUrl,
@@ -168,11 +168,11 @@ internal data class FossIdConfig(
      */
     fun createNamingProvider(): FossIdNamingProvider {
         val namingProjectPattern = options[NAMING_PROJECT_PATTERN_PROPERTY]?.also {
-            log.info { "Naming pattern for projects is $it." }
+            logger.info { "Naming pattern for projects is $it." }
         }
 
         val namingScanPattern = options[NAMING_SCAN_PATTERN_PROPERTY]?.also {
-            log.info { "Naming pattern for scans is $it." }
+            logger.info { "Naming pattern for scans is $it." }
         }
 
         val namingConventionVariables = options

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdNamingProvider.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdNamingProvider.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.scanner.scanners.fossid
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * This class provides names for projects and scans when the FossID scanner creates them, following a given pattern.
@@ -74,7 +74,7 @@ internal class FossIdNamingProvider(
     private fun replaceNamingConventionVariables(
         namingConventionPattern: String, builtins: Map<String, String>, namingConventionVariables: Map<String, String>
     ): String {
-        log.info { "Parameterizing the name with pattern '$namingConventionPattern'." }
+        logger.info { "Parameterizing the name with pattern '$namingConventionPattern'." }
         val currentTimestamp = FORMATTER.format(LocalDateTime.now())
 
         val allVariables =

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -46,7 +46,7 @@ import org.ossreviewtoolkit.utils.common.unpack
 import org.ossreviewtoolkit.utils.common.withoutPrefix
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.ortToolsDirectory
 
 /**
@@ -154,7 +154,7 @@ class ScanCode internal constructor(
         val scannerDir = unpackDir.resolve("scancode-toolkit-$versionWithoutHyphen")
 
         if (scannerDir.resolve(command()).isFile) {
-            log.info { "Skipping to bootstrap $name as it was found in $unpackDir." }
+            logger.info { "Skipping to bootstrap $name as it was found in $unpackDir." }
             return scannerDir
         }
 
@@ -171,15 +171,15 @@ class ScanCode internal constructor(
 
         // Download ScanCode to a file instead of unpacking directly from the response body as doing so on the > 200 MiB
         // archive causes issues.
-        log.info { "Downloading $scannerName from $url... " }
+        logger.info { "Downloading $scannerName from $url... " }
         unpackDir.safeMkdirs()
         val scannerArchive = OkHttpClientHelper.downloadFile(url, unpackDir).getOrThrow()
 
-        log.info { "Unpacking '$scannerArchive' to '$unpackDir'... " }
+        logger.info { "Unpacking '$scannerArchive' to '$unpackDir'... " }
         scannerArchive.unpack(unpackDir)
 
         if (!scannerArchive.delete()) {
-            log.warn { "Unable to delete temporary file '$scannerArchive'." }
+            logger.warn { "Unable to delete temporary file '$scannerArchive'." }
         }
 
         return scannerDir
@@ -212,7 +212,7 @@ class ScanCode internal constructor(
         mapTimeoutErrors(issues)
 
         return with(process) {
-            if (stderr.isNotBlank()) log.debug { stderr }
+            if (stderr.isNotBlank()) logger.debug { stderr }
 
             summary.copy(issues = issues)
         }

--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
@@ -43,7 +43,7 @@ import org.ossreviewtoolkit.scanner.PathScanner
 import org.ossreviewtoolkit.scanner.experimental.AbstractScannerWrapperFactory
 import org.ossreviewtoolkit.scanner.experimental.PathScannerWrapper
 import org.ossreviewtoolkit.scanner.experimental.ScanContext
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 // An arbitrary name to use for the multipart body being sent.
 private const val FAKE_WFP_FILE_NAME = "fake.wfp"
@@ -64,7 +64,7 @@ class ScanOss internal constructor(
     }
 
     private val config = ScanOssConfig.create(scannerConfig).also {
-        log.info { "The $scannerName API URL is ${it.apiUrl}." }
+        logger.info { "The $scannerName API URL is ${it.apiUrl}." }
     }
 
     private val service = ScanOssService.create(config.apiUrl)
@@ -95,7 +95,7 @@ class ScanOss internal constructor(
                 // TODO: Consider not applying the (somewhat arbitrary) blacklist.
                 .filter { !it.isDirectory && !BlacklistRules.hasBlacklistedExt(it.name) }
                 .forEach {
-                    this@ScanOss.log.info { "Computing fingerprint for file ${it.absolutePath}..." }
+                    this@ScanOss.logger.info { "Computing fingerprint for file ${it.absolutePath}..." }
                     append(createWfpForFile(it.path))
                 }
         }

--- a/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
+++ b/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
@@ -54,7 +54,7 @@ import org.ossreviewtoolkit.scanner.scanners.scancode.generateScannerDetails
 import org.ossreviewtoolkit.scanner.scanners.scancode.generateSummary
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 import retrofit2.HttpException
@@ -135,7 +135,7 @@ class ClearlyDefinedStorage(
         } catch (e: IllegalArgumentException) {
             e.showStackTrace()
 
-            log.warn { "Could not obtain ClearlyDefined coordinates for package '${id.toCoordinates()}'." }
+            logger.warn { "Could not obtain ClearlyDefined coordinates for package '${id.toCoordinates()}'." }
 
             EMPTY_RESULT
         }
@@ -146,7 +146,7 @@ class ClearlyDefinedStorage(
      * identifier, as we try to lookup source code results if a GitHub repository is known.
      */
     private suspend fun readFromClearlyDefined(id: Identifier, coordinates: Coordinates): Result<List<ScanResult>> {
-        log.info { "Looking up results for '${id.toCoordinates()}'." }
+        logger.info { "Looking up results for '${id.toCoordinates()}'." }
 
         return try {
             val tools = service.harvestTools(
@@ -162,7 +162,7 @@ class ClearlyDefinedStorage(
             } ?: EMPTY_RESULT
         } catch (e: HttpException) {
             e.response()?.errorBody()?.string()?.let {
-                log.error { "Error response from ClearlyDefined is: $it" }
+                logger.error { "Error response from ClearlyDefined is: $it" }
             }
 
             handleException(id, e)
@@ -181,7 +181,7 @@ class ClearlyDefinedStorage(
         val message = "Error when reading results for package '${id.toCoordinates()}' from ClearlyDefined: " +
                 e.collectMessages()
 
-        log.error { message }
+        logger.error { message }
 
         return Result.failure(ScanStorageException(message))
     }

--- a/scanner/src/main/kotlin/storages/FileBasedStorage.kt
+++ b/scanner/src/main/kotlin/storages/FileBasedStorage.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.scanner.ScanResultsStorage
 import org.ossreviewtoolkit.scanner.experimental.ScanStorageException
 import org.ossreviewtoolkit.utils.common.collectMessages
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.ossreviewtoolkit.utils.ort.storage.FileStorage
 
@@ -64,7 +64,7 @@ class FileBasedStorage(
             val message = "Could not read scan results for '${id.toCoordinates()}' from path '$path': " +
                     it.collectMessages()
 
-            log.info { message }
+            logger.info { message }
 
             throw ScanStorageException(message)
         }
@@ -77,7 +77,7 @@ class FileBasedStorage(
             val message = "Did not store scan result for '${id.toCoordinates()}' because a scan result for the same " +
                     "scanner and provenance was already stored."
 
-            log.warn { message }
+            logger.warn { message }
 
             return Result.failure(ScanStorageException(message))
         }
@@ -90,7 +90,7 @@ class FileBasedStorage(
 
         return runCatching {
             backend.write(path, input)
-            log.debug { "Stored scan result for '${id.toCoordinates()}' at path '$path'." }
+            logger.debug { "Stored scan result for '${id.toCoordinates()}' at path '$path'." }
         }.onFailure {
             if (it is IllegalArgumentException || it is IOException) {
                 it.showStackTrace()
@@ -98,7 +98,7 @@ class FileBasedStorage(
                 val message = "Could not store scan result for '${id.toCoordinates()}' at path '$path': " +
                         it.collectMessages()
 
-                log.warn { message }
+                logger.warn { message }
 
                 return Result.failure(ScanStorageException(message))
             }

--- a/scanner/src/main/kotlin/storages/PostgresStorage.kt
+++ b/scanner/src/main/kotlin/storages/PostgresStorage.kt
@@ -53,7 +53,7 @@ import org.ossreviewtoolkit.scanner.experimental.ScanStorageException
 import org.ossreviewtoolkit.scanner.storages.utils.ScanResultDao
 import org.ossreviewtoolkit.scanner.storages.utils.ScanResults
 import org.ossreviewtoolkit.utils.common.collectMessages
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 private val TABLE_NAME = ScanResults.tableName
@@ -142,7 +142,7 @@ class PostgresStorage(
                 val message = "Could not read scan results for ${id.toCoordinates()} from database: " +
                         it.collectMessages()
 
-                log.info { message }
+                logger.info { message }
 
                 return Result.failure(ScanStorageException(message))
             }
@@ -174,7 +174,7 @@ class PostgresStorage(
                 val message = "Could not read scan results for ${pkg.id.toCoordinates()} with " +
                         "$scannerCriteria from database: ${it.collectMessages()}"
 
-                log.info { message }
+                logger.info { message }
 
                 return Result.failure(ScanStorageException(message))
             }
@@ -224,7 +224,7 @@ class PostgresStorage(
                 val message = "Could not read scan results with $scannerCriteria from database: " +
                         it.collectMessages()
 
-                log.info { message }
+                logger.info { message }
 
                 return Result.failure(ScanStorageException(message))
             }
@@ -232,7 +232,7 @@ class PostgresStorage(
     }
 
     override fun addInternal(id: Identifier, scanResult: ScanResult): Result<Unit> {
-        log.info { "Storing scan result for ${id.toCoordinates()} in storage." }
+        logger.info { "Storing scan result for ${id.toCoordinates()} in storage." }
 
         // TODO: Check if there is already a matching entry for this provenance and scanner details.
 
@@ -248,7 +248,7 @@ class PostgresStorage(
 
             val message = "Could not store scan result for '${id.toCoordinates()}': ${it.collectMessages()}"
 
-            log.warn { message }
+            logger.warn { message }
 
             throw ScanStorageException(message)
         }.map { /* Unit */ }

--- a/scanner/src/main/kotlin/storages/Sw360Storage.kt
+++ b/scanner/src/main/kotlin/storages/Sw360Storage.kt
@@ -46,7 +46,7 @@ import org.ossreviewtoolkit.scanner.experimental.ScanStorageException
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * The SW360 storage back-end uses the SW360-client library in order to read/add attachments from the configured
@@ -98,7 +98,7 @@ class Sw360Storage(
         }.recoverCatching {
             val message = "Could not read scan results for ${id.toCoordinates()} in SW360: ${it.message}"
 
-            log.info { message }
+            logger.info { message }
 
             throw ScanStorageException(message)
         }
@@ -121,7 +121,7 @@ class Sw360Storage(
                 .map { releaseClient.uploadAttachments(it) }
 
             if (uploadResult.isPresent && uploadResult.get().isSuccess) {
-                log.debug { "Stored scan result for '${id.toCoordinates()}' in SW360." }
+                logger.debug { "Stored scan result for '${id.toCoordinates()}' in SW360." }
             } else {
                 throw ScanStorageException("Failed to upload scan results for '${id.toCoordinates()}' to SW360.")
             }
@@ -129,7 +129,7 @@ class Sw360Storage(
             val message = "Failed to add scan results for '${id.toCoordinates()}' to SW360: " +
                     it.collectMessages()
 
-            log.info { message }
+            logger.info { message }
 
             throw ScanStorageException(message)
         }

--- a/utils/ort/src/funTest/kotlin/storage/HttpFileStorageFunTest.kt
+++ b/utils/ort/src/funTest/kotlin/storage/HttpFileStorageFunTest.kt
@@ -38,12 +38,12 @@ import java.net.InetSocketAddress
 
 import kotlin.random.Random
 
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 class HttpFileStorageFunTest : WordSpec() {
     private val loopback = InetAddress.getLoopbackAddress()
     private val port = Random.nextInt(1024, 49152) // See https://en.wikipedia.org/wiki/Registered_port.
-        .also { log.debug { "Using port $it for HTTP server." } }
+        .also { logger.debug { "Using port $it for HTTP server." } }
 
     private val handler = object : HttpHandler {
         val requests = mutableMapOf<String, String>()

--- a/utils/ort/src/main/kotlin/DeclaredLicenseProcessor.kt
+++ b/utils/ort/src/main/kotlin/DeclaredLicenseProcessor.kt
@@ -133,7 +133,7 @@ object DeclaredLicenseProcessor {
         runCatching {
             declaredLicense.toSpdx()
         }.onFailure {
-            log.debug { "Could not parse declared license '$declaredLicense': ${it.collectMessages()}" }
+            logger.debug { "Could not parse declared license '$declaredLicense': ${it.collectMessages()}" }
         }.getOrNull()
 }
 

--- a/utils/ort/src/main/kotlin/Logger.kt
+++ b/utils/ort/src/main/kotlin/Logger.kt
@@ -34,7 +34,7 @@ val loggerOfClass = ConcurrentHashMap<Any, KotlinLogger>()
 /**
  * An extension property for adding a log instance to any (unique) class.
  */
-val Any.log: KotlinLogger
+val Any.logger: KotlinLogger
     inline get() = loggerOfClass.getOrPut(this::class.java) {
         this::class.qualifiedName?.let { name ->
             require(isOrtClass(this::class.java)) {

--- a/utils/ort/src/main/kotlin/NetRcAuthenticator.kt
+++ b/utils/ort/src/main/kotlin/NetRcAuthenticator.kt
@@ -37,7 +37,7 @@ class NetRcAuthenticator : Authenticator() {
         netrcFileNames.forEach { name ->
             val netrcFile = Os.userHomeDirectory.resolve(name)
             if (netrcFile.isFile) {
-                log.debug { "Parsing '$netrcFile' for machine '$requestingHost'." }
+                logger.debug { "Parsing '$netrcFile' for machine '$requestingHost'." }
 
                 // Read the file on each function call to be up-to-date with any changes.
                 val netrcText = netrcFile.readText()
@@ -74,7 +74,7 @@ internal fun getNetrcAuthentication(contents: String, machine: String): Password
         }
 
         if (login != null && password != null) {
-            OrtAuthenticator.log.debug { "Found a '$machineFound' entry for '$machine'." }
+            OrtAuthenticator.logger.debug { "Found a '$machineFound' entry for '$machine'." }
             return PasswordAuthentication(login, password.toCharArray())
         }
     }

--- a/utils/ort/src/main/kotlin/OkHttpClientHelper.kt
+++ b/utils/ort/src/main/kotlin/OkHttpClientHelper.kt
@@ -76,7 +76,7 @@ object OkHttpClientHelper {
         OrtAuthenticator.install()
         OrtProxySelector.install()
 
-        if (log.delegate.isDebugEnabled) {
+        if (logger.delegate.isDebugEnabled) {
             // Allow tracking down leaked connections.
             Logger.getLogger(OkHttpClient::javaClass.name).level = Level.FINE
         }
@@ -101,7 +101,7 @@ object OkHttpClientHelper {
                 }.onFailure {
                     it.showStackTrace()
 
-                    log.error {
+                    logger.error {
                         "HTTP request to '${request.url}' failed with an exception: ${it.collectMessages()}"
                     }
                 }.getOrThrow()
@@ -254,7 +254,7 @@ fun OkHttpClient.download(url: String, acceptEncoding: String? = null): Result<P
  */
 fun OkHttpClient.execute(request: Request): Response =
     newCall(request).execute().also { response ->
-        OkHttpClientHelper.log.debug {
+        OkHttpClientHelper.logger.debug {
             if (response.cacheResponse != null) {
                 "Retrieved ${response.request.url} from local cache."
             } else {

--- a/utils/ort/src/main/kotlin/OrtAuthenticator.kt
+++ b/utils/ort/src/main/kotlin/OrtAuthenticator.kt
@@ -43,7 +43,7 @@ class OrtAuthenticator(private val original: Authenticator? = null) : Authentica
             } else {
                 OrtAuthenticator(current).also {
                     setDefault(it)
-                    log.info { "Authenticator was successfully installed." }
+                    logger.info { "Authenticator was successfully installed." }
                 }
             }
         }
@@ -57,10 +57,10 @@ class OrtAuthenticator(private val original: Authenticator? = null) : Authentica
             return if (current is OrtAuthenticator) {
                 current.original.also {
                     setDefault(it)
-                    log.info { "Authenticator was successfully uninstalled." }
+                    logger.info { "Authenticator was successfully uninstalled." }
                 }
             } else {
-                log.info { "Authenticator is not installed." }
+                logger.info { "Authenticator is not installed." }
                 current
             }
         }
@@ -103,7 +103,7 @@ class OrtAuthenticator(private val original: Authenticator? = null) : Authentica
                 }
             }
 
-            null -> log.warn { "No requestor type set for password authentication." }
+            null -> logger.warn { "No requestor type set for password authentication." }
         }
 
         return super.getPasswordAuthentication()

--- a/utils/ort/src/main/kotlin/OrtProxySelector.kt
+++ b/utils/ort/src/main/kotlin/OrtProxySelector.kt
@@ -52,7 +52,7 @@ class OrtProxySelector(private val fallback: ProxySelector? = null) : ProxySelec
             } else {
                 OrtProxySelector(current).also {
                     setDefault(it)
-                    log.info { "Proxy selector was successfully installed." }
+                    logger.info { "Proxy selector was successfully installed." }
                 }
             }
         }
@@ -66,10 +66,10 @@ class OrtProxySelector(private val fallback: ProxySelector? = null) : ProxySelec
             return if (current is OrtProxySelector) {
                 current.fallback.also {
                     setDefault(it)
-                    log.info { "Proxy selector was successfully uninstalled." }
+                    logger.info { "Proxy selector was successfully uninstalled." }
                 }
             } else {
-                log.info { "Proxy selector is not installed." }
+                logger.info { "Proxy selector is not installed." }
                 current
             }
         }

--- a/utils/ort/src/main/kotlin/storage/HttpFileStorage.kt
+++ b/utils/ort/src/main/kotlin/storage/HttpFileStorage.kt
@@ -29,7 +29,7 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * A [FileStorage] that stores files on an HTTP server.
@@ -78,7 +78,7 @@ class HttpFileStorage(
             .url(urlForPath(path))
             .build()
 
-        log.debug { "Reading file from storage: ${request.url}" }
+        logger.debug { "Reading file from storage: ${request.url}" }
 
         val response = OkHttpClientHelper.execute(request)
         if (response.isSuccessful) {
@@ -102,7 +102,7 @@ class HttpFileStorage(
                 .url(urlForPath(path))
                 .build()
 
-            log.debug { "Writing file to storage: ${request.url}" }
+            logger.debug { "Writing file to storage: ${request.url}" }
 
             return OkHttpClientHelper.execute(request).use { response ->
                 if (!response.isSuccessful) {

--- a/utils/ort/src/main/kotlin/storage/LocalFileStorage.kt
+++ b/utils/ort/src/main/kotlin/storage/LocalFileStorage.kt
@@ -24,7 +24,7 @@ import java.io.InputStream
 import java.io.OutputStream
 
 import org.ossreviewtoolkit.utils.common.safeMkdirs
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * A [FileStorage] that stores files in a [directory] of the local file system. The [read] and [write] operations are
@@ -38,7 +38,7 @@ open class LocalFileStorage(
 ) : FileStorage {
     init {
         if (!directory.exists()) {
-            log.debug { "Creating directory '${directory.invariantSeparatorsPath}' for local file storage." }
+            logger.debug { "Creating directory '${directory.invariantSeparatorsPath}' for local file storage." }
             directory.safeMkdirs()
         } else {
             require(directory.isDirectory) {

--- a/utils/ort/src/test/kotlin/LoggerTest.kt
+++ b/utils/ort/src/test/kotlin/LoggerTest.kt
@@ -33,22 +33,22 @@ private class OtherClass
 class LoggerTest : WordSpec({
     "A logger instance" should {
         "be shared between different instances of the same class" {
-            val a = DummyClass().log
-            val b = DummyClass().log
+            val a = DummyClass().logger
+            val b = DummyClass().logger
 
             a shouldBeSameInstanceAs b
         }
 
         "not be shared between instances of different classes" {
-            val a = DummyClass().log
-            val b = OtherClass().log
+            val a = DummyClass().logger
+            val b = OtherClass().logger
 
             a shouldNotBeSameInstanceAs b
         }
 
         "refuse to be used on a non-ORT class" {
             shouldThrow<IllegalArgumentException> {
-                String().log.info { "Hello from a String." }
+                String().logger.info { "Hello from a String." }
             }
         }
 

--- a/utils/ort/src/test/kotlin/test/other/OrtLogTestExtension.kt
+++ b/utils/ort/src/test/kotlin/test/other/OrtLogTestExtension.kt
@@ -23,7 +23,7 @@ package test.other
 import java.io.File
 
 import org.ossreviewtoolkit.utils.common.CommandLineTool
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * A test class simulating an external base class for ORT extensions. This is used to check whether extensions are
@@ -38,7 +38,7 @@ abstract class OrtLogTestBaseExtension : CommandLineTool
  */
 class OrtLogTestExtension : OrtLogTestBaseExtension() {
     override fun command(workingDir: File?): String {
-        log.info { "Test of the logger." }
+        logger.info { "Test of the logger." }
         return "success"
     }
 }

--- a/utils/scripting/src/main/kotlin/ScriptRunner.kt
+++ b/utils/scripting/src/main/kotlin/ScriptRunner.kt
@@ -31,7 +31,7 @@ import kotlin.time.measureTimedValue
 
 import kotlinx.coroutines.runBlocking
 
-import org.ossreviewtoolkit.utils.ort.log
+import org.ossreviewtoolkit.utils.ort.logger
 
 /**
  * A class providing the framework to run Kotlin scripts.
@@ -54,7 +54,7 @@ abstract class ScriptRunner {
             runBlocking { scriptingHost.compiler.invoke(script.toScriptSource(), compConfig) }
         }
 
-        log.info { "Compiling the script took $duration." }
+        logger.info { "Compiling the script took $duration." }
 
         logReports(result.reports)
 
@@ -69,7 +69,7 @@ abstract class ScriptRunner {
             scriptingHost.eval(script.toScriptSource(), compConfig, evalConfig)
         }
 
-        log.info { "Evaluating the script took $duration." }
+        logger.info { "Evaluating the script took $duration." }
 
         logReports(result.reports)
 
@@ -82,11 +82,11 @@ abstract class ScriptRunner {
     private fun logReports(reports: List<ScriptDiagnostic>) =
         reports.forEach { report ->
             when (report.severity) {
-                ScriptDiagnostic.Severity.DEBUG -> log.debug(report.message, report.exception)
-                ScriptDiagnostic.Severity.INFO -> log.info(report.message, report.exception)
-                ScriptDiagnostic.Severity.WARNING -> log.warn(report.message, report.exception)
-                ScriptDiagnostic.Severity.ERROR -> log.error(report.message, report.exception)
-                ScriptDiagnostic.Severity.FATAL -> log.fatal(report.message, report.exception)
+                ScriptDiagnostic.Severity.DEBUG -> logger.debug(report.message, report.exception)
+                ScriptDiagnostic.Severity.INFO -> logger.info(report.message, report.exception)
+                ScriptDiagnostic.Severity.WARNING -> logger.warn(report.message, report.exception)
+                ScriptDiagnostic.Severity.ERROR -> logger.error(report.message, report.exception)
+                ScriptDiagnostic.Severity.FATAL -> logger.fatal(report.message, report.exception)
             }
         }
 }


### PR DESCRIPTION
This is a preparation to ease an eventual migration to directly using
the Log4j Kotlin API [1] or SLF4J [2] / kotlin-logging [3], which all
promote the use of `logger` as opposed to `log`.

[1]: https://logging.apache.org/log4j/kotlin/index.html
[2]: https://www.slf4j.org/manual.html
[3]: https://github.com/MicroUtils/kotlin-logging

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>