### PR TITLE
Osv: Enable queries for the 'Pub' ecosystem

### DIFF
--- a/advisor/src/funTest/kotlin/OsvFunTest.kt
+++ b/advisor/src/funTest/kotlin/OsvFunTest.kt
@@ -45,6 +45,7 @@ class OsvFunTest : StringSpec({
             "Maven:com.jfinal:jfinal:1.4",
             "NPM::rebber:1.0.0",
             "NuGet::Microsoft.ChakraCore:1.10.0",
+            "Pub::http:0.13.1",
             "PyPI::Plone:3.2"
         ).map { identifierToPackage(it) }
 

--- a/advisor/src/main/kotlin/advisors/Osv.kt
+++ b/advisor/src/main/kotlin/advisors/Osv.kt
@@ -146,6 +146,7 @@ private fun createRequest(pkg: Package): VulnerabilitiesForPackageRequest? {
         "NPM" -> Ecosystem.NPM
         "NuGet" -> Ecosystem.NUGET
         "Maven" -> Ecosystem.MAVEN
+        "Pub" -> Ecosystem.PUB
         "PyPI" -> Ecosystem.PYPI
         else -> null
     }

--- a/clients/osv/src/main/kotlin/Model.kt
+++ b/clients/osv/src/main/kotlin/Model.kt
@@ -106,6 +106,7 @@ object Ecosystem {
     const val NUGET = "NuGet"
     const val OSS_FUZZ = "OSS-Fuzz"
     const val PACKAGIST = "Packagist"
+    const val PUB = "Pub"
     const val PYPI = "PyPI"
     const val RUBY_GEMS = "RubyGems"
 }


### PR DESCRIPTION
Adjust the mapping to enable queries for "Pub", which was missing in the initial implementation.

Note that there are currently just two entries in the database [1], so the impact is small.

[1] https://osv.dev/list
