### PR TITLE
VcsInfo: Drop support for deserializing the legacy format

### DIFF
--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
     api(libs.jacksonDataformatXml)
     api(libs.jacksonDataformatYaml)
 
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation(libs.bundles.exposed)
     implementation(libs.bundles.hoplite)
     implementation(libs.hikari)

--- a/model/src/main/kotlin/VcsInfo.kt
+++ b/model/src/main/kotlin/VcsInfo.kt
@@ -19,23 +19,11 @@
 
 package org.ossreviewtoolkit.model
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
-
-import kotlin.reflect.full.memberProperties
-
-import org.ossreviewtoolkit.utils.common.fieldNamesOrEmpty
-import org.ossreviewtoolkit.utils.common.textValueOrEmpty
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 
 /**
  * Bundles general Version Control System information.
  */
-@JsonDeserialize(using = VcsInfoDeserializer::class)
 data class VcsInfo(
     /**
      * The type of the VCS, for example Git, GitRepo, Mercurial, etc.
@@ -101,32 +89,3 @@ data class VcsInfo(
  * Return this [VcsInfo] if not null or else [VcsInfo.EMPTY].
  */
 fun VcsInfo?.orEmpty(): VcsInfo = this ?: VcsInfo.EMPTY
-
-private class VcsInfoDeserializer : StdDeserializer<VcsInfo>(VcsInfo::class.java) {
-    companion object {
-        val KNOWN_FIELDS by lazy {
-            VcsInfo::class.memberProperties.map { PROPERTY_NAMING_STRATEGY.translate(it.name) } +
-                    PROPERTY_NAMING_STRATEGY.translate("resolvedRevision")
-        }
-    }
-
-    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): VcsInfo {
-        val node = p.codec.readTree<JsonNode>(p)
-
-        val fields = node.fieldNamesOrEmpty().asSequence().toList()
-        (fields - KNOWN_FIELDS).let { unknownFields ->
-            if (unknownFields.isNotEmpty()) {
-                throw UnrecognizedPropertyException.from(p, VcsInfo::class.java, unknownFields.first(), KNOWN_FIELDS)
-            }
-        }
-
-        return VcsInfo(
-            VcsType(node["type"].textValueOrEmpty()),
-            node["url"].textValueOrEmpty(),
-            // For backward compatibility, if resolved_revision is set, prefer it over revision because it is more
-            // specific.
-            node["resolved_revision"]?.textValue() ?: node["revision"].textValueOrEmpty(),
-            node["path"].textValueOrEmpty()
-        )
-    }
-}

--- a/model/src/test/kotlin/VcsInfoTest.kt
+++ b/model/src/test/kotlin/VcsInfoTest.kt
@@ -19,92 +19,10 @@
 
 package org.ossreviewtoolkit.model
 
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
-import com.fasterxml.jackson.module.kotlin.readValue
-
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.matchers.collections.containAll
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 class VcsInfoTest : WordSpec({
-    "Deserializing VcsInfo" should {
-        "work when all fields are given" {
-            val yaml = """
-                ---
-                type: "type"
-                url: "url"
-                revision: "revision"
-                path: "path"
-                """.trimIndent()
-
-            println(yaml)
-
-            val vcsInfo = yamlMapper.readValue<VcsInfo>(yaml)
-
-            with(vcsInfo) {
-                type shouldBe VcsType("type")
-                url shouldBe "url"
-                revision shouldBe "revision"
-                path shouldBe "path"
-            }
-        }
-
-        "assign empty strings to missing fields when only type is set" {
-            val yaml = """
-                ---
-                type: "type"
-                """.trimIndent()
-
-            val vcsInfo = yamlMapper.readValue<VcsInfo>(yaml)
-
-            with(vcsInfo) {
-                type shouldBe VcsType("type")
-                url shouldBe ""
-                revision shouldBe ""
-                path shouldBe ""
-            }
-        }
-
-        "assign empty strings to missing fields when only path is set" {
-            val yaml = """
-                ---
-                path: "path"
-                """.trimIndent()
-
-            val vcsInfo = yamlMapper.readValue<VcsInfo>(yaml)
-
-            with(vcsInfo) {
-                type shouldBe VcsType.UNKNOWN
-                url shouldBe ""
-                revision shouldBe ""
-                path shouldBe "path"
-            }
-        }
-
-        "fail if the input contains unknown fields" {
-            val yaml = """
-                ---
-                type: "type"
-                url: "url"
-                revision: "revision"
-                resolved_revision: "resolved_revision"
-                path: "path"
-                unknown: "unknown"
-                """.trimIndent()
-
-            val exception = shouldThrow<UnrecognizedPropertyException> {
-                yamlMapper.readValue<VcsInfo>(yaml)
-            }
-
-            with(exception) {
-                propertyName shouldBe "unknown"
-                knownPropertyIds should containAll<Any>("type", "url", "revision", "resolved_revision", "path")
-            }
-        }
-    }
-
     "Merging VcsInfo" should {
         "ignore empty information" {
             val inputA = VcsInfo(


### PR DESCRIPTION
The last change to the format has been made in June 2021, see [1]. As support for deserializing legacy ORT formats dating back to about more than a year ago has been dropped in recent changes, remove also this deserializer to reduce technical debt.

Note: The deserializer had been introduced for assigning empty strings as default values to properties with absent values [2]. As the serializer always serializes all properties, that mechanism is not needed (anymore).

[1] https://github.com/oss-review-toolkit/ort/commit/abd41579bd1e882870350dbcc7db781e22ec5c56 
[2] https://github.com/oss-review-toolkit/ort/commit/66aa368e7cbddf94e090555ba115f92e9b8ebc45

Node: I've added the `breaking change` label as it removes deserializing legacy format. However, it is not really breaking as it's been broken already by preceeding changes. 

