### PR TITLE
Gradle: Allow Kotlin script files in source root again

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -254,6 +254,7 @@ subprojects {
 
     tasks.withType<KotlinCompile>().configureEach {
         val customCompilerArgs = listOf(
+            "-Xallow-any-scripts-in-source-roots",
             "-Xallow-result-return-type",
             "-opt-in=kotlin.contracts.ExperimentalContracts",
             "-opt-in=kotlin.io.path.ExperimentalPathApi",


### PR DESCRIPTION
Kotlin 1.7.20 changed its behavior and warns about Kotlin script files that are "used along with regular Kotlin sources", which fails the build as ORT treats warnings as errors. Restore the old behavior to allow such script files.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>