### PR TITLE
Rule: Extract some matcher logic to OrtResult to enable re-use

### DIFF
--- a/evaluator/src/main/kotlin/Rule.kt
+++ b/evaluator/src/main/kotlin/Rule.kt
@@ -113,12 +113,7 @@ abstract class Rule(
         object : RuleMatcher {
             override val description = "hasLabel(${listOfNotNull(label, value).joinToString()})"
 
-            override fun matches() =
-                if (value == null) {
-                    label in ruleSet.ortResult.labels
-                } else {
-                    ruleSet.ortResult.labels[label] == value
-                }
+            override fun matches() = ruleSet.ortResult.hasLabel(label, value)
         }
 
     /**

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -495,4 +495,15 @@ data class OrtResult(
      */
     fun getLabelValues(key: String): Set<String> =
         labels[key]?.split(',').orEmpty().mapTo(mutableSetOf()) { it.trim() }
+
+    /**
+     * Return true if a [label] with [value] exists in this [OrtResult]. If [value] is null the value of the label is
+     * ignored.
+     */
+    fun hasLabel(label: String, value: String? = null) =
+        if (value == null) {
+            label in labels
+        } else {
+            labels[label] == value
+        }
 }


### PR DESCRIPTION
This allows using the logic without a Rule context from the policy rules.


