### PR TITLE
Jenkinsfile: Use the `ort-config` repository by default

### DIFF
--- a/integrations/jenkins/Jenkinsfile
+++ b/integrations/jenkins/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
         string(
             name: 'ORT_CONFIG_VCS_URL',
             description: 'Optional VCS clone URL of the ORT configuration',
-            defaultValue: ''
+            defaultValue: 'https://github.com/oss-review-toolkit/ort-config.git'
         )
 
         string(


### PR DESCRIPTION
This demonstrates how to use the `ort-config` repository to provide an example configuration.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>