### PR TITLE
PackageCurationData: Refer to "the" instead of "this" package

### DIFF
--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -51,7 +51,7 @@ data class PackageCurationData(
     val cpe: String? = null,
 
     /**
-     * The set of authors of this package.
+     * The set of authors of the package.
      */
     val authors: SortedSet<String>? = null,
 


### PR DESCRIPTION
"this" sounds like an instance of `PackageCurationData`, but what is meant is the `Package` instance the `PackageCurationData` gets applied to.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>