### PR TITLE
Hash: Drop support for deserializing the legacy format

### DIFF
--- a/analyzer/src/test/assets/package-curations.yml
+++ b/analyzer/src/test/assets/package-curations.yml
@@ -5,12 +5,14 @@
     homepage_url: "http://home.page"
     binary_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     source_artifact:
       url: ""
-      hash: ""
-      hash_algorithm: ""
+      hash:
+        value: ""
+        algorithm: ""
     vcs:
       type: ""
       url: "http://url.git"

--- a/docs/config-file-curations-yml.md
+++ b/docs/config-file-curations-yml.md
@@ -65,12 +65,14 @@ The structure of the curations file consist of one or more `id` entries:
     homepage_url: "http://example.com"
     binary_artifact:
       url: "http://example.com/binary.zip"
-      hash: "ddce269a1e3d054cae349621c198dd52"
-      hash_algorithm: "MD5"
+      hash: 
+        value: "ddce269a1e3d054cae349621c198dd52"
+        algorithm: "MD5"
     source_artifact:
       url: "http://example.com/sources.zip"
-      hash: "ddce269a1e3d054cae349621c198dd52"
-      hash_algorithm: "MD5"
+      hash: 
+        value: "ddce269a1e3d054cae349621c198dd52"
+        algorithm: "MD5"
     vcs:
       type: "Git"
       url: "http://example.com/repo.git"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -214,12 +214,14 @@ analyzer:
         homepage_url: "https://github.com/isaacs/abbrev-js#readme"
         binary_artifact:
           url: ""
-          hash: ""
-          hash_algorithm: ""
+          hash:
+            value: ""
+            algorithm: ""
         source_artifact:
           url: "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
-          hash: "91b4792588a7738c25f35dd6f63752a2f8776135"
-          hash_algorithm: "SHA-1"
+          hash:
+            value: "91b4792588a7738c25f35dd6f63752a2f8776135"
+            algorithm: "SHA-1"
         vcs:
           type: "Git"
           url: "git+ssh://git@github.com/isaacs/abbrev-js.git"

--- a/examples/curations.yml
+++ b/examples/curations.yml
@@ -11,12 +11,14 @@
 #    homepage_url: "http://example.com"
 #    binary_artifact:
 #      url: "http://example.com/binary.zip"
-#      hash: "ddce269a1e3d054cae349621c198dd52"
-#      hash_algorithm: "MD5"
+#      hash:
+#        value: "ddce269a1e3d054cae349621c198dd52"
+#        algorithm: "MD5"
 #    source_artifact:
 #      url: "http://example.com/sources.zip"
-#      hash: "ddce269a1e3d054cae349621c198dd52"
-#      hash_algorithm: "MD5"
+#      hash:
+#        value: "ddce269a1e3d054cae349621c198dd52"
+#        algorithm: "MD5"
 #    vcs:
 #      type: "Git"
 #      url: "http://example.com/repo.git"

--- a/integrations/schemas/curations-schema.json
+++ b/integrations/schemas/curations-schema.json
@@ -50,30 +50,10 @@
               },
               "hash": {
                 "$ref": "#/definitions/hash"
-              },
-              "hash_algorithm": {
-                "type": "string"
               }
-            },
-            "if": {
-              "properties": {
-                "hash": {
-                  "type": "object"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "hash"
-              ]
-            },
-            "else": {
-              "required": [
-                "hash",
-                "hash_algorithm"
-              ]
             },
             "required": [
+              "hash",
               "url"
             ]
           },
@@ -85,30 +65,10 @@
               },
               "hash": {
                 "$ref": "#/definitions/hash"
-              },
-              "hash_algorithm": {
-                "type": "string"
               }
-            },
-            "if": {
-              "properties": {
-                "hash": {
-                  "type": "object"
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "hash"
-              ]
-            },
-            "else": {
-              "required": [
-                "hash",
-                "hash_algorithm"
-              ]
             },
             "required": [
+              "hash",
               "url"
             ]
           },
@@ -170,7 +130,7 @@
       "type": "object"
     },
     "hash": {
-      "type": ["string", "object"],
+      "type": ["object"],
       "properties": {
         "value": {
           "type": "string"

--- a/model/src/main/kotlin/Hash.kt
+++ b/model/src/main/kotlin/Hash.kt
@@ -19,12 +19,6 @@
 
 package org.ossreviewtoolkit.model
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer
-
 import java.io.File
 import java.util.Base64
 
@@ -34,7 +28,6 @@ import org.ossreviewtoolkit.utils.common.encodeHex
 /**
  * A class that bundles a hash algorithm with its hash value.
  */
-@JsonDeserialize(using = HashDeserializer::class)
 data class Hash(
     /**
      * The value calculated using the hash algorithm.
@@ -103,21 +96,4 @@ data class Hash(
      * Verify that the provided [hash] matches this hash.
      */
     fun verify(hash: Hash): Boolean = algorithm == hash.algorithm && value.equals(hash.value, ignoreCase = true)
-}
-
-private class HashDeserializer : StdDeserializer<Hash>(Hash::class.java) {
-    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Hash {
-        val node = p.codec.readTree<JsonNode>(p)
-        return if (node.isTextual) {
-            val hashValue = node.textValue()
-            if (p.nextFieldName() == "hash_algorithm") {
-                val hashAlgorithm = p.nextTextValue()
-                Hash.create(hashValue, hashAlgorithm)
-            } else {
-                Hash.create(hashValue)
-            }
-        } else {
-            Hash.create(node["value"].textValue(), node["algorithm"].textValue())
-        }
-    }
 }


### PR DESCRIPTION
The model for the `Hash` class has been changed in 2019.
Use the new format throughout the code base and drop handling of the legacy format to reduce technical debt.