### PR TITLE
evaluator: Clone project sources at most once

### DIFF
--- a/evaluator/src/main/kotlin/ProjectSourceRule.kt
+++ b/evaluator/src/main/kotlin/ProjectSourceRule.kt
@@ -22,7 +22,6 @@ package org.ossreviewtoolkit.evaluator
 import java.io.File
 
 import org.ossreviewtoolkit.model.LicenseSource
-import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.utils.getRepositoryPath
@@ -33,15 +32,14 @@ import org.ossreviewtoolkit.utils.common.FileMatcher
  */
 open class ProjectSourceRule(
     ruleSet: RuleSet,
-    name: String,
-    projectSourceResolver: SourceTreeResolver = ruleSet.ortResult.createResolver()
+    name: String
 ) : OrtResultRule(ruleSet, name) {
     /**
      * The directory containing the source code of the project. Accessing the property for the first time triggers a
      * clone and may take a while.
      */
     @Suppress("MemberVisibilityCanBePrivate") // This property is used in rules.
-    val projectSourcesDir: File by lazy { projectSourceResolver.rootDir }
+    val projectSourcesDir: File by lazy { ruleSet.projectSourceResolver.rootDir }
 
     private val detectedLicensesForFilePath: Map<String, Set<String>> by lazy {
         val result = mutableMapOf<String, MutableSet<String>>()
@@ -160,6 +158,3 @@ open class ProjectSourceRule(
                 projectSourceGetVcsType() in types
         }
 }
-
-private fun OrtResult.createResolver() =
-    SourceTreeResolver.forRemoteRepository(repository.vcsProcessed)

--- a/evaluator/src/main/kotlin/RuleSet.kt
+++ b/evaluator/src/main/kotlin/RuleSet.kt
@@ -37,7 +37,8 @@ import org.ossreviewtoolkit.model.utils.createLicenseInfoResolver
 class RuleSet(
     val ortResult: OrtResult,
     val licenseInfoResolver: LicenseInfoResolver,
-    val resolutionProvider: ResolutionProvider
+    val resolutionProvider: ResolutionProvider,
+    val projectSourceResolver: SourceTreeResolver
 ) {
     companion object : Logging
 
@@ -161,5 +162,8 @@ fun ruleSet(
     ortResult: OrtResult,
     licenseInfoResolver: LicenseInfoResolver = ortResult.createLicenseInfoResolver(),
     resolutionProvider: ResolutionProvider = DefaultResolutionProvider.create(),
+    projectSourceResolver: SourceTreeResolver = SourceTreeResolver.forRemoteRepository(
+        ortResult.repository.vcsProcessed
+    ),
     configure: RuleSet.() -> Unit = { }
-) = RuleSet(ortResult, licenseInfoResolver, resolutionProvider).apply(configure)
+) = RuleSet(ortResult, licenseInfoResolver, resolutionProvider, projectSourceResolver).apply(configure)

--- a/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
+++ b/evaluator/src/test/kotlin/ProjectSourceRuleTest.kt
@@ -161,9 +161,11 @@ class ProjectSourceRuleTest : WordSpec({
 
 private fun createRule(projectSourcesDir: File, ortResult: OrtResult = OrtResult.EMPTY) =
     ProjectSourceRule(
-        ruleSet = ruleSet(ortResult),
-        name = "RULE_NAME",
-        projectSourceResolver = SourceTreeResolver.forLocalDirectory(projectSourcesDir)
+        ruleSet = ruleSet(
+            ortResult = ortResult,
+            projectSourceResolver = SourceTreeResolver.forLocalDirectory(projectSourcesDir)
+        ),
+        name = "RULE_NAME"
     )
 
 private fun File.addFiles(vararg paths: String, content: String = "") {


### PR DESCRIPTION
When executing multiple project source rules which access the project's source tree, the sources get cloned once per `ProjectSourceRule` instance contained in the `RuleSet`. These redundant clone operations slow down the execution without need.

Ensure that project sources are cloned at most once per rule set or rather evaluator run respectively.

Fixes: #6064.

