### PR TITLE
Upgrade Batect to version 0.83.0

### DIFF
--- a/batect
+++ b/batect
@@ -8,8 +8,8 @@
     # You should commit this file to version control alongside the rest of your project. It should not be installed globally.
     # For more information, visit https://github.com/batect/batect.
 
-    VERSION="0.82.0"
-    CHECKSUM="${BATECT_DOWNLOAD_CHECKSUM:-6d3e7e26e718f705d8a344c85048c2821aedd8ae84fec1db2251fe6f3adec3ea}"
+    VERSION="0.83.0"
+    CHECKSUM="${BATECT_DOWNLOAD_CHECKSUM:-bb4c01409985dc962cf4d0fe60968885e9032ccf3c557e98bcd8a6879c5cb7fb}"
     DOWNLOAD_URL_ROOT=${BATECT_DOWNLOAD_URL_ROOT:-"https://updates.batect.dev/v1/files"}
     DOWNLOAD_URL=${BATECT_DOWNLOAD_URL:-"$DOWNLOAD_URL_ROOT/$VERSION/batect-$VERSION.jar"}
     QUIET_DOWNLOAD=${BATECT_QUIET_DOWNLOAD:-false}

--- a/batect.cmd
+++ b/batect.cmd
@@ -6,7 +6,7 @@ rem For more information, visit https://github.com/batect/batect.
 
 setlocal EnableDelayedExpansion
 
-set "version=0.82.0"
+set "version=0.83.0"
 
 if "%BATECT_CACHE_DIR%" == "" (
     set "BATECT_CACHE_DIR=%USERPROFILE%\.batect\cache"
@@ -22,7 +22,7 @@ $ErrorActionPreference = 'Stop'^
 
 ^
 
-$Version='0.82.0'^
+$Version='0.83.0'^
 
 ^
 
@@ -48,7 +48,7 @@ $UrlEncodedVersion = [Uri]::EscapeDataString($Version)^
 
 $DownloadUrl = getValueOrDefault $env:BATECT_DOWNLOAD_URL "$DownloadUrlRoot/$UrlEncodedVersion/batect-$UrlEncodedVersion.jar"^
 
-$ExpectedChecksum = getValueOrDefault $env:BATECT_DOWNLOAD_CHECKSUM '6d3e7e26e718f705d8a344c85048c2821aedd8ae84fec1db2251fe6f3adec3ea'^
+$ExpectedChecksum = getValueOrDefault $env:BATECT_DOWNLOAD_CHECKSUM 'bb4c01409985dc962cf4d0fe60968885e9032ccf3c557e98bcd8a6879c5cb7fb'^
 
 ^
 


### PR DESCRIPTION
See [1].

[1]: https://github.com/batect/batect/releases/tag/0.83.0

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>