### PR TITLE
Re-align path exclude patterns with the changed behavior

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -1,7 +1,7 @@
 ---
 excludes:
   paths:
-  - pattern: "**/src/{funTest,test}/**"
+  - pattern: "**/src/{:funTest|test}/**"
     reason: "TEST_OF"
     comment: >-
       Licenses contained in this directory are used for testing and do not apply to the OSS Review Toolkit.
@@ -9,7 +9,7 @@ excludes:
     reason: "EXAMPLE_OF"
     comment: >-
       This directory contains example files with licenses that do not apply to the OSS Review Toolkit.
-  - pattern: "utils/spdx/src/main/kotlin/{SpdxDeclaredLicenseMapping,SpdxLicense,SpdxLicenseException,SpdxSimpleLicenseMapping}.kt"
+  - pattern: "utils/spdx/src/main/kotlin/{:SpdxDeclaredLicenseMapping|SpdxLicense|SpdxLicenseException|SpdxSimpleLicenseMapping}.kt"
     reason: "DATA_FILE_OF"
     comment: >-
       Licenses contained in this class are used for processing licenses and do not apply to the OSS Review Toolkit.

--- a/utils/common/src/test/kotlin/FileMatcherTest.kt
+++ b/utils/common/src/test/kotlin/FileMatcherTest.kt
@@ -80,4 +80,13 @@ class FileMatcherTest : StringSpec({
             matches("license") shouldBe true
         }
     }
+
+    "Groups of subpatterns can be matched" {
+        FileMatcher("*.{:java|class}", ignoreCase = false).apply {
+            matches("x.java") shouldBe true
+            matches("x.class") shouldBe true
+            matches("x.cpp") shouldBe false
+            matches("dir/x.java") shouldBe false
+        }
+    }
 })


### PR DESCRIPTION
The migration from `Java`'s path matcher to `AntPathMatcher` was a breaking change (unintended) for patterns which
match groups of subpatterns. Migrate existing patterns to the new notation and add a test case illustrating the current behavior.

Fixes: #5901.