### PR TITLE
SpdxDocumentFile: Prefer VCS information from SPDX over working tree

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/spdx-project-xyz-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/spdx-project-xyz-expected-output.yml
@@ -121,11 +121,11 @@ packages:
       algorithm: ""
   vcs:
     type: "Git"
-    url: "<REPLACE_URL>"
-    revision: "<REPLACE_REVISION>"
-    path: "analyzer/src/funTest/assets/projects/synthetic/spdx/libs/openssl"
+    url: "ssh://github.com/openssl/openssl.git"
+    revision: "e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
+    path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL_PROCESSED>"
-    revision: "<REPLACE_REVISION>"
-    path: "analyzer/src/funTest/assets/projects/synthetic/spdx/libs/openssl"
+    url: "ssh://git@github.com/openssl/openssl.git"
+    revision: "e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
+    path: ""

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -296,10 +296,10 @@ class SpdxDocumentFile(
     private fun SpdxPackage.toPackage(definitionFile: File?, doc: SpdxResolvedDocument): Package {
         val packageDescription = description.takeUnless { it.isEmpty() } ?: summary
 
-        // If the VCS information cannot be determined from the VCS working tree itself, fall back to try getting it
-        // from the download location.
+        // If the VCS information cannot be parsed from the download location, fall back to try getting it from the VCS
+        // working tree.
         val packageDir = definitionFile?.resolveSibling(packageFilename)
-        val vcs = packageDir?.let { VersionControlSystem.forDirectory(it)?.getInfo() } ?: getVcsInfo().orEmpty()
+        val vcs = getVcsInfo() ?: packageDir?.let { VersionControlSystem.forDirectory(it)?.getInfo() }.orEmpty()
 
         val generatedFromRelations = doc.relationships.filter {
             it.relationshipType == SpdxRelationship.Type.GENERATED_FROM


### PR DESCRIPTION
Prefer the VCS information provided by the SPDX metadata of a package over the VCS information gathered from the local working tree. Otherwise it is not possible to define in SPDX that the source code of a package is located in a different VCS because the local working tree will always be preferred.
