### PR TITLE
PathExcludeGeneratorTest: Consistently use the term `directory` in test cases

### DIFF
--- a/helper-cli/src/test/kotlin/PathExcludeGeneratorTest.kt
+++ b/helper-cli/src/test/kotlin/PathExcludeGeneratorTest.kt
@@ -51,7 +51,7 @@ class PathExcludeGeneratorTest : WordSpec({
             )
         }
 
-        "return excludes for a dir containing a regex special characters, e.g. the dot" {
+        "return excludes for a directory which contains regex special characters, e.g. the dot" {
             val files = listOf(
                 ".github/file.ext"
             )


### PR DESCRIPTION
Make the terminology in test case names consistent.
