### PR TITLE
ScanCode: use pinned dependency constraints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -157,7 +157,8 @@ RUN /opt/ort/bin/import_proxy_certs.sh && \
 
 # Add scanners (in versions known to work).
 ARG SCANCODE_VERSION
-RUN pip install --no-cache-dir scancode-toolkit==$SCANCODE_VERSION
+RUN wget https://raw.githubusercontent.com/nexB/scancode-toolkit/v$SCANCODE_VERSION/requirements.txt
+RUN pip install --no-cache-dir --constraint requirements.txt scancode-toolkit==$SCANCODE_VERSION
 
 ARG PYTHON_INSPECTOR_VERSION
 RUN pip install --no-cache-dir python-inspector==$PYTHON_INSPECTOR_VERSION


### PR DESCRIPTION
This PR fetches the requirements.txt from ScanCode repo
to use them as constraints in a pip installation command.
This guarantees that the dependency versions are tested
to work with the ScanCode version

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>