### PR TITLE
GeneratePathExcludeCommand: Add a preference for filename patterns

### DIFF
--- a/helper-cli/src/main/kotlin/utils/PathExcludeGenerator.kt
+++ b/helper-cli/src/main/kotlin/utils/PathExcludeGenerator.kt
@@ -97,7 +97,7 @@ internal object PathExcludeGenerator {
             files.filter { pathExcludeExclude.matches(it.path) }.toSet()
         }
 
-        return greedySetCover(filesForPathExcludes).toSet()
+        return greedySetCover(filesForPathExcludes, FILE_EXCLUDE_COMPARATOR).toSet()
     }
 
     internal fun createExcludePatterns(filenamePattern: String, files: Set<File>): Set<String> {
@@ -277,3 +277,11 @@ private val PATH_EXCLUDE_REASON_FOR_FILENAME = listOf(
     "setup.py" to BUILD_TOOL_OF,
     "test_*.c" to BUILD_TOOL_OF
 ).checkPatterns { it.first }
+
+/** Prefer filename patterns with fewer wildcards, then shorter ones. **/
+private val FILE_EXCLUDE_COMPARATOR =
+    compareByDescending<PathExclude> {
+        it.pattern.substringAfterLast('/').count { c -> c == '*' }
+    }.thenByDescending { exclude ->
+        exclude.pattern.length
+    }

--- a/helper-cli/src/test/kotlin/PathExcludeGeneratorTest.kt
+++ b/helper-cli/src/test/kotlin/PathExcludeGeneratorTest.kt
@@ -80,6 +80,19 @@ class PathExcludeGeneratorTest : WordSpec({
 
             patterns.sorted().joinToString("\n") shouldBe expectedPatterns
         }
+
+        "prefer the pattern with least amount of wildcards" {
+            // Candidate patterns are 'build*.sh' and '*coverage*.sh' as both match.
+            // TODO: The result should be 'build*.sh' as it has fewer wildcards.
+            val files = listOf(
+                "build-coverage.sh",
+                "build-coverage-e2e.sh"
+            )
+
+            val patterns = generateFileExcludes(files).map { it.pattern }
+
+            patterns should containExactlyInAnyOrder("*coverage*.sh")
+        }
     }
 
     "generatePathExcludes()" should {

--- a/helper-cli/src/test/kotlin/PathExcludeGeneratorTest.kt
+++ b/helper-cli/src/test/kotlin/PathExcludeGeneratorTest.kt
@@ -83,7 +83,6 @@ class PathExcludeGeneratorTest : WordSpec({
 
         "prefer the pattern with least amount of wildcards" {
             // Candidate patterns are 'build*.sh' and '*coverage*.sh' as both match.
-            // TODO: The result should be 'build*.sh' as it has fewer wildcards.
             val files = listOf(
                 "build-coverage.sh",
                 "build-coverage-e2e.sh"
@@ -91,7 +90,7 @@ class PathExcludeGeneratorTest : WordSpec({
 
             val patterns = generateFileExcludes(files).map { it.pattern }
 
-            patterns should containExactlyInAnyOrder("*coverage*.sh")
+            patterns should containExactlyInAnyOrder("build*.sh")
         }
     }
 

--- a/helper-cli/src/test/kotlin/UtilsTest.kt
+++ b/helper-cli/src/test/kotlin/UtilsTest.kt
@@ -34,5 +34,20 @@ class UtilsTest : WordSpec({
 
             greedySetCover(sets) should containExactlyInAnyOrder("c")
         }
+
+        "resolve a tie using the given comparator" {
+            val sets = mapOf(
+                "aa" to setOf(1),
+                "b" to setOf(1)
+            )
+
+            greedySetCover(sets) { a, b ->
+                a.length - b.length
+            } should containExactlyInAnyOrder("aa")
+
+            greedySetCover(sets) { a, b ->
+                b.length - a.length
+            } should containExactlyInAnyOrder("b")
+        }
     }
 })


### PR DESCRIPTION
Make the behavior a bit less dependent on the the order of the hard-coded patterns, and hopefully return simpler patterns.

See individual commits.