### PR TITLE
DependencyRule: Add a helper function to get the direct dependencies

### DIFF
--- a/evaluator/src/main/kotlin/DependencyRule.kt
+++ b/evaluator/src/main/kotlin/DependencyRule.kt
@@ -78,7 +78,8 @@ class DependencyRule(
     fun directDependencies() = dependency.visitDependencies { it.toList() }
 
     /**
-     * A [RuleMatcher] that checks if the level of the [dependency] inside the dependency tree equals [level].
+     * A [RuleMatcher] that checks if the level of the [dependency] inside the dependency tree equals [level], which
+     * starts with 0 for a direct dependency.
      */
     fun isAtTreeLevel(level: Int) =
         object : RuleMatcher {

--- a/evaluator/src/main/kotlin/DependencyRule.kt
+++ b/evaluator/src/main/kotlin/DependencyRule.kt
@@ -73,6 +73,11 @@ class DependencyRule(
         "$name - ${pkg.id.toCoordinates()} (dependency of ${project.id.toCoordinates()} in scope $scopeName)"
 
     /**
+     * Return the direct dependencies of the [dependency].
+     */
+    fun directDependencies() = dependency.visitDependencies { it.toList() }
+
+    /**
      * A [RuleMatcher] that checks if the level of the [dependency] inside the dependency tree equals [level].
      */
     fun isAtTreeLevel(level: Int) =


### PR DESCRIPTION
Some rules might only need to look at the direct dependencies.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>