### PR TITLE
ScannerWrapper: Inline `ScannerDetails` to deduplicate the `name`

### DIFF
--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -188,14 +188,14 @@ class ScannerCommand : CliktCommand(name = "scan", help = "Run external license 
 
         if (projectScannerWrappers.isNotEmpty()) {
             println("Scanning projects with:")
-            println(projectScannerWrappers.joinToString { "\t${it.name} (version ${it.details.version})" })
+            println(projectScannerWrappers.joinToString { "\t${it.name} (version ${it.version})" })
         } else {
             println("Projects will not be scanned.")
         }
 
         if (packageScannerWrappers.isNotEmpty()) {
             println("Scanning packages with:")
-            println(packageScannerWrappers.joinToString { "\t${it.name} (version ${it.details.version})" })
+            println(packageScannerWrappers.joinToString { "\t${it.name} (version ${it.version})" })
         } else {
             println("Packages will not be scanned.")
         }

--- a/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
+++ b/scanner/src/funTest/kotlin/scanners/ScannerIntegrationFunTest.kt
@@ -89,8 +89,9 @@ class ScannerIntegrationFunTest : StringSpec() {
 
     class DummyScanner : PathScannerWrapper {
         override val name = "Dummy"
-        override val details = ScannerDetails(name = name, version = "1.0.0", configuration = "")
-        override val criteria = ScannerCriteria.forDetails(details)
+        override val version = "1.0.0"
+        override val configuration = ""
+        override val criteria = ScannerCriteria.forDetails(ScannerDetails(name, version, configuration))
 
         override fun scanPath(path: File, context: ScanContext): ScanSummary {
             val licenseFindings = path.listFiles().orEmpty().mapTo(sortedSetOf()) { file ->

--- a/scanner/src/main/kotlin/CommandLinePathScannerWrapper.kt
+++ b/scanner/src/main/kotlin/CommandLinePathScannerWrapper.kt
@@ -26,7 +26,6 @@ import kotlin.time.measureTimedValue
 
 import org.apache.logging.log4j.kotlin.Logging
 
-import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.Os
 
@@ -92,16 +91,9 @@ abstract class CommandLinePathScannerWrapper(
     protected val scannerPath by lazy { scannerDir.resolve(command()) }
 
     /**
-     * The configuration used by the scanner, should contain command line options that influence the scan result.
-     */
-    abstract val configuration: String
-
-    /**
      * The actual version of the scanner, or an empty string in case of failure.
      */
-    val version by lazy { getVersion(scannerDir) }
-
-    override val details by lazy { ScannerDetails(name, version, configuration) }
+    override val version by lazy { getVersion(scannerDir) }
 
     /**
      * Bootstrap the scanner to be ready for use, like downloading and / or configuring it.

--- a/scanner/src/main/kotlin/ScanController.kt
+++ b/scanner/src/main/kotlin/ScanController.kt
@@ -29,6 +29,7 @@ import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.UnknownProvenance
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.provenance.NestedProvenance
@@ -249,7 +250,7 @@ class ScanController(
             scanners.map { scanner ->
                 ScanResult(
                     provenance = UnknownProvenance,
-                    scanner = scanner.details,
+                    scanner = ScannerDetails(scanner.name, scanner.version, scanner.configuration),
                     summary = ScanSummary(
                         startTime = Instant.now(),
                         endTime = Instant.now(),

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -44,6 +44,7 @@ import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.ScannerRun
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
@@ -506,7 +507,7 @@ class Scanner(
             return scanners.associateWith { scanner ->
                 ScanResult(
                     provenance = provenance,
-                    scanner = scanner.details,
+                    scanner = ScannerDetails(scanner.name, scanner.version, scanner.configuration),
                     summary = summary
                 )
             }
@@ -520,7 +521,7 @@ class Scanner(
 
                 logger.info { "Scan of $provenance with path scanner '${scanner.name}' finished." }
 
-                ScanResult(provenance, scanner.details, summary)
+                ScanResult(provenance, ScannerDetails(scanner.name, scanner.version, scanner.configuration), summary)
             }
         } finally {
             downloadDir.safeDeleteRecursively(force = true)

--- a/scanner/src/main/kotlin/ScannerWrapper.kt
+++ b/scanner/src/main/kotlin/ScannerWrapper.kt
@@ -26,7 +26,6 @@ import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
-import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.utils.common.NamedPlugin
@@ -48,9 +47,14 @@ sealed interface ScannerWrapper {
     val name: String
 
     /**
-     * The details of the scanner.
+     * The version of the scanner.
      */
-    val details: ScannerDetails
+    val version: String
+
+    /**
+     * The configuration of the scanner, could be command line arguments for example.
+     */
+    val configuration: String
 
     /**
      * The [ScannerCriteria] object to be used when looking up existing scan results from a scan storage. By default,

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.kotlin.Logging
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
@@ -57,9 +58,12 @@ class Askalono internal constructor(
     }
 
     override val name = "Askalono"
-    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
     override val expectedVersion = BuildConfig.ASKALONO_VERSION
     override val configuration = ""
+
+    override val criteria by lazy {
+        ScannerCriteria.fromConfig(ScannerDetails(name, version, configuration), scannerConfig)
+    }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "askalono.exe" else "askalono").joinToString(File.separator)

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.kotlin.Logging
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
@@ -64,9 +65,12 @@ class BoyterLc internal constructor(
     }
 
     override val name = "BoyterLc"
-    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
     override val expectedVersion = BuildConfig.BOYTER_LC_VERSION
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
+
+    override val criteria by lazy {
+        ScannerCriteria.fromConfig(ScannerDetails(name, version, configuration), scannerConfig)
+    }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "lc.exe" else "lc").joinToString(File.separator)

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.kotlin.Logging
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.ScanSummary
+import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
@@ -56,9 +57,12 @@ class Licensee internal constructor(
     }
 
     override val name = "Licensee"
-    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
     override val expectedVersion = BuildConfig.LICENSEE_VERSION
     override val configuration = CONFIGURATION_OPTIONS.joinToString(" ")
+
+    override val criteria by lazy {
+        ScannerCriteria.fromConfig(ScannerDetails(name, version, configuration), scannerConfig)
+    }
 
     override fun command(workingDir: File?) =
         listOfNotNull(workingDir, if (Os.isWindows) "licensee.bat" else "licensee").joinToString(File.separator)

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -89,7 +89,7 @@ import org.ossreviewtoolkit.utils.ort.showStackTrace
  * gets a Git repository URL as input and would be a good match for [ProvenanceScannerWrapper].
  */
 class FossId internal constructor(
-    name: String,
+    override val name: String,
     private val scannerConfig: ScannerConfiguration,
     private val config: FossIdConfig
 ) : PackageScannerWrapper {
@@ -171,9 +171,11 @@ class FossId internal constructor(
 
     private val service = FossIdRestService.create(config.serverUrl)
 
+    override val version = service.version
+    override val configuration = ""
     override val criteria: ScannerCriteria? = null
-    override val name: String = "FossId"
-    override val details = ScannerDetails(name, service.version, "")
+
+    val details by lazy { ScannerDetails(name, version, configuration) }
 
     override fun filterSecretOptions(options: Options) =
         options.mapValues { (k, v) ->

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -63,7 +63,7 @@ import org.ossreviewtoolkit.utils.ort.ortToolsDirectory
  *   contain an SPDX expression.
  */
 class ScanCode internal constructor(
-    name: String,
+    override val name: String,
     private val scannerConfig: ScannerConfiguration
 ) : CommandLinePathScannerWrapper(name) {
     companion object : Logging {
@@ -103,9 +103,11 @@ class ScanCode internal constructor(
             ScanCode(name, scannerConfig)
     }
 
-    override val name = SCANNER_NAME
-    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
     override val expectedVersion = BuildConfig.SCANCODE_VERSION
+
+    override val criteria by lazy {
+        ScannerCriteria.fromConfig(ScannerDetails(name, version, configuration), scannerConfig)
+    }
 
     override val configuration by lazy {
         buildList {

--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
@@ -66,10 +66,13 @@ class ScanOss internal constructor(
 
     private val service = ScanOssService.create(config.apiUrl)
 
-    override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }
-
     // TODO: Find out the best / cheapest way to query the SCANOSS server for its version.
-    override val details = ScannerDetails(name, BuildConfig.SCANOSS_VERSION, "")
+    override val version = BuildConfig.SCANOSS_VERSION
+    override val configuration = ""
+
+    override val criteria by lazy {
+        ScannerCriteria.fromConfig(ScannerDetails(name, version, configuration), scannerConfig)
+    }
 
     /**
      * The name of the file corresponding to the fingerprints can be sent to SCANOSS for more precise matches.

--- a/scanner/src/test/kotlin/ScannerTest.kt
+++ b/scanner/src/test/kotlin/ScannerTest.kt
@@ -797,10 +797,13 @@ class ScannerTest : WordSpec({
 private class FakePackageScannerWrapper(
     val packageProvenanceResolver: PackageProvenanceResolver = FakePackageProvenanceResolver(),
     val sourceCodeOriginPriority: List<SourceCodeOrigin> = listOf(SourceCodeOrigin.VCS, SourceCodeOrigin.ARTIFACT),
-    name: String = "fake"
+    override val name: String = "fake"
 ) : PackageScannerWrapper {
-    override val details = ScannerDetails(name, "1.0.0", "config")
-    override val name = details.name
+    override val version = "1.0.0"
+    override val configuration = "config"
+
+    val details by lazy { ScannerDetails(name, version, configuration) }
+
     override val criteria: ScannerCriteria? = ScannerCriteria.forDetails(details)
 
     override fun scanPackage(pkg: Package, context: ScanContext): ScanResult =
@@ -811,8 +814,12 @@ private class FakePackageScannerWrapper(
  * An implementation of [ProvenanceScannerWrapper] that creates empty scan results.
  */
 private class FakeProvenanceScannerWrapper : ProvenanceScannerWrapper {
-    override val details = ScannerDetails("fake", "1.0.0", "config")
-    override val name = details.name
+    override val name = "fake"
+    override val version = "1.0.0"
+    override val configuration = "config"
+
+    val details by lazy { ScannerDetails(name, version, configuration) }
+
     override val criteria = ScannerCriteria.forDetails(details)
 
     override fun scanProvenance(provenance: KnownProvenance, context: ScanContext): ScanResult =
@@ -823,8 +830,12 @@ private class FakeProvenanceScannerWrapper : ProvenanceScannerWrapper {
  * An implementation of [PathScannerWrapper] that creates scan results with one license finding for each file.
  */
 private class FakePathScannerWrapper : PathScannerWrapper {
-    override val details = ScannerDetails("fake", "1.0.0", "config")
-    override val name = details.name
+    override val name = "fake"
+    override val version = "1.0.0"
+    override val configuration = "config"
+
+    val details by lazy { ScannerDetails(name, version, configuration) }
+
     override val criteria = ScannerCriteria.forDetails(details)
 
     override fun scanPath(path: File, context: ScanContext): ScanSummary {

--- a/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
@@ -33,7 +33,6 @@ import io.mockk.spyk
 import java.io.File
 
 import org.ossreviewtoolkit.model.PackageType
-import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.scanner.ScanContext
 import org.ossreviewtoolkit.utils.common.ProcessCapture
@@ -114,7 +113,9 @@ class ScanCodeTest : WordSpec({
             every { process.errorMessage } returns "some error message"
 
             val scannerSpy = spyk(scanner)
-            every { scannerSpy.details } returns ScannerDetails("ScanCode", "30.1.0", "")
+            every { scannerSpy.name } returns "ScanCode"
+            every { scannerSpy.version } returns "30.1.0"
+            every { scannerSpy.configuration } returns ""
             every { scannerSpy.runScanCode(any(), any()) } answers {
                 val resultFile = File("src/test/assets/scancode-with-issues.json")
                 val targetFile = secondArg<File>()


### PR DESCRIPTION
Having `ScannerDetails` as part of `ScannerWrapper` creates a
recursion pitfall for bootstrappable `CommandLinePathScannerWrapper`s as
they must not access the `ScannerDetails` to get the `name` during
bootstrapping as that would also trigger getting the `version` which is
not known before bootstrapping succeeded.

To avoid running into that pitfall, inline the `version` and
`configuration` properties, and only create `ScannerDetails` when
needed.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>