### PR TITLE
ProjectSourceRule: Add a matcher for the project's VCS type

### DIFF
--- a/evaluator/src/main/kotlin/ProjectSourceRule.kt
+++ b/evaluator/src/main/kotlin/ProjectSourceRule.kt
@@ -24,6 +24,7 @@ import java.io.File
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.RepositoryProvenance
+import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.utils.getRepositoryPath
 import org.ossreviewtoolkit.utils.common.FileMatcher
 
@@ -92,6 +93,11 @@ open class ProjectSourceRule(
         }
 
     /**
+     * Return the [VcsType] of the project's code repository.
+     */
+    fun projectSourceGetVcsType(): VcsType = ortResult.repository.vcsProcessed.type
+
+    /**
      * Return the file paths matching any of the given [glob expressions][patterns] with its file content matching
      * [contentPattern].
      */
@@ -137,6 +143,21 @@ open class ProjectSourceRule(
 
             override fun matches(): Boolean =
                 projectSourceFindFilesWithContent(contentPattern, *patterns).isNotEmpty()
+        }
+
+    /**
+     * A [RuleMatcher] that checks whether the [VcsType] of the project's code repository is contained in the given
+     * [vcsTypes].
+     */
+    fun projectSourceHasVcsType(vararg vcsTypes: VcsType): RuleMatcher =
+        object : RuleMatcher {
+            private val types = vcsTypes.toSet()
+
+            override val description =
+                "projectSourceHasVcsType('${vcsTypes.joinToString()}')"
+
+            override fun matches(): Boolean =
+                projectSourceGetVcsType() in types
         }
 }
 

--- a/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
+++ b/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
@@ -178,7 +178,12 @@ private fun File.addDirs(vararg paths: String) {
     }
 }
 
-private fun ortResultWithDetectedLicenses(vararg detectedLicensesForFilePath: Pair<String, Set<String>>): OrtResult {
+private fun ortResultWithDetectedLicenses(vararg detectedLicensesForFilePath: Pair<String, Set<String>>): OrtResult =
+    createOrtResult(detectedLicensesForFilePath.toMap())
+
+private fun createOrtResult(
+    detectedLicensesForFilePath: Map<String, Set<String>> = emptyMap()
+): OrtResult {
     val id = Identifier("Maven:org.oss-review-toolkit:example:1.0")
     val vcsInfo = VcsInfo(
         type = VcsType.GIT,

--- a/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
+++ b/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
@@ -149,6 +149,19 @@ class ProjectSourceRuleTest : WordSpec({
             )
         }
     }
+
+    "projectSourceHasVcsType" should {
+        "return true if and only if any of the given VCS types match the VCS type of the project's code repository" {
+            val rule = createRule(
+                createSpecTempDir(),
+                createOrtResult(projectVcsType = VcsType.GIT)
+            )
+
+            rule.projectSourceHasVcsType(VcsType.GIT).matches() shouldBe true
+            rule.projectSourceHasVcsType(VcsType.GIT_REPO).matches() shouldBe false
+            rule.projectSourceHasVcsType(VcsType.GIT, VcsType.GIT_REPO).matches() shouldBe true
+        }
+    }
 })
 
 private fun createRule(projectSourcesDir: File, ortResult: OrtResult = OrtResult.EMPTY) =
@@ -182,11 +195,12 @@ private fun ortResultWithDetectedLicenses(vararg detectedLicensesForFilePath: Pa
     createOrtResult(detectedLicensesForFilePath.toMap())
 
 private fun createOrtResult(
-    detectedLicensesForFilePath: Map<String, Set<String>> = emptyMap()
+    detectedLicensesForFilePath: Map<String, Set<String>> = emptyMap(),
+    projectVcsType: VcsType = VcsType.GIT
 ): OrtResult {
     val id = Identifier("Maven:org.oss-review-toolkit:example:1.0")
     val vcsInfo = VcsInfo(
-        type = VcsType.GIT,
+        type = projectVcsType,
         url = "https://github.com/oss-review-toolkit/example.git",
         revision = "0000000000000000000000000000000000000000"
     )


### PR DESCRIPTION
See individual commits.

Part of https://github.com/oss-review-toolkit/ort/issues/5621.