### PR TITLE
Upgrade Detekt to version 1.22

### DIFF
--- a/.detekt.yml
+++ b/.detekt.yml
@@ -3,8 +3,8 @@
 # https://github.com/arturbosch/detekt/blob/master/detekt-cli/src/main/resources/default-detekt-config.yml.
 
 complexity:
-  ComplexMethod:
-    threshold: 33
+  CyclomaticComplexMethod:
+    threshold: 25
   LongMethod:
     threshold: 158
   LongParameterList:
@@ -23,6 +23,10 @@ coroutines:
 # Formatting rules are implemented via the ktlint plugin. As ktlint does not allow exceptions, we need to disable
 # respective rules completely.
 formatting:
+  AnnotationOnSeparateLine:
+    active: false
+  ArgumentListWrapping:
+    active: false
   ChainWrapping:
     active: false
   FinalNewline:
@@ -38,6 +42,8 @@ formatting:
   NoWildcardImports:
     active: false
   ParameterListWrapping:
+    active: false
+  SpacingBetweenDeclarationsWithAnnotations:
     active: false
 
 naming:

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -610,8 +610,11 @@ class Pub(
     private fun commandPub(): String = "${command()} pub"
 
     private fun commandFlutter(): String =
-        if (flutterAbsolutePath.isDirectory) "$flutterAbsolutePath${File.separator}$flutterCommand pub"
-        else "$flutterCommand pub"
+        if (flutterAbsolutePath.isDirectory) {
+            "$flutterAbsolutePath${File.separator}$flutterCommand pub"
+        } else {
+            "$flutterCommand pub"
+        }
 
     override fun run(workingDir: File?, vararg args: CharSequence): ProcessCapture {
         var result = ProcessCapture(workingDir, *commandPub().split(' ').toTypedArray(), *args)

--- a/clients/clearly-defined/src/main/kotlin/Enums.kt
+++ b/clients/clearly-defined/src/main/kotlin/Enums.kt
@@ -29,32 +29,19 @@ import kotlinx.serialization.json.jsonPrimitive
  */
 @Serializable
 enum class ComponentType {
-    @SerialName("npm")
-    NPM,
-    @SerialName("crate")
-    CRATE,
-    @SerialName("git")
-    GIT,
-    @SerialName("maven")
-    MAVEN,
-    @SerialName("composer")
-    COMPOSER,
-    @SerialName("nuget")
-    NUGET,
-    @SerialName("gem")
-    GEM,
-    @SerialName("go")
-    GO,
-    @SerialName("pod")
-    POD,
-    @SerialName("pypi")
-    PYPI,
-    @SerialName("sourcearchive")
-    SOURCE_ARCHIVE,
-    @SerialName("deb")
-    DEBIAN,
-    @SerialName("debsrc")
-    DEBIAN_SOURCES;
+    @SerialName("npm") NPM,
+    @SerialName("crate") CRATE,
+    @SerialName("git") GIT,
+    @SerialName("maven") MAVEN,
+    @SerialName("composer") COMPOSER,
+    @SerialName("nuget") NUGET,
+    @SerialName("gem") GEM,
+    @SerialName("go") GO,
+    @SerialName("pod") POD,
+    @SerialName("pypi") PYPI,
+    @SerialName("sourcearchive") SOURCE_ARCHIVE,
+    @SerialName("deb") DEBIAN,
+    @SerialName("debsrc") DEBIAN_SOURCES;
 
     companion object {
         @JvmStatic
@@ -71,32 +58,19 @@ enum class ComponentType {
  */
 @Serializable
 enum class Provider {
-    @SerialName("npmjs")
-    NPM_JS,
-    @SerialName("cocoapods")
-    COCOAPODS,
-    @SerialName("cratesio")
-    CRATES_IO,
-    @SerialName("github")
-    GITHUB,
-    @SerialName("gitlab")
-    GITLAB,
-    @SerialName("packagist")
-    PACKAGIST,
-    @SerialName("golang")
-    GOLANG,
-    @SerialName("mavencentral")
-    MAVEN_CENTRAL,
-    @SerialName("mavengoogle")
-    MAVEN_GOOGLE,
-    @SerialName("nuget")
-    NUGET,
-    @SerialName("rubygems")
-    RUBYGEMS,
-    @SerialName("pypi")
-    PYPI,
-    @SerialName("debian")
-    DEBIAN;
+    @SerialName("npmjs") NPM_JS,
+    @SerialName("cocoapods") COCOAPODS,
+    @SerialName("cratesio") CRATES_IO,
+    @SerialName("github") GITHUB,
+    @SerialName("gitlab") GITLAB,
+    @SerialName("packagist") PACKAGIST,
+    @SerialName("golang") GOLANG,
+    @SerialName("mavencentral") MAVEN_CENTRAL,
+    @SerialName("mavengoogle") MAVEN_GOOGLE,
+    @SerialName("nuget") NUGET,
+    @SerialName("rubygems") RUBYGEMS,
+    @SerialName("pypi") PYPI,
+    @SerialName("debian") DEBIAN;
 
     companion object {
         @JvmStatic
@@ -113,10 +87,8 @@ enum class Provider {
  */
 @Serializable
 enum class Nature {
-    @SerialName("license")
-    LICENSE,
-    @SerialName("notice")
-    NOTICE
+    @SerialName("license") LICENSE,
+    @SerialName("notice") NOTICE
 }
 
 /**
@@ -124,16 +96,11 @@ enum class Nature {
  */
 @Serializable
 enum class ContributionType {
-    @SerialName("Missing")
-    MISSING,
-    @SerialName("Incorrect")
-    INCORRECT,
-    @SerialName("Incomplete")
-    INCOMPLETE,
-    @SerialName("Ambiguous")
-    AMBIGUOUS,
-    @SerialName("Other")
-    OTHER
+    @SerialName("Missing") MISSING,
+    @SerialName("Incorrect") INCORRECT,
+    @SerialName("Incomplete") INCOMPLETE,
+    @SerialName("Ambiguous") AMBIGUOUS,
+    @SerialName("Other") OTHER
 }
 
 /**

--- a/clients/fossid-webapp/src/main/kotlin/model/status/DownloadStatus.kt
+++ b/clients/fossid-webapp/src/main/kotlin/model/status/DownloadStatus.kt
@@ -24,8 +24,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 enum class DownloadStatus {
     FAILED,
     FINISHED,
+
     @JsonProperty("NOT FINISHED")
     NOT_FINISHED,
+
     @JsonProperty("NOT STARTED")
     NOT_STARTED
 }

--- a/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
+++ b/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
@@ -103,7 +103,9 @@ open class GitWorkingTree(
         val patchedUrl = repositoryUrlPrefixReplacements.entries.fold(url) { url, (prefix, replacement) ->
             if (url.startsWith(prefix)) {
                 "$replacement${url.removePrefix(prefix)}"
-            } else url
+            } else {
+                url
+            }
         }
 
         return takeIf { patchedUrl == url } ?: copy(url = patchedUrl)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 buildConfigPlugin = "3.1.0"
-detektPlugin = "1.21.0"
+detektPlugin = "1.22.0"
 dokkaPlugin = "1.7.20"
 downloadPlugin = "5.3.0"
 graalPlugin = "0.12.0"

--- a/model/src/main/kotlin/utils/FindingCurationMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingCurationMatcher.kt
@@ -68,9 +68,11 @@ class FindingCurationMatcher {
         curation: LicenseFindingCuration,
         relativeFindingPath: String = ""
     ): LicenseFinding? =
-        if (!matches(finding, curation, relativeFindingPath)) finding
-        else if (curation.concludedLicense.toString() == SpdxConstants.NONE) null
-        else finding.copy(license = curation.concludedLicense)
+        when {
+            !matches(finding, curation, relativeFindingPath) -> finding
+            curation.concludedLicense.toString() == SpdxConstants.NONE -> null
+            else -> finding.copy(license = curation.concludedLicense)
+        }
 
     /**
      * Applies the given [curations] to the given [findings]. In case multiple curations match any given finding all

--- a/model/src/test/kotlin/ProjectTest.kt
+++ b/model/src/test/kotlin/ProjectTest.kt
@@ -70,8 +70,12 @@ private fun createDependencyGraph(qualified: Boolean = false): DependencyGraph {
         "test" to listOf(RootDependencyIndex(4), RootDependencyIndex(3)),
         "partial" to listOf(RootDependencyIndex(1))
     )
-    val scopeMapping = if (qualified) plainScopeMapping.mapKeys { DependencyGraph.qualifyScope(projectId, it.key) }
-    else plainScopeMapping
+
+    val scopeMapping = if (qualified) {
+        plainScopeMapping.mapKeys { DependencyGraph.qualifyScope(projectId, it.key) }
+    } else {
+        plainScopeMapping
+    }
 
     return DependencyGraph(dependencies, sortedSetOf(exampleRef, csvRef), scopeMapping)
 }

--- a/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
@@ -293,12 +293,15 @@ class FreemarkerTemplateProcessor(
         ): List<ResolvedLicense> =
             mergeResolvedLicenses(
                 models.filter { !omitExcluded || !it.excluded }.flatMap { model ->
-                    val chosenResolvedLicenseInfo = if (skipLicenseChoices) model.license else licenseView.filter(
-                        model.license,
-                        model.licenseChoices
-                    )
+                    val chosenResolvedLicenseInfo = if (skipLicenseChoices) {
+                        model.license
+                    } else {
+                        licenseView.filter(model.license, model.licenseChoices)
+                    }
+
                     val licenses = chosenResolvedLicenseInfo.filter(licenseView).licenses
                     val filteredLicenses = if (omitExcluded) licenses.filterExcluded() else licenses
+
                     if (omitNotPresent) filteredLicenses.filter(::isLicensePresent) else filteredLicenses
                 }
             )

--- a/utils/spdx/build.gradle.kts
+++ b/utils/spdx/build.gradle.kts
@@ -170,7 +170,7 @@ fun Task.generateEnumClass(
     enumFile.writeText(getLicenseHeader())
     enumFile.appendText(
         """
-        |@file:Suppress("MaxLineLength")
+        |@file:Suppress("EnumEntryNameCase", "MaxLineLength")
         |
         |package org.ossreviewtoolkit.utils.spdx
         |

--- a/utils/spdx/src/main/kotlin/SpdxLicense.kt
+++ b/utils/spdx/src/main/kotlin/SpdxLicense.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-@file:Suppress("MaxLineLength")
+@file:Suppress("EnumEntryNameCase", "MaxLineLength")
 
 package org.ossreviewtoolkit.utils.spdx
 

--- a/utils/spdx/src/main/kotlin/SpdxLicenseException.kt
+++ b/utils/spdx/src/main/kotlin/SpdxLicenseException.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-@file:Suppress("MaxLineLength")
+@file:Suppress("EnumEntryNameCase", "MaxLineLength")
 
 package org.ossreviewtoolkit.utils.spdx
 


### PR DESCRIPTION
The `ComplexMethod` rule was renamed to `CyclomaticComplexMethod`, and revisiting the `threshold` revealed that it can be lowered compared to before (but still needs to be higher than the default of 15).

New rules demand annotated declarations to be on separate lines and to be separated by blank lines, like

    @SerialName("npm")
    NPM,

    @SerialName("crate")
    CRATE,

While this notation makes sense if the declarations are documented (and thus already separated by blank lines), for undocumented declarations (esp. as part of `@Serializable` classes) a more compact notation makes sense:

    @SerialName("package_name") val packageName: String,
    @SerialName("installed_version") val installedVersion: String,

Disable rules that prevent this notation, as it is already used e.g. in the `PythonInspector` class. Also, in general disable rules that would require too many code changes at this point.

Otherwise address the code inspection hints.

For the release notes see [1].

[1]: https://github.com/detekt/detekt/releases/tag/v1.22.0

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>