### PR TITLE
Fix an NPE with `getCommonParentFile()`

### DIFF
--- a/utils/common/src/main/kotlin/Utils.kt
+++ b/utils/common/src/main/kotlin/Utils.kt
@@ -95,7 +95,7 @@ fun getCommonParentFile(files: Collection<File>): File =
     files.map {
         it.normalize().parent
     }.reduceOrNull { prefix, path ->
-        prefix?.commonPrefixWith(path)
+        prefix?.commonPrefixWith(path.orEmpty())
     }.orEmpty().let {
         File(it)
     }

--- a/utils/common/src/test/kotlin/UtilsTest.kt
+++ b/utils/common/src/test/kotlin/UtilsTest.kt
@@ -30,24 +30,26 @@ import java.io.File
 
 class UtilsTest : WordSpec({
     "getCommonParentFile" should {
+        fun getCommonParentFile(vararg files: String) = getCommonParentFile(files.map { File(it) })
+
         "return a file with an empty path for an empty list" {
-            getCommonParentFile(emptyList()) shouldBe File("")
+            getCommonParentFile() shouldBe File("")
         }
 
         "return the parent file for a single file" {
-            getCommonParentFile(listOf(File("/foo/bar"))) shouldBe File("/foo")
+            getCommonParentFile("/foo/bar") shouldBe File("/foo")
         }
 
         "return a file with an empty path for files that have no parent in common".config(enabled = Os.isWindows) {
-            getCommonParentFile(listOf(File("C:/foo"), File("D:/bar"))) shouldBe File("")
+            getCommonParentFile("C:/foo", "D:/bar") shouldBe File("")
         }
 
         "return the root directory for different files with absolute paths".config(enabled = !Os.isWindows) {
-            getCommonParentFile(listOf(File("/foo"), File("/bar"))) shouldBe File("/")
+            getCommonParentFile("/foo", "/bar") shouldBe File("/")
         }
 
         "return the common parent for relative files" {
-            getCommonParentFile(listOf(File("common/foo"), File("common/bar"))) shouldBe File("common")
+            getCommonParentFile("common/foo", "common/bar") shouldBe File("common")
         }
     }
 

--- a/utils/common/src/test/kotlin/UtilsTest.kt
+++ b/utils/common/src/test/kotlin/UtilsTest.kt
@@ -48,6 +48,10 @@ class UtilsTest : WordSpec({
             getCommonParentFile("/foo", "/bar") shouldBe File("/")
         }
 
+        "return the relative root directory for different files with relative paths" {
+            getCommonParentFile("foo/bar.ext", "bar.ext") shouldBe File("")
+        }
+
         "return the common parent for relative files" {
             getCommonParentFile("common/foo", "common/bar") shouldBe File("common")
         }


### PR DESCRIPTION
See individual commits.

Part of https://github.com/oss-review-toolkit/ort/issues/5763.