### PR TITLE
Gracefully handle nested provenance resolution failures

### DIFF
--- a/scanner/src/main/kotlin/ScanController.kt
+++ b/scanner/src/main/kotlin/ScanController.kt
@@ -21,6 +21,8 @@ package org.ossreviewtoolkit.scanner
 
 import java.time.Instant
 
+import org.apache.logging.log4j.kotlin.Logging
+
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.OrtIssue
@@ -54,6 +56,8 @@ class ScanController(
      */
     val config: ScannerConfiguration
 ) {
+    companion object : Logging
+
     /**
      * A map of package [Identifier]s to a list of [OrtIssue]s that occurred during provenance resolution for the
      * respective package.
@@ -89,10 +93,14 @@ class ScanController(
     private val scanResults = mutableMapOf<ScannerWrapper, MutableMap<KnownProvenance, MutableList<ScanResult>>>()
 
     fun addProvenanceResolutionIssue(id: Identifier, issue: OrtIssue) {
+        logger.log(issue.severity.toLog4jLevel()) { issue.message }
+
         provenanceResolutionIssues.getOrPut(id) { mutableListOf() } += issue
     }
 
     fun addIssue(id: Identifier, issue: OrtIssue) {
+        logger.log(issue.severity.toLog4jLevel()) { issue.message }
+
         issues.getOrPut(id) { mutableListOf() } += issue
     }
 

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -228,6 +228,9 @@ class Scanner(
                             )
                         )
                     }
+
+                    // If resolving the nested repositories failed, we can still scan the main repository.
+                    controller.addNestedProvenance(provenance, NestedProvenance(provenance, emptyMap()))
                 }
             }
         }


### PR DESCRIPTION
Add a fallback so that an assumption in the code holds in additional cases, where that assumption lead to a crash before.

See individual commits.