### PR TITLE
GoMod: Fix support for replace directives

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
@@ -69,15 +69,15 @@ project:
     - id: "Go::github.com/stretchr/testify:1.7.2"
       linkage: "PROJECT_STATIC"
       dependencies:
-      - id: "Go::github.com/davecgh/go-spew:1.1.0"
+      - id: "Go::github.com/atomtree/go-spew:1.1.0"
         linkage: "PROJECT_STATIC"
       - id: "Go::github.com/pmezard/go-difflib:1.0.0"
         linkage: "PROJECT_STATIC"
       - id: "Go::gopkg.in/yaml.v3:3.0.1"
         linkage: "PROJECT_STATIC"
 packages:
-- id: "Go::github.com/davecgh/go-spew:1.1.0"
-  purl: "pkg:golang/github.com%2Fdavecgh%2Fgo-spew@1.1.0"
+- id: "Go::github.com/atomtree/go-spew:1.1.0"
+  purl: "pkg:golang/github.com%2Fatomtree%2Fgo-spew@1.1.0"
   declared_licenses: []
   declared_licenses_processed: {}
   description: ""
@@ -94,12 +94,12 @@ packages:
       algorithm: ""
   vcs:
     type: "Git"
-    url: "https://github.com/davecgh/go-spew.git"
+    url: "https://github.com/atomtree/go-spew.git"
     revision: "v1.1.0"
     path: ""
   vcs_processed:
     type: "Git"
-    url: "https://github.com/davecgh/go-spew.git"
+    url: "https://github.com/atomtree/go-spew.git"
     revision: "v1.1.0"
     path: ""
 - id: "Go::github.com/fatih/color:1.13.0"

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod/go.mod
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod/go.mod
@@ -18,4 +18,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/stretchr/testify => github.com/stretchr/testify v1.7.2
+replace (
+	github.com/davecgh/go-spew => github.com/atomtree/go-spew v1.1.0
+	github.com/stretchr/testify => github.com/stretchr/testify v1.7.2
+)

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod/go.sum
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod/go.sum
@@ -1,5 +1,5 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/atomtree/go-spew v1.1.0 h1:KjEMybcuoWwCRanmru/udgfqjF9x/4vK7xqemHRIvMY=
+github.com/atomtree/go-spew v1.1.0/go.mod h1:rs2vmnyPLfme+A8Q4p2wgaVO0IXdVcdi+6yCyexFI+w=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=


### PR DESCRIPTION
Change `getModuleInfos` to return a map which associates the module paths to the related module info. The keys of the map contain both, the paths of replaced modules and those of their replacements. This fixes support for replace directives which do not only replace the version but also the path of a module. Previously, this caused a `NoSuchElementException` because module infos where only associated to the path of the replacing module, but the output of `go mod graph` also contains the paths of replaced modules.

Fixes #5604.