### PR TITLE
Gradle: Upgrade the Dokka plugin to version 1.7.20

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 buildConfigPlugin = "3.1.0"
 detektPlugin = "1.21.0"
-dokkaPlugin = "1.7.10"
+dokkaPlugin = "1.7.20"
 downloadPlugin = "5.2.1"
 graalPlugin = "0.12.0"
 # @pin this version until https://github.com/ExpediaGroup/graphql-kotlin/issues/1526 is resolved.


### PR DESCRIPTION
See [1].

[1]: https://github.com/Kotlin/dokka/releases/tag/v1.7.20

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>