### PR TITLE
Evaluator: Allow making arbitrary file checks on the project's source tree

### DIFF
--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -147,13 +147,13 @@ class ExamplesFunTest : StringSpec() {
             val result = evaluator.run(script)
 
             result.violations.map { it.rule } shouldContainExactlyInAnyOrder listOf(
-                "UNHANDLED_LICENSE",
                 "COPYLEFT_LIMITED_IN_SOURCE",
-                "VULNERABILITY_IN_PACKAGE",
-                "HIGH_SEVERITY_VULNERABILITY_IN_PACKAGE",
                 "DEPRECATED_SCOPE_EXCLUDE_REASON_IN_ORT_YML",
+                "HIGH_SEVERITY_VULNERABILITY_IN_PACKAGE",
                 "MISSING_CONTRIBUTING_FILE",
-                "MISSING_README_FILE_LICENSE_SECTION"
+                "MISSING_README_FILE_LICENSE_SECTION",
+                "UNHANDLED_LICENSE",
+                "VULNERABILITY_IN_PACKAGE"
             )
         }
 

--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -151,7 +151,8 @@ class ExamplesFunTest : StringSpec() {
                 "COPYLEFT_LIMITED_IN_SOURCE",
                 "VULNERABILITY_IN_PACKAGE",
                 "HIGH_SEVERITY_VULNERABILITY_IN_PACKAGE",
-                "DEPRECATED_SCOPE_EXCLUDE_REASON_IN_ORT_YML"
+                "DEPRECATED_SCOPE_EXCLUDE_REASON_IN_ORT_YML",
+                "MISSING_CONTRIBUTING_FILE"
             )
         }
 

--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -152,7 +152,8 @@ class ExamplesFunTest : StringSpec() {
                 "VULNERABILITY_IN_PACKAGE",
                 "HIGH_SEVERITY_VULNERABILITY_IN_PACKAGE",
                 "DEPRECATED_SCOPE_EXCLUDE_REASON_IN_ORT_YML",
-                "MISSING_CONTRIBUTING_FILE"
+                "MISSING_CONTRIBUTING_FILE",
+                "MISSING_README_FILE_LICENSE_SECTION"
             )
         }
 

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -55,6 +55,7 @@ import org.ossreviewtoolkit.cli.utils.outputGroup
 import org.ossreviewtoolkit.cli.utils.readOrtResult
 import org.ossreviewtoolkit.cli.utils.writeOrtResult
 import org.ossreviewtoolkit.evaluator.Evaluator
+import org.ossreviewtoolkit.evaluator.SourceTree
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
@@ -310,7 +311,15 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate ORT re
         val resolutionProvider = DefaultResolutionProvider.create(ortResultInput, resolutionsFile)
         val licenseClassifications =
             licenseClassificationsFile.takeIf { it.isFile }?.readValue<LicenseClassifications>().orEmpty()
-        val evaluator = Evaluator(ortResultInput, licenseInfoResolver, resolutionProvider, licenseClassifications)
+        val projectSourceTree = SourceTree.forRemoteRepository(ortResultInput.repository.vcsProcessed)
+
+        val evaluator = Evaluator(
+            ortResultInput,
+            licenseInfoResolver,
+            resolutionProvider,
+            licenseClassifications,
+            projectSourceTree
+        )
 
         val (evaluatorRun, duration) = measureTimedValue { evaluator.run(script) }
 

--- a/evaluator/build.gradle.kts
+++ b/evaluator/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     api(project(":model"))
     api(project(":utils:scripting-utils"))
 
+    implementation(project(":downloader"))
     implementation(project(":utils:ort-utils"))
     implementation(project(":utils:spdx-utils"))
 

