### PR TITLE
Example-rules: Refactor for readability

### DIFF
--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -228,6 +228,27 @@ fun RuleSet.copyleftInDependencyRule() = dependencyRule("COPYLEFT_IN_DEPENDENCY"
     }
 }
 
+fun RuleSet.copyleftLimitedInDependencyRule() = dependencyRule("COPYLEFT_LIMITED_IN_DEPENDENCY_RULE") {
+    require {
+        +isAtTreeLevel(0)
+        +isStaticallyLinked()
+    }
+
+    licenseRule("COPYLEFT_LIMITED_IN_DEPENDENCY_RULE", LicenseView.CONCLUDED_OR_DECLARED_OR_DETECTED) {
+        require {
+            +isCopyleftLimited()
+        }
+
+        // Use issue() instead of error() if you want to set the severity.
+        issue(
+            Severity.WARNING,
+            "The project ${project.id.toCoordinates()} has a statically linked direct dependency licensed " +
+                    "under the ScanCode copyleft-left categorized license $license.",
+            howToFixDefault()
+        )
+    }
+}
+
 // Define the set of policy rules.
 val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     // Define a rule that is executed for each package.
@@ -240,27 +261,7 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
 
     // Define a rule that is executed for each dependency of a project.
     copyleftInDependencyRule()
-
-    dependencyRule("COPYLEFT_LIMITED_IN_DEPENDENCY_RULE") {
-        require {
-            +isAtTreeLevel(0)
-            +isStaticallyLinked()
-        }
-
-        licenseRule("COPYLEFT_LIMITED_IN_DEPENDENCY_RULE", LicenseView.CONCLUDED_OR_DECLARED_OR_DETECTED) {
-            require {
-                +isCopyleftLimited()
-            }
-
-            // Use issue() instead of error() if you want to set the severity.
-            issue(
-                Severity.WARNING,
-                "The project ${project.id.toCoordinates()} has a statically linked direct dependency licensed " +
-                        "under the ScanCode copyleft-left categorized license $license.",
-                howToFixDefault()
-            )
-        }
-    }
+    copyleftLimitedInDependencyRule()
 
     ortResultRule("DEPRECATED_SCOPE_EXCLUDE_REASON_IN_ORT_YML") {
         val reasons = ortResult.repository.config.excludes.scopes.mapTo(mutableSetOf()) { it.reason }

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -265,9 +265,11 @@ fun RuleSet.deprecatedScopeExcludeReasonInOrtYmlRule() = ortResultRule("DEPRECAT
     }
 }
 
-// Define the set of policy rules.
+/**
+ * The set of policy rules.
+ */
 val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
-    // Define a rule that is executed for each package.
+    // Rules which get executed for each package:
     unhandledLicenseRule()
     unmappedDeclaredLicenseRule()
     copyleftInSourceRule()
@@ -275,9 +277,11 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     vulnerabilityInPackageRule()
     highSeverityVulnerabilityInPackageRule()
 
-    // Define a rule that is executed for each dependency of a project.
+    // Rules which get executed for each dependency (of any project):
     copyleftInDependencyRule()
     copyleftLimitedInDependencyRule()
+
+    // Rules which get executed once:
     deprecatedScopeExcludeReasonInOrtYmlRule()
 }
 

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -241,13 +241,13 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     // Define a rule that is executed for each dependency of a project.
     copyleftInDependencyRule()
 
