### PR TITLE
Revert "OkHttpClientHelper: Set OkHttp's logging to "fine" in ORT's "debug" log level"

### DIFF
--- a/utils/ort/src/main/kotlin/OkHttpClientHelper.kt
+++ b/utils/ort/src/main/kotlin/OkHttpClientHelper.kt
@@ -23,8 +23,6 @@ import java.io.File
 import java.io.IOException
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
-import java.util.logging.Level
-import java.util.logging.Logger
 
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -75,11 +73,6 @@ object OkHttpClientHelper {
     private val defaultClient by lazy {
         OrtAuthenticator.install()
         OrtProxySelector.install()
-
-        if (logger.delegate.isDebugEnabled) {
-            // Allow tracking down leaked connections.
-            Logger.getLogger(OkHttpClient::javaClass.name).level = Level.FINE
-        }
 
         val cacheDirectory = ortDataDirectory.resolve(CACHE_DIRECTORY)
         val cache = Cache(cacheDirectory, MAX_CACHE_SIZE_IN_BYTES)


### PR DESCRIPTION
This reverts commit 66de71f as it did not produce the expected helpful
log output, and the leaked connection has been resolved anyway, see [1].

[1]: https://github.com/oss-review-toolkit/ort/issues/5236

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>