### PR TITLE
Replace pipdeptree with python-inspector #4637 #3671

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ ARG CRT_FILES=""
 # Set this to the ScanCode version to use.
 ARG SCANCODE_VERSION="30.1.0"
 
+# Set this to the Python Inspector version to use.
+ARG PYTHON_INSPECTOR_VERSION="0.6.4"
+
 FROM eclipse-temurin:11-jdk-jammy AS build
 
 COPY . /usr/local/src/ort
@@ -155,6 +158,9 @@ RUN /opt/ort/bin/import_proxy_certs.sh && \
 # Add scanners (in versions known to work).
 ARG SCANCODE_VERSION
 RUN pip install --no-cache-dir scancode-toolkit==$SCANCODE_VERSION
+
+ARG PYTHON_INSPECTOR_VERSION
+RUN pip install --no-cache-dir python-inspector==$PYTHON_INSPECTOR_VERSION
 
 FROM run AS dist
 

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -26,14 +26,13 @@ project:
   - name: "install"
     dependencies:
     - id: "PyPI::ply:3.11"
-    - id: "PyPI::rdflib:5.0.0"
+    - id: "PyPI::rdflib:6.2.0"
       dependencies:
       - id: "PyPI::isodate:0.6.1"
         dependencies:
         - id: "PyPI::six:1.16.0"
-      - id: "PyPI::pyparsing:2.4.7"
-      - id: "PyPI::six:1.16.0"
-    - id: "PyPI::six:1.16.0"
+      - id: "PyPI::pyparsing:3.0.9"
+      - id: "PyPI::setuptools:65.2.0"
 packages:
 - id: "PyPI::isodate:0.6.1"
   purl: "pkg:pypi/isodate@0.6.1"
@@ -101,27 +100,26 @@ packages:
     url: ""
     revision: ""
     path: ""
-- id: "PyPI::pyparsing:2.4.7"
-  purl: "pkg:pypi/pyparsing@2.4.7"
-  authors:
-  - "Paul McGuire"
+- id: "PyPI::pyparsing:3.0.9"
+  purl: "pkg:pypi/pyparsing@3.0.9"
   declared_licenses:
   - "MIT License"
   declared_licenses_processed:
     spdx_expression: "MIT"
     mapped:
       MIT License: "MIT"
-  description: "Python parsing module"
-  homepage_url: "https://github.com/pyparsing/pyparsing/"
+  description: "pyparsing module - Classes and methods to define and execute parsing\
+    \ grammars"
+  homepage_url: ""
   binary_artifact:
-    url: "https://files.pythonhosted.org/packages/8a/bb/488841f56197b13700afd5658fc279a2025a39e22449b7cf29864669b15d/pyparsing-2.4.7-py2.py3-none-any.whl"
+    url: "https://files.pythonhosted.org/packages/6c/10/a7d0fa5baea8fe7b50f448ab742f26f52b80bfca85ac2be9d35cdd9a3246/pyparsing-3.0.9-py3-none-any.whl"
     hash:
-      value: "dbfd0a241aad2595f43377ec7f1836ea"
+      value: "9b7c6d2c436bc7eba41f5f239b391b4c"
       algorithm: "MD5"
   source_artifact:
-    url: "https://files.pythonhosted.org/packages/c1/47/dfc9c342c9842bbe0036c7f763d2d6686bcf5eb1808ba3e170afdb282210/pyparsing-2.4.7.tar.gz"
+    url: "https://files.pythonhosted.org/packages/71/22/207523d16464c40a0310d2d4d8926daffa00ac1f5b1576170a32db749636/pyparsing-3.0.9.tar.gz"
     hash:
-      value: "f0953e47a0112f7a65aec2305ffdf7b4"
+      value: "fadc2f3bf5872bf6310576a86c3566e0"
       algorithm: "MD5"
   vcs:
     type: ""
@@ -133,29 +131,30 @@ packages:
     url: "https://github.com/pyparsing/pyparsing.git"
     revision: ""
     path: ""
-- id: "PyPI::rdflib:5.0.0"
-  purl: "pkg:pypi/rdflib@5.0.0"
+- id: "PyPI::rdflib:6.2.0"
+  purl: "pkg:pypi/rdflib@6.2.0"
   authors:
   - "Daniel 'eikeon' Krech"
   declared_licenses:
   - "BSD License"
-  - "BSD-3-Clause"
+  - "bsd-3-clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped:
+      bsd-3-clause: "BSD-3-Clause"
       BSD License: "BSD-3-Clause"
   description: "RDFLib is a Python library for working with RDF, a simple yet powerful\
     \ language for representing information."
   homepage_url: "https://github.com/RDFLib/rdflib"
   binary_artifact:
