### PR TITLE
ResolvedLicense: Fix `toResolvedCopyrights()`

### DIFF
--- a/model/src/main/kotlin/licenses/ResolvedLicense.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicense.kt
@@ -127,7 +127,7 @@ private fun Collection<ResolvedCopyrightFinding>.toResolvedCopyrights(process: B
     val result = CopyrightStatementsProcessor.process(statementToFinding.keys)
 
     val processedCopyrights = result.processedStatements.map { (statement, originalStatements) ->
-        val findings = originalStatements.mapTo(mutableSetOf()) { statementToFinding.getValue(statement) }
+        val findings = originalStatements.mapTo(mutableSetOf()) { statementToFinding.getValue(it) }
         ResolvedCopyright(statement, findings)
     }
 

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -281,6 +281,17 @@ class LicenseInfoResolverTest : WordSpec({
                 "(c) 2011 Holder",
                 "(c) 2012 Holder"
             )
+
+            result should containCopyrightStatementsForLicenseExactly(
+                "Apache-2.0",
+                "(c) 2009-2010 Holder",
+                process = true
+            )
+            result should containCopyrightStatementsForLicenseExactly(
+                "MIT",
+                "(c) 2011-2012 Holder",
+                process = true
+            )
         }
 
         "mark copyright garbage as garbage" {
@@ -748,13 +759,14 @@ private fun containCopyrightGarbageForProvenanceExactly(
 
 private fun containCopyrightStatementsForLicenseExactly(
     license: String,
-    vararg copyrights: String
+    vararg copyrights: String,
+    process: Boolean = false
 ): Matcher<ResolvedLicenseInfo?> =
     transformingCollectionMatcher(
         expected = copyrights.toList(),
         matcher = ::containExactlyInAnyOrder
     ) { resolvedLicenseInfo ->
-        resolvedLicenseInfo[SpdxSingleLicenseExpression.parse(license)]?.getCopyrights(process = false).orEmpty()
+        resolvedLicenseInfo[SpdxSingleLicenseExpression.parse(license)]?.getCopyrights(process = process).orEmpty()
     }
 
 private fun containOnlyLicenseSources(vararg licenseSources: LicenseSource): Matcher<ResolvedLicenseInfo?> =


### PR DESCRIPTION
When searching the copyright findings for a statement the code was erroneously using the processed statement instead of the unprocessed statement. If the processed statement was different to the original statement this lead to an exception, because the map of original statements to their findings did not contain an entry with that key. Also, this error limited the list of findings in the `ResolvedCopyright` to those which exactly match the processed statement.

This is fixup for 3e9d11d.