### PR TITLE
DefaultPackageProvenanceResolver: Improve error reporting

### DIFF
--- a/scanner/src/main/kotlin/provenance/PackageProvenanceResolver.kt
+++ b/scanner/src/main/kotlin/provenance/PackageProvenanceResolver.kt
@@ -218,7 +218,7 @@ class DefaultPackageProvenanceResolver(
 
             if (revisionCandidates.isEmpty()) {
                 addAndLogMessage(
-                    "Could not find any revision candidates for package '${pkg.id.toCoordinates()}' with VCS " +
+                    "Could not find any revision candidates for package '${pkg.id.toCoordinates()}' with " +
                             "${pkg.vcsProcessed}."
                 )
             }
@@ -262,7 +262,7 @@ class DefaultPackageProvenanceResolver(
                 }
             }
 
-            val message = "Could not resolve revision for package '${pkg.id.toCoordinates()}' with VCS " +
+            val message = "Could not resolve revision for package '${pkg.id.toCoordinates()}' with " +
                     "${pkg.vcsProcessed}:\n${messages.joinToString("\n") { "\t$it" }}"
 
             storage.putProvenance(pkg.id, pkg.vcsProcessed, UnresolvedPackageProvenance(message))


### PR DESCRIPTION
Add the reasons why revision candidates could not be resolved to the exception that is thrown if no revision could be resolved. This ensures that these reasons do not only appear in the log output but also in the `OrtIssue` which will be added to the reports.