### PR TITLE
Path matching improvements

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -61,7 +61,7 @@ curations:
     reason: "DATA_OF"
     comment: >-
       These files are part of PHP Composer and include a mapping from human readable strings to SPDX license ids.
-  - path: "docs/**.md"
+  - path: "docs/**/*.md"
     concluded_license: "Apache-2.0"
     reason: "DOCUMENTATION_OF"
     comment: >-

--- a/docs/config-file-ort-yml.md
+++ b/docs/config-file-ort-yml.md
@@ -144,7 +144,7 @@ e.g.:
 ```yaml
 curations:
   license_findings:
-  - path: "src/**.cpp"
+  - path: "src/**/*.cpp"
     start_lines: "3"
     line_count: 11
     detected_license: "GPL-2.0-only"

--- a/docs/config-file-package-configuration-yml.md
+++ b/docs/config-file-package-configuration-yml.md
@@ -54,7 +54,7 @@ see [excluding paths](config-file-ort-yml.md#excluding-paths) and
     reason: "DOCUMENTATION_OF"
     comment: "This directory contains documentation which is not distributed."
   license_finding_curations:
-  - path: "src/**.cpp"
+  - path: "src/**/*.cpp"
     start_lines: "3"
     line_count: 11
     detected_license: "GPL-2.0-only"
@@ -137,7 +137,7 @@ The code below shows an example for `packages.yml`:
     reason: "DOCUMENTATION_OF"
     comment: "This directory contains documentation which is not distributed."
   license_finding_curations:
-  - path: "src/**.cpp"
+  - path: "src/**/*.cpp"
     start_lines: "3"
     line_count: 11
     detected_license: "GPL-2.0-only"
@@ -151,7 +151,7 @@ The code below shows an example for `packages.yml`:
     reason: "DOCUMENTATION_OF"
     comment: "This directory contains documentation which is not distributed."
   license_finding_curations:
-  - path: "src/**.cpp"
+  - path: "src/**/*.cpp"
     start_lines: "3"
     line_count: 11
     detected_license: "GPL-2.0-only"

--- a/examples/curations.ort.yml
+++ b/examples/curations.ort.yml
@@ -1,6 +1,6 @@
 curations:
   license_findings:
-  - path: "src/**.cpp"
+  - path: "src/**/*.cpp"
     start_lines: "3,8"
     line_count: 1
     detected_license: "GPL-2.0-only"

--- a/model/src/main/kotlin/config/PathExclude.kt
+++ b/model/src/main/kotlin/config/PathExclude.kt
@@ -45,6 +45,9 @@ data class PathExclude(
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val comment: String = ""
 ) {
+    /**
+     * Return true if and only if this [PathExclude] matches the given [path].
+     */
     fun matches(path: String) = FileMatcher.match(
         pattern = pattern.removePrefix("./"),
         path = path

--- a/model/src/main/kotlin/config/PathExclude.kt
+++ b/model/src/main/kotlin/config/PathExclude.kt
@@ -21,8 +21,7 @@ package org.ossreviewtoolkit.model.config
 
 import com.fasterxml.jackson.annotation.JsonInclude
 
-import java.nio.file.FileSystems
-import java.nio.file.Paths
+import org.ossreviewtoolkit.utils.common.FileMatcher
 
 /**
  * Defines paths which should be excluded. Each file that is matched by the [glob][pattern] is marked as excluded. If a
@@ -46,9 +45,8 @@ data class PathExclude(
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val comment: String = ""
 ) {
-    private val glob by lazy {
-        FileSystems.getDefault().getPathMatcher("glob:${pattern.removePrefix("./")}")
-    }
-
-    fun matches(path: String) = glob.matches(Paths.get(path))
+    fun matches(path: String) = FileMatcher.match(
+        pattern = pattern.removePrefix("./"),
+        path = path
+    )
 }

--- a/model/src/main/kotlin/utils/FindingCurationMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingCurationMatcher.kt
@@ -19,12 +19,10 @@
 
 package org.ossreviewtoolkit.model.utils
 
-import java.nio.file.FileSystems
-import java.nio.file.Paths
-
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.licenses.LicenseFindingCurationResult
+import org.ossreviewtoolkit.utils.common.FileMatcher
 import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 
 /**
@@ -35,10 +33,10 @@ class FindingCurationMatcher {
         finding: LicenseFinding,
         curation: LicenseFindingCuration,
         relativeFindingPath: String
-    ): Boolean =
-        FileSystems.getDefault()
-            .getPathMatcher("glob:${curation.path}")
-            .matches(Paths.get(finding.location.prependPath(relativeFindingPath)))
+    ): Boolean = FileMatcher.match(
+        pattern = curation.path,
+        path = finding.location.prependPath(relativeFindingPath)
+    )
 
     private fun isStartLineMatching(finding: LicenseFinding, curation: LicenseFindingCuration): Boolean =
         curation.startLines.isEmpty() || curation.startLines.any { it == finding.location.startLine }

--- a/model/src/test/assets/package-configuration.yml
+++ b/model/src/test/assets/package-configuration.yml
@@ -5,7 +5,7 @@ path_excludes:
   reason: "DOCUMENTATION_OF"
   comment: "This directory contains documentation which is not distributed."
 license_finding_curations:
-- path: "src/**.cpp"
+- path: "src/**/*.cpp"
   start_lines: "3"
   line_count: 11
   detected_license: "GPL-2.0-only"

--- a/model/src/test/kotlin/config/ExcludesTest.kt
+++ b/model/src/test/kotlin/config/ExcludesTest.kt
@@ -55,7 +55,7 @@ class ExcludesTest : WordSpec() {
 
     private val pathExclude1 = PathExclude("path1", PathExcludeReason.BUILD_TOOL_OF, "")
     private val pathExclude2 = PathExclude("path2", PathExcludeReason.BUILD_TOOL_OF, "")
-    private val pathExclude3 = PathExclude("**.ext", PathExcludeReason.BUILD_TOOL_OF, "")
+    private val pathExclude3 = PathExclude("**/*.ext", PathExcludeReason.BUILD_TOOL_OF, "")
     private val pathExclude4 = PathExclude("**/file.ext", PathExcludeReason.BUILD_TOOL_OF, "")
 
     private val scope1 = Scope("scope1", sortedSetOf(PackageReference(id)))

--- a/model/src/test/kotlin/config/PathExcludeTest.kt
+++ b/model/src/test/kotlin/config/PathExcludeTest.kt
@@ -25,15 +25,13 @@ import io.kotest.matchers.shouldBe
 /**
  * This class tests [PathExclude] members functions
  */
-class PathExcludeTest : WordSpec() {
-    init {
-        "isPathExcluded" should {
-            "ignore leading './' in the matching path" {
-                val pathExcludeWithLeadingDot = PathExclude("./path1", PathExcludeReason.BUILD_TOOL_OF, "")
+class PathExcludeTest : WordSpec({
+    "isPathExcluded" should {
+        "ignore leading './' in the matching path" {
+            val pathExcludeWithLeadingDot = PathExclude("./path1", PathExcludeReason.BUILD_TOOL_OF, "")
 
-                pathExcludeWithLeadingDot.matches("path1") shouldBe true
-                pathExcludeWithLeadingDot.matches("path2") shouldBe false
-            }
+            pathExcludeWithLeadingDot.matches("path1") shouldBe true
+            pathExcludeWithLeadingDot.matches("path2") shouldBe false
         }
     }
-}
+})

--- a/model/src/test/kotlin/config/PathExcludeTest.kt
+++ b/model/src/test/kotlin/config/PathExcludeTest.kt
@@ -25,10 +25,9 @@ import io.kotest.matchers.shouldBe
 class PathExcludeTest : WordSpec({
     "isPathExcluded" should {
         "ignore leading './' in the matching path" {
-            val pathExclude = pathExclude("./path1")
+            val pathExclude = pathExclude("./path")
 
-            pathExclude.matches("path1") shouldBe true
-            pathExclude.matches("path2") shouldBe false
+            pathExclude.matches("path") shouldBe true
         }
     }
 })

--- a/model/src/test/kotlin/config/PathExcludeTest.kt
+++ b/model/src/test/kotlin/config/PathExcludeTest.kt
@@ -22,9 +22,6 @@ package org.ossreviewtoolkit.model.config
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
-/**
- * This class tests [PathExclude] members functions
- */
 class PathExcludeTest : WordSpec({
     "isPathExcluded" should {
         "ignore leading './' in the matching path" {

--- a/model/src/test/kotlin/config/PathExcludeTest.kt
+++ b/model/src/test/kotlin/config/PathExcludeTest.kt
@@ -29,6 +29,14 @@ class PathExcludeTest : WordSpec({
 
             pathExclude.matches("path") shouldBe true
         }
+
+        "match zero up to multiple segments for a leading double asterisk" {
+            val pathExclude = pathExclude("**/path/file.ext")
+
+            pathExclude.matches("path/file.ext") shouldBe false // TODO: matches() should return true in this case.
+            pathExclude.matches("1/path/file.ext") shouldBe true
+            pathExclude.matches("1/2/path/file.ext") shouldBe true
+        }
     }
 })
 

--- a/model/src/test/kotlin/config/PathExcludeTest.kt
+++ b/model/src/test/kotlin/config/PathExcludeTest.kt
@@ -25,10 +25,10 @@ import io.kotest.matchers.shouldBe
 class PathExcludeTest : WordSpec({
     "isPathExcluded" should {
         "ignore leading './' in the matching path" {
-            val pathExcludeWithLeadingDot = PathExclude("./path1", PathExcludeReason.BUILD_TOOL_OF, "")
+            val pathExclude = PathExclude("./path1", PathExcludeReason.BUILD_TOOL_OF, "")
 
-            pathExcludeWithLeadingDot.matches("path1") shouldBe true
-            pathExcludeWithLeadingDot.matches("path2") shouldBe false
+            pathExclude.matches("path1") shouldBe true
+            pathExclude.matches("path2") shouldBe false
         }
     }
 })

--- a/model/src/test/kotlin/config/PathExcludeTest.kt
+++ b/model/src/test/kotlin/config/PathExcludeTest.kt
@@ -25,10 +25,12 @@ import io.kotest.matchers.shouldBe
 class PathExcludeTest : WordSpec({
     "isPathExcluded" should {
         "ignore leading './' in the matching path" {
-            val pathExclude = PathExclude("./path1", PathExcludeReason.BUILD_TOOL_OF)
+            val pathExclude = pathExclude("./path1")
 
             pathExclude.matches("path1") shouldBe true
             pathExclude.matches("path2") shouldBe false
         }
     }
 })
+
+private fun pathExclude(pattern: String) = PathExclude(pattern, PathExcludeReason.BUILD_TOOL_OF)

--- a/model/src/test/kotlin/config/PathExcludeTest.kt
+++ b/model/src/test/kotlin/config/PathExcludeTest.kt
@@ -25,7 +25,7 @@ import io.kotest.matchers.shouldBe
 class PathExcludeTest : WordSpec({
     "isPathExcluded" should {
         "ignore leading './' in the matching path" {
-            val pathExclude = PathExclude("./path1", PathExcludeReason.BUILD_TOOL_OF, "")
+            val pathExclude = PathExclude("./path1", PathExcludeReason.BUILD_TOOL_OF)
 
             pathExclude.matches("path1") shouldBe true
             pathExclude.matches("path2") shouldBe false

--- a/model/src/test/kotlin/config/PathExcludeTest.kt
+++ b/model/src/test/kotlin/config/PathExcludeTest.kt
@@ -33,7 +33,7 @@ class PathExcludeTest : WordSpec({
         "match zero up to multiple segments for a leading double asterisk" {
             val pathExclude = pathExclude("**/path/file.ext")
 
-            pathExclude.matches("path/file.ext") shouldBe false // TODO: matches() should return true in this case.
+            pathExclude.matches("path/file.ext") shouldBe true
             pathExclude.matches("1/path/file.ext") shouldBe true
             pathExclude.matches("1/2/path/file.ext") shouldBe true
         }

--- a/model/src/test/kotlin/config/PathExcludeTest.kt
+++ b/model/src/test/kotlin/config/PathExcludeTest.kt
@@ -26,11 +26,11 @@ import io.kotest.matchers.shouldBe
  * This class tests [PathExclude] members functions
  */
 class PathExcludeTest : WordSpec() {
-    private val pathExcludeWithLeadingDot = PathExclude("./path1", PathExcludeReason.BUILD_TOOL_OF, "")
-
     init {
         "isPathExcluded" should {
             "ignore leading './' in the matching path" {
+                val pathExcludeWithLeadingDot = PathExclude("./path1", PathExcludeReason.BUILD_TOOL_OF, "")
+
                 pathExcludeWithLeadingDot.matches("path1") shouldBe true
                 pathExcludeWithLeadingDot.matches("path2") shouldBe false
             }

--- a/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
+++ b/model/src/test/kotlin/config/RepositoryConfigurationTest.kt
@@ -41,7 +41,7 @@ class RepositoryConfigurationTest : WordSpec({
             val configuration = """
                 excludes:
                   paths:
-                  - pattern: "android/**build.gradle"
+                  - pattern: "android/**/build.gradle"
                     reason: "BUILD_TOOL_OF"
                     comment: "project comment"
                 """.trimIndent()

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
@@ -5,7 +5,7 @@ path_excludes:
   reason: "EXAMPLE_OF"
   comment: "The project is an example."
 - _id: 1
-  pattern: "**.java"
+  pattern: "**/*.java"
   reason: "EXAMPLE_OF"
   comment: "These are example files."
 scope_excludes:
@@ -943,7 +943,7 @@ severe_issue_threshold: "WARNING"
 severe_rule_violation_threshold: "WARNING"
 repository_configuration: "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/project/build.gradle\"\
   \n    reason: \"EXAMPLE_OF\"\n    comment: \"The project is an example.\"\n  - pattern:\
-  \ \"**.java\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"These are example files.\"\
+  \ \"**/*.java\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"These are example files.\"\
   \n  scopes:\n  - pattern: \"testCompile\"\n    reason: \"TEST_DEPENDENCY_OF\"\n\
   \    comment: \"The scope only contains test dependencies.\"\nresolutions:\n  rule_violations:\n\
   \  - message: \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment:\

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -6,7 +6,7 @@
     "comment" : "The project is an example."
   }, {
     "_id" : 1,
-    "pattern" : "**.java",
+    "pattern" : "**/*.java",
     "reason" : "EXAMPLE_OF",
     "comment" : "These are example files."
   } ],
@@ -1047,7 +1047,7 @@
   },
   "severe_issue_threshold" : "WARNING",
   "severe_rule_violation_threshold" : "WARNING",
-  "repository_configuration" : "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/project/build.gradle\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"The project is an example.\"\n  - pattern: \"**.java\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"These are example files.\"\n  scopes:\n  - pattern: \"testCompile\"\n    reason: \"TEST_DEPENDENCY_OF\"\n    comment: \"The scope only contains test dependencies.\"\nresolutions:\n  rule_violations:\n  - message: \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2 is not an issue.\"\nlicense_choices:\n  repository_license_choices:\n  - given: \"GPL-2.0-only OR MIT\"\n    choice: \"MIT\"\n  package_license_choices:\n  - package_id: \"Maven:com.h2database:h2:1.4.200\"\n    license_choices:\n    - given: \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\n",
+  "repository_configuration" : "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/project/build.gradle\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"The project is an example.\"\n  - pattern: \"**/*.java\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"These are example files.\"\n  scopes:\n  - pattern: \"testCompile\"\n    reason: \"TEST_DEPENDENCY_OF\"\n    comment: \"The scope only contains test dependencies.\"\nresolutions:\n  rule_violations:\n  - message: \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2 is not an issue.\"\nlicense_choices:\n  repository_license_choices:\n  - given: \"GPL-2.0-only OR MIT\"\n    choice: \"MIT\"\n  package_license_choices:\n  - package_id: \"Maven:com.h2database:h2:1.4.200\"\n    license_choices:\n    - given: \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\n",
   "labels" : {
     "job_parameters.JOB_PARAM_1" : "label job param 1",
     "job_parameters.JOB_PARAM_2" : "label job param 2",

--- a/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/reporter/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -5,7 +5,7 @@ path_excludes:
   reason: "EXAMPLE_OF"
   comment: "The project is an example."
 - _id: 1
-  pattern: "**.java"
+  pattern: "**/*.java"
   reason: "EXAMPLE_OF"
   comment: "These are example files."
 scope_excludes:
@@ -947,7 +947,7 @@ severe_issue_threshold: "WARNING"
 severe_rule_violation_threshold: "WARNING"
 repository_configuration: "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/project/build.gradle\"\
   \n    reason: \"EXAMPLE_OF\"\n    comment: \"The project is an example.\"\n  - pattern:\
-  \ \"**.java\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"These are example files.\"\
+  \ \"**/*.java\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"These are example files.\"\
   \n  scopes:\n  - pattern: \"testCompile\"\n    reason: \"TEST_DEPENDENCY_OF\"\n\
   \    comment: \"The scope only contains test dependencies.\"\nresolutions:\n  rule_violations:\n\
   \  - message: \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment:\

--- a/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/reporter/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -909,7 +909,7 @@ excludes:
   - pattern: "sub/module/project/build.gradle"
     reason: "EXAMPLE_OF"
     comment: "The project is an example."
-  - pattern: "**.java"
+  - pattern: "**/*.java"
     reason: "EXAMPLE_OF"
     comment: "These are example files."
   scopes:

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -22,7 +22,7 @@ repository:
       - pattern: "sub/module/project/build.gradle"
         reason: "EXAMPLE_OF"
         comment: "The project is an example."
-      - pattern: "**.java"
+      - pattern: "**/*.java"
         reason: "EXAMPLE_OF"
         comment: "These are example files."
       scopes:


### PR DESCRIPTION
The changes migrate all externally facing glob expressions, e.g. for

- path excludes
- license finding curations 
- parameter for the `ListLicensesCommand` of the `helper-cli`

..., to use the `AntPathMatcher` which makes the asterisk match also zero path segments, which previously hasn't been working. 

For example, `**/file.ext` now matches `file.ext`. Further on, `**` now only matches path segments / directories, but not parts of the filename anymore. So for example, from now on `**.java` doesn't work anymore and `**/*.java` should be used instead.

See individual commits.

Fixes #4357.