### PR TITLE
fix: CI to use grade-build caching errors

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
         java-version: 11
         cache: gradle
     - name: Build all classes
-      uses: burrunan/gradle-cache-action@v1
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: --stacktrace classes -x :reporter-web-app:yarnBuild
   build-reporter-web-app:
@@ -41,7 +41,7 @@ jobs:
         java-version: 11
         cache: gradle
     - name: Build the reporter-web-app
-      uses: burrunan/gradle-cache-action@v1
+      uses: gradle/gradle-build-action@v2
       with:
         job-id: build-reporter-web-app
         arguments: --stacktrace :reporter-web-app:yarnBuild
@@ -58,7 +58,7 @@ jobs:
         java-version: 11
         cache: gradle
     - name: Run unit tests
-      uses: burrunan/gradle-cache-action@v1
+      uses: gradle/gradle-build-action@v2
       with:
         job-id: test
         arguments: test jacocoTestReport -x :reporter-web-app:yarnBuild
@@ -94,7 +94,7 @@ jobs:
         java-version: 11
         cache: gradle
     - name: Run functional tests
-      uses: burrunan/gradle-cache-action@v1
+      uses: gradle/gradle-build-action@v2
       with:
         job-id: funTest-non-analyzer
         arguments: funTest jacocoFunTestReport -x :analyzer:funTest

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -23,7 +23,7 @@ jobs:
         java-version: 11
         cache: gradle
     - name: Check for Detekt Issues
-      uses: burrunan/gradle-cache-action@v1
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: --stacktrace detekt
     - name: Upload SARIF File


### PR DESCRIPTION
## Context
This is a fix regarding failing build CIs (e.g. [this one](https://github.com/oss-review-toolkit/ort/runs/7860071001?check_suite_focus=true)) 

## Cause
`burrunan/gradle-cache-action` has some issues caching because by default it removes some files. Related issue: https://github.com/burrunan/gradle-cache-action/issues/35

## Resolution
This can be easily fixed using [`gradle-build-action`](https://github.com/gradle/gradle-build-action
). It gives the boolean option to cache ([Read Docs](https://github.com/gradle/gradle-build-action#caching)), By Default, caching is enabled.

### Files Changed

#### [`.github/workflows/build-and-test.yml`](https://github.com/Siddhant-K-code/ort/blob/b564762b1795379e6de0eed2e03ba6cbcdd0fa0b/.github/workflows/build-and-test.yml):

- Change of GitHub Action
- I have set `cache-disabled: false` (to be more readable & to educate people about the functionality of this)

#### [`.github/workflows/static-analysis.yml`](https://github.com/Siddhant-K-code/ort/blob/b564762b1795379e6de0eed2e03ba6cbcdd0fa0b/.github/workflows/static-analysis.yml)

- Change of GitHub Action (not required though, but it should be consistent to get rid of future errors)

