### PR TITLE
  Renovate: Disable updates to (Docker base images in) Batect files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,9 @@
     "config:base",
     "docker:disable"
   ],
+  "batect": {
+    "enabled": false
+  },
   "ignoreDeps": [
     "org.eclipse.sw360:client"
   ],


### PR DESCRIPTION
This still leaves "batect-wrapper" enabled to receive updates to Batect
itself. This implements https://github.com/oss-review-toolkit/ort/commit/0e66cf28397d7bf4bdf42ed5279c5cba8a9045b6 properly which was reverted in https://github.com/oss-review-toolkit/ort/commit/7aa61bf96b2b2752da785c47445883e65494bb91.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>