-    url: "https://files.pythonhosted.org/packages/d0/6b/6454aa1db753c0f8bc265a5bd5c10b5721a4bb24160fb4faf758cf6be8a1/rdflib-5.0.0-py3-none-any.whl"
+    url: "https://files.pythonhosted.org/packages/50/fb/a0f8b6ab6598b49871a48a189dc1942fb0b0543ab4c84f689486233ef1ec/rdflib-6.2.0-py3-none-any.whl"
     hash:
-      value: "8ad1eb4d67ade138370fb45ce1cb3412"
+      value: "ef0f58b20c1423a745e4697c9f5c7cb7"
       algorithm: "MD5"
   source_artifact:
-    url: "https://files.pythonhosted.org/packages/2f/ae/a50934a7ed4f9d80bbc0e0cf725c7fd2208f2e433efbf881ed0c0317a7f1/rdflib-5.0.0.tar.gz"
+    url: "https://files.pythonhosted.org/packages/fc/8d/2d1c8a08471b4333657c98a3048642095f844f10cd1d4e28f9b08725c7bd/rdflib-6.2.0.tar.gz"
     hash:
-      value: "80d7c6adc2e4040cdd8dade2e0e61403"
+      value: "1c1cc2ba4a03d21cb65a64ad97d75b19"
       algorithm: "MD5"
   vcs:
     type: ""
@@ -165,6 +164,38 @@ packages:
   vcs_processed:
     type: "Git"
     url: "https://github.com/RDFLib/rdflib.git"
+    revision: ""
+    path: ""
+- id: "PyPI::setuptools:65.2.0"
+  purl: "pkg:pypi/setuptools@65.2.0"
+  authors:
+  - "Python Packaging Authority"
+  declared_licenses:
+  - "MIT License"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+    mapped:
+      MIT License: "MIT"
+  description: "Easily download, build, install, upgrade, and uninstall Python packages"
+  homepage_url: "https://github.com/pypa/setuptools"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/e5/6f/942e63ec2a5c881df147782b97dc4715ca082dec9de41f43e1013faef710/setuptools-65.2.0-py3-none-any.whl"
+    hash:
+      value: "832c67899e7250823fbf08c43ffaa487"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/15/a7/b4cab9eca586ed17c66b3aced23ccf945312c50742614039d0cd71c870bd/setuptools-65.2.0.tar.gz"
+    hash:
+      value: "90ce497683b81b7c9943637ea0dd6817"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/pypa/setuptools.git"
     revision: ""
     path: ""
 - id: "PyPI::six:1.16.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/python-inspector-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/python-inspector-expected-output.yml
