### PR TITLE
Git: Fix a potential issue with updateSubmodules()

### DIFF
--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -231,7 +231,7 @@ class Git : VersionControlSystem(), CommandLineTool {
         }
 
     private fun updateSubmodules(workingTree: WorkingTree) {
-        if (!workingTree.workingDir.resolve(".gitmodules").isFile) return
+        if (!workingTree.getRootPath().resolve(".gitmodules").isFile) return
 
         val configOption = REPOSITORY_URL_PREFIX_REPLACEMENTS.flatMap { (prefix, replacement) ->
             listOf("-c", "url.$replacement.insteadOf=$prefix")


### PR DESCRIPTION
According to the class documentation of `WorkingTree`, the `workingDir` does not necessarily need to be the root directory of the tree. However, the `.gitmodules` file should be interpreted as such only if it resides in the root directory of the tree.

Note: Discovered in context of #6166.
