### PR TITLE
Docker: Use Java 17 by default to build and run ORT

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	ignore = untracked
 [submodule "sbt-multi-project-example"]
 	path = analyzer/src/funTest/assets/projects/external/sbt-multi-project-example
-	url = https://github.com/pbassiner/sbt-multi-project-example.git
+	url = https://github.com/oss-review-toolkit/sbt-multi-project-example.git
 	ignore = untracked
 [submodule "dart-http"]
 	path = analyzer/src/funTest/assets/projects/external/dart-http

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
+# Set this to the Java version to use in the base image (and to build and run ORT with).
+ARG JAVA_VERSION=17
+
 # Use OpenJDK Eclipe Temurin Ubuntu LTS
-FROM eclipse-temurin:11-jdk-jammy as ort-base-image
+FROM eclipse-temurin:$JAVA_VERSION-jdk-jammy as ort-base-image
 
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en

--- a/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/sbt-multi-project-example-expected-output.yml
@@ -2,13 +2,13 @@
 repository:
   vcs:
     type: "Git"
-    url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-    revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+    url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+    revision: "3c4e434b241b1f1addc97794932043b86afc2548"
     path: ""
   vcs_processed:
     type: "Git"
-    url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-    revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+    url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+    revision: "3c4e434b241b1f1addc97794932043b86afc2548"
     path: ""
   config: {}
 analyzer:
@@ -26,8 +26,8 @@ analyzer:
     allow_dynamic_versions: false
   result:
     projects:
-    - id: "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
-      definition_file_path: "common/target-scala-2.12-common_2.12-0.1-SNAPSHOT.pom"
+    - id: "SBT:com.pbassiner:common_2.12:0.1.0-SNAPSHOT"
+      definition_file_path: "common/target-scala-2.12-common_2.12-0.1.0-SNAPSHOT.pom"
       authors:
       - "com.pbassiner"
       declared_licenses: []
@@ -39,8 +39,8 @@ analyzer:
         path: ""
       vcs_processed:
         type: "Git"
-        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+        revision: "3c4e434b241b1f1addc97794932043b86afc2548"
         path: "common"
       homepage_url: ""
       scopes:
@@ -67,7 +67,7 @@ analyzer:
             dependencies:
             - id: "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
             - id: "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
-        - id: "Maven:org.scala-lang:scala-library:2.12.3"
+        - id: "Maven:org.scala-lang:scala-library:2.12.15"
         - id: "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
       - name: "test"
         dependencies:
@@ -79,8 +79,8 @@ analyzer:
           - id: "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
           - id: "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
           - id: "Maven:org.scalactic:scalactic_2.12:3.0.4"
-    - id: "SBT:com.pbassiner:multi1_2.12:0.1-SNAPSHOT"
-      definition_file_path: "multi1/target-scala-2.12-multi1_2.12-0.1-SNAPSHOT.pom"
+    - id: "SBT:com.pbassiner:multi1_2.12:0.1.0-SNAPSHOT"
+      definition_file_path: "multi1/target-scala-2.12-multi1_2.12-0.1.0-SNAPSHOT.pom"
       authors:
       - "com.pbassiner"
       declared_licenses: []
@@ -92,8 +92,8 @@ analyzer:
         path: ""
       vcs_processed:
         type: "Git"
-        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+        revision: "3c4e434b241b1f1addc97794932043b86afc2548"
         path: "multi1"
       homepage_url: ""
       scopes:
@@ -126,9 +126,9 @@ analyzer:
             dependencies:
             - id: "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
             - id: "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
-        - id: "Maven:org.scala-lang:scala-library:2.12.3"
+        - id: "Maven:org.scala-lang:scala-library:2.12.15"
         - id: "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
-        - id: "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
+        - id: "SBT:com.pbassiner:common_2.12:0.1.0-SNAPSHOT"
           linkage: "PROJECT_DYNAMIC"
       - name: "test"
         dependencies:
@@ -140,8 +140,8 @@ analyzer:
           - id: "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
           - id: "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
           - id: "Maven:org.scalactic:scalactic_2.12:3.0.4"
