### PR TITLE
OrtResultRule: Eliminate a redundant constructor parameter

### DIFF
--- a/evaluator/src/main/kotlin/OrtResultRule.kt
+++ b/evaluator/src/main/kotlin/OrtResultRule.kt
@@ -27,12 +27,12 @@ import org.ossreviewtoolkit.model.OrtResult
 open class OrtResultRule(
     ruleSet: RuleSet,
     name: String,
-
+) : Rule(ruleSet, name) {
     /**
      * The [OrtResult] to check.
      */
-    val ortResult: OrtResult,
-) : Rule(ruleSet, name) {
+    val ortResult = ruleSet.ortResult
+
     override val description = "Evaluating ORT result rule '$name'."
 
     override fun issueSource() = "$name - ORT result"

--- a/evaluator/src/main/kotlin/RuleSet.kt
+++ b/evaluator/src/main/kotlin/RuleSet.kt
@@ -47,7 +47,7 @@ class RuleSet(
      * A DSL function to configure an [OrtResultRule]. The rule is applied once to [ortResult].
      */
     fun ortResultRule(name: String, configure: OrtResultRule.() -> Unit) {
-        OrtResultRule(this, name, ortResult).apply {
+        OrtResultRule(this, name).apply {
             configure()
             evaluate()
         }


### PR DESCRIPTION
Previously, the `OrtResult` instance was passed twice, via the
constructor parameters `ruleSet.ortResult` and `ortResult`. So, remove
the parameter `ortResult` to eliminate the redundancy, but keep it as a
property for convenience and to not break any implementations, e.g.
`rules.kts`.

Context: #5621.