### PR TITLE
OrtResultRule: Add issue function

### DIFF
--- a/evaluator/src/main/kotlin/OrtResultRule.kt
+++ b/evaluator/src/main/kotlin/OrtResultRule.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.evaluator
 
 import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.Severity
 
 /**
  * A [Rule] to check an [OrtResult].
@@ -36,6 +37,16 @@ open class OrtResultRule(
     override val description = "Evaluating ORT result rule '$name'."
 
     override fun issueSource() = "$name - ORT result"
+
+    fun issue(severity: Severity, message: String, howToFix: String = ""): Unit =
+        issue(
+            severity = severity,
+            pkgId = null,
+            license = null,
+            licenseSource = null,
+            message = message,
+            howToFix = howToFix
+        )
 
     fun hint(message: String, howToFix: String = ""): Unit =
         hint(


### PR DESCRIPTION
For consistency with the other rule classes, add an `issue` function to
`OrtResultRule`.

Fixes #5573.
