### PR TITLE
MavenSupport: Also take the `url` into account when fixing the SCM

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
@@ -12,8 +12,8 @@ project:
     mapped:
       Apache License, Version 2.0: "Apache-2.0"
   vcs:
-    type: ""
-    url: ""
+    type: "Git"
+    url: "https://example.com/git/repository.git"
     revision: ""
     path: ""
   vcs_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
@@ -12,8 +12,8 @@ project:
     mapped:
       Apache License, Version 2.0: "Apache-2.0"
   vcs:
-    type: ""
-    url: ""
+    type: "Git"
+    url: "https://example.com/git/repository.git"
     revision: ""
     path: ""
   vcs_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
@@ -12,8 +12,8 @@ project:
     mapped:
       Apache License, Version 2.0: "Apache-2.0"
   vcs:
-    type: ""
-    url: ""
+    type: "Git"
+    url: "https://example.com/git/repository.git"
     revision: ""
     path: ""
   vcs_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/maven/pom.xml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven/pom.xml
@@ -7,6 +7,11 @@
     <version>1.0-SNAPSHOT</version>
     <name>maven-project</name>
     <url>http://maven.apache.org</url>
+    <scm>
+        <connection>scm:git:https://example.com/git/repository.git</connection>
+        <developerConnection>scm:git:https://example.com/git/repository.git</developerConnection>
+        <url>https://example.com/git/repository</url>
+    </scm>
     <organization>
         <name>The Apache Software Foundation</name>
     </organization>

--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -180,6 +180,12 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
                             scm.connection = parentScm.connection
                         }
                     }
+
+                    parentScm.url?.let { parentUrl ->
+                        if (parentUrl.isNotBlank() && scm.url.startsWith(parentUrl)) {
+                            scm.url = parentScm.url
+                        }
+                    }
                 }
 
                 parent = parent.parent

