### PR TITLE
evaluator: Extend the API for making file checks against the project's source code

### DIFF
--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -151,6 +151,7 @@ class ExamplesFunTest : StringSpec() {
                 "DEPRECATED_SCOPE_EXCLUDE_REASON_IN_ORT_YML",
                 "HIGH_SEVERITY_VULNERABILITY_IN_PACKAGE",
                 "MISSING_CONTRIBUTING_FILE",
+                "MISSING_README_FILE_LICENSE_SECTION",
                 "UNHANDLED_LICENSE",
                 "VULNERABILITY_IN_PACKAGE"
             )

--- a/evaluator/src/main/kotlin/ProjectSourceRule.kt
+++ b/evaluator/src/main/kotlin/ProjectSourceRule.kt
@@ -57,6 +57,18 @@ open class ProjectSourceRule(
         }
 
     /**
+     * Return the file paths matching any of the given [glob expressions][patterns] with its file content matching
+     * [contentPattern].
+     */
+    fun projectSourceFindFilesWithContent(contentPattern: String, vararg patterns: String): List<File> =
+        projectSourceFindFiles(*patterns).filter { path ->
+            val content = projectSourcesDir.resolve(path).readText()
+            val regex = contentPattern.toRegex(setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.MULTILINE))
+
+            content.matches(regex)
+        }
+
+    /**
      * A [RuleMatcher] that checks whether the project's source tree contains at least one directory matching any of the
      * provided [glob expressions][patterns].
      */
@@ -75,6 +87,19 @@ open class ProjectSourceRule(
         object : RuleMatcher {
             override val description = "projectSourceHasFile('${patterns.joinToString()}')"
             override fun matches(): Boolean = projectSourceFindFiles(*patterns).isNotEmpty()
+        }
+
+    /**
+     * A [RuleMatcher] that checks whether the project's source tree contains at least one file matching any of the
+     * given [glob expressions][patterns] with its file content matching [contentPattern].
+     */
+    fun projectSourceHasFileWithContent(contentPattern: String, vararg patterns: String): RuleMatcher =
+        object : RuleMatcher {
+            override val description =
+                "projectSourceHasFileWithContents('$contentPattern', '${patterns.joinToString()}')"
+
+            override fun matches(): Boolean =
+                projectSourceFindFilesWithContent(contentPattern, *patterns).isNotEmpty()
         }
 }
 

