### PR TITLE
Conan: Add support for Conan lockfiles

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/conan-py/lockfile.lock
+++ b/analyzer/src/funTest/assets/projects/synthetic/conan-py/lockfile.lock
@@ -1,0 +1,33 @@
+{
+ "graph_lock": {
+  "nodes": {
+   "0": {
+    "ref": "Poco/1.9.3",
+    "options": "cxx_14=False\nenable_apacheconnector=False\nenable_cppparser=False\nenable_crypto=True\nenable_data=True\nenable_data_mysql=False\nenable_data_odbc=False\nenable_data_sqlite=True\nenable_json=True\nenable_mongodb=True\nenable_net=True\nenable_netssl=True\nenable_netssl_win=True\nenable_pagecompiler=False\nenable_pagecompiler_file2page=False\nenable_pdf=False\nenable_pocodoc=False\nenable_redis=True\nenable_sevenzip=False\nenable_tests=False\nenable_util=True\nenable_xml=True\nenable_zip=True\nforce_openssl=True\npoco_unbundled=False\nshared=False\nopenssl:386=False\nopenssl:capieng_dialog=False\nopenssl:enable_capieng=False\nopenssl:enable_weak_ssl_ciphers=False\nopenssl:no_aria=False\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_blake2=False\nopenssl:no_camellia=False\nopenssl:no_cast=False\nopenssl:no_chacha=False\nopenssl:no_cms=False\nopenssl:no_comp=False\nopenssl:no_ct=False\nopenssl:no_deprecated=False\nopenssl:no_des=False\nopenssl:no_dgram=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_ec=False\nopenssl:no_ecdh=False\nopenssl:no_ecdsa=False\nopenssl:no_engine=False\nopenssl:no_filenames=False\nopenssl:no_fips=False\nopenssl:no_gost=False\nopenssl:no_idea=False\nopenssl:no_legacy=False\nopenssl:no_md2=True\nopenssl:no_md4=False\nopenssl:no_mdc2=False\nopenssl:no_ocsp=False\nopenssl:no_pinshared=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rfc3779=False\nopenssl:no_rmd160=False\nopenssl:no_seed=False\nopenssl:no_sm2=False\nopenssl:no_sm3=False\nopenssl:no_sm4=False\nopenssl:no_sock=False\nopenssl:no_srp=False\nopenssl:no_srtp=False\nopenssl:no_sse2=False\nopenssl:no_ssl=False\nopenssl:no_ssl3=False\nopenssl:no_stdio=False\nopenssl:no_threads=False\nopenssl:no_tls1=False\nopenssl:no_ts=False\nopenssl:no_whirlpool=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nzlib:shared=False",
+    "requires": [
+     "1"
+    ],
+    "path": "conanfile.py",
+    "context": "host"
+   },
+   "1": {
+    "ref": "openssl/3.0.0",
+    "options": "386=False\ncapieng_dialog=False\nenable_capieng=False\nenable_weak_ssl_ciphers=False\nno_aria=False\nno_asm=False\nno_async=False\nno_bf=False\nno_blake2=False\nno_camellia=False\nno_cast=False\nno_chacha=False\nno_cms=False\nno_comp=False\nno_ct=False\nno_deprecated=False\nno_des=False\nno_dgram=False\nno_dh=False\nno_dsa=False\nno_dso=False\nno_ec=False\nno_ecdh=False\nno_ecdsa=False\nno_engine=False\nno_filenames=False\nno_fips=False\nno_gost=False\nno_idea=False\nno_legacy=False\nno_md2=True\nno_md4=False\nno_mdc2=False\nno_ocsp=False\nno_pinshared=False\nno_rc2=False\nno_rc4=False\nno_rc5=False\nno_rfc3779=False\nno_rmd160=False\nno_seed=False\nno_sm2=False\nno_sm3=False\nno_sm4=False\nno_sock=False\nno_srp=False\nno_srtp=False\nno_sse2=False\nno_ssl=False\nno_ssl3=False\nno_stdio=False\nno_threads=False\nno_tls1=False\nno_ts=False\nno_whirlpool=False\nno_zlib=False\nopenssldir=None\nshared=False\nzlib:shared=False",
+    "package_id": "73fc7f3ed0faf0fd80110346c52171985a5794b4",
+    "requires": [
+     "2"
+    ],
+    "context": "host"
+   },
+   "2": {
+    "ref": "zlib/1.2.12",
+    "options": "shared=False",
+    "package_id": "7bc8c2c85db7a618e5320dc997f27fc33e1df074",
+    "context": "host"
+   }
+  },
+  "revisions_enabled": false
+ },
+ "version": "0.4",
+ "profile_host": "[settings]\narch=x86_64\narch_build=x86_64\nbuild_type=Release\ncompiler=gcc\ncompiler.libcxx=libstdc++\ncompiler.version=6.3\nos=Windows\nos_build=Windows\n[options]\n[build_requires]\n[env]\n"
+}

--- a/analyzer/src/funTest/kotlin/managers/SpdxDocumentFileFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/SpdxDocumentFileFunTest.kt
@@ -202,7 +202,7 @@ class SpdxDocumentFileFunTest : WordSpec({
                 revision = vcsRevision
             )
 
-            val analyzer = Analyzer(AnalyzerConfiguration())
+            val analyzer = Analyzer(AnalyzerConfiguration(allowDynamicVersions = true))
             val managedFiles = analyzer.findManagedFiles(testProjectDir)
 
             val analyzerRun = analyzer.analyze(managedFiles).analyzer.shouldNotBeNull()

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -96,6 +96,12 @@ ort:
           # intercept requests to the registry.
           disableRegistryCertificateVerification: false
 
+      Conan:
+        # Holds a name of the lockfile. Required if allowDynamicVersions = false.
+        # The lockfile should be located in the same directory as the conanfile.py or conanfile.txt.
+        options:
+          lockfileName: "lockfile.lock"
+
   advisor:
     nexusIq:
       serverUrl: 'https://rest-api-url-of-your-nexus-iq-server'


### PR DESCRIPTION
Require a lockfile if a path to the lockfile is configured in `config.yml`.

Only lockfiles located in the same directory as the definition file are
supported.

The test for Conan lockfiles cannot complete successfully when ran
locally as `package id` differs depending on operating system. The
`package id` in the test is set to the one calculated on Linux.

Signed-off-by: Oleksandr Yarosevych <fixed-term.oleksandr.yarosevych@bosch.io>