### PR TITLE
Pip: Get package metadata from python-inspector

### DIFF
--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -17,9 +17,14 @@
  * License-Filename: LICENSE
  */
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     // Apply core plugins.
     `java-library`
+
+    // Apply third-party plugins.
+    alias(libs.plugins.kotlinSerialization)
 }
 
 repositories {
@@ -63,10 +68,21 @@ dependencies {
     implementation(libs.jacksonModuleKotlin)
     implementation(libs.jruby)
     implementation(libs.kotlinxCoroutines)
+    implementation(libs.kotlinxSerialization)
     implementation(libs.semver4j)
     implementation(libs.sw360Client)
     implementation(libs.toml4j)
 
     testImplementation(libs.mockk)
     testImplementation(libs.wiremock)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    val customCompilerArgs = listOf(
+        "-opt-in=kotlinx.serialization.ExperimentalSerializationApi"
+    )
+
+    kotlinOptions {
+        freeCompilerArgs = freeCompilerArgs + customCompilerArgs
+    }
 }

--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -33,26 +33,23 @@ packages:
 - id: "PyPI::click:8.1.3"
   purl: "pkg:pypi/click@8.1.3"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
-  - "BSD License"
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "Composable command line interface toolkit"
+  description: "\\$ click\\_"
   homepage_url: "https://palletsprojects.com/p/click/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/c2/f1/df59e28c642d583f7dacffb1e0965d0e00b218e0186d7858ac5233dce840/click-8.1.3-py3-none-any.whl"
     hash:
-      value: "7a8260e7bdac219be27f0bdda48e79ce"
-      algorithm: "MD5"
+      value: "bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/59/87/84326af34517fca8c58418d148f2403df25303e02736832403587318e9e8/click-8.1.3.tar.gz"
     hash:
-      value: "a804b085de7a3ff96968e38e0f6f2e05"
-      algorithm: "MD5"
+      value: "7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -66,27 +63,25 @@ packages:
 - id: "PyPI::flask:0.12"
   purl: "pkg:pypi/flask@0.12"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
   - "BSD"
-  - "BSD License"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "A microframework based on Werkzeug, Jinja2 and good intentions"
+  description: "Flask"
   homepage_url: "http://github.com/pallets/flask/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/0e/e9/37ee66dde483dceefe45bb5e92b387f990d4f097df40c400cf816dcebaa4/Flask-0.12-py2.py3-none-any.whl"
     hash:
-      value: "d3351b10f54446203ac0fd8839850c62"
-      algorithm: "MD5"
+      value: "7f03bb2c255452444f7265eddb51601806e5447b6f8a2d50bbc77a654a14c118"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/4b/3a/4c20183df155dd2e39168e35d53a388efb384a512ca6c73001d8292c094a/Flask-0.12.tar.gz"
     hash:
-      value: "c1d30f51cff4a38f9454b23328a15c5a"
-      algorithm: "MD5"
+      value: "93e803cdbe326a61ebd5c5d353959397c85f829bec610d59cb635c9f97d7ca8b"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -100,26 +95,23 @@ packages:
 - id: "PyPI::gunicorn:19.6.0"
   purl: "pkg:pypi/gunicorn@19.6.0"
   authors:
-  - "Benoit Chesneau"
+  - "Benoit Chesneau <benoitc@e-engura.com>"
   declared_licenses:
   - "MIT"
-  - "MIT License"
   declared_licenses_processed:
     spdx_expression: "MIT"
-    mapped:
-      MIT License: "MIT"
-  description: "WSGI HTTP Server for UNIX"
+  description: "Gunicorn"
   homepage_url: "http://gunicorn.org"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/72/de/ec28a64885e0b390063379cca601b60b1f9e51367e0c76030ac8a5cddd5e/gunicorn-19.6.0-py2.py3-none-any.whl"
     hash:
-      value: "ab69dff52e2e0bccb25bf1e3a82e1448"
-      algorithm: "MD5"
+      value: "723234ea1fa8dff370ab69830ba8bc37469a7cba13fd66055faeef24085e6530"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/84/ce/7ea5396efad1cef682bbc4068e72a0276341d9d9d0f501da609fab9fcb80/gunicorn-19.6.0.tar.gz"
     hash:
-      value: "338e5e8a83ea0f0625f768dba4597530"
-      algorithm: "MD5"
+      value: "813f6916d18a4c8e90efde72f419308b357692f81333cb1125f80013d22fb618"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -133,26 +125,23 @@ packages:
 - id: "PyPI::itsdangerous:2.1.2"
   purl: "pkg:pypi/itsdangerous@2.1.2"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
-  - "BSD License"
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "Safely pass data to untrusted environments and back."
+  description: "ItsDangerous"
   homepage_url: "https://palletsprojects.com/p/itsdangerous/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/68/5f/447e04e828f47465eeab35b5d408b7ebaaaee207f48b7136c5a7267a30ae/itsdangerous-2.1.2-py3-none-any.whl"
     hash:
-      value: "efb0813a44f2abd3b7b375cfcb8b95c2"
-      algorithm: "MD5"
+      value: "2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/7f/a1/d3fb83e7a61fa0c0d3d08ad0a94ddbeff3731c05212617dff3a94e097f08/itsdangerous-2.1.2.tar.gz"
     hash:
-      value: "c1bc730ddf53b8374eaa823f24eb6438"
-      algorithm: "MD5"
+      value: "5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -166,28 +155,25 @@ packages:
 - id: "PyPI::jinja2:2.8.1"
   purl: "pkg:pypi/jinja2@2.8.1"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
   - "BSD"
-  - "BSD License"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "A small but fast and easy to use stand-alone template engine written\
-    \ in pure python."
+  description: "Jinja2"
   homepage_url: "http://jinja.pocoo.org/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/67/ea/92b1d9d8f2dc43302df7f5271b9500bbfc237386782343561a5f62beb306/Jinja2-2.8.1-py2.py3-none-any.whl"
     hash:
-      value: "7472b9df828747c2d44eb539558bbf7a"
-      algorithm: "MD5"
+      value: "3997cf273f1424207c60d5895264f74483fce72702f15a7cd51a8551d43663ca"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/5f/bd/5815d4d925a2b8cbbb4b4960f018441b0c65f24ba29f3bdcfb3c8218a307/Jinja2-2.8.1.tar.gz"
     hash:
-      value: "150a8f1c180272753cf46dd3cdd6decf"
-      algorithm: "MD5"
+      value: "35341f3a97b46327b3ef1eb624aadea87a535b8f50863036e085e7c426ac5891"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -201,26 +187,23 @@ packages:
 - id: "PyPI::markupsafe:2.1.1"
   purl: "pkg:pypi/markupsafe@2.1.1"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
-  - "BSD License"
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "Safely add untrusted strings to HTML/XML markup."
+  description: "MarkupSafe"
   homepage_url: "https://palletsprojects.com/p/markupsafe/"
   binary_artifact:
-    url: "https://files.pythonhosted.org/packages/d9/60/94e9de017674f88a514804e2924bdede9a642aba179d2045214719d6ec76/MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl"
+    url: "https://files.pythonhosted.org/packages/9e/82/2e089c6f34e77c073aa5a67040d368aac0dfb9b8ccbb46d381452c26fc33/MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
     hash:
-      value: "edd92cc0efdc919430f86fac719864d7"
-      algorithm: "MD5"
+      value: "10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/1d/97/2288fe498044284f39ab8950703e88abbac2abbdf65524d576157af70556/MarkupSafe-2.1.1.tar.gz"
     hash:
-      value: "9809f9fdd98bc835b0c21aa8f79cbf30"
-      algorithm: "MD5"
+      value: "7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -234,26 +217,23 @@ packages:
 - id: "PyPI::werkzeug:2.2.2"
   purl: "pkg:pypi/werkzeug@2.2.2"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
-  - "BSD License"
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "The comprehensive WSGI web application library."
+  description: "Werkzeug"
   homepage_url: "https://palletsprojects.com/p/werkzeug/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/c8/27/be6ddbcf60115305205de79c29004a0c6bc53cec814f733467b1bb89386d/Werkzeug-2.2.2-py3-none-any.whl"
     hash:
-      value: "7d1583943fb626014027b4fbd75507a0"
-      algorithm: "MD5"
+      value: "f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/f8/c1/1c8e539f040acd80f844c69a5ef8e2fccdf8b442dabb969e497b55d544e1/Werkzeug-2.2.2.tar.gz"
     hash:
-      value: "9d7e50c5bb3a9fc12823b5faf374b90e"
-      algorithm: "MD5"
+      value: "7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/spdx-tools-python-expected-output.yml
@@ -37,27 +37,25 @@ packages:
 - id: "PyPI::isodate:0.6.1"
   purl: "pkg:pypi/isodate@0.6.1"
   authors:
-  - "Gerhard Weis"
+  - "Gerhard Weis <gerhard.weis@proclos.com>"
   declared_licenses:
   - "BSD"
-  - "BSD License"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "An ISO 8601 date/time/duration parser and formatter"
+  description: "ISO 8601 date/time parser"
   homepage_url: "https://github.com/gweis/isodate/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/b6/85/7882d311924cbcfc70b1890780763e36ff0b140c7e51c110fc59a532f087/isodate-0.6.1-py2.py3-none-any.whl"
     hash:
-      value: "c8a5fcd645030db98daa82b8e56fda89"
-      algorithm: "MD5"
+      value: "0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/db/7a/c0a56c7d56c7fa723988f122fa1f1ccf8c5c4ccc48efad0d214b49e5b1af/isodate-0.6.1.tar.gz"
     hash:
-      value: "1a310658b30a48641bafb5652ad91c40"
-      algorithm: "MD5"
+      value: "48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -71,25 +69,26 @@ packages:
 - id: "PyPI::ply:3.11"
   purl: "pkg:pypi/ply@3.11"
   authors:
-  - "David Beazley"
+  - "David Beazley <dave@dabeaz.com>"
   declared_licenses:
   - "BSD"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-  description: "Python Lex & Yacc"
+  description: "PLY is yet another implementation of lex and yacc for Python. Some\
+    \ notable"
   homepage_url: "http://www.dabeaz.com/ply/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl"
     hash:
-      value: "62b6ad5affddc9926ab5571f390cc840"
-      algorithm: "MD5"
+      value: "096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz"
     hash:
-      value: "6465f602e656455affcd7c5734c638f8"
-      algorithm: "MD5"
+      value: "00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -103,25 +102,25 @@ packages:
 - id: "PyPI::pyparsing:2.4.7"
   purl: "pkg:pypi/pyparsing@2.4.7"
   authors:
-  - "Paul McGuire"
+  - "Paul McGuire <ptmcg@users.sourceforge.net>"
   declared_licenses:
   - "MIT License"
   declared_licenses_processed:
     spdx_expression: "MIT"
     mapped:
       MIT License: "MIT"
-  description: "Python parsing module"
+  description: "PyParsing -- A Python Parsing Module"
   homepage_url: "https://github.com/pyparsing/pyparsing/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/8a/bb/488841f56197b13700afd5658fc279a2025a39e22449b7cf29864669b15d/pyparsing-2.4.7-py2.py3-none-any.whl"
     hash:
-      value: "dbfd0a241aad2595f43377ec7f1836ea"
-      algorithm: "MD5"
+      value: "ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/c1/47/dfc9c342c9842bbe0036c7f763d2d6686bcf5eb1808ba3e170afdb282210/pyparsing-2.4.7.tar.gz"
     hash:
-      value: "f0953e47a0112f7a65aec2305ffdf7b4"
-      algorithm: "MD5"
+      value: "c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -135,27 +134,23 @@ packages:
 - id: "PyPI::rdflib:5.0.0"
   purl: "pkg:pypi/rdflib@5.0.0"
   authors:
-  - "Daniel 'eikeon' Krech"
+  - "Daniel 'eikeon' Krech <eikeon@eikeon.com>"
   declared_licenses:
-  - "BSD License"
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "RDFLib is a Python library for working with RDF, a simple yet powerful\
-    \ language for representing information."
+  description: "RDFLib is a Python library for working with"
   homepage_url: "https://github.com/RDFLib/rdflib"
   binary_artifact:
-    url: "https://files.pythonhosted.org/packages/d0/6b/6454aa1db753c0f8bc265a5bd5c10b5721a4bb24160fb4faf758cf6be8a1/rdflib-5.0.0-py3-none-any.whl"
+    url: ""
     hash:
-      value: "8ad1eb4d67ade138370fb45ce1cb3412"
-      algorithm: "MD5"
+      value: ""
+      algorithm: ""
   source_artifact:
     url: "https://files.pythonhosted.org/packages/2f/ae/a50934a7ed4f9d80bbc0e0cf725c7fd2208f2e433efbf881ed0c0317a7f1/rdflib-5.0.0.tar.gz"
     hash:
-      value: "80d7c6adc2e4040cdd8dade2e0e61403"
-      algorithm: "MD5"
+      value: "78149dd49d385efec3b3adfbd61c87afaf1281c30d3fcaf1b323b34f603fb155"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -169,26 +164,23 @@ packages:
 - id: "PyPI::six:1.16.0"
   purl: "pkg:pypi/six@1.16.0"
   authors:
-  - "Benjamin Peterson"
+  - "Benjamin Peterson <benjamin@python.org>"
   declared_licenses:
   - "MIT"
-  - "MIT License"
   declared_licenses_processed:
     spdx_expression: "MIT"
-    mapped:
-      MIT License: "MIT"
-  description: "Python 2 and 3 compatibility utilities"
+  description: ".. image:: https://img.shields.io/pypi/v/six.svg"
   homepage_url: "https://github.com/benjaminp/six"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
     hash:
-      value: "529d7fd7e14612ccde86417b4402d6f3"
-      algorithm: "MD5"
+      value: "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"
     hash:
-      value: "a7c927740e4964dd29b72cebfc1429bb"
-      algorithm: "MD5"
+      value: "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -34,24 +34,21 @@ packages:
 - id: "PyPI::click:6.7"
   purl: "pkg:pypi/click@6.7"
   authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD License"
-  declared_licenses_processed:
-    unmapped:
-    - "BSD License"
-  description: "A simple wrapper around optparse for powerful command line utilities."
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
   homepage_url: "http://github.com/mitsuhiko/click"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/34/c1/8806f99713ddb993c5366c362b2f908f18269f8d792aff1abfd700775a77/click-6.7-py2.py3-none-any.whl"
     hash:
-      value: "5e7a4e296b3212da2ff11017675d7a4d"
-      algorithm: "MD5"
+      value: "29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/95/d9/c3336b6b5711c3ab9d1d3a80f1a3e2afeb9d8c02a7166462f6cc96570897/click-6.7.tar.gz"
     hash:
-      value: "fc4cc00c4863833230d3af92af48abd4"
-      algorithm: "MD5"
+      value: "f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -65,27 +62,25 @@ packages:
 - id: "PyPI::flask:1.0"
   purl: "pkg:pypi/flask@1.0"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
   - "BSD"
-  - "BSD License"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "A simple framework for building complex web applications."
+  description: "Flask"
   homepage_url: "https://www.palletsprojects.com/p/flask/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/55/b1/4365193655df97227ace49311365cc296e74b60c7f5c63d23cd30175e2f6/Flask-1.0-py2.py3-none-any.whl"
     hash:
-      value: "4c0757a5a489d4db8260c6d722c5e6b0"
-      algorithm: "MD5"
+      value: "b1883637bbee4dc7bc98d900792d0a304d609fce0f5bd9ca91d1b6457e5918dd"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/99/ab/eedb921f26adf7057ade1291f9c1bfa35a506d64894f58546457ef658772/Flask-1.0.tar.gz"
     hash:
-      value: "7140df3116386c7af0f389800a91817b"
-      algorithm: "MD5"
+      value: "7fab1062d11dd0038434e790d18c5b9133fd9e6b7257d707c4578ccc1e38b67c"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -99,25 +94,21 @@ packages:
 - id: "PyPI::itsdangerous:0.24"
   purl: "pkg:pypi/itsdangerous@0.24"
   authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD License"
-  declared_licenses_processed:
-    unmapped:
-    - "BSD License"
-  description: "Various helpers to pass trusted data to untrusted environments and\
-    \ back."
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: "It's Dangerous"
   homepage_url: "http://github.com/mitsuhiko/itsdangerous"
   binary_artifact:
-    url: "https://files.pythonhosted.org/packages/dc/b4/a60bcdba945c00f6d608d8975131ab3f25b22f2bcfe1dab221165194b2d4/itsdangerous-0.24.tar.gz"
+    url: ""
     hash:
-      value: "a3d55aa79369aef5345c036a8a26307f"
-      algorithm: "MD5"
+      value: ""
+      algorithm: ""
   source_artifact:
     url: "https://files.pythonhosted.org/packages/dc/b4/a60bcdba945c00f6d608d8975131ab3f25b22f2bcfe1dab221165194b2d4/itsdangerous-0.24.tar.gz"
     hash:
-      value: "a3d55aa79369aef5345c036a8a26307f"
-      algorithm: "MD5"
+      value: "cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -131,26 +122,23 @@ packages:
 - id: "PyPI::jinja2:2.11.3"
   purl: "pkg:pypi/jinja2@2.11.3"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
-  - "BSD License"
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "A very fast and expressive template engine."
+  description: "Jinja"
   homepage_url: "https://palletsprojects.com/p/jinja/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/7e/c2/1eece8c95ddbc9b1aeb64f5783a9e07a286de42191b7204d67b7496ddf35/Jinja2-2.11.3-py2.py3-none-any.whl"
     hash:
-      value: "8e733c6f4cdef7f6a336299e8e548dfa"
-      algorithm: "MD5"
+      value: "03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/4f/e7/65300e6b32e69768ded990494809106f87da1d436418d5f1367ed3966fd7/Jinja2-2.11.3.tar.gz"
     hash:
-      value: "231dc00d34afb2672c497713fa9cdaaa"
-      algorithm: "MD5"
+      value: "a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -164,27 +152,25 @@ packages:
 - id: "PyPI::markupsafe:1.0"
   purl: "pkg:pypi/markupsafe@1.0"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
   - "BSD"
-  - "BSD License"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "Implements a XML/HTML/XHTML Markup safe string for Python"
+  description: "MarkupSafe"
   homepage_url: "http://github.com/pallets/markupsafe"
   binary_artifact:
-    url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
+    url: ""
     hash:
-      value: "2fcedc9284d50e577b5192e8e3578355"
-      algorithm: "MD5"
+      value: ""
+      algorithm: ""
   source_artifact:
     url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
     hash:
-      value: "2fcedc9284d50e577b5192e8e3578355"
-      algorithm: "MD5"
+      value: "a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -198,26 +184,23 @@ packages:
 - id: "PyPI::werkzeug:0.15.3"
   purl: "pkg:pypi/werkzeug@0.15.3"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
-  - "BSD License"
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "The comprehensive WSGI web application library."
+  description: "Werkzeug"
   homepage_url: "https://palletsprojects.com/p/werkzeug/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/3d/bf/79101bd1d6a2b3fe0888e8d6e039800b173f26b7388308fc4bcc45de8d0a/Werkzeug-0.15.3-py2.py3-none-any.whl"
     hash:
-      value: "5e1e9fb526428fbafe0eccadc2015a5c"
-      algorithm: "MD5"
+      value: "97660b282aa7e29f94f3fe378e5c7162d7ab9d601a8dbb1cbb2ffc8f0e54607d"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/9c/6d/854f2aa124dcfeb901815492b7fa7f026d114a18784c1c679fbdea36c809/Werkzeug-0.15.3.tar.gz"
     hash:
-      value: "2da857b57e7e4c5b6403369a9d1c15a9"
-      algorithm: "MD5"
+      value: "cfd1281b1748288e59762c0e174d64d8bcb2b70e7c57bc4a1203c8825af24ac3"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-python3-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-python3-expected-output.yml
@@ -26,28 +26,26 @@ packages:
 - id: "PyPI::django:2.2.20"
   purl: "pkg:pypi/django@2.2.20"
   authors:
-  - "Django Software Foundation"
+  - "Django Software Foundation <foundation@djangoproject.com>"
   declared_licenses:
   - "BSD"
-  - "BSD License"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "A high-level Python Web framework that encourages rapid development\
-    \ and clean, pragmatic design."
+  description: "Django is a high-level Python Web framework that encourages rapid\
+    \ development"
   homepage_url: "https://www.djangoproject.com/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/b1/88/bd220ea3e4e12c42f2215285cb101d925f95e42b093f390c823e61c94f00/Django-2.2.20-py3-none-any.whl"
     hash:
-      value: "97add963ed8a45386a704b494a8c59a2"
-      algorithm: "MD5"
+      value: "2484f115891ab1a0e9ae153602a641fbc15d7894c036d79fb78662c0965d7954"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/3c/e0/2ab562729727dc25d800134f811f8e15e56fb28c44dfab5222a51b9d2b20/Django-2.2.20.tar.gz"
     hash:
-      value: "947060d96ccc0a05e8049d839e541b25"
-      algorithm: "MD5"
+      value: "2569f9dc5f8e458a5e988b03d6b7a02bda59b006d6782f4ea0fd590ed7336a64"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -61,26 +59,23 @@ packages:
 - id: "PyPI::pytz:2022.4"
   purl: "pkg:pypi/pytz@2022.4"
   authors:
-  - "Stuart Bishop"
+  - "Stuart Bishop <stuart@stuartbishop.net>"
   declared_licenses:
   - "MIT"
-  - "MIT License"
   declared_licenses_processed:
     spdx_expression: "MIT"
-    mapped:
-      MIT License: "MIT"
-  description: "World timezone definitions, modern and historical"
+  description: "pytz - World Timezone Definitions for Python"
   homepage_url: "http://pythonhosted.org/pytz"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/d8/66/309545413162bc8271c73e622499a41cdc37217b499febe26155ff9f93ed/pytz-2022.4-py2.py3-none-any.whl"
     hash:
-      value: "24bcf3f123fd3538b25b96905fc44e00"
-      algorithm: "MD5"
+      value: "2c0784747071402c6e99f0bafdb7da0fa22645f06554c7ae06bf6358897e9c91"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/31/da/2d48d3499b59c7f3c5d5e1c79fcee5537c320c8ab7b7a0cd2db578bc34b3/pytz-2022.4.tar.gz"
     hash:
-      value: "b1d2ed6592bbdf6002ef52b4ab8e2efe"
-      algorithm: "MD5"
+      value: "48ce799d83b6f8aab2020e369b627446696619e79645419610b9facd909b3174"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -94,26 +89,23 @@ packages:
 - id: "PyPI::sqlparse:0.4.3"
   purl: "pkg:pypi/sqlparse@0.4.3"
   authors:
-  - "Andi Albrecht"
+  - "Andi Albrecht <albrecht.andi@gmail.com>"
   declared_licenses:
-  - "BSD License"
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "A non-validating SQL parser."
+  description: "python-sqlparse - Parse SQL statements"
   homepage_url: "https://github.com/andialbrecht/sqlparse"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/97/d3/31dd2c3e48fc2060819f4acb0686248250a0f2326356306b38a42e059144/sqlparse-0.4.3-py3-none-any.whl"
     hash:
-      value: "7f21dd4bc74215d68702b8de53dd92a3"
-      algorithm: "MD5"
+      value: "0323c0ec29cd52bceabc1b4d9d579e311f3e4961b98d174201d5622a23b85e34"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/ba/fa/5b7662b04b69f3a34b8867877e4dbf2a37b7f2a5c0bbb5a9eed64efd1ad1/sqlparse-0.4.3.tar.gz"
     hash:
-      value: "180fb4e11a3f79b119868d7c102d7816"
-      algorithm: "MD5"
+      value: "69ca804846bb114d2ec380e4360a8a340db83f0ccf3afceeb1404df028f57268"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
@@ -30,24 +30,21 @@ packages:
 - id: "PyPI::click:6.7"
   purl: "pkg:pypi/click@6.7"
   authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD License"
-  declared_licenses_processed:
-    unmapped:
-    - "BSD License"
-  description: "A simple wrapper around optparse for powerful command line utilities."
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
   homepage_url: "http://github.com/mitsuhiko/click"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/34/c1/8806f99713ddb993c5366c362b2f908f18269f8d792aff1abfd700775a77/click-6.7-py2.py3-none-any.whl"
     hash:
-      value: "5e7a4e296b3212da2ff11017675d7a4d"
-      algorithm: "MD5"
+      value: "29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/95/d9/c3336b6b5711c3ab9d1d3a80f1a3e2afeb9d8c02a7166462f6cc96570897/click-6.7.tar.gz"
     hash:
-      value: "fc4cc00c4863833230d3af92af48abd4"
-      algorithm: "MD5"
+      value: "f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -61,27 +58,25 @@ packages:
 - id: "PyPI::flask:1.0"
   purl: "pkg:pypi/flask@1.0"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
   - "BSD"
-  - "BSD License"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "A simple framework for building complex web applications."
+  description: "Flask"
   homepage_url: "https://www.palletsprojects.com/p/flask/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/55/b1/4365193655df97227ace49311365cc296e74b60c7f5c63d23cd30175e2f6/Flask-1.0-py2.py3-none-any.whl"
     hash:
-      value: "4c0757a5a489d4db8260c6d722c5e6b0"
-      algorithm: "MD5"
+      value: "b1883637bbee4dc7bc98d900792d0a304d609fce0f5bd9ca91d1b6457e5918dd"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/99/ab/eedb921f26adf7057ade1291f9c1bfa35a506d64894f58546457ef658772/Flask-1.0.tar.gz"
     hash:
-      value: "7140df3116386c7af0f389800a91817b"
-      algorithm: "MD5"
+      value: "7fab1062d11dd0038434e790d18c5b9133fd9e6b7257d707c4578ccc1e38b67c"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -95,25 +90,21 @@ packages:
 - id: "PyPI::itsdangerous:0.24"
   purl: "pkg:pypi/itsdangerous@0.24"
   authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD License"
-  declared_licenses_processed:
-    unmapped:
-    - "BSD License"
-  description: "Various helpers to pass trusted data to untrusted environments and\
-    \ back."
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: "It's Dangerous"
   homepage_url: "http://github.com/mitsuhiko/itsdangerous"
   binary_artifact:
-    url: "https://files.pythonhosted.org/packages/dc/b4/a60bcdba945c00f6d608d8975131ab3f25b22f2bcfe1dab221165194b2d4/itsdangerous-0.24.tar.gz"
+    url: ""
     hash:
-      value: "a3d55aa79369aef5345c036a8a26307f"
-      algorithm: "MD5"
+      value: ""
+      algorithm: ""
   source_artifact:
     url: "https://files.pythonhosted.org/packages/dc/b4/a60bcdba945c00f6d608d8975131ab3f25b22f2bcfe1dab221165194b2d4/itsdangerous-0.24.tar.gz"
     hash:
-      value: "a3d55aa79369aef5345c036a8a26307f"
-      algorithm: "MD5"
+      value: "cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -127,28 +118,25 @@ packages:
 - id: "PyPI::jinja2:2.10.1"
   purl: "pkg:pypi/jinja2@2.10.1"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
   - "BSD"
-  - "BSD License"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "A small but fast and easy to use stand-alone template engine written\
-    \ in pure python."
+  description: "Jinja2"
   homepage_url: "http://jinja.pocoo.org/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/1d/e7/fd8b501e7a6dfe492a433deb7b9d833d39ca74916fa8bc63dd1a4947a671/Jinja2-2.10.1-py2.py3-none-any.whl"
     hash:
-      value: "93ca8152bf9ca03214158a49d542402f"
-      algorithm: "MD5"
+      value: "14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/93/ea/d884a06f8c7f9b7afbc8138b762e80479fb17aedbbe2b06515a12de9378d/Jinja2-2.10.1.tar.gz"
     hash:
-      value: "0ae535be40fd215a8114a090c8b68e5a"
-      algorithm: "MD5"
+      value: "065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -162,27 +150,25 @@ packages:
 - id: "PyPI::markupsafe:1.0"
   purl: "pkg:pypi/markupsafe@1.0"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
   - "BSD"
-  - "BSD License"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "Implements a XML/HTML/XHTML Markup safe string for Python"
+  description: "MarkupSafe"
   homepage_url: "http://github.com/pallets/markupsafe"
   binary_artifact:
-    url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
+    url: ""
     hash:
-      value: "2fcedc9284d50e577b5192e8e3578355"
-      algorithm: "MD5"
+      value: ""
+      algorithm: ""
   source_artifact:
     url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
     hash:
-      value: "2fcedc9284d50e577b5192e8e3578355"
-      algorithm: "MD5"
+      value: "a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -196,26 +182,23 @@ packages:
 - id: "PyPI::werkzeug:0.15.3"
   purl: "pkg:pypi/werkzeug@0.15.3"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
-  - "BSD License"
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "The comprehensive WSGI web application library."
+  description: "Werkzeug"
   homepage_url: "https://palletsprojects.com/p/werkzeug/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/3d/bf/79101bd1d6a2b3fe0888e8d6e039800b173f26b7388308fc4bcc45de8d0a/Werkzeug-0.15.3-py2.py3-none-any.whl"
     hash:
-      value: "5e1e9fb526428fbafe0eccadc2015a5c"
-      algorithm: "MD5"
+      value: "97660b282aa7e29f94f3fe378e5c7162d7ab9d601a8dbb1cbb2ffc8f0e54607d"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/9c/6d/854f2aa124dcfeb901815492b7fa7f026d114a18784c1c679fbdea36c809/Werkzeug-0.15.3.tar.gz"
     hash:
-      value: "2da857b57e7e4c5b6403369a9d1c15a9"
-      algorithm: "MD5"
+      value: "cfd1281b1748288e59762c0e174d64d8bcb2b70e7c57bc4a1203c8825af24ac3"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/pipenv-python3-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pipenv-python3-expected-output.yml
@@ -25,28 +25,26 @@ packages:
 - id: "PyPI::django:2.1.11"
   purl: "pkg:pypi/django@2.1.11"
   authors:
-  - "Django Software Foundation"
+  - "Django Software Foundation <foundation@djangoproject.com>"
   declared_licenses:
   - "BSD"
-  - "BSD License"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "A high-level Python Web framework that encourages rapid development\
-    \ and clean, pragmatic design."
+  description: "Django is a high-level Python Web framework that encourages rapid\
+    \ development"
   homepage_url: "https://www.djangoproject.com/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/8c/49/d5038239995594281478bf209f8d93524ad342d500009a697b27f884668a/Django-2.1.11-py3-none-any.whl"
     hash:
-      value: "5419065b487d22f584ca9d42df971092"
-      algorithm: "MD5"
+      value: "305b6c4fce9e03bb746e35780c2c4d52f29ea1669f15633cfd41bc8821c74c76"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/e0/e9/7e6008abee3eb2a40704c95a5cfc8a9627012df1580289d3df0f34c99766/Django-2.1.11.tar.gz"
     hash:
-      value: "42f0d3ccdcd89c566a30765ee0e25d42"
-      algorithm: "MD5"
+      value: "1a41831eace203fd1939edf899e07d7abd12ce9bafc3d9a5a63a24a8d1d12bd5"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -60,26 +58,23 @@ packages:
 - id: "PyPI::pytz:2019.3"
   purl: "pkg:pypi/pytz@2019.3"
   authors:
-  - "Stuart Bishop"
+  - "Stuart Bishop <stuart@stuartbishop.net>"
   declared_licenses:
   - "MIT"
-  - "MIT License"
   declared_licenses_processed:
     spdx_expression: "MIT"
-    mapped:
-      MIT License: "MIT"
-  description: "World timezone definitions, modern and historical"
+  description: "pytz - World Timezone Definitions for Python"
   homepage_url: "http://pythonhosted.org/pytz"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/e7/f9/f0b53f88060247251bf481fa6ea62cd0d25bf1b11a87888e53ce5b7c8ad2/pytz-2019.3-py2.py3-none-any.whl"
     hash:
-      value: "cb3da4cc0427d718d2478350e0b4b169"
-      algorithm: "MD5"
+      value: "1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/82/c3/534ddba230bd4fbbd3b7a3d35f3341d014cca213f369a9940925e7e5f691/pytz-2019.3.tar.gz"
     hash:
-      value: "c3d84a465fc56a4edd52cca8873ac0df"
-      algorithm: "MD5"
+      value: "b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/poetry-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/poetry-expected-output.yml
@@ -26,26 +26,23 @@ packages:
 - id: "PyPI::graphviz:0.19.1"
   purl: "pkg:pypi/graphviz@0.19.1"
   authors:
-  - "Sebastian Bank"
+  - "Sebastian Bank <sebastian.bank@uni-leipzig.de>"
   declared_licenses:
   - "MIT"
-  - "MIT License"
   declared_licenses_processed:
     spdx_expression: "MIT"
-    mapped:
-      MIT License: "MIT"
-  description: "Simple Python interface for Graphviz"
+  description: "Graphviz"
   homepage_url: "https://github.com/xflr6/graphviz"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/9d/fb/886e8ec7862989afc0c35d15813b6c665fe134cc6027cdde2fa300abe9a2/graphviz-0.19.1-py3-none-any.whl"
     hash:
-      value: "c0e5b8e7497c70c0c4cd83cc8c3bdedf"
-      algorithm: "MD5"
+      value: "f34088c08be2ec16279dfa9c3b4ff3d1453c5c67597a33e2819b000e18d4c546"
+      algorithm: "SHA-256"
   source_artifact:
-    url: "https://files.pythonhosted.org/packages/f6/14/aa3ec10e4ab1524ba69f4742ef9cfa01fd668d0840afe5d5e6f708a95031/graphviz-0.19.1.zip"
+    url: ""
     hash:
-      value: "d89e5ac1159e330aa7455f6fafbcd3ea"
-      algorithm: "MD5"
+      value: ""
+      algorithm: ""
   vcs:
     type: ""
     url: ""
@@ -59,26 +56,23 @@ packages:
 - id: "PyPI::jinja2:3.0.1"
   purl: "pkg:pypi/jinja2@3.0.1"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
-  - "BSD License"
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "A very fast and expressive template engine."
+  description: "Jinja"
   homepage_url: "https://palletsprojects.com/p/jinja/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/80/21/ae597efc7ed8caaa43fb35062288baaf99a7d43ff0cf66452ddf47604ee6/Jinja2-3.0.1-py3-none-any.whl"
     hash:
-      value: "b377af8123a32e992984222bff51e152"
-      algorithm: "MD5"
+      value: "1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/39/11/8076571afd97303dfeb6e466f27187ca4970918d4b36d5326725514d3ed3/Jinja2-3.0.1.tar.gz"
     hash:
-      value: "25ba6ef98c164878acff1036fbd72a1d"
-      algorithm: "MD5"
+      value: "703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -92,26 +86,23 @@ packages:
 - id: "PyPI::markupsafe:2.0.1"
   purl: "pkg:pypi/markupsafe@2.0.1"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
-  - "BSD License"
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "Safely add untrusted strings to HTML/XML markup."
+  description: "MarkupSafe"
   homepage_url: "https://palletsprojects.com/p/markupsafe/"
   binary_artifact:
-    url: "https://files.pythonhosted.org/packages/81/8b/f28eac2790d49dde61f89ae9e007ac65002edc90bb2dd63c3b9e653820d2/MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl"
+    url: "https://files.pythonhosted.org/packages/53/e8/601efa63c4058311a8bda7984a2fe554b9da574044967d7aee253661ee46/MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
     hash:
-      value: "f42b3feff99f5f5f0fa9637d2e790288"
-      algorithm: "MD5"
+      value: "168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/bf/10/ff66fea6d1788c458663a84d88787bae15d45daa16f6b3ef33322a51fc7e/MarkupSafe-2.0.1.tar.gz"
     hash:
-      value: "892e0fefa3c488387e5cc0cad2daa523"
-      algorithm: "MD5"
+      value: "594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/python-inspector-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/python-inspector-expected-output.yml
@@ -30,24 +30,21 @@ packages:
 - id: "PyPI::click:6.7"
   purl: "pkg:pypi/click@6.7"
   authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD License"
-  declared_licenses_processed:
-    unmapped:
-    - "BSD License"
-  description: "A simple wrapper around optparse for powerful command line utilities."
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: ""
   homepage_url: "http://github.com/mitsuhiko/click"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/34/c1/8806f99713ddb993c5366c362b2f908f18269f8d792aff1abfd700775a77/click-6.7-py2.py3-none-any.whl"
     hash:
-      value: "5e7a4e296b3212da2ff11017675d7a4d"
-      algorithm: "MD5"
+      value: "29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/95/d9/c3336b6b5711c3ab9d1d3a80f1a3e2afeb9d8c02a7166462f6cc96570897/click-6.7.tar.gz"
     hash:
-      value: "fc4cc00c4863833230d3af92af48abd4"
-      algorithm: "MD5"
+      value: "f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -61,27 +58,25 @@ packages:
 - id: "PyPI::flask:1.0"
   purl: "pkg:pypi/flask@1.0"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
   - "BSD"
-  - "BSD License"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "A simple framework for building complex web applications."
+  description: "Flask"
   homepage_url: "https://www.palletsprojects.com/p/flask/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/55/b1/4365193655df97227ace49311365cc296e74b60c7f5c63d23cd30175e2f6/Flask-1.0-py2.py3-none-any.whl"
     hash:
-      value: "4c0757a5a489d4db8260c6d722c5e6b0"
-      algorithm: "MD5"
+      value: "b1883637bbee4dc7bc98d900792d0a304d609fce0f5bd9ca91d1b6457e5918dd"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/99/ab/eedb921f26adf7057ade1291f9c1bfa35a506d64894f58546457ef658772/Flask-1.0.tar.gz"
     hash:
-      value: "7140df3116386c7af0f389800a91817b"
-      algorithm: "MD5"
+      value: "7fab1062d11dd0038434e790d18c5b9133fd9e6b7257d707c4578ccc1e38b67c"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -95,25 +90,21 @@ packages:
 - id: "PyPI::itsdangerous:0.24"
   purl: "pkg:pypi/itsdangerous@0.24"
   authors:
-  - "Armin Ronacher"
-  declared_licenses:
-  - "BSD License"
-  declared_licenses_processed:
-    unmapped:
-    - "BSD License"
-  description: "Various helpers to pass trusted data to untrusted environments and\
-    \ back."
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  description: "It's Dangerous"
   homepage_url: "http://github.com/mitsuhiko/itsdangerous"
   binary_artifact:
-    url: "https://files.pythonhosted.org/packages/dc/b4/a60bcdba945c00f6d608d8975131ab3f25b22f2bcfe1dab221165194b2d4/itsdangerous-0.24.tar.gz"
+    url: ""
     hash:
-      value: "a3d55aa79369aef5345c036a8a26307f"
-      algorithm: "MD5"
+      value: ""
+      algorithm: ""
   source_artifact:
     url: "https://files.pythonhosted.org/packages/dc/b4/a60bcdba945c00f6d608d8975131ab3f25b22f2bcfe1dab221165194b2d4/itsdangerous-0.24.tar.gz"
     hash:
-      value: "a3d55aa79369aef5345c036a8a26307f"
-      algorithm: "MD5"
+      value: "cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -127,26 +118,23 @@ packages:
 - id: "PyPI::jinja2:2.11.3"
   purl: "pkg:pypi/jinja2@2.11.3"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
-  - "BSD License"
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "A very fast and expressive template engine."
+  description: "Jinja"
   homepage_url: "https://palletsprojects.com/p/jinja/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/7e/c2/1eece8c95ddbc9b1aeb64f5783a9e07a286de42191b7204d67b7496ddf35/Jinja2-2.11.3-py2.py3-none-any.whl"
     hash:
-      value: "8e733c6f4cdef7f6a336299e8e548dfa"
-      algorithm: "MD5"
+      value: "03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/4f/e7/65300e6b32e69768ded990494809106f87da1d436418d5f1367ed3966fd7/Jinja2-2.11.3.tar.gz"
     hash:
-      value: "231dc00d34afb2672c497713fa9cdaaa"
-      algorithm: "MD5"
+      value: "a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -160,27 +148,25 @@ packages:
 - id: "PyPI::markupsafe:1.0"
   purl: "pkg:pypi/markupsafe@1.0"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
   - "BSD"
-  - "BSD License"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
     mapped:
       BSD: "BSD-3-Clause"
-      BSD License: "BSD-3-Clause"
-  description: "Implements a XML/HTML/XHTML Markup safe string for Python"
+  description: "MarkupSafe"
   homepage_url: "http://github.com/pallets/markupsafe"
   binary_artifact:
-    url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
+    url: ""
     hash:
-      value: "2fcedc9284d50e577b5192e8e3578355"
-      algorithm: "MD5"
+      value: ""
+      algorithm: ""
   source_artifact:
     url: "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
     hash:
-      value: "2fcedc9284d50e577b5192e8e3578355"
-      algorithm: "MD5"
+      value: "a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""
@@ -194,26 +180,23 @@ packages:
 - id: "PyPI::werkzeug:0.15.3"
   purl: "pkg:pypi/werkzeug@0.15.3"
   authors:
-  - "Armin Ronacher"
+  - "Armin Ronacher <armin.ronacher@active-4.com>"
   declared_licenses:
-  - "BSD License"
   - "BSD-3-Clause"
   declared_licenses_processed:
     spdx_expression: "BSD-3-Clause"
-    mapped:
-      BSD License: "BSD-3-Clause"
-  description: "The comprehensive WSGI web application library."
+  description: "Werkzeug"
   homepage_url: "https://palletsprojects.com/p/werkzeug/"
   binary_artifact:
     url: "https://files.pythonhosted.org/packages/3d/bf/79101bd1d6a2b3fe0888e8d6e039800b173f26b7388308fc4bcc45de8d0a/Werkzeug-0.15.3-py2.py3-none-any.whl"
     hash:
-      value: "5e1e9fb526428fbafe0eccadc2015a5c"
-      algorithm: "MD5"
+      value: "97660b282aa7e29f94f3fe378e5c7162d7ab9d601a8dbb1cbb2ffc8f0e54607d"
+      algorithm: "SHA-256"
   source_artifact:
     url: "https://files.pythonhosted.org/packages/9c/6d/854f2aa124dcfeb901815492b7fa7f026d114a18784c1c679fbdea36c809/Werkzeug-0.15.3.tar.gz"
     hash:
-      value: "2da857b57e7e4c5b6403369a9d1c15a9"
-      algorithm: "MD5"
+      value: "cfd1281b1748288e59762c0e174d64d8bcb2b70e7c57bc4a1203c8825af24ac3"
+      algorithm: "SHA-256"
   vcs:
     type: ""
     url: ""

--- a/analyzer/src/funTest/kotlin/managers/PipFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PipFunTest.kt
@@ -26,6 +26,7 @@ import java.io.File
 
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
+import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
@@ -42,7 +43,7 @@ class PipFunTest : WordSpec({
         "resolve setup.py dependencies correctly for spdx-tools-python" {
             val definitionFile = projectsDir.resolve("external/spdx-tools-python/setup.py")
 
-            val result = createPip().resolveSingleProject(definitionFile)
+            val result = createPip(pythonVersion = "2.7").resolveSingleProject(definitionFile)
             val expectedResult = projectsDir.resolve("external/spdx-tools-python-expected-output.yml").readText()
 
             result.toYaml() shouldBe expectedResult
@@ -59,7 +60,7 @@ class PipFunTest : WordSpec({
                 path = vcsPath
             )
 
-            val result = createPip().resolveSingleProject(definitionFile)
+            val result = createPip(pythonVersion = "2.7").resolveSingleProject(definitionFile)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -116,4 +117,14 @@ class PipFunTest : WordSpec({
     }
 })
 
-private fun createPip() = Pip("PIP", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())
+private fun createPip(pythonVersion: String = "3.10") =
+    Pip("PIP", USER_DIR, createAnalyzerConfiguration(pythonVersion), RepositoryConfiguration())
+
+private fun createAnalyzerConfiguration(pythonVersion: String) =
+    AnalyzerConfiguration(
+        packageManagers = mapOf(
+            Pip.Factory().managerName to PackageManagerConfiguration(
+                options = mapOf("pythonVersion" to pythonVersion)
+            )
+        )
+    )

--- a/analyzer/src/funTest/kotlin/managers/utils/PythonInspectorFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/utils/PythonInspectorFunTest.kt
@@ -25,38 +25,23 @@ import io.kotest.matchers.should
 
 import java.io.File
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.decodeFromStream
-
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
-import org.ossreviewtoolkit.utils.test.createSpecTempDir
 
 class PythonInspectorFunTest : StringSpec({
     val projectsDir = File("src/funTest/assets/projects").absoluteFile
-    val json = Json { ignoreUnknownKeys = true }
 
     "python-inspector output can be deserialized" {
         val definitionFile = projectsDir.resolve("synthetic/pip/requirements.txt")
         val workingDir = definitionFile.parentFile
-        val outputFile = createSpecTempDir().resolve("python-inspector.json")
 
-        try {
+        val result = try {
             PythonInspector.run(
                 workingDir = workingDir,
-                outputFile = outputFile.absolutePath,
                 definitionFile = definitionFile,
                 pythonVersion = "27"
             )
         } finally {
             workingDir.resolve(".cache").safeDeleteRecursively(force = true)
-        }
-
-        val result = withContext(Dispatchers.IO) {
-            outputFile.inputStream().use {
-                json.decodeFromStream<PythonInspectorResult>(it)
-            }
         }
 
         result.resolvedDependencies should haveSize(1)

--- a/analyzer/src/funTest/kotlin/managers/utils/PythonInspectorFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/utils/PythonInspectorFunTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers.utils
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.haveSize
+import io.kotest.matchers.should
+
+import java.io.File
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+
+import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
+import org.ossreviewtoolkit.utils.test.createSpecTempDir
+
+class PythonInspectorFunTest : StringSpec({
+    val projectsDir = File("src/funTest/assets/projects").absoluteFile
+    val json = Json { ignoreUnknownKeys = true }
+
+    "python-inspector output can be deserialized" {
+        val definitionFile = projectsDir.resolve("synthetic/pip/requirements.txt")
+        val workingDir = definitionFile.parentFile
+        val outputFile = createSpecTempDir().resolve("python-inspector.json")
+
+        try {
+            PythonInspector.run(
+                workingDir = workingDir,
+                outputFile = outputFile.absolutePath,
+                definitionFile = definitionFile,
+                pythonVersion = "27"
+            )
+        } finally {
+            workingDir.resolve(".cache").safeDeleteRecursively(force = true)
+        }
+
+        val result = withContext(Dispatchers.IO) {
+            outputFile.inputStream().use {
+                json.decodeFromStream<PythonInspectorResult>(it)
+            }
+        }
+
+        result.resolvedDependencies should haveSize(1)
+        result.packages should haveSize(10)
+    }
+})

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -42,6 +42,7 @@ import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
+import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
@@ -200,6 +201,11 @@ abstract class PackageManager(
             return vcsFromWorkingTree.merge(processPackageVcs(vcsFromProject, *fallbackUrls))
         }
     }
+
+    /**
+     * The [Options] from the [PackageManagerConfiguration] for this [package manager][managerName].
+     */
+    protected val options: Options = analyzerConfig.getPackageManagerConfiguration(managerName)?.options.orEmpty()
 
     /**
      * Optional mapping of found [definitionFiles] before dependency resolution.

--- a/analyzer/src/main/kotlin/managers/DotNet.kt
+++ b/analyzer/src/main/kotlin/managers/DotNet.kt
@@ -62,9 +62,7 @@ class DotNet(
         ) = DotNet(managerName, analysisRoot, analyzerConfig, repoConfig)
     }
 
-    private val directDependenciesOnly =
-        analyzerConfig.getPackageManagerConfiguration(managerName)?.options?.get(OPTION_DIRECT_DEPENDENCIES_ONLY)
-            .toBoolean()
+    private val directDependenciesOnly = options[OPTION_DIRECT_DEPENDENCIES_ONLY].toBoolean()
 
     private val reader = DotNetPackageFileReader()
 

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -109,9 +109,7 @@ open class Npm(
         ) = Npm(managerName, analysisRoot, analyzerConfig, repoConfig)
     }
 
-    private val legacyPeerDeps =
-        analyzerConfig.getPackageManagerConfiguration(managerName)?.options?.get(OPTION_LEGACY_PEER_DEPS)
-            .toBoolean()
+    private val legacyPeerDeps = options[OPTION_LEGACY_PEER_DEPS].toBoolean()
 
     private val graphBuilder = DependencyGraphBuilder(NpmDependencyHandler(this))
 

--- a/analyzer/src/main/kotlin/managers/NuGet.kt
+++ b/analyzer/src/main/kotlin/managers/NuGet.kt
@@ -61,9 +61,7 @@ class NuGet(
         ) = NuGet(managerName, analysisRoot, analyzerConfig, repoConfig)
     }
 
-    private val directDependenciesOnly =
-        analyzerConfig.getPackageManagerConfiguration(managerName)?.options?.get(OPTION_DIRECT_DEPENDENCIES_ONLY)
-            .toBoolean()
+    private val directDependenciesOnly = options[OPTION_DIRECT_DEPENDENCIES_ONLY].toBoolean()
 
     private val reader = NuGetPackageFileReader()
 

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.kotlin.Logging
 
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
+import org.ossreviewtoolkit.analyzer.managers.utils.PythonInspector
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
@@ -134,41 +135,6 @@ object PythonVersion : CommandLineTool, Logging {
         } else {
             Os.getPathFromEnvironment("python$version")?.path
         }
-}
-
-object PythonInspector : CommandLineTool {
-    override fun command(workingDir: File?) = "python-inspector"
-
-    override fun transformVersion(output: String) = output.removePrefix("Python-inspector version: ")
-
-    override fun getVersionRequirement(): Requirement = Requirement.buildIvy("[0.7.1,)")
-
-    fun run(
-        workingDir: File,
-        outputFile: String,
-        definitionFile: File,
-        pythonVersion: String = "38",
-    ): ProcessCapture {
-        val commandLineOptions = buildList {
-            add("--python-version")
-            add(pythonVersion)
-
-            add("--json-pdt")
-            add(outputFile)
-
-            add("--analyze-setup-py-insecurely")
-
-            if (definitionFile.name == "setup.py") {
-                add("--setup-py")
-            } else {
-                add("--requirement")
-            }
-
-            add(definitionFile.absolutePath)
-        }
-
-        return run(workingDir, *commandLineOptions.toTypedArray())
-    }
 }
 
 /**

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -110,7 +110,7 @@ class Pip(
         // 1. Get metadata about the local project via `python setup.py`.
         // 2. Get the dependency tree and dependency metadata via python-inspector.
 
-        val project = getProjectBasics(definitionFile)
+        val project = getProjectMetadata(definitionFile)
         val (packages, installDependencies) = getInstallDependencies(definitionFile)
 
         // TODO: Handle "extras" and "tests" dependencies.
@@ -121,7 +121,7 @@ class Pip(
         return listOf(ProjectAnalyzerResult(project.copy(scopeDependencies = scopes), packages))
     }
 
-    private fun getProjectBasics(definitionFile: File): Project {
+    private fun getProjectMetadata(definitionFile: File): Project {
         val authors = sortedSetOf<String>()
         val declaredLicenses = sortedSetOf<String>()
 

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -111,7 +111,7 @@ class Pip(
         // 2. Get the dependency tree and dependency metadata via python-inspector.
 
         val project = getProjectMetadata(definitionFile)
-        val (packages, installDependencies) = getInstallDependencies(definitionFile)
+        val (packages, installDependencies) = runPythonInspector(definitionFile)
 
         // TODO: Handle "extras" and "tests" dependencies.
         val scopes = sortedSetOf(
@@ -202,7 +202,7 @@ class Pip(
         )
     }
 
-    private fun getInstallDependencies(definitionFile: File): Pair<SortedSet<Package>, SortedSet<PackageReference>> {
+    private fun runPythonInspector(definitionFile: File): Pair<SortedSet<Package>, SortedSet<PackageReference>> {
         val workingDir = definitionFile.parentFile
 
         logger.info {

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -76,7 +76,7 @@ class Pip(
     analysisRoot: File,
     analyzerConfig: AnalyzerConfiguration,
     repoConfig: RepositoryConfiguration
-) : PackageManager(name, analysisRoot, analyzerConfig, repoConfig), CommandLineTool {
+) : PackageManager(name, analysisRoot, analyzerConfig, repoConfig) {
     companion object : Logging {
         private const val SHORT_STRING_MAX_CHARS = 200
     }
@@ -104,10 +104,6 @@ class Pip(
                 "The 'pythonVersion' option must be one of ${PYTHON_VERSIONS.joinToString { "'$it'" }}."
             }
         }
-
-    override fun command(workingDir: File?) = "pip"
-
-    override fun transformVersion(output: String) = output.removePrefix("pip ").substringBefore(' ')
 
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {
         // For an overview, dependency resolution involves the following steps:

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -105,10 +105,6 @@ class Pip(
         }
 
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {
-        // For an overview, dependency resolution involves the following steps:
-        // 1. Get metadata about the local project via `python setup.py`.
-        // 2. Get the dependency tree and dependency metadata via python-inspector.
-
         val project = getProjectMetadata(definitionFile)
         val result = runPythonInspector(definitionFile)
 

--- a/analyzer/src/main/kotlin/managers/Yarn2.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn2.kt
@@ -135,10 +135,8 @@ class Yarn2(
      */
     private val yarn2ExecutablesByPath: MutableMap<File, String> = mutableMapOf()
 
-    private val disableRegistryCertificateVerification = analyzerConfig.getPackageManagerConfiguration(managerName)
-        ?.options
-        ?.get(OPTION_DISABLE_REGISTRY_CERTIFICATE_VERIFICATION)
-        .toBoolean()
+    private val disableRegistryCertificateVerification =
+        options[OPTION_DISABLE_REGISTRY_CERTIFICATE_VERIFICATION].toBoolean()
 
     // A builder to build the dependency graph of the project.
     private val graphBuilder = DependencyGraphBuilder(Yarn2DependencyHandler())

--- a/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
+++ b/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
@@ -23,6 +23,9 @@ import com.vdurmont.semver4j.Requirement
 
 import java.io.File
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.ProcessCapture
 
@@ -60,3 +63,53 @@ internal object PythonInspector : CommandLineTool {
         return run(workingDir, *commandLineOptions.toTypedArray())
     }
 }
+
+@Serializable
+internal data class PythonInspectorResult(
+    @SerialName("resolved_dependencies") val resolvedDependencies: List<PythonInspectorResolvedDependency>,
+    val packages: List<PythonInspectorPackage>
+)
+
+@Serializable
+internal data class PythonInspectorResolvedDependency(
+    val key: String,
+    @SerialName("package_name") val packageName: String,
+    @SerialName("installed_version") val installedVersion: String,
+    val dependencies: List<PythonInspectorResolvedDependency>
+)
+
+@Serializable
+internal data class PythonInspectorPackage(
+    val type: String,
+    val namespace: String?,
+    val name: String,
+    val version: String,
+    val description: String,
+    val parties: List<PythonInspectorParty>,
+    @SerialName("homepage_url") val homepageUrl: String,
+    @SerialName("download_url") val downloadUrl: String,
+    val size: Long,
+    val sha1: String?,
+    val md5: String?,
+    val sha256: String?,
+    val sha512: String?,
+    @SerialName("code_view_url") val codeViewUrl: String?,
+    @SerialName("vcs_url") val vcsUrl: String?,
+    val copyright: String?,
+    @SerialName("license_expression") val licenseExpression: String?,
+    @SerialName("declared_license") val declaredLicense: String,
+    @SerialName("source_packages") val sourcePackages: List<String>,
+    @SerialName("repository_homepage_url") val repositoryHomepageUrl: String?,
+    @SerialName("repository_download_url") val repositoryDownloadUrl: String?,
+    @SerialName("api_data_url") val apiDataUrl: String,
+    val purl: String
+)
+
+@Serializable
+internal class PythonInspectorParty(
+    val type: String,
+    val role: String,
+    val name: String?,
+    val email: String?,
+    val url: String?
+)

--- a/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
+++ b/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers.utils
+
+import com.vdurmont.semver4j.Requirement
+
+import java.io.File
+
+import org.ossreviewtoolkit.utils.common.CommandLineTool
+import org.ossreviewtoolkit.utils.common.ProcessCapture
+
+object PythonInspector : CommandLineTool {
+    override fun command(workingDir: File?) = "python-inspector"
+
+    override fun transformVersion(output: String) = output.removePrefix("Python-inspector version: ")
+
+    override fun getVersionRequirement(): Requirement = Requirement.buildIvy("[0.7.1,)")
+
+    fun run(
+        workingDir: File,
+        outputFile: String,
+        definitionFile: File,
+        pythonVersion: String = "38",
+    ): ProcessCapture {
+        val commandLineOptions = buildList {
+            add("--python-version")
+            add(pythonVersion)
+
+            add("--json-pdt")
+            add(outputFile)
+
+            add("--analyze-setup-py-insecurely")
+
+            if (definitionFile.name == "setup.py") {
+                add("--setup-py")
+            } else {
+                add("--requirement")
+            }
+
+            add(definitionFile.absolutePath)
+        }
+
+        return run(workingDir, *commandLineOptions.toTypedArray())
+    }
+}

--- a/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
+++ b/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
@@ -53,12 +53,16 @@ internal object PythonInspector : CommandLineTool {
         workingDir: File,
         definitionFile: File,
         pythonVersion: String = "38",
+        operatingSystem: String = "linux"
     ): PythonInspectorResult {
         val outputFile = createOrtTempFile(prefix = "python-inspector", suffix = ".json")
 
         val commandLineOptions = buildList {
             add("--python-version")
             add(pythonVersion)
+
+            add("--operating-system")
+            add(operatingSystem)
 
             add("--json-pdt")
             add(outputFile.absolutePath)

--- a/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
+++ b/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
@@ -26,7 +26,7 @@ import java.io.File
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.ProcessCapture
 
-object PythonInspector : CommandLineTool {
+internal object PythonInspector : CommandLineTool {
     override fun command(workingDir: File?) = "python-inspector"
 
     override fun transformVersion(output: String) = output.removePrefix("Python-inspector version: ")


### PR DESCRIPTION
Get the metadata of Python packages from the python-inspector output. There are two follow-ups for this PR planned:

* Change the default values for `operatingSystem` and `pythonVersion` to use the current operating system and the installed Python version.
* Update the Dockerfile with the new reduced requirements for the Python installation.