-    dependencyRule("COPYLEFT_LIMITED_STATIC_LINK_IN_DIRECT_DEPENDENCY") {
+    dependencyRule("COPYLEFT_LIMITED_IN_DEPENDENCY_RULE") {
         require {
             +isAtTreeLevel(0)
             +isStaticallyLinked()
         }
 
-        licenseRule("LINKED_WEAK_COPYLEFT", LicenseView.CONCLUDED_OR_DECLARED_OR_DETECTED) {
+        licenseRule("COPYLEFT_LIMITED_IN_DEPENDENCY_RULE", LicenseView.CONCLUDED_OR_DECLARED_OR_DETECTED) {
             require {
                 +isCopyleftLimited()
             }

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -213,6 +213,21 @@ fun RuleSet.highSeverityVulnerabilityInPackageRule() = packageRule("HIGH_SEVERIT
     )
 }
 
+fun RuleSet.copyleftInDependencyRule() = dependencyRule("COPYLEFT_IN_DEPENDENCY") {
+    licenseRule("COPYLEFT_IN_DEPENDENCY", LicenseView.CONCLUDED_OR_DECLARED_OR_DETECTED) {
+        require {
+            +isCopyleft()
+        }
+
+        issue(
+            Severity.ERROR,
+            "The project ${project.id.toCoordinates()} has a dependency licensed under the ScanCode " +
+                    "copyleft categorized license $license.",
+            howToFixDefault()
+        )
+    }
+}
+
 // Define the set of policy rules.
 val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     // Define a rule that is executed for each package.
@@ -224,20 +239,7 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     highSeverityVulnerabilityInPackageRule()
 
     // Define a rule that is executed for each dependency of a project.
-    dependencyRule("COPYLEFT_IN_DEPENDENCY") {
-        licenseRule("COPYLEFT_IN_DEPENDENCY", LicenseView.CONCLUDED_OR_DECLARED_OR_DETECTED) {
-            require {
-                +isCopyleft()
-            }
-
-            issue(
-                Severity.ERROR,
-                "The project ${project.id.toCoordinates()} has a dependency licensed under the ScanCode " +
-                        "copyleft categorized license $license.",
-                howToFixDefault()
-            )
-        }
-    }
+    copyleftInDependencyRule()
 
     dependencyRule("COPYLEFT_LIMITED_STATIC_LINK_IN_DIRECT_DEPENDENCY") {
         require {

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -194,6 +194,25 @@ fun RuleSet.vulnerabilityInPackageRule() = packageRule("VULNERABILITY_IN_PACKAGE
     )
 }
 
+fun RuleSet.highSeverityVulnerabilityInPackageRule() = packageRule("HIGH_SEVERITY_VULNERABILITY_IN_PACKAGE") {
+    val maxAcceptedSeverity = "5.0"
+    val scoringSystem = "CVSS2"
+
+    require {
+        -isExcluded()
+        +hasVulnerability(maxAcceptedSeverity, scoringSystem) { value, threshold ->
+            value.toFloat() >= threshold.toFloat()
+        }
+    }
+
+    issue(
+        Severity.ERROR,
+        "The package ${pkg.id.toCoordinates()} has a vulnerability with $scoringSystem severity > " +
+                "$maxAcceptedSeverity",
+        howToFixDefault()
+    )
+}
+
 // Define the set of policy rules.
 val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     // Define a rule that is executed for each package.
@@ -202,25 +221,7 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     copyleftInSourceRule()
     copyleftInSourceLimitedRule()
     vulnerabilityInPackageRule()
-
-    packageRule("HIGH_SEVERITY_VULNERABILITY_IN_PACKAGE") {
-        val maxAcceptedSeverity = "5.0"
-        val scoringSystem = "CVSS2"
-
-        require {
-            -isExcluded()
-            +hasVulnerability(maxAcceptedSeverity, scoringSystem) { value, threshold ->
-                value.toFloat() >= threshold.toFloat()
-            }
-        }
-
-        issue(
-            Severity.ERROR,
-            "The package ${pkg.id.toCoordinates()} has a vulnerability with $scoringSystem severity > " +
-                    "$maxAcceptedSeverity",
-            howToFixDefault()
-        )
-    }
+    highSeverityVulnerabilityInPackageRule()
 
     // Define a rule that is executed for each dependency of a project.
     dependencyRule("COPYLEFT_IN_DEPENDENCY") {

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -129,32 +129,39 @@ fun RuleSet.unmappedDeclaredLicenseRule() = packageRule("UNMAPPED_DECLARED_LICEN
     }
 }
 
+fun RuleSet.copyleftInSourceRule() = packageRule("COPYLEFT_IN_SOURCE") {
+    require {
+        -isExcluded()
+    }
+
+    licenseRule("COPYLEFT_IN_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+        require {
+            -isExcluded()
+            +isCopyleft()
+        }
+
+        val message = if (licenseSource == LicenseSource.DETECTED) {
+            "The ScanCode copyleft categorized license $license was ${licenseSource.name.lowercase()} " +
+                    "in package ${pkg.id.toCoordinates()}."
+        } else {
+            "The package ${pkg.id.toCoordinates()} has the ${licenseSource.name.lowercase()} ScanCode copyleft " +
+                    "catalogized license $license."
+        }
+
+        error(message, howToFixDefault())
+    }
+}
+
 // Define the set of policy rules.
 val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     // Define a rule that is executed for each package.
     unhandledLicenseRule()
     unmappedDeclaredLicenseRule()
+    copyleftInSourceRule()
 
-    packageRule("COPYLEFT_IN_SOURCE") {
+    packageRule("COPYLEFT_LIMITED_IN_SOURCE") {
         require {
             -isExcluded()
-        }
-
-        licenseRule("COPYLEFT_IN_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
-            require {
-                -isExcluded()
-                +isCopyleft()
-            }
-
-            val message = if (licenseSource == LicenseSource.DETECTED) {
-                "The ScanCode copyleft categorized license $license was ${licenseSource.name.lowercase()} " +
-                        "in package ${pkg.id.toCoordinates()}."
-            } else {
-                "The package ${pkg.id.toCoordinates()} has the ${licenseSource.name.lowercase()} ScanCode copyleft " +
-                        "catalogized license $license."
-            }
-
-            error(message, howToFixDefault())
         }
 
         licenseRule("COPYLEFT_LIMITED_IN_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_OR_DETECTED) {

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -115,24 +115,25 @@ fun RuleSet.unhandledLicenseRule() = packageRule("UNHANDLED_LICENSE") {
     }
 }
 
+fun RuleSet.unmappedDeclaredLicenseRule() = packageRule("UNMAPPED_DECLARED_LICENSE") {
+    require {
+        -isExcluded()
+    }
+
+    resolvedLicenseInfo.licenseInfo.declaredLicenseInfo.processed.unmapped.forEach { unmappedLicense ->
+        warning(
+            "The declared license '$unmappedLicense' could not be mapped to a valid license or parsed as an SPDX " +
+                    "expression. The license was found in package ${pkg.id.toCoordinates()}.",
+            howToFixDefault()
+        )
+    }
+}
+
 // Define the set of policy rules.
 val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     // Define a rule that is executed for each package.
     unhandledLicenseRule()
-
-    packageRule("UNMAPPED_DECLARED_LICENSE") {
-        require {
-            -isExcluded()
-        }
-
-        resolvedLicenseInfo.licenseInfo.declaredLicenseInfo.processed.unmapped.forEach { unmappedLicense ->
-            warning(
-                "The declared license '$unmappedLicense' could not be mapped to a valid license or parsed as an SPDX " +
-                        "expression. The license was found in package ${pkg.id.toCoordinates()}.",
-                howToFixDefault()
-            )
-        }
-    }
+    unmappedDeclaredLicenseRule()
 
     packageRule("COPYLEFT_IN_SOURCE") {
         require {

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -152,41 +152,42 @@ fun RuleSet.copyleftInSourceRule() = packageRule("COPYLEFT_IN_SOURCE") {
     }
 }
 
+fun RuleSet.copyleftInSourceLimitedRule() = packageRule("COPYLEFT_LIMITED_IN_SOURCE") {
+    require {
+        -isExcluded()
+    }
+
+    licenseRule("COPYLEFT_LIMITED_IN_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_OR_DETECTED) {
+        require {
+            -isExcluded()
+            +isCopyleftLimited()
+        }
+
+        val licenseSourceName = licenseSource.name.lowercase()
+        val message = if (licenseSource == LicenseSource.DETECTED) {
+            if (pkg.id.type == "Unmanaged") {
+                "The ScanCode copyleft-limited categorized license $license was $licenseSourceName in package " +
+                        "${pkg.id.toCoordinates()}."
+            } else {
+                "The ScanCode copyleft-limited categorized license $license was $licenseSourceName in package " +
+                        "${pkg.id.toCoordinates()}."
+            }
+        } else {
+            "The package ${pkg.id.toCoordinates()} has the $licenseSourceName ScanCode copyleft-limited " +
+                    "categorized license $license."
+        }
+
+        error(message, howToFixDefault())
+    }
+}
+
 // Define the set of policy rules.
 val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     // Define a rule that is executed for each package.
     unhandledLicenseRule()
     unmappedDeclaredLicenseRule()
     copyleftInSourceRule()
-
-    packageRule("COPYLEFT_LIMITED_IN_SOURCE") {
-        require {
-            -isExcluded()
-        }
-
-        licenseRule("COPYLEFT_LIMITED_IN_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_OR_DETECTED) {
-            require {
-                -isExcluded()
-                +isCopyleftLimited()
-            }
-
-            val licenseSourceName = licenseSource.name.lowercase()
-            val message = if (licenseSource == LicenseSource.DETECTED) {
-                if (pkg.id.type == "Unmanaged") {
-                    "The ScanCode copyleft-limited categorized license $license was $licenseSourceName in package " +
-                            "${pkg.id.toCoordinates()}."
-                } else {
-                    "The ScanCode copyleft-limited categorized license $license was $licenseSourceName in package " +
-                            "${pkg.id.toCoordinates()}."
-                }
-            } else {
-                "The package ${pkg.id.toCoordinates()} has the $licenseSourceName ScanCode copyleft-limited " +
-                        "categorized license $license."
-            }
-
-            error(message, howToFixDefault())
-        }
-    }
+    copyleftInSourceLimitedRule()
 
     packageRule("VULNERABILITY_IN_PACKAGE") {
         require {

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -92,31 +92,33 @@ fun PackageRule.LicenseRule.isCopyleftLimited() =
  * Example policy rules
  */
 
+fun RuleSet.unhandledLicenseRule() = packageRule("UNHANDLED_LICENSE") {
+    // Do not trigger this rule on packages that have been excluded in the .ort.yml.
+    require {
+        -isExcluded()
+    }
+
+    // Define a rule that is executed for each license of the package.
+    licenseRule("UNHANDLED_LICENSE", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+        require {
+            -isExcluded()
+            -isHandled()
+        }
+
+        // Throw an error message including guidance how to fix the issue.
+        error(
+            "The license $license is currently not covered by policy rules. " +
+                    "The license was ${licenseSource.name.lowercase()} in package " +
+                    "${pkg.id.toCoordinates()}",
+            howToFixDefault()
+        )
+    }
+}
+
 // Define the set of policy rules.
 val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     // Define a rule that is executed for each package.
-    packageRule("UNHANDLED_LICENSE") {
-        // Do not trigger this rule on packages that have been excluded in the .ort.yml.
-        require {
-            -isExcluded()
-        }
-
-        // Define a rule that is executed for each license of the package.
-        licenseRule("UNHANDLED_LICENSE", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
-            require {
-                -isExcluded()
-                -isHandled()
-            }
-
-            // Throw an error message including guidance how to fix the issue.
-            error(
-                "The license $license is currently not covered by policy rules. " +
-                        "The license was ${licenseSource.name.lowercase()} in package " +
-                        "${pkg.id.toCoordinates()}",
-                howToFixDefault()
-            )
-        }
-    }
+    unhandledLicenseRule()
 
     packageRule("UNMAPPED_DECLARED_LICENSE") {
         require {

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -54,9 +54,8 @@ val handledLicenses = listOf(
 }
 
 /**
- * Function to return Markdown-formatted text to aid users with resolving violations.
+ * Return the Markdown-formatted text to aid users with resolving violations.
  */
-
 fun PackageRule.howToFixDefault() = """
         A text written in MarkDown to help users resolve policy violations
         which may link to additional resources.

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -181,6 +181,19 @@ fun RuleSet.copyleftInSourceLimitedRule() = packageRule("COPYLEFT_LIMITED_IN_SOU
     }
 }
 
+fun RuleSet.vulnerabilityInPackageRule() = packageRule("VULNERABILITY_IN_PACKAGE") {
+    require {
+        -isExcluded()
+        +hasVulnerability()
+    }
+
+    issue(
+        Severity.WARNING,
+        "The package ${pkg.id.toCoordinates()} has a vulnerability",
+        howToFixDefault()
+    )
+}
+
 // Define the set of policy rules.
 val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     // Define a rule that is executed for each package.
@@ -188,19 +201,7 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     unmappedDeclaredLicenseRule()
     copyleftInSourceRule()
     copyleftInSourceLimitedRule()
-
-    packageRule("VULNERABILITY_IN_PACKAGE") {
-        require {
-            -isExcluded()
-            +hasVulnerability()
-        }
-
-        issue(
-            Severity.WARNING,
-            "The package ${pkg.id.toCoordinates()} has a vulnerability",
-            howToFixDefault()
-        )
-    }
+    vulnerabilityInPackageRule()
 
     packageRule("HIGH_SEVERITY_VULNERABILITY_IN_PACKAGE") {
         val maxAcceptedSeverity = "5.0"

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -249,6 +249,22 @@ fun RuleSet.copyleftLimitedInDependencyRule() = dependencyRule("COPYLEFT_LIMITED
     }
 }
 
+fun RuleSet.deprecatedScopeExcludeReasonInOrtYmlRule() = ortResultRule("DEPRECATED_SCOPE_EXCLUDE_REASON_IN_ORT_YML") {
+    val reasons = ortResult.repository.config.excludes.scopes.mapTo(mutableSetOf()) { it.reason }
+
+    @Suppress("DEPRECATION")
+    val deprecatedReasons = setOf(ScopeExcludeReason.TEST_TOOL_OF)
+
+    reasons.intersect(deprecatedReasons).forEach { offendingReason ->
+        warning(
+            "The repository configuration is using the deprecated scope exclude reason '$offendingReason'.",
+            "Please use only non-deprecated scope exclude reasons, see " +
+                    "https://github.com/oss-review-toolkit/ort/blob/main/model/src/main/" +
+                    "kotlin/config/ScopeExcludeReason.kt."
+        )
+    }
+}
+
 // Define the set of policy rules.
 val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     // Define a rule that is executed for each package.
@@ -262,22 +278,7 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     // Define a rule that is executed for each dependency of a project.
     copyleftInDependencyRule()
     copyleftLimitedInDependencyRule()
-
-    ortResultRule("DEPRECATED_SCOPE_EXCLUDE_REASON_IN_ORT_YML") {
-        val reasons = ortResult.repository.config.excludes.scopes.mapTo(mutableSetOf()) { it.reason }
-
-        @Suppress("DEPRECATION")
-        val deprecatedReasons = setOf(ScopeExcludeReason.TEST_TOOL_OF)
-
-        reasons.intersect(deprecatedReasons).forEach { offendingReason ->
-            warning(
-                "The repository configuration is using the deprecated scope exclude reason '$offendingReason'.",
-                "Please use only non-deprecated scope exclude reasons, see " +
-                        "https://github.com/oss-review-toolkit/ort/blob/main/model/src/main/" +
-                        "kotlin/config/ScopeExcludeReason.kt."
-            )
-        }
-    }
+    deprecatedScopeExcludeReasonInOrtYmlRule()
 }
 
 // Populate the list of policy rule violations to return.


### PR DESCRIPTION
Extract each policy rule into a separate top level function. This reduces the level of nesting and increases the abstraction level of the rule set creation code. Now that code provides a nice overview over all policy rules. While at it, the naming of rules has been made a tad more consistent.

Changes are in context of #5621 as preparation for adding further rules.