### PR TITLE
Add a `helper-cli` commands to import and merge license classifications

### DIFF
--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -94,6 +94,7 @@ dependencies {
     implementation(libs.commonsCompress)
     implementation(libs.exposedCore)
     implementation(libs.hikari)
+    implementation(libs.jacksonModuleKotlin)
     implementation(libs.jslt)
     implementation(libs.log4jApiToSlf4j)
     implementation(libs.logbackClassic)

--- a/helper-cli/src/main/kotlin/HelperMain.kt
+++ b/helper-cli/src/main/kotlin/HelperMain.kt
@@ -34,6 +34,7 @@ import com.github.ajalt.clikt.parameters.options.switch
 import kotlin.system.exitProcess
 
 import org.ossreviewtoolkit.helper.commands.*
+import org.ossreviewtoolkit.helper.commands.classifications.LicenseClassificationsCommand
 import org.ossreviewtoolkit.helper.commands.packageconfig.PackageConfigurationCommand
 import org.ossreviewtoolkit.helper.commands.packagecuration.PackageCurationsCommand
 import org.ossreviewtoolkit.helper.commands.repoconfig.RepositoryConfigurationCommand
@@ -78,6 +79,7 @@ internal class HelperMain : CliktCommand(name = ORTH_NAME, epilog = "* denotes r
             DownloadResultsFromPostgresCommand(),
             ImportCopyrightGarbageCommand(),
             ImportScanResultsCommand(),
+            LicenseClassificationsCommand(),
             ListCopyrightsCommand(),
             ListLicenseCategoriesCommand(),
             ListLicensesCommand(),

--- a/helper-cli/src/main/kotlin/commands/classifications/ImportCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/classifications/ImportCommand.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands.classifications
+
+import com.fasterxml.jackson.module.kotlin.readValue
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.enum
+import com.github.ajalt.clikt.parameters.types.file
+
+import java.net.URL
+
+import org.apache.logging.log4j.kotlin.Logging
+
+import org.ossreviewtoolkit.model.jsonMapper
+import org.ossreviewtoolkit.model.licenses.LicenseCategorization
+import org.ossreviewtoolkit.model.licenses.LicenseCategory
+import org.ossreviewtoolkit.model.licenses.LicenseClassifications
+import org.ossreviewtoolkit.model.yamlMapper
+import org.ossreviewtoolkit.utils.common.expandTilde
+import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
+
+internal class ImportCommand : CliktCommand(
+    help = "Import license classifications from supported providers to ORT format."
+) {
+    private val provider by argument(
+        help = "The name of the provider to import license classifications from. Must be one of " +
+                "${enumValues<LicenseClassificationProvider>().map { it.name }}."
+    ).enum<LicenseClassificationProvider>()
+
+    // TODO: Make this default to the provider name with clikt 4, see https://github.com/ajalt/clikt/issues/381.
+    private val prefix by option(
+        "--prefix", "-p",
+        help = "A prefix to use for all category names declared by the provider's classifications."
+    )
+
+    private val licenseClassificationsFile by option(
+        "--output", "-o",
+        help = "The file to write the provided license classifications to."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+
+    override fun run() {
+        val classifications = provider.getClassifications().run {
+            prefix?.let { prefixCategoryNames(it) } ?: this
+        }.sort()
+
+        val yaml = yamlMapper.writeValueAsString(classifications)
+
+        licenseClassificationsFile?.run {
+            writeText(yaml)
+        } ?: println(yaml)
+    }
+}
+
+private data class EclipseLicenses(
+    val meta: Map<String, String>,
+    val approved: Map<String, String>,
+    val restricted: Map<String, String>
+)
+
+private enum class LicenseClassificationProvider(val url: String) : Logging {
+    ECLIPSE("https://www.eclipse.org/legal/licenses.json") {
+        override fun getClassifications(): LicenseClassifications {
+            val json = jsonMapper.readValue<EclipseLicenses>(URL(url))
+
+            logger.info { "Importing Eclipse license classifications dated ${json.meta["updated"]}." }
+
+            val approved = LicenseCategory("approved")
+            val restricted = LicenseCategory("restricted")
+            val categorizations = mutableListOf<LicenseCategorization>()
+
+            json.approved.mapTo(categorizations) { (id, _) ->
+                LicenseCategorization(SpdxSingleLicenseExpression.parse(id), setOf(approved.name))
+            }
+
+            json.restricted.mapTo(categorizations) { (id, _) ->
+                LicenseCategorization(SpdxSingleLicenseExpression.parse(id), setOf(restricted.name))
+            }
+
+            return LicenseClassifications(
+                categories = listOf(approved, restricted),
+                categorizations = categorizations
+            )
+        }
+    },
+    LDBCOLLECTOR("https://github.com/maxhbr/LDBcollector/raw/generated/ort/license-classifications.yml") {
+        override fun getClassifications(): LicenseClassifications = yamlMapper.readValue(URL(url))
+    };
+
+    abstract fun getClassifications(): LicenseClassifications
+}

--- a/helper-cli/src/main/kotlin/commands/classifications/LicenseClassificationsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/classifications/LicenseClassificationsCommand.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands.classifications
+
+import com.github.ajalt.clikt.core.NoOpCliktCommand
+import com.github.ajalt.clikt.core.subcommands
+
+import org.ossreviewtoolkit.model.licenses.LicenseClassifications
+
+class LicenseClassificationsCommand : NoOpCliktCommand(
+    help = "Commands for working with license classifications."
+) {
+    init {
+        subcommands(
+            ImportCommand(),
+            MergeCommand()
+        )
+    }
+}
+
+internal fun LicenseClassifications.prefixCategoryNames(prefix: String) =
+    LicenseClassifications(
+        categories = categories.map { it.copy(name = prefix + it.name) },
+        categorizations = categorizations.map { categorization ->
+            categorization.copy(categories = categorization.categories.mapTo(mutableSetOf()) { prefix + it })
+        }
+    )
+
+internal fun LicenseClassifications.sort() =
+    LicenseClassifications(
+        categories = categories.sortedBy { it.name },
+        categorizations = categorizations.sortedBy { it.id.toString() }.map {
+            it.copy(categories = it.categories.toSortedSet())
+        }
+    )

--- a/helper-cli/src/main/kotlin/commands/classifications/MergeCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/classifications/MergeCommand.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.helper.commands.classifications
+
+import com.fasterxml.jackson.module.kotlin.readValue
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.check
+import com.github.ajalt.clikt.parameters.arguments.convert
+import com.github.ajalt.clikt.parameters.arguments.multiple
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.file
+
+import org.ossreviewtoolkit.model.licenses.LicenseClassifications
+import org.ossreviewtoolkit.model.yamlMapper
+import org.ossreviewtoolkit.utils.common.expandTilde
+
+internal class MergeCommand : CliktCommand(
+    help = "Merge multiple files with license classifications into one."
+) {
+    private val licenseClassificationsFiles by argument(
+        help = "The license classifications file to merge, in order. Existing classifications will be maintained " +
+                "unless they are redefined, in which case they will be overwritten."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+        .multiple()
+        .check("At least two files are required for merging.") { it.size >= 2 }
+
+    private val mergedLicenseClassificationsFile by option(
+        "--output", "-o",
+        help = "The file to write the merged license classifications to."
+    ).convert { it.expandTilde() }
+        .file(mustExist = false, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = false)
+        .convert { it.absoluteFile.normalize() }
+
+    override fun run() {
+        val mergedClassifications = licenseClassificationsFiles.map {
+            yamlMapper.readValue<LicenseClassifications>(it)
+        }.reduce { existing, other ->
+            existing.merge(other)
+        }.sort()
+
+        val yaml = yamlMapper.writeValueAsString(mergedClassifications)
+
+        mergedLicenseClassificationsFile?.run {
+            writeText(yaml)
+        } ?: println(yaml)
+    }
+}


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.