### PR TITLE
OrtAuthenticator: Use credentials in URL when provided

### DIFF
--- a/utils/ort/src/main/kotlin/OrtAuthenticator.kt
+++ b/utils/ort/src/main/kotlin/OrtAuthenticator.kt
@@ -68,9 +68,9 @@ class OrtAuthenticator(private val original: Authenticator? = null) : Authentica
         }
     }
 
-    // First look for (potentially machine-specific) credentials in a netrc-style file, then look for generic
-    // credentials passed as environment variables.
-    private val delegateAuthenticators = listOf(NetRcAuthenticator(), EnvVarAuthenticator())
+    // First look if the credentials are already present in the URL, then search for (potentially machine-specific)
+    // credentials in a netrc-style file, and finally look for generic credentials passed as environment variables.
+    private val delegateAuthenticators = listOf(UserInfoAuthenticator(), NetRcAuthenticator(), EnvVarAuthenticator())
 
     private val serverAuthentication: ConcurrentHashMap<String, PasswordAuthentication> = ConcurrentHashMap()
 

--- a/utils/ort/src/main/kotlin/UserInfoAuthenticator.kt
+++ b/utils/ort/src/main/kotlin/UserInfoAuthenticator.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 The ORT Project Authors (See <https://github.com/oss-review-toolkit/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.utils.ort
+
+import java.net.Authenticator
+import java.net.PasswordAuthentication
+
+/**
+ * A trivial [Authenticator] that checks if the credentials are already present in the URL. If this is the case, the
+ * credentials will be used for password authentication.
+ */
+class UserInfoAuthenticator : Authenticator() {
+    override fun getPasswordAuthentication(): PasswordAuthentication? {
+        if (requestorType == RequestorType.SERVER) {
+            requestingURL?.userInfo?.let {
+                val credentials = it.split(":", limit = 2)
+                if (credentials.size == 2) {
+                    return PasswordAuthentication(credentials.first(), credentials.last().toCharArray())
+                }
+            }
+        }
+
+        return super.getPasswordAuthentication()
+    }
+}

--- a/utils/ort/src/test/kotlin/UtilsTest.kt
+++ b/utils/ort/src/test/kotlin/UtilsTest.kt
@@ -35,7 +35,10 @@ import io.mockk.verify
 
 import java.net.Authenticator
 import java.net.PasswordAuthentication
+import java.net.URL
 import java.nio.file.Paths
+
+import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class UtilsTest : WordSpec({
     "filterVersionNames" should {
@@ -408,6 +411,29 @@ class UtilsTest : WordSpec({
             verify {
                 OrtAuthenticator.install()
                 OrtProxySelector.install()
+            }
+        }
+
+        "return the credentials present in the URL if any" {
+            val host = "www.example.org"
+            val port = 442
+            val scheme = "https"
+            val url = URL("https://foo:bar@www.example.org")
+
+            val auth = OrtAuthenticator().requestPasswordAuthenticationInstance(
+                host,
+                null,
+                port,
+                null,
+                null,
+                scheme,
+                url,
+                Authenticator.RequestorType.SERVER
+            )
+
+            auth shouldNotBeNull {
+                userName shouldBe "foo"
+                String(password) shouldBe "bar"
             }
         }
     }


### PR DESCRIPTION
When a URL contains credentials (in the 'userInfo' part of the URL), the Authenticator should use them and stop searching for credentials. This commit extracts the credentials from the URL and use them for password authentication.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>
