### PR TITLE
gradle: Remove the task for packaging the broken shadow JAR

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -17,8 +17,6 @@
  * License-Filename: LICENSE
  */
 
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 import java.nio.charset.Charset
 
 @Suppress("DSL_SCOPE_VIOLATION") // See https://youtrack.jetbrains.com/issue/KTIJ-19369.
@@ -28,7 +26,6 @@ plugins {
 
     // Apply third-party plugins.
     alias(libs.plugins.graal)
-    alias(libs.plugins.shadow)
 }
 
 application {
@@ -62,10 +59,6 @@ graal {
 
     mainClass("org.ossreviewtoolkit.cli.OrtMainKt")
     outputName("ort")
-}
-
-tasks.withType<ShadowJar>().configureEach {
-    isZip64 = true
 }
 
 tasks.named<CreateStartScripts>("startScripts").configure {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ graalPlugin = "0.12.0"
 graphQlPlugin = "6.3.3"
 ideaExtPlugin = "1.1.7"
 kotlinPlugin = "1.8.0"
-shadowPlugin = "7.1.2"
 versionCatalogUpdatePlugin = "0.7.0"
 versionsPlugin = "0.44.0"
 
@@ -71,7 +70,6 @@ graphQl = { id = "com.expediagroup.graphql", version.ref = "graphQlPlugin" }
 ideaExt = { id = "org.jetbrains.gradle.plugin.idea-ext", version.ref = "ideaExtPlugin" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinPlugin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinPlugin" }
-shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadowPlugin" }
 versionCatalogUpdate = { id = "nl.littlerobots.version-catalog-update", version.ref = "versionCatalogUpdatePlugin" }
 versions = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin" }
 

--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -17,26 +17,17 @@
  * License-Filename: LICENSE
  */
 
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 import java.nio.charset.Charset
 
 @Suppress("DSL_SCOPE_VIOLATION") // See https://youtrack.jetbrains.com/issue/KTIJ-19369.
 plugins {
     // Apply core plugins.
     application
-
-    // Apply third-party plugins.
-    alias(libs.plugins.shadow)
 }
 
 application {
     applicationName = "orth"
     mainClass.set("org.ossreviewtoolkit.helper.HelperMainKt")
-}
-
-tasks.withType<ShadowJar>().configureEach {
-    isZip64 = true
 }
 
 tasks.named<CreateStartScripts>("startScripts").configure {


### PR DESCRIPTION
Running ORT via its shadow JAR exhibits bugs, e.g. #6318, which do not exist when using ORT via its normal distribution or distribution archive. The latter comes with a shell script which takes care of setting the options for running ORT propertly, e.g. the classpath, and should be used as replacement for the shadow JAR.

Note: The shadow JAR had been introduced as replacement for a custom fat JAR task, see a41a44715e9e7efea90d6d1f2942d319b51cf6ba.

Closes #6318.