--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -189,10 +189,10 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
         }
 
         private fun parseScm(scm: Scm?): VcsInfo {
-            val connection = scm?.connection.orEmpty()
-            val tag = scm?.tag?.takeIf { it != "HEAD" }.orEmpty()
+            val connection = scm?.connection
+            if (connection.isNullOrEmpty()) return VcsInfo.EMPTY
 
-            if (connection.isEmpty()) return VcsInfo.EMPTY
+            val tag = scm.tag?.takeIf { it != "HEAD" }.orEmpty()
 
             return SCM_REGEX.matcher(connection).let { matcher ->
                 if (matcher.matches()) {

--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -159,15 +159,15 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
         fun parseVcsInfo(mavenProject: MavenProject) = parseScm(getOriginalScm(mavenProject))
 
         /**
-         * When asking Maven for the SCM URL of a POM that does not itself define an SCM URL, Maven returns the SCM
-         * URL of the first parent POM (if any) that defines one and appends the artifactIds of all child POMs to it,
-         * separated by slashes.
-         * This behavior is fundamentally broken because it invalidates the SCM URL for all VCS that cannot limit
-         * cloning to a specific path within a repository, or use a different syntax for that. Also, the assumption
-         * that the source code for a child artifact is stored in a top-level directory named like the artifactId
-         * inside the parent artifact's repository is often not correct.
-         * To address this, determine the SCM URL of the parent (if any) that is closest to the root POM and whose
-         * SCM URL still is a prefix of the child POM's SCM URL.
+         * When asking Maven for the SCM connection or the SCM URL of a POM that does not itself define these values,
+         * Maven returns the values of the first parent POM (if any) that defines one and appends the artifactIds of all
+         * child POMs to it, separated by slashes.
+         * This behavior is fundamentally broken because it invalidates the SCM connection / URL for all VCS that cannot
+         * limit cloning to a specific path within a repository, or use a different syntax for that. Also, the
+         * assumption that the source code for a child artifact is stored in a top-level directory named like the
+         * artifactId inside the parent artifact's repository is often not correct.
+         * To address this, determine the SCM connection and URL of the parent (if any) that is closest to the root POM
+         * and whose SCM connection / URL still is a prefix of the child POM's SCM values.
          */
         fun getOriginalScm(mavenProject: MavenProject): Scm? {
             val scm = mavenProject.scm

--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -170,14 +170,14 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
          * SCM URL still is a prefix of the child POM's SCM URL.
          */
         fun getOriginalScm(mavenProject: MavenProject): Scm? {
-            var scm = mavenProject.scm
+            val scm = mavenProject.scm
             var parent = mavenProject.parent
 
             while (parent != null) {
                 parent.scm?.let { parentScm ->
                     parentScm.connection?.let { parentConnection ->
                         if (parentConnection.isNotBlank() && scm.connection.startsWith(parentConnection)) {
-                            scm = parentScm
+                            scm.connection = parentScm.connection
                         }
                     }
                 }

--- a/analyzer/src/test/kotlin/managers/utils/MavenSupportTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/MavenSupportTest.kt
@@ -30,6 +30,27 @@ import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 
 class MavenSupportTest : WordSpec({
+    "getOriginalScm()" should {
+        "return the parent's SCM connection if the child SCM uses the parent's SCM connection implicitly" {
+            val mavenProject = MavenProject().apply {
+                scm = Scm().apply {
+                    connection = "scm:git:https://github.com/spring-projects/spring-boot.git/childArtifactName"
+                    url = "https://github.com/oss-review-toolkit/correctUrl"
+                }
+                parent = MavenProject().apply {
+                    scm = Scm().apply {
+                        connection = "scm:git:https://github.com/spring-projects/spring-boot.git"
+                        url = "https://github.com/spring-projects/spring-boot"
+                    }
+                }
+            }
+
+            MavenSupport.getOriginalScm(mavenProject)?.connection shouldBe
+                    "scm:git:https://github.com/spring-projects/spring-boot.git"
+            MavenSupport.getOriginalScm(mavenProject)?.url shouldBe "https://github.com/oss-review-toolkit/correctUrl"
+        }
+    }
+
     "parseVcsInfo()" should {
         "handle GitRepo URLs" {
             val mavenProject = MavenProject().apply {

--- a/analyzer/src/test/kotlin/managers/utils/MavenSupportTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/MavenSupportTest.kt
@@ -49,6 +49,25 @@ class MavenSupportTest : WordSpec({
                     "scm:git:https://github.com/spring-projects/spring-boot.git"
             MavenSupport.getOriginalScm(mavenProject)?.url shouldBe "https://github.com/oss-review-toolkit/correctUrl"
         }
+
+        "return the parent's SCM URL if the child SCM uses the parent's SCM URL implicitly" {
+            val mavenProject = MavenProject().apply {
+                scm = Scm().apply {
+                    connection = "scm:git:https://github.com/oss-review-toolkit/childConnection.git"
+                    url = "https://github.com/spring-projects/spring-boot/childArtifactName"
+                }
+                parent = MavenProject().apply {
+                    scm = Scm().apply {
+                        connection = "scm:git:https://github.com/oss-review-toolkit/parentConnection.git"
+                        url = "https://github.com/spring-projects/spring-boot"
+                    }
+                }
+            }
+
+            MavenSupport.getOriginalScm(mavenProject)?.connection shouldBe
+                    "scm:git:https://github.com/oss-review-toolkit/childConnection.git"
+            MavenSupport.getOriginalScm(mavenProject)?.url shouldBe "https://github.com/spring-projects/spring-boot"
+        }
     }
 
     "parseVcsInfo()" should {


### PR DESCRIPTION
For POMs that do not set an SCM URL itself, the fixup of the SCM does
not work if the parent SCM does not set an `connection`, but only the
`url`. This results in an unwanted original SCM URL.
For instance, spring-boot-starter-parent [1] only sets the `url` and not
the `connection`. This results in an original SCM `url` like
'https://github.com/spring-projects/spring-boot/childArtifactName'.
The issue this causes is, that the `Project`'s `VcsInfo` is merged with
this original SCM's URL as `fallbackUrl`, causing the path to be set to
`childArtifactName`, which is not available in the child repository.
Fix this issue, by also taking the `url` into account when replacing the
SCM with the parent's one.

[1]: https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-parent/2.7.4/spring-boot-starter-parent-2.7.4.pom