### PR TITLE
PythonInspector: Enable verbose output

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
+++ b/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
@@ -90,6 +90,8 @@ internal object PythonInspector : CommandLineTool {
                     add(setupFile.absolutePath)
                 }
             }
+
+            add("--verbose")
         }
 
         return try {


### PR DESCRIPTION
If the python-inspector runs into an exception only the stacktrace is printed by default. Meaningful error messages are only printed if the "--verbose" flag is provided.