### PR TITLE
Gradle: Set a duplicate handling strategy (to handle "classpath.index")

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -355,6 +355,7 @@ subprojects {
     }
 
     tasks.withType<Jar>().configureEach {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         isPreserveFileTimestamps = false
         isReproducibleFileOrder = true
 


### PR DESCRIPTION
Starting with IntelliJ IDEA 2022.3, an IDE build creates "classpath.index" per module which Gradle does not know how to handle and fails with

    Entry classpath.index is a duplicate but no duplicate handling
    strategy has been set.

Solve that by setting an appropriate duplicate handling strategy to exclude all but the first file. Also see [1].

[1]: https://youtrack.jetbrains.com/issue/IDEA-305759

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>