### PR TITLE
ArchiveUtils: Use the fluent `safeMkdirs()` in one more place

### DIFF
--- a/utils/common/src/main/kotlin/ArchiveUtils.kt
+++ b/utils/common/src/main/kotlin/ArchiveUtils.kt
@@ -230,7 +230,7 @@ fun File.unpackDeb(targetDirectory: File, filter: (ArchiveEntry) -> Boolean = { 
 
         DEB_NESTED_ARCHIVES.forEach { name ->
             val subDirectoryName = name.substringBefore('.')
-            val subDirectory = targetDirectory.resolve(subDirectoryName).apply { safeMkdirs() }
+            val subDirectory = targetDirectory.resolve(subDirectoryName).safeMkdirs()
             val file = tempDir.resolve(name)
             file.unpack(subDirectory, filter = filter)
         }


### PR DESCRIPTION
Thsi is a fixup for cf9f4c8.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>