### PR TITLE
Analyzer: Remove a duplicate log message

### DIFF
--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -300,17 +300,12 @@ private class PackageManagerRunner(
      */
     suspend fun start() {
         if (mustRunAfter.isNotEmpty()) {
-            Analyzer.logger.info {
-                "${manager.managerName} is waiting for the following package managers to complete: " +
-                        mustRunAfter.joinToString(postfix = ".")
-            }
-
             finishedPackageManagersState.first { finishedPackageManagers ->
                 val remaining = mustRunAfter - finishedPackageManagers
 
                 if (remaining.isNotEmpty()) {
                     Analyzer.logger.info {
-                        "${manager.managerName} is still waiting for the following package managers to complete: " +
+                        "${manager.managerName} is waiting for the following package managers to complete: " +
                                 remaining.joinToString(postfix = ".")
                     }
                 }


### PR DESCRIPTION
The inner log statement is also triggered initially when `finishedPackageManagers` is empty, so the almost identical log messages were shown both. Remove the outer one to avoid that duplication.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>