### PR TITLE
github/workflows: Quietly bootstrap the Batect distribution

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -118,7 +118,7 @@ jobs:
     - name: Validate Batect wrapper scripts
       uses: batect/batect-wrapper-validation-action@v0
     - name: Run functional tests
-      run: ./batect --enable-buildkit --config-var gradle_console=plain funTest -- jacocoFunTestReport -p analyzer
+      run: BATECT_QUIET_DOWNLOAD=true ./batect --enable-buildkit --config-var gradle_console=plain funTest -- jacocoFunTestReport -p analyzer
     - name: Upload code coverage data
       uses: codecov/codecov-action@v3
       with:


### PR DESCRIPTION
The download progress bar looks broken in CI logs, so just disable it.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>