### PR TITLE
getting-started: Remove the hint about ScanCode getting bootstrapped

### DIFF
--- a/docs/config-file-license-classifications-yml.md
+++ b/docs/config-file-license-classifications-yml.md
@@ -57,6 +57,6 @@ cli/build/install/ort/bin/ort evaluate
 [generated license-classifications.yml]: https://github.com/maxhbr/LDBcollector/blob/generated/ort/license-classifications.yml
 [LDBcollector]: https://github.com/maxhbr/LDBcollector
 [Rules]: file-rules-kts.md
-[Notice templates]: notice-templates.md
+[Notice templates]: reporters/notice-templates.md
 [license-classifications.yml example]: ../examples/license-classifications.yml
 [example.rules.kts]: ../examples/evaluator-rules/src/main/resources/example.rules.kts

--- a/docs/dir-custom-license-texts.md
+++ b/docs/dir-custom-license-texts.md
@@ -2,7 +2,7 @@
 
 ORT does provide the license texts for all [SPDX licenses](https://spdx.org/licenses/) and for all license references
 from [ScanCode](https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses). These license
-texts will be used when generating open source notices using the [NoticeTemplateReporter](./notice-templates.md).
+texts will be used when generating open source notices using the [NoticeTemplateReporter](reporters/notice-templates.md).
 
 If you need a license text that is not provided by ORT you can put it in the custom license texts directory. By default,
 it is located at `$ORT_CONFIG_DIR/custom-license-texts`. Alternatively, you can pass a different location to the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -348,8 +348,8 @@ Created 'NoticeTemplate' report: [reporter-output-dir]/NOTICE_default
 
 If you do not want to run the _evaluator_ you can pass the _scanner_ result e.g. `[scanner-output-dir]/scan-result.yml`
 to the `reporter` instead. To learn how you can customize generated notices see
-[notice-templates.md](notice-templates.md). To learn how to customize the how-to-fix texts for scanner and analyzer
-issues see [how-to-fix-text-provider-kts.md](how-to-fix-text-provider-kts.md).
+[notice-templates.md](reporters/notice-templates.md). To learn how to customize the how-to-fix texts for scanner and
+analyzer issues see [how-to-fix-text-provider-kts.md](how-to-fix-text-provider-kts.md).
 
 ## 8. Curating Package Metadata or License Findings
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -264,8 +264,8 @@ that explores the source code of a software package could be integrated. The act
 same machine, for example we will soon integrate the [ClearlyDefined](https://clearlydefined.io/) scanner backend which
 will perform the actual scanning remotely.
 
-For this tutorial we will use `ScanCode`. You do not have to install the tool manually, it will automatically be
-bootstrapped by the `scanner`.
+For this tutorial [ScanCode](https://github.com/nexB/scancode-toolkit) is used as a scanner. Please install it according
+to [these instructions](https://github.com/nexB/scancode-toolkit/#installation) first.
 
 As for the _analyzer_ you can get the command line options for the `scanner` using the `--help` option:
 


### PR DESCRIPTION
Scanners do not get bootstrapped anymore as of 721ee9d, so replace that part of the docs with a link to ScanCode installation docs.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>