### PR TITLE
Npm: Improve loading of remote package details

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/NpmDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NpmDependencyHandler.kt
@@ -21,6 +21,8 @@ package org.ossreviewtoolkit.analyzer.managers.utils
 
 import java.io.File
 
+import kotlinx.coroutines.runBlocking
+
 import org.ossreviewtoolkit.analyzer.managers.Npm
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
@@ -79,5 +81,7 @@ class NpmDependencyHandler(private val npm: Npm) : DependencyHandler<NpmModuleIn
     override fun linkageFor(dependency: NpmModuleInfo): PackageLinkage = PackageLinkage.DYNAMIC
 
     override fun createPackage(dependency: NpmModuleInfo, issues: MutableList<OrtIssue>): Package =
-        npm.parsePackage(dependency.workingDir, dependency.packageFile).second
+        runBlocking {
+            npm.parsePackage(dependency.workingDir, dependency.packageFile).second
+        }
 }


### PR DESCRIPTION
Run the external process to lookup remote package details in a separate coroutine asynchronously. In the cache, only store the Deferred with the result. This should reduce contention on the cache map, since it is no longer necessary to wait for the process to finish.

Extract the caching logic to a new function that invokes the original getRemotePackageDetails() function. That way subclasses benefit from the caching mechanism as well.