--- a/evaluator/src/main/kotlin/Evaluator.kt
+++ b/evaluator/src/main/kotlin/Evaluator.kt
@@ -40,12 +40,21 @@ class Evaluator(
     licenseInfoResolver: LicenseInfoResolver = ortResult.createLicenseInfoResolver(),
     resolutionProvider: ResolutionProvider = DefaultResolutionProvider.create(),
     licenseClassifications: LicenseClassifications = LicenseClassifications(),
+    projectSourceTree: SourceTree = SourceTree.forRemoteRepository(ortResult.repository.vcsProcessed),
     time: Instant = Instant.now()
 ) : ScriptRunner() {
     override val compConfig = createJvmCompilationConfigurationFromTemplate<RulesScriptTemplate>()
 
     override val evalConfig = ScriptEvaluationConfiguration {
-        constructorArgs(ortResult, licenseInfoResolver, resolutionProvider, licenseClassifications, time)
+        constructorArgs(
+            ortResult,
+            licenseInfoResolver,
+            resolutionProvider,
+            licenseClassifications,
+            projectSourceTree,
+            time
+        )
+
         scriptsInstancesSharing(true)
     }
 

--- a/evaluator/src/main/kotlin/OrtResultRule.kt
+++ b/evaluator/src/main/kotlin/OrtResultRule.kt
@@ -83,6 +83,17 @@ open class OrtResultRule(
         )
 
     /**
+     * A [RuleMatcher] that checks whether the project's source tree contains at least one directory matching any of the
+     * provided [glob expressions][patterns].
+     */
+    fun sourceTreeHasDirectory(vararg patterns: String): RuleMatcher =
+        object : RuleMatcher {
+            override val description = "sourceTreeHasDirectory('${patterns.joinToString()}')"
+
+            override fun matches(): Boolean = projectSourceTree.hasDirectory(*patterns)
+        }
+
+    /**
      * A [RuleMatcher] that checks whether the project's source tree contains at least one file matching any of the
      * given [glob expressions][patterns].
      */

--- a/evaluator/src/main/kotlin/OrtResultRule.kt
+++ b/evaluator/src/main/kotlin/OrtResultRule.kt
@@ -81,4 +81,15 @@ open class OrtResultRule(
             message = message,
             howToFix = howToFix
         )
+
+    /**
+     * A [RuleMatcher] that checks whether the project's source tree contains at least one file matching any of the
+     * given [glob expressions][patterns].
+     */
+    fun sourceTreeHasFile(vararg patterns: String): RuleMatcher =
+        object : RuleMatcher {
+            override val description = "sourceTreeHasFile('${patterns.joinToString()}')"
+
+            override fun matches(): Boolean = projectSourceTree.hasFile(*patterns)
+        }
 }

--- a/evaluator/src/main/kotlin/OrtResultRule.kt
+++ b/evaluator/src/main/kotlin/OrtResultRule.kt
@@ -34,6 +34,13 @@ open class OrtResultRule(
      */
     val ortResult = ruleSet.ortResult
 
+    /**
+     * The source tree of the project. Accessing the property may trigger cloning the repository and thus may take a
+     * while.
+     */
+    val projectSourceTree: SourceTree
+        get() = ruleSet.projectSourceTree
+
     override val description = "Evaluating ORT result rule '$name'."
 
     override fun issueSource() = "$name - ORT result"

--- a/evaluator/src/main/kotlin/OrtResultRule.kt
+++ b/evaluator/src/main/kotlin/OrtResultRule.kt
@@ -103,4 +103,16 @@ open class OrtResultRule(
 
             override fun matches(): Boolean = projectSourceTree.hasFile(*patterns)
         }
+
+    /**
+     * A [RuleMatcher] that checks whether the project's source tree contains at least one file matching any of the
+     * given [glob expressions][patterns] with its file content matching [contentPattern].
+     */
+    fun sourceTreeHasFileWithContents(contentPattern: String, vararg patterns: String): RuleMatcher =
+        object : RuleMatcher {
+            override val description = "sourceTreeHasFileWithContents('$contentPattern', '${patterns.joinToString()}')"
+
+            override fun matches(): Boolean =
+                projectSourceTree.findFilesWithContent(contentPattern, *patterns).isNotEmpty()
+        }
 }

