### PR TITLE
Disable the Renovate dependency dashboard issue

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "config:base",
     "docker:disable"
   ],
+  "dependencyDashboard:false",
   "batect": {
     "enabled": false
   },


### PR DESCRIPTION
Closes #6127. The individual update PRs should be enough.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>