### PR TITLE
model: Fix the `Set` contract for data classes that implement `Comparable`

### DIFF
--- a/model/src/main/kotlin/CuratedPackage.kt
+++ b/model/src/main/kotlin/CuratedPackage.kt
@@ -44,7 +44,12 @@ data class CuratedPackage(
     /**
      * A comparison function to sort packages by their identifier.
      */
-    override fun compareTo(other: CuratedPackage) = metadata.id.compareTo(other.metadata.id)
+    override fun compareTo(other: CuratedPackage) =
+        when {
+            metadata.id < other.metadata.id -> -1
+            metadata.id > other.metadata.id -> 1
+            else -> if (this == other) 0 else 1 // Return arbitrary inequality.
+        }
 
     /**
      * Return a [Package] representing the same package as this one but which does not have any curations applied.

--- a/model/src/main/kotlin/DependencyGraph.kt
+++ b/model/src/main/kotlin/DependencyGraph.kt
@@ -332,10 +332,14 @@ class DependencyReference(
      * Define an order on [DependencyReference] instances. Instances are ordered by their indices and fragment indices.
      */
     override fun compareTo(other: DependencyReference): Int =
-        if (pkg != other.pkg) {
-            pkg - other.pkg
-        } else {
-            fragment - other.fragment
+        when {
+            pkg < other.pkg -> -1
+            pkg > other.pkg -> 1
+            else -> when {
+                fragment < other.fragment -> -1
+                fragment > other.fragment -> 1
+                else -> if (this == other) 0 else 1 // Return arbitrary inequality.
+            }
         }
 }
 

--- a/model/src/main/kotlin/LicenseFinding.kt
+++ b/model/src/main/kotlin/LicenseFinding.kt
@@ -50,7 +50,7 @@ data class LicenseFinding(
     val score: Float? = null
 ) : Comparable<LicenseFinding> {
     companion object {
-        private val COMPARATOR = compareBy<LicenseFinding>({ it.license.toString() }, { it.location })
+        private val COMPARATOR = compareBy<LicenseFinding>({ it.license.toString() }, { it.location }, { it.score })
 
         /**
          * Create a [LicenseFinding] with [detectedLicenseMapping]s applied.

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -155,7 +155,12 @@ data class Package(
     /**
      * A comparison function to sort packages by their identifier.
      */
-    override fun compareTo(other: Package) = id.compareTo(other.id)
+    override fun compareTo(other: Package) =
+        when {
+            id < other.id -> -1
+            id > other.id -> 1
+            else -> if (this == other) 0 else 1 // Return arbitrary inequality.
+        }
 
     /**
      * Compares this package with [other] and creates a [PackageCurationData] containing the values from this package

--- a/model/src/main/kotlin/PackageReference.kt
+++ b/model/src/main/kotlin/PackageReference.kt
@@ -98,7 +98,12 @@ data class PackageReference(
      * A comparison function to sort package references by their identifier. This function ignores all other properties
      * except for [id].
      */
-    override fun compareTo(other: PackageReference) = id.compareTo(other.id)
+    override fun compareTo(other: PackageReference) =
+        when {
+            id < other.id -> -1
+            id > other.id -> 1
+            else -> if (this == other) 0 else 1 // Return arbitrary inequality.
+        }
 
     /**
      * Return whether the package identified by [id] is a (transitive) dependency of this reference.

--- a/model/src/main/kotlin/Project.kt
+++ b/model/src/main/kotlin/Project.kt
@@ -155,7 +155,12 @@ data class Project(
     /**
      * A comparison function to sort projects by their identifier.
      */
-    override fun compareTo(other: Project) = id.compareTo(other.id)
+    override fun compareTo(other: Project) =
+        when {
+            id < other.id -> -1
+            id > other.id -> 1
+            else -> if (this == other) 0 else 1 // Return arbitrary inequality.
+        }
 
     /**
      * Return whether the package identified by [id] is contained as a (transitive) dependency in this project.

--- a/model/src/main/kotlin/Scope.kt
+++ b/model/src/main/kotlin/Scope.kt
@@ -63,7 +63,12 @@ data class Scope(
     /**
      * A comparison function to sort scopes by their name.
      */
-    override fun compareTo(other: Scope) = compareValuesBy(this, other) { it.name }
+    override fun compareTo(other: Scope) =
+        when {
+            name < other.name -> -1
+            name > other.name -> 1
+            else -> if (this == other) 0 else 1 // Return arbitrary inequality.
+        }
 
     /**
      * Return whether the package identified by [id] is contained as a (transitive) dependency in this scope.


### PR DESCRIPTION
Kotlin's data classes have auto-generated `equals()` functions that take all primary properties into account. When implementing the `Comparable` interface for those classes, i.e. to give them a defined order in a `SortedSet`, special attention needs to be put on `compareTo()` to return 0 if and only if `equals()` returns true. This is required because "a sorted set performs all element comparisons using its compareTo method, so two elements that are deemed equal by this method are, from the standpoint of the sorted set, equal" [1]. This means that sorted sets are considered equal if for all their respective elements `compareTo()` returns 0. So if `compareTo()` is implemented to not consider all properties for an equality check, this can lead to unexpected results, for example when using Kotest's data class matchers.

Fix this and obey the general contract of the `Set` interface by taking all properties into account if the properties to sort on are equal. As the ordering does not matter if not all properties are equal but the properties to sort on are, arbitrarily return 1 from `compareTo()` in that case.

[1]: https://docs.oracle.com/javase/8/docs/api/java/util/SortedSet.html

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>