### PR TITLE
PythonInspector: Provide default value for classifiers

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
+++ b/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
@@ -130,7 +130,7 @@ internal object PythonInspector : CommandLineTool {
     @Serializable
     internal data class DeclaredLicense(
         val license: String,
-        val classifiers: List<String>
+        val classifiers: List<String> = emptyList()
     )
 
     @Serializable


### PR DESCRIPTION
The `classifiers` property can be missing in the python-inspector output so provide a default value.