### PR TITLE
Renovate: Ignore Spring 6 which requires Java 17

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,5 +15,13 @@
     "reporter-web-app",
     "**/src/funTest/assets/**",
     "**/src/test/assets/**"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "org.springframework:spring-core"
+      ],
+      "allowedVersions": "< 6.0.0"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -5,10 +5,6 @@
     "docker:disable"
   ],
   "ignoreDeps": [
-    "org.apache.maven.resolver:maven-resolver-connector-basic",
-    "org.apache.maven.resolver:maven-resolver-transport-file",
-    "org.apache.maven.resolver:maven-resolver-transport-http",
-    "org.apache.maven.resolver:maven-resolver-transport-wagon",
     "org.eclipse.sw360:client"
   ],
   "ignorePaths": [
@@ -17,6 +13,15 @@
     "**/src/test/assets/**"
   ],
   "packageRules": [
+    {
+      "matchPackageNames": [
+        "org.apache.maven.resolver:maven-resolver-connector-basic",
+        "org.apache.maven.resolver:maven-resolver-transport-file",
+        "org.apache.maven.resolver:maven-resolver-transport-http",
+        "org.apache.maven.resolver:maven-resolver-transport-wagon"
+      ],
+      "allowedVersions": "< 1.8.0"
+    },
     {
       "matchPackageNames": [
         "org.springframework:spring-core"


### PR DESCRIPTION
ORT is stuck on Java 11, see [1].

[1]: https://github.com/oss-review-toolkit/ort/pull/4948

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>