### PR TITLE
common-utils: Make safeMkdirs fluent

### DIFF
--- a/downloader/src/main/kotlin/vcs/Git.kt
+++ b/downloader/src/main/kotlin/vcs/Git.kt
@@ -151,7 +151,7 @@ class Git : VersionControlSystem(), CommandLineTool {
 
                     git.repository.config.setBoolean("core", null, "sparseCheckout", true)
 
-                    val gitInfoDir = targetDir.resolve(".git/info").apply { safeMkdirs() }
+                    val gitInfoDir = targetDir.resolve(".git/info").safeMkdirs()
                     val path = vcs.path.let { if (it.startsWith("/")) it else "/$it" }
                     val globPatterns = getSparseCheckoutGlobPatterns() + path
 

--- a/utils/common/src/main/kotlin/Extensions.kt
+++ b/utils/common/src/main/kotlin/Extensions.kt
@@ -110,8 +110,7 @@ fun File.safeCopyRecursively(target: File, overwrite: Boolean = false) {
                 // Windows, so do a better check here.
                 if (dir.toFile().isSymbolicLink()) return FileVisitResult.SKIP_SUBTREE
 
-                val targetDir = targetPath.resolve(sourcePath.relativize(dir))
-                targetDir.toFile().safeMkdirs()
+                targetPath.resolve(sourcePath.relativize(dir)).toFile().safeMkdirs()
 
                 return FileVisitResult.CONTINUE
             }
@@ -157,16 +156,15 @@ fun File.safeDeleteRecursively(force: Boolean = false, baseDirectory: File? = nu
 }
 
 /**
- * Create all missing intermediate directories without failing if any already exists.
- *
- * @throws IOException if any missing directory could not be created.
+ * Create all missing intermediate directories without failing if any already exists. Returns the [File] it was called
+ * on if successful, otherwise throws an [IOException].
  */
-fun File.safeMkdirs() {
+fun File.safeMkdirs(): File {
     // Do not blindly trust mkdirs() returning "false" as it can fail for edge-cases like
     // File(File("/tmp/parent1/parent2"), "/").mkdirs() if parent1 does not exist, although the directory is
     // successfully created.
     if (isDirectory || mkdirs() || isDirectory) {
-        return
+        return this
     }
 
     throw IOException("Could not create directory '$absolutePath'.")

--- a/utils/common/src/test/kotlin/ArchiveUtilsTest.kt
+++ b/utils/common/src/test/kotlin/ArchiveUtilsTest.kt
@@ -420,7 +420,7 @@ class ArchiveUtilsTest : WordSpec() {
         "packZip" should {
             "not follow symbolic links".config(enabled = Os.isLinux) {
                 val inputDir = createTestTempDir()
-                val parentDir = inputDir.resolve("parent").apply { safeMkdirs() }
+                val parentDir = inputDir.resolve("parent").safeMkdirs()
                 val readmeFile = parentDir.resolve("readme.txt").apply { writeText("Hello World!") }
 
                 withContext(Dispatchers.IO) {

--- a/utils/common/src/test/kotlin/ExtensionsTest.kt
+++ b/utils/common/src/test/kotlin/ExtensionsTest.kt
@@ -114,7 +114,7 @@ class ExtensionsTest : WordSpec({
     "File.isSymbolicLink" should {
         val tempDir = createSpecTempDir()
         val file = tempDir.resolve("file").apply { createNewFile() }
-        val directory = tempDir.resolve("directory").apply { safeMkdirs() }
+        val directory = tempDir.resolve("directory").safeMkdirs()
 
         "return 'false' for non-existent files" {
             tempDir.resolve("non-existent").let { nonExistent ->

--- a/utils/ort/src/funTest/kotlin/storage/LocalFileStorageFunTest.kt
+++ b/utils/ort/src/funTest/kotlin/storage/LocalFileStorageFunTest.kt
@@ -135,8 +135,7 @@ class LocalFileStorageFunTest : WordSpec() {
 
             "fail if the target path is a directory" {
                 storage { storage, directory ->
-                    val dir = directory.resolve("dir")
-                    dir.safeMkdirs()
+                    val dir = directory.resolve("dir").safeMkdirs()
 
                     shouldThrow<FileNotFoundException> {
                         storage.write("dir", "content".byteInputStream())

--- a/utils/scripting/src/main/kotlin/OrtScriptCompilationConfiguration.kt
+++ b/utils/scripting/src/main/kotlin/OrtScriptCompilationConfiguration.kt
@@ -53,7 +53,7 @@ class OrtScriptCompilationConfiguration : ScriptCompilationConfiguration({
     hostConfiguration(
         ScriptingHostConfiguration {
             jvm {
-                val scriptCacheDir = ortDataDirectory.resolve("cache/scripts").apply { safeMkdirs() }
+                val scriptCacheDir = ortDataDirectory.resolve("cache/scripts").safeMkdirs()
 
                 compilationCache(
                     CompiledScriptJarsCache { script, configuration ->


### PR DESCRIPTION
Make the `safeMkdirs` function fluent because it allows nicer code in some places.