### PR TITLE
ExperimentalScanner: Explain why a superfluous `suspend` modifier is kept

### DIFF
--- a/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
+++ b/scanner/src/main/kotlin/experimental/ExperimentalScanner.kt
@@ -70,6 +70,8 @@ class ExperimentalScanner(
 
     private val archiver = scannerConfig.archive.createFileArchiver()
 
+    // Keep the suspend modifier to prepare callers for this function to start using coroutines.
+    @Suppress("RedundantSuspendModifier")
     suspend fun scan(ortResult: OrtResult, skipExcluded: Boolean): OrtResult {
         val startTime = Instant.now()
 


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>