-    - id: "SBT:com.pbassiner:multi2_2.12:0.1-SNAPSHOT"
-      definition_file_path: "multi2/target-scala-2.12-multi2_2.12-0.1-SNAPSHOT.pom"
+    - id: "SBT:com.pbassiner:multi2_2.12:0.1.0-SNAPSHOT"
+      definition_file_path: "multi2/target-scala-2.12-multi2_2.12-0.1.0-SNAPSHOT.pom"
       authors:
       - "com.pbassiner"
       declared_licenses: []
@@ -153,8 +153,8 @@ analyzer:
         path: ""
       vcs_processed:
         type: "Git"
-        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+        revision: "3c4e434b241b1f1addc97794932043b86afc2548"
         path: "multi2"
       homepage_url: ""
       scopes:
@@ -188,9 +188,9 @@ analyzer:
             dependencies:
             - id: "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
             - id: "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
-        - id: "Maven:org.scala-lang:scala-library:2.12.3"
+        - id: "Maven:org.scala-lang:scala-library:2.12.15"
         - id: "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
-        - id: "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
+        - id: "SBT:com.pbassiner:common_2.12:0.1.0-SNAPSHOT"
           linkage: "PROJECT_DYNAMIC"
       - name: "test"
         dependencies:
@@ -202,8 +202,8 @@ analyzer:
           - id: "Maven:org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4"
           - id: "Maven:org.scala-lang.modules:scala-xml_2.12:1.0.5"
           - id: "Maven:org.scalactic:scalactic_2.12:3.0.4"
-    - id: "SBT:com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT"
-      definition_file_path: "target-scala-2.12-sbt-multi-project-example_2.12-0.1-SNAPSHOT.pom"
+    - id: "SBT:com.pbassiner:sbt-multi-project-example_2.12:0.1.0-SNAPSHOT"
+      definition_file_path: "target-scala-2.12-sbt-multi-project-example_2.12-0.1.0-SNAPSHOT.pom"
       authors:
       - "com.pbassiner"
       declared_licenses: []
@@ -215,14 +215,14 @@ analyzer:
         path: ""
       vcs_processed:
         type: "Git"
-        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+        revision: "3c4e434b241b1f1addc97794932043b86afc2548"
         path: ""
       homepage_url: ""
       scopes:
       - name: "compile"
         dependencies:
-        - id: "Maven:org.scala-lang:scala-library:2.12.3"
+        - id: "Maven:org.scala-lang:scala-library:2.12.15"
     packages:
     - metadata:
         id: "Maven:ch.qos.logback:logback-classic:1.2.3"
@@ -880,28 +880,26 @@ analyzer:
           path: ""
       curations: []
     - metadata:
-        id: "Maven:org.scala-lang:scala-library:2.12.3"
-        purl: "pkg:maven/org.scala-lang/scala-library@2.12.3"
+        id: "Maven:org.scala-lang:scala-library:2.12.15"
+        purl: "pkg:maven/org.scala-lang/scala-library@2.12.15"
         authors:
         - "LAMP/EPFL"
         - "Lightbend, Inc."
         declared_licenses:
-        - "BSD 3-Clause"
+        - "Apache-2.0"
         declared_licenses_processed:
-          spdx_expression: "BSD-3-Clause"
-          mapped:
-            BSD 3-Clause: "BSD-3-Clause"
+          spdx_expression: "Apache-2.0"
         description: "Standard library for the Scala Programming Language"
-        homepage_url: "http://www.scala-lang.org/"
+        homepage_url: "https://www.scala-lang.org/"
         binary_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.12.3/scala-library-2.12.3.jar"
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.12.15/scala-library-2.12.15.jar"
           hash:
-            value: "f2e496f21af2d80b48e0a61773f84c3a76a0d06f"
+            value: "0f2e89c89340282c9625ac57efb451056f31af57"
             algorithm: "SHA-1"
         source_artifact:
