### PR TITLE
model: Align the `hasIssues` implementations

### DIFF
--- a/model/src/main/kotlin/AdvisorRecord.kt
+++ b/model/src/main/kotlin/AdvisorRecord.kt
@@ -84,11 +84,7 @@ data class AdvisorRecord(
     /**
      * True if any of the [advisorResults] contain [OrtIssue]s.
      */
-    val hasIssues by lazy {
-        advisorResults.any { (_, results) ->
-            results.any { it.summary.issues.isNotEmpty() }
-        }
-    }
+    val hasIssues by lazy { collectIssues().isNotEmpty() }
 
     /**
      * Return a map of all [Package]s and the associated [Vulnerabilities][Vulnerability].

--- a/model/src/main/kotlin/ScanRecord.kt
+++ b/model/src/main/kotlin/ScanRecord.kt
@@ -58,9 +58,5 @@ data class ScanRecord(
     /**
      * True if any of the [scanResults] contain [OrtIssue]s.
      */
-    val hasIssues by lazy {
-        scanResults.any { (_, results) ->
-            results.any { it.summary.issues.isNotEmpty() }
-        }
-    }
+    val hasIssues by lazy { collectIssues().isNotEmpty() }
 }


### PR DESCRIPTION
Align the implementations in `AdvisorRecord` and `ScanRecord` with the (less redundant) one in `AnalyzerResult`.

Part of #5681.