### PR TITLE
Gradle: Trivially align the way to get a plugin's version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,7 @@ buildscript {
         resolutionStrategy {
             // Work around the Kotlin plugin to depend on an outdated version of the Download plugin, see
             // https://youtrack.jetbrains.com/issue/KT-53822.
-            force("de.undercouch:gradle-download-task:${libs.plugins.download.get().version}")
+            force("de.undercouch:gradle-download-task:${libs.versions.downloadPlugin.get()}")
         }
     }
 }


### PR DESCRIPTION
Directly get the version property instead of the version of the plugin property. This aligns with other code and is slightly simpler.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>