### PR TITLE
Change `downloadSourceArtifact` to take a `RemoteArtifact`

### DIFF
--- a/scanner/src/main/kotlin/provenance/ProvenanceDownloader.kt
+++ b/scanner/src/main/kotlin/provenance/ProvenanceDownloader.kt
@@ -62,10 +62,9 @@ class DefaultProvenanceDownloader(
         val downloadDir = createOrtTempDir()
 
         when (provenance) {
-            // TODO: Add dedicated download functions for VcsInfo and RemoteArtifact to the Downloader.
+            // TODO: Add dedicated download functions for VcsInfo to the Downloader.
             is ArtifactProvenance -> {
-                val pkg = Package.EMPTY.copy(sourceArtifact = provenance.sourceArtifact)
-                downloader.downloadSourceArtifact(pkg, downloadDir)
+                downloader.downloadSourceArtifact(provenance.sourceArtifact, downloadDir)
             }
 
             is RepositoryProvenance -> {


### PR DESCRIPTION
Other properties than `RemoteArtifact` from the former `Package` were only used for logging, and the provenance-based scanner does set the package's `id` to an empty value anyway, so simplify the code by just taking the necessary `RemoteArtifact` as a function parameter.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>