### PR TITLE
Json schema ort config

### DIFF
--- a/integrations/schemas/ort-configuration-schema.json
+++ b/integrations/schemas/ort-configuration-schema.json
@@ -1,0 +1,579 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "https://oss-review-toolkit.org/ort-configuration.yml",
+    "title": "ORT configuration",
+    "description": "The main configuration file for the OSS-Review-Toolkit (ORT). A full list of all available options can be found at https://github.com/oss-review-toolkit/ort/blob/main/model/src/main/resources/reference.yml.",
+    "type": "object",
+    "properties": {
+        "ort": {
+            "properties": {
+                "licenseFilePatterns": {
+                    "$ref": "#/definitions/LicenseFilePatterns"
+                },
+                "severeIssueThreshold": {
+                    "$ref": "#/definitions/Severity"
+                },
+                "severeRuleViolationThreshold": {
+                    "$ref": "#/definitions/Severity"
+                },
+                "enableRepositoryPackageCurations": {
+                    "type": "boolean"
+                },
+                "enableRepositoryPackageConfigurations": {
+                    "type": "boolean"
+                },
+                "analyzer": {
+                    "$ref": "#/definitions/Analyzer"
+                },
+                "advisor": {
+                    "$ref": "#/definitions/Advisor"
+                },
+                "downloader": {
+                    "$ref": "#/definitions/Downloader"
+                },
+                "scanner": {
+                    "$ref": "#/definitions/Scanner"
+                },
+                "reporter": {
+                    "$ref": "#/definitions/Reporter"
+                },
+                "notifier": {
+                    "$ref": "#/definitions/Notifier"
+                }
+            }
+        }
+    },
+    "required": [
+        "ort"
+    ],
+    "definitions": {
+        "Advisor": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nexusIq": {
+                    "$ref": "#/definitions/NexusIq"
+                },
+                "vulnerableCode": {
+                    "$ref": "#/definitions/VulnerableCode"
+                },
+                "gitHubDefects": {
+                    "$ref": "#/definitions/GitHubDefects"
+                },
+                "osv": {
+                    "$ref": "#/definitions/Osv"
+                },
+                "options": {
+                    "$ref": "#/definitions/AdvisorOptions"
+                }
+            }
+        },
+        "GitHubDefects": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "token": {
+                    "type": "string"
+                },
+                "labelFilter": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "maxNumberOfIssuesPerRepository": {
+                    "type": "integer"
+                },
+                "parallelRequests": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "labelFilter"
+            ]
+        },
+        "NexusIq": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "serverUrl": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "browseUrl": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "serverUrl"
+            ],
+            "title": "NexusIq"
+        },
+        "AdvisorOptions": {
+            "type": "object",
+            "additionalProperties": { "type": "object" }
+        },
+        "CustomAdvisor": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiKey": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "apiKey"
+            ],
+            "title": "CustomAdvisor"
+        },
+        "Osv": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "serverUrl": {
+                    "type": "string",
+                    "format": "uri"
+                }
+            }
+        },
+        "VulnerableCode": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "serverUrl": {
+                    "type": "string",
+                    "format": "uri"
+                }
+            },
+            "required": [
+                "serverUrl"
+            ]
+        },
+        "Analyzer": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowDynamicVersions": {
+                    "type": "boolean"
+                },
+                "enabledPackageManagers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PackageManagers"
+                    }
+                },
+                "disabledPackageManagers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PackageManagers"
+                    }
+                },
+                "packageManagers": {
+                    "$ref": "#/definitions/PackageManagerConfigs"
+                },
+                "sw360Configuration": {
+                    "$ref": "#/definitions/Sw360Configuration"
+                }
+            }
+        },
+        "PackageManagerConfigs": {
+            "type": "object",
+            "additionalProperties": { "type": "object" }
+        },
+        "Sw360Configuration": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "restUrl": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "authUrl": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                },
+                "clientId": {
+                    "type": "string"
+                },
+                "clientPassword": {
+                    "type": "string"
+                },
+                "token": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "authUrl",
+                "clientId",
+                "restUrl",
+                "username"
+            ]
+        },
+        "Downloader": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowMovingRevisions": {
+                    "type": "boolean"
+                },
+                "includedLicenseCategories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sourceCodeOrigins": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SourceCodeOrigins"
+                    }
+                }
+            }
+        },
+        "LicenseFilePatterns": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "licenseFilenames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "patentFilenames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "rootLicenseFilenames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "Notifier": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mail": {
+                    "$ref": "#/definitions/Mail"
+                },
+                "jira": {
+                    "$ref": "#/definitions/Jira"
+                }
+            }
+        },
+        "Jira": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "host": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "Mail": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostName": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                },
+                "port": {
+                    "type": "integer"
+                },
+                "useSsl": {
+                    "type": "boolean"
+                },
+                "fromAddress": {
+                    "type": "string"
+                }
+            }
+        },
+        "Reporter": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "options": {
+                    "$ref": "#/definitions/ReporterOptions"
+                }
+            },
+            "required": [
+                "options"
+            ]
+        },
+        "ReporterOptions": {
+            "type": "object",
+            "additionalProperties": { "type": "object" }
+        },
+        "Scanner": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "skipConcluded": {
+                    "type": "boolean"
+                },
+                "archive": {
+                    "$ref": "#/definitions/Archive"
+                },
+                "createMissingArchives": {
+                    "type": "boolean"
+                },
+                "detectedLicenseMapping": {
+                    "$ref": "#/definitions/DetectedLicenseMapping"
+                },
+                "options": {
+                    "$ref": "#/definitions/ScannerOptions"
+                },
+                "storages": {
+                    "$ref": "#/definitions/Storages"
+                },
+                "storageReaders": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/StorageTypes"
+                    }
+                },
+                "storageWriters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/StorageTypes"
+                    }
+                },
+                "ignorePatterns": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "provenanceStorage": {
+                    "$ref": "#/definitions/ProvenanceStorage"
+                }
+            }
+        },
+        "Archive": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "fileStorage": {
+                    "$ref": "#/definitions/FileStorage"
+                },
+                "postgresStorage": {
+                    "$ref": "#/definitions/PostgresConfig"
+                }
+            }
+        },
+        "FileStorage": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "localFileStorage": {
+                    "$ref": "#/definitions/LocalFileStorage"
+                },
+                "httpFileStorage": {
+                    "§ref": "#/definitions/HttpFileStorage"
+                }
+            },
+            "required": [
+                "localFileStorage"
+            ]
+        },
+        "LocalFileStorage": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "directory": {
+                    "type": "string"
+                },
+                "compression": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "directory"
+            ]
+        },
+        "HttpFileStorage": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "query": {
+                    "type": "string"
+                },
+                "headers": {
+                    "$ref": "#/definitions/Headers"
+                }
+            },
+            "required": [
+                "url"
+            ]
+        },
+        "PostgresConfig": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "connection": {
+                    "$ref": "#/definitions/Connection"
+                }
+            },
+            "required": [
+                "connection"
+            ]
+        },
+        "Connection": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                },
+                "sslmode": {
+                    "type": "string"
+                },
+                "sslcert": {
+                    "type": "string"
+                },
+                "sslkey": {
+                    "type": "string"
+                },
+                "sslrootcert": {
+                    "type": "string"
+                },
+                "parallelTransactions": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "url",
+                "username"
+            ]
+        },
+        "DetectedLicenseMapping": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+        },
+        "ScannerOptions": {
+            "type": "object",
+            "additionalProperties": { "type": "object" }
+        },
+        "ProvenanceStorage": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fileStorage": {
+                    "$ref": "#/definitions/FileStorage"
+                },
+                "postgresStorage": {
+                    "$ref": "#/definitions/PostgresConfig"
+                }
+            },
+            "required": [
+                "fileStorage",
+                "postgresStorage"
+            ],
+            "title": "ProvenanceStorage"
+        },
+        "Storages": {
+            "type": "object",
+            "additionalProperties": { "type": "object" }
+        },
+        "Severity": {
+            "enum": [
+                "HINT",
+                "WARNING",
+                "ERROR"
+            ]
+        },
+        "PackageManagers": {
+            "enum": [
+                "Bower",
+                "Bundler",
+                "Cargo",
+                "Carthage",
+                "CocoaPods",
+                "Composer",
+                "Conan",
+                "DotNet",
+                "GoDep",
+                "GoMod",
+                "Gradle",
+                "Maven",
+                "NPM",
+                "NuGet",
+                "PIP",
+                "Pipenv",
+                "PNPM",
+                "Poetry",
+                "Pub",
+                "SBT",
+                "SpdxDocumentFile",
+                "Stack",
+                "Unmanaged",
+                "Yarn",
+                "Yarn2"
+            ]
+        },
+        "SourceCodeOrigins": {
+            "enum": [
+                "ARTIFACT",
+                "VCS"
+            ]
+        },
+        "StorageTypes": {
+            "enum": [
+                "clearlyDefined",
+                "http",
+                "local",
+                "postgres"
+            ]
+        },
+        "Headers": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+        }
+    }
+}

--- a/model/src/test/kotlin/JsonSchemaTest.kt
+++ b/model/src/test/kotlin/JsonSchemaTest.kt
@@ -99,6 +99,19 @@ class JsonSchemaTest : StringSpec() {
 
             errors should beEmpty()
         }
+
+        "reference.yml validates successfully" {
+            val ortConfigurationSchema = JsonSchemaFactory
+                .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V6))
+                .objectMapper(mapper)
+                .build()
+                .getSchema(File("../integrations/schemas/ort-configuration-schema.json").toURI())
+            val referenceConfigFile = File("src/main/resources/reference.yml").toJsonNode()
+
+            val errors = ortConfigurationSchema.validate(referenceConfigFile)
+
+            errors should beEmpty()
+        }
     }
 
     private fun File.toJsonNode() = mapper.readTree(inputStream())


### PR DESCRIPTION
Add schema that validates and enables autocompletion for well typed
configuration options. However loosely typed configuration options like
the analyzer's `packageMangers` options which require a `Map`, are
currently omitted by allowing `"additionalProperties": { "type":
"object" }`, which results in allowing all keys and values in the
validation.