@@ -1,0 +1,226 @@
+---
+project:
+  id: "PIP::src/funTest/assets/projects/synthetic/python-inspector/requirements.txt:<REPLACE_REVISION>"
+  definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/python-inspector/requirements.txt"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scopes:
+  - name: "install"
+    dependencies:
+    - id: "PyPI::flask:1.0"
+      dependencies:
+      - id: "PyPI::click:6.7"
+      - id: "PyPI::itsdangerous:0.24"
+      - id: "PyPI::jinja2:2.11.3"
+        dependencies:
+        - id: "PyPI::markupsafe:1.0"
+      - id: "PyPI::werkzeug:0.15.3"
+packages:
+- id: "PyPI::click:6.7"
+  purl: "pkg:pypi/click@6.7"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD License"
+  declared_licenses_processed:
+    unmapped:
+    - "BSD License"
+  description: "A simple wrapper around optparse for powerful command line utilities."
+  homepage_url: "http://github.com/mitsuhiko/click"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/34/c1/8806f99713ddb993c5366c362b2f908f18269f8d792aff1abfd700775a77/click-6.7-py2.py3-none-any.whl"
+    hash:
+      value: "5e7a4e296b3212da2ff11017675d7a4d"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/95/d9/c3336b6b5711c3ab9d1d3a80f1a3e2afeb9d8c02a7166462f6cc96570897/click-6.7.tar.gz"
+    hash:
+      value: "fc4cc00c4863833230d3af92af48abd4"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/mitsuhiko/click.git"
+    revision: ""
+    path: ""
+- id: "PyPI::flask:1.0"
+  purl: "pkg:pypi/flask@1.0"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD"
+  - "BSD License"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD: "BSD-3-Clause"
+      BSD License: "BSD-3-Clause"
+  description: "A simple framework for building complex web applications."
+  homepage_url: "https://www.palletsprojects.com/p/flask/"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/55/b1/4365193655df97227ace49311365cc296e74b60c7f5c63d23cd30175e2f6/Flask-1.0-py2.py3-none-any.whl"
+    hash:
+      value: "4c0757a5a489d4db8260c6d722c5e6b0"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/99/ab/eedb921f26adf7057ade1291f9c1bfa35a506d64894f58546457ef658772/Flask-1.0.tar.gz"
+    hash:
+      value: "7140df3116386c7af0f389800a91817b"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/pallets/flask.git"
+    revision: ""
+    path: ""
+- id: "PyPI::itsdangerous:0.24"
+  purl: "pkg:pypi/itsdangerous@0.24"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD License"
+  declared_licenses_processed:
+    unmapped:
+    - "BSD License"
+  description: "Various helpers to pass trusted data to untrusted environments and\
+    \ back."
+  homepage_url: "http://github.com/mitsuhiko/itsdangerous"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/dc/b4/a60bcdba945c00f6d608d8975131ab3f25b22f2bcfe1dab221165194b2d4/itsdangerous-0.24.tar.gz"
+    hash:
+      value: "a3d55aa79369aef5345c036a8a26307f"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/dc/b4/a60bcdba945c00f6d608d8975131ab3f25b22f2bcfe1dab221165194b2d4/itsdangerous-0.24.tar.gz"
+    hash:
+      value: "a3d55aa79369aef5345c036a8a26307f"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/mitsuhiko/itsdangerous.git"
+    revision: ""
+    path: ""
+- id: "PyPI::jinja2:2.11.3"
+  purl: "pkg:pypi/jinja2@2.11.3"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD License"
+  - "BSD-3-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD License: "BSD-3-Clause"
+  description: "A very fast and expressive template engine."
+  homepage_url: "https://palletsprojects.com/p/jinja/"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/7e/c2/1eece8c95ddbc9b1aeb64f5783a9e07a286de42191b7204d67b7496ddf35/Jinja2-2.11.3-py2.py3-none-any.whl"
+    hash:
+      value: "8e733c6f4cdef7f6a336299e8e548dfa"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/4f/e7/65300e6b32e69768ded990494809106f87da1d436418d5f1367ed3966fd7/Jinja2-2.11.3.tar.gz"
+    hash:
+      value: "231dc00d34afb2672c497713fa9cdaaa"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/pallets/jinja.git"
+    revision: ""
+    path: ""
+- id: "PyPI::markupsafe:1.0"
+  purl: "pkg:pypi/markupsafe@1.0"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD"
+  - "BSD License"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD: "BSD-3-Clause"
+      BSD License: "BSD-3-Clause"
+  description: "Implements a XML/HTML/XHTML Markup safe string for Python"
+  homepage_url: "http://github.com/pallets/markupsafe"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
+    hash:
+      value: "2fcedc9284d50e577b5192e8e3578355"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
+    hash:
+      value: "2fcedc9284d50e577b5192e8e3578355"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/pallets/markupsafe.git"
+    revision: ""
+    path: ""
+- id: "PyPI::werkzeug:0.15.3"
+  purl: "pkg:pypi/werkzeug@0.15.3"
+  authors:
+  - "Armin Ronacher"
+  declared_licenses:
+  - "BSD License"
+  - "BSD-3-Clause"
+  declared_licenses_processed:
+    spdx_expression: "BSD-3-Clause"
+    mapped:
+      BSD License: "BSD-3-Clause"
+  description: "The comprehensive WSGI web application library."
+  homepage_url: "https://palletsprojects.com/p/werkzeug/"
+  binary_artifact:
+    url: "https://files.pythonhosted.org/packages/3d/bf/79101bd1d6a2b3fe0888e8d6e039800b173f26b7388308fc4bcc45de8d0a/Werkzeug-0.15.3-py2.py3-none-any.whl"
+    hash:
+      value: "5e1e9fb526428fbafe0eccadc2015a5c"
+      algorithm: "MD5"
+  source_artifact:
+    url: "https://files.pythonhosted.org/packages/9c/6d/854f2aa124dcfeb901815492b7fa7f026d114a18784c1c679fbdea36c809/Werkzeug-0.15.3.tar.gz"
+    hash:
+      value: "2da857b57e7e4c5b6403369a9d1c15a9"
+      algorithm: "MD5"
+  vcs:
+    type: ""
+    url: ""
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/pallets/werkzeug.git"
+    revision: ""
+    path: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/python-inspector/requirements.txt
+++ b/analyzer/src/funTest/assets/projects/synthetic/python-inspector/requirements.txt
@@ -1,0 +1,7 @@
+click>6,<6.8
+Flask==1.0
+itsdangerous<0.25
+license-expression ; platform_system == "Windows"
+Jinja2==2.11.3
+MarkupSafe==1.0
+Werkzeug==0.15.3