--- a/evaluator/src/main/kotlin/ProjectSourceRule.kt
+++ b/evaluator/src/main/kotlin/ProjectSourceRule.kt
@@ -60,13 +60,15 @@ open class ProjectSourceRule(
      * Return the file paths matching any of the given [glob expressions][patterns] with its file content matching
      * [contentPattern].
      */
-    fun projectSourceFindFilesWithContent(contentPattern: String, vararg patterns: String): List<File> =
-        projectSourceFindFiles(*patterns).filter { path ->
+    fun projectSourceFindFilesWithContent(contentPattern: String, vararg patterns: String): List<File> {
+        val regex = contentPattern.toRegex(setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.MULTILINE))
+
+        return projectSourceFindFiles(*patterns).filter { path ->
             val content = projectSourcesDir.resolve(path).readText()
-            val regex = contentPattern.toRegex(setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.MULTILINE))
 
             content.matches(regex)
         }
+    }
 
     /**
      * A [RuleMatcher] that checks whether the project's source tree contains at least one directory matching any of the

--- a/evaluator/src/main/kotlin/ProjectSourceRule.kt
+++ b/evaluator/src/main/kotlin/ProjectSourceRule.kt
@@ -40,11 +40,31 @@ open class ProjectSourceRule(
     val projectSourcesDir: File by lazy { projectSourceResolver.rootDir }
 
     /**
+     * Return all directories from the project's source tree which match any of the
+     * provided [glob expressions][patterns].
+     */
+    fun projectSourceFindDirectories(vararg patterns: String): List<File> =
+        projectSourcesDir.walkBottomUp().filterTo(mutableListOf()) {
+            it.isDirectory && FileMatcher.match(patterns.toList(), it.relativeTo(projectSourcesDir).path)
+        }
+
+    /**
      * Return all files from the project's source tree which match any of the provided [glob expressions][patterns].
      */
     fun projectSourceFindFiles(vararg patterns: String): List<File> =
         projectSourcesDir.walkBottomUp().filterTo(mutableListOf()) {
             it.isFile && FileMatcher.match(patterns.toList(), it.relativeTo(projectSourcesDir).path)
+        }
+
+    /**
+     * A [RuleMatcher] that checks whether the project's source tree contains at least one directory matching any of the
+     * provided [glob expressions][patterns].
+     */
+    fun projectSourceHasDirectory(vararg patterns: String): RuleMatcher =
+        object : RuleMatcher {
+            override val description = "projectSourceHasDirectory('${patterns.joinToString()}')"
+
+            override fun matches(): Boolean = projectSourceFindDirectories(*patterns).isNotEmpty()
         }
 
     /**

--- a/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
+++ b/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
@@ -130,7 +130,7 @@ private fun File.addFiles(vararg paths: String, content: String = "") {
         resolve(path).apply {
             parentFile.mkdirs()
             createNewFile()
-            writeText(content)
+            if (content.isNotEmpty()) writeText(content)
         }
     }
 }

--- a/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
+++ b/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
@@ -96,6 +96,24 @@ class ProjectSourceRuleTest : WordSpec({
             rule.projectSourceHasDirectory("a").matches() shouldBe false
         }
     }
+
+    "projectSourceHasFileWithContent()" should {
+        "return true if there is a file matching the given glob pattern with its content matching the given regex" {
+            val dir = createSpecTempDir().apply {
+                addFiles(
+                    "README.md",
+                    content = """
+                        
+                        ## License
+                    
+                    """.trimIndent()
+                )
+            }
+            val rule = createOrtResultRule(dir)
+
+            rule.projectSourceHasFileWithContent(".*^#{1,2} License$.*", "README.md").matches() shouldBe true
+        }
+    }
 })
 
 private fun createOrtResultRule(projectSourcesDir: File): ProjectSourceRule =
@@ -105,13 +123,14 @@ private fun createOrtResultRule(projectSourcesDir: File): ProjectSourceRule =
         projectSourceResolver = SourceTreeResolver.forLocalDirectory(projectSourcesDir)
     )
 
-private fun File.addFiles(vararg paths: String) {
+private fun File.addFiles(vararg paths: String, content: String = "") {
     require(isDirectory)
 
     paths.forEach { path ->
         resolve(path).apply {
             parentFile.mkdirs()
             createNewFile()
+            writeText(content)
         }
     }
 }

--- a/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
+++ b/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
@@ -62,6 +62,40 @@ class ProjectSourceRuleTest : WordSpec({
             rule.projectSourceHasFile("README.md").matches() shouldBe false
         }
     }
+
+    "projectSourceHasDirectory()" should {
+        "return true if at least one directory matches the given glob pattern" {
+            val dir = createSpecTempDir().apply {
+                addDirs("a/b/c")
+            }
+            val rule = createOrtResultRule(dir)
+
+            with(rule) {
+                projectSourceHasDirectory("a").matches() shouldBe true
+                projectSourceHasDirectory("a/b").matches() shouldBe true
+                projectSourceHasDirectory("**/b/**").matches() shouldBe true
+                projectSourceHasDirectory("**/c").matches() shouldBe true
+            }
+        }
+
+        "return false if only a file matches the given glob pattern" {
+            val dir = createSpecTempDir().apply {
+                addFiles("a")
+            }
+            val rule = createOrtResultRule(dir)
+
+            rule.projectSourceHasDirectory("a").matches() shouldBe false
+        }
+
+        "return false if no directory matches the given glob pattern" {
+            val dir = createSpecTempDir().apply {
+                addDirs("b")
+            }
+            val rule = createOrtResultRule(dir)
+
+            rule.projectSourceHasDirectory("a").matches() shouldBe false
+        }
+    }
 })
 
 private fun createOrtResultRule(projectSourcesDir: File): ProjectSourceRule =

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -264,6 +264,28 @@ fun RuleSet.deprecatedScopeExcludeReasonInOrtYmlRule() = ortResultRule("DEPRECAT
     }
 }
 
