### PR TITLE
Conan: Pass the definition file name when calling `conan info`

### DIFF
--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -145,7 +145,7 @@ class Conan(
             conanConfig?.also { configureRemoteAuthentication(it) }
 
             val jsonFile = createOrtTempDir().resolve("info.json")
-            run(workingDir, "info", ".", "--json", jsonFile.absolutePath, *DUMMY_COMPILER_SETTINGS)
+            run(workingDir, "info", definitionFile.name, "--json", jsonFile.absolutePath, *DUMMY_COMPILER_SETTINGS)
 
             val pkgInfos = jsonMapper.readTree(jsonFile)
             jsonFile.parentFile.safeDeleteRecursively(force = true)


### PR DESCRIPTION
If "conanfile.txt" and "conanfile.py" both exist in the same repository,
calling `conan.info` defaults to using "conanfile.py". This causes
issues if the currently analyzed file is "conanfile.txt". To fix this,
pass the name of the currently analyzed definition file to "conan info".
