### PR TITLE
GitWorkingTree: Remove a superfluous null-fallback

### DIFF
--- a/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
+++ b/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
@@ -111,7 +111,7 @@ open class GitWorkingTree(workingDir: File, vcsType: VcsType) : WorkingTree(work
 
     override fun getRevision(): String = repo.exactRef(Constants.HEAD)?.objectId?.name().orEmpty()
 
-    override fun getRootPath(): File = repo.workTree ?: workingDir
+    override fun getRootPath(): File = repo.workTree
 
     override fun listRemoteBranches(): List<String> =
         runCatching {


### PR DESCRIPTION
JGit's `getWorkTree()` is annotated as `@NonNull`, so the fallback in
the null-case does not make any sense.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>