--- a/evaluator/src/main/kotlin/RuleSet.kt
+++ b/evaluator/src/main/kotlin/RuleSet.kt
@@ -37,7 +37,8 @@ import org.ossreviewtoolkit.model.utils.createLicenseInfoResolver
 class RuleSet(
     val ortResult: OrtResult,
     val licenseInfoResolver: LicenseInfoResolver,
-    val resolutionProvider: ResolutionProvider
+    val resolutionProvider: ResolutionProvider,
+    val projectSourceTree: SourceTree
 ) {
     companion object : Logging
 
@@ -152,5 +153,6 @@ fun ruleSet(
     ortResult: OrtResult,
     licenseInfoResolver: LicenseInfoResolver = ortResult.createLicenseInfoResolver(),
     resolutionProvider: ResolutionProvider = DefaultResolutionProvider.create(),
+    projectSourceTree: SourceTree = SourceTree.forRemoteRepository(ortResult.repository.vcsProcessed),
     configure: RuleSet.() -> Unit = { }
-) = RuleSet(ortResult, licenseInfoResolver, resolutionProvider).apply(configure)
+) = RuleSet(ortResult, licenseInfoResolver, resolutionProvider, projectSourceTree).apply(configure)

--- a/evaluator/src/main/kotlin/RulesScriptTemplate.kt
+++ b/evaluator/src/main/kotlin/RulesScriptTemplate.kt
@@ -56,6 +56,7 @@ open class RulesScriptTemplate(
     val licenseInfoResolver: LicenseInfoResolver,
     val resolutionProvider: ResolutionProvider,
     val licenseClassifications: LicenseClassifications,
+    val projectSourceTree: SourceTree,
     val time: Instant
 ) {
     val ruleViolations = mutableListOf<RuleViolation>()

--- a/evaluator/src/main/kotlin/SourceTree.kt
+++ b/evaluator/src/main/kotlin/SourceTree.kt
@@ -28,6 +28,7 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
+import org.ossreviewtoolkit.utils.common.FileMatcher
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 
 class SourceTree private constructor(
@@ -52,9 +53,26 @@ class SourceTree private constructor(
                     downloadDir
                 }
             )
+
+        fun forLocalDir(dir: File, vcsType: VcsType) =
+            SourceTree(
+                vcsType = vcsType,
+                getRepositoryRoot = { dir }
+            )
     }
 
     val rootDir by lazy {
         getRepositoryRoot()
+    }
+
+    /**
+     * Return true if any of the given [glob expressions][patterns] match an existing file.
+     */
+    fun hasFile(vararg patterns: String): Boolean {
+        val matcher = FileMatcher(patterns.toSet())
+
+        return rootDir.walkBottomUp().filter {
+            it.isFile && matcher.matches(it.relativeTo(rootDir).path)
+        }.count() > 0
     }
 }

--- a/evaluator/src/main/kotlin/SourceTree.kt
+++ b/evaluator/src/main/kotlin/SourceTree.kt
@@ -98,4 +98,16 @@ class SourceTree private constructor(
             file.takeIf { it.isFile }?.let { it.relativeTo(rootDir).path }
         }.filterTo(mutableSetOf()) { matcher.matches(it) }
     }
+
+    /**
+     * Return the file paths matching any of the given [glob expressions][patterns] with its file content matching
+     * [contentPattern].
+     */
+    fun findFilesWithContent(contentPattern: String, vararg patterns: String) =
+        findFiles(*patterns).filterTo(mutableSetOf()) { path ->
+            val content = rootDir.resolve(path).readText()
+            val regex = contentPattern.toRegex(setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.MULTILINE))
+
+            content.matches(regex)
+        }
 }

