### PR TITLE
Unify hasLabel() and labelContains()

### DIFF
--- a/evaluator/src/main/kotlin/Rule.kt
+++ b/evaluator/src/main/kotlin/Rule.kt
@@ -107,25 +107,14 @@ abstract class Rule(
 
     /**
      * A [RuleMatcher] that checks whether a [label] exists in the [ORT result][OrtResult.labels]. If [value] is null
-     * the value of the label is ignored.
+     * the value of the label is ignored. If [splitValue] is true, the label value is interpreted as comma-separated
+     * list.
      */
-    fun hasLabel(label: String, value: String? = null) =
+    fun hasLabel(label: String, value: String? = null, splitValue: Boolean = true) =
         object : RuleMatcher {
-            override val description = "hasLabel(${listOfNotNull(label, value).joinToString()})"
+            override val description = "hasLabel(${listOfNotNull(label, value, splitValue).joinToString()})"
 
-            override fun matches() = ruleSet.ortResult.hasLabel(label, value, splitValue = false)
-        }
-
-    /**
-     * A [RuleMatcher] that checks whether a [label] exists in the [ORT result][OrtResult.labels] and contains a
-     * specific [value]. The value of the label is interpreted as a comma-separated list. The check is successful if
-     * this list contains the [value].
-     */
-    fun labelContains(label: String, value: String) =
-        object : RuleMatcher {
-            override val description = "labelContains($label, $value)"
-
-            override fun matches() = value in ruleSet.ortResult.getLabelValues(label)
+            override fun matches() = ruleSet.ortResult.hasLabel(label, value, splitValue)
         }
 
     /**

--- a/evaluator/src/main/kotlin/Rule.kt
+++ b/evaluator/src/main/kotlin/Rule.kt
@@ -113,7 +113,7 @@ abstract class Rule(
         object : RuleMatcher {
             override val description = "hasLabel(${listOfNotNull(label, value).joinToString()})"
 
-            override fun matches() = ruleSet.ortResult.hasLabel(label, value)
+            override fun matches() = ruleSet.ortResult.hasLabel(label, value, splitValue = false)
         }
 
     /**

--- a/evaluator/src/test/kotlin/RuleTest.kt
+++ b/evaluator/src/test/kotlin/RuleTest.kt
@@ -144,25 +144,29 @@ class RuleTest : WordSpec() {
 
                 matcher.matches() shouldBe false
             }
-        }
 
-        "labelContains()" should {
             "return true if the ORT result contains the label with the value" {
-                val matcher = createRule().labelContains("list", "value2")
+                val matcher = createRule().hasLabel("list", "value2")
 
                 matcher.matches() shouldBe true
             }
 
             "return false if the ORT result does not contain the label" {
-                val matcher = createRule().labelContains("missing", "value")
+                val matcher = createRule().hasLabel("missing", "value")
 
                 matcher.matches() shouldBe false
             }
 
             "return false if the ORT result does not contain the label with the value" {
-                val matcher = createRule().labelContains("list", "value4")
+                val matcher = createRule().hasLabel("list", "value4")
 
                 matcher.matches() shouldBe false
+            }
+
+            "return true if the ORT result contains the label values which includes commas" {
+                val matcher = createRule().hasLabel("list", "value1, value2, value3", splitValue = false)
+
+                matcher.matches() shouldBe true
             }
         }
     }

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -498,11 +498,13 @@ data class OrtResult(
 
     /**
      * Return true if a [label] with [value] exists in this [OrtResult]. If [value] is null the value of the label is
-     * ignored.
+     * ignored. If [splitValue] is true, the label value is interpreted as comma-separated list.
      */
-    fun hasLabel(label: String, value: String? = null) =
+    fun hasLabel(label: String, value: String? = null, splitValue: Boolean = true) =
         if (value == null) {
             label in labels
+        } else if (splitValue) {
+            value in getLabelValues(label)
         } else {
             labels[label] == value
         }


### PR DESCRIPTION
See individual commits.

**Breaking change:** Policy rules which use `labelContains()` must be changed to use `hasLabel()` instead.