### PR TITLE
GenerateScopeExcludesCommand: Add the scope 'build_requires' for Conan

### DIFF
--- a/helper-cli/src/main/kotlin/commands/repoconfig/GenerateScopeExcludesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/repoconfig/GenerateScopeExcludesCommand.kt
@@ -115,6 +115,13 @@ private fun getScopeExcludesForPackageManager(packageManagerName: String): List<
                 comment = "Packages for development only."
             )
         )
+        "Conan" -> listOf(
+            ScopeExclude(
+                pattern = "build_requires",
+                reason = ScopeExcludeReason.DEV_DEPENDENCY_OF,
+                comment = "Packages for development only."
+            )
+        )
         "GoMod" -> listOf(
             ScopeExclude(
                 pattern = "vendor",


### PR DESCRIPTION
See also https://docs.conan.io/en/1.35/devtools/build_requires.html.
