### PR TITLE
Make sure that static and object mocks are canceled

### DIFF
--- a/advisor/src/test/kotlin/advisors/GitHubDefectsTest.kt
+++ b/advisor/src/test/kotlin/advisors/GitHubDefectsTest.kt
@@ -32,6 +32,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.unmockkAll
 import io.mockk.verify
 
 import java.net.URI
@@ -62,6 +63,10 @@ import org.ossreviewtoolkit.utils.common.enumSetOf
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class GitHubDefectsTest : WordSpec({
+    afterTest {
+        unmockkAll()
+    }
+
     "retrievePackageFindings" should {
         "return an empty result for packages not hosted on GitHub" {
             val vcs = VcsInfo(type = VcsType.GIT, url = "https://www.example.org/repo/test.git", revision = "1")

--- a/analyzer/src/test/kotlin/managers/CarthageTest.kt
+++ b/analyzer/src/test/kotlin/managers/CarthageTest.kt
@@ -20,11 +20,15 @@
 package org.ossreviewtoolkit.analyzer.managers
 
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.Tuple2
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import io.kotest.matchers.shouldBe
 
 import io.mockk.every
 import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 
 import java.io.File
 import java.net.URL
@@ -37,6 +41,10 @@ import org.ossreviewtoolkit.utils.test.USER_DIR
 class CarthageTest : WordSpec() {
     private val carthage =
         Carthage("Carthage", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())
+
+    override fun afterTest(f: suspend (Tuple2<TestCase, TestResult>) -> Unit) {
+        unmockkAll()
+    }
 
     init {
         "resolveDependencies" should {

--- a/analyzer/src/test/kotlin/managers/utils/MavenDependencyHandlerTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/MavenDependencyHandlerTest.kt
@@ -31,6 +31,7 @@ import io.kotest.matchers.string.contain
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 
 import java.io.IOException
 
@@ -50,6 +51,10 @@ import org.ossreviewtoolkit.model.Severity
 class MavenDependencyHandlerTest : WordSpec({
     beforeSpec {
         mockkStatic(Artifact::identifier)
+    }
+
+    afterSpec {
+        unmockkAll()
     }
 
     "identifierFor" should {

--- a/downloader/src/test/kotlin/vcs/GitTest.kt
+++ b/downloader/src/test/kotlin/vcs/GitTest.kt
@@ -29,6 +29,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.unmockkAll
 import io.mockk.verify
 
 import java.net.Authenticator
@@ -57,6 +58,10 @@ class GitTest : WordSpec({
     afterSpec {
         Authenticator.setDefault(originalAuthenticator)
         CredentialsProvider.setDefault(originalCredentialsProvider)
+    }
+
+    afterTest {
+        unmockkAll()
     }
 
     "Git" should {

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdUrlProviderTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdUrlProviderTest.kt
@@ -24,6 +24,7 @@ import io.kotest.matchers.shouldBe
 
 import io.mockk.every
 import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 
 import java.net.PasswordAuthentication
 import java.net.URI
@@ -32,6 +33,10 @@ import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.ort.requestPasswordAuthentication
 
 class FossIdUrlProviderTest : StringSpec({
+    afterTest {
+        unmockkAll()
+    }
+
     "URLs are not changed if no mapping is provided" {
         val urlProvider = FossIdUrlProvider.create()
 

--- a/utils/ort/src/test/kotlin/OkHttpClientHelperTest.kt
+++ b/utils/ort/src/test/kotlin/OkHttpClientHelperTest.kt
@@ -31,6 +31,7 @@ import io.kotest.matchers.types.shouldNotBeSameInstanceAs
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 
 import java.io.IOException
 import java.time.Duration
@@ -44,6 +45,10 @@ import okhttp3.ResponseBody
 import okio.BufferedSource
 
 class OkHttpClientHelperTest : WordSpec({
+    afterTest {
+        unmockkAll()
+    }
+
     "buildClient()" should {
         "return the same client instance when no configuration is specified" {
             val clientA = OkHttpClientHelper.buildClient()

--- a/utils/ort/src/test/kotlin/UtilsTest.kt
+++ b/utils/ort/src/test/kotlin/UtilsTest.kt
@@ -31,6 +31,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 import io.mockk.verify
 
 import java.net.Authenticator
@@ -420,17 +421,22 @@ class UtilsTest : WordSpec({
             mockkObject(OrtAuthenticator)
             mockkObject(OrtProxySelector)
             mockkStatic(Authenticator::class)
-            val passwordAuth = mockk<PasswordAuthentication>()
 
-            every {
-                Authenticator.requestPasswordAuthentication(host, null, port, scheme, null, null)
-            } returns passwordAuth
+            try {
+                val passwordAuth = mockk<PasswordAuthentication>()
 
-            requestPasswordAuthentication(host, port, scheme) shouldBe passwordAuth
+                every {
+                    Authenticator.requestPasswordAuthentication(host, null, port, scheme, null, null)
+                } returns passwordAuth
 
-            verify {
-                OrtAuthenticator.install()
-                OrtProxySelector.install()
+                requestPasswordAuthentication(host, port, scheme) shouldBe passwordAuth
+
+                verify {
+                    OrtAuthenticator.install()
+                    OrtProxySelector.install()
+                }
+            } finally {
+                unmockkAll()
             }
         }
 


### PR DESCRIPTION
Always unmock mocked objects and static functions so that they are not leaked.