### PR TITLE
LicenseClassification: Ensure `licensesByCategory` contains all keys

### DIFF
--- a/model/src/main/kotlin/licenses/LicenseClassifications.kt
+++ b/model/src/main/kotlin/licenses/LicenseClassifications.kt
@@ -56,6 +56,10 @@ data class LicenseClassifications(
                     getOrPut(category) { mutableSetOf() } += license.id
                 }
             }
+
+            categories.forEach { category ->
+                putIfAbsent(category.name, mutableSetOf())
+            }
         }
     }
 

--- a/model/src/test/kotlin/licenses/LicenseClassificationsTest.kt
+++ b/model/src/test/kotlin/licenses/LicenseClassificationsTest.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.model.licenses
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -110,6 +111,14 @@ class LicenseClassificationsTest : WordSpec({
             permissiveLicenses shouldNotBeNull {
                 permissiveLicenses should containExactlyInAnyOrder(lic1.id, lic2.id)
             }
+        }
+
+        "maintain empty categories" {
+            val licenseClassifications = LicenseClassifications(
+                categories = listOf(LicenseCategory("permissive"))
+            )
+
+            licenseClassifications.licensesByCategory["permissive"] shouldNotBeNull { shouldBeEmpty() }
         }
 
         "return null when querying the licenses for an unknown category" {


### PR DESCRIPTION
Make the `Map` contain all category names as keys in order to simplify
its use.