--- a/analyzer/src/funTest/kotlin/managers/PipFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PipFunTest.kt
@@ -99,6 +99,21 @@ class PipFunTest : WordSpec() {
 
                 result.toYaml() shouldBe expectedResult
             }
+
+            "capture metadata using python-inspector" {
+                val definitionFile = projectsDir.resolve("synthetic/python-inspector/requirements.txt")
+                val vcsPath = vcsDir.getPathToRoot(definitionFile.parentFile)
+
+                val result = createPip().resolveSingleProject(definitionFile)
+                val expectedResult = patchExpectedResult(
+                    projectsDir.resolve("synthetic/python-inspector-expected-output.yml"),
+                    url = normalizeVcsUrl(vcsUrl),
+                    revision = vcsRevision,
+                    path = vcsPath
+                )
+
+                result.toYaml() shouldBe expectedResult
+            }
         }
     }
 

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -33,7 +33,6 @@ import org.apache.logging.log4j.kotlin.Logging
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.downloader.VersionControlSystem
-import org.ossreviewtoolkit.model.EMPTY_JSON_NODE
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
@@ -62,14 +61,8 @@ import org.ossreviewtoolkit.utils.spdx.SpdxLicenseIdExpression
 // https://pip.pypa.io/en/stable/news/#id176.
 private const val PIP_VERSION = "20.3.4"
 
-// See https://github.com/naiquevin/pipdeptree.
-private const val PIPDEPTREE_VERSION = "2.2.1"
-
 private val PHONY_DEPENDENCIES = mapOf(
-    "pipdeptree" to "", // A dependency of pipdeptree itself.
     "pkg-resources" to "0.0.0", // Added by a bug with some Ubuntu distributions.
-    "setuptools" to "", // A dependency of pipdeptree itself.
-    "wheel" to "" // A dependency of pipdeptree itself.
 )
 
 private fun isPhonyDependency(name: String, version: String): Boolean =
@@ -142,6 +135,34 @@ object PythonVersion : CommandLineTool, Logging {
         }
 }
 
