### PR TITLE
GitWorkingTree: Fix an isse with `repo.use`

### DIFF
--- a/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
+++ b/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
@@ -57,9 +57,7 @@ open class GitWorkingTree(
 ) : WorkingTree(workingDir, vcsType) {
     companion object : Logging
 
-    private val repo by lazy { findGitOrSubmoduleDir(workingDir) }
-
-    fun <T> useRepo(block: Repository.() -> T): T = repo.use(block)
+    fun <T> useRepo(block: Repository.() -> T): T = findGitOrSubmoduleDir(workingDir).use(block)
 
     override fun isValid(): Boolean = useRepo { objectDatabase?.exists() == true }
 


### PR DESCRIPTION
The implementation followed the approach to create one instance of
`Repository` for each use and close it at the end of the respective
usage, see [1].

Recently, a minor refactoring was done to prevent forgetting to close
the `Repository` instance after use, see [2]. Unfortunately, `repo` was
turned into a `lazy` property, so that only one `Repository` instance
gets created in total. This yields an uncaught exception like e.g. [3],
because closed `Repository` instances must not be used.

Address the issue by fixing up [2] to create a new `Repository` instance
again for each use.

[1] https://github.com/oss-review-toolkit/ort/commit/4bac08f19d67b169171d0cd63139fc298f932112
[2] https://github.com/oss-review-toolkit/ort/commit/7dd7e61df7cb08bbd9a8a5f77cff2c20cb560d56
[3] `org.eclipse.jgit.lib.Repository - close() called when useCnt is already zero for Repository`
    java.lang.IllegalStateException: null
    at org.eclipse.jgit.lib.Repository.close(Repository.java:951)

