### PR TITLE
analyzer: Make `ClearlyDefinedPackageCurationProviderTest` a `funTest`

### DIFF
--- a/analyzer/src/funTest/kotlin/curation/ClearlyDefinedPackageCurationProviderFunTest.kt
+++ b/analyzer/src/funTest/kotlin/curation/ClearlyDefinedPackageCurationProviderFunTest.kt
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.utils.spdx.toSpdx
 
-class ClearlyDefinedPackageCurationProviderTest : WordSpec({
+class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
     "The production server" should {
         val provider = ClearlyDefinedPackageCurationProvider()
 

--- a/analyzer/src/test/kotlin/curation/ClearlyDefinedPackageCurationProviderTest.kt
+++ b/analyzer/src/test/kotlin/curation/ClearlyDefinedPackageCurationProviderTest.kt
@@ -38,7 +38,7 @@ import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
  * A test for [ClearlyDefinedPackageCurationProvider], which uses a mock server. This allows testing some specific
  * error conditions.
  */
-class ClearlyDefinedPackageCurationProviderMockTest : WordSpec({
+class ClearlyDefinedPackageCurationProviderTest : WordSpec({
     val server = WireMockServer(
         WireMockConfiguration.options()
             .dynamicPort()


### PR DESCRIPTION
The test talks to the real servers and thus should be a functional test. This makes room for `ClearlyDefinedPackageCurationProviderMockTest` to drop "Mock" from its name in turn.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>