### PR TITLE
Subversion: Trivially improve / align the comments for named paramaters

### DIFF
--- a/downloader/src/main/kotlin/vcs/Subversion.kt
+++ b/downloader/src/main/kotlin/vcs/Subversion.kt
@@ -107,8 +107,8 @@ class Subversion : VersionControlSystem() {
                         svnUrl,
                         SVNRevision.HEAD,
                         SVNRevision.HEAD,
-                        /*fetchLocks =*/ false,
-                        /*recursive =*/ false
+                        /* fetchLocks = */ false,
+                        /* recursive = */ false
                     ) { dirEntry ->
                         if (dirEntry.name.isNotEmpty()) refs += "$namespace/${dirEntry.relativePath}"
                     }


### PR DESCRIPTION
There should be single spaces at the begin and end for readability.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>