### PR TITLE
Upgrade Batect to version 0.81.1

### DIFF
--- a/batect
+++ b/batect
@@ -8,8 +8,8 @@
     # You should commit this file to version control alongside the rest of your project. It should not be installed globally.
     # For more information, visit https://github.com/batect/batect.
 
-    VERSION="0.81.0"
-    CHECKSUM="${BATECT_DOWNLOAD_CHECKSUM:-8959e8925c54ba4fec7ce14d22587488335d40668f56767642633bbab102d094}"
+    VERSION="0.81.1"
+    CHECKSUM="${BATECT_DOWNLOAD_CHECKSUM:-0e15559080bbbac00ca30ff8099a0b19e7cb61ea5f1dc0d38334cf67e513a556}"
     DOWNLOAD_URL_ROOT=${BATECT_DOWNLOAD_URL_ROOT:-"https://updates.batect.dev/v1/files"}
     DOWNLOAD_URL=${BATECT_DOWNLOAD_URL:-"$DOWNLOAD_URL_ROOT/$VERSION/batect-$VERSION.jar"}
     QUIET_DOWNLOAD=${BATECT_QUIET_DOWNLOAD:-false}

--- a/batect.cmd
+++ b/batect.cmd
@@ -6,7 +6,7 @@ rem For more information, visit https://github.com/batect/batect.
 
 setlocal EnableDelayedExpansion
 
-set "version=0.81.0"
+set "version=0.81.1"
 
 if "%BATECT_CACHE_DIR%" == "" (
     set "BATECT_CACHE_DIR=%USERPROFILE%\.batect\cache"
@@ -22,7 +22,7 @@ $ErrorActionPreference = 'Stop'^
 
 ^
 
-$Version='0.81.0'^
+$Version='0.81.1'^
 
 ^
 
@@ -48,7 +48,7 @@ $UrlEncodedVersion = [Uri]::EscapeDataString($Version)^
 
 $DownloadUrl = getValueOrDefault $env:BATECT_DOWNLOAD_URL "$DownloadUrlRoot/$UrlEncodedVersion/batect-$UrlEncodedVersion.jar"^
 
-$ExpectedChecksum = getValueOrDefault $env:BATECT_DOWNLOAD_CHECKSUM '8959e8925c54ba4fec7ce14d22587488335d40668f56767642633bbab102d094'^
+$ExpectedChecksum = getValueOrDefault $env:BATECT_DOWNLOAD_CHECKSUM '0e15559080bbbac00ca30ff8099a0b19e7cb61ea5f1dc0d38334cf67e513a556'^
 
 ^
 


### PR DESCRIPTION
See [1].

[1]: https://github.com/batect/batect/releases/tag/0.81.1

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>