### PR TITLE
cli: Turn commands into plugins

### DIFF
--- a/cli/src/main/kotlin/OrtCommand.kt
+++ b/cli/src/main/kotlin/OrtCommand.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+
+import org.ossreviewtoolkit.utils.common.NamedPlugin
+
+/**
+ * An interface for [CliktCommand]-based ORT commands that come as named plugins.
+ */
+abstract class OrtCommand(name: String, help: String) : CliktCommand(name = name, help = help), NamedPlugin {
+    companion object {
+        /**
+         * All ORT commands available in the classpath, associated by their names.
+         */
+        val ALL by lazy { NamedPlugin.getAll<OrtCommand>() }
+    }
+
+    override val name = commandName
+}

--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -151,20 +151,7 @@ class OrtMain : CliktCommand(name = ORT_NAME, invokeWithoutSubcommand = true) {
             helpFormatter = OrtHelpFormatter()
         }
 
-        subcommands(
-            AdvisorCommand(),
-            AnalyzerCommand(),
-            ConfigCommand(),
-            DownloaderCommand(),
-            EvaluatorCommand(),
-            NotifierCommand(),
-            ReporterCommand(),
-            RequirementsCommand(),
-            ScannerCommand(),
-            UploadCurationsCommand(),
-            UploadResultToPostgresCommand(),
-            UploadResultToSw360Command()
-        )
+        subcommands(OrtCommand.ALL.values)
 
         versionOption(
             version = env.ortVersion,

--- a/cli/src/main/kotlin/commands/AdvisorCommand.kt
+++ b/cli/src/main/kotlin/commands/AdvisorCommand.kt
@@ -20,7 +20,6 @@
 package org.ossreviewtoolkit.cli.commands
 
 import com.github.ajalt.clikt.core.BadParameterValue
-import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.core.requireObject
@@ -36,6 +35,7 @@ import com.github.ajalt.clikt.parameters.types.file
 
 import org.ossreviewtoolkit.advisor.Advisor
 import org.ossreviewtoolkit.cli.GlobalOptions
+import org.ossreviewtoolkit.cli.OrtCommand
 import org.ossreviewtoolkit.cli.utils.SeverityStats
 import org.ossreviewtoolkit.cli.utils.configurationGroup
 import org.ossreviewtoolkit.cli.utils.outputGroup
@@ -49,7 +49,10 @@ import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
-class AdvisorCommand : CliktCommand(name = "advise", help = "Check dependencies for security vulnerabilities.") {
+class AdvisorCommand : OrtCommand(
+    name = "advise",
+    help = "Check dependencies for security vulnerabilities."
+) {
     private val ortFile by option(
         "--ort-file", "-i",
         help = "An ORT result file with an analyzer result to use."

--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -20,7 +20,6 @@
 package org.ossreviewtoolkit.cli.commands
 
 import com.github.ajalt.clikt.core.BadParameterValue
-import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.core.requireObject
@@ -46,6 +45,7 @@ import org.ossreviewtoolkit.analyzer.curation.OrtConfigPackageCurationProvider
 import org.ossreviewtoolkit.analyzer.curation.SimplePackageCurationProvider
 import org.ossreviewtoolkit.analyzer.curation.Sw360PackageCurationProvider
 import org.ossreviewtoolkit.cli.GlobalOptions
+import org.ossreviewtoolkit.cli.OrtCommand
 import org.ossreviewtoolkit.cli.utils.SeverityStats
 import org.ossreviewtoolkit.cli.utils.configurationGroup
 import org.ossreviewtoolkit.cli.utils.inputGroup
@@ -66,7 +66,10 @@ import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
-class AnalyzerCommand : CliktCommand(name = "analyze", help = "Determine dependencies of a software project.") {
+class AnalyzerCommand : OrtCommand(
+    name = "analyze",
+    help = "Determine dependencies of a software project."
+) {
     private val inputDir by option(
         "--input-dir", "-i",
         help = "The project directory to analyze. As a special case, if only one package manager is enabled, this " +

--- a/cli/src/main/kotlin/commands/ConfigCommand.kt
+++ b/cli/src/main/kotlin/commands/ConfigCommand.kt
@@ -22,7 +22,6 @@ package org.ossreviewtoolkit.cli.commands
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 
-import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.parameters.options.convert
@@ -31,13 +30,17 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.file
 
 import org.ossreviewtoolkit.cli.GlobalOptions
+import org.ossreviewtoolkit.cli.OrtCommand
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.OrtConfigurationWrapper
 import org.ossreviewtoolkit.model.config.REFERENCE_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.expandTilde
 
-class ConfigCommand : CliktCommand(name = "config", help = "Show different ORT configurations") {
+class ConfigCommand : OrtCommand(
+    name = "config",
+    help = "Show different ORT configurations"
+) {
     private val showDefault by option(
         "--show-default",
         help = "Show the default configuration used when no custom configuration is present."

--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.cli.commands
 
-import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.parameters.groups.default
@@ -40,6 +39,7 @@ import java.io.File
 import org.ossreviewtoolkit.cli.GlobalOptions
 import org.ossreviewtoolkit.cli.GroupTypes.FileType
 import org.ossreviewtoolkit.cli.GroupTypes.StringType
+import org.ossreviewtoolkit.cli.OrtCommand
 import org.ossreviewtoolkit.cli.utils.OPTION_GROUP_INPUT
 import org.ossreviewtoolkit.cli.utils.configurationGroup
 import org.ossreviewtoolkit.cli.utils.inputGroup
@@ -75,7 +75,10 @@ import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.ossreviewtoolkit.utils.spdx.model.SpdxLicenseChoice
 
-class DownloaderCommand : CliktCommand(name = "download", help = "Fetch source code from a remote location.") {
+class DownloaderCommand : OrtCommand(
+    name = "download",
+    help = "Fetch source code from a remote location."
+) {
     private val input by mutuallyExclusiveOptions(
         option(
             "--ort-file", "-i",

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.cli.commands
 
-import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.core.requireObject
@@ -43,6 +42,7 @@ import org.ossreviewtoolkit.analyzer.curation.FilePackageCurationProvider
 import org.ossreviewtoolkit.cli.GlobalOptions
 import org.ossreviewtoolkit.cli.GroupTypes.FileType
 import org.ossreviewtoolkit.cli.GroupTypes.StringType
+import org.ossreviewtoolkit.cli.OrtCommand
 import org.ossreviewtoolkit.cli.utils.OPTION_GROUP_CONFIGURATION
 import org.ossreviewtoolkit.cli.utils.OPTION_GROUP_RULE
 import org.ossreviewtoolkit.cli.utils.PackageConfigurationOption
@@ -81,7 +81,10 @@ import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
-class EvaluatorCommand : CliktCommand(name = "evaluate", help = "Evaluate ORT result files against policy rules.") {
+class EvaluatorCommand : OrtCommand(
+    name = "evaluate",
+    help = "Evaluate ORT result files against policy rules."
+) {
     private val ortFile by option(
         "--ort-file", "-i",
         help = "The ORT result file to read as input."

--- a/cli/src/main/kotlin/commands/NotifierCommand.kt
+++ b/cli/src/main/kotlin/commands/NotifierCommand.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.cli.commands
 
-import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.parameters.options.associate
@@ -30,6 +29,7 @@ import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
 import org.ossreviewtoolkit.cli.GlobalOptions
+import org.ossreviewtoolkit.cli.OrtCommand
 import org.ossreviewtoolkit.cli.utils.configurationGroup
 import org.ossreviewtoolkit.cli.utils.inputGroup
 import org.ossreviewtoolkit.cli.utils.readOrtResult
@@ -41,7 +41,10 @@ import org.ossreviewtoolkit.utils.ort.ORT_NOTIFIER_SCRIPT_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
-class NotifierCommand : CliktCommand(name = "notify", help = "Create notifications based on an ORT result.") {
+class NotifierCommand : OrtCommand(
+    name = "notify",
+    help = "Create notifications based on an ORT result."
+) {
     private val ortFile by option(
         "--ort-file", "-i",
         help = "The ORT result file to read as input."

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -20,7 +20,6 @@
 package org.ossreviewtoolkit.cli.commands
 
 import com.github.ajalt.clikt.core.BadParameterValue
-import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.parameters.groups.mutuallyExclusiveOptions
@@ -42,6 +41,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 
 import org.ossreviewtoolkit.cli.GlobalOptions
+import org.ossreviewtoolkit.cli.OrtCommand
 import org.ossreviewtoolkit.cli.utils.OPTION_GROUP_CONFIGURATION
 import org.ossreviewtoolkit.cli.utils.PackageConfigurationOption
 import org.ossreviewtoolkit.cli.utils.configurationGroup
@@ -80,7 +80,7 @@ import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
-class ReporterCommand : CliktCommand(
+class ReporterCommand : OrtCommand(
     name = "report",
     help = "Present Analyzer, Scanner and Evaluator results in various formats."
 ) {

--- a/cli/src/main/kotlin/commands/RequirementsCommand.kt
+++ b/cli/src/main/kotlin/commands/RequirementsCommand.kt
@@ -19,13 +19,13 @@
 
 package org.ossreviewtoolkit.cli.commands
 
-import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 
 import java.io.File
 import java.lang.reflect.Modifier
 
 import org.ossreviewtoolkit.analyzer.PackageManager
+import org.ossreviewtoolkit.cli.OrtCommand
 import org.ossreviewtoolkit.cli.utils.logger
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
@@ -37,7 +37,10 @@ import org.ossreviewtoolkit.utils.spdx.scanCodeLicenseTextDir
 
 import org.reflections.Reflections
 
-class RequirementsCommand : CliktCommand(help = "Check for the command line tools required by ORT.") {
+class RequirementsCommand : OrtCommand(
+    name = "requirements",
+    help = "Check for the command line tools required by ORT."
+) {
     override fun run() {
         val reflections = Reflections("org.ossreviewtoolkit")
         val classes = reflections.getSubTypesOf(CommandLineTool::class.java)

--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -20,7 +20,6 @@
 package org.ossreviewtoolkit.cli.commands
 
 import com.github.ajalt.clikt.core.BadParameterValue
-import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.core.requireObject
@@ -41,6 +40,7 @@ import com.github.ajalt.clikt.parameters.types.file
 import kotlinx.coroutines.runBlocking
 
 import org.ossreviewtoolkit.cli.GlobalOptions
+import org.ossreviewtoolkit.cli.OrtCommand
 import org.ossreviewtoolkit.cli.utils.OPTION_GROUP_INPUT
 import org.ossreviewtoolkit.cli.utils.SeverityStats
 import org.ossreviewtoolkit.cli.utils.configurationGroup
@@ -67,7 +67,10 @@ import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
-class ScannerCommand : CliktCommand(name = "scan", help = "Run external license / copyright scanners.") {
+class ScannerCommand : OrtCommand(
+    name = "scan",
+    help = "Run external license / copyright scanners."
+) {
     private val input by mutuallyExclusiveOptions(
         option(
             "--ort-file", "-i",

--- a/cli/src/main/kotlin/commands/UploadCurationsCommand.kt
+++ b/cli/src/main/kotlin/commands/UploadCurationsCommand.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.cli.commands
 
-import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
@@ -35,6 +34,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
+import org.ossreviewtoolkit.cli.OrtCommand
 import org.ossreviewtoolkit.cli.utils.inputGroup
 import org.ossreviewtoolkit.cli.utils.logger
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService
@@ -58,7 +58,7 @@ import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 
 import retrofit2.HttpException
 
-class UploadCurationsCommand : CliktCommand(
+class UploadCurationsCommand : OrtCommand(
     name = "upload-curations",
     help = "Upload ORT package curations to ClearlyDefined."
 ) {

--- a/cli/src/main/kotlin/commands/UploadResultToPostgresCommand.kt
+++ b/cli/src/main/kotlin/commands/UploadResultToPostgresCommand.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.cli.commands
 
-import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.flag
@@ -38,6 +37,7 @@ import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.transactions.transaction
 
 import org.ossreviewtoolkit.cli.GlobalOptions
+import org.ossreviewtoolkit.cli.OrtCommand
 import org.ossreviewtoolkit.cli.utils.inputGroup
 import org.ossreviewtoolkit.cli.utils.readOrtResult
 import org.ossreviewtoolkit.model.OrtResult
@@ -50,7 +50,7 @@ import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
-class UploadResultToPostgresCommand : CliktCommand(
+class UploadResultToPostgresCommand : OrtCommand(
     name = "upload-result-to-postgres",
     help = "Upload an ORT result to a PostgreSQL database."
 ) {

--- a/cli/src/main/kotlin/commands/UploadResultToPostgresCommand.kt
+++ b/cli/src/main/kotlin/commands/UploadResultToPostgresCommand.kt
@@ -52,9 +52,7 @@ import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 class UploadResultToPostgresCommand : CliktCommand(
     name = "upload-result-to-postgres",
-    help = "Upload an ORT result to a PostgreSQL database.",
-    epilog = "EXPERIMENTAL: The command is still in development and usage will likely change in the near future. The " +
-            "command expects that a PostgresStorage for the scanner is configured."
+    help = "Upload an ORT result to a PostgreSQL database."
 ) {
     private val ortFile by option(
         "--ort-file", "-i",

--- a/cli/src/main/kotlin/commands/UploadResultToSw360Command.kt
+++ b/cli/src/main/kotlin/commands/UploadResultToSw360Command.kt
@@ -56,9 +56,7 @@ import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 
 class UploadResultToSw360Command : CliktCommand(
     name = "upload-result-to-sw360",
-    help = "Upload an ORT result to SW360.",
-    epilog = "EXPERIMENTAL: The command is still in development and usage will likely change in the near future. The " +
-            "command expects that a Sw360Storage for the scanner is configured."
+    help = "Upload an ORT result to SW360."
 ) {
     private val ortFile by option(
         "--ort-file", "-i",

--- a/cli/src/main/kotlin/commands/UploadResultToSw360Command.kt
+++ b/cli/src/main/kotlin/commands/UploadResultToSw360Command.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.cli.commands
 
-import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.flag
@@ -37,6 +36,7 @@ import org.eclipse.sw360.clients.rest.resource.releases.SW360Release
 import org.eclipse.sw360.clients.utils.SW360ClientException
 
 import org.ossreviewtoolkit.cli.GlobalOptions
+import org.ossreviewtoolkit.cli.OrtCommand
 import org.ossreviewtoolkit.cli.utils.inputGroup
 import org.ossreviewtoolkit.cli.utils.logger
 import org.ossreviewtoolkit.cli.utils.readOrtResult
@@ -54,7 +54,7 @@ import org.ossreviewtoolkit.utils.common.packZip
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 
-class UploadResultToSw360Command : CliktCommand(
+class UploadResultToSw360Command : OrtCommand(
     name = "upload-result-to-sw360",
     help = "Upload an ORT result to SW360."
 ) {

--- a/cli/src/main/resources/META-INF/services/org.ossreviewtoolkit.cli.OrtCommand
+++ b/cli/src/main/resources/META-INF/services/org.ossreviewtoolkit.cli.OrtCommand
@@ -1,0 +1,12 @@
+org.ossreviewtoolkit.cli.commands.AdvisorCommand
+org.ossreviewtoolkit.cli.commands.AnalyzerCommand
+org.ossreviewtoolkit.cli.commands.ConfigCommand
+org.ossreviewtoolkit.cli.commands.DownloaderCommand
+org.ossreviewtoolkit.cli.commands.EvaluatorCommand
+org.ossreviewtoolkit.cli.commands.NotifierCommand
+org.ossreviewtoolkit.cli.commands.ReporterCommand
+org.ossreviewtoolkit.cli.commands.RequirementsCommand
+org.ossreviewtoolkit.cli.commands.ScannerCommand
+org.ossreviewtoolkit.cli.commands.UploadCurationsCommand
+org.ossreviewtoolkit.cli.commands.UploadResultToPostgresCommand
+org.ossreviewtoolkit.cli.commands.UploadResultToSw360Command


### PR DESCRIPTION
This allows to provide external subcommands to ORT at runtime.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>