### PR TITLE
Dockerfile: Do not patch the Gradle distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -258,8 +258,6 @@ WORKDIR /usr/local/src/ort
 # Prepare Gradle
 RUN scripts/import_proxy_certs.sh \
     && scripts/set_gradle_proxy.sh \
-    && sed -i -r 's,(^distributionUrl=)(.+)-all\.zip$,\1\2-bin.zip,' gradle/wrapper/gradle-wrapper.properties \
-    && sed -i -r '/distributionSha256Sum=[0-9a-f]{64}/d' gradle/wrapper/gradle-wrapper.properties \
     && ./gradlew --no-daemon --stacktrace -Pversion=$ORT_VERSION :cli:distTar :helper-cli:startScripts
 
 RUN mkdir -p /opt/ort \


### PR DESCRIPTION
This is not necessary anymore as of 22e10db.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>