### PR TITLE
clearly-defined: Use `find` instead of `single` to create enums

### DIFF
--- a/clients/clearly-defined/src/main/kotlin/Enums.kt
+++ b/clients/clearly-defined/src/main/kotlin/Enums.kt
@@ -58,7 +58,7 @@ enum class ComponentType {
 
     companion object {
         @JvmStatic
-        fun fromString(value: String) = enumValues<ComponentType>().single { it.toString() == value }
+        fun fromString(value: String) = enumValues<ComponentType>().find { it.toString() == value }
     }
 
     // Align the string representation with the serial name to make Retrofit's GET request work. Also see:
@@ -100,7 +100,7 @@ enum class Provider {
 
     companion object {
         @JvmStatic
-        fun fromString(value: String) = enumValues<Provider>().single { it.toString() == value }
+        fun fromString(value: String) = enumValues<Provider>().find { it.toString() == value }
     }
 
     // Align the string representation with the serial name to make Retrofit's GET request work. Also see:


### PR DESCRIPTION
It is manually ensured that there are no duplicate string representations for enum values, so use `find` instead of `single` to avoid all values always being iterated over.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>