### PR TITLE
github/workflows: Enable CodeQL analysis for Kotlin / Java

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,3 @@
+paths-ignore:
+  - '**/src/funTest/assets/**'
+  - '**/src/test/assets/**'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,6 +45,30 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: --scan :reporter-web-app:yarnBuild
+  codeql-analysis:
+    needs: build
+    runs-on: ubuntu-22.04
+    permissions:
+      security-events: write
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: java
+        tools: latest
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 11
+    - name: Build all classes
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: -Dorg.gradle.jvmargs=-Xmx1g classes -x :reporter-web-app:yarnBuild
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
   test:
     needs: build
     runs-on: ubuntu-22.04

--- a/utils/scripting/src/main/kotlin/OrtScriptCompilationConfiguration.kt
+++ b/utils/scripting/src/main/kotlin/OrtScriptCompilationConfiguration.kt
@@ -76,8 +76,7 @@ class OrtScriptCompilationConfiguration : ScriptCompilationConfiguration({
     }
 })
 
-// Use MD5 for speed.
-private val digest = MessageDigest.getInstance("MD5")
+private val digest = MessageDigest.getInstance("SHA-1")
 
 private fun generateUniqueName(script: SourceCode, configuration: ScriptCompilationConfiguration): String {
     digest.reset()


### PR DESCRIPTION
See [1].

[1]: https://github.blog/changelog/2022-11-28-codeql-code-scanning-launches-kotlin-analysis-support-beta/

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>