### PR TITLE
Fix glob pattern docs to not refer to `FileSystem.getPathMatcher` anymore

### DIFF
--- a/model/src/main/kotlin/utils/FileArchiver.kt
+++ b/model/src/main/kotlin/utils/FileArchiver.kt
@@ -42,8 +42,8 @@ import org.ossreviewtoolkit.utils.ort.storage.FileStorage
  */
 class FileArchiver(
     /**
-     * A collection of globs to match the paths of files that shall be archived. For details about the glob pattern see
-     * [java.nio.file.FileSystem.getPathMatcher].
+     * A collection of globs to match the paths of files that shall be archived. For details about the glob patterns see
+     * [FileMatcher].
      */
     patterns: Collection<String>,
 
@@ -54,8 +54,8 @@ class FileArchiver(
 ) {
     constructor(
         /**
-         * A collection of globs to match the paths of files that shall be archived. For details about the glob pattern
-         * see [java.nio.file.FileSystem.getPathMatcher].
+         * A collection of globs to match the paths of files that shall be archived. For details about the glob patterns
+         * see [FileMatcher].
          */
         patterns: Collection<String>,
 

--- a/utils/common/src/main/kotlin/FileMatcher.kt
+++ b/utils/common/src/main/kotlin/FileMatcher.kt
@@ -28,7 +28,7 @@ class FileMatcher(
     /**
      * The collection of [glob patterns][1] to consider for matching.
      *
-     * [1]: https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob
+     * [1]: https://docs.spring.io/spring-framework/docs/current/javadoc-api/index.html?org/springframework/util/AntPathMatcher.html
      */
     val patterns: Collection<String>,
 


### PR DESCRIPTION
Generally refer to `FileMatcher`, and only from there refer to the `AntPathMatcher` implementation as a detail.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>