### PR TITLE
FindingsMatcher: Do not import `NOASSERTION` directly

### DIFF
--- a/model/src/main/kotlin/utils/FindingsMatcher.kt
+++ b/model/src/main/kotlin/utils/FindingsMatcher.kt
@@ -27,7 +27,7 @@ import kotlin.math.min
 import org.ossreviewtoolkit.model.CopyrightFinding
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.TextLocation
-import org.ossreviewtoolkit.utils.spdx.SpdxConstants.NOASSERTION
+import org.ossreviewtoolkit.utils.spdx.SpdxConstants
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseException
 import org.ossreviewtoolkit.utils.spdx.SpdxLicenseWithExceptionExpression
 import org.ossreviewtoolkit.utils.spdx.toSpdx
@@ -271,7 +271,7 @@ fun associateLicensesWithExceptions(
     // Associate remaining "orphan" exceptions with "NOASSERTION" to turn them into valid SPDX expressions and at the
     // same time "marking" them for review as "NOASSERTION" is not a real license.
     remainingExceptions.mapTo(fixedLicenses) { exception ->
-        exception.copy(license = "$NOASSERTION WITH ${exception.license}".toSpdx())
+        exception.copy(license = "${SpdxConstants.NOASSERTION} WITH ${exception.license}".toSpdx())
     }
 
     return fixedLicenses


### PR DESCRIPTION
Using `$NOASSERTION` in a string looks awfully similar to the literal "NOASSERTION". Make more clear that this is not the literal string but a variable by reducing the import to `SpdxConstants`.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>