### PR TITLE
analyzer: Use the HTTPS instead of the Git protocol in VCS processed 

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-cyclic-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-cyclic-expected-output-app.yml
@@ -11479,7 +11479,7 @@ shared_packages:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "git://android.googlesource.com/platform/tools/sherpa.git"
+    url: "https://android.googlesource.com/platform/tools/sherpa.git"
     revision: ""
     path: ""
 - id: "Maven:androidx.constraintlayout:constraintlayout-solver:2.0.1"
@@ -11511,7 +11511,7 @@ shared_packages:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "git://android.googlesource.com/platform/tools/sherpa.git"
+    url: "https://android.googlesource.com/platform/tools/sherpa.git"
     revision: ""
     path: ""
 - id: "Maven:androidx.dynamicanimation:dynamicanimation:1.0.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -2527,7 +2527,7 @@ packages:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "git://git.coolaj86.com/coolaj86/atob.js.git"
+    url: "https://git.coolaj86.com/coolaj86/atob.js.git"
     revision: "755cfea7899074a17e83a248c7cfc3960d956d82"
     path: ""
 - id: "NPM::babel-cli:6.26.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
@@ -907,7 +907,7 @@ packages:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "git://git.coolaj86.com/coolaj86/atob.js.git"
+    url: "https://git.coolaj86.com/coolaj86/atob.js.git"
     revision: "755cfea7899074a17e83a248c7cfc3960d956d82"
     path: ""
 - id: "NPM::autolinker:0.28.1"

--- a/analyzer/src/funTest/kotlin/managers/BabelFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/BabelFunTest.kt
@@ -44,7 +44,7 @@ class BabelFunTest : WordSpec() {
                 val packageFile = projectDir.resolve("package.json")
 
                 val expectedResult = patchExpectedResult(
-                    projectDir.parentFile.resolve("${projectDir.name}-expected-output.yml"),
+                    projectDir.parentFile.resolve("npm-babel-expected-output.yml"),
                     url = normalizeVcsUrl(vcsUrl),
                     revision = vcsRevision
                 )

--- a/utils/ort/src/main/kotlin/Utils.kt
+++ b/utils/ort/src/main/kotlin/Utils.kt
@@ -177,6 +177,11 @@ fun normalizeVcsUrl(vcsUrl: String): String {
         return url
     }
 
+    // Avoid using the unauthenticated Git protocol, which is blocked by many VCS hosts.
+    if (url.startsWith("git://")) {
+        url = "https://${url.removePrefix("git://")}"
+    }
+
     // URLs to Git repos may omit the scheme and use an SCP-like URL that uses ":" to separate the host from the path,
     // see https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a. Make this an explicit ssh URL, so it can be parsed
     // by Java's URI class.


### PR DESCRIPTION
See individual commits.

Note: This moves forwards scanning ORT with ORT, e.g. #5696.