### PR TITLE
PathExcludeGenerator: Minor preparations

### DIFF
--- a/helper-cli/src/main/kotlin/utils/PathExcludeGenerator.kt
+++ b/helper-cli/src/main/kotlin/utils/PathExcludeGenerator.kt
@@ -61,8 +61,8 @@ internal object PathExcludeGenerator {
         dirsToExclude.forEach { (dir, reason) ->
             if (dir.getAncestorFiles().intersect(dirsToExclude.keys).isEmpty()) {
                 result += PathExclude(
-                      pattern = "${dir.path}/**",
-                      reason = reason
+                    pattern = "${dir.path}/**",
+                    reason = reason
                 )
             }
         }

--- a/helper-cli/src/main/kotlin/utils/PathExcludeGenerator.kt
+++ b/helper-cli/src/main/kotlin/utils/PathExcludeGenerator.kt
@@ -39,6 +39,11 @@ internal object PathExcludeGenerator {
      */
     fun generatePathExcludes(filePaths: Collection<String>): List<PathExclude> {
         val files = filePaths.mapTo(mutableSetOf()) { File(it) }
+
+        return generateExcludesForDirectories(files).toList()
+    }
+
+    private fun generateExcludesForDirectories(files: Set<File>): Set<PathExclude> {
         val dirs = getAllDirs(files)
 
         val dirsToExclude = mutableMapOf<File, PathExcludeReason>()
@@ -62,7 +67,7 @@ internal object PathExcludeGenerator {
             }
         }
 
-        return result.toList()
+        return result
     }
 }
 

--- a/helper-cli/src/main/kotlin/utils/PathExcludeGenerator.kt
+++ b/helper-cli/src/main/kotlin/utils/PathExcludeGenerator.kt
@@ -90,6 +90,15 @@ private fun File.getAncestorFiles(): List<File> {
     return result
 }
 
+private fun <T> Collection<T>.checkNoDuplicatePatterns(keySelector: (T) -> String) =
+    apply {
+        val duplicatePatterns = getDuplicates(keySelector).keys
+
+        require(duplicatePatterns.isEmpty()) {
+            "Found duplicate patterns: ${duplicatePatterns.joinToString()}."
+        }
+    }
+
 private val PATH_EXCLUDES_REASON_FOR_DIR_NAME = listOf(
     "*checkstyle*" to BUILD_TOOL_OF,
     "*conformance*" to BUILD_TOOL_OF,
@@ -132,10 +141,4 @@ private val PATH_EXCLUDES_REASON_FOR_DIR_NAME = listOf(
     "tools" to BUILD_TOOL_OF,
     "tutorial" to DOCUMENTATION_OF,
     "winbuild" to BUILD_TOOL_OF,
-).apply {
-    val duplicatePatterns = getDuplicates { it.first }.keys
-
-    require(duplicatePatterns.isEmpty()) {
-        "Found duplicate patterns: ${duplicatePatterns.joinToString()}."
-    }
-}
+).checkNoDuplicatePatterns { it.first }

--- a/helper-cli/src/main/kotlin/utils/PathExcludeGenerator.kt
+++ b/helper-cli/src/main/kotlin/utils/PathExcludeGenerator.kt
@@ -66,7 +66,7 @@ internal object PathExcludeGenerator {
     }
 }
 
-private fun getAllDirs(files: Set<File>): Set<File> =
+private fun getAllDirs(files: Collection<File>): Set<File> =
     files.flatMapTo(mutableSetOf()) { it.getAncestorFiles() }
 
 /**

--- a/helper-cli/src/main/kotlin/utils/PathExcludeGenerator.kt
+++ b/helper-cli/src/main/kotlin/utils/PathExcludeGenerator.kt
@@ -44,7 +44,7 @@ internal object PathExcludeGenerator {
     }
 
     private fun generateExcludesForDirectories(files: Set<File>): Set<PathExclude> {
-        val dirs = getAllDirs(files)
+        val dirs = getAllDirectories(files)
 
         val dirsToExclude = mutableMapOf<File, PathExcludeReason>()
 
@@ -71,7 +71,7 @@ internal object PathExcludeGenerator {
     }
 }
 
-private fun getAllDirs(files: Collection<File>): Set<File> =
+private fun getAllDirectories(files: Collection<File>): Set<File> =
     files.flatMapTo(mutableSetOf()) { it.getAncestorFiles() }
 
 /**


### PR DESCRIPTION
This PR is a preparation for extending the generation to match filenames, (in addition to just full directories).

Part of #5763.