### PR TITLE
OsvFunTest: Ensure that queries for Composer packages work

### DIFF
--- a/advisor/src/funTest/kotlin/OsvFunTest.kt
+++ b/advisor/src/funTest/kotlin/OsvFunTest.kt
@@ -39,15 +39,13 @@ class OsvFunTest : StringSpec({
         val osv = createOsv()
         val packages = listOf(
             "Crate::sys-info:0.7.0",
+            "Composer:prestashop:ps_facetedsearch:3.0.0",
             "Gem::rack:2.0.4",
             "Go::github.com/nats-io/nats-server/v2:2.1.0",
             "Maven:com.jfinal:jfinal:1.4",
             "NPM::rebber:1.0.0",
             "NuGet::Microsoft.ChakraCore:1.10.0",
             "PyPI::Plone:3.2"
-            // TODO: Add an identifier for a composer package after https://github.com/google/osv.dev/issues/497 got
-            //       fixed. That issue causes queries for vulnerabilities of the "Packagist" ecosystem to always return
-            //       an empty result.
         ).map { identifierToPackage(it) }
 
         val packageFindings = osv.retrievePackageFindings(packages)


### PR DESCRIPTION
The queries for the Packagist ecosistem have started working on the backend-side, see [1].

[1] https://github.com/google/osv.dev/issues/497
