### PR TITLE
docker: Prepare base layer to non privileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1.4
 
 # Copyright (C) 2020 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,7 @@ ARG USER_ID=1000
 ARG USER_GID=$USER_ID
 ARG HOMEDIR=/home/ort
 ENV HOME=$HOMEDIR
+ENV USER=$USERNAME
 
 # Non privileged user
 RUN groupadd --gid $USER_GID $USERNAME \
@@ -81,6 +82,9 @@ RUN groupadd --gid $USER_GID $USERNAME \
     --shell /bin/bash \
     --home-dir $HOMEDIR \
     --create-home $USERNAME
+
+RUN chgrp $USER /opt \
+    && chmod g+wx /opt
 
 # sudo support
 RUN echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,8 +83,8 @@ RUN echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
 
 COPY docker/00-add_local_path.sh /etc/profile.d/
 
-# Copy ort scripts
-COPY scripts /etc/scripts
+# Import certificates scripts only
+COPY scripts/import_certificates.sh /etc/scripts/import_certificates.sh
 
 # Set this to a directory containing CRT-files for custom certificates that ORT and all build tools should know about.
 ARG CRT_FILES=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     dirmngr \
     gcc \
     git \
+    g++ \
     gnupg2 \
     iproute2 \
     libarchive-tools \
+    libffi-dev \
+    libgmp-dev \
     libz-dev \
     locales \
+    lzma \
+    make \
     netbase \
     openssh-client \
     openssl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,6 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
-RUN echo $LANG > /etc/locale.gen \
-    && locale-gen en_US.UTF-8 \
-    && update-locale LANG=en_US.UTF-8
-
 # Base package set
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -57,6 +53,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     wget \
     xz-utils \
     && rm -rf /var/lib/apt/lists/*
+
+RUN echo $LANG > /etc/locale.gen \
+    && locale-gen $LANG \
+    && update-locale LANG=$LANG
 
 ARG USERNAME=ort
 ARG USER_ID=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,10 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
+# Check and set apt proxy
+COPY docker/set_apt_proxy.sh /etc/scripts/set_apt_proxy.sh
+RUN /etc/scripts/set_apt_proxy.sh
+
 # Base package set
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/Dockerfile
+++ b/Dockerfile
@@ -330,7 +330,7 @@ ENV ANDROID_HOME=/opt/android-sdk
 COPY --from=androidbuild /usr/bin/repo /usr/bin/
 COPY --from=androidbuild /etc/profile.d/android.sh /etc/profile.d/
 COPY --chown=$USERNAME:$USERNAME --from=androidbuild ${ANDROID_HOME} ${ANDROID_HOME}
-RUN chmod o+rw ${ANDROID_HOME}
+RUN chmod -R o+rw ${ANDROID_HOME}
 
 # External repositories for SBT
 ARG SBT_VERSION=1.6.1

--- a/docker/set_apt_proxy.sh
+++ b/docker/set_apt_proxy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+if [ -n "$http_proxy" ]; then
+    cat << EOF > /etc/apt/apt.conf.d/proxy.conf
+Acquire {
+    HTTP::proxy "$http_proxy";
+    HTTPS::proxy "$http_proxy";
+}
+EOF
+fi


### PR DESCRIPTION
To accomplish the last step of docker multi stage change, we need take small step to achieve the result of the draft PR https://github.com/oss-review-toolkit/ort/pull/6041, as too big to change in a single step.

This initial needed changes accomplish:

- Updated the version of dockerfile spec to accept build-contexts ( buildx )
- Add extra packages to base to eliminate the need of a builder image, reducing build time after cached and providing the minimal packages needed to language package managers  build native bindings, mostly cargo, ruby and python 
- Make base image run as non-privileged user instead of root
- Add proxy script for apt, as now image is user based and apt will run in sudo mode
- Modify permissions on android deploy dir, as now need to be run as user, and github actions use a **runner** user called runner.