### PR TITLE
Evaluator: Allow making arbitrary file checks on the project's source, take 2

### DIFF
--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -150,6 +150,7 @@ class ExamplesFunTest : StringSpec() {
                 "COPYLEFT_LIMITED_IN_SOURCE",
                 "DEPRECATED_SCOPE_EXCLUDE_REASON_IN_ORT_YML",
                 "HIGH_SEVERITY_VULNERABILITY_IN_PACKAGE",
+                "MISSING_CONTRIBUTING_FILE",
                 "UNHANDLED_LICENSE",
                 "VULNERABILITY_IN_PACKAGE"
             )

--- a/evaluator/build.gradle.kts
+++ b/evaluator/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     api(project(":model"))
     api(project(":utils:scripting-utils"))
 
+    implementation(project(":downloader"))
     implementation(project(":utils:ort-utils"))
     implementation(project(":utils:spdx-utils"))
 

--- a/evaluator/src/main/kotlin/OrtResultRule.kt
+++ b/evaluator/src/main/kotlin/OrtResultRule.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.evaluator
 
-import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Severity
 
 /**

--- a/evaluator/src/main/kotlin/ProjectSourceRule.kt
+++ b/evaluator/src/main/kotlin/ProjectSourceRule.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 EPAM Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.evaluator
+
+import java.io.File
+
+import org.ossreviewtoolkit.model.OrtResult
+
+/**
+ * An [OrtResultRule] which allows downloading the project's source code if needed.
+ */
+open class ProjectSourceRule(
+    ruleSet: RuleSet,
+    name: String,
+    projectSourceResolver: SourceTreeResolver = ruleSet.ortResult.createResolver()
+) : OrtResultRule(ruleSet, name) {
+    /**
+     * The directory containing the source code of the project. Accessing the property for the first time triggers a
+     * clone and may take a while.
+     */
+    val projectSourcesDir: File by lazy { projectSourceResolver.rootDir }
+}
+
+private fun OrtResult.createResolver() =
+    SourceTreeResolver.forRemoteRepository(repository.vcsProcessed)

--- a/evaluator/src/main/kotlin/RuleSet.kt
+++ b/evaluator/src/main/kotlin/RuleSet.kt
@@ -57,6 +57,16 @@ class RuleSet(
     }
 
     /**
+     * A DSL function to configure an [ProjectSourceRule]. The rule is applied once to [ortResult].
+     */
+    fun projectSourceRule(name: String, configure: ProjectSourceRule.() -> Unit) {
+        ProjectSourceRule(this, name).apply {
+            configure()
+            evaluate()
+        }
+    }
+
+    /**
      * A DSL function to configure a [PackageRule]. The rule is applied to each [Package] and [Project] contained in
      * [ortResult].
      */

--- a/evaluator/src/main/kotlin/SourceTreeResolver.kt
+++ b/evaluator/src/main/kotlin/SourceTreeResolver.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 EPAM Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.evaluator
+
+import java.io.File
+
+import org.apache.logging.log4j.kotlin.Logging
+
+import org.ossreviewtoolkit.downloader.Downloader
+import org.ossreviewtoolkit.model.Package
+import org.ossreviewtoolkit.model.SourceCodeOrigin
+import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.model.config.DownloaderConfiguration
+import org.ossreviewtoolkit.utils.ort.createOrtTempDir
+
+class SourceTreeResolver private constructor(getRepositoryRoot: () -> File) {
+    companion object : Logging {
+        fun forRemoteRepository(vcsInfo: VcsInfo) =
+            SourceTreeResolver {
+                val downloadDir = createOrtTempDir()
+                val downloaderConfiguration = DownloaderConfiguration(sourceCodeOrigins = listOf(SourceCodeOrigin.VCS))
+                val downloader = Downloader(downloaderConfiguration)
+                val pkg = Package.EMPTY.copy(vcsProcessed = vcsInfo)
+
+                downloader.download(pkg, downloadDir)
+
+                downloadDir
+            }
+    }
+
+    val rootDir: File by lazy {
+        logger.info {
+            "The evaluator rules attempt to access the project's source code for the first time. Fetching sources..."
+        }
+
+        getRepositoryRoot()
+    }
+}

