### PR TITLE
github/workflows: Disable setup-java's Gradle cache

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,6 @@ jobs:
       with:
         distribution: temurin
         java-version: 11
-        cache: gradle
     - name: Build all classes
       uses: gradle/gradle-build-action@v2
       with:
@@ -39,7 +38,6 @@ jobs:
       with:
         distribution: temurin
         java-version: 11
-        cache: gradle
     - name: Build the reporter-web-app
       uses: gradle/gradle-build-action@v2
       with:
@@ -55,7 +53,6 @@ jobs:
       with:
         distribution: temurin
         java-version: 11
-        cache: gradle
     - name: Run unit tests
       uses: gradle/gradle-build-action@v2
       with:
@@ -90,7 +87,6 @@ jobs:
       with:
         distribution: temurin
         java-version: 11
-        cache: gradle
     - name: Run functional tests
       uses: gradle/gradle-build-action@v2
       with:
@@ -111,7 +107,6 @@ jobs:
       with:
         distribution: temurin
         java-version: 11
-        cache: gradle
     - name: Validate Batect wrapper scripts
       uses: batect/batect-wrapper-validation-action@v0
     - name: Run functional tests

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -21,7 +21,6 @@ jobs:
       with:
         distribution: temurin
         java-version: 11
-        cache: gradle
     - name: Check for Detekt Issues
       uses: gradle/gradle-build-action@v2
       with:


### PR DESCRIPTION
The cache for dependencies downloaded by Gradle from the setup-java action interferes with the gradle-build-action, see [1].

[1]: https://github.com/gradle/gradle-build-action/issues/433

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>