-          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.12.3/scala-library-2.12.3-sources.jar"
+          url: "https://repo.maven.apache.org/maven2/org/scala-lang/scala-library/2.12.15/scala-library-2.12.15-sources.jar"
           hash:
-            value: "499c91b0a64bc706eee174481a3b7dde81b3591d"
+            value: "5e789d895ee2b8b02577db7b6bbb5409798b7daf"
             algorithm: "SHA-1"
         vcs:
           type: "Git"

--- a/analyzer/src/funTest/kotlin/managers/PnpmFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PnpmFunTest.kt
@@ -30,7 +30,7 @@ import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
-import org.ossreviewtoolkit.utils.test.patchActualResultObject
+import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class PnpmFunTest : WordSpec({
@@ -53,10 +53,7 @@ class PnpmFunTest : WordSpec({
 
             val expectedResult = getExpectedResult(rootProjectDir, "pnpm-workspaces-expected-output.yml")
 
-            patchActualResultObject(
-                ortResult,
-                patchStartAndEndTime = true
-            ).withResolvedScopes().toYaml() shouldBe expectedResult
+            patchActualResult(ortResult.withResolvedScopes(), patchStartAndEndTime = true) shouldBe expectedResult
         }
     }
 })

--- a/analyzer/src/funTest/kotlin/managers/SbtFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/SbtFunTest.kt
@@ -19,8 +19,6 @@
 
 package org.ossreviewtoolkit.analyzer.managers
 
