### PR TITLE
PythonInspector: Make license nullable

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
+++ b/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
@@ -129,7 +129,7 @@ internal object PythonInspector : CommandLineTool {
 
     @Serializable
     internal data class DeclaredLicense(
-        val license: String,
+        val license: String? = null,
         val classifiers: List<String> = emptyList()
     )
 


### PR DESCRIPTION
The `license` property can be missing in the python-inspector output so make it nullable and provide a default value.