### PR TITLE
FilePackageCurationProvider: Filter out non-existing files

### DIFF
--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -42,9 +42,11 @@ ort:
     - name: File
       config:
         path: '/some-path/curations.yml'
+        mustExist: true
     - name: File
       config:
         path: '/some-path/curations-dir'
+        mustExist: false
     - name: OrtConfig
       enabled: '${USE_ORT_CONFIG_CURATIONS:-true}'
     - name: ClearlyDefined

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -68,11 +68,11 @@ class OrtConfigurationTest : WordSpec({
                 PackageCurationProviderConfiguration(name = "DefaultDir"),
                 PackageCurationProviderConfiguration(
                     name = "File",
-                    config = mapOf("path" to "/some-path/curations.yml")
+                    config = mapOf("path" to "/some-path/curations.yml", "mustExist" to "true")
                 ),
                 PackageCurationProviderConfiguration(
                     name = "File",
-                    config = mapOf("path" to "/some-path/curations-dir")
+                    config = mapOf("path" to "/some-path/curations-dir", "mustExist" to "false")
                 ),
                 PackageCurationProviderConfiguration(name = "OrtConfig", enabled = true),
                 PackageCurationProviderConfiguration(


### PR DESCRIPTION
This avoids the need for `$ORT_CONFIG_DIR/curations.yml` to be present.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>