### PR TITLE
ScanStorageConfiguration: Default to provenance based storage

### DIFF
--- a/model/src/main/kotlin/config/ScanStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/ScanStorageConfiguration.kt
@@ -65,7 +65,7 @@ data class FileBasedStorageConfiguration(
     /**
      * The way that scan results are stored, defaults to [StorageType.PACKAGE_BASED].
      */
-    val type: StorageType = StorageType.PACKAGE_BASED
+    val type: StorageType = StorageType.PROVENANCE_BASED
 ) : ScanStorageConfiguration
 
 /**
@@ -80,7 +80,7 @@ data class PostgresStorageConfiguration(
     /**
      * The way that scan results are stored, defaults to [StorageType.PACKAGE_BASED].
      */
-    val type: StorageType = StorageType.PACKAGE_BASED
+    val type: StorageType = StorageType.PROVENANCE_BASED
 ) : ScanStorageConfiguration
 
 /**


### PR DESCRIPTION
This makes it less likely to use the wrong storage type, because provenance based scanning has become default recently.

