### PR TITLE
OrtConfigurationTest: Fix a test name

### DIFF
--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -42,7 +42,7 @@ import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class OrtConfigurationTest : WordSpec({
     "OrtConfiguration" should {
-        "be deserializable from HOCON" {
+        "be deserializable from YAML" {
             val refConfig = File("src/main/resources/$REFERENCE_CONFIG_FILENAME")
             val ortConfig = OrtConfiguration.load(file = refConfig)
 


### PR DESCRIPTION
The name was still referring to the HOCON format which has been replaced by YAML.
