### PR TITLE
EvaluatedModelReporter: Remove unused measureTimedValue

### DIFF
--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelReporter.kt
@@ -21,8 +21,6 @@ package org.ossreviewtoolkit.reporter.reporters.evaluatedmodel
 
 import java.io.File
 
-import kotlin.time.measureTimedValue
-
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
@@ -49,9 +47,7 @@ class EvaluatedModelReporter : Reporter {
         outputDir: File,
         options: Map<String, String>
     ): List<File> {
-        val evaluatedModel = measureTimedValue {
-            EvaluatedModel.create(input, options[OPTION_DEDUPLICATE_DEPENDENCY_TREE].toBoolean())
-        }
+        val evaluatedModel = EvaluatedModel.create(input, options[OPTION_DEDUPLICATE_DEPENDENCY_TREE].toBoolean())
 
         val outputFiles = mutableListOf<File>()
         val outputFileFormats = options[OPTION_OUTPUT_FILE_FORMATS]
@@ -64,8 +60,8 @@ class EvaluatedModelReporter : Reporter {
 
             outputFile.bufferedWriter().use {
                 when (fileFormat) {
-                    FileFormat.JSON -> evaluatedModel.value.toJson(it)
-                    FileFormat.YAML -> evaluatedModel.value.toYaml(it)
+                    FileFormat.JSON -> evaluatedModel.toJson(it)
+                    FileFormat.YAML -> evaluatedModel.toYaml(it)
                     else -> throw IllegalArgumentException("Unsupported Evaluated Model file format '$fileFormat'.")
                 }
             }


### PR DESCRIPTION
This is fixup for b51d943.