### PR TITLE
analyzer: Prefer the `beEmpty` matcher

### DIFF
--- a/analyzer/src/funTest/kotlin/managers/BundlerFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/BundlerFunTest.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.analyzer.managers
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.haveSubstring
@@ -70,7 +71,7 @@ class BundlerFunTest : WordSpec() {
                             Identifier("Bundler::src/funTest/assets/projects/synthetic/bundler/no-lockfile/Gemfile:")
                     project.definitionFilePath shouldBe
                             "analyzer/src/funTest/assets/projects/synthetic/bundler/no-lockfile/Gemfile"
-                    packages.size shouldBe 0
+                    packages should beEmpty()
                     issues.size shouldBe 1
                     issues.first().message should haveSubstring("IllegalArgumentException: No lockfile found in")
                 }

--- a/analyzer/src/funTest/kotlin/managers/ComposerFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/ComposerFunTest.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.analyzer.managers
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.haveSubstring
@@ -66,7 +67,7 @@ class ComposerFunTest : StringSpec() {
                 )
                 project.definitionFilePath shouldBe
                         "analyzer/src/funTest/assets/projects/synthetic/composer/no-lockfile/composer.json"
-                packages.size shouldBe 0
+                packages should beEmpty()
                 issues.size shouldBe 1
                 issues.first().message should haveSubstring("IllegalArgumentException: No lockfile found in")
             }

--- a/analyzer/src/funTest/kotlin/managers/GoDepFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoDepFunTest.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.analyzer.managers
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -76,7 +77,7 @@ class GoDepFunTest : WordSpec() {
                             Identifier("GoDep::src/funTest/assets/projects/synthetic/godep/no-lockfile/Gopkg.toml:")
                     project.definitionFilePath shouldBe
                             "analyzer/src/funTest/assets/projects/synthetic/godep/no-lockfile/Gopkg.toml"
-                    packages.size shouldBe 0
+                    packages should beEmpty()
                     issues.size shouldBe 1
                     issues.first().message should haveSubstring("IllegalArgumentException: No lockfile found in")
                 }
@@ -89,7 +90,7 @@ class GoDepFunTest : WordSpec() {
 
                 with(result) {
                     project shouldNotBe Project.EMPTY
-                    issues.size shouldBe 0
+                    issues should beEmpty()
                 }
             }
 

--- a/analyzer/src/funTest/kotlin/managers/PubFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PubFunTest.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.analyzer.managers
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.haveSubstring
@@ -103,7 +104,7 @@ class PubFunTest : WordSpec() {
                 val result = createPub().resolveSingleProject(packageFile)
 
                 with(result) {
-                    packages.size shouldBe 0
+                    packages should beEmpty()
                     issues.size shouldBe 1
                     issues.first().message should haveSubstring("IllegalArgumentException: No lockfile found in")
                 }

--- a/analyzer/src/test/kotlin/PackageManagerTest.kt
+++ b/analyzer/src/test/kotlin/PackageManagerTest.kt
@@ -24,6 +24,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.maps.beEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
@@ -162,7 +163,7 @@ class PackageManagerTest : WordSpec({
         "find no files if no package managers are active" {
             val managedFiles = PackageManager.findManagedFiles(projectDir, emptySet())
 
-            managedFiles.size shouldBe 0
+            managedFiles should beEmpty()
         }
 
         "fail if the provided file is not a directory" {


### PR DESCRIPTION
In contrast to comparing the size to 0, this also shows the unexpected content.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>