+fun RuleSet.missingCiConfigurationRule() = projectSourceRule("MISSING_CI_CONFIGURATION") {
+    require {
+        -AnyOf(
+            projectSourceHasFile(
+                ".appveyor.yml",
+                ".bitbucket-pipelines.yml",
+                ".gitlab-ci.yml",
+                ".travis.yml"
+            ),
+            projectSourceHasDirectory(
+                ".circleci",
+                ".github/workflows"
+            )
+        )
+    }
+
+    error(
+        message = "This project does not have any known CI configuration files.",
+        howToFix = "Please setup a CI. If you already have setup a CI and the error persists, please contact support."
+    )
+}
+
 fun RuleSet.missingContributingFileRule() = projectSourceRule("MISSING_CONTRIBUTING_FILE") {
     require {
         -projectSourceHasFile("CONTRIBUTING.md")
@@ -290,6 +312,7 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
 
     // Rules which get executed once:
     deprecatedScopeExcludeReasonInOrtYmlRule()
+    missingCiConfigurationRule()
     missingContributingFileRule()
 }
 

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -314,6 +314,26 @@ fun RuleSet.missingContributingFileRule() = projectSourceRule("MISSING_CONTRIBUT
     error("The project's code repository does not contain the file 'CONTRIBUTING.md'.")
 }
 
+fun RuleSet.missingReadmeFileRule() = projectSourceRule("MISSING_README_FILE") {
+    require {
+        -projectSourceHasFile("README.md")
+    }
+
+    error("The project's code repository does not contain the file 'README.md'.")
+}
+
+fun RuleSet.missingReadmeFileLicenseSectionRule() = projectSourceRule("MISSING_README_FILE_LICENSE_SECTION") {
+    require {
+        +projectSourceHasFile("README.md")
+        -projectSourceHasFileWithContent(".*^#{1,2} License$.*", "README.md")
+    }
+
+    error(
+        message = "This project does not seem to have any known CI configuration files.",
+        howToFix = "Please add a license section to the file 'README.md' in the root directory."
+    )
+}
+
 /**
  * The set of policy rules.
  */
@@ -335,6 +355,8 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     deprecatedScopeExcludeReasonInOrtYmlRule()
     missingCiConfigurationRule()
     missingContributingFileRule()
+    missingReadmeFileRule()
+    missingReadmeFileLicenseSectionRule()
 }
 
 // Populate the list of policy rule violations to return.

--- a/examples/evaluator-rules/src/main/resources/example.rules.kts
+++ b/examples/evaluator-rules/src/main/resources/example.rules.kts
@@ -329,8 +329,8 @@ fun RuleSet.missingReadmeFileLicenseSectionRule() = projectSourceRule("MISSING_R
     }
 
     error(
-        message = "This project does not seem to have any known CI configuration files.",
-        howToFix = "Please add a license section to the file 'README.md' in the root directory."
+        message = "The file 'README.md' is missing a \"License\" section.",
+        howToFix = "Please add a \"License\" section to the file 'README.md'."
     )
 }
 
@@ -351,8 +351,10 @@ val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
     copyleftLimitedInDependencyRule()
 
     // Rules which get executed once:
-    dependencyInProjectSourceRule()
     deprecatedScopeExcludeReasonInOrtYmlRule()
+
+    // Prior to open sourcing use case rules (which get executed once):
+    dependencyInProjectSourceRule()
     missingCiConfigurationRule()
     missingContributingFileRule()
     missingReadmeFileRule()


### PR DESCRIPTION
Extend the `ProjectSourceRule` to allow making further types of file checks and illustrate the use of each respective new API
with a policy rule derived from a real world use case.

Implements parts of #5621.