### PR TITLE
README: Remove limitations for Python analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,12 +382,9 @@ supported:
 * PHP
   * [Composer](https://getcomposer.org/)
 * Python
-  * [PIP](https://pip.pypa.io/) (limitations:
-    [Python 2.7 or 3.8 and PIP 18.1 only](https://github.com/oss-review-toolkit/ort/issues/3671))
-  * [Pipenv](https://pipenv.pypa.io/en/latest/) (limitations:
-    [Python 2.7 or 3.8 and PIP 18.1 only](https://github.com/oss-review-toolkit/ort/issues/3671))
-  * [Poetry](https://python-poetry.org/) (limitations:
-    [Python 2.7 or 3.8 and PIP 18.1 only](https://github.com/oss-review-toolkit/ort/issues/3671))
+  * [PIP](https://pip.pypa.io/)
+  * [Pipenv](https://pipenv.pypa.io/en/latest/)
+  * [Poetry](https://python-poetry.org/)
 * Ruby
   * [Bundler](https://bundler.io/) (limitations:
     [restricted to the version available on the host](https://github.com/oss-review-toolkit/ort/issues/1308))


### PR DESCRIPTION
Ticket linked with limitations[1] has been closed as Python version is now configurable.

[1]: https://github.com/oss-review-toolkit/ort/issues/3671

Signed-off-by: Thomas Steenbergen <thomas_steenbergen@epam.com>