+object PythonInspector : CommandLineTool {
+    override fun command(workingDir: File?) = "python-inspector"
+
+    fun runPythonInspector(
+        workingDir: File,
+        outputFile: String,
+        requirementsFile: String?,
+        setupPyFile: String?,
+        pythonVersion: String = "38",
+    ): ProcessCapture {
+        var commandLineOptions = listOf(
+            "python-inspector",
+            "--python-version", pythonVersion,
+            "--json-pdt", outputFile,
+        )
+
+        if (requirementsFile != null) {
+            commandLineOptions += listOf("--requirement", requirementsFile)
+        } else if (setupPyFile != null) {
+            commandLineOptions += listOf("--setup-py", setupPyFile)
+        }
+
+        val process = ProcessCapture(workingDir, *commandLineOptions.toTypedArray())
+        process.requireSuccess()
+        return process
+    }
+}
+
 /**
  * The [PIP](https://pip.pypa.io/) package manager for Python. Also see
  * [install_requires vs requirements files](https://packaging.python.org/discussions/install-requires-vs-requirements/)
@@ -208,16 +229,15 @@ class Pip(
 
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {
         // For an overview, dependency resolution involves the following steps:
-        // 1. Install dependencies via pip (inside a virtualenv, for isolation from globally installed packages).
-        // 2. Get metadata about the local project via `python setup.py`.
-        // 3. Get the hierarchy of dependencies via pipdeptree.
-        // 4. Get additional remote package metadata via PyPIJSON.
+        // 1. Get metadata about the local project via `python setup.py`.
+        // 2. Get the hierarchy of dependencies via python-inspector.
+        // 3. Get additional remote package metadata via PyPI JSON.
 
         val workingDir = definitionFile.parentFile
         val virtualEnvDir = setupVirtualEnv(workingDir, definitionFile)
 
         val project = getProjectBasics(definitionFile, virtualEnvDir)
-        val (packages, installDependencies) = getInstallDependencies(definitionFile, virtualEnvDir, project.id.name)
+        val (packages, installDependencies) = getInstallDependencies(definitionFile, virtualEnvDir)
 
         // TODO: Handle "extras" and "tests" dependencies.
         val scopes = sortedSetOf(
@@ -312,37 +332,43 @@ class Pip(
     }
 
     private fun getInstallDependencies(
-        definitionFile: File, virtualEnvDir: File, projectName: String
+        definitionFile: File, virtualEnvDir: File,
     ): Pair<SortedSet<Package>, SortedSet<PackageReference>> {
         val packages = sortedSetOf<Package>()
         val installDependencies = sortedSetOf<PackageReference>()
 
         val workingDir = definitionFile.parentFile
 
-        // List all packages installed locally in the virtualenv.
-        val pipdeptree = runInVirtualEnv(virtualEnvDir, workingDir, "pipdeptree", "-l", "--json-tree")
+        val jsonFile = createOrtTempDir().resolve("python-inspector.json")
+
+        val pythonInspector = if (definitionFile.name == "setup.py") {
+            PythonInspector.runPythonInspector(
+                workingDir = workingDir,
+                outputFile = jsonFile.absolutePath,
+                setupPyFile = definitionFile.absolutePath,
+                requirementsFile = null
+            )
+        } else {
+            PythonInspector.runPythonInspector(
+                workingDir = workingDir,
+                outputFile = jsonFile.absolutePath,
+                requirementsFile = definitionFile.absolutePath,
+                setupPyFile = null
+            )
+        }
 
         // Get the locally available metadata for all installed packages as a fallback.
         val installedPackages = getInstalledPackagesWithLocalMetaData(virtualEnvDir, workingDir).associateBy { it.id }
 
-        if (pipdeptree.isSuccess) {
-            val fullDependencyTree = jsonMapper.readTree(pipdeptree.stdout)
+        if (pythonInspector.isSuccess) {
+            val fullDependencyTree = jsonMapper.readTree(jsonFile)
+            jsonFile.parentFile.safeDeleteRecursively(force = true)
 
-            val projectDependencies = if (definitionFile.name == "setup.py") {
-                // The tree contains a root node for the project itself and pipdeptree's dependencies are also at the
-                // root next to it, as siblings.
-                fullDependencyTree.find {
-                    it["package_name"].textValue() == projectName
-                }?.get("dependencies") ?: run {
-                    logger.info { "The '$projectName' project does not declare any dependencies." }
-                    EMPTY_JSON_NODE
-                }
-            } else {
-                // The tree does not contain a node for the project itself. Its dependencies are on the root level
-                // together with the dependencies of pipdeptree itself, which we need to filter out.
-                fullDependencyTree.filterNot {
-                    isPhonyDependency(it["package_name"].textValue(), it["installed_version"].textValueOrEmpty())
-                }
+            val projectDependencies = fullDependencyTree.filterNot {
+                isPhonyDependency(
+                    it["package_name"].textValue(),
+                    it["installed_version"].textValueOrEmpty()
+                )
             }
 
             val allIds = sortedSetOf<Identifier>()
@@ -355,7 +381,7 @@ class Pip(
             }
         } else {
             logger.error {
-                "Unable to determine dependencies for project in directory '$workingDir':\n${pipdeptree.stderr}"
+                "Unable to determine dependencies for project in directory '$workingDir':\n${pythonInspector.stderr}"
             }
         }
 
@@ -501,14 +527,6 @@ class Pip(
         } else {
             runPipInVirtualEnv(virtualEnvDir, workingDir, "install", "pip==$PIP_VERSION")
         }
-        pip.requireSuccess()
-
-        // Install pipdeptree inside the virtualenv as that's the only way to make it report only the project's
-        // dependencies instead of those of all (globally) installed packages, see
-        // https://github.com/naiquevin/pipdeptree#known-issues.
-        // We only depend on pipdeptree to be at least version 0.5.0 for JSON output, but we stick to a fixed
-        // version to be sure to get consistent results.
-        pip = runPipInVirtualEnv(virtualEnvDir, workingDir, "install", "pipdeptree==$PIPDEPTREE_VERSION")
         pip.requireSuccess()
 
         // TODO: Find a way to make installation of packages with native extensions work on Windows where often the


### PR DESCRIPTION
This PR replaces pipdeptree with python-inspector to resolve Python packages dependencies found in requirement files. 

python-inspector can resolve dependencies for any target Python version and OS (and not only the one running the tool).
In this integration in ORT, it replaces pipdeptree pretty much in place as python-inspector implements a similar output data structure by design to ease the integration.

Reference: https://github.com/nexB/python-inspector
Reference: https://github.com/oss-review-toolkit/ort/issues/4637
Reference: https://github.com/oss-review-toolkit/ort/issues/3671
Signed-off-by: Tushar Goel <tushar.goel.dav@gmail.com>
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>
