### PR TITLE
OrtMain: Print which ORT config file is being looked for

### DIFF
--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -186,6 +186,8 @@ class OrtMain : CliktCommand(name = ORT_NAME, invokeWithoutSubcommand = true) {
             }
         } else {
             println(getOrtHeader(env.ortVersion))
+            println("Looking for ORT configuration in the following file:")
+            println("\t" + configFile.absolutePath + " (does not exist)".takeIf { !configFile.exists() }.orEmpty())
         }
     }
 


### PR DESCRIPTION
Similar to like in the analyzer and evaluator commands for their specific configuration files, print which main ORT configuration file is being looked for to assist with debugging.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>