--- a/evaluator/src/main/kotlin/SourceTree.kt
+++ b/evaluator/src/main/kotlin/SourceTree.kt
@@ -66,7 +66,18 @@ class SourceTree private constructor(
     }
 
     /**
-     * Return true if any of the given [glob expressions][patterns] match an existing file.
+     * Return true if any of the given [glob expressions][patterns] match an existing directory.
+     */
+    fun hasDirectory(vararg patterns: String): Boolean {
+        val matcher = FileMatcher(patterns.toSet())
+
+        return rootDir.walkBottomUp().filter {
+            it.isDirectory && matcher.matches(it.relativeTo(rootDir).path)
+        }.count() > 0
+    }
+
+    /**
+     * Return true if any of the given glob expressions match an existing file.
      */
     fun hasFile(vararg patterns: String): Boolean {
         val matcher = FileMatcher(patterns.toSet())

--- a/evaluator/src/main/kotlin/SourceTree.kt
+++ b/evaluator/src/main/kotlin/SourceTree.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 EPAM Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.evaluator
+
+import java.io.File
+
+import org.apache.logging.log4j.kotlin.Logging
+
+import org.ossreviewtoolkit.downloader.Downloader
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
+import org.ossreviewtoolkit.utils.ort.createOrtTempDir
+
+class SourceTree private constructor(
+    val vcsType: VcsType,
+    getRepositoryRoot: () -> File
+) {
+    companion object : Logging {
+        fun forRemoteRepository(vcsInfo: VcsInfo) =
+            SourceTree(
+                vcsType = vcsInfo.type,
+                getRepositoryRoot = {
+                    logger.info {
+                        "Downloading ${vcsInfo.type} source code repository: '${vcsInfo.url}'..."
+                    }
+
+                    val downloadDir = createOrtTempDir()
+                    val downloader = Downloader(DownloaderConfiguration())
+                    val pkg = Package.EMPTY.copy(vcsProcessed = vcsInfo)
+
+                    downloader.download(pkg, downloadDir)
+
+                    downloadDir
+                }
+            )
+    }
+
+    val rootDir by lazy {
+        getRepositoryRoot()
+    }
+}

--- a/evaluator/src/main/kotlin/SourceTree.kt
+++ b/evaluator/src/main/kotlin/SourceTree.kt
@@ -68,22 +68,34 @@ class SourceTree private constructor(
     /**
      * Return true if any of the given [glob expressions][patterns] match an existing directory.
      */
-    fun hasDirectory(vararg patterns: String): Boolean {
+    fun hasDirectory(vararg patterns: String): Boolean =
+        findDirectories(*patterns).isNotEmpty()
+
+    /**
+     * Return the directory paths matching any of the given [glob expressions][patterns].
+     */
+    fun findDirectories(vararg patterns: String): Set<String> {
         val matcher = FileMatcher(patterns.toSet())
 
-        return rootDir.walkBottomUp().filter {
-            it.isDirectory && matcher.matches(it.relativeTo(rootDir).path)
-        }.count() > 0
+        return rootDir.walkBottomUp().mapNotNull { file ->
+            file.takeIf { it.isDirectory }?.let { it.relativeTo(rootDir).path }
+        }.filterTo(mutableSetOf()) { matcher.matches(it) }
     }
 
     /**
      * Return true if any of the given glob expressions match an existing file.
      */
-    fun hasFile(vararg patterns: String): Boolean {
+    fun hasFile(vararg patterns: String): Boolean =
+        findFiles(*patterns).isNotEmpty()
+
+    /**
+     * Return the file paths matching any of the given [glob expressions][patterns].
+     */
+    fun findFiles(vararg patterns: String): Set<String> {
         val matcher = FileMatcher(patterns.toSet())
 
-        return rootDir.walkBottomUp().filter {
-            it.isFile && matcher.matches(it.relativeTo(rootDir).path)
-        }.count() > 0
+        return rootDir.walkBottomUp().mapNotNull { file ->
+            file.takeIf { it.isFile }?.let { it.relativeTo(rootDir).path }
+        }.filterTo(mutableSetOf()) { matcher.matches(it) }
     }
 }

--- a/evaluator/src/test/kotlin/OrtResultRuleTest.kt
+++ b/evaluator/src/test/kotlin/OrtResultRuleTest.kt
@@ -63,6 +63,38 @@ class OrtResultRuleTest : WordSpec({
             rule.sourceTreeHasFile("README.md").matches() shouldBe false
         }
     }
+
+    "sourceTreeHasDirectory()" should {
+        "return true if at least one directory matches the given glob pattern" {
+            val dir = createSpecTempDir().apply {
+                addDirs("a/b/c")
+            }
+            val rule = createOrtResultRule(dir)
+
+            with(rule) {
+                sourceTreeHasDirectory("a").matches() shouldBe true
+                sourceTreeHasDirectory("a/b").matches() shouldBe true
+                sourceTreeHasDirectory("**/b/**").matches() shouldBe true
+                sourceTreeHasDirectory("**/c").matches() shouldBe true
+            }
+        }
+
+        "return false if only a file matches the given glob pattern" {
+            val dir = createSpecTempDir().apply {
+                addFiles("a")
+            }
+            val rule = createOrtResultRule(dir)
+
+            rule.sourceTreeHasDirectory("a").matches() shouldBe false
+        }
+
+        "return false if neither any file nor directory matches the given glob pattern" {
+            val dir = createSpecTempDir()
+            val rule = createOrtResultRule(dir)
+
+            rule.sourceTreeHasDirectory("a").matches() shouldBe false
+        }
+    }
 })
 
 private fun createOrtResultRule(projectSourcesDir: File) =

--- a/evaluator/src/test/kotlin/OrtResultRuleTest.kt
+++ b/evaluator/src/test/kotlin/OrtResultRuleTest.kt
@@ -95,6 +95,24 @@ class OrtResultRuleTest : WordSpec({
             rule.sourceTreeHasDirectory("a").matches() shouldBe false
         }
     }
+
+    "hasFileWithContents()" should {
+        "return true if there is a file matching the given glob pattern with its content matching the given regex" {
+            val dir = createSpecTempDir().apply {
+                addFiles(
+                    "README.md",
+                    content = """
+                        
+                        ## License
+                    
+                    """.trimIndent()
+                )
+            }
+            val rule = createOrtResultRule(dir)
+
+            rule.sourceTreeHasFileWithContents(".*^#{1,2} License$.*", "README.md").matches() shouldBe true
+        }
+    }
 })
 
 private fun createOrtResultRule(projectSourcesDir: File) =
