### PR TITLE
CocoaPods: Set the correct pURL for an empty package

### DIFF
--- a/analyzer/src/main/kotlin/managers/CocoaPods.kt
+++ b/analyzer/src/main/kotlin/managers/CocoaPods.kt
@@ -53,6 +53,7 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.model.orEmpty
 import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.collectMessages
@@ -172,7 +173,7 @@ class CocoaPods(
     }
 
     private fun getPackage(id: Identifier, workingDir: File): Package {
-        val podspec = getPodspec(id, workingDir) ?: return Package.EMPTY.copy(id = id)
+        val podspec = getPodspec(id, workingDir) ?: return Package.EMPTY.copy(id = id, purl = id.toPurl())
 
         val vcs = podspec.source["git"]?.let { url ->
             VcsInfo(


### PR DESCRIPTION
When the pod command can't find any .podspec file for a pod, an empty package will be returned for which only the identifier is set. The empty pURL property in the `Package` object can cause failures later in the Advisor, when requesting vulnerabilities for packages using the pURL. Therefore, it's necessary to set the correct pURL for an empty package explicitly, because when using `Package.EMPTY` it's always empty.
