### PR TITLE
RequirementsCommand: Do not fail if no specific version is requested

### DIFF
--- a/cli/src/main/kotlin/commands/RequirementsCommand.kt
+++ b/cli/src/main/kotlin/commands/RequirementsCommand.kt
@@ -133,7 +133,10 @@ class RequirementsCommand : CliktCommand(help = "Check for the command line tool
                                 Pair("\t+ ", "Found version '$actualVersion'.")
                             }
                         }.getOrElse {
-                            statusCode = statusCode or 2
+                            if (tool.getVersionRequirement() != CommandLineTool.ANY_VERSION) {
+                                statusCode = statusCode or 2
+                            }
+
                             Pair("\t+ ", "Could not determine the version.")
                         }
                     } else {


### PR DESCRIPTION
Do not set the exit code to 2 if a tool version cannot be determined,
and the tool does not set a version requirement.