### PR TITLE
Pub: Use stdout instead of stderr to get version

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -601,7 +601,7 @@ class Pub(
     override fun getVersion(workingDir: File?): String {
         val result = ProcessCapture(workingDir, command(workingDir), getVersionArguments()).requireSuccess()
 
-        return transformVersion(result.stderr)
+        return transformVersion(result.stdout)
     }
 
     override fun command(workingDir: File?): String =


### PR DESCRIPTION
The version is printed on stdout, not on stderr. This fixes the issue
that no version is detected when running `requirements.