### PR TITLE
Mappers: Increase the code point limit for SnakeYAML to 2GB

### DIFF
--- a/model/src/main/kotlin/Mappers.kt
+++ b/model/src/main/kotlin/Mappers.kt
@@ -32,8 +32,6 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 
-import org.ossreviewtoolkit.utils.common.gibibytes
-
 import org.yaml.snakeyaml.LoaderOptions
 
 val PROPERTY_NAMING_STRATEGY = PropertyNamingStrategies.SNAKE_CASE as PropertyNamingStrategies.NamingBase
@@ -54,11 +52,12 @@ val jsonMapper = JsonMapper().apply(mapperConfig)
 val xmlMapper = XmlMapper().apply(mapperConfig)
 
 private val loaderOptions = LoaderOptions().apply {
-    // Set the code point limit to 1GB, required since SnakeYAML 1.32. Also see:
+    // Set the code point limit to the maximum possible value which is approximately 2GB, required since SnakeYAML 1.32.
+    // Also see:
     // https://github.com/FasterXML/jackson-dataformats-text/tree/2.15/yaml#maximum-input-yaml-document-size-3-mb
     // https://github.com/FasterXML/jackson-dataformats-text/issues/337
     // TODO: Consider making this configurable.
-    codePointLimit = 1.gibibytes.toInt()
+    codePointLimit = Int.MAX_VALUE
 }
 private val yamlFactory = YAMLFactory.builder().loaderOptions(loaderOptions).build()
 val yamlMapper = YAMLMapper(yamlFactory).apply(mapperConfig).enable(YAMLGenerator.Feature.ALLOW_LONG_KEYS)


### PR DESCRIPTION
Increase the code point limit because ORT result files can exceed 1GB for large projects.

Fixes #6316.