### PR TITLE
MavenSupport: Improve license parsing

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenSupport.kt
@@ -148,8 +148,8 @@ class MavenSupport(private val workspaceReader: WorkspaceReader) {
 
         fun parseLicenses(mavenProject: MavenProject) =
             mavenProject.licenses.mapNotNull { license ->
-                license.name ?: license.url ?: license.comments
-            }.filter { it.isNotBlank() }.toSortedSet()
+                listOfNotNull(license.name, license.url, license.comments).firstOrNull { it.isNotBlank() }
+            }.toSortedSet()
 
         fun processDeclaredLicenses(licenses: Set<String>): ProcessedDeclaredLicense =
             // See http://maven.apache.org/ref/3.6.3/maven-model/maven.html#project which says: "If multiple licenses


### PR DESCRIPTION
Previously, if one of the fields used to get the declared license was not null but blank the other fields were ignored. Instead, take the first field that is neither null nor blank.
