### PR TITLE
Gradle: Suppress DSL_SCOPE_VIOLATION

### DIFF
--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -19,6 +19,7 @@
 
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+@Suppress("DSL_SCOPE_VIOLATION") // See https://youtrack.jetbrains.com/issue/KTIJ-19369.
 plugins {
     // Apply core plugins.
     `java-library`

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -21,6 +21,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 import java.nio.charset.Charset
 
+@Suppress("DSL_SCOPE_VIOLATION") // See https://youtrack.jetbrains.com/issue/KTIJ-19369.
 plugins {
     // Apply core plugins.
     application

--- a/evaluator/build.gradle.kts
+++ b/evaluator/build.gradle.kts
@@ -19,6 +19,7 @@
 
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+@Suppress("DSL_SCOPE_VIOLATION") // See https://youtrack.jetbrains.com/issue/KTIJ-19369.
 plugins {
     // Apply core plugins.
     `java-library`

--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -21,6 +21,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 import java.nio.charset.Charset
 
+@Suppress("DSL_SCOPE_VIOLATION") // See https://youtrack.jetbrains.com/issue/KTIJ-19369.
 plugins {
     // Apply core plugins.
     application


### PR DESCRIPTION
This silences false-positive error messages in IntellJ [1]. This commit addresses files which were forgotten in e66786e.

[1]: https://youtrack.jetbrains.com/issue/KTIJ-19369
