### PR TITLE
Conan: Do not log passwords

### DIFF
--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -52,6 +52,7 @@ import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.Os
+import org.ossreviewtoolkit.utils.common.masked
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.common.stashDirectories
 import org.ossreviewtoolkit.utils.common.textValueOrEmpty
@@ -223,7 +224,7 @@ class Conan(
                 if (auth != null) {
                     // Configure Conan's authentication based on ORT's authentication for the remote.
                     runCatching {
-                        run("user", "-r", remoteName, "-p", String(auth.password), auth.userName)
+                        run("user", "-r", remoteName, "-p", String(auth.password).masked(), auth.userName.masked())
                     }.onFailure {
                         logger.error { "Failed to configure user authentication for remote '$remoteName'." }
                     }

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -614,7 +614,7 @@ class Pub(
         if (flutterAbsolutePath.isDirectory) "$flutterAbsolutePath${File.separator}$flutterCommand pub"
         else "$flutterCommand pub"
 
-    override fun run(workingDir: File?, vararg args: String): ProcessCapture {
+    override fun run(workingDir: File?, vararg args: CharSequence): ProcessCapture {
         var result = ProcessCapture(workingDir, *commandPub().split(' ').toTypedArray(), *args)
         if (result.isError) {
             // If Pub fails with the message that Flutter should be used instead, fall back to using Flutter.

--- a/utils/common/src/main/kotlin/CommandLineTool.kt
+++ b/utils/common/src/main/kotlin/CommandLineTool.kt
@@ -65,7 +65,7 @@ interface CommandLineTool {
     /**
      * Run the command in the [workingDir] directory with arguments as specified by [args] and the given [environment].
      */
-    fun run(vararg args: String, workingDir: File? = null, environment: Map<String, String> = emptyMap()) =
+    fun run(vararg args: CharSequence, workingDir: File? = null, environment: Map<String, String> = emptyMap()) =
         ProcessCapture(
             *command(workingDir).split(' ').toTypedArray(),
             *args,
@@ -76,7 +76,7 @@ interface CommandLineTool {
     /**
      * Run the command in the [workingDir] directory with arguments as specified by [args].
      */
-    fun run(workingDir: File?, vararg args: String) =
+    fun run(workingDir: File?, vararg args: CharSequence) =
         ProcessCapture(workingDir, *command(workingDir).split(' ').toTypedArray(), *args).requireSuccess()
 
     /**

--- a/utils/common/src/main/kotlin/MaskedString.kt
+++ b/utils/common/src/main/kotlin/MaskedString.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.utils.common
+
+/**
+ * A class that wraps a [CharSequence] and overrides some functions to return a configurable mask string
+ * instead of the actual content. The main use case for this class is to prevent that sensitive information like
+ * passwords are visible in log output. The class can be used everywhere a [CharSequence] is accepted.
+ */
+data class MaskedString(
+    /** The wrapped string. */
+    val value: CharSequence,
+
+    /** A string that is returned by the toString method instead of the actual value. */
+    val mask: String = DEFAULT_MASK
+) : CharSequence by mask {
+    companion object {
+        const val DEFAULT_MASK = "*****"
+    }
+
+    override fun toString() = mask
+}
+
+/**
+ * Return an array with strings from the given [args]. If one of the input strings is a [MaskedString], include its
+ * actual value. So, this function can be used to access the unmasked strings.
+ */
+fun unmaskedStrings(vararg args: CharSequence): Array<out String> =
+    args.map { s ->
+        when (s) {
+            is MaskedString -> s.value.toString()
+            else -> s.toString()
+        }
+    }.toTypedArray()
+
+/**
+ * Convert this [CharSequence] to a [MaskedString] which uses the provided [mask].
+ */
+fun CharSequence.masked(mask: String = MaskedString.DEFAULT_MASK): MaskedString = MaskedString(this, mask)

--- a/utils/common/src/test/kotlin/MaskedStringTest.kt
+++ b/utils/common/src/test/kotlin/MaskedStringTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2022 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.utils.common
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldHaveLength
+
+class MaskedStringTest : StringSpec({
+    "CharSequence functions can be invoked" {
+        val masked = MaskedString("This is a test.")
+
+        masked shouldHaveLength MaskedString.DEFAULT_MASK.length
+        masked.substring(1..3) shouldBe MaskedString.DEFAULT_MASK.substring(1..3)
+    }
+
+    "toString returns a default mask" {
+        val masked = MaskedString("mySecretPassword")
+
+        masked.toString() shouldBe MaskedString.DEFAULT_MASK
+    }
+
+    "toString returns the configured mask" {
+        val mask = "???"
+        val masked = MaskedString("anotherSecret", mask)
+
+        masked.toString() shouldBe mask
+    }
+
+    "The string is masked when referenced in a join expression" {
+        val strings = listOf("foo", MaskedString("bar"), "baz")
+
+        val joinResult = strings.joinToString()
+
+        joinResult shouldBe "foo, ${MaskedString.DEFAULT_MASK}, baz"
+    }
+
+    "Two objects can be compared with equals" {
+        val masked1 = MaskedString("value", "mask")
+        val masked2 = MaskedString("value", "mask")
+        val masked3 = MaskedString("value1", "mask")
+        val masked4 = MaskedString("value", "mask1")
+
+        masked1 shouldBe masked2
+        masked1 shouldNotBe masked3
+        masked1 shouldNotBe masked4
+        masked1 shouldNotBe Object()
+    }
+
+    "unmaskedStrings() returns unmasked strings" {
+        val str = unmaskedStrings("foo", MaskedString("bar"), "baz").joinToString()
+
+        str shouldBe "foo, bar, baz"
+    }
+
+    "A CharSequence can be converted to a MaskedString" {
+        val value = "This is some text"
+        val mask = "+++"
+
+        val maskedValue = value.masked(mask)
+
+        maskedValue.value shouldBe value
+        maskedValue.mask shouldBe mask
+    }
+})

--- a/utils/common/src/test/kotlin/ProcessCaptureTest.kt
+++ b/utils/common/src/test/kotlin/ProcessCaptureTest.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.utils.common
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 
 class ProcessCaptureTest : StringSpec({
     "Environment variables should be passed correctly" {
@@ -33,5 +34,19 @@ class ProcessCaptureTest : StringSpec({
 
         proc.exitValue shouldBe 0
         proc.stdout.trimEnd() shouldBe "This is some path: /foo/bar"
+    }
+
+    "Masked strings should be processed correctly" {
+        val masked = MaskedString("echo unmasked")
+        val proc = if (Os.isWindows) {
+            ProcessCapture("cmd.exe", "/c", masked)
+        } else {
+            ProcessCapture("sh", "-c", masked)
+        }
+
+        proc.exitValue shouldBe 0
+        proc.stdout.trimEnd() shouldBe "unmasked"
+
+        proc.commandLine shouldContain MaskedString.DEFAULT_MASK
     }
 })


### PR DESCRIPTION
Since Conan uses `ProcessCapture` to run `conan user` commands, the whole command line including the password is logged. This PR adds a mechanism to mask specific arguments when using `ProcessCapture`, so that sensitive information can be hidden.