### PR TITLE
RuleSet: Eliminate redundant default values for constructor paramaters

### DIFF
--- a/evaluator/src/main/kotlin/RuleSet.kt
+++ b/evaluator/src/main/kotlin/RuleSet.kt
@@ -149,5 +149,5 @@ fun ruleSet(
     ortResult: OrtResult,
     licenseInfoResolver: LicenseInfoResolver = ortResult.createLicenseInfoResolver(),
     resolutionProvider: ResolutionProvider = DefaultResolutionProvider.create(),
-    configure: RuleSet.() -> Unit
+    configure: RuleSet.() -> Unit = { }
 ) = RuleSet(ortResult, licenseInfoResolver, resolutionProvider).apply(configure)

--- a/evaluator/src/main/kotlin/RuleSet.kt
+++ b/evaluator/src/main/kotlin/RuleSet.kt
@@ -35,8 +35,8 @@ import org.ossreviewtoolkit.utils.ort.logger
  */
 class RuleSet(
     val ortResult: OrtResult,
-    val licenseInfoResolver: LicenseInfoResolver = ortResult.createLicenseInfoResolver(),
-    val resolutionProvider: ResolutionProvider = DefaultResolutionProvider.create(ortResult)
+    val licenseInfoResolver: LicenseInfoResolver,
+    val resolutionProvider: ResolutionProvider
 ) {
     /**
      * The list of all issues created by the rules of this [RuleSet].

--- a/evaluator/src/test/kotlin/DependencyRuleTest.kt
+++ b/evaluator/src/test/kotlin/DependencyRuleTest.kt
@@ -26,7 +26,7 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageReference
 
 class DependencyRuleTest : WordSpec() {
-    private val ruleSet = RuleSet(ortResult)
+    private val ruleSet = ruleSet(ortResult) { }
 
     private fun createRule(pkg: Package, dependency: PackageReference) =
         DependencyRule(

--- a/evaluator/src/test/kotlin/DependencyRuleTest.kt
+++ b/evaluator/src/test/kotlin/DependencyRuleTest.kt
@@ -26,7 +26,7 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageReference
 
 class DependencyRuleTest : WordSpec() {
-    private val ruleSet = ruleSet(ortResult) { }
+    private val ruleSet = ruleSet(ortResult)
 
     private fun createRule(pkg: Package, dependency: PackageReference) =
         DependencyRule(

--- a/evaluator/src/test/kotlin/PackageRuleTest.kt
+++ b/evaluator/src/test/kotlin/PackageRuleTest.kt
@@ -30,7 +30,7 @@ import org.ossreviewtoolkit.utils.spdx.SpdxLicenseIdExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
 
 class PackageRuleTest : WordSpec() {
-    private val ruleSet = RuleSet(ortResult)
+    private val ruleSet = ruleSet(ortResult) { }
 
     private fun createPackageRule(pkg: Package) =
         PackageRule(ruleSet, "test", pkg, emptyList(), ruleSet.licenseInfoResolver.resolveLicenseInfo(pkg.id))

--- a/evaluator/src/test/kotlin/PackageRuleTest.kt
+++ b/evaluator/src/test/kotlin/PackageRuleTest.kt
@@ -30,7 +30,7 @@ import org.ossreviewtoolkit.utils.spdx.SpdxLicenseIdExpression
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
 
 class PackageRuleTest : WordSpec() {
-    private val ruleSet = ruleSet(ortResult) { }
+    private val ruleSet = ruleSet(ortResult)
 
     private fun createPackageRule(pkg: Package) =
         PackageRule(ruleSet, "test", pkg, emptyList(), ruleSet.licenseInfoResolver.resolveLicenseInfo(pkg.id))

--- a/evaluator/src/test/kotlin/RuleTest.kt
+++ b/evaluator/src/test/kotlin/RuleTest.kt
@@ -30,7 +30,7 @@ import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseIdExpression
 
 class RuleTest : WordSpec() {
-    private val ruleSet = ruleSet(ortResult) { }
+    private val ruleSet = ruleSet(ortResult)
     private val id = Identifier("type:namespace:name:version")
     private val license = SpdxLicenseIdExpression("license")
     private val licenseSource = LicenseSource.DECLARED

--- a/evaluator/src/test/kotlin/RuleTest.kt
+++ b/evaluator/src/test/kotlin/RuleTest.kt
@@ -30,7 +30,7 @@ import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseIdExpression
 
 class RuleTest : WordSpec() {
-    private val ruleSet = RuleSet(ortResult)
+    private val ruleSet = ruleSet(ortResult) { }
     private val id = Identifier("type:namespace:name:version")
     private val license = SpdxLicenseIdExpression("license")
     private val licenseSource = LicenseSource.DECLARED


### PR DESCRIPTION
Currently, instances of `RuleSet` get constructed in two ways:

1. Tests call the constructor directly.
2. `rules.kts` calls the functions `ruleSet()` which in turn creates the
   instance.

Both, the constructor as well as the mentioned function, have
(redundant) default parameter values. Change the construction in tests
to also utilize `ruleSet()` and eliminate the now unnecessary default
values for the constructor parameters.

Context of #5621.