### PR TITLE
Revert "analyzer: Stop using the unauthenticated Git protocol in VCS processed"

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gradle-android-cyclic-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gradle-android-cyclic-expected-output-app.yml
@@ -11479,7 +11479,7 @@ shared_packages:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "https://android.googlesource.com/platform/tools/sherpa.git"
+    url: "git://android.googlesource.com/platform/tools/sherpa.git"
     revision: ""
     path: ""
 - id: "Maven:androidx.constraintlayout:constraintlayout-solver:2.0.1"
@@ -11511,7 +11511,7 @@ shared_packages:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "https://android.googlesource.com/platform/tools/sherpa.git"
+    url: "git://android.googlesource.com/platform/tools/sherpa.git"
     revision: ""
     path: ""
 - id: "Maven:androidx.dynamicanimation:dynamicanimation:1.0.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -2527,7 +2527,7 @@ packages:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "https://git.coolaj86.com/coolaj86/atob.js.git"
+    url: "git://git.coolaj86.com/coolaj86/atob.js.git"
     revision: "755cfea7899074a17e83a248c7cfc3960d956d82"
     path: ""
 - id: "NPM::babel-cli:6.26.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
@@ -907,7 +907,7 @@ packages:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "https://git.coolaj86.com/coolaj86/atob.js.git"
+    url: "git://git.coolaj86.com/coolaj86/atob.js.git"
     revision: "755cfea7899074a17e83a248c7cfc3960d956d82"
     path: ""
 - id: "NPM::autolinker:0.28.1"

--- a/utils/ort/src/main/kotlin/Utils.kt
+++ b/utils/ort/src/main/kotlin/Utils.kt
@@ -177,11 +177,6 @@ fun normalizeVcsUrl(vcsUrl: String): String {
         return url
     }
 
-    // Avoid using the unauthenticated Git protocol, which is blocked by many VCS hosts.
-    if (url.startsWith("git://")) {
-        url = "https://${url.removePrefix("git://")}"
-    }
-
     // URLs to Git repos may omit the scheme and use an SCP-like URL that uses ":" to separate the host from the path,
     // see https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a. Make this an explicit ssh URL, so it can be parsed
     // by Java's URI class.


### PR DESCRIPTION
This reverts commit 4c57907f5f3c95f229f824c8cd802ce0efdf660b as it prevents ORT to download repositories that doesn't support https.

Signed-off-by: Andriy Zhernovskyi <ext-andriy.zhernovskyi@here.com>
