### PR TITLE
OsvServiceFunTest: Be lenient about the array order in all tests

### DIFF
--- a/clients/osv/src/funTest/kotlin/OsvServiceFunTest.kt
+++ b/clients/osv/src/funTest/kotlin/OsvServiceFunTest.kt
@@ -54,7 +54,10 @@ class OsvServiceFunTest : StringSpec({
         val result = OsvService().getVulnerabilitiesForPackage(VULNERABILITY_FOR_PACKAGE_BY_COMMIT_REQUEST)
 
         result.shouldBeSuccess {
-            OsvApiClient.JSON.encodeToString(it) shouldEqualJson expectedResult
+            OsvApiClient.JSON.encodeToString(it).shouldEqualJson(
+                expectedResult,
+                compareJsonOptions { arrayOrder = ArrayOrder.Lenient }
+            )
         }
     }
 
@@ -64,7 +67,10 @@ class OsvServiceFunTest : StringSpec({
         val result = OsvService().getVulnerabilitiesForPackage(VULNERABILITY_FOR_PACKAGE_BY_NAME_AND_VERSION)
 
         result.shouldBeSuccess {
-            OsvApiClient.JSON.encodeToString(it) shouldEqualJson expectedResult
+            OsvApiClient.JSON.encodeToString(it).shouldEqualJson(
+                expectedResult,
+                compareJsonOptions { arrayOrder = ArrayOrder.Lenient }
+            )
         }
     }
 


### PR DESCRIPTION
So far this was only done for "getVulnerabilityForId() returns the expected vulnerability for the given ID". Consistently do this in all tests to avoid breakages due changes in array order only.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>