### PR TITLE
LicenseClassifications: Exclude properties from serialization

### DIFF
--- a/model/src/main/kotlin/licenses/LicenseClassifications.kt
+++ b/model/src/main/kotlin/licenses/LicenseClassifications.kt
@@ -48,15 +48,13 @@ data class LicenseClassifications(
 ) {
     /** A property for fast look-ups of licenses for a given category. */
     val licensesByCategory: Map<String, Set<SpdxSingleLicenseExpression>> by lazy {
-        val result = mutableMapOf<String, MutableSet<SpdxSingleLicenseExpression>>()
-
-        categorizations.forEach { license ->
-            license.categories.forEach { category ->
-                result.getOrPut(category) { mutableSetOf() } += license.id
+        buildMap<String, MutableSet<SpdxSingleLicenseExpression>> {
+            categorizations.forEach { license ->
+                license.categories.forEach { category ->
+                    getOrPut(category) { mutableSetOf() } += license.id
+                }
             }
         }
-
-        result
     }
 
     /** A property for fast look-ups of categories for a given license. */

--- a/model/src/main/kotlin/licenses/LicenseClassifications.kt
+++ b/model/src/main/kotlin/licenses/LicenseClassifications.kt
@@ -61,13 +61,7 @@ data class LicenseClassifications(
 
     /** A property for fast look-ups of categories for a given license. */
     val categoriesByLicense: Map<SpdxSingleLicenseExpression, Set<String>> by lazy {
-        val result = mutableMapOf<SpdxSingleLicenseExpression, Set<String>>()
-
-        categorizations.forEach { license ->
-            result[license.id] = license.categories
-        }
-
-        result
+        categorizations.associate { it.id to it.categories }
     }
 
     /** A property allowing convenient access to the names of all categories defined. */

--- a/model/src/main/kotlin/licenses/LicenseClassifications.kt
+++ b/model/src/main/kotlin/licenses/LicenseClassifications.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.model.licenses
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 
 import java.util.SortedSet
@@ -47,6 +48,7 @@ data class LicenseClassifications(
     val categorizations: List<LicenseCategorization> = emptyList()
 ) {
     /** A property for fast look-ups of licenses for a given category. */
+    @get:JsonIgnore
     val licensesByCategory: Map<String, Set<SpdxSingleLicenseExpression>> by lazy {
         buildMap<String, MutableSet<SpdxSingleLicenseExpression>> {
             categorizations.forEach { license ->
@@ -58,11 +60,13 @@ data class LicenseClassifications(
     }
 
     /** A property for fast look-ups of categories for a given license. */
+    @get:JsonIgnore
     val categoriesByLicense: Map<SpdxSingleLicenseExpression, Set<String>> by lazy {
         categorizations.associate { it.id to it.categories }
     }
 
     /** A property allowing convenient access to the names of all categories defined. */
+    @get:JsonIgnore
     val categoryNames: SortedSet<String> by lazy {
         categories.mapTo(sortedSetOf()) { it.name }
     }


### PR DESCRIPTION
See individual commits.

This enables using the serialization in https://github.com/oss-review-toolkit/ort-config/issues/59.