-import com.fasterxml.jackson.module.kotlin.readValue
-
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
@@ -29,19 +27,16 @@ import java.io.File
 import org.ossreviewtoolkit.analyzer.Analyzer
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.downloader.vcs.Git
-import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
-import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
-import org.ossreviewtoolkit.utils.test.patchActualResultObject
+import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
-import org.ossreviewtoolkit.utils.test.readOrtResult
 
 class SbtFunTest : StringSpec({
     "Dependencies of the external 'sbt-multi-project-example' multi-project should be detected correctly" {
         val projectName = "sbt-multi-project-example"
         val projectDir = File("src/funTest/assets/projects/external/$projectName").absoluteFile
-        val expectedOutputFile = projectDir.parentFile.resolve("$projectName-expected-output.yml")
+        val expectedResult = patchExpectedResult(projectDir.parentFile.resolve("$projectName-expected-output.yml"))
 
         // Clean any previously generated POM files / target directories.
         Git().run(projectDir, "clean", "-fd")
@@ -50,18 +45,21 @@ class SbtFunTest : StringSpec({
             analyze(findManagedFiles(projectDir, setOf(Sbt.Factory())))
         }
 
-        val expectedResult = readOrtResult(expectedOutputFile)
-
-        patchActualResultObject(ortResult, patchStartAndEndTime = true).withResolvedScopes() shouldBe expectedResult
+        patchActualResult(ortResult.withResolvedScopes(), patchStartAndEndTime = true) shouldBe expectedResult
     }
 
     "Dependencies of the synthetic 'http4s-template' project should be detected correctly" {
         val projectName = "sbt-http4s-template"
         val projectDir = File("src/funTest/assets/projects/synthetic/$projectName").absoluteFile
-        val expectedOutputFile = projectDir.parentFile.resolve("$projectName-expected-output.yml")
         val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
         val vcsUrl = vcsDir.getRemoteUrl()
         val vcsRevision = vcsDir.getRevision()
+        val expectedResult = patchExpectedResult(
+            projectDir.parentFile.resolve("$projectName-expected-output.yml"),
+            url = vcsUrl,
+            revision = vcsRevision,
+            urlProcessed = normalizeVcsUrl(vcsUrl)
+        )
 
         // Clean any previously generated POM files / target directories.
         Git().run(projectDir, "clean", "-fd")
@@ -70,15 +68,6 @@ class SbtFunTest : StringSpec({
             analyze(findManagedFiles(projectDir, setOf(Sbt.Factory())))
         }
 
-        val expectedResult = yamlMapper.readValue<OrtResult>(
-            patchExpectedResult(
-                expectedOutputFile,
-                url = vcsUrl,
-                revision = vcsRevision,
-                urlProcessed = normalizeVcsUrl(vcsUrl)
-            )
-        )
-
-        patchActualResultObject(ortResult, patchStartAndEndTime = true).withResolvedScopes() shouldBe expectedResult
+        patchActualResult(ortResult.withResolvedScopes(), patchStartAndEndTime = true) shouldBe expectedResult
     }
 })

--- a/batect.yml
+++ b/batect.yml
@@ -55,7 +55,7 @@ config_variables:
 
 containers:
   build:
-    image: eclipse-temurin:11-jdk-jammy
+    image: eclipse-temurin:17-jdk-jammy
     <<: *common-container-config
   run:
     build_directory: <{batect.project_directory}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -298,6 +298,11 @@ subprojects {
     }
 
     tasks.withType<Test>().configureEach {
+        if (javaVersion.isCompatibleWith(JavaVersion.VERSION_17)) {
+            // See https://kotest.io/docs/next/extensions/system_extensions.html#system-environment.
+            jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
+        }
+
         val testSystemProperties = mutableListOf("gradle.build.dir" to project.buildDir.path)
 
         listOf(

--- a/docker/legacy/Dockerfile
+++ b/docker/legacy/Dockerfile
@@ -26,13 +26,16 @@ ARG ORT_VERSION="DOCKER-SNAPSHOT"
 # Set this to a directory containing CRT-files for custom certificates that ORT and all build tools should know about.
 ARG CRT_FILES=""
 
+# Set this to the Java version to use in the base image (and to build and run ORT with).
+ARG JAVA_VERSION=17
+
 # Set this to the ScanCode version to use.
 ARG SCANCODE_VERSION="31.2.1"
 
 # Set this to the Python Inspector version to use.
 ARG PYTHON_INSPECTOR_VERSION="0.9.2"
 
-FROM eclipse-temurin:11-jdk-jammy AS build
+FROM eclipse-temurin:$JAVA_VERSION-jdk-jammy AS build
 
 COPY . /usr/local/src/ort
 
@@ -46,7 +49,7 @@ RUN --mount=type=cache,target=/tmp/.gradle/ \
     scripts/set_gradle_proxy.sh && \
     ./gradlew --no-daemon --stacktrace -Pversion=$ORT_VERSION :cli:installDist :helper-cli:startScripts
 
-FROM eclipse-temurin:11-jdk-jammy AS run
+FROM eclipse-temurin:$JAVA_VERSION-jdk-jammy AS run
 
 ENV \
     # Package manager versions.

--- a/model/src/test/assets/sbt-multi-project-example-graph-old.yml
+++ b/model/src/test/assets/sbt-multi-project-example-graph-old.yml
@@ -2,13 +2,13 @@
 repository:
   vcs:
     type: "Git"
-    url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-    revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+    url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+    revision: "3c4e434b241b1f1addc97794932043b86afc2548"
     path: ""
   vcs_processed:
     type: "Git"
-    url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-    revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+    url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+    revision: "3c4e434b241b1f1addc97794932043b86afc2548"
     path: ""
   config: {}
 analyzer:
@@ -26,8 +26,8 @@ analyzer:
     allow_dynamic_versions: false
   result:
     projects:
-    - id: "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
-      definition_file_path: "common/target-scala-2.12-common_2.12-0.1-SNAPSHOT.pom"
+    - id: "SBT:com.pbassiner:common_2.12:0.1.0-SNAPSHOT"
+      definition_file_path: "common/target-scala-2.12-common_2.12-0.1.0-SNAPSHOT.pom"
       authors:
       - "com.pbassiner"
       declared_licenses: []
@@ -39,14 +39,14 @@ analyzer:
         path: ""
       vcs_processed:
         type: "Git"
-        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+        revision: "3c4e434b241b1f1addc97794932043b86afc2548"
         path: "common"
       homepage_url: ""
       scope_names:
       - "compile"
       - "test"
-    - id: "SBT:com.pbassiner:multi1_2.12:0.1-SNAPSHOT"
+    - id: "SBT:com.pbassiner:multi1_2.12:0.1.0-SNAPSHOT"
       definition_file_path: "multi1/target-scala-2.12-multi1_2.12-0.1-SNAPSHOT.pom"
       authors:
       - "com.pbassiner"
@@ -59,15 +59,15 @@ analyzer:
         path: ""
       vcs_processed:
         type: "Git"
-        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+        revision: "3c4e434b241b1f1addc97794932043b86afc2548"
         path: "multi1"
       homepage_url: ""
       scope_names:
       - "compile"
       - "test"
-    - id: "SBT:com.pbassiner:multi2_2.12:0.1-SNAPSHOT"
-      definition_file_path: "multi2/target-scala-2.12-multi2_2.12-0.1-SNAPSHOT.pom"
+    - id: "SBT:com.pbassiner:multi2_2.12:0.1.0-SNAPSHOT"
+      definition_file_path: "multi2/target-scala-2.12-multi2_2.12-0.1.0-SNAPSHOT.pom"
       authors:
       - "com.pbassiner"
       declared_licenses: []
@@ -79,8 +79,8 @@ analyzer:
         path: ""
       vcs_processed:
         type: "Git"
-        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+        revision: "3c4e434b241b1f1addc97794932043b86afc2548"
         path: "multi2"
       homepage_url: ""
       scope_names:
@@ -99,8 +99,8 @@ analyzer:
         path: ""
       vcs_processed:
         type: "Git"
-        url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-        revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+        url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+        revision: "3c4e434b241b1f1addc97794932043b86afc2548"
         path: ""
       homepage_url: ""
       scope_names:
@@ -762,7 +762,7 @@ analyzer:
           path: ""
       curations: []
     - package:
-        id: "Maven:org.scala-lang:scala-library:2.12.3"
+        id: "Maven:org.scala-lang:scala-library:2.12.15"
         purl: "pkg:maven/org.scala-lang/scala-library@2.12.3"
         authors:
         - "LAMP/EPFL"
@@ -1254,7 +1254,7 @@ analyzer:
         - "Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9"
         - "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
         - "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
-        - "Maven:org.scala-lang:scala-library:2.12.3"
+        - "Maven:org.scala-lang:scala-library:2.12.15"
         - "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
         - "Maven:org.scalacheck:scalacheck_2.12:1.13.5"
         - "Maven:org.scala-sbt:test-interface:1.0"
@@ -1266,7 +1266,7 @@ analyzer:
         - "Maven:org.scalaz:scalaz-core_2.12:7.2.8"
         - "Maven:com.github.julien-truffaut:monocle-macro_2.12:1.4.0"
         - "Maven:org.typelevel:macro-compat_2.12:1.1.1"
-        - "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
+        - "SBT:com.pbassiner:common_2.12:0.1.0-SNAPSHOT"
         - "Maven:com.github.pureconfig:pureconfig_2.12:0.8.0"
         - "Maven:com.chuusai:shapeless_2.12:2.3.2"
         - "Maven:com.github.pureconfig:pureconfig-macros_2.12:0.8.0"
@@ -1318,7 +1318,7 @@ analyzer:
             - pkg: 26
             - pkg: 31
         scopes:
-          com.pbassiner:common_2.12:0.1-SNAPSHOT:compile:
+          com.pbassiner:common_2.12:0.1.0-SNAPSHOT:compile:
           - root: 0
           - root: 3
           - root: 4
@@ -1326,10 +1326,10 @@ analyzer:
           - root: 11
           - root: 15
           - root: 16
-          com.pbassiner:common_2.12:0.1-SNAPSHOT:test:
+          com.pbassiner:common_2.12:0.1.0-SNAPSHOT:test:
           - root: 17
           - root: 19
-          com.pbassiner:multi1_2.12:0.1-SNAPSHOT:compile:
+          com.pbassiner:multi1_2.12:0.1.0-SNAPSHOT:compile:
           - root: 0
           - root: 23
           - root: 25
@@ -1340,10 +1340,10 @@ analyzer:
           - root: 15
           - root: 16
           - root: 27
-          com.pbassiner:multi1_2.12:0.1-SNAPSHOT:test:
+          com.pbassiner:multi1_2.12:0.1.0-SNAPSHOT:test:
           - root: 17
           - root: 19
-          com.pbassiner:multi2_2.12:0.1-SNAPSHOT:compile:
+          com.pbassiner:multi2_2.12:0.1.0-SNAPSHOT:compile:
           - root: 0
           - root: 28
           - root: 3
@@ -1353,7 +1353,7 @@ analyzer:
           - root: 15
           - root: 16
           - root: 27
-          com.pbassiner:multi2_2.12:0.1-SNAPSHOT:test:
+          com.pbassiner:multi2_2.12:0.1.0-SNAPSHOT:test:
           - root: 17
           - root: 19
           com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT:compile:

--- a/model/src/test/assets/sbt-multi-project-example-graph.yml
+++ b/model/src/test/assets/sbt-multi-project-example-graph.yml
@@ -2,13 +2,13 @@
 repository:
   vcs:
     type: "Git"
-    url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-    revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+    url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+    revision: "3c4e434b241b1f1addc97794932043b86afc2548"
     path: ""
   vcs_processed:
     type: "Git"
-    url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-    revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+    url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+    revision: "3c4e434b241b1f1addc97794932043b86afc2548"
     path: ""
   config: {}
 analyzer:
@@ -26,7 +26,7 @@ analyzer:
     allow_dynamic_versions: false
   result:
     projects:
-      - id: "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
+      - id: "SBT:com.pbassiner:common_2.12:0.1.0-SNAPSHOT"
         definition_file_path: "common/target-scala-2.12-common_2.12-0.1-SNAPSHOT.pom"
         authors:
           - "com.pbassiner"
@@ -39,14 +39,14 @@ analyzer:
           path: ""
         vcs_processed:
           type: "Git"
-          url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-          revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+          url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+          revision: "3c4e434b241b1f1addc97794932043b86afc2548"
           path: "common"
         homepage_url: ""
         scope_names:
           - "compile"
           - "test"
-      - id: "SBT:com.pbassiner:multi1_2.12:0.1-SNAPSHOT"
+      - id: "SBT:com.pbassiner:multi1_2.12:0.1.0-SNAPSHOT"
         definition_file_path: "multi1/target-scala-2.12-multi1_2.12-0.1-SNAPSHOT.pom"
         authors:
           - "com.pbassiner"
@@ -59,14 +59,14 @@ analyzer:
           path: ""
         vcs_processed:
           type: "Git"
-          url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-          revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+          url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+          revision: "3c4e434b241b1f1addc97794932043b86afc2548"
           path: "multi1"
         homepage_url: ""
         scope_names:
           - "compile"
           - "test"
-      - id: "SBT:com.pbassiner:multi2_2.12:0.1-SNAPSHOT"
+      - id: "SBT:com.pbassiner:multi2_2.12:0.1.0-SNAPSHOT"
         definition_file_path: "multi2/target-scala-2.12-multi2_2.12-0.1-SNAPSHOT.pom"
         authors:
           - "com.pbassiner"
@@ -79,8 +79,8 @@ analyzer:
           path: ""
         vcs_processed:
           type: "Git"
-          url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-          revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+          url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+          revision: "3c4e434b241b1f1addc97794932043b86afc2548"
           path: "multi2"
         homepage_url: ""
         scope_names:
@@ -99,8 +99,8 @@ analyzer:
           path: ""
         vcs_processed:
           type: "Git"
-          url: "https://github.com/pbassiner/sbt-multi-project-example.git"
-          revision: "31687c099ea6d645e819ef9d6ac9fc4c757a96bc"
+          url: "https://github.com/oss-review-toolkit/sbt-multi-project-example.git"
+          revision: "3c4e434b241b1f1addc97794932043b86afc2548"
           path: ""
         homepage_url: ""
         scope_names:
@@ -762,7 +762,7 @@ analyzer:
             path: ""
         curations: []
       - package:
-          id: "Maven:org.scala-lang:scala-library:2.12.3"
+          id: "Maven:org.scala-lang:scala-library:2.12.15"
           purl: "pkg:maven/org.scala-lang/scala-library@2.12.3"
           authors:
             - "LAMP/EPFL"
@@ -1254,7 +1254,7 @@ analyzer:
           - "Maven:com.fasterxml.jackson.core:jackson-databind:2.8.9"
           - "Maven:com.fasterxml.jackson.core:jackson-annotations:2.8.0"
           - "Maven:com.fasterxml.jackson.core:jackson-core:2.8.9"
-          - "Maven:org.scala-lang:scala-library:2.12.3"
+          - "Maven:org.scala-lang:scala-library:2.12.15"
           - "Maven:org.slf4j:jcl-over-slf4j:1.7.25"
           - "Maven:org.scalacheck:scalacheck_2.12:1.13.5"
           - "Maven:org.scala-sbt:test-interface:1.0"
@@ -1266,13 +1266,13 @@ analyzer:
           - "Maven:org.scalaz:scalaz-core_2.12:7.2.8"
           - "Maven:com.github.julien-truffaut:monocle-macro_2.12:1.4.0"
           - "Maven:org.typelevel:macro-compat_2.12:1.1.1"
-          - "SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT"
+          - "SBT:com.pbassiner:common_2.12:0.1.0-SNAPSHOT"
           - "Maven:com.github.pureconfig:pureconfig_2.12:0.8.0"
           - "Maven:com.chuusai:shapeless_2.12:2.3.2"
           - "Maven:com.github.pureconfig:pureconfig-macros_2.12:0.8.0"
           - "Maven:org.scala-lang:scala-compiler:2.12.3"
         scopes:
-          com.pbassiner:common_2.12:0.1-SNAPSHOT:compile:
+          com.pbassiner:common_2.12:0.1.0-SNAPSHOT:compile:
             - root: 0
             - root: 3
             - root: 4
@@ -1280,10 +1280,10 @@ analyzer:
             - root: 11
             - root: 15
             - root: 16
-          com.pbassiner:common_2.12:0.1-SNAPSHOT:test:
+          com.pbassiner:common_2.12:0.1.0-SNAPSHOT:test:
             - root: 17
             - root: 19
-          com.pbassiner:multi1_2.12:0.1-SNAPSHOT:compile:
+          com.pbassiner:multi1_2.12:0.1.0-SNAPSHOT:compile:
             - root: 0
             - root: 23
             - root: 25
@@ -1294,10 +1294,10 @@ analyzer:
             - root: 15
             - root: 16
             - root: 27
-          com.pbassiner:multi1_2.12:0.1-SNAPSHOT:test:
+          com.pbassiner:multi1_2.12:0.1.0-SNAPSHOT:test:
             - root: 17
             - root: 19
-          com.pbassiner:multi2_2.12:0.1-SNAPSHOT:compile:
+          com.pbassiner:multi2_2.12:0.1.0-SNAPSHOT:compile:
             - root: 0
             - root: 28
             - root: 3
@@ -1307,7 +1307,7 @@ analyzer:
             - root: 15
             - root: 16
             - root: 27
-          com.pbassiner:multi2_2.12:0.1-SNAPSHOT:test:
+          com.pbassiner:multi2_2.12:0.1.0-SNAPSHOT:test:
             - root: 17
             - root: 19
           com.pbassiner:sbt-multi-project-example_2.12:0.1-SNAPSHOT:compile:

--- a/model/src/test/kotlin/AbstractDependencyNavigatorTest.kt
+++ b/model/src/test/kotlin/AbstractDependencyNavigatorTest.kt
@@ -94,7 +94,7 @@ abstract class AbstractDependencyNavigatorTest : WordSpec() {
                     this should containAll(
                         Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"),
                         Identifier("Maven:org.scala-lang:scala-reflect:2.12.2"),
-                        Identifier("Maven:org.scala-lang:scala-library:2.12.3")
+                        Identifier("Maven:org.scala-lang:scala-library:2.12.15")
                     )
                 }
 
@@ -157,7 +157,7 @@ abstract class AbstractDependencyNavigatorTest : WordSpec() {
                 compileDependencies should containAll(
                     Identifier("Maven:com.typesafe.akka:akka-actor_2.12:2.5.6"),
                     Identifier("Maven:org.scala-lang:scala-reflect:2.12.2"),
-                    Identifier("Maven:org.scala-lang:scala-library:2.12.3")
+                    Identifier("Maven:org.scala-lang:scala-library:2.12.15")
                 )
             }
 
@@ -263,7 +263,7 @@ abstract class AbstractDependencyNavigatorTest : WordSpec() {
                             Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
                         ),
                         Identifier("Maven:net.logstash.logback:logstash-logback-encoder:4.11") to emptyList(),
-                        Identifier("Maven:org.scala-lang:scala-library:2.12.3") to emptyList(),
+                        Identifier("Maven:org.scala-lang:scala-library:2.12.15") to emptyList(),
                         Identifier("Maven:org.scala-lang:scala-reflect:2.12.2") to listOf(
                             Identifier("Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2")
                         ),
@@ -304,7 +304,7 @@ abstract class AbstractDependencyNavigatorTest : WordSpec() {
                     Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6"),
                     Identifier("Maven:com.typesafe.scala-logging:scala-logging_2.12:3.7.2"),
                     Identifier("Maven:net.logstash.logback:logstash-logback-encoder:4.11"),
-                    Identifier("Maven:org.scala-lang:scala-library:2.12.3"),
+                    Identifier("Maven:org.scala-lang:scala-library:2.12.15"),
                     Identifier("Maven:org.slf4j:jcl-over-slf4j:1.7.25"),
                     Identifier("Maven:org.scalacheck:scalacheck_2.12:1.13.5"),
                     Identifier("Maven:org.scalatest:scalatest_2.12:3.0.4")
@@ -320,7 +320,7 @@ abstract class AbstractDependencyNavigatorTest : WordSpec() {
 
         "collectSubProjects" should {
             "find all the sub projects of a project" {
-                val projectId = Identifier("SBT:com.pbassiner:multi1_2.12:0.1-SNAPSHOT")
+                val projectId = Identifier("SBT:com.pbassiner:multi1_2.12:0.1.0-SNAPSHOT")
                 testResult.getProject(projectId) shouldNotBeNull {
                     val subProjectIds = navigator.collectSubProjects(this)
 
@@ -402,4 +402,4 @@ abstract class AbstractDependencyNavigatorTest : WordSpec() {
 }
 
 /** Identifier of the project used by the tests. */
-private val PROJECT_ID = Identifier("SBT:com.pbassiner:common_2.12:0.1-SNAPSHOT")
+private val PROJECT_ID = Identifier("SBT:com.pbassiner:common_2.12:0.1.0-SNAPSHOT")

--- a/utils/test/src/main/kotlin/Utils.kt
+++ b/utils/test/src/main/kotlin/Utils.kt
@@ -92,9 +92,6 @@ fun patchActualResult(
 ): String =
     patchActualResult(yamlMapper.writeValueAsString(result), patchStartAndEndTime)
 
-fun patchActualResultObject(result: OrtResult, patchStartAndEndTime: Boolean = false): OrtResult =
-    yamlMapper.readValue(patchActualResult(result, patchStartAndEndTime))
-
 fun readOrtResult(file: String) = readOrtResult(File(file))
 
 fun readOrtResult(file: File) = file.mapper().readValue<OrtResult>(patchExpectedResult(file))


### PR DESCRIPTION
This basically reapplies the commit reverted in 960f702 as it was agreed in the community meeting that by now Java 17 should be the default [1], but the Java version should be configurable via a Docker build argument. Users that need to analyze projects incompatible with Java 17 should use `--build-arg JAVA_VERSION=11` with `docker build` to restore the previous behavior.

[1]: https://github.com/oss-review-toolkit/ort/wiki/Community-Meeting#2022-12-15-last-meeting-before-holiday-season

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>