### PR TITLE
Rename `LicenseFilenamePatterns` to `LicenseFilePatterns`

### DIFF
--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -43,7 +43,7 @@ import kotlin.system.exitProcess
 
 import org.ossreviewtoolkit.cli.commands.*
 import org.ossreviewtoolkit.cli.utils.logger
-import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
+import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.expandTilde
@@ -185,7 +185,7 @@ class OrtMain : CliktCommand(name = ORT_NAME, invokeWithoutSubcommand = true) {
         // Make options available to subcommands and apply static configuration.
         val ortConfiguration = OrtConfiguration.load(configArguments, configFile)
         currentContext.findOrSetObject { GlobalOptions(ortConfiguration, forceOverwrite) }
-        LicenseFilenamePatterns.configure(ortConfiguration.licenseFilePatterns)
+        LicenseFilePatterns.configure(ortConfiguration.licenseFilePatterns)
 
         if (helpAll) {
             registeredSubcommands().forEach {

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -58,7 +58,7 @@ import org.ossreviewtoolkit.evaluator.Evaluator
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
-import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
+import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.config.orEmpty
@@ -294,7 +294,7 @@ class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate ORT re
             copyrightGarbage = copyrightGarbage,
             addAuthorsToCopyrights = config.addAuthorsToCopyrights,
             archiver = config.scanner.archive.createFileArchiver(),
-            licenseFilenamePatterns = LicenseFilenamePatterns.getInstance()
+            licenseFilePatterns = LicenseFilePatterns.getInstance()
         )
 
         val resolutionProvider = DefaultResolutionProvider.create(ortResultInput, resolutionsFile)

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -51,7 +51,7 @@ import org.ossreviewtoolkit.cli.utils.logger
 import org.ossreviewtoolkit.cli.utils.outputGroup
 import org.ossreviewtoolkit.cli.utils.readOrtResult
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
-import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
+import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.config.orEmpty
@@ -234,7 +234,7 @@ class ReporterCommand : CliktCommand(
             copyrightGarbage = copyrightGarbage,
             addAuthorsToCopyrights = config.addAuthorsToCopyrights,
             archiver = config.scanner.archive.createFileArchiver(),
-            licenseFilenamePatterns = LicenseFilenamePatterns.getInstance()
+            licenseFilePatterns = LicenseFilePatterns.getInstance()
         )
 
         val licenseClassifications =

--- a/downloader/src/main/kotlin/VersionControlSystem.kt
+++ b/downloader/src/main/kotlin/VersionControlSystem.kt
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.kotlin.Logging
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
-import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
+import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.orEmpty
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.collectMessages
@@ -151,7 +151,7 @@ abstract class VersionControlSystem {
          */
         internal fun getSparseCheckoutGlobPatterns(): List<String> {
             val globPatterns = mutableListOf("*$ORT_REPO_CONFIG_FILENAME")
-            val licensePatterns = LicenseFilenamePatterns.getInstance()
+            val licensePatterns = LicenseFilePatterns.getInstance()
             return licensePatterns.allLicenseFilenames.generateCapitalizationVariants().mapTo(globPatterns) { "**/$it" }
         }
 

--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.Instant
 import java.util.SortedSet
 
-import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
+import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
 import org.ossreviewtoolkit.utils.common.FileMatcher
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
@@ -98,7 +98,7 @@ data class ScanSummary(
     fun filterByPath(path: String): ScanSummary {
         if (path.isBlank()) return this
 
-        val rootLicenseMatcher = RootLicenseMatcher(LicenseFilenamePatterns.getInstance())
+        val rootLicenseMatcher = RootLicenseMatcher(LicenseFilePatterns.getInstance())
         val applicableLicenseFiles = rootLicenseMatcher.getApplicableRootLicenseFindingsForDirectories(
             licenseFindings = licenseFindings,
             directories = listOf(path)

--- a/model/src/main/kotlin/config/FileArchiverConfiguration.kt
+++ b/model/src/main/kotlin/config/FileArchiverConfiguration.kt
@@ -80,7 +80,7 @@ fun FileArchiverConfiguration?.createFileArchiver(): FileArchiver? {
         else -> FileArchiverFileStorage(LocalFileStorage(FileArchiver.DEFAULT_ARCHIVE_DIR))
     }
 
-    val patterns = LicenseFilenamePatterns.getInstance().allLicenseFilenames
+    val patterns = LicenseFilePatterns.getInstance().allLicenseFilenames
 
     return FileArchiver(patterns, storage)
 }

--- a/model/src/main/kotlin/config/LicenseFilePatterns.kt
+++ b/model/src/main/kotlin/config/LicenseFilePatterns.kt
@@ -19,7 +19,7 @@
 
 package org.ossreviewtoolkit.model.config
 
-data class LicenseFilenamePatterns(
+data class LicenseFilePatterns(
     /**
      * A list of globs that match default license file names. The patterns are supposed to be used case-insensitively.
      */
@@ -43,7 +43,7 @@ data class LicenseFilenamePatterns(
     val allLicenseFilenames = (licenseFilenames + patentFilenames + rootLicenseFilenames).distinct()
 
     companion object {
-        val DEFAULT = LicenseFilenamePatterns(
+        val DEFAULT = LicenseFilePatterns(
             licenseFilenames = listOf(
                 "copying*",
                 "copyright",
@@ -62,14 +62,14 @@ data class LicenseFilenamePatterns(
             )
         )
 
-        private var instance: LicenseFilenamePatterns = DEFAULT
+        private var instance: LicenseFilePatterns = DEFAULT
 
         @Synchronized
-        fun configure(patterns: LicenseFilenamePatterns) {
+        fun configure(patterns: LicenseFilePatterns) {
             instance = patterns
         }
 
         @Synchronized
-        fun getInstance(): LicenseFilenamePatterns = instance
+        fun getInstance(): LicenseFilePatterns = instance
     }
 }

--- a/model/src/main/kotlin/config/OrtConfiguration.kt
+++ b/model/src/main/kotlin/config/OrtConfiguration.kt
@@ -37,7 +37,7 @@ data class OrtConfiguration(
     /**
      * The license file patterns.
      */
-    val licenseFilePatterns: LicenseFilenamePatterns = LicenseFilenamePatterns.DEFAULT,
+    val licenseFilePatterns: LicenseFilePatterns = LicenseFilePatterns.DEFAULT,
 
     /**
      * A flag to indicate whether authors should be considered as copyright holders.

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -30,7 +30,7 @@ import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
-import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
+import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.model.utils.FindingCurationMatcher
@@ -45,14 +45,14 @@ class LicenseInfoResolver(
     private val copyrightGarbage: CopyrightGarbage,
     val addAuthorsToCopyrights: Boolean,
     val archiver: FileArchiver?,
-    val licenseFilenamePatterns: LicenseFilenamePatterns = LicenseFilenamePatterns.DEFAULT
+    val licenseFilePatterns: LicenseFilePatterns = LicenseFilePatterns.DEFAULT
 ) {
     private val resolvedLicenseInfo = ConcurrentHashMap<Identifier, ResolvedLicenseInfo>()
     private val resolvedLicenseFiles = ConcurrentHashMap<Identifier, ResolvedLicenseFileInfo>()
     private val rootLicenseMatcher = RootLicenseMatcher(
-        licenseFilenamePatterns = licenseFilenamePatterns.copy(rootLicenseFilenames = emptyList())
+        licenseFilePatterns = licenseFilePatterns.copy(rootLicenseFilenames = emptyList())
     )
-    private val findingsMatcher = FindingsMatcher(RootLicenseMatcher(licenseFilenamePatterns))
+    private val findingsMatcher = FindingsMatcher(RootLicenseMatcher(licenseFilePatterns))
 
     /**
      * Get the [ResolvedLicenseInfo] for the project or package identified by [id].

--- a/model/src/main/kotlin/utils/OrtResultExtensions.kt
+++ b/model/src/main/kotlin/utils/OrtResultExtensions.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.model.utils
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
-import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
+import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.licenses.DefaultLicenseInfoProvider
 import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
 
@@ -40,7 +40,7 @@ fun OrtResult.createLicenseInfoResolver(
         copyrightGarbage,
         addAuthorsToCopyrights,
         archiver,
-        LicenseFilenamePatterns.getInstance()
+        LicenseFilePatterns.getInstance()
     )
 
 /**

--- a/model/src/main/kotlin/utils/RootLicenseMatcher.kt
+++ b/model/src/main/kotlin/utils/RootLicenseMatcher.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.model.utils
 import java.io.File
 
 import org.ossreviewtoolkit.model.LicenseFinding
-import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
+import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.utils.common.FileMatcher
 import org.ossreviewtoolkit.utils.common.getAllAncestorDirectories
 
@@ -30,22 +30,22 @@ import org.ossreviewtoolkit.utils.common.getAllAncestorDirectories
  * A heuristic for determining which (root) license files apply to any file or directory.
  *
  * For any given directory the heuristic tries to assign license files by utilizing
- * [LicenseFilenamePatterns.licenseFilenames] and patent files by utilizing [LicenseFilenamePatterns.patentFilenames]
- * independently of one another. The [LicenseFilenamePatterns.rootLicenseFilenames] serve only as fallback to find
- * license files if there isn't any match for [LicenseFilenamePatterns.licenseFilenames].
+ * [LicenseFilePatterns.licenseFilenames] and patent files by utilizing [LicenseFilePatterns.patentFilenames]
+ * independently of one another. The [LicenseFilePatterns.rootLicenseFilenames] serve only as fallback to find
+ * license files if there isn't any match for [LicenseFilePatterns.licenseFilenames].
  *
  * To determine the (root) license files applicable for a specific directory, all filenames in that directory are
- * matched against [LicenseFilenamePatterns.licenseFilenames]. If there are matches then these are used as result,
+ * matched against [LicenseFilePatterns.licenseFilenames]. If there are matches then these are used as result,
  * otherwise that search is repeated recursively in the parent directory. If there is no parent directory (because the
  * root was already searched but no result was found) then start from scratch using the fallback pattern
- * [LicenseFilenamePatterns.rootLicenseFilenames].
+ * [LicenseFilePatterns.rootLicenseFilenames].
  *
  * Patent files are assigned in an analog way, but without any fallback pattern.
  */
-class RootLicenseMatcher(licenseFilenamePatterns: LicenseFilenamePatterns = LicenseFilenamePatterns.DEFAULT) {
-    private val licenseFileMatcher = createFileMatcher(licenseFilenamePatterns.licenseFilenames)
-    private val patentFileMatcher = createFileMatcher(licenseFilenamePatterns.patentFilenames)
-    private val rootLicenseFileMatcher = createFileMatcher(licenseFilenamePatterns.rootLicenseFilenames)
+class RootLicenseMatcher(licenseFilePatterns: LicenseFilePatterns = LicenseFilePatterns.DEFAULT) {
+    private val licenseFileMatcher = createFileMatcher(licenseFilePatterns.licenseFilenames)
+    private val patentFileMatcher = createFileMatcher(licenseFilePatterns.patentFilenames)
+    private val rootLicenseFileMatcher = createFileMatcher(licenseFilePatterns.rootLicenseFilenames)
 
     /**
      * Return a mapping from the given relative [directories] to the licenses findings for the (root) license files

--- a/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseInfoResolverTest.kt
@@ -52,7 +52,7 @@ import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
-import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
+import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.LicenseFindingCurationReason
 import org.ossreviewtoolkit.model.config.PathExclude
@@ -624,7 +624,7 @@ class LicenseInfoResolverTest : WordSpec({
 
             val archiveDir = File("src/test/assets/archive")
             val archiver = FileArchiver(
-                patterns = LicenseFilenamePatterns.DEFAULT.licenseFilenames,
+                patterns = LicenseFilePatterns.DEFAULT.licenseFilenames,
                 storage = LocalFileStorage(archiveDir)
             )
             val resolver = createResolver(licenseInfos, archiver = archiver)

--- a/reporter/src/main/kotlin/ReporterInput.kt
+++ b/reporter/src/main/kotlin/ReporterInput.kt
@@ -75,7 +75,7 @@ data class ReporterInput(
         copyrightGarbage = copyrightGarbage,
         addAuthorsToCopyrights = ortConfig.addAuthorsToCopyrights,
         archiver = ortConfig.scanner.archive.createFileArchiver(),
-        licenseFilenamePatterns = ortConfig.licenseFilePatterns
+        licenseFilePatterns = ortConfig.licenseFilePatterns
     ),
 
     /**

--- a/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
@@ -518,7 +518,7 @@ private fun ReporterInput.replaceOrtResult(ortResult: OrtResult): ReporterInput 
             copyrightGarbage = copyrightGarbage,
             addAuthorsToCopyrights = licenseInfoResolver.addAuthorsToCopyrights,
             archiver = licenseInfoResolver.archiver,
-            licenseFilenamePatterns = licenseInfoResolver.licenseFilenamePatterns
+            licenseFilePatterns = licenseInfoResolver.licenseFilePatterns
         )
     )
 

--- a/utils/test/src/main/kotlin/Extensions.kt
+++ b/utils/test/src/main/kotlin/Extensions.kt
@@ -26,7 +26,7 @@ import java.io.File
 import java.net.InetSocketAddress
 import java.net.Proxy
 
-import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
+import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.utils.FileArchiver
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
@@ -43,7 +43,7 @@ infix fun <T : Any> T?.shouldNotBeNull(block: T.() -> Unit) {
 
 fun FileArchiver.Companion.createDefault(): FileArchiver =
     FileArchiver(
-        patterns = LicenseFilenamePatterns.DEFAULT.allLicenseFilenames.map { "**/$it" },
+        patterns = LicenseFilePatterns.DEFAULT.allLicenseFilenames.map { "**/$it" },
         storage = LocalFileStorage(DEFAULT_ARCHIVE_DIR)
     )
 


### PR DESCRIPTION
Align with the `licenseFilePatterns` configuration option name, which is shorter and "name" is somewhat implied by "pattern" anyway.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>