### PR TITLE
Pip: fix operating system name for macOS

### DIFF
--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -46,7 +46,7 @@ object Python : CommandLineTool {
 
 private const val OPTION_OPERATING_SYSTEM = "operatingSystem"
 private const val OPTION_OPERATING_SYSTEM_DEFAULT = "linux"
-private val OPERATING_SYSTEMS = listOf(OPTION_OPERATING_SYSTEM_DEFAULT, "mac", "windows")
+private val OPERATING_SYSTEMS = listOf(OPTION_OPERATING_SYSTEM_DEFAULT, "macos", "windows")
 
 private const val OPTION_PYTHON_VERSION = "pythonVersion"
 private const val OPTION_PYTHON_VERSION_DEFAULT = "3.10"
@@ -58,7 +58,7 @@ private val PYTHON_VERSIONS = listOf("2.7", "3.6", "3.7", "3.8", "3.9", OPTION_P
  * and [setup.py vs. requirements.txt](https://caremad.io/posts/2013/07/setup-vs-requirement/).
  *
  * This package manager supports the following [options][PackageManagerConfiguration.options]:
- * - *operatingSystem*: The name of the operating system to resolve dependencies for. One of "linux", "mac", or
+ * - *operatingSystem*: The name of the operating system to resolve dependencies for. One of "linux", "macos", or
  *   "windows". Defaults to "linux".
  * - *pythonVersion*: The Python version to resolve dependencies for. Defaults to "3.10".
  */


### PR DESCRIPTION
The code currently inputs operatingSystem of macOS as "mac" when running python-inspector.

However, python-inspector expects the option of macOS to be "macos".

Signed-off-by: Michael Yoo <vbtkdpf148@gmail.com>