### PR TITLE
docs/config-file-ort-yml.md: Update a link for the glob patterns

### DIFF
--- a/docs/config-file-ort-yml.md
+++ b/docs/config-file-ort-yml.md
@@ -61,8 +61,8 @@ excludes:
 
 Where the list of available options for `reason` is defined in
 [PathExcludeReason.kt](../model/src/main/kotlin/config/PathExcludeReason.kt).
-For how to write a glob pattern, please see this
-[tutorial](https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob).
+For how to write a glob pattern, please see the
+[AntPathMatcher documentation](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/util/AntPathMatcher.html).
 
 The path exclude above has the following effects:
 


### PR DESCRIPTION
As the implementation has been changed to use `AntPathMatcher` instead of `Java`'s path matcher, align also the link to the documentation, see also https://github.com/oss-review-toolkit/ort/pull/5907.

Relates to #5901.
