### PR TITLE
(helper-)cli: Consistently allow all used log levels to be set explicitly

### DIFF
--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -91,8 +91,9 @@ class OrtMain : CliktCommand(name = ORT_NAME, invokeWithoutSubcommand = true) {
         .default(ortConfigDirectory.resolve(ORT_CONFIG_FILENAME))
 
     private val logLevel by option(help = "Set the verbosity level of log output.").switch(
-        "--info" to Level.INFO,
         "--debug" to Level.DEBUG,
+        "--error" to Level.ERROR,
+        "--info" to Level.INFO,
         "--warn" to Level.WARN
     ).default(Level.WARN)
 

--- a/helper-cli/src/main/kotlin/HelperMain.kt
+++ b/helper-cli/src/main/kotlin/HelperMain.kt
@@ -69,8 +69,10 @@ fun main(args: Array<String>) {
 
 internal class HelperMain : CliktCommand(name = ORTH_NAME, epilog = "* denotes required options.") {
     private val logLevel by option(help = "Set the verbosity level of log output.").switch(
+        "--debug" to Level.DEBUG,
+        "--error" to Level.ERROR,
         "--info" to Level.INFO,
-        "--debug" to Level.DEBUG
+        "--warn" to Level.WARN
     ).default(Level.WARN)
 
     private val stacktrace by option(help = "Print out the stacktrace for all exceptions.").flag()


### PR DESCRIPTION
This is a follow-up to 6933ea7 with the same rationale. While at it, also sort the entries alphabetically.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>