### PR TITLE
FilePackageCurationProvider: Fix creating directory providers from config

### DIFF
--- a/analyzer/src/main/kotlin/curation/FilePackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/FilePackageCurationProvider.kt
@@ -38,7 +38,7 @@ class FilePackageCurationProviderConfig(
     /**
      * The path of the package curation file or directory.
      */
-    val path: String
+    val path: File
 )
 
 open class FilePackageCurationProviderFactory : PackageCurationProviderFactory<FilePackageCurationProviderConfig> {
@@ -48,21 +48,21 @@ open class FilePackageCurationProviderFactory : PackageCurationProviderFactory<F
         FilePackageCurationProvider.from(config)
 
     override fun parseConfig(config: Map<String, String>) =
-        FilePackageCurationProviderConfig(path = config.getValue("path"))
+        FilePackageCurationProviderConfig(path = File(config.getValue("path")))
 }
 
 class DefaultFilePackageCurationProviderFactory : FilePackageCurationProviderFactory() {
     override val name = "DefaultFile"
 
     override fun parseConfig(config: Map<String, String>) =
-        FilePackageCurationProviderConfig(path = ortConfigDirectory.resolve(ORT_PACKAGE_CURATIONS_FILENAME).path)
+        FilePackageCurationProviderConfig(path = ortConfigDirectory.resolve(ORT_PACKAGE_CURATIONS_FILENAME))
 }
 
 class DefaultDirPackageCurationProviderFactory : FilePackageCurationProviderFactory() {
     override val name = "DefaultDir"
 
     override fun parseConfig(config: Map<String, String>) =
-        FilePackageCurationProviderConfig(path = ortConfigDirectory.resolve(ORT_PACKAGE_CURATIONS_DIRNAME).path)
+        FilePackageCurationProviderConfig(path = ortConfigDirectory.resolve(ORT_PACKAGE_CURATIONS_DIRNAME))
 }
 
 /**
@@ -76,7 +76,7 @@ class FilePackageCurationProvider(
 
     companion object : Logging {
         fun from(config: FilePackageCurationProviderConfig) =
-            with(File(config.path)) { from(file = this, dir = this) }
+            with(config.path) { from(file = this, dir = this) }
 
         fun from(file: File? = null, dir: File? = null): FilePackageCurationProvider {
             val curationFiles = mutableListOf<File>()

--- a/analyzer/src/test/kotlin/curation/FilePackageCurationProviderTest.kt
+++ b/analyzer/src/test/kotlin/curation/FilePackageCurationProviderTest.kt
@@ -28,7 +28,6 @@ import io.kotest.matchers.shouldBe
 
 import java.io.File
 
-import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.Identifier
 
 class FilePackageCurationProviderTest : StringSpec() {
@@ -43,7 +42,7 @@ class FilePackageCurationProviderTest : StringSpec() {
         }
 
         "Provider can read from multiple yaml files" {
-            val provider = FilePackageCurationProvider(FileFormat.findFilesWithKnownExtensions(curationsDir))
+            val provider = FilePackageCurationProvider(curationsDir)
             val idsWithExistingCurations = listOf(
                 Identifier("maven", "org.ossreviewtoolkit", "example", "1.0"),
                 Identifier("maven", "org.foo", "bar", "0.42")
@@ -57,7 +56,7 @@ class FilePackageCurationProviderTest : StringSpec() {
         }
 
         "Provider can read from a single file and directories" {
-            val provider = FilePackageCurationProvider.from(curationsFile, curationsDir)
+            val provider = FilePackageCurationProvider(curationsFile, curationsDir)
 
             val idsWithExistingCurations = listOf(
                 // File

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -272,7 +272,7 @@ class EvaluatorCommand : OrtCommand(
         }
 
         if (packageCurationsDir != null || packageCurationsFile != null) {
-            val curations = FilePackageCurationProvider.from(packageCurationsFile, packageCurationsDir).packageCurations
+            val curations = FilePackageCurationProvider(packageCurationsFile, packageCurationsDir).packageCurations
             ortResultInput = ortResultInput.replacePackageCurations(curations)
         }
 

--- a/helper-cli/src/main/kotlin/commands/packagecuration/SetCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packagecuration/SetCommand.kt
@@ -57,7 +57,7 @@ class SetCommand : CliktCommand(
         .convert { it.absoluteFile.normalize() }
 
     override fun run() {
-        val curations = FilePackageCurationProvider.from(packageCurationsFile, packageCurationsDir).packageCurations
+        val curations = FilePackageCurationProvider(packageCurationsFile, packageCurationsDir).packageCurations
 
         val ortResult = readOrtResult(ortFile).replacePackageCurations(curations)
 


### PR DESCRIPTION
While the previous implementation did an `isDirectory` check, the implementation was still calling the `FilePackageCurationProvider` constructor directly which assumes all `File` instances to really be files.

Address that by instead relying on the existing logic in `from()`, and creating another convenience `from()` function that takes a `FilePackageCurationProviderConfig`.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>