@@ -106,13 +124,14 @@ private fun createOrtResultRule(projectSourcesDir: File) =
         name = "RULE_NAME"
     )
 
-private fun File.addFiles(vararg paths: String) {
+private fun File.addFiles(vararg paths: String, content: String = "") {
     require(isDirectory)
 
     paths.forEach { path ->
         resolve(path).apply {
             parentFile.mkdirs()
             createNewFile()
+            writeText(content)
         }
     }
 }

--- a/evaluator/src/test/kotlin/OrtResultRuleTest.kt
+++ b/evaluator/src/test/kotlin/OrtResultRuleTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2022 EPAM Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.evaluator
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import java.io.File
+
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.utils.test.createSpecTempDir
+
+class OrtResultRuleTest : WordSpec({
+    "sourceTreeHasFile()" should {
+        "return true if at least one file matches the given glob pattern" {
+            val dir = createSpecTempDir().apply {
+                addFiles(
+                    "README.md",
+                    "module/docs/LICENSE.txt"
+                )
+            }
+            val rule = createOrtResultRule(dir)
+
+            with(rule) {
+                sourceTreeHasFile("README.md").matches() shouldBe true
+                sourceTreeHasFile("**/README.md").matches() shouldBe true
+                sourceTreeHasFile("**/LICENSE*").matches() shouldBe true
+                sourceTreeHasFile("**/*.txt").matches() shouldBe true
+            }
+        }
+
+        "return false if only a directory matches the given glob pattern" {
+            val dir = createSpecTempDir().apply {
+                addDirs("README.md")
+            }
+            val rule = createOrtResultRule(dir)
+
+            rule.sourceTreeHasFile("README.md").matches() shouldBe false
+        }
+
+        "return false if neither any file nor directory matches the given glob pattern" {
+            val dir = createSpecTempDir()
+            val rule = createOrtResultRule(dir)
+
+            rule.sourceTreeHasFile("README.md").matches() shouldBe false
+        }
+    }
+})
+
+private fun createOrtResultRule(projectSourcesDir: File) =
+    OrtResultRule(
+        ruleSet = ruleSet(
+            ortResult = OrtResult.EMPTY,
+            projectSourceTree = SourceTree.forLocalDir(projectSourcesDir, VcsType.GIT)
+        ),
+        name = "RULE_NAME"
+    )
+
+private fun File.addFiles(vararg paths: String) {
+    require(isDirectory)
+
+    paths.forEach { path ->
+        resolve(path).apply {
+            parentFile.mkdirs()
+            createNewFile()
+        }
+    }
+}
+
+private fun File.addDirs(vararg paths: String) {
+    require(isDirectory)
+
+    paths.forEach { path ->
+        resolve(path).mkdirs()
+    }
+}

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -180,6 +180,26 @@ fun RuleSet.copyleftInSourceLimitedRule() = packageRule("COPYLEFT_LIMITED_IN_SOU
     }
 }
 
