### PR TITLE
Extensions: Extend the exception message in case `safeMkdirs()` fails

### DIFF
--- a/utils/common/src/main/kotlin/Extensions.kt
+++ b/utils/common/src/main/kotlin/Extensions.kt
@@ -169,7 +169,23 @@ fun File.safeMkdirs() {
         return
     }
 
-    throw IOException("Could not create directory '$absolutePath'.")
+    val message = buildString {
+        append("Could not create directory '$absolutePath'.")
+        if (exists()) append(" It exists but is not a directory.")
+        appendLine()
+
+        appendLine("Parent permissions are:")
+        var currentParent = parentFile
+        while (currentParent != null) {
+            appendLine(
+                "${currentParent.name}: exists=${exists()}, execute=${canExecute()}, read=${canRead()}, " +
+                        "write=${canWrite()}."
+            )
+            currentParent = currentParent.parentFile
+        }
+    }
+
+    throw IOException(message)
 }
 
 /**


### PR DESCRIPTION
This helps debugging permission issues esp. in Docker containers.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>