### PR TITLE
ScriptRunner: Add the `sourcePath` and `location` of compile errors to the log

### DIFF
--- a/utils/scripting/src/main/kotlin/ScriptRunner.kt
+++ b/utils/scripting/src/main/kotlin/ScriptRunner.kt
@@ -83,12 +83,19 @@ abstract class ScriptRunner {
 
     private fun logReports(reports: List<ScriptDiagnostic>) =
         reports.forEach { report ->
+            val renderedReport = report.render(
+                withSeverity = false,
+                withLocation = true,
+                withException = false,
+                withStackTrace = false
+            )
+
             when (report.severity) {
-                ScriptDiagnostic.Severity.DEBUG -> logger.debug(report.message, report.exception)
-                ScriptDiagnostic.Severity.INFO -> logger.info(report.message, report.exception)
-                ScriptDiagnostic.Severity.WARNING -> logger.warn(report.message, report.exception)
-                ScriptDiagnostic.Severity.ERROR -> logger.error(report.message, report.exception)
-                ScriptDiagnostic.Severity.FATAL -> logger.fatal(report.message, report.exception)
+                ScriptDiagnostic.Severity.DEBUG -> logger.debug(renderedReport, report.exception)
+                ScriptDiagnostic.Severity.INFO -> logger.info(renderedReport, report.exception)
+                ScriptDiagnostic.Severity.WARNING -> logger.warn(renderedReport, report.exception)
+                ScriptDiagnostic.Severity.ERROR -> logger.error(renderedReport, report.exception)
+                ScriptDiagnostic.Severity.FATAL -> logger.fatal(renderedReport, report.exception)
             }
         }
 }


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>