### PR TITLE
NuGetSupport: Refactoring first couple of steps

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-direct-dependencies-only-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-direct-dependencies-only-expected-output.yml
@@ -171,7 +171,6 @@ packages:
 issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "NuGet"
-  message: "Failed to get package data for 'NuGet::foobar:1.2.3': IOException: Failed\
-    \ to retrieve package data for 'foobar' from any of [https://api.nuget.org/v3/registration5-gz-semver2,\
+  message: "Failed to get package data for 'NuGet::foobar:1.2.3' from any of [https://api.nuget.org/v3/registration5-gz-semver2,\
     \ https://pkgs.dev.azure.com/ms/20953fb4-d427-4ad6-b78c-13142d0c5462/_packaging/64e3bf16-3e04-41cd-b90f-60fdc9ccf494/nuget/v3/registrations2-semver2]."
   severity: "ERROR"

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output-with-nuspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output-with-nuspec.yml
@@ -638,7 +638,6 @@ packages:
 issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "NuGet"
-  message: "Failed to get package data for 'NuGet::foobar:1.2.3': IOException: Failed\
-    \ to retrieve package data for 'foobar' from any of [https://api.nuget.org/v3/registration5-gz-semver2,\
+  message: "Failed to get package data for 'NuGet::foobar:1.2.3' from any of [https://api.nuget.org/v3/registration5-gz-semver2,\
     \ https://pkgs.dev.azure.com/ms/20953fb4-d427-4ad6-b78c-13142d0c5462/_packaging/64e3bf16-3e04-41cd-b90f-60fdc9ccf494/nuget/v3/registrations2-semver2]."
   severity: "ERROR"

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
@@ -632,7 +632,6 @@ packages:
 issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "NuGet"
-  message: "Failed to get package data for 'NuGet::foobar:1.2.3': IOException: Failed\
-    \ to retrieve package data for 'foobar' from any of [https://api.nuget.org/v3/registration5-gz-semver2,\
+  message: "Failed to get package data for 'NuGet::foobar:1.2.3' from any of [https://api.nuget.org/v3/registration5-gz-semver2,\
     \ https://pkgs.dev.azure.com/ms/20953fb4-d427-4ad6-b78c-13142d0c5462/_packaging/64e3bf16-3e04-41cd-b90f-60fdc9ccf494/nuget/v3/registrations2-semver2]."
   severity: "ERROR"

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-direct-dependencies-only-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-direct-dependencies-only-expected-output.yml
@@ -171,7 +171,6 @@ packages:
 issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "NuGet"
-  message: "Failed to get package data for 'NuGet::foobar:1.2.3': IOException: Failed\
-    \ to retrieve package data for 'foobar' from any of [https://api.nuget.org/v3/registration5-gz-semver2,\
+  message: "Failed to get package data for 'NuGet::foobar:1.2.3' from any of [https://api.nuget.org/v3/registration5-gz-semver2,\
     \ https://pkgs.dev.azure.com/ms/20953fb4-d427-4ad6-b78c-13142d0c5462/_packaging/64e3bf16-3e04-41cd-b90f-60fdc9ccf494/nuget/v3/registrations2-semver2]."
   severity: "ERROR"

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
@@ -632,7 +632,6 @@ packages:
 issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "NuGet"
-  message: "Failed to get package data for 'NuGet::foobar:1.2.3': IOException: Failed\
-    \ to retrieve package data for 'foobar' from any of [https://api.nuget.org/v3/registration5-gz-semver2,\
+  message: "Failed to get package data for 'NuGet::foobar:1.2.3' from any of [https://api.nuget.org/v3/registration5-gz-semver2,\
     \ https://pkgs.dev.azure.com/ms/20953fb4-d427-4ad6-b78c-13142d0c5462/_packaging/64e3bf16-3e04-41cd-b90f-60fdc9ccf494/nuget/v3/registrations2-semver2]."
   severity: "ERROR"

--- a/analyzer/src/main/kotlin/managers/DotNet.kt
+++ b/analyzer/src/main/kotlin/managers/DotNet.kt
@@ -70,8 +70,7 @@ class DotNet(
         listOf(
             resolveNuGetDependencies(
                 definitionFile,
-                reader,
-                NuGetSupport(definitionFile),
+                NuGetSupport(managerName, analysisRoot, reader, definitionFile),
                 directDependenciesOnly
             )
         )

--- a/analyzer/src/main/kotlin/managers/DotNet.kt
+++ b/analyzer/src/main/kotlin/managers/DotNet.kt
@@ -33,7 +33,6 @@ import org.ossreviewtoolkit.analyzer.managers.utils.NuGetDependency
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetSupport
 import org.ossreviewtoolkit.analyzer.managers.utils.OPTION_DIRECT_DEPENDENCIES_ONLY
 import org.ossreviewtoolkit.analyzer.managers.utils.XmlPackageFileReader
-import org.ossreviewtoolkit.analyzer.managers.utils.resolveNuGetDependencies
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
@@ -66,14 +65,12 @@ class DotNet(
 
     private val reader = DotNetPackageFileReader()
 
-    override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> =
-        listOf(
-            resolveNuGetDependencies(
-                definitionFile,
-                NuGetSupport(managerName, analysisRoot, reader, definitionFile),
-                directDependenciesOnly
-            )
-        )
+    override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {
+        val support = NuGetSupport(managerName, analysisRoot, reader, definitionFile)
+        val projectAnalyzerResult = support.resolveNuGetDependencies(definitionFile, directDependenciesOnly)
+
+        return listOf(projectAnalyzerResult)
+    }
 }
 
 /**

--- a/analyzer/src/main/kotlin/managers/DotNet.kt
+++ b/analyzer/src/main/kotlin/managers/DotNet.kt
@@ -67,7 +67,7 @@ class DotNet(
 
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {
         val support = NuGetSupport(managerName, analysisRoot, reader)
-        val projectAnalyzerResult = support.resolveNuGetDependencies(definitionFile, directDependenciesOnly)
+        val projectAnalyzerResult = support.resolveDependencies(definitionFile, directDependenciesOnly)
 
         return listOf(projectAnalyzerResult)
     }

--- a/analyzer/src/main/kotlin/managers/DotNet.kt
+++ b/analyzer/src/main/kotlin/managers/DotNet.kt
@@ -66,7 +66,7 @@ class DotNet(
     private val reader = DotNetPackageFileReader()
 
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {
-        val support = NuGetSupport(managerName, analysisRoot, reader, definitionFile)
+        val support = NuGetSupport(managerName, analysisRoot, reader)
         val projectAnalyzerResult = support.resolveNuGetDependencies(definitionFile, directDependenciesOnly)
 
         return listOf(projectAnalyzerResult)

--- a/analyzer/src/main/kotlin/managers/DotNet.kt
+++ b/analyzer/src/main/kotlin/managers/DotNet.kt
@@ -71,7 +71,7 @@ class DotNet(
             resolveNuGetDependencies(
                 definitionFile,
                 reader,
-                NuGetSupport.create(definitionFile),
+                NuGetSupport(definitionFile),
                 directDependenciesOnly
             )
         )

--- a/analyzer/src/main/kotlin/managers/NuGet.kt
+++ b/analyzer/src/main/kotlin/managers/NuGet.kt
@@ -69,8 +69,12 @@ class NuGet(
         listOf(
             resolveNuGetDependencies(
                 definitionFile,
-                reader,
-                NuGetSupport(definitionFile),
+                NuGetSupport(
+                    managerName,
+                    analysisRoot,
+                    reader,
+                    definitionFile
+                ),
                 directDependenciesOnly
             )
         )

--- a/analyzer/src/main/kotlin/managers/NuGet.kt
+++ b/analyzer/src/main/kotlin/managers/NuGet.kt
@@ -65,7 +65,7 @@ class NuGet(
     private val reader = NuGetPackageFileReader()
 
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {
-        val support = NuGetSupport(managerName, analysisRoot, reader, definitionFile)
+        val support = NuGetSupport(managerName, analysisRoot, reader)
         val projectAnalyzerResult = support.resolveNuGetDependencies(definitionFile, directDependenciesOnly)
 
         return listOf(projectAnalyzerResult)

--- a/analyzer/src/main/kotlin/managers/NuGet.kt
+++ b/analyzer/src/main/kotlin/managers/NuGet.kt
@@ -66,7 +66,7 @@ class NuGet(
 
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {
         val support = NuGetSupport(managerName, analysisRoot, reader)
-        val projectAnalyzerResult = support.resolveNuGetDependencies(definitionFile, directDependenciesOnly)
+        val projectAnalyzerResult = support.resolveDependencies(definitionFile, directDependenciesOnly)
 
         return listOf(projectAnalyzerResult)
     }

--- a/analyzer/src/main/kotlin/managers/NuGet.kt
+++ b/analyzer/src/main/kotlin/managers/NuGet.kt
@@ -33,7 +33,6 @@ import org.ossreviewtoolkit.analyzer.managers.utils.NuGetDependency
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetSupport
 import org.ossreviewtoolkit.analyzer.managers.utils.OPTION_DIRECT_DEPENDENCIES_ONLY
 import org.ossreviewtoolkit.analyzer.managers.utils.XmlPackageFileReader
-import org.ossreviewtoolkit.analyzer.managers.utils.resolveNuGetDependencies
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
@@ -65,19 +64,12 @@ class NuGet(
 
     private val reader = NuGetPackageFileReader()
 
-    override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> =
-        listOf(
-            resolveNuGetDependencies(
-                definitionFile,
-                NuGetSupport(
-                    managerName,
-                    analysisRoot,
-                    reader,
-                    definitionFile
-                ),
-                directDependenciesOnly
-            )
-        )
+    override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {
+        val support = NuGetSupport(managerName, analysisRoot, reader, definitionFile)
+        val projectAnalyzerResult = support.resolveNuGetDependencies(definitionFile, directDependenciesOnly)
+
+        return listOf(projectAnalyzerResult)
+    }
 }
 
 /**

--- a/analyzer/src/main/kotlin/managers/NuGet.kt
+++ b/analyzer/src/main/kotlin/managers/NuGet.kt
@@ -70,7 +70,7 @@ class NuGet(
             resolveNuGetDependencies(
                 definitionFile,
                 reader,
-                NuGetSupport.create(definitionFile),
+                NuGetSupport(definitionFile),
                 directDependenciesOnly
             )
         )

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -250,7 +250,7 @@ class NuGetSupport(
                 val packageReferences = sortedSetOf<PackageReference>()
 
                 buildDependencyTree(
-                    references = allDependencies.map { Identifier("NuGet::${it.name}:${it.version}") },
+                    references = allDependencies.map { it.getId() },
                     dependencies = packageReferences,
                     packages = packages,
                     issues = issues,
@@ -342,6 +342,8 @@ private fun resolveLocalSpec(definitionFile: File): File? =
 
 private fun getIdentifier(name: String, version: String) =
     Identifier(type = "NuGet", namespace = "", name = name, version = version)
+
+private fun NuGetDependency.getId() = Identifier("NuGet::$name:$version")
 
 /**
  * A class that bundles properties of a single NuGet dependency.

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -305,11 +305,11 @@ class NuGetSupport(
             }.awaitAll()
         }
 
-        // Note: Remove a trailing slash as one is always added later to separate from the path, and a double-slash
-        // would break the URL!
         return serviceIndices
             .flatMap { it.resources }
             .filter { it.type == REGISTRATIONS_BASE_URL_TYPE }
+            // Note: Remove a trailing slash as one is always added later to separate from the path, and a double-slash
+            // would break the URL!
             .map { it.id.removeSuffix("/") }
     }
 }

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -212,11 +212,12 @@ class NuGetSupport(
             // grow really huge.
             if (packageIsNew) {
                 // TODO: Consider mapping dependency groups to scopes.
-                val referredDependencies =
-                    all.details.dependencyGroups.flatMapTo(mutableSetOf()) { it.dependencies }
+                val dependencyReferences = all.details.dependencyGroups.flatMapTo(mutableSetOf()) { group ->
+                    group.dependencies.map { it.getId() }
+                }
 
                 buildDependencyTree(
-                    referredDependencies.map { it.getId() },
+                    dependencyReferences,
                     packageMap,
                     pkgRef.dependencies,
                     packages,

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -109,23 +109,7 @@ class NuGetSupport(
         }
     }
 
-    private val registrationsBaseUrls: List<String> = run {
-        val configFile = definitionFile.parentFile.searchUpwardsForFile("nuget.config", ignoreCase = true)
-        val serviceIndexUrls = configFile?.let { NuGetConfigFileReader.getRegistrationsBaseUrls(it) }
-            ?: listOf(DEFAULT_SERVICE_INDEX_URL)
-        val serviceIndices = runBlocking {
-            serviceIndexUrls.map {
-                async { JSON_MAPPER.readValueFromUrl<ServiceIndex>(it) }
-            }.awaitAll()
-        }
-
-        // Note: Remove a trailing slash as one is always added later to separate from the path, and a double-slash
-        // would break the URL!
-        serviceIndices
-            .flatMap { it.resources }
-            .filter { it.type == REGISTRATIONS_BASE_URL_TYPE }
-            .map { it.id.removeSuffix("/") }
-    }
+    private val registrationsBaseUrls: List<String> = getRegistrationsBaseUrls(definitionFile)
 
     private val packageMap = mutableMapOf<Identifier, Pair<AllPackageData, Package>>()
 
@@ -305,6 +289,24 @@ class NuGetSupport(
             homepageUrl = "",
             scopeDependencies = scopes
         )
+    }
+
+    private fun getRegistrationsBaseUrls(definitionFile: File): List<String> {
+        val configFile = definitionFile.parentFile.searchUpwardsForFile("nuget.config", ignoreCase = true)
+        val serviceIndexUrls = configFile?.let { NuGetConfigFileReader.getRegistrationsBaseUrls(it) }
+            ?: listOf(DEFAULT_SERVICE_INDEX_URL)
+        val serviceIndices = runBlocking {
+            serviceIndexUrls.map {
+                async { JSON_MAPPER.readValueFromUrl<ServiceIndex>(it) }
+            }.awaitAll()
+        }
+
+        // Note: Remove a trailing slash as one is always added later to separate from the path, and a double-slash
+        // would break the URL!
+        return serviceIndices
+            .flatMap { it.resources }
+            .filter { it.type == REGISTRATIONS_BASE_URL_TYPE }
+            .map { it.id.removeSuffix("/") }
     }
 }
 

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -146,12 +146,11 @@ class NuGetSupport(
                 continue
             }
 
-            val nupkgUrl = packageData.packageContent
-            val nuspecUrl = nupkgUrl.replace(".${id.version}.nupkg", ".nuspec")
-
             val allPackageData = runBlocking {
                 val packageDetails = async { JSON_MAPPER.readValueFromUrl<PackageDetails>(packageData.catalogEntry) }
+                val nuspecUrl = packageData.packageContent.replace(".${id.version}.nupkg", ".nuspec")
                 val packageSpec = async { XML_MAPPER.readValueFromUrl<PackageSpec>(nuspecUrl) }
+
                 AllPackageData(packageData, packageDetails.await(), packageSpec.await())
             }
 

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -231,7 +231,7 @@ class NuGetSupport(
         }
     }
 
-    fun resolveNuGetDependencies(definitionFile: File, directDependenciesOnly: Boolean): ProjectAnalyzerResult {
+    fun resolveDependencies(definitionFile: File, directDependenciesOnly: Boolean): ProjectAnalyzerResult {
         val workingDir = definitionFile.parentFile
 
         val packages = sortedSetOf<Package>()

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -65,13 +65,12 @@ internal const val OPTION_DIRECT_DEPENDENCIES_ONLY = "directDependenciesOnly"
 // See https://docs.microsoft.com/en-us/nuget/api/overview.
 private const val DEFAULT_SERVICE_INDEX_URL = "https://api.nuget.org/v3/index.json"
 private const val REGISTRATIONS_BASE_URL_TYPE = "RegistrationsBaseUrl/3.6.0"
-
 private val VERSION_RANGE_CHARS = charArrayOf('[', ']', '(', ')', ',')
+
+private val JSON_MAPPER = JsonMapper().registerKotlinModule()
 
 class NuGetSupport(serviceIndexUrls: List<String> = listOf(DEFAULT_SERVICE_INDEX_URL)) {
     companion object : Logging {
-        val JSON_MAPPER = JsonMapper().registerKotlinModule()
-
         val XML_MAPPER = XmlMapper(
             XmlFactory().apply {
                 // Work-around for https://github.com/FasterXML/jackson-module-kotlin/issues/138.

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -69,6 +69,8 @@ private val VERSION_RANGE_CHARS = charArrayOf('[', ']', '(', ')', ',')
 
 private val JSON_MAPPER = JsonMapper().registerKotlinModule()
 
+// TODO: Add support for lock files, see
+//       https://devblogs.microsoft.com/nuget/enable-repeatable-package-restores-using-a-lock-file/.
 class NuGetSupport(
     private val managerName: String,
     private val analysisRoot: File,
@@ -197,9 +199,6 @@ class NuGetSupport(
 
                     buildDependencyTree(
                         referredDependencies.map { dependency ->
-                            // TODO: Add support for lock files, see
-                            //       https://devblogs.microsoft.com/nuget/enable-repeatable-package-restores-using-a-lock-file/.
-
                             // Resolve to the lowest applicable version, see
                             // https://docs.microsoft.com/en-us/nuget/concepts/dependency-resolution#lowest-applicable-version.
                             val version = dependency.range.trim { it.isWhitespace() || it in VERSION_RANGE_CHARS }

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -343,7 +343,7 @@ private fun resolveLocalSpec(definitionFile: File): File? =
 private fun getIdentifier(name: String, version: String) =
     Identifier(type = "NuGet", namespace = "", name = name, version = version)
 
-private fun NuGetDependency.getId() = Identifier("NuGet::$name:$version")
+private fun NuGetDependency.getId() = getIdentifier(name, version)
 
 /**
  * A class that bundles properties of a single NuGet dependency.

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -198,17 +198,7 @@ class NuGetSupport(
                         all.details.dependencyGroups.flatMapTo(mutableSetOf()) { it.dependencies }
 
                     buildDependencyTree(
-                        referredDependencies.map { dependency ->
-                            // Resolve to the lowest applicable version, see
-                            // https://docs.microsoft.com/en-us/nuget/concepts/dependency-resolution#lowest-applicable-version.
-                            val version = dependency.range.trim { it.isWhitespace() || it in VERSION_RANGE_CHARS }
-                                .split(',').first().trim()
-
-                            // TODO: Add support resolving to the highest version for floating versions, see
-                            //       https://docs.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions.
-
-                            getIdentifier(dependency.id, version)
-                        },
+                        referredDependencies.map { it.getId() },
                         pkgRef.dependencies,
                         packages,
                         issues,
@@ -343,6 +333,18 @@ private fun getIdentifier(name: String, version: String) =
     Identifier(type = "NuGet", namespace = "", name = name, version = version)
 
 private fun NuGetDependency.getId() = getIdentifier(name, version)
+
+private fun Dependency.getId(): Identifier {
+    // Resolve to the lowest applicable version, see
+    // https://docs.microsoft.com/en-us/nuget/concepts/dependency-resolution#lowest-applicable-version.
+    val version = range.trim { it.isWhitespace() || it in VERSION_RANGE_CHARS }
+        .split(',').first().trim()
+
+    // TODO: Add support resolving to the highest version for floating versions, see
+    //       https://docs.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions.
+
+    return getIdentifier(id, version)
+}
 
 /**
  * A class that bundles properties of a single NuGet dependency.


### PR DESCRIPTION
The relationship between the the logic in NugetSupport and the package managers using it was partially of cyclic nature.
Also the code has some tight coupling making it overall relatively hard to work with. 
This PR removes these cyclic things and removes a few further hurdles in order to enable further refactoring and clean-up.
So, the goal is: enable further refactoring (with less complexity).

Breaking change: Because the issue message has been changed slightly. Resolution might need adjustments, see change in `dotnet-expected-output-with-nuspec.yml` for how to adjust the test.
