### PR TITLE
EvaluatorCommand: Fix the check if package curations should be replaced

### DIFF
--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -270,7 +270,7 @@ class EvaluatorCommand : OrtCommand(
             ortResultInput = ortResultInput.replaceConfig(config)
         }
 
-        if (packageConfigurationOption != null) {
+        if (packageCurationsDir != null || packageCurationsFile != null) {
             val curations = FilePackageCurationProvider.from(packageCurationsFile, packageCurationsDir).packageCurations
             ortResultInput = ortResultInput.replacePackageCurations(curations)
         }


### PR DESCRIPTION
Use the `packageCurationsDir` and `packageCurationsFile` options to check if the curations should be replaced, instead of the unrelated `packageConfigurationOption`.

This is fixup for 84ef89f.