### PR TITLE
model: Fix inconsistent `has_issues` in test input files

### DIFF
--- a/model/src/test/assets/result-with-issues-graph.yml
+++ b/model/src/test/assets/result-with-issues-graph.yml
@@ -1397,7 +1397,7 @@ analyzer:
           to: 29
         - from: 28
           to: 30
-    has_issues: false
+    has_issues: true
 scanner: null
 advisor: null
 evaluator: null

--- a/model/src/test/assets/result-with-issues-scopes.yml
+++ b/model/src/test/assets/result-with-issues-scopes.yml
@@ -1364,7 +1364,7 @@ analyzer:
             revision: ""
             path: ""
         curations: []
-    has_issues: false
+    has_issues: true
 scanner: null
 advisor: null
 evaluator: null


### PR DESCRIPTION
Correct the serialized value of `has_issues` for test input files that actually have issues (in references or scopes). Note that this is "just" an inconsistency that does not matter in test as the value of `has_issues` is not deserialized but determined programmatically.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>