### PR TITLE
Add encoding to FossId credentials in URL mappings

### DIFF
--- a/cli/src/main/resources/logback.xml
+++ b/cli/src/main/resources/logback.xml
@@ -36,4 +36,5 @@
     <logger name="org.ossreviewtoolkit.reporter.reporters.fossid.FossIdReporter" level="INFO" />
     <logger name="org.ossreviewtoolkit.scanner.scanners.fossid.FossId" level="INFO" />
     <logger name="org.ossreviewtoolkit.scanner.scanners.fossid.FossIdConfig" level="INFO" />
+    <logger name="org.ossreviewtoolkit.scanner.scanners.fossid.FossIdUrlProvider" level="INFO" />
 </configuration>

--- a/helper-cli/src/main/resources/logback.xml
+++ b/helper-cli/src/main/resources/logback.xml
@@ -36,4 +36,5 @@
     <logger name="org.ossreviewtoolkit.reporter.reporters.fossid.FossIdReporter" level="INFO" />
     <logger name="org.ossreviewtoolkit.scanner.scanners.fossid.FossId" level="INFO" />
     <logger name="org.ossreviewtoolkit.scanner.scanners.fossid.FossIdConfig" level="INFO" />
+    <logger name="org.ossreviewtoolkit.scanner.scanners.fossid.FossIdUrlProvider" level="INFO" />
 </configuration>

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdUrlProvider.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdUrlProvider.kt
@@ -66,7 +66,14 @@ internal class FossIdUrlProvider private constructor(
          */
         fun create(
             urlMapping: Collection<String> = emptyList()
-        ): FossIdUrlProvider = FossIdUrlProvider(urlMapping.toRegexMapping())
+        ): FossIdUrlProvider {
+            val mappings = urlMapping.toRegexMapping()
+            mappings.forEach {
+                logger.info { "Mapping ${it.key} -> ${it.value}." }
+            }
+
+            return FossIdUrlProvider(mappings)
+        }
 
         /**
          * Create a new instance of [FossIdUrlProvider] and configure the URL mappings from the given configuration
@@ -144,8 +151,12 @@ internal class FossIdUrlProvider private constructor(
             if (replaced != repoUrl) {
                 logger.info { "URL mapping applied to $repoUrl: Mapped to $replaced." }
                 return replaceVariables(replaced)
+            } else {
+                logger.debug { "Mapping $regex did not match." }
             }
         }
+
+        logger.info { "No matching URL mapping could be found for '$repoUrl'." }
 
         return repoUrl
     }

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdUrlProvider.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdUrlProvider.kt
@@ -24,6 +24,7 @@ import java.net.PasswordAuthentication
 
 import org.apache.logging.log4j.kotlin.Logging
 
+import org.ossreviewtoolkit.utils.common.percentEncode
 import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.common.toUri
 import org.ossreviewtoolkit.utils.ort.requestPasswordAuthentication
@@ -112,7 +113,8 @@ internal class FossIdUrlProvider private constructor(
          * Replace the variables related to credentials with the values in [auth].
          */
         private fun String.insertCredentials(auth: PasswordAuthentication): String =
-            replace(VAR_USERNAME, auth.userName).replace(VAR_PASSWORD, String(auth.password))
+            replace(VAR_USERNAME, auth.userName.percentEncode())
+                .replace(VAR_PASSWORD, String(auth.password).percentEncode())
 
         /**
          * Construct a URL mapping from the elements in this [Collection]. The resulting [Map] contains regular

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdUrlProviderTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdUrlProviderTest.kt
@@ -28,6 +28,7 @@ import io.mockk.mockkStatic
 import java.net.PasswordAuthentication
 import java.net.URI
 
+import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.ort.requestPasswordAuthentication
 
 class FossIdUrlProviderTest : StringSpec({
@@ -78,6 +79,20 @@ class FossIdUrlProviderTest : StringSpec({
         val expectedUrl = "https://$USER:$PASSWORD@$otherHost:$PORT/$PATH"
         val urlMapping = listOf("$regex  ->  $replace", "foo -> bar")
         mockAuthenticator(host = otherHost)
+
+        val urlProvider = FossIdUrlProvider.create(urlMapping)
+        val url = urlProvider.getUrl(REPO_URL)
+
+        url shouldBe expectedUrl
+    }
+
+    "URL encoding should be applied for credentials" {
+        val username = "test/user"
+        val password = "se#@et?boh"
+        val auth = PasswordAuthentication(username, password.toCharArray())
+        val expectedUrl = REPO_URL.replaceCredentialsInUri("$username:$password")
+        val urlMapping = listOf(ADD_CREDENTIALS_MAPPING)
+        mockAuthenticator(authentication = auth)
 
         val urlProvider = FossIdUrlProvider.create(urlMapping)
         val url = urlProvider.getUrl(REPO_URL)


### PR DESCRIPTION
Refer to the single commits for further details.