### PR TITLE
GitWorkingTree: Clear VCS path if submodule is not initialized.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -97,6 +97,8 @@ jobs:
           pip install --no-cache-dir --constraint requirements.txt scancode-toolkit==$SCANCODE_VERSION
     - name: Checkout Repository
       uses: actions/checkout@v3
+      with:
+        submodules: recursive
     - name: Setup Java
       uses: actions/setup-java@v3
       with:

--- a/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
+++ b/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
@@ -70,18 +70,17 @@ open class GitWorkingTree(
             SubmoduleWalk.forIndex(repo).use { walk ->
                 while (walk.next()) {
                     val path = "$prefix${walk.path}"
-                    paths += path
 
                     if (walk.repository == null) {
                         logger.info {
                             "Git submodule at '$path' not initialized. Cannot recursively list its submodules."
                         }
+                    } else {
+                        paths += path
 
-                        continue
-                    }
-
-                    walk.repository.use { submoduleRepo ->
-                        listSubmodules(path, submoduleRepo, paths)
+                        walk.repository.use { submoduleRepo ->
+                            listSubmodules(path, submoduleRepo, paths)
+                        }
                     }
                 }
             }

--- a/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
+++ b/downloader/src/main/kotlin/vcs/GitWorkingTree.kt
@@ -72,7 +72,7 @@ open class GitWorkingTree(
                     val path = "$prefix${walk.path}"
 
                     if (walk.repository == null) {
-                        logger.info {
+                        logger.warn {
                             "Git submodule at '$path' not initialized. Cannot recursively list its submodules."
                         }
                     } else {


### PR DESCRIPTION
The nested repository information and the scanner cache require that the VCS path is empty, which is typically done when resolving a submodule (from the local path to the upstream repo).
This resolution is not possbile if the submodule is not initialized.

Signed-off-by: Stefano Bennati <stefano.bennati@here.com>

Closes: #6146 

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
