### PR TITLE
GoMod: Add `-buildvcs=false` when running `go list`

### DIFF
--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -222,7 +222,7 @@ class GoMod(
      * directive applied.
      */
     private fun getModuleInfos(projectDir: File): List<ModuleInfo> {
-        val list = run("list", "-m", "-json", "all", workingDir = projectDir)
+        val list = run("list", "-m", "-json", "-buildvcs=false", "all", workingDir = projectDir)
 
         list.stdout.byteInputStream().use { inputStream ->
             val result = mutableListOf<ModuleInfo>()
@@ -265,7 +265,8 @@ class GoMod(
         val result = mutableSetOf<String>()
 
         val list = run(
-            "list", "-deps", "-f", "{{with .Module}}{{.Path}} {{.Version}}{{end}}", "./...", workingDir = projectDir
+            "list", "-deps", "-f", "{{with .Module}}{{.Path}} {{.Version}}{{end}}", "-buildvcs=false", "./...",
+            workingDir = projectDir
         )
 
         list.stdout.lines().forEach { line ->


### PR DESCRIPTION
Go stamps binaries with version control information. Disable this by providing `-buildvcs=false` [1] when running go list because it is not required to gather dependency information and can lead to this error:

error obtaining VCS status: exit status 128

Fixes #5982.

[1]: https://pkg.go.dev/cmd/go