### PR TITLE
FossID: Support URL mappings

### DIFF
--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -156,7 +156,6 @@ ort:
         namingVariableVar3: myUnit
 
         waitForResult: false
-        addAuthenticationToUrl: false
 
         keepFailedScans: false
         deltaScans: true
@@ -166,6 +165,8 @@ ort:
         detectCopyrightStatements: true
 
         timeout: 60
+
+        urlMappingExample: "https://my-repo.example.org(?<repoPath>.*) -> ssh://my-mapped-repo.example.org${repoPath}"
 
     storages:
       local:

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -31,7 +31,6 @@ import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNot
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 import java.io.File
@@ -166,7 +165,13 @@ class OrtConfigurationTest : WordSpec({
                     sw360Storage.token shouldBe "token"
                 }
 
-                options shouldNot beNull()
+                options shouldNotBeNull {
+                    val fossIdOptions = getValue("FossId")
+                    val mapping = "https://my-repo.example.org(?<repoPath>.*) -> " +
+                            "ssh://my-mapped-repo.example.org\${repoPath}"
+                    fossIdOptions["urlMappingExample"] shouldBe mapping
+                }
+
                 storageReaders shouldContainExactly listOf("local", "postgres", "http", "clearlyDefined")
                 storageWriters shouldContainExactly listOf("postgres")
 

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -20,7 +20,6 @@
 package org.ossreviewtoolkit.scanner.scanners.fossid
 
 import java.io.IOException
-import java.net.Authenticator
 import java.time.Instant
 
 import kotlin.time.Duration
@@ -78,8 +77,6 @@ import org.ossreviewtoolkit.scanner.experimental.ProvenanceScannerWrapper
 import org.ossreviewtoolkit.scanner.experimental.ScanContext
 import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
-import org.ossreviewtoolkit.utils.common.toUri
-import org.ossreviewtoolkit.utils.ort.requestPasswordAuthentication
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 /**
@@ -142,24 +139,6 @@ class FossId internal constructor(
                 "identification_reuse_type" to "specific_scan",
                 "specific_code" to existingScanCode
             )
-
-        /**
-         * This function fetches credentials for [repoUrl] and insert them between the URL scheme and the host. If no
-         * matching host is found by [Authenticator], the [repoUrl] is returned untouched.
-         */
-        private fun queryAuthenticator(repoUrl: String): String {
-            val repoUri = repoUrl.toUri().getOrElse {
-                logger.warn { "The repository URL '$repoUrl' is not valid." }
-                return repoUrl
-            }
-
-            logger.info { "Requesting authentication for host ${repoUri.host} ..." }
-
-            val creds = requestPasswordAuthentication(repoUri)
-            return creds?.let {
-                repoUrl.replaceCredentialsInUri("${creds.userName}:${String(creds.password)}")
-            } ?: repoUrl
-        }
     }
 
     class FossIdFactory : AbstractScannerWrapperFactory<FossId>("FossId") {
@@ -189,6 +168,7 @@ class FossId internal constructor(
 
     private val secretKeys = listOf("serverUrl", "apiKey", "user")
     private val namingProvider = config.createNamingProvider()
+    private val urlProvider = config.createUrlProvider()
 
     // A list of all scans created in an ORT run, to be able to delete them in case of error.
     // The reasoning is that either all these scans are successful, either none is created at all (clean slate).
@@ -424,7 +404,7 @@ class FossId internal constructor(
             logger.info { "No scan found for $url and revision $revision. Creating scan..." }
 
             val scanCode = namingProvider.createScanCode(projectName)
-            val newUrl = if (config.addAuthenticationToUrl) queryAuthenticator(url) else url
+            val newUrl = urlProvider.getUrl(url)
             createScan(projectCode, scanCode, newUrl, revision)
 
             logger.info { "Initiating the download..." }
@@ -472,11 +452,7 @@ class FossId internal constructor(
             namingProvider.createScanCode(projectName, DeltaTag.DELTA)
         }
 
-        val newUrl = if (config.addAuthenticationToUrl) {
-            queryAuthenticator(urlWithoutCredentials)
-        } else {
-            urlWithoutCredentials
-        }
+        val newUrl = urlProvider.getUrl(urlWithoutCredentials)
 
         createScan(projectCode, scanCode, newUrl, revision)
 

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
@@ -210,5 +210,5 @@ internal data class FossIdConfig(
     /**
      * Create a [FossIdUrlProvider] helper object based on the configuration stored in this object.
      */
-    fun createUrlProvider() = FossIdUrlProvider.create(addAuthenticationToUrl)
+    fun createUrlProvider() = FossIdUrlProvider.create()
 }

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
@@ -33,7 +33,6 @@ import org.ossreviewtoolkit.model.config.ScannerConfiguration
  * * **"apiKey":** The API key of the user which connects to the FossID server.
  * * **"waitForResult":** When set to false, ORT does not wait for repositories to be downloaded nor scans to be
  *   completed. As a consequence, scan results won't be available in ORT result.
- * * **"addAuthenticationToUrl":** If set, ORT will add credentials from its Authenticator to the URLs sent to FossID.
  * * **"deltaScans":** If set, ORT will create delta scans. When only changes in a repository need to be scanned,
  *   delta scans reuse the identifications of the latest scan on this repository to reduce the amount of findings. If
  *   *deltaScans* is set and no scan exist yet, an initial scan called "origin" scan will be created.
@@ -50,6 +49,28 @@ import org.ossreviewtoolkit.model.config.ScannerConfiguration
  *   variables prefixed by "$" e.g. "$Var1_$Var2". Variables are also passed as options and are prefixed by
  *   [NAMING_CONVENTION_VARIABLE_PREFIX] e.g. namingVariableVar1 = "foo".
  * * **"namingScanPattern":** A pattern for scan names when scans are created on the FossID instance.
+ *
+ * URL mapping options. These options allow transforming the URLs of specific repositories before they are passed to
+ * the FossID service. This may be necessary if FossID uses a different mechanism to clone a repository, e.g. via SSH
+ * instead of HTTP. Options of this form start with the prefix [FossIdUrlProvider.PREFIX_URL_MAPPING] followed by an
+ * arbitrary name. Their values define the mapping to be applied consisting of two parts separated by the string
+ * " -> ":
+ * * A regular expression to match the repository URL.
+ * * The replacement to be used for this repository URL. It can access the capture groups defined by the regular
+ * expression, so that rather flexible transformations can be achieved. In addition, it can contain the variables
+ * "#user" and "#password" that are replaced by the credentials known for the target host.
+ *
+ * The example
+ *
+ * `mapExampleRepo = https://my-repo.example.org(?<repoPath>.*) -> ssh://my-mapped-repo.example.org${repoPath}`
+ *
+ * would change the scheme from "https" to "ssh" and the host name for all repositories hosted on
+ * "my-repo.example.org". With
+ *
+ * `mapAddCredentials =
+ *   (?<scheme>)://(?<host>)(?<port>:\\d+)?(?<repoPath>.*) -> ${scheme}://#user:#password@${host}${port}${repoPath}`
+ *
+ * every repository URL would be added credentials. Mappings are applied in the order they are defined.
  */
 internal data class FossIdConfig(
     /** The URL where the FossID service is running. */
@@ -63,9 +84,6 @@ internal data class FossIdConfig(
 
     /** Flag whether the scanner should wait for the completion of FossID scans. */
     val waitForResult: Boolean,
-
-    /** Flag whether credentials should be passed to FossID in URLs. */
-    val addAuthenticationToUrl: Boolean,
 
     /** Flag whether failed scans should be kept. */
     val keepFailedScans: Boolean,
@@ -99,9 +117,6 @@ internal data class FossIdConfig(
 
         /** Name of the configuration property for the API key. */
         private const val API_KEY_PROPERTY = "apiKey"
-
-        /** Name of the configuration property controlling that credentials are added to URLs. */
-        private const val CREDENTIALS_IN_URL_PROPERTY = "addAuthenticationToUrl"
 
         /** Name of the configuration property controlling whether ORT should wait for FossID results. */
         private const val WAIT_FOR_RESULT_PROPERTY = "waitForResult"
@@ -152,7 +167,6 @@ internal data class FossIdConfig(
                 ?: throw IllegalArgumentException("No FossID API Key configuration found.")
 
             val waitForResult = fossIdScannerOptions[WAIT_FOR_RESULT_PROPERTY]?.toBoolean() ?: true
-            val addAuthenticationToUrl = fossIdScannerOptions[CREDENTIALS_IN_URL_PROPERTY]?.toBoolean() ?: false
 
             val keepFailedScans = fossIdScannerOptions[KEEP_FAILED_SCANS_PROPERTY]?.toBoolean() ?: false
             val deltaScans = fossIdScannerOptions[DELTA_SCAN_PROPERTY]?.toBoolean() ?: false
@@ -176,7 +190,6 @@ internal data class FossIdConfig(
                 user = user,
                 apiKey = apiKey,
                 waitForResult = waitForResult,
-                addAuthenticationToUrl = addAuthenticationToUrl,
                 keepFailedScans = keepFailedScans,
                 deltaScans = deltaScans,
                 deltaScanLimit = deltaScanLimit,
@@ -210,5 +223,5 @@ internal data class FossIdConfig(
     /**
      * Create a [FossIdUrlProvider] helper object based on the configuration stored in this object.
      */
-    fun createUrlProvider() = FossIdUrlProvider.create()
+    fun createUrlProvider() = FossIdUrlProvider.create(options)
 }

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdConfig.kt
@@ -206,4 +206,9 @@ internal data class FossIdConfig(
 
         return FossIdNamingProvider(namingProjectPattern, namingScanPattern, namingConventionVariables)
     }
+
+    /**
+     * Create a [FossIdUrlProvider] helper object based on the configuration stored in this object.
+     */
+    fun createUrlProvider() = FossIdUrlProvider.create(addAuthenticationToUrl)
 }

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdUrlProvider.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdUrlProvider.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.fossid
+
+import java.net.Authenticator
+
+import org.apache.logging.log4j.kotlin.Logging
+
+import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
+import org.ossreviewtoolkit.utils.common.toUri
+import org.ossreviewtoolkit.utils.ort.requestPasswordAuthentication
+
+/**
+ * An internal helper class that generates the URLs used by [FossId] to check out the repositories to be scanned.
+ *
+ * The URLs used by FossId can sometimes be different from the normal package URLs. For instance, credentials may need
+ * to be added. This class takes care of such mappings.
+ */
+internal class FossIdUrlProvider private constructor(
+    /** Flag whether credentials should be passed to FossID in URLs. */
+    val addAuthenticationToUrl: Boolean
+) {
+    companion object : Logging {
+        fun create(addAuthenticationToUrl: Boolean): FossIdUrlProvider = FossIdUrlProvider(addAuthenticationToUrl)
+
+        /**
+         * This function fetches credentials for [repoUrl] and insert them between the URL scheme and the host. If no
+         * matching host is found by [Authenticator], the [repoUrl] is returned untouched.
+         */
+        private fun queryAuthenticator(repoUrl: String): String {
+            val repoUri = repoUrl.toUri().getOrElse {
+                logger.warn { "The repository URL '$repoUrl' is not valid." }
+                return repoUrl
+            }
+
+            logger.info { "Requesting authentication for host ${repoUri.host} ..." }
+
+            val creds = requestPasswordAuthentication(repoUri)
+            return creds?.let {
+                repoUrl.replaceCredentialsInUri("${creds.userName}:${String(creds.password)}")
+            } ?: repoUrl
+        }
+    }
+
+    /**
+     * Return the URL to be passed to FossID when creating a scan from the given [repoUrl].
+     */
+    fun getUrl(repoUrl: String): String {
+        if (!addAuthenticationToUrl) return repoUrl
+
+        return queryAuthenticator(repoUrl)
+    }
+}

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdUrlProvider.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdUrlProvider.kt
@@ -43,6 +43,9 @@ internal class FossIdUrlProvider private constructor(
     private val urlMapping: Map<Regex, String>
 ) {
     companion object : Logging {
+        /** The prefix of option keys that define a URL mapping. */
+        internal const val PREFIX_URL_MAPPING = "urlMapping"
+
         /** Variable in the mapping replacement string that references the username. */
         private const val VAR_USERNAME = "#username"
 
@@ -63,6 +66,13 @@ internal class FossIdUrlProvider private constructor(
         fun create(
             urlMapping: Collection<String> = emptyList()
         ): FossIdUrlProvider = FossIdUrlProvider(urlMapping.toRegexMapping())
+
+        /**
+         * Create a new instance of [FossIdUrlProvider] and configure the URL mappings from the given configuration
+         * [options].
+         */
+        fun create(options: Map<String, String>): FossIdUrlProvider =
+            create(options.filter { it.key.startsWith(PREFIX_URL_MAPPING) }.values)
 
         /**
          * Try to fetch credentials for [repoUrl] from the current [Authenticator]. Return *null* if no matching host

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
@@ -49,7 +49,6 @@ class FossIdConfigTest : WordSpec({
                 "user" to USER,
                 "apiKey" to API_KEY,
                 "waitForResult" to "false",
-                "addAuthenticationToUrl" to "false",
                 "keepFailedScans" to "true",
                 "deltaScans" to "true",
                 "deltaScanLimit" to "42",
@@ -66,7 +65,6 @@ class FossIdConfigTest : WordSpec({
                 user = USER,
                 apiKey = API_KEY,
                 waitForResult = false,
-                addAuthenticationToUrl = false,
                 keepFailedScans = true,
                 deltaScans = true,
                 deltaScanLimit = 42,
@@ -92,7 +90,6 @@ class FossIdConfigTest : WordSpec({
                 user = USER,
                 apiKey = API_KEY,
                 waitForResult = true,
-                addAuthenticationToUrl = false,
                 keepFailedScans = false,
                 deltaScans = false,
                 deltaScanLimit = Int.MAX_VALUE,
@@ -177,6 +174,23 @@ class FossIdConfigTest : WordSpec({
             val scanCode = namingProvider.createScanCode("TestProject", FossId.DeltaTag.DELTA)
 
             scanCode shouldBe "TestProject_TestOrganization_TestUnit_delta"
+        }
+    }
+
+    "createUrlProvider" should {
+        "initialize correct URL mappings" {
+            val url = "https://changeit.example.org/foo"
+            val scannerConfig = mapOf(
+                "serverUrl" to SERVER_URL,
+                "user" to USER,
+                "apiKey" to API_KEY,
+                "urlMappingChangeHost" to "$url -> $SERVER_URL"
+            ).toScannerConfig()
+
+            val fossIdConfig = FossIdConfig.create(scannerConfig)
+            val urlProvider = fossIdConfig.createUrlProvider()
+
+            urlProvider.getUrl(url) shouldBe SERVER_URL
         }
     }
 

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
@@ -180,6 +180,35 @@ class FossIdConfigTest : WordSpec({
         }
     }
 
+    "createUrlProvider" should {
+        "create a URL provider with a disabled add authentication flag" {
+            val scannerConfig = mapOf(
+                "serverUrl" to SERVER_URL,
+                "user" to USER,
+                "apiKey" to API_KEY
+            ).toScannerConfig()
+
+            val fossIdConfig = FossIdConfig.create(scannerConfig)
+            val urlProvider = fossIdConfig.createUrlProvider()
+
+            urlProvider.addAuthenticationToUrl shouldBe false
+        }
+
+        "create a URL provider with an enabled add authentication flag" {
+            val scannerConfig = mapOf(
+                "serverUrl" to SERVER_URL,
+                "user" to USER,
+                "apiKey" to API_KEY,
+                "addAuthenticationToUrl" to "true"
+            ).toScannerConfig()
+
+            val fossIdConfig = FossIdConfig.create(scannerConfig)
+            val urlProvider = fossIdConfig.createUrlProvider()
+
+            urlProvider.addAuthenticationToUrl shouldBe true
+        }
+    }
+
     "createService" should {
         "create a correctly configured FossIdRestService" {
             val loginPage = "Welcome to FossID"

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdConfigTest.kt
@@ -180,35 +180,6 @@ class FossIdConfigTest : WordSpec({
         }
     }
 
-    "createUrlProvider" should {
-        "create a URL provider with a disabled add authentication flag" {
-            val scannerConfig = mapOf(
-                "serverUrl" to SERVER_URL,
-                "user" to USER,
-                "apiKey" to API_KEY
-            ).toScannerConfig()
-
-            val fossIdConfig = FossIdConfig.create(scannerConfig)
-            val urlProvider = fossIdConfig.createUrlProvider()
-
-            urlProvider.addAuthenticationToUrl shouldBe false
-        }
-
-        "create a URL provider with an enabled add authentication flag" {
-            val scannerConfig = mapOf(
-                "serverUrl" to SERVER_URL,
-                "user" to USER,
-                "apiKey" to API_KEY,
-                "addAuthenticationToUrl" to "true"
-            ).toScannerConfig()
-
-            val fossIdConfig = FossIdConfig.create(scannerConfig)
-            val urlProvider = fossIdConfig.createUrlProvider()
-
-            urlProvider.addAuthenticationToUrl shouldBe true
-        }
-    }
-
     "createService" should {
         "create a correctly configured FossIdRestService" {
             val loginPage = "Welcome to FossID"

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -842,7 +842,6 @@ private fun createConfig(
         user = USER,
         apiKey = API_KEY,
         waitForResult = waitForResult,
-        addAuthenticationToUrl = false,
         keepFailedScans = false,
         deltaScans = deltaScans,
         deltaScanLimit = deltaScanLimit,

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdUrlProviderTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdUrlProviderTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.scanners.fossid
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+import io.mockk.every
+import io.mockk.mockkStatic
+
+import java.net.PasswordAuthentication
+import java.net.URI
+
+import org.ossreviewtoolkit.utils.ort.requestPasswordAuthentication
+
+class FossIdUrlProviderTest : StringSpec({
+    "URLs are not changed if no credentials need to be added" {
+        val urlProvider = FossIdUrlProvider.create(addAuthenticationToUrl = false)
+
+        urlProvider.getUrl(REPO_URL) shouldBe REPO_URL
+    }
+
+    "Credentials should be added to URLs" {
+        mockAuthenticator()
+        val expectedUrl = "https://$USER:$PASSWORD@$HOST:$PORT/$PATH"
+        val urlProvider = FossIdUrlProvider.create(addAuthenticationToUrl = true)
+
+        val url = urlProvider.getUrl(REPO_URL)
+
+        url shouldBe expectedUrl
+    }
+
+    "Missing credentials should be handled" {
+        mockAuthenticator(authentication = null)
+        val urlProvider = FossIdUrlProvider.create(addAuthenticationToUrl = true)
+
+        val url = urlProvider.getUrl(REPO_URL)
+
+        url shouldBe REPO_URL
+    }
+})
+
+private const val HOST = "repo.example.org"
+private const val PORT = 4711
+private const val PATH = "tests/fossid.git"
+private const val REPO_URL = "https://$HOST:$PORT/$PATH"
+private const val USER = "scott"
+private const val PASSWORD = "tiger"
+private val AUTHENTICATION = PasswordAuthentication(USER, PASSWORD.toCharArray())
+
+/**
+ * Mock a request for authentication for the given [url] to return the specified [authentication].
+ */
+private fun mockAuthenticator(url: String = REPO_URL, authentication: PasswordAuthentication? = AUTHENTICATION) {
+    mockkStatic("org.ossreviewtoolkit.utils.ort.UtilsKt")
+    every { requestPasswordAuthentication(URI(url)) } returns authentication
+}


### PR DESCRIPTION
In our setup, we have cases in which FossID requires a different URL to scan a project than the repository URL used by ORT. To support such cases, this PR adds a mechanism based on regular expressions to map repository URLs to different URLs. To enable this, the FossID-specific scanner configuration can list an arbitrary number of mapping regular expressions. These are applied to the URL of the current package before it is passed to FossID.