### PR TITLE
Introduce and use `ScanSummary.EMPTY`

### DIFF
--- a/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
+++ b/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
@@ -23,7 +23,6 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
 import java.io.File
-import java.time.Instant
 
 import org.ossreviewtoolkit.model.AccessStatistics
 import org.ossreviewtoolkit.model.AnalyzerResult
@@ -227,11 +226,8 @@ private fun createOrtResult(
                         ScanResult(
                             provenance = RepositoryProvenance(vcsInfo, vcsInfo.revision),
                             scanner = ScannerDetails.EMPTY,
-                            summary = ScanSummary(
+                            summary = ScanSummary.EMPTY.copy(
                                 licenseFindings = licenseFindings,
-                                copyrightFindings = sortedSetOf(),
-                                startTime = Instant.EPOCH,
-                                endTime = Instant.EPOCH,
                                 packageVerificationCode = "0000000000000000000000000000000000000000"
                             )
                         )

--- a/evaluator/src/test/kotlin/TestData.kt
+++ b/evaluator/src/test/kotlin/TestData.kt
@@ -265,15 +265,11 @@ val ortResult = OrtResult(
                     ScanResult(
                         provenance = UnknownProvenance,
                         scanner = ScannerDetails.EMPTY,
-                        summary = ScanSummary(
-                            startTime = Instant.EPOCH,
-                            endTime = Instant.EPOCH,
-                            packageVerificationCode = "",
+                        summary = ScanSummary.EMPTY.copy(
                             licenseFindings = sortedSetOf(
                                 LicenseFinding("LicenseRef-a", TextLocation("LICENSE", 1)),
                                 LicenseFinding("LicenseRef-b", TextLocation("LICENSE", 2))
-                            ),
-                            copyrightFindings = sortedSetOf()
+                            )
                         )
                     )
                 )

--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -74,6 +74,20 @@ data class ScanSummary(
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val issues: List<OrtIssue> = emptyList()
 ) {
+    companion object {
+        /**
+         * A constant for a [ScannerRun] where all properties are empty.
+         */
+        @JvmField
+        val EMPTY = ScanSummary(
+            startTime = Instant.EPOCH,
+            endTime = Instant.EPOCH,
+            packageVerificationCode = "",
+            licenseFindings = sortedSetOf(),
+            copyrightFindings = sortedSetOf()
+        )
+    }
+
     @get:JsonIgnore
     val licenses: Set<SpdxExpression> = licenseFindings.mapTo(mutableSetOf()) { it.license }
 

--- a/model/src/test/kotlin/licenses/TestData.kt
+++ b/model/src/test/kotlin/licenses/TestData.kt
@@ -19,8 +19,6 @@
 
 package org.ossreviewtoolkit.model.licenses
 
-import java.time.Instant
-
 import org.ossreviewtoolkit.model.AccessStatistics
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.AnalyzerRun
@@ -149,12 +147,8 @@ val scanResults = listOf(
         ScanResult(
             provenance = provenance,
             scanner = ScannerDetails.EMPTY,
-            summary = ScanSummary(
-                startTime = Instant.EPOCH,
-                endTime = Instant.EPOCH,
-                packageVerificationCode = "",
+            summary = ScanSummary.EMPTY.copy(
                 licenseFindings = licenseFindings,
-                copyrightFindings = sortedSetOf()
             )
         )
     )

--- a/reporter/src/funTest/kotlin/TestData.kt
+++ b/reporter/src/funTest/kotlin/TestData.kt
@@ -240,10 +240,7 @@ val ORT_RESULT = OrtResult(
                     ScanResult(
                         provenance = UnknownProvenance,
                         scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
-                        summary = ScanSummary(
-                            startTime = Instant.EPOCH,
-                            endTime = Instant.EPOCH,
-                            packageVerificationCode = "",
+                        summary = ScanSummary.EMPTY.copy(
                             licenseFindings = sortedSetOf(
                                 LicenseFinding(
                                     license = "MIT",
@@ -263,23 +260,14 @@ val ORT_RESULT = OrtResult(
                     ScanResult(
                         provenance = UnknownProvenance,
                         scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
-                        summary = ScanSummary(
-                            startTime = Instant.EPOCH,
-                            endTime = Instant.EPOCH,
-                            packageVerificationCode = "",
-                            licenseFindings = sortedSetOf(),
-                            copyrightFindings = sortedSetOf()
-                        )
+                        summary = ScanSummary.EMPTY
                     )
                 ),
                 Identifier("NPM:@ort:no-license-file:1.0") to listOf(
                     ScanResult(
                         provenance = UnknownProvenance,
                         scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
-                        summary = ScanSummary(
-                            startTime = Instant.EPOCH,
-                            endTime = Instant.EPOCH,
-                            packageVerificationCode = "",
+                        summary = ScanSummary.EMPTY.copy(
                             licenseFindings = sortedSetOf(
                                 LicenseFinding(
                                     license = "MIT",
@@ -304,10 +292,7 @@ val ORT_RESULT = OrtResult(
                             )
                         ),
                         scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
-                        summary = ScanSummary(
-                            startTime = Instant.EPOCH,
-                            endTime = Instant.EPOCH,
-                            packageVerificationCode = "",
+                        summary = ScanSummary.EMPTY.copy(
                             licenseFindings = sortedSetOf(
                                 LicenseFinding(
                                     license = "MIT",
@@ -340,10 +325,7 @@ val ORT_RESULT = OrtResult(
                             )
                         ),
                         scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
-                        summary = ScanSummary(
-                            startTime = Instant.EPOCH,
-                            endTime = Instant.EPOCH,
-                            packageVerificationCode = "",
+                        summary = ScanSummary.EMPTY.copy(
                             licenseFindings = sortedSetOf(
                                 LicenseFinding(
                                     license = "MIT",
@@ -384,10 +366,7 @@ val ORT_RESULT = OrtResult(
                             )
                         ),
                         scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
-                        summary = ScanSummary(
-                            startTime = Instant.EPOCH,
-                            endTime = Instant.EPOCH,
-                            packageVerificationCode = "",
+                        summary = ScanSummary.EMPTY.copy(
                             licenseFindings = sortedSetOf(
                                 LicenseFinding(
                                     license = "MIT",
@@ -420,10 +399,7 @@ val ORT_RESULT = OrtResult(
                             )
                         ),
                         scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
-                        summary = ScanSummary(
-                            startTime = Instant.EPOCH,
-                            endTime = Instant.EPOCH,
-                            packageVerificationCode = "",
+                        summary = ScanSummary.EMPTY.copy(
                             licenseFindings = sortedSetOf(
                                 LicenseFinding(
                                     license = "BSD-3-Clause",

--- a/reporter/src/funTest/kotlin/reporters/spdx/SpdxDocumentReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/spdx/SpdxDocumentReporterFunTest.kt
@@ -29,7 +29,6 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import java.io.File
-import java.time.Instant
 
 import org.ossreviewtoolkit.model.AccessStatistics
 import org.ossreviewtoolkit.model.AnalyzerResult
@@ -298,9 +297,7 @@ private val ortResult = OrtResult(
                             )
                         ),
                         scanner = ScannerDetails.EMPTY,
-                        summary = ScanSummary(
-                            startTime = Instant.EPOCH,
-                            endTime = Instant.EPOCH,
+                        summary = ScanSummary.EMPTY.copy(
                             packageVerificationCode = "0000000000000000000000000000000000000000",
                             licenseFindings = sortedSetOf(
                                 LicenseFinding(
@@ -331,9 +328,7 @@ private val ortResult = OrtResult(
                             resolvedRevision = "deadbeef"
                         ),
                         scanner = ScannerDetails.EMPTY,
-                        summary = ScanSummary(
-                            startTime = Instant.EPOCH,
-                            endTime = Instant.EPOCH,
+                        summary = ScanSummary.EMPTY.copy(
                             packageVerificationCode = "0000000000000000000000000000000000000000",
                             licenseFindings = sortedSetOf(
                                 LicenseFinding(

--- a/reporter/src/test/kotlin/reporters/OpossumReporterTest.kt
+++ b/reporter/src/test/kotlin/reporters/OpossumReporterTest.kt
@@ -482,9 +482,7 @@ private fun createOrtResult(): OrtResult {
                                 version = "1.2.3",
                                 configuration = "configuration"
                             ),
-                            summary = ScanSummary(
-                                startTime = Instant.EPOCH,
-                                endTime = Instant.EPOCH,
+                            summary = ScanSummary.EMPTY.copy(
                                 packageVerificationCode = "0000000000000000000000000000000000000000",
                                 licenseFindings = sortedSetOf(
                                     LicenseFinding(
@@ -519,7 +517,7 @@ private fun createOrtResult(): OrtResult {
                                 version = "1.2.3",
                                 configuration = "otherConfiguration"
                             ),
-                            summary = ScanSummary(
+                            summary = ScanSummary.EMPTY.copy(
                                 startTime = Instant.EPOCH,
                                 endTime = Instant.EPOCH,
                                 packageVerificationCode = "0000000000000000000000000000000000000000",

--- a/reporter/src/test/kotlin/reporters/fossid/FossIdReporterTest.kt
+++ b/reporter/src/test/kotlin/reporters/fossid/FossIdReporterTest.kt
@@ -136,7 +136,7 @@ class FossIdReporterTest : WordSpec({
 
         "use HTML_DYNAMIC as default report type" {
             val (serviceMock, reporterMock) = createReporterMock()
-            val input = createReporterInput(listOf(SCANCODE_1))
+            val input = createReporterInput(SCANCODE_1)
 
             reporterMock.generateReport(input, DIRECTORY_SAMPLE, DEFAULT_OPTIONS)
 
@@ -154,7 +154,7 @@ class FossIdReporterTest : WordSpec({
 
         "allow to specify a report type" {
             val (serviceMock, reporterMock) = createReporterMock()
-            val input = createReporterInput(listOf(SCANCODE_1))
+            val input = createReporterInput(SCANCODE_1)
 
             reporterMock.generateReport(
                 input, DIRECTORY_SAMPLE,
@@ -175,7 +175,7 @@ class FossIdReporterTest : WordSpec({
 
         "use INCLUDE_ALL_LICENSES as default selection type" {
             val (serviceMock, reporterMock) = createReporterMock()
-            val input = createReporterInput(listOf(SCANCODE_1))
+            val input = createReporterInput(SCANCODE_1)
 
             reporterMock.generateReport(input, DIRECTORY_SAMPLE, DEFAULT_OPTIONS)
 
@@ -193,7 +193,7 @@ class FossIdReporterTest : WordSpec({
 
         "allow to specify a selection type" {
             val (serviceMock, reporterMock) = createReporterMock()
-            val input = createReporterInput(listOf(SCANCODE_1))
+            val input = createReporterInput(SCANCODE_1)
 
             reporterMock.generateReport(
                 input, DIRECTORY_SAMPLE,
@@ -214,7 +214,7 @@ class FossIdReporterTest : WordSpec({
 
         "generate a report for each given scancode" {
             val (serviceMock, reporterMock) = createReporterMock()
-            val input = createReporterInput(listOf(SCANCODE_1, SCANCODE_2))
+            val input = createReporterInput(SCANCODE_1, SCANCODE_2)
 
             reporterMock.generateReport(input, DIRECTORY_SAMPLE, DEFAULT_OPTIONS)
 
@@ -226,7 +226,7 @@ class FossIdReporterTest : WordSpec({
 
         "return the generated file(s)" {
             val (_, reporterMock) = createReporterMock()
-            val input = createReporterInput(listOf(SCANCODE_1))
+            val input = createReporterInput(SCANCODE_1)
 
             val result = reporterMock.generateReport(input, DIRECTORY_SAMPLE, DEFAULT_OPTIONS)
 
@@ -248,7 +248,7 @@ private fun createReporterMock(): Pair<FossIdRestService, FossIdReporter> {
     return serviceMock to reporterMock
 }
 
-private fun createReporterInput(scanCodes: List<String> = emptyList()): ReporterInput {
+private fun createReporterInput(vararg scanCodes: String): ReporterInput {
     val analyzedVcs = VcsInfo(
         type = VcsType.GIT,
         revision = "master",

--- a/reporter/src/test/kotlin/reporters/fossid/FossIdReporterTest.kt
+++ b/reporter/src/test/kotlin/reporters/fossid/FossIdReporterTest.kt
@@ -256,7 +256,11 @@ private fun createReporterInput(vararg scanCodes: String): ReporterInput {
         path = "sub/path"
     )
 
-    val results = scanCodes.groupBy({ Identifier.EMPTY.copy(name = it) }) { createScanResult(it) }.toSortedMap()
+    val results = scanCodes.associateByTo(
+        destination = sortedMapOf(),
+        keySelector = { Identifier.EMPTY.copy(name = it) },
+        valueTransform = { listOf(createScanResult(it)) }
+    )
 
     return ReporterInput(
         OrtResult(

--- a/reporter/src/test/kotlin/reporters/fossid/FossIdReporterTest.kt
+++ b/reporter/src/test/kotlin/reporters/fossid/FossIdReporterTest.kt
@@ -35,7 +35,6 @@ import io.mockk.mockkStatic
 import io.mockk.spyk
 
 import java.io.File
-import java.time.Instant
 
 import org.ossreviewtoolkit.clients.fossid.FossIdRestService
 import org.ossreviewtoolkit.clients.fossid.FossIdServiceWithVersion
@@ -290,8 +289,6 @@ private fun createScanResult(scanCode: String): ScanResult =
     ScanResult(
         provenance = UnknownProvenance,
         scanner = ScannerDetails.EMPTY,
-        summary = ScanSummary(
-            Instant.now(), Instant.now(), "", sortedSetOf(), sortedSetOf()
-        ),
+        summary = ScanSummary.EMPTY,
         additionalData = mapOf(FossIdReporter.SCAN_CODE_KEY to scanCode)
     )

--- a/reporter/src/test/kotlin/reporters/fossid/FossIdReporterTest.kt
+++ b/reporter/src/test/kotlin/reporters/fossid/FossIdReporterTest.kt
@@ -286,9 +286,12 @@ private fun createReporterInput(vararg scanCodes: String): ReporterInput {
     )
 }
 
-private fun createScanResult(scanCode: String): ScanResult {
-    val summary = ScanSummary(
-        Instant.now(), Instant.now(), "", sortedSetOf(), sortedSetOf()
+private fun createScanResult(scanCode: String): ScanResult =
+    ScanResult(
+        provenance = UnknownProvenance,
+        scanner = ScannerDetails.EMPTY,
+        summary = ScanSummary(
+            Instant.now(), Instant.now(), "", sortedSetOf(), sortedSetOf()
+        ),
+        additionalData = mapOf(FossIdReporter.SCAN_CODE_KEY to scanCode)
     )
-    return ScanResult(UnknownProvenance, ScannerDetails.EMPTY, summary, mapOf(FossIdReporter.SCAN_CODE_KEY to scanCode))
-}

--- a/reporter/src/test/kotlin/reporters/freemarker/FreeMarkerTemplateProcessorTest.kt
+++ b/reporter/src/test/kotlin/reporters/freemarker/FreeMarkerTemplateProcessorTest.kt
@@ -93,10 +93,7 @@ private fun scanResults(
         ScanResult(
             provenance = RepositoryProvenance(vcsInfo = vcsInfo, resolvedRevision = vcsInfo.revision),
             scanner = ScannerDetails(name = "scanner", version = "1.0", configuration = ""),
-            summary = ScanSummary(
-                startTime = Instant.EPOCH,
-                endTime = Instant.EPOCH,
-                packageVerificationCode = "",
+            summary = ScanSummary.EMPTY.copy(
                 licenseFindings = licenseFindings,
                 copyrightFindings = copyrightFindings,
             )

--- a/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
@@ -97,8 +97,6 @@ class ScannerIntegrationFunTest : StringSpec() {
         override val criteria: ScannerCriteria = ScannerCriteria.forDetails(details)
 
         override fun scanPath(path: File, context: ScanContext): ScanSummary {
-            val time = Instant.now()
-
             val licenseFindings = path.listFiles().orEmpty().mapTo(sortedSetOf()) { file ->
                 LicenseFinding(
                     license = SpdxConstants.NONE,
@@ -107,8 +105,8 @@ class ScannerIntegrationFunTest : StringSpec() {
             }
 
             return ScanSummary(
-                startTime = time,
-                endTime = time,
+                startTime = Instant.EPOCH,
+                endTime = Instant.EPOCH,
                 packageVerificationCode = "",
                 licenseFindings = licenseFindings,
                 copyrightFindings = sortedSetOf(),

--- a/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
@@ -23,7 +23,6 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
 import java.io.File
-import java.time.Instant
 
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.PackageType
@@ -104,13 +103,8 @@ class ScannerIntegrationFunTest : StringSpec() {
                 )
             }
 
-            return ScanSummary(
-                startTime = Instant.EPOCH,
-                endTime = Instant.EPOCH,
-                packageVerificationCode = "",
-                licenseFindings = licenseFindings,
-                copyrightFindings = sortedSetOf(),
-                issues = mutableListOf()
+            return ScanSummary.EMPTY.copy(
+                licenseFindings = licenseFindings
             )
         }
     }

--- a/scanner/src/funTest/kotlin/storages/AbstractProvenanceBasedStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractProvenanceBasedStorageFunTest.kt
@@ -218,9 +218,6 @@ private fun createScannerDetails(
     configuration: String = "configuration"
 ) = ScannerDetails(name, version, configuration)
 
-private fun createScanSummary(licenseFindings: Set<LicenseFinding> = emptySet()) =
-    ScanSummary(Instant.EPOCH, Instant.EPOCH, "", licenseFindings.toSortedSet(), sortedSetOf())
-
 private fun createScanResult(
     provenance: Provenance = createKnownProvenance(),
     scannerDetails: ScannerDetails = createScannerDetails(),
@@ -229,9 +226,13 @@ private fun createScanResult(
     ScanResult(
         provenance,
         scannerDetails,
-        createScanSummary(
+        ScanSummary(
+            startTime = Instant.EPOCH,
+            endTime = Instant.EPOCH,
+            packageVerificationCode = "",
             licenseFindings = sortedSetOf(
                 LicenseFinding(license, TextLocation("file.txt", 1, 2))
-            )
+            ),
+            copyrightFindings = sortedSetOf()
         )
     )

--- a/scanner/src/funTest/kotlin/storages/AbstractProvenanceBasedStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractProvenanceBasedStorageFunTest.kt
@@ -28,8 +28,6 @@ import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.should
 
-import java.time.Instant
-
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.HashAlgorithm
@@ -226,13 +224,9 @@ private fun createScanResult(
     ScanResult(
         provenance,
         scannerDetails,
-        ScanSummary(
-            startTime = Instant.EPOCH,
-            endTime = Instant.EPOCH,
-            packageVerificationCode = "",
+        ScanSummary.EMPTY.copy(
             licenseFindings = sortedSetOf(
                 LicenseFinding(license, TextLocation("file.txt", 1, 2))
-            ),
-            copyrightFindings = sortedSetOf()
+            )
         )
     )

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
@@ -99,7 +99,7 @@ abstract class AbstractStorageFunTest(vararg listeners: TestListener) : WordSpec
 
     private val scannerCriteriaForDetails1 = ScannerCriteria.forDetails(scannerDetails1, Semver.VersionDiff.PATCH)
 
-    private val scanSummaryWithFiles = ScanSummary(
+    private val scanSummaryWithFiles = ScanSummary.EMPTY.copy(
         startTime = Instant.EPOCH + Duration.ofMinutes(1),
         endTime = Instant.EPOCH + Duration.ofMinutes(2),
         packageVerificationCode = "packageVerificationCode",
@@ -107,7 +107,6 @@ abstract class AbstractStorageFunTest(vararg listeners: TestListener) : WordSpec
             LicenseFinding("license-1.1", DUMMY_TEXT_LOCATION),
             LicenseFinding("license-1.2", DUMMY_TEXT_LOCATION)
         ),
-        copyrightFindings = sortedSetOf(),
         issues = mutableListOf(
             OrtIssue(source = "source-1", message = "error-1"),
             OrtIssue(source = "source-2", message = "error-2")

--- a/scanner/src/funTest/kotlin/storages/ClearlyDefinedStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/ClearlyDefinedStorageFunTest.kt
@@ -70,7 +70,7 @@ class ClearlyDefinedStorageFunTest : StringSpec({
                             "--package true --processes 2 --strip-root true --summary true --summary-key-files true " +
                             "--timeout 1000.0 --url true"
                 ),
-                summary = ScanSummary(
+                summary = ScanSummary.EMPTY.copy(
                     startTime = Instant.parse("2020-02-14T00:36:14.000335513Z"),
                     endTime = Instant.parse("2020-02-14T00:36:37.000492119Z"),
                     packageVerificationCode = SpdxConstants.NONE,
@@ -84,9 +84,7 @@ class ClearlyDefinedStorageFunTest : StringSpec({
                             ),
                             score = 60.87f
                         )
-                    ),
-                    copyrightFindings = sortedSetOf(),
-                    issues = emptyList()
+                    )
                 )
             )
         }
@@ -115,13 +113,10 @@ class ClearlyDefinedStorageFunTest : StringSpec({
                             "--license-text-diagnostics true --package true --processes 2 --strip-root true " +
                             "--summary true --summary-key-files true --timeout 1000.0 --url true"
                 ),
-                summary = ScanSummary(
+                summary = ScanSummary.EMPTY.copy(
                     startTime = Instant.parse("2022-05-02T07:34:28.000784295Z"),
                     endTime = Instant.parse("2022-05-02T07:34:59.000958218Z"),
-                    packageVerificationCode = SpdxConstants.NONE,
-                    licenseFindings = sortedSetOf(),
-                    copyrightFindings = sortedSetOf(),
-                    issues = emptyList()
+                    packageVerificationCode = SpdxConstants.NONE
                 )
             )
         }

--- a/scanner/src/test/kotlin/ScannerTest.kt
+++ b/scanner/src/test/kotlin/ScannerTest.kt
@@ -35,7 +35,6 @@ import io.mockk.verify
 
 import java.io.File
 import java.io.IOException
-import java.time.Instant
 import java.util.SortedSet
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
@@ -824,7 +823,7 @@ private class FakePathScannerWrapper : PathScannerWrapper {
             LicenseFinding("Apache-2.0", TextLocation(file.relativeTo(path).path, 1, 2))
         }.toSortedSet()
 
-        return createScanSummary(licenseFindings = licenseFindings)
+        return ScanSummary.EMPTY.copy(licenseFindings = licenseFindings)
     }
 }
 
@@ -963,9 +962,6 @@ private fun VcsInfo.Companion.valid() =
         revision = "f42e41a8fedc1e0acd78fab147e91fa047cb2853"
     )
 
-private fun createScanSummary(licenseFindings: Set<LicenseFinding> = emptySet()) =
-    ScanSummary(Instant.EPOCH, Instant.EPOCH, "", licenseFindings.toSortedSet(), sortedSetOf())
-
 private fun createScanResult(
     provenance: Provenance,
     scannerDetails: ScannerDetails,
@@ -976,7 +972,7 @@ private fun createScanResult(
     ScanResult(
         provenance,
         scannerDetails,
-        createScanSummary(licenseFindings)
+        ScanSummary.EMPTY.copy(licenseFindings = licenseFindings)
     )
 
 private fun createNestedScanResult(
@@ -995,7 +991,7 @@ private fun createStoredScanResult(provenance: Provenance, scannerDetails: Scann
     ScanResult(
         provenance,
         scannerDetails,
-        createScanSummary(
+        ScanSummary.EMPTY.copy(
             licenseFindings = sortedSetOf(
                 LicenseFinding("Apache-2.0", TextLocation("storage.txt", 1, 2))
             )

--- a/scanner/src/test/kotlin/provenance/NestedProvenanceScanResultTest.kt
+++ b/scanner/src/test/kotlin/provenance/NestedProvenanceScanResultTest.kt
@@ -25,8 +25,6 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 
-import java.time.Instant
-
 import org.ossreviewtoolkit.model.CopyrightFinding
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.RepositoryProvenance
@@ -118,12 +116,12 @@ private val scannerDetails = ScannerDetails(name = "scanner", version = "1.0.0",
 private val scanResultRoot = ScanResult(
     provenance = provenanceRoot,
     scanner = scannerDetails,
-    summary = createScanSummary(
-        licenseFindings = listOf(
+    summary = ScanSummary.EMPTY.copy(
+        licenseFindings = sortedSetOf(
             LicenseFinding("Apache-2.0", TextLocation("file", 1)),
             LicenseFinding("Apache-2.0", TextLocation("submodules/file", 1))
         ),
-        copyrightFindings = listOf(
+        copyrightFindings = sortedSetOf(
             CopyrightFinding("Copyright", TextLocation("file", 1)),
             CopyrightFinding("Copyright", TextLocation("submodules/file", 1))
         )
@@ -133,12 +131,12 @@ private val scanResultRoot = ScanResult(
 private val scanResultSubmoduleA = ScanResult(
     provenance = provenanceSubmoduleA,
     scanner = scannerDetails,
-    summary = createScanSummary(
-        licenseFindings = listOf(
+    summary = ScanSummary.EMPTY.copy(
+        licenseFindings = sortedSetOf(
             LicenseFinding("Apache-2.0", TextLocation("fileA", 1)),
             LicenseFinding("Apache-2.0", TextLocation("dir/fileA", 1))
         ),
-        copyrightFindings = listOf(
+        copyrightFindings = sortedSetOf(
             CopyrightFinding("Copyright", TextLocation("fileA", 1)),
             CopyrightFinding("Copyright", TextLocation("dir/fileA", 1))
         )
@@ -148,12 +146,12 @@ private val scanResultSubmoduleA = ScanResult(
 private val scanResultSubmoduleB = ScanResult(
     provenance = provenanceSubmoduleA,
     scanner = scannerDetails,
-    summary = createScanSummary(
-        licenseFindings = listOf(
+    summary = ScanSummary.EMPTY.copy(
+        licenseFindings = sortedSetOf(
             LicenseFinding("Apache-2.0", TextLocation("fileB", 1)),
             LicenseFinding("Apache-2.0", TextLocation("dir/fileB", 1))
         ),
-        copyrightFindings = listOf(
+        copyrightFindings = sortedSetOf(
             CopyrightFinding("Copyright", TextLocation("fileB", 1)),
             CopyrightFinding("Copyright", TextLocation("dir/fileB", 1))
         )
@@ -168,14 +166,5 @@ private val nestedProvenanceScanResult = NestedProvenanceScanResult(
         provenanceSubmoduleB to listOf(scanResultSubmoduleB)
     )
 )
-
-private fun createScanSummary(licenseFindings: List<LicenseFinding>, copyrightFindings: List<CopyrightFinding>) =
-    ScanSummary(
-        startTime = Instant.now(),
-        endTime = Instant.now(),
-        packageVerificationCode = "",
-        licenseFindings = licenseFindings.toSortedSet(),
-        copyrightFindings = copyrightFindings.toSortedSet()
-    )
 
 private fun NestedProvenance.getRepositoryUrls() = getProvenances().map { (it as RepositoryProvenance).vcsInfo.url }

--- a/scanner/src/test/kotlin/storages/CompositeStorageTest.kt
+++ b/scanner/src/test/kotlin/storages/CompositeStorageTest.kt
@@ -32,8 +32,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 
-import java.time.Instant
-
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseFinding
@@ -81,12 +79,9 @@ private fun licenseFinding(index: Int): LicenseFinding =
  */
 private fun createScanResult(resultCount: Int): ScanResult {
     val licenseFindings = List(resultCount) { licenseFinding(it) }
-    val summary = ScanSummary(
-        startTime = Instant.now(),
-        endTime = Instant.now(),
+    val summary = ScanSummary.EMPTY.copy(
         packageVerificationCode = "test$resultCount",
-        licenseFindings = licenseFindings.toSortedSet(),
-        copyrightFindings = sortedSetOf()
+        licenseFindings = licenseFindings.toSortedSet()
     )
     val provenance = ArtifactProvenance(sourceArtifact = RemoteArtifact.EMPTY)
     val scanner = ScannerDetails("scanner$resultCount", "v$resultCount", "testConfig")


### PR DESCRIPTION
This eliminates repetition of default values in scan summary constructions.
It prepares for further refactoring steps.

Part of #5681.