### PR TITLE
PostgresConnection: Exclude some default value from serialization

### DIFF
--- a/model/src/main/kotlin/config/PostgresConnection.kt
+++ b/model/src/main/kotlin/config/PostgresConnection.kt
@@ -19,6 +19,8 @@
 
 package org.ossreviewtoolkit.model.config
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class PostgresConnection(
@@ -53,18 +55,21 @@ data class PostgresConnection(
      * The full path of the certificate file.
      * See: https://jdbc.postgresql.org/documentation/head/connect.html
      */
+    @JsonInclude(Include.NON_NULL)
     val sslcert: String? = null,
 
     /**
      * The full path of the key file.
      * See: https://jdbc.postgresql.org/documentation/head/connect.html
      */
+    @JsonInclude(Include.NON_NULL)
     val sslkey: String? = null,
 
     /**
      * The full path of the root certificate file.
      * See: https://jdbc.postgresql.org/documentation/head/connect.html
      */
+    @JsonInclude(Include.NON_NULL)
     val sslrootcert: String? = null,
 
     /**


### PR DESCRIPTION
Clean-up the output of `ort config --show-active` a bit.