+fun RuleSet.dependencyInProjectSourceRule() = ortResultRule("DEPENDENCY_IN_PROJECT_SOURCE_RULE") {
+    val denyDirPatterns = listOf(
+        "**/node_modules" to setOf("NPM", "Yarn", "PNPM"),
+        "**/vendor" to setOf("GoMod", "GoDep")
+    )
+
+    denyDirPatterns.forEach { (pattern, packageManagers) ->
+        val offendingDirs = projectSourceTree.findDirectories(pattern)
+
+        if (offendingDirs.isNotEmpty()) {
+            issue(
+                Severity.ERROR,
+                "The directories ${offendingDirs.joinToString()} belong to the package manager(s) " +
+                        "${packageManagers.joinToString()} and must not be committed.",
+                "Please delete the directories: ${offendingDirs.joinToString()}."
+            )
+        }
+    }
+}
+
 fun RuleSet.vulnerabilityInPackageRule() = packageRule("VULNERABILITY_IN_PACKAGE") {
     require {
         -isExcluded()
@@ -311,6 +331,7 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     copyleftLimitedInDependencyRule()
 
     // Rules which get executed once:
+    dependencyInProjectSourceRule()
     deprecatedScopeExcludeReasonInOrtYmlRule()
     missingCiConfigurationRule()
     missingContributingFileRule()

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -314,6 +314,26 @@ fun RuleSet.missingContributingFileRule() = ortResultRule("MISSING_CONTRIBUTING_
     error("The project's code repository does not contain the file 'CONTRIBUTING.md'.")
 }
 
+fun RuleSet.missingReadmeFileRule() = ortResultRule("MISSING_README_FILE") {
+    require {
+        -sourceTreeHasFile("README.md")
+    }
+
+    error("The project's code repository does not contain the file 'README.md'.")
+}
+
+fun RuleSet.missingReadmeFileLicenseSectionRule() = ortResultRule("MISSING_README_FILE_LICENSE_SECTION") {
+    require {
+        +sourceTreeHasFile("README.md")
+        -sourceTreeHasFileWithContents(".*^#{1,2} License$.*", "README.md")
+    }
+
+    error(
+        message = "This project does not seem to have any known CI configuration files.",
+        howToFix = "Please add a license section to the file 'README.md' in the root directory."
+    )
+}
+
 /**
  * The set of policy rules.
  */
@@ -335,6 +355,8 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     deprecatedScopeExcludeReasonInOrtYmlRule()
     missingCiConfigurationRule()
     missingContributingFileRule()
+    missingReadmeFileRule()
+    missingReadmeFileLicenseSectionRule()
 }
 
 // Populate the list of policy rule violations to return.

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -264,6 +264,14 @@ fun RuleSet.deprecatedScopeExcludeReasonInOrtYmlRule() = ortResultRule("DEPRECAT
     }
 }
 
+fun RuleSet.missingContributingFileRule() = ortResultRule("MISSING_CONTRIBUTING_FILE") {
+    require {
+        -sourceTreeHasFile("CONTRIBUTING.md")
+    }
+
+    error("The project's code repository does not contain the file 'CONTRIBUTING.md'.")
+}
+
 /**
  * The set of policy rules.
  */
@@ -282,6 +290,7 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
 
     // Rules which get executed once:
     deprecatedScopeExcludeReasonInOrtYmlRule()
+    missingContributingFileRule()
 }
 
 // Populate the list of policy rule violations to return.

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -351,8 +351,10 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     copyleftLimitedInDependencyRule()
 
     // Rules which get executed once:
