### PR TITLE
CopyrightStatementsProcessor: Do not use sorted maps / sets in the `Result`

### DIFF
--- a/helper-cli/src/main/kotlin/commands/ListCopyrightsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListCopyrightsCommand.kt
@@ -101,10 +101,10 @@ internal class ListCopyrightsCommand : CliktCommand(
             .mapValues { it.value.flatten().toSortedSet() }
 
         val result = buildString {
-            copyrightStatements.forEach { (processedStatement, unprocessedStatements) ->
+            copyrightStatements.toSortedMap().forEach { (processedStatement, unprocessedStatements) ->
                 appendLine(processedStatement)
                 if (showRawStatements && unprocessedStatements.size > 1) {
-                    unprocessedStatements.forEach {
+                    unprocessedStatements.sorted().forEach {
                         appendLine("  $it")
                     }
                 }

--- a/utils/ort/src/test/kotlin/CopyrightStatementsProcessorTest.kt
+++ b/utils/ort/src/test/kotlin/CopyrightStatementsProcessorTest.kt
@@ -49,7 +49,7 @@ class CopyrightStatementsProcessorTest : WordSpec({
             val actualResult = CopyrightStatementsProcessor.process(statements)
 
             actualResult.processedStatements shouldHaveSize 1
-            actualResult.processedStatements.firstKey() shouldBe "Copyright (C) 2017, 2022 The ORT Project Authors"
+            actualResult.processedStatements.keys.first() shouldBe "Copyright (C) 2017, 2022 The ORT Project Authors"
             actualResult.unprocessedStatements should beEmpty()
         }
     }


### PR DESCRIPTION
There is no reason for the in-memory representation to be sorted, so sort
only the "visualizations" for the serialized result in
`CopyrightStatementsProcessorTest` and the console output in
`ListCopyrightsCommand`.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>