### PR TITLE
Npm: Do not fail hard if enriching incomplete data from the NPM registry fails

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
@@ -20,6 +20,7 @@ project:
   scopes:
   - name: "dependencies"
     dependencies:
+    - id: "NPM::angular-tileview:0.6.1"
     - id: "NPM::is-win:1.0.8"
     - id: "NPM::is-windows:1.0.2"
   - name: "devDependencies"
@@ -636,6 +637,34 @@ project:
         dependencies:
         - id: "NPM::has-flag:3.0.0"
 packages:
+- id: "NPM::angular-tileview:0.6.1"
+  purl: "pkg:npm/angular-tileview@0.6.1"
+  declared_licenses:
+  - "MIT"
+  declared_licenses_processed:
+    spdx_expression: "MIT"
+  description: "A tileview for angular"
+  homepage_url: "https://github.com/tinydesk/angular-tileview#readme"
+  binary_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  source_artifact:
+    url: ""
+    hash:
+      value: ""
+      algorithm: ""
+  vcs:
+    type: "Git"
+    url: "git+https://github.com/tinydesk/angular-tileview.git"
+    revision: ""
+    path: ""
+  vcs_processed:
+    type: "Git"
+    url: "https://github.com/tinydesk/angular-tileview.git"
+    revision: ""
+    path: ""
 - id: "NPM::ansi-green:0.1.1"
   purl: "pkg:npm/ansi-green@0.1.1"
   authors:

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls/package-lock.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls/package-lock.json
@@ -4,6 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "angular-tileview": {
+      "version": "git+ssh://git@github.com/tinydesk/angular-tileview.git#ccf991b973e78e06d1c59e77200721e159a2d9e7",
+      "from": "angular-tileview@github:tinydesk/angular-tileview"
+    },
     "ansi-green": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls/package.json
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls/package.json
@@ -8,6 +8,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "angular-tileview": "github:tinydesk/angular-tileview",
     "is-win": "https://registry.npmjs.org/is-win/-/is-win-1.0.8.tgz",
     "is-windows": "https://github.com/jonschlinkert/is-windows/archive/1.0.2.tar.gz"
   },

--- a/analyzer/src/main/kotlin/managers/Pnpm.kt
+++ b/analyzer/src/main/kotlin/managers/Pnpm.kt
@@ -20,8 +20,6 @@
 
 package org.ossreviewtoolkit.analyzer.managers
 
-import com.fasterxml.jackson.databind.JsonNode
-
 import com.vdurmont.semver4j.Requirement
 
 import java.io.File
@@ -31,7 +29,6 @@ import org.ossreviewtoolkit.analyzer.managers.utils.hasPnpmLockFile
 import org.ossreviewtoolkit.analyzer.managers.utils.mapDefinitionFilesForPnpm
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
-import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.realFile
 
@@ -91,10 +88,4 @@ class Pnpm(
         // We do not actually depend on any features specific to a PNPM version, but we still want to stick to a
         // fixed major version to be sure to get consistent results.
         checkVersion()
-
-    override fun getRemotePackageDetails(workingDir: File, packageName: String): JsonNode {
-        val process = run(workingDir, "view", "--json", packageName)
-
-        return jsonMapper.readTree(process.stdout)
-    }
 }


### PR DESCRIPTION
This allows to handle packages that were never published to the NPM
registry but only ever referenced by (short) repository URL.
    
Fixes #5632.