### PR TITLE
Set the code point limit for SnakeYAML to 1GB

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -244,10 +244,6 @@ subprojects {
                 // Ensure that all transitive versions of Kotlin libraries match our version of Kotlin.
                 force("org.jetbrains.kotlin:kotlin-reflect:${rootProject.libs.versions.kotlinPlugin.get()}")
                 force("org.jetbrains.kotlin:kotlin-script-runtime:${rootProject.libs.versions.kotlinPlugin.get()}")
-
-                // Starting with version 1.32 the YAML file size is limited to 3 MiB, which is not configurable yet via
-                // Hoplite or Jackson.
-                force("org.yaml:snakeyaml:1.31")
             }
         }
     }

--- a/model/src/main/kotlin/Mappers.kt
+++ b/model/src/main/kotlin/Mappers.kt
@@ -26,9 +26,12 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.node.MissingNode
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+
+import org.yaml.snakeyaml.LoaderOptions
 
 val PROPERTY_NAMING_STRATEGY = PropertyNamingStrategies.SNAKE_CASE as PropertyNamingStrategies.NamingBase
 
@@ -46,6 +49,15 @@ val mapperConfig: ObjectMapper.() -> Unit = {
 
 val jsonMapper = JsonMapper().apply(mapperConfig)
 val xmlMapper = XmlMapper().apply(mapperConfig)
-val yamlMapper = YAMLMapper().apply(mapperConfig)
+
+private val loaderOptions = LoaderOptions().apply {
+    // Set the code point limit to 1GB, required since SnakeYAML 1.32. Also see:
+    // https://github.com/FasterXML/jackson-dataformats-text/tree/2.15/yaml#maximum-input-yaml-document-size-3-mb
+    // https://github.com/FasterXML/jackson-dataformats-text/issues/337
+    // TODO: Consider making this configurable.
+    codePointLimit = 1024 * 1024 * 1024
+}
+private val yamlFactory = YAMLFactory.builder().loaderOptions(loaderOptions).build()
+val yamlMapper = YAMLMapper(yamlFactory).apply(mapperConfig)
 
 val EMPTY_JSON_NODE: JsonNode = MissingNode.getInstance()


### PR DESCRIPTION
Since version 1.32 [1] SnakeYAML sets the limit for incoming data to 3MB. Since Jackson 2.14 [2] it is possible to override this default, so hardcode the limit to 1GB to allow parsing large ORT result files.

[1]: https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes
[2]: https://github.com/FasterXML/jackson-dataformats-text/issues/337
