### PR TITLE
Npm: Cache the results of `npm view`

### DIFF
--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -369,7 +369,7 @@ open class Npm(
         }
 
     /** Cache for submodules identified by its moduleDir absolutePath */
-    private val submodulesCache: ConcurrentHashMap<String, List<File>> = ConcurrentHashMap()
+    private val submodulesCache = ConcurrentHashMap<String, List<File>>()
 
     /**
      * Find the directories which are defined as submodules of the project within [moduleDir].


### PR DESCRIPTION
Cache the results of the `npm view` call to improve performance in scans with many projects that have many overlapping dependencies.