### PR TITLE
helper-cli: Add options for configuring the path exclude generation

### DIFF
--- a/helper-cli/src/main/kotlin/commands/packageconfig/CreateCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packageconfig/CreateCommand.kt
@@ -108,7 +108,7 @@ internal class CreateCommand : CliktCommand(
         outputDir.safeMkdirs()
 
         val scanResultsStorage = FileBasedStorage(LocalFileStorage(scanResultsStorageDir))
-        val scanResults = scanResultsStorage.read(packageId).getOrDefault(emptyList()).run {
+        val scanResults = scanResultsStorage.read(packageId).getOrThrow().run {
             listOfNotNull(
                 find { it.provenance is RepositoryProvenance },
                 find { it.provenance is ArtifactProvenance }


### PR DESCRIPTION
Allow for generating excludes only for offending file / license findings.

Part of https://github.com/oss-review-toolkit/ort/issues/5763.