### PR TITLE
Scanner: Return early if there are no missing archives

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -587,6 +587,8 @@ class Scanner(
         val provenancesWithMissingArchives = controller.getNestedProvenancesByPackage()
             .filterNot { (_, nestedProvenance) -> archiver.hasArchive(nestedProvenance.root) }
 
+        if (provenancesWithMissingArchives.isEmpty()) return
+
         logger.info { "Creating file archives for ${provenancesWithMissingArchives.size} package(s)." }
 
         val duration = measureTime {


### PR DESCRIPTION
This avoids log output like:

    Creating file archives for 0 package(s).
    Created file archives for 0 package(s) in 1.969us.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>