### PR TITLE
ScanSummary: Fix an old reference to `ScanRecord`

### DIFF
--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -68,7 +68,7 @@ data class ScanSummary(
 
     /**
      * The list of issues that occurred during the scan. This property is not serialized if the list is empty to reduce
-     * the size of the result file. If there are no issues at all, [ScanRecord.hasIssues] already contains that
+     * the size of the result file. If there are no issues at all, [ScannerRun.hasIssues] already contains that
      * information.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)


### PR DESCRIPTION
The `ScanRecord` class has been removed in 9d9a449.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>