### PR TITLE
import_certificates.sh: Fix Copying of Certificates

### DIFF
--- a/scripts/import_certificates.sh
+++ b/scripts/import_certificates.sh
@@ -49,5 +49,5 @@ fi
 
 # Also add the certificates to the system certificates, e.g. for curl to work.
 echo "Adding certificates to the system certificates..."
-cp -r "$FILE_PREFIX" /usr/local/share/ca-certificates/
+cp -r "$FILE_PREFIX"* /usr/local/share/ca-certificates/
 update-ca-certificates


### PR DESCRIPTION
Add missing wildcard to enable copying of certificates into the proper directory for update-ca-certificates to install.
Without the wildcard the cp command explicitly looks for the prefix that is never supposed to be a concrete file.
Fixes error message `cp: cannot stat 'proxy-': No such file or directory`

Signed-off-by: Jens Erdmann <jens.erdmann@web.de>

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
