### PR TITLE
GitWorkingTreeFunTest: Make testing for remote branches less flaky

### DIFF
--- a/downloader/src/funTest/kotlin/vcs/GitWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitWorkingTreeFunTest.kt
@@ -24,7 +24,6 @@ import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.maps.beEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 
 import java.io.File
 
@@ -45,19 +44,8 @@ class GitWorkingTreeFunTest : StringSpec({
         zipFile.unpack(zipContentDir)
     }
 
-    "Detected Git version is not empty" {
-        val version = git.getVersion()
-        println("Git version $version detected.")
-        version shouldNotBe ""
-    }
-
     "Git detects non-working-trees" {
         git.getWorkingTree(ortDataDirectory).isValid() shouldBe false
-    }
-
-    "Git correctly detects URLs to remote repositories" {
-        git.isApplicableUrl("https://bitbucket.org/yevster/spdxtraxample.git") shouldBe true
-        git.isApplicableUrl("https://hg.sr.ht/~duangle/paniq_legacy") shouldBe false
     }
 
     "Detected Git working tree information is correct" {

--- a/downloader/src/funTest/kotlin/vcs/GitWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitWorkingTreeFunTest.kt
@@ -66,7 +66,8 @@ class GitWorkingTreeFunTest : StringSpec({
     "Git correctly lists remote branches" {
         val workingTree = git.getWorkingTree(zipContentDir)
 
-        workingTree.listRemoteBranches() should containExactlyInAnyOrder(
+        // Ignore auto-created branches by Dependabot to avoid regular updates to this list.
+        workingTree.listRemoteBranches().filterNot { it.startsWith("dependabot/") } should containExactlyInAnyOrder(
             "main",
             "pre-commit-ci-update-config"
         )

--- a/downloader/src/test/kotlin/vcs/GitTest.kt
+++ b/downloader/src/test/kotlin/vcs/GitTest.kt
@@ -22,6 +22,7 @@ package org.ossreviewtoolkit.downloader.vcs
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 import io.mockk.every
 import io.mockk.just
@@ -42,19 +43,33 @@ import org.eclipse.jgit.transport.URIish
 import org.ossreviewtoolkit.utils.ort.requestPasswordAuthentication
 
 class GitTest : WordSpec({
+    // Make sure that the initialization logic runs.
+    val git = Git()
+
     var originalCredentialsProvider: CredentialsProvider? = null
     var originalAuthenticator: Authenticator? = null
 
     beforeSpec {
         originalCredentialsProvider = CredentialsProvider.getDefault()
         originalAuthenticator = Authenticator.getDefault()
-
-        Git() // Make sure that the initialization logic runs.
     }
 
     afterSpec {
         Authenticator.setDefault(originalAuthenticator)
         CredentialsProvider.setDefault(originalCredentialsProvider)
+    }
+
+    "Git" should {
+        "be able to get the version" {
+            val version = git.getVersion()
+            println("Git version $version detected.")
+            version shouldNotBe ""
+        }
+
+        "detect URLs to remote repositories" {
+            git.isApplicableUrl("https://bitbucket.org/yevster/spdxtraxample.git") shouldBe true
+            git.isApplicableUrl("https://hg.sr.ht/~duangle/paniq_legacy") shouldBe false
+        }
     }
 
     "The CredentialsProvider" should {


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.