### PR TITLE
Minor FossId improvements

### DIFF
--- a/clients/fossid-webapp/src/main/kotlin/Extensions.kt
+++ b/clients/fossid-webapp/src/main/kotlin/Extensions.kt
@@ -80,7 +80,7 @@ suspend fun FossIdRestService.getFossIdVersion(): String? {
  */
 suspend fun FossIdRestService.getProject(user: String, apiKey: String, projectCode: String) =
     getProject(
-        PostRequestBody("get_information", PROJECT_GROUP, user, apiKey, "project_code" to projectCode)
+        PostRequestBody("get_information", PROJECT_GROUP, user, apiKey, mapOf("project_code" to projectCode))
     )
 
 /**
@@ -90,7 +90,7 @@ suspend fun FossIdRestService.getProject(user: String, apiKey: String, projectCo
  */
 suspend fun FossIdRestService.listScansForProject(user: String, apiKey: String, projectCode: String) =
     listScansForProject(
-        PostRequestBody("get_all_scans", PROJECT_GROUP, user, apiKey, "project_code" to projectCode)
+        PostRequestBody("get_all_scans", PROJECT_GROUP, user, apiKey, mapOf("project_code" to projectCode))
     )
 
 /**
@@ -111,9 +111,11 @@ suspend fun FossIdRestService.createProject(
             PROJECT_GROUP,
             user,
             apiKey,
-            "project_code" to projectCode,
-            "project_name" to projectName,
-            "comment" to comment
+            mapOf(
+                "project_code" to projectCode,
+                "project_name" to projectName,
+                "comment" to comment
+            )
         )
     )
 
@@ -136,11 +138,13 @@ suspend fun FossIdRestService.createScan(
             SCAN_GROUP,
             user,
             apiKey,
-            "project_code" to projectCode,
-            "scan_code" to scanCode,
-            "scan_name" to scanCode,
-            "git_repo_url" to gitRepoUrl,
-            "git_branch" to gitBranch
+            mapOf(
+                "project_code" to projectCode,
+                "scan_code" to scanCode,
+                "scan_name" to scanCode,
+                "git_repo_url" to gitRepoUrl,
+                "git_branch" to gitBranch
+            )
         )
     )
 
@@ -161,8 +165,10 @@ suspend fun FossIdRestService.runScan(
             SCAN_GROUP,
             user,
             apiKey,
-            "scan_code" to scanCode,
-            *options
+            buildMap {
+                put("scan_code", scanCode)
+                putAll(options)
+            }
         )
     )
 
@@ -178,9 +184,11 @@ suspend fun FossIdRestService.deleteScan(user: String, apiKey: String, scanCode:
             SCAN_GROUP,
             user,
             apiKey,
-            "scan_code" to scanCode,
-            "delete_identifications" to "1"
-        )
+            mapOf(
+                "scan_code" to scanCode,
+                "delete_identifications" to "1"
+            )
+         )
     )
 
 /**
@@ -195,7 +203,7 @@ suspend fun FossIdRestService.downloadFromGit(user: String, apiKey: String, scan
             SCAN_GROUP,
             user,
             apiKey,
-            "scan_code" to scanCode
+            mapOf("scan_code" to scanCode)
         )
     )
 
@@ -207,7 +215,7 @@ suspend fun FossIdRestService.downloadFromGit(user: String, apiKey: String, scan
 suspend fun FossIdRestService.checkDownloadStatus(user: String, apiKey: String, scanCode: String) =
     checkDownloadStatus(
         PostRequestBody(
-            "check_status_download_content_from_git", SCAN_GROUP, user, apiKey, "scan_code" to scanCode
+            "check_status_download_content_from_git", SCAN_GROUP, user, apiKey, mapOf("scan_code" to scanCode)
         )
     )
 
@@ -218,7 +226,7 @@ suspend fun FossIdRestService.checkDownloadStatus(user: String, apiKey: String, 
  */
 suspend fun FossIdRestService.listScanResults(user: String, apiKey: String, scanCode: String) =
     listScanResults(
-        PostRequestBody("get_results", SCAN_GROUP, user, apiKey, "scan_code" to scanCode)
+        PostRequestBody("get_results", SCAN_GROUP, user, apiKey, mapOf("scan_code" to scanCode))
     )
 
 /**
@@ -233,7 +241,7 @@ suspend fun FossIdRestService.listMarkedAsIdentifiedFiles(user: String, apiKey: 
             SCAN_GROUP,
             user,
             apiKey,
-            "scan_code" to scanCode
+            mapOf("scan_code" to scanCode)
         )
     )
 
@@ -245,7 +253,7 @@ suspend fun FossIdRestService.listMarkedAsIdentifiedFiles(user: String, apiKey: 
 suspend fun FossIdRestService.listIdentifiedFiles(user: String, apiKey: String, scanCode: String) =
     listIdentifiedFiles(
         PostRequestBody(
-            "get_identified_files", SCAN_GROUP, user, apiKey, "scan_code" to scanCode
+            "get_identified_files", SCAN_GROUP, user, apiKey, mapOf("scan_code" to scanCode)
         )
     )
 
@@ -257,7 +265,7 @@ suspend fun FossIdRestService.listIdentifiedFiles(user: String, apiKey: String, 
 suspend fun FossIdRestService.listIgnoredFiles(user: String, apiKey: String, scanCode: String) =
     listIgnoredFiles(
         PostRequestBody(
-            "get_ignored_files", SCAN_GROUP, user, apiKey, "scan_code" to scanCode
+            "get_ignored_files", SCAN_GROUP, user, apiKey, mapOf("scan_code" to scanCode)
         )
     )
 
@@ -269,7 +277,7 @@ suspend fun FossIdRestService.listIgnoredFiles(user: String, apiKey: String, sca
 suspend fun FossIdRestService.listPendingFiles(user: String, apiKey: String, scanCode: String) =
     listPendingFiles(
         PostRequestBody(
-            "get_pending_files", SCAN_GROUP, user, apiKey, "scan_code" to scanCode
+            "get_pending_files", SCAN_GROUP, user, apiKey, mapOf("scan_code" to scanCode)
         )
     )
 
@@ -281,7 +289,7 @@ suspend fun FossIdRestService.listPendingFiles(user: String, apiKey: String, sca
 suspend fun FossIdRestService.listIgnoreRules(user: String, apiKey: String, scanCode: String) =
     listIgnoreRules(
         PostRequestBody(
-            "ignore_rules_show", SCAN_GROUP, user, apiKey, "scan_code" to scanCode
+            "ignore_rules_show", SCAN_GROUP, user, apiKey, mapOf("scan_code" to scanCode)
         )
     )
 
@@ -304,10 +312,12 @@ suspend fun FossIdRestService.createIgnoreRule(
             SCAN_GROUP,
             user,
             apiKey,
-            "scan_code" to scanCode,
-            "type" to type.name.lowercase(),
-            "value" to value,
-            "apply_to" to scope.name.lowercase()
+            mapOf(
+                "scan_code" to scanCode,
+                "type" to type.name.lowercase(),
+                "value" to value,
+                "apply_to" to scope.name.lowercase()
+            )
         )
     )
 
@@ -329,9 +339,11 @@ suspend fun FossIdRestService.generateReport(
             SCAN_GROUP,
             user,
             apiKey,
-            "scan_code" to scanCode,
-            "report_type" to reportType.toString(),
-            "selection_type" to selectionType.name.lowercase()
+            mapOf(
+                "scan_code" to scanCode,
+                "report_type" to reportType.toString(),
+                "selection_type" to selectionType.name.lowercase()
+            )
         )
     )
 

--- a/clients/fossid-webapp/src/main/kotlin/Extensions.kt
+++ b/clients/fossid-webapp/src/main/kotlin/Extensions.kt
@@ -150,8 +150,11 @@ suspend fun FossIdRestService.createScan(
  * The HTTP request is sent with [user] and [apiKey] as credentials.
  */
 suspend fun FossIdRestService.runScan(
-    user: String, apiKey: String, scanCode: String, vararg options: Pair<String, String>
-) =
+    user: String,
+    apiKey: String,
+    scanCode: String,
+    vararg options: Pair<String, String>
+): EntityResponseBody<Nothing> =
     runScan(
         PostRequestBody(
             "run",

--- a/clients/fossid-webapp/src/main/kotlin/Extensions.kt
+++ b/clients/fossid-webapp/src/main/kotlin/Extensions.kt
@@ -157,7 +157,7 @@ suspend fun FossIdRestService.runScan(
     user: String,
     apiKey: String,
     scanCode: String,
-    vararg options: Pair<String, String>
+    options: Map<String, String> = emptyMap()
 ): EntityResponseBody<Nothing> =
     runScan(
         PostRequestBody(

--- a/clients/fossid-webapp/src/main/kotlin/PostRequestBody.kt
+++ b/clients/fossid-webapp/src/main/kotlin/PostRequestBody.kt
@@ -26,5 +26,5 @@ class PostRequestBody(
     apiKey: String,
     vararg options: Pair<String, String>
 ) {
-    val data: MutableMap<String, String> = mutableMapOf("username" to user, "key" to apiKey, *options)
+    val data = mapOf("username" to user, "key" to apiKey, *options)
 }

--- a/clients/fossid-webapp/src/main/kotlin/PostRequestBody.kt
+++ b/clients/fossid-webapp/src/main/kotlin/PostRequestBody.kt
@@ -24,7 +24,7 @@ class PostRequestBody(
     val group: String,
     user: String,
     apiKey: String,
-    vararg pairs: Pair<String, String>
+    vararg options: Pair<String, String>
 ) {
-    val data: MutableMap<String, String> = mutableMapOf("username" to user, "key" to apiKey, *pairs)
+    val data: MutableMap<String, String> = mutableMapOf("username" to user, "key" to apiKey, *options)
 }

--- a/clients/fossid-webapp/src/main/kotlin/PostRequestBody.kt
+++ b/clients/fossid-webapp/src/main/kotlin/PostRequestBody.kt
@@ -24,7 +24,11 @@ class PostRequestBody(
     val group: String,
     user: String,
     apiKey: String,
-    vararg options: Pair<String, String>
+    options: Map<String, String> = emptyMap()
 ) {
-    val data = mapOf("username" to user, "key" to apiKey, *options)
+    val data = buildMap {
+        put("username", user)
+        put("key", apiKey)
+        putAll(options)
+    }
 }

--- a/clients/fossid-webapp/src/main/kotlin/PostRequestBody.kt
+++ b/clients/fossid-webapp/src/main/kotlin/PostRequestBody.kt
@@ -19,16 +19,24 @@
 
 package org.ossreviewtoolkit.clients.fossid
 
-class PostRequestBody(
+data class PostRequestBody private constructor(
     val action: String,
     val group: String,
-    user: String,
-    apiKey: String,
-    options: Map<String, String> = emptyMap()
+    val data: Map<String, String>
 ) {
-    val data = buildMap {
-        put("username", user)
-        put("key", apiKey)
-        putAll(options)
-    }
+    constructor(
+        action: String,
+        group: String,
+        user: String,
+        apiKey: String,
+        options: Map<String, String> = emptyMap()
+    ) : this(
+        action,
+        group,
+        buildMap {
+            put("username", user)
+            put("key", apiKey)
+            putAll(options)
+        }
+    )
 }

--- a/clients/fossid-webapp/src/main/kotlin/VersionedFossIdService.kt
+++ b/clients/fossid-webapp/src/main/kotlin/VersionedFossIdService.kt
@@ -33,6 +33,6 @@ open class VersionedFossIdService(
         apiKey: String,
         scanCode: String
     ): EntityResponseBody<out UnversionedScanDescription> = delegate.checkScanStatus(
-        PostRequestBody("check_status", SCAN_GROUP, user, apiKey, "scan_code" to scanCode)
+        PostRequestBody("check_status", SCAN_GROUP, user, apiKey, mapOf("scan_code" to scanCode))
     )
 }

--- a/clients/fossid-webapp/src/main/kotlin/VersionedFossIdService2021dot2.kt
+++ b/clients/fossid-webapp/src/main/kotlin/VersionedFossIdService2021dot2.kt
@@ -30,6 +30,6 @@ class VersionedFossIdService2021dot2(
         scanCode: String
     ): EntityResponseBody<out UnversionedScanDescription> =
         delegate.checkScanStatus2021dot2(
-            PostRequestBody("check_status", SCAN_GROUP, user, apiKey, "scan_code" to scanCode)
+            PostRequestBody("check_status", SCAN_GROUP, user, apiKey, mapOf("scan_code" to scanCode))
         )
 }

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -591,7 +591,7 @@ class FossId internal constructor(
             )
 
             val scanResult = service.runScan(
-                config.user, config.apiKey, scanCode, *runOptions, *optionsFromConfig
+                config.user, config.apiKey, scanCode, mapOf(*runOptions, *optionsFromConfig)
             )
 
             // Scans that were added to the queue are interpreted as an error by FossID before version 2021.2.

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -384,7 +384,7 @@ class FossIdTest : WordSpec({
                     USER,
                     API_KEY,
                     scanCode,
-                    *arrayOf(
+                    mapOf(
                         "auto_identification_detect_declaration" to "0",
                         "auto_identification_detect_copyright" to "0"
                     )
@@ -400,7 +400,7 @@ class FossIdTest : WordSpec({
                     USER,
                     API_KEY,
                     scanCode,
-                    *arrayOf(
+                    mapOf(
                         "auto_identification_detect_declaration" to "0",
                         "auto_identification_detect_copyright" to "0"
                     )
@@ -429,7 +429,7 @@ class FossIdTest : WordSpec({
                     USER,
                     API_KEY,
                     scanCode,
-                    *arrayOf(
+                    mapOf(
                         "auto_identification_detect_declaration" to "0",
                         "auto_identification_detect_copyright" to "0"
                     )
@@ -448,7 +448,7 @@ class FossIdTest : WordSpec({
                     USER,
                     API_KEY,
                     scanCode,
-                    *arrayOf(
+                    mapOf(
                         "auto_identification_detect_declaration" to "0",
                         "auto_identification_detect_copyright" to "0"
                     )
@@ -475,7 +475,7 @@ class FossIdTest : WordSpec({
                     USER,
                     API_KEY,
                     scanCode,
-                    *arrayOf(
+                    mapOf(
                         "auto_identification_detect_declaration" to "0",
                         "auto_identification_detect_copyright" to "0"
                     )
@@ -559,8 +559,8 @@ class FossIdTest : WordSpec({
                     USER,
                     API_KEY,
                     scanCode,
-                    *FossId.deltaScanRunParameters(originCode),
-                    *arrayOf(
+                    mapOf(
+                        *FossId.deltaScanRunParameters(originCode),
                         "auto_identification_detect_declaration" to "0",
                         "auto_identification_detect_copyright" to "0"
                     )
@@ -600,8 +600,8 @@ class FossIdTest : WordSpec({
                     USER,
                     API_KEY,
                     scanCode,
-                    *FossId.deltaScanRunParameters(originCode),
-                    *arrayOf(
+                    mapOf(
+                        *FossId.deltaScanRunParameters(originCode),
                         "auto_identification_detect_declaration" to "0",
                         "auto_identification_detect_copyright" to "0"
                     )
@@ -648,7 +648,7 @@ class FossIdTest : WordSpec({
                     USER,
                     API_KEY,
                     scanCode,
-                    *arrayOf(
+                    mapOf(
                         "auto_identification_detect_declaration" to "0",
                         "auto_identification_detect_copyright" to "0"
                     )

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -643,8 +643,16 @@ class FossIdTest : WordSpec({
                 service.checkDownloadStatus(USER, API_KEY, scanCode)
             }
 
-            coVerify(exactly = 0) {
-                service.runScan(USER, API_KEY, scanCode, any())
+            coVerify(exactly = 1) {
+                service.runScan(
+                    USER,
+                    API_KEY,
+                    scanCode,
+                    *arrayOf(
+                        "auto_identification_detect_declaration" to "0",
+                        "auto_identification_detect_copyright" to "0"
+                    )
+                )
             }
         }
 


### PR DESCRIPTION
The original motivation of changing something was to eliminate the redundant spread operators in all callers of `runScan()`.
When dropping the redundant spread operators the callers which provided multiple pairs as varargs became a tad hard to read.
So, this PR refactors to use the type `Map` for the options, and thereby eliminates the rundant spread operators.
