### PR TITLE
Dockerfile: Ensure that the `.ort` data directory exists

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -129,7 +129,11 @@ jobs:
     - name: Run functional tests
       run: |
           echo "Running as $(id)."
-          BATECT_QUIET_DOWNLOAD=true ./batect --enable-buildkit --config-var gradle_build_scan=true --config-var gradle_console=plain funTestAnalyzer
+          BATECT_QUIET_DOWNLOAD=true ./batect --enable-buildkit \
+              --config-var docker_build_user_id=1001 \
+              --config-var gradle_build_scan=true \
+              --config-var gradle_console=plain \
+              funTestAnalyzer
     - name: Upload code coverage data
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -127,7 +127,9 @@ jobs:
     - name: Validate Batect wrapper scripts
       uses: batect/batect-wrapper-validation-action@v0
     - name: Run functional tests
-      run: BATECT_QUIET_DOWNLOAD=true ./batect --enable-buildkit --config-var gradle_build_scan=true --config-var gradle_console=plain funTestAnalyzer
+      run: |
+          echo "Running as $(id)."
+          BATECT_QUIET_DOWNLOAD=true ./batect --enable-buildkit --config-var gradle_build_scan=true --config-var gradle_console=plain funTestAnalyzer
     - name: Upload code coverage data
       uses: codecov/codecov-action@v3
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -448,4 +448,7 @@ ENV PATH=$PATH:/opt/ort/bin
 USER $USERNAME
 WORKDIR $HOMEDIR
 
+# Ensure that the ORT data directory exists to be able to mount the config into it with correct permissions.
+RUN mkdir -p "$HOMEDIR/.ort"
+
 ENTRYPOINT ["/opt/ort/bin/ort"]

--- a/batect.yml
+++ b/batect.yml
@@ -18,6 +18,9 @@
 forbid_telemetry: true
 
 config_variables:
+  docker_build_user_id:
+    description: The id to use for the user running ORT
+    default: 1000
   gradle_build_scan:
     description: Enabling of Gradle build scans
     # Supported values: "true", "false"
@@ -58,6 +61,8 @@ containers:
     image: eclipse-temurin:11-jdk-jammy
     <<: *common-container-config
   run:
+    build_args:
+      USER_ID: <{docker_build_user_id}
     build_directory: <{batect.project_directory}
     build_target: run
     <<: *common-container-config


### PR DESCRIPTION
It is common practice to mount a host-side ORT config directory into the Docker container at `/home/ort/.ort/config`. While Docker infers the permissions for the `config` directory from the corresponding directory on the host, for the intermediate `.ort` directory (which did not exist in the container prior to this change) there is no corresponding directory on the host, so Docker uses `root:root` ownership. Fix the ownership to be `ort:ort` by ensuring that the `.ort` directory exists in the container.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>