### PR TITLE
Add linebreak so "==Dependencies" is correctly displayed as headline

### DIFF
--- a/reporter/src/funTest/assets/asciidoc-template-reporter-expected-result.adoc
+++ b/reporter/src/funTest/assets/asciidoc-template-reporter-expected-result.adoc
@@ -20,6 +20,7 @@ The applicable license information is listed below:
 ** +Copyright 1+
 
 <<<
+
 == Dependencies
 
 This software depends on external packages and source code.

--- a/reporter/src/main/resources/templates/asciidoc/disclosure_document.ftl
+++ b/reporter/src/main/resources/templates/asciidoc/disclosure_document.ftl
@@ -75,6 +75,7 @@ The applicable license information is listed below:
 [/#if]
 <<<
 [#-- Add the licenses of all dependencies. --]
+
 == Dependencies
 
 [#if packages?has_content]


### PR DESCRIPTION
Fixes the issue seen in below screenshot:

![grafik](https://user-images.githubusercontent.com/40762532/193041857-a93ba880-b968-4d2b-aa78-198c7e95fecc.png)
