### PR TITLE
Scanner: Remove a superfluous package filter

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -107,10 +107,7 @@ fun scanOrtResult(
     val consolidatedProjects = consolidateProjectPackagesByVcs(ortResult.getProjects(skipExcluded))
     val projectPackages = consolidatedProjects.keys
 
-    val projectPackageIds = projectPackages.map { it.id }
-    val packages = ortResult.getPackages(skipExcluded)
-        .filter { it.pkg.id !in projectPackageIds }
-        .map { it.pkg }
+    val packages = ortResult.getPackages(skipExcluded).map { it.pkg }
 
     val scanResults = runBlocking {
         val deferredProjectScan = async {


### PR DESCRIPTION
`OrtResult.getPackages()` only returns packages from an analyzer result,
and as of https://github.com/oss-review-toolkit/ort/commit/01c598a04c5745dc7408f6f84b619bc62d13592e package ids cannot clash with project ids, so there is
no need to filter out projects here.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>