### PR TITLE
JsonSchemaTest: Add a test that validates the ort-configuration-schema

### DIFF
--- a/model/src/test/kotlin/JsonSchemaTest.kt
+++ b/model/src/test/kotlin/JsonSchemaTest.kt
@@ -99,6 +99,19 @@ class JsonSchemaTest : StringSpec() {
 
             errors should beEmpty()
         }
+
+        "reference.yml validates successfully" {
+            val ortConfigurationSchema = JsonSchemaFactory
+                .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
+                .objectMapper(mapper)
+                .build()
+                .getSchema(File("../integrations/schemas/ort-configuration-schema.json").toURI())
+            val referenceConfigFile = File("src/main/resources/reference.yml").toJsonNode()
+
+            val errors = ortConfigurationSchema.validate(referenceConfigFile)
+
+            errors should beEmpty()
+        }
     }
 
     private fun File.toJsonNode() = mapper.readTree(inputStream())


### PR DESCRIPTION
Validate the `ort-configuration-schema.json` against the `reference.yml` file.

This test will pass once https://github.com/oss-review-toolkit/ort/pull/5757 is merged.