### PR TITLE
possibility to call cli with --warn option - compability with ort-gitlab-ci

### DIFF
--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -92,7 +92,8 @@ class OrtMain : CliktCommand(name = ORT_NAME, invokeWithoutSubcommand = true) {
 
     private val logLevel by option(help = "Set the verbosity level of log output.").switch(
         "--info" to Level.INFO,
-        "--debug" to Level.DEBUG
+        "--debug" to Level.DEBUG,
+        "--warn" to Level.WARN
     ).default(Level.WARN)
 
     private val stacktrace by option(help = "Print out the stacktrace for all exceptions.").flag()


### PR DESCRIPTION
in https://github.com/oss-review-toolkit/ort-gitlab-ci/blob/main/scripts/set-defaults.sh#L12 the default log level is set to info.
if you set it to warn the ort cli will report an error because --warn is not allowed on the command line

To have more compability with the ort-gitlab-ci project this change will help a lot




Signed-off-by: Jürgen Wischer <33184634+unclejay80@users.noreply.github.com>

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
