### PR TITLE
Analyzer: Ignore composer-runtime-api

### DIFF
--- a/analyzer/src/main/kotlin/managers/Composer.kt
+++ b/analyzer/src/main/kotlin/managers/Composer.kt
@@ -62,7 +62,8 @@ const val COMPOSER_LOCK_FILE = "composer.lock"
 
 private val EXCLUDED_PACKAGES = setOf(
     "php", // Exclude the PHP runtime itself.
-    "composer-plugin-api" // Exclude the package to specify the supported composer plugin versions.
+    "composer-plugin-api", // Exclude the package to specify the supported composer plugin versions.
+    "composer-runtime-api" // Exclude the package to specify the supported composer versions for additional features.
 )
 
 /**


### PR DESCRIPTION
Hi,

Since Composer has been updated to version 2, it is necessary to ignore `composer-runtime-api`, along with `composer-plugin-api`.
See https://getcomposer.org/doc/articles/composer-platform-dependencies.md#runtime-package-composer-runtime-api for more details.

Thanks,

Camille 

Signed-off-by: Camille Moulin <cmoulin@inno3.fr>

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
