### PR TITLE
Require ORT versions to start with a digit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,9 +64,9 @@ buildscript {
 // Only override a default version (which usually is "unspecified"), but not a custom version.
 if (version == Project.DEFAULT_VERSION) {
     version = Git.open(rootDir).use { git ->
-        // Make the output exactly match "git describe --abbrev=10 --always --tags --dirty", which is what is used in
-        // "scripts/docker_build.sh", to make the hash match what JitPack uses.
-        val description = git.describe().setAbbrev(10).setAlways(true).setTags(true).call()
+        // Make the output exactly match "git describe --abbrev=10 --always --tags --dirty --match=[0-9]*", which is
+        // what is used in "scripts/docker_build.sh", to make the hash match what JitPack uses.
+        val description = git.describe().setAbbrev(10).setAlways(true).setTags(true).setMatch("[0-9]*").call()
 
         // Simulate the "--dirty" option with JGit.
         description.takeUnless { git.status().call().hasUncommittedChanges() } ?: "$description-dirty"

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -21,7 +21,7 @@
 DOCKER_ARGS=$@
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
-GIT_REVISION=$(git describe --abbrev=10 --always --tags --dirty)
+GIT_REVISION=$(git describe --abbrev=10 --always --tags --dirty --match=[0-9]*)
 
 echo "Setting ORT_VERSION to $GIT_REVISION."
 docker buildx build \


### PR DESCRIPTION
This prevents Git from determining the ORT version relative to arbitrary tags like the recently added "legacy-dockerfile" tag.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>