### PR TITLE
init.gradle: Ignore BOM dependencies when comparing dependency trees

### DIFF
--- a/analyzer/src/main/resources/scripts/init.gradle
+++ b/analyzer/src/main/resources/scripts/init.gradle
@@ -251,7 +251,7 @@ class AbstractDependencyTreePlugin<T> implements Plugin<T> {
         /**
          * Return true if the provided DependencyResult represents an imported Maven BOM.
          */
-        private boolean isBom(DependencyResult dependencyResult) {
+        private static boolean isBom(DependencyResult dependencyResult) {
             if (dependencyResult instanceof ResolvedDependencyResult &&
                     dependencyResult.selected.hasProperty('variants')) {
                 return dependencyResult.selected.variants.every {
@@ -394,7 +394,8 @@ class AbstractDependencyTreePlugin<T> implements Plugin<T> {
 
             def resultDependencies = dependencyResult instanceof ResolvedDependencyResult ?
                     dependencyResult.selected.dependencies : [] as Set<DependencyResult>
-            if (dependency.dependencies.size() != resultDependencies.size()) {
+            // Ignore the BOM dependencies for calculating the count since they are skipped by `fetchDependency`.
+            if (dependency.dependencies.size() != resultDependencies.count { !isBom(it) }) {
                 return false
             }
 


### PR DESCRIPTION
When comparing dependency trees, the count of sub dependencies should not include BOM dependencies, since they are skipped by the `fetchDependency` function.
This solves a bug where an Android project shipping 'androidx.appcompat:appcompat:1.5.1' would hang indefinitely. This is because, for instance, 'kotlinx-coroutines-android:1.6.1' depends on 'kotlinx-coroutines-core:1.6.1, kotlin-stdlib-jdk8:1.6.0 and kotlinx-coroutines-bom:1.6.1'. Since no ORT dependency is created for 'kotlinx-coroutines-bom' because it's a BOM file, it should also not be taken in account when comparing dependency trees. Otherwise, comparison would always fail, leading to a cache miss and overgrowth of the latter.

Signed-off-by: Nicolas Nobelis <nicolas.nobelis@bosch.io>