### PR TITLE
WorkingTreeCache: Ignore the VCS path

### DIFF
--- a/scanner/src/main/kotlin/provenance/NestedProvenanceResolver.kt
+++ b/scanner/src/main/kotlin/provenance/NestedProvenanceResolver.kt
@@ -83,7 +83,6 @@ class DefaultNestedProvenanceResolver(
             vcs.updateWorkingTree(
                 workingTree,
                 provenance.resolvedRevision,
-                path = provenance.vcsInfo.path,
                 recursive = true
             ).onFailure { throw it }
 

--- a/scanner/src/main/kotlin/provenance/PackageProvenanceResolver.kt
+++ b/scanner/src/main/kotlin/provenance/PackageProvenanceResolver.kt
@@ -220,7 +220,19 @@ class DefaultPackageProvenanceResolver(
 
             revisionCandidates.forEachIndexed { index, revision ->
                 logger.info { "Trying revision candidate '$revision' (${index + 1} of ${revisionCandidates.size})." }
-                val result = vcs.updateWorkingTree(workingTree, revision, pkg.vcsProcessed.path, recursive = false)
+                val result = vcs.updateWorkingTree(workingTree, revision, recursive = false)
+
+                if (pkg.vcsProcessed.path.isNotBlank() &&
+                    !workingTree.workingDir.resolve(pkg.vcsProcessed.path).exists()
+                ) {
+                    logger.info {
+                        "Discarding revision '$revision' because the requested VCS path '${pkg.vcsProcessed.path}' " +
+                                "does not exist."
+                    }
+
+                    return@forEachIndexed
+                }
+
                 if (result.isSuccess) {
                     val resolvedRevision = workingTree.getRevision()
 


### PR DESCRIPTION
    Ignore the VCS path when initializing the working tree. The scanner
    implementation always scans full repositories, so sparse checkout are
    not required. This improves the performance if an analyzer repositories
    contains many projects in different directories, because previously one
    working tree for each of them would have been created during scanning.
    Now only one working tree is created for this repository.
    
    Add a check to the `PackageProvenanceResolver` to verify that the VCS
    path from the package metadata exists, because the working tree would
    now not throw an exception anymore if it does not exist.