### PR TITLE
Analyzer: Fix `mustRunAfter` to eventually hang when configured globally 

### DIFF
--- a/analyzer/src/funTest/kotlin/AnalyzerFunTest.kt
+++ b/analyzer/src/funTest/kotlin/AnalyzerFunTest.kt
@@ -48,7 +48,6 @@ class AnalyzerFunTest : WordSpec({
                 repoConfig
             )
 
-            // TODO: This test currently fails.
             shouldCompleteWithin(20, TimeUnit.SECONDS) {
                 analyzer.analyze(info)
             }

--- a/analyzer/src/funTest/kotlin/AnalyzerFunTest.kt
+++ b/analyzer/src/funTest/kotlin/AnalyzerFunTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.concurrent.shouldCompleteWithin
+
+import java.util.concurrent.TimeUnit
+
+import org.ossreviewtoolkit.analyzer.managers.Gradle
+import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
+import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
+import org.ossreviewtoolkit.model.config.RepositoryConfiguration
+import org.ossreviewtoolkit.utils.test.createTestTempDir
+
+class AnalyzerFunTest : WordSpec({
+    "A globally configured 'mustRunAfter'" should {
+        "not block when depending on a package manager for which no definition files have been found" {
+            val inputDir = createTestTempDir()
+            val gradleDefinitionFile = inputDir.resolve("gradle.build").apply { writeText("// Dummy file") }
+
+            val gradleConfig = PackageManagerConfiguration(mustRunAfter = listOf("NPM"))
+            val analyzerConfig = AnalyzerConfiguration().copy(packageManagers = mapOf("Gradle" to gradleConfig))
+            val repoConfig = RepositoryConfiguration()
+
+            val analyzer = Analyzer(analyzerConfig)
+            val gradle = Gradle("Gradle", inputDir, analyzerConfig, repoConfig)
+            val info = Analyzer.ManagedFileInfo(
+                inputDir,
+                mapOf(gradle to listOf(gradleDefinitionFile)),
+                repoConfig
+            )
+
+            // TODO: This test currently fails.
+            shouldCompleteWithin(20, TimeUnit.SECONDS) {
+                analyzer.analyze(info)
+            }
+        }
+    }
+})

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -153,7 +153,7 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
         runBlocking {
             managedFiles.entries.map { (manager, files) ->
                 val mustRunAfter = config.getPackageManagerConfiguration(manager.managerName)?.mustRunAfter?.toSet()
-                    ?: packageManagerDependencies[manager]?.mapTo(mutableSetOf()) { it.managerName }.orEmpty()
+                    ?: packageManagerDependencies[manager].orEmpty()
 
                 PackageManagerRunner(
                     manager = manager,
@@ -175,12 +175,12 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
 
     private fun determinePackageManagerDependencies(
         managedFiles: Map<PackageManager, List<File>>
-    ): Map<PackageManager, Set<PackageManager>> {
+    ): Map<PackageManager, Set<String>> {
         val packageManagersWithFiles = managedFiles.keys.associateByTo(sortedMapOf(String.CASE_INSENSITIVE_ORDER)) {
             it.managerName
         }
 
-        val result = mutableMapOf<PackageManager, MutableSet<PackageManager>>()
+        val result = mutableMapOf<PackageManager, MutableSet<String>>()
 
         managedFiles.keys.forEach { packageManager ->
             val dependencies = packageManager.findPackageManagerDependencies(managedFiles)
@@ -194,7 +194,7 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
                                 "definition files for $name."
                     }
                 } else {
-                    result.getOrPut(packageManager) { mutableSetOf() } += managerForName
+                    result.getOrPut(packageManager) { mutableSetOf() } += name
                 }
             }
 
@@ -207,7 +207,7 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
                                 "definition files for $name."
                     }
                 } else {
-                    result.getOrPut(managerForName) { mutableSetOf() } += packageManager
+                    result.getOrPut(managerForName) { mutableSetOf() } += packageManager.managerName
                 }
             }
         }

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -176,7 +176,7 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
     private fun determinePackageManagerDependencies(
         managedFiles: Map<PackageManager, List<File>>
     ): Map<PackageManager, Set<PackageManager>> {
-        val allPackageManagers =
+        val packageManagersWithFiles =
             managedFiles.keys.associateBy { it.managerName }.toSortedMap(String.CASE_INSENSITIVE_ORDER)
 
         val result = mutableMapOf<PackageManager, MutableSet<PackageManager>>()
@@ -184,7 +184,7 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
         managedFiles.keys.forEach { packageManager ->
             val dependencies = packageManager.findPackageManagerDependencies(managedFiles)
             dependencies.mustRunAfter.forEach { name ->
-                val managerForName = allPackageManagers[name]
+                val managerForName = packageManagersWithFiles[name]
 
                 if (managerForName == null) {
                     logger.debug {
@@ -197,7 +197,7 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
             }
 
             dependencies.mustRunBefore.forEach { name ->
-                val managerForName = allPackageManagers[name]
+                val managerForName = packageManagersWithFiles[name]
 
                 if (managerForName == null) {
                     logger.debug {

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -183,6 +183,7 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
 
         managedFiles.keys.forEach { packageManager ->
             val dependencies = packageManager.findPackageManagerDependencies(managedFiles)
+
             dependencies.mustRunAfter.forEach { name ->
                 val managerForName = packageManagersWithFiles[name]
 

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -176,8 +176,9 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
     private fun determinePackageManagerDependencies(
         managedFiles: Map<PackageManager, List<File>>
     ): Map<PackageManager, Set<PackageManager>> {
-        val packageManagersWithFiles =
-            managedFiles.keys.associateBy { it.managerName }.toSortedMap(String.CASE_INSENSITIVE_ORDER)
+        val packageManagersWithFiles = managedFiles.keys.associateByTo(sortedMapOf(String.CASE_INSENSITIVE_ORDER)) {
+            it.managerName
+        }
 
         val result = mutableMapOf<PackageManager, MutableSet<PackageManager>>()
 

--- a/model/src/test/kotlin/config/AnalyzerConfigurationTest.kt
+++ b/model/src/test/kotlin/config/AnalyzerConfigurationTest.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.model.config
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.maps.containExactly as containExactlyEntries
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -106,7 +107,7 @@ class AnalyzerConfigurationTest : WordSpec({
 
             with(self.merge(other)) {
                 packageManagers shouldNotBeNull {
-                    this should io.kotest.matchers.maps.containExactly(
+                    this should containExactlyEntries(
                         "Gradle" to PackageManagerConfiguration(
                             mustRunAfter = listOf("NPM"),
                             options = mapOf("option1" to "value1", "option2" to "value2")

--- a/model/src/test/kotlin/config/PackageManagerConfigurationTest.kt
+++ b/model/src/test/kotlin/config/PackageManagerConfigurationTest.kt
@@ -21,6 +21,7 @@ package org.ossreviewtoolkit.model.config
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.maps.containExactly as containExactlyEntries
 import io.kotest.matchers.should
 
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
@@ -50,7 +51,7 @@ class PackageManagerConfigurationTest : WordSpec({
             val other = PackageManagerConfiguration(options = mapOf("option" to "value2"))
 
             self.merge(other).options shouldNotBeNull {
-                this should io.kotest.matchers.maps.containExactly("option" to "value2")
+                this should containExactlyEntries("option" to "value2")
             }
         }
 
@@ -59,7 +60,7 @@ class PackageManagerConfigurationTest : WordSpec({
             val other = PackageManagerConfiguration(options = mapOf("option2" to "value2"))
 
             self.merge(other).options shouldNotBeNull {
-                this should io.kotest.matchers.maps.containExactly("option1" to "value1", "option2" to "value2")
+                this should containExactlyEntries("option1" to "value1", "option2" to "value2")
             }
         }
     }


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.