### PR TITLE
ResolvedLicense: Fix a regression in `toResolvedCopyrights()`

### DIFF
--- a/model/src/main/kotlin/licenses/ResolvedLicense.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicense.kt
@@ -120,14 +120,14 @@ data class ResolvedLicense(
     }
 }
 
-private fun Collection<ResolvedCopyrightFinding>.toResolvedCopyrights(process: Boolean): List<ResolvedCopyright> {
+internal fun Collection<ResolvedCopyrightFinding>.toResolvedCopyrights(process: Boolean): List<ResolvedCopyright> {
     if (!process) return map { ResolvedCopyright(it.statement, setOf(it)) }
 
-    val statementToFinding = associateBy { it.statement }
-    val result = CopyrightStatementsProcessor.process(statementToFinding.keys)
+    val statementToFindings = groupBy { it.statement }
+    val result = CopyrightStatementsProcessor.process(statementToFindings.keys)
 
     val processedCopyrights = result.processedStatements.map { (statement, originalStatements) ->
-        val findings = originalStatements.mapTo(mutableSetOf()) { statementToFinding.getValue(it) }
+        val findings = originalStatements.flatMapTo(mutableSetOf()) { statementToFindings.getValue(it) }
         ResolvedCopyright(statement, findings)
     }
 

--- a/model/src/main/kotlin/licenses/ResolvedLicense.kt
+++ b/model/src/main/kotlin/licenses/ResolvedLicense.kt
@@ -121,9 +121,12 @@ data class ResolvedLicense(
 }
 
 internal fun Collection<ResolvedCopyrightFinding>.toResolvedCopyrights(process: Boolean): List<ResolvedCopyright> {
-    if (!process) return map { ResolvedCopyright(it.statement, setOf(it)) }
-
     val statementToFindings = groupBy { it.statement }
+
+    if (!process) {
+        return statementToFindings.map { (statement, findings) -> ResolvedCopyright(statement, findings.toSet()) }
+    }
+
     val result = CopyrightStatementsProcessor.process(statementToFindings.keys)
 
     val processedCopyrights = result.processedStatements.map { (statement, originalStatements) ->

--- a/model/src/test/kotlin/licenses/ResolvedLicenseTest.kt
+++ b/model/src/test/kotlin/licenses/ResolvedLicenseTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.licenses
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+import org.ossreviewtoolkit.model.TextLocation
+
+class ResolvedLicenseTest : StringSpec({
+    "Copyright findings with the same statement across different files should be listed in the result" {
+        val originalFindings = listOf(
+            ResolvedCopyrightFinding(
+                statement = "Copyright (C) 2022 The ORT Project Authors",
+                location = TextLocation(
+                    path = "/path/to/file/A",
+                    line = 2
+                ),
+                matchingPathExcludes = emptyList()
+            ),
+            ResolvedCopyrightFinding(
+                statement = "Copyright (C) 2022 The ORT Project Authors",
+                location = TextLocation(
+                    path = "/path/to/file/B",
+                    line = 2
+                ),
+                matchingPathExcludes = emptyList()
+            ),
+        )
+
+        val resolvedCopyrights = originalFindings.toResolvedCopyrights(process = true)
+
+        resolvedCopyrights shouldHaveSize 1
+        with(resolvedCopyrights.first()) {
+            statement shouldBe "Copyright (C) 2022 The ORT Project Authors"
+            findings.map { it.location.path }.shouldContainExactlyInAnyOrder("/path/to/file/A", "/path/to/file/B")
+        }
+    }
+})

--- a/model/src/test/kotlin/licenses/ResolvedLicenseTest.kt
+++ b/model/src/test/kotlin/licenses/ResolvedLicenseTest.kt
@@ -47,7 +47,7 @@ class ResolvedLicenseTest : StringSpec({
             ),
         )
 
-        val resolvedCopyrights = originalFindings.toResolvedCopyrights(process = true)
+        val resolvedCopyrights = originalFindings.toResolvedCopyrights(process = false)
 
         resolvedCopyrights shouldHaveSize 1
         with(resolvedCopyrights.first()) {


### PR DESCRIPTION
The `associateBy()` was unintentionally deduplicating original findings with the same statement. Fix that by using `groupBy()` (and `flatMapTo()`) instead. Also add a test for the wanted behavior. See [1] for the original report with another proposed fix; this fix is more minimal.

[1]: https://github.com/oss-review-toolkit/ort/pull/6104

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>