### PR TITLE
Add a non-ambiguous declared license mapping to `Apache-2.0`

### DIFF
--- a/utils/spdx/src/main/resources/declared-license-mapping.yml
+++ b/utils/spdx/src/main/resources/declared-license-mapping.yml
@@ -111,6 +111,7 @@
 "Apache License, V2 or later": Apache-2.0
 "Apache License, V2.0 or later": Apache-2.0
 "Apache License, Version 2": Apache-2.0
+"Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)": Apache-2.0
 "Apache License, Version 2.0 and Common Development And Distribution License (CDDL) Version 1.0": Apache-2.0 AND CDDL-1.0
 "Apache License, Version 2.0 and\n        Common Development And Distribution License (CDDL) Version 1.0": Apache-2.0 AND CDDL-1.0
 "Apache License, Version 2.0": Apache-2.0


### PR DESCRIPTION
As seen in [1].

[1]: https://github.com/iziz/libPhoneNumber-iOS/blob/0.9.15/libPhoneNumber-iOS.podspec#L10

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>