### PR TITLE
AdvisorRecord: Drop deserialization backwards compatibility

### DIFF
--- a/model/src/test/kotlin/AdvisorRecordTest.kt
+++ b/model/src/test/kotlin/AdvisorRecordTest.kt
@@ -20,16 +20,11 @@
 
 package org.ossreviewtoolkit.model
 
-import com.fasterxml.jackson.module.kotlin.readValue
-
-import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
-import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.maps.haveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
@@ -39,53 +34,6 @@ import java.time.Instant
 import org.ossreviewtoolkit.utils.common.enumSetOf
 
 class AdvisorRecordTest : WordSpec({
-    "Deserialization" should {
-        "work for a map of advisor results" {
-            val yaml = """
-            ---
-            advisor_results:
-              type:namespace:name:version:
-              - vulnerabilities: []
-                advisor:
-                  name: "advisor"
-                summary:
-                  start_time: "1970-01-01T00:00:00Z"
-                  end_time: "1970-01-01T00:00:00Z"
-            has_issues: false
-        """.trimIndent()
-
-            val record = shouldNotThrowAny { yamlMapper.readValue<AdvisorRecord>(yaml) }
-            record.advisorResults should haveSize(1)
-            record.advisorResults.entries.single().let { (id, results) ->
-                id shouldBe Identifier("type:namespace:name:version")
-                results shouldHaveSize 1
-            }
-        }
-
-        "work for a legacy AdvisorRecord with AdvisorResultContainers" {
-            val yaml = """
-            ---
-            advisor_results:
-            - id: "type:namespace:name:version"
-              results:
-              - vulnerabilities: []
-                advisor:
-                  name: "advisor"
-                summary:
-                  start_time: "1970-01-01T00:00:00Z"
-                  end_time: "1970-01-01T00:00:00Z"
-            has_issues: false
-        """.trimIndent()
-
-            val record = shouldNotThrowAny { yamlMapper.readValue<AdvisorRecord>(yaml) }
-            record.advisorResults should haveSize(1)
-            record.advisorResults.entries.single().let { (id, results) ->
-                id shouldBe Identifier("type:namespace:name:version")
-                results shouldHaveSize 1
-            }
-        }
-    }
-
     "hasIssues" should {
         "return false given the record has no issues" {
             val vul1 = createVulnerability("CVE-2021-1")


### PR DESCRIPTION
The old format has become legacy in march 2021. So drop the support for deserializing it to simplify the code. The value of such old advisor data is questionable anyway.

Also note that vulnerabilities also had a legacy format from 2021 for which the support already has been dropped.

[1] https://github.com/oss-review-toolkit/ort/commit/d297c58f8afe76fd6567ec6fda610b2461c19b1e
