### PR TITLE
ScanCode: Strip all spaces when parsing (non-)configuration options

### DIFF
--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -49,6 +49,7 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.orEmpty
 import org.ossreviewtoolkit.utils.common.CommandLineTool
+import org.ossreviewtoolkit.utils.common.splitOnWhitespace
 import org.ossreviewtoolkit.utils.common.textValueOrEmpty
 import org.ossreviewtoolkit.utils.common.unquote
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
@@ -332,7 +333,7 @@ private fun getResolvedVersion(
     // "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)", for more details see
     // https://doc.rust-lang.org/cargo/commands/cargo-metadata.html.
     node["dependencies"].forEach {
-        val substrings = it.textValue().split(' ')
+        val substrings = it.textValue().splitOnWhitespace()
         require(substrings.size > 1) { "Unexpected format while parsing dependency JSON node." }
 
         if (substrings[0] == dependencyName) return substrings[1]

--- a/analyzer/src/main/kotlin/managers/Carthage.kt
+++ b/analyzer/src/main/kotlin/managers/Carthage.kt
@@ -41,6 +41,7 @@ import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.orEmpty
+import org.ossreviewtoolkit.utils.common.splitOnWhitespace
 import org.ossreviewtoolkit.utils.common.unquote
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 
@@ -124,7 +125,7 @@ class Carthage(
     }
 
     private fun parseDependencyLine(line: String, workingDir: String): Package {
-        val split = line.split(' ')
+        val split = line.splitOnWhitespace()
 
         require(split.size == 3) {
             "A dependency line must consist of exactly 3 space separated elements."

--- a/analyzer/src/main/kotlin/managers/Composer.kt
+++ b/analyzer/src/main/kotlin/managers/Composer.kt
@@ -53,6 +53,7 @@ import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.fieldNamesOrEmpty
+import org.ossreviewtoolkit.utils.common.splitOnWhitespace
 import org.ossreviewtoolkit.utils.common.stashDirectories
 import org.ossreviewtoolkit.utils.common.textValueOrEmpty
 import org.ossreviewtoolkit.utils.ort.showStackTrace
@@ -105,7 +106,7 @@ class Composer(
         // The version string can be something like:
         // Composer version 1.5.1 2017-08-09 16:07:22
         // Composer version @package_branch_alias_version@ (1.0.0-beta2) 2016-03-27 16:00:34
-        output.split(' ').dropLast(2).last().removeSurrounding("(", ")")
+        output.splitOnWhitespace().dropLast(2).last().removeSurrounding("(", ")")
 
     override fun getVersionRequirement(): Requirement = Requirement.buildIvy("[1.5,)")
 

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -52,6 +52,7 @@ import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.orEmpty
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.Os
+import org.ossreviewtoolkit.utils.common.splitOnWhitespace
 import org.ossreviewtoolkit.utils.common.stashDirectories
 import org.ossreviewtoolkit.utils.common.withoutSuffix
 
@@ -162,7 +163,7 @@ class GoMod(
         edges.stdout.lines().forEach { line ->
             if (line.isBlank()) return@forEach
 
-            val columns = line.split(' ')
+            val columns = line.splitOnWhitespace()
             require(columns.size == 2) { "Expected exactly one occurrence of ' ' on any non-blank line." }
 
             val parent = parseModuleEntry(columns[0])
@@ -270,10 +271,8 @@ class GoMod(
         )
 
         list.stdout.lines().forEach { line ->
-            val columns = line.split(' ')
-            if (columns.size != 2) return@forEach
-
-            result += columns[0]
+            val columns = line.splitOnWhitespace()
+            if (columns.size in 1..2) result += columns[0]
         }
 
         return result

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -265,6 +265,7 @@ class GoMod(
     private fun getTransitiveMainModuleDependencies(projectDir: File): Set<String> {
         val result = mutableSetOf<String>()
 
+        // See https://pkg.go.dev/text/template for the format syntax.
         val list = run(
             "list", "-deps", "-f", "{{with .Module}}{{.Path}} {{.Version}}{{end}}", "-buildvcs=false", "./...",
             workingDir = projectDir

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -56,6 +56,7 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.model.utils.DependencyGraphBuilder
 import org.ossreviewtoolkit.utils.common.Os
+import org.ossreviewtoolkit.utils.common.splitOnWhitespace
 import org.ossreviewtoolkit.utils.common.temporaryProperties
 import org.ossreviewtoolkit.utils.ort.createOrtTempFile
 
@@ -183,7 +184,7 @@ class Gradle(
         // Set the value to empirically determined 8 GiB if no value is set in "~/.gradle/gradle.properties".
         val jvmArgs = gradleProperties.find { (key, _) ->
             key == "org.gradle.jvmargs"
-        }?.second?.split(' ').orEmpty().toMutableList()
+        }?.second?.splitOnWhitespace().orEmpty().toMutableList()
 
         if (jvmArgs.none { it.contains(JAVA_MAX_HEAP_SIZE_OPTION, ignoreCase = true) }) {
             jvmArgs += "$JAVA_MAX_HEAP_SIZE_OPTION$JAVA_MAX_HEAP_SIZE_VALUE"

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -61,6 +61,7 @@ import org.ossreviewtoolkit.utils.common.ProcessCapture
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.realFile
 import org.ossreviewtoolkit.utils.common.safeMkdirs
+import org.ossreviewtoolkit.utils.common.splitOnWhitespace
 import org.ossreviewtoolkit.utils.common.textValueOrEmpty
 import org.ossreviewtoolkit.utils.common.unpack
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
@@ -617,11 +618,12 @@ class Pub(
         }
 
     override fun run(workingDir: File?, vararg args: CharSequence): ProcessCapture {
-        var result = ProcessCapture(workingDir, *commandPub().split(' ').toTypedArray(), *args)
+        var result = ProcessCapture(workingDir, *commandPub().splitOnWhitespace().toTypedArray(), *args)
         if (result.isError) {
             // If Pub fails with the message that Flutter should be used instead, fall back to using Flutter.
             if ("Flutter users should run `flutter" in result.errorMessage) {
-                result = ProcessCapture(workingDir, *commandFlutter().split(' ').toTypedArray(), *args).requireSuccess()
+                result = ProcessCapture(workingDir, *commandFlutter().splitOnWhitespace().toTypedArray(), *args)
+                    .requireSuccess()
             } else {
                 throw IOException(result.errorMessage)
             }
@@ -636,7 +638,7 @@ class Pub(
             // For Flutter projects it is not enough to run `dart pub get`. Instead, use `flutter pub get` which
             // installs the required dependencies and also creates the `local.properties` file which is required for
             // the Android analysis.
-            ProcessCapture(workingDir, *commandFlutter().split(' ').toTypedArray(), "get").requireSuccess()
+            ProcessCapture(workingDir, *commandFlutter().splitOnWhitespace().toTypedArray(), "get").requireSuccess()
         } else {
             // The "get" command creates a "pubspec.lock" file (if not yet present) except for projects without any
             // dependencies, see https://dart.dev/tools/pub/cmd/pub-get.

--- a/downloader/src/main/kotlin/vcs/MercurialWorkingTree.kt
+++ b/downloader/src/main/kotlin/vcs/MercurialWorkingTree.kt
@@ -45,7 +45,7 @@ class MercurialWorkingTree(workingDir: File, vcsType: VcsType) : WorkingTree(wor
     override fun listRemoteBranches(): List<String> {
         val branches = MercurialCommand.run(workingDir, "branches").stdout.trimEnd()
         return branches.lines().map {
-            it.split(' ').first()
+            it.substringBefore(' ')
         }.sorted()
     }
 
@@ -55,7 +55,7 @@ class MercurialWorkingTree(workingDir: File, vcsType: VcsType) : WorkingTree(wor
         MercurialCommand.run(workingDir, "pull", "-r", "default")
         val tags = MercurialCommand.run(workingDir, "cat", "-r", "default", ".hgtags").stdout.trimEnd()
         return tags.lines().map {
-            it.split(' ').last()
+            it.substringAfterLast(' ')
         }.sorted()
     }
 }

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -41,6 +41,7 @@ import org.ossreviewtoolkit.utils.common.ProcessCapture
 import org.ossreviewtoolkit.utils.common.isTrue
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.common.safeMkdirs
+import org.ossreviewtoolkit.utils.common.splitOnWhitespace
 import org.ossreviewtoolkit.utils.common.unpack
 import org.ossreviewtoolkit.utils.common.withoutPrefix
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
@@ -115,9 +116,9 @@ class ScanCode internal constructor(
 
     private val scanCodeConfiguration = scannerConfig.options?.get("ScanCode").orEmpty()
 
-    private val configurationOptions = scanCodeConfiguration["commandLine"]?.split(' ')
+    private val configurationOptions = scanCodeConfiguration["commandLine"]?.splitOnWhitespace()
         ?: DEFAULT_CONFIGURATION_OPTIONS
-    private val nonConfigurationOptions = scanCodeConfiguration["commandLineNonConfig"]?.split(' ')
+    private val nonConfigurationOptions = scanCodeConfiguration["commandLineNonConfig"]?.splitOnWhitespace()
         ?: DEFAULT_NON_CONFIGURATION_OPTIONS
 
     val commandLineOptions by lazy {

--- a/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
+++ b/scanner/src/test/kotlin/scanners/scancode/ScanCodeTest.kt
@@ -86,6 +86,22 @@ class ScanCodeTest : WordSpec({
             scannerWithConfig.commandLineOptions.joinToString(" ") shouldBe
                     "--command --line --commandLineNonConfig"
         }
+
+        "be handled correctly when containing multiple spaces" {
+            val scannerWithConfig = ScanCode(
+                "ScanCode",
+                ScannerConfiguration(
+                    options = mapOf(
+                        "ScanCode" to mapOf(
+                            "commandLine" to " --command  --line  ",
+                            "commandLineNonConfig" to "  -n -c "
+                        )
+                    )
+                )
+            )
+
+            scannerWithConfig.commandLineOptions shouldBe listOf("--command", "--line", "-n", "-c")
+        }
     }
 
     "scanPath" should {

--- a/utils/common/src/main/kotlin/CommandLineTool.kt
+++ b/utils/common/src/main/kotlin/CommandLineTool.kt
@@ -67,7 +67,7 @@ interface CommandLineTool {
      */
     fun run(vararg args: CharSequence, workingDir: File? = null, environment: Map<String, String> = emptyMap()) =
         ProcessCapture(
-            *command(workingDir).split(' ').toTypedArray(),
+            *command(workingDir).splitOnWhitespace().toTypedArray(),
             *args,
             workingDir = workingDir,
             environment = environment
@@ -77,13 +77,13 @@ interface CommandLineTool {
      * Run the command in the [workingDir] directory with arguments as specified by [args].
      */
     fun run(workingDir: File?, vararg args: CharSequence) =
-        ProcessCapture(workingDir, *command(workingDir).split(' ').toTypedArray(), *args).requireSuccess()
+        ProcessCapture(workingDir, *command(workingDir).splitOnWhitespace().toTypedArray(), *args).requireSuccess()
 
     /**
      * Get the version of the command by parsing its output.
      */
     fun getVersion(workingDir: File? = null): String {
-        val version = run(workingDir, *getVersionArguments().split(' ').toTypedArray())
+        val version = run(workingDir, *getVersionArguments().splitOnWhitespace().toTypedArray())
 
         // Some tools actually report the version to stderr, so try that as a fallback.
         val versionString = sequenceOf(version.stdout, version.stderr).map {

--- a/utils/common/src/main/kotlin/Extensions.kt
+++ b/utils/common/src/main/kotlin/Extensions.kt
@@ -417,6 +417,13 @@ fun String.replaceCredentialsInUri(userInfo: String? = null) =
     }.getOrDefault(this)
 
 /**
+ * Return all substrings that do not contain any whitespace as a list.
+ */
+fun String.splitOnWhitespace(): List<String> = nonSpaceRegex.findAll(this).mapTo(mutableListOf()) { it.value }
+
+private val nonSpaceRegex = Regex("\\S+")
+
+/**
  * Return this string lower-cased except for the first character which is upper-cased.
  */
 fun String.titlecase() = lowercase().uppercaseFirstChar()


### PR DESCRIPTION
Leading / trailing or multiple consecutive inner spaces led to empty arguments which, when passed to ScanCode, cause weird behavior, like the result file not being written. Fix that stripping any / multiple spaces when splitting options.

Fixes #6102.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>