### PR TITLE
MavenSupport: Filter blank declared licenses

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -149,7 +149,7 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
         fun parseLicenses(mavenProject: MavenProject) =
             mavenProject.licenses.mapNotNull { license ->
                 license.name ?: license.url ?: license.comments
-            }.toSortedSet()
+            }.filter { it.isNotBlank() }.toSortedSet()
 
         fun processDeclaredLicenses(licenses: Set<String>): ProcessedDeclaredLicense =
             // See http://maven.apache.org/ref/3.6.3/maven-model/maven.html#project which says: "If multiple licenses


### PR DESCRIPTION
Do not add blank license strings to the list of declared licenses.