### PR TITLE
EvaluatorCommand: Fix-up replacing curations

### DIFF
--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -267,8 +267,8 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate ORT re
             ortResultInput = ortResultInput.replaceConfig(config)
         }
 
-        val curations = FilePackageCurationProvider.from(packageCurationsFile, packageCurationsDir).packageCurations
-        if (curations.isNotEmpty()) {
+        if (packageConfigurationOption != null) {
+            val curations = FilePackageCurationProvider.from(packageCurationsFile, packageCurationsDir).packageCurations
             ortResultInput = ortResultInput.replacePackageCurations(curations)
         }
 


### PR DESCRIPTION
The command allows overriding all curations by the ones provided via the option `--package-curations-file` or `--package-curations-dir`. Make that override work no matter if the curations are empty, to allow for "clearing" the curations.