--- a/evaluator/src/main/kotlin/SourceTreeResolver.kt
+++ b/evaluator/src/main/kotlin/SourceTreeResolver.kt
@@ -43,6 +43,8 @@ class SourceTreeResolver private constructor(getRepositoryRoot: () -> File) {
 
                 downloadDir
             }
+
+        fun forLocalDirectory(dir: File) = SourceTreeResolver { dir }
     }
 
     val rootDir: File by lazy {

--- a/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
+++ b/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2022 EPAM Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.evaluator
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import java.io.File
+
+import org.ossreviewtoolkit.model.OrtResult
+import org.ossreviewtoolkit.utils.test.createSpecTempDir
+
+class ProjectSourceRuleTest : WordSpec({
+    "projectSourceHasFile()" should {
+        "return true if at least one file matches the given glob pattern" {
+            val dir = createSpecTempDir().apply {
+                addFiles(
+                    "README.md",
+                    "module/docs/LICENSE.txt"
+                )
+            }
+            val rule = createOrtResultRule(dir)
+
+            with(rule) {
+                projectSourceHasFile("README.md").matches() shouldBe true
+                projectSourceHasFile("**/README.md").matches() shouldBe true
+                projectSourceHasFile("**/LICENSE*").matches() shouldBe true
+                projectSourceHasFile("**/*.txt").matches() shouldBe true
+            }
+        }
+
+        "return false if only a directory matches the given glob pattern" {
+            val dir = createSpecTempDir().apply {
+                addDirs("README.md")
+            }
+            val rule = createOrtResultRule(dir)
+
+            rule.projectSourceHasFile("README.md").matches() shouldBe false
+        }
+
+        "return false if neither any file nor directory matches the given glob pattern" {
+            val dir = createSpecTempDir()
+            val rule = createOrtResultRule(dir)
+
+            rule.projectSourceHasFile("README.md").matches() shouldBe false
+        }
+    }
+})
+
+private fun createOrtResultRule(projectSourcesDir: File): ProjectSourceRule =
+    ProjectSourceRule(
+        ruleSet = ruleSet(ortResult = OrtResult.EMPTY),
+        name = "RULE_NAME",
+        projectSourceResolver = SourceTreeResolver.forLocalDirectory(projectSourcesDir)
+    )
+
+private fun File.addFiles(vararg paths: String) {
+    require(isDirectory)
+
+    paths.forEach { path ->
+        resolve(path).apply {
+            parentFile.mkdirs()
+            createNewFile()
+        }
+    }
+}
+
+private fun File.addDirs(vararg paths: String) {
+    require(isDirectory)
+
+    paths.forEach { path ->
+        resolve(path).mkdirs()
+    }
+}

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -264,6 +264,14 @@ fun RuleSet.deprecatedScopeExcludeReasonInOrtYmlRule() = ortResultRule("DEPRECAT
     }
 }
 
+fun RuleSet.missingContributingFileRule() = projectSourceRule("MISSING_CONTRIBUTING_FILE") {
+    require {
+        -projectSourceHasFile("CONTRIBUTING.md")
+    }
+
+    error("The project's code repository does not contain the file 'CONTRIBUTING.md'.")
+}
+
 /**
  * The set of policy rules.
  */
@@ -282,6 +290,7 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
 
     // Rules which get executed once:
     deprecatedScopeExcludeReasonInOrtYmlRule()
+    missingContributingFileRule()
 }
 
 // Populate the list of policy rule violations to return.


### PR DESCRIPTION
See individual commits.

Note: The project's source tree will be cloned in the evaluator only if the rules needed it / if the file checks are actually used.

This implements parts of https://github.com/oss-review-toolkit/ort/issues/5621.