### PR TITLE
downloader: Migrate from JSch to MINA as the SSH backend for JGit

### DIFF
--- a/downloader/build.gradle.kts
+++ b/downloader/build.gradle.kts
@@ -27,16 +27,8 @@ dependencies {
 
     implementation(project(":utils:ort-utils"))
 
-    // Force the generated Maven POM to use the same version of "jsch" Gradle resolves the version conflict to.
-    implementation("com.jcraft:jsch") {
-        version {
-            strictly("0.1.55")
-        }
-    }
-
     implementation(libs.jgit)
-    implementation(libs.jgitJsch)
-    implementation(libs.jschAgentProxy)
+    implementation(libs.jgitSshApacheAgent)
     implementation(libs.svnkit)
 
     testImplementation(libs.mockk)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,6 @@ jackson = "2.13.4"
 jgit = "6.3.0.202209071007-r"
 jiraRestClient = "5.2.4"
 jruby = "9.3.9.0"
-jschAgentProxy = "0.0.9"
 jslt = "0.1.13"
 jsonSchemaValidator = "1.0.73"
 kotest = "5.5.3"
@@ -111,11 +110,10 @@ jacksonDatatypeJsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datat
 jacksonModuleJaxbAnnotations = { module = "com.fasterxml.jackson.module:jackson-module-jaxb-annotations", version.ref = "jackson" }
 jacksonModuleKotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
-jgitJsch = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.jsch", version.ref = "jgit" }
+jgitSshApacheAgent = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.apache.agent", version.ref = "jgit" }
 jiraRestClientApi = { module = "com.atlassian.jira:jira-rest-java-client-api", version.ref = "jiraRestClient" }
 jiraRestClientApp = { module = "com.atlassian.jira:jira-rest-java-client-app", version.ref = "jiraRestClient" }
 jruby = { module = "org.jruby:jruby-complete", version.ref = "jruby" }
-jschAgentProxy = { module = "com.jcraft:jsch.agentproxy.jsch", version.ref = "jschAgentProxy" }
 jslt = { module = "com.schibsted.spt.data:jslt", version.ref = "jslt" }
 jsonSchemaValidator = { module = "com.networknt:json-schema-validator", version.ref = "jsonSchemaValidator" }
 kotestAssertionsCore = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }


### PR DESCRIPTION
The used `org.eclipse.jgit.ssh.apache.agent` artifact has build-in
ssh-agent support. As of https://github.com/oss-review-toolkit/ort/commit/43ff39eea3627f4586ecf53f1791d91154698ec3 there should have been no need anymore
to avoid "keyboard-interactive" prompts as the `CredentialsProvider` is
explicit set to ORT's own `AuthenticatorCredentialsProvider` only.

Resolves #6029.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>