### PR TITLE
declared-license-mapping: Add mapping for GPL-3.0-only

### DIFF
--- a/utils/spdx/src/main/resources/declared-license-mapping.yml
+++ b/utils/spdx/src/main/resources/declared-license-mapping.yml
@@ -248,6 +248,7 @@
 "GNU General Public License (GPL), version 2, with the Classpath exception": GPL-2.0-only WITH Classpath-exception-2.0
 "GNU General Public License 3": GPL-3.0-only
 "GNU General Public License Version 2": GPL-2.0-only
+"GNU General Public License Version 3 (GPL v3)": GPL-3.0-only
 "GNU General Public License v2 (GPLv2)": GPL-2.0-only
 "GNU General Public License v2 or later (GPLv2+)": GPL-2.0-or-later
 "GNU General Public License v2.0 only, with Classpath exception": GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION
Found in [1].

[1]: https://repo1.maven.org/maven2/org/tmatesoft/sqljet/sqljet/1.1.15/sqljet-1.1.15.pom