-    dependencyInProjectSourceRule()
     deprecatedScopeExcludeReasonInOrtYmlRule()
+
+    // Prior to open sourcing use case rules (which get executed once):
+    dependencyInProjectSourceRule()
     missingCiConfigurationRule()
     missingContributingFileRule()
     missingReadmeFileRule()

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -264,6 +264,28 @@ fun RuleSet.deprecatedScopeExcludeReasonInOrtYmlRule() = ortResultRule("DEPRECAT
     }
 }
 
+fun RuleSet.missingCiConfigurationRule() = ortResultRule("MISSING_CI_CONFIGURATION") {
+    require {
+        -AnyOf(
+            sourceTreeHasFile(
+                ".appveyor.yml",
+                ".bitbucket-pipelines.yml",
+                ".gitlab-ci.yml",
+                ".travis.yml"
+            ),
+            sourceTreeHasDirectory(
+                ".circleci",
+                ".github"
+            )
+        )
+    }
+
+    error(
+        message = "This project does not seem to have any known CI configuration files.",
+        howToFix = "Please setup a CI. If you already have setup a CI and the error persists, please contact support."
+    )
+}
+
 fun RuleSet.missingContributingFileRule() = ortResultRule("MISSING_CONTRIBUTING_FILE") {
     require {
         -sourceTreeHasFile("CONTRIBUTING.md")
@@ -290,6 +312,7 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
 
     // Rules which get executed once:
     deprecatedScopeExcludeReasonInOrtYmlRule()
+    missingCiConfigurationRule()
     missingContributingFileRule()
 }
 

--- a/model/src/main/kotlin/utils/OrtResultExtensions.kt
+++ b/model/src/main/kotlin/utils/OrtResultExtensions.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.model.utils
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.model.licenses.DefaultLicenseInfoProvider
@@ -67,6 +68,22 @@ fun OrtResult.createLicenseInfoResolver(
         archiver,
         LicenseFilenamePatterns.getInstance()
     )
+
+/**
+ * Return the path where the repository given by [provenance] is linked into the source tree.
+ */
+fun OrtResult.getRepositoryPath(provenance: RepositoryProvenance): String {
+    repository.nestedRepositories.forEach { (path, vcsInfo) ->
+        if (vcsInfo.type == provenance.vcsInfo.type
+            && vcsInfo.url == provenance.vcsInfo.url
+            && vcsInfo.revision == provenance.resolvedRevision
+        ) {
+            return "/$path/"
+        }
+    }
+
+    return "/"
+}
 
 /**
  * Copy this [OrtResult] and add all [labels] to the existing labels, overwriting existing labels on conflict.

--- a/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
@@ -54,6 +54,7 @@ import org.ossreviewtoolkit.model.licenses.ResolvedLicense
 import org.ossreviewtoolkit.model.licenses.ResolvedLicenseFileInfo
 import org.ossreviewtoolkit.model.licenses.ResolvedLicenseInfo
 import org.ossreviewtoolkit.model.licenses.filterExcluded
+import org.ossreviewtoolkit.model.utils.getRepositoryPath
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.expandTilde
@@ -482,22 +483,6 @@ internal fun OrtResult.deduplicateProjectScanResults(targetProjects: Set<Identif
     } ?: sortedMapOf()
 
     return replaceScanResults(scanResults)
-}
-
-/**
- * Return the path where the repository given by [provenance] is linked into the source tree.
- */
-private fun OrtResult.getRepositoryPath(provenance: RepositoryProvenance): String {
-    repository.nestedRepositories.forEach { (path, vcsInfo) ->
-        if (vcsInfo.type == provenance.vcsInfo.type
-            && vcsInfo.url == provenance.vcsInfo.url
-            && vcsInfo.revision == provenance.resolvedRevision
-        ) {
-            return "/$path/"
-        }
-    }
-
-    return "/"
 }
 
 /**


### PR DESCRIPTION
See individual commits.

Note: The project's source tree will be cloned in the evaluator only if the rules needed it / if the file checks are actually used.

This implements parts of #5621.