### PR TITLE
Logger: Remove an obsolete `Suppress` annotation

### DIFF
--- a/utils/ort/src/main/kotlin/Logger.kt
+++ b/utils/ort/src/main/kotlin/Logger.kt
@@ -17,8 +17,6 @@
  * License-Filename: LICENSE
  */
 
-@file:Suppress("TooManyFunctions")
-
 package org.ossreviewtoolkit.utils.ort
 
 import java.util.concurrent.ConcurrentHashMap


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>