### PR TITLE
ci(github): Start enforcing of Conventional Commits

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,62 @@
+# Commitlint configuration.
+# See: https://github.com/conventional-changelog/commitlint/blob/master/docs/reference-rules.md
+---
+rules:
+  body-leading-blank:
+    - 2
+    - always
+  body-max-line-length:
+    - 2
+    - always
+    - 75
+  footer-leading-blank:
+    - 2
+    - always
+  header-max-length:
+    - 2
+    - always
+    - 75
+  scope-case:
+    - 2
+    - never
+    - - sentence-case
+      - start-case
+  subject-case:
+    - 2
+    - always
+    - - pascal-case
+      - sentence-case
+      - start-case
+      - upper-case
+  subject-empty:
+    - 2
+    - never
+  subject-full-stop:
+    - 2
+    - never
+    - .
+  type-case:
+    - 2
+    - always
+    - lower-case
+  type-empty:
+    - 2
+    - never
+  type-enum:
+    - 2
+    - always
+    - - build
+      - chore
+      - ci
+      - deps
+      - docs
+      - feat
+      - fix
+      - perf
+      - refactor
+      - revert
+      - style
+      - test
+  signed-off-by:
+    - 2
+    - always

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,6 +9,15 @@ on:
       - main
 
 jobs:
+  commit-lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: .commitlintrc.yml
   copyright-license:
     runs-on: ubuntu-22.04
     env:

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
-    "docker:disable"
+    "docker:disable",
+    ":semanticCommitScopeDisabled",
+    ":semanticCommitTypeAll(deps)"
   ],
   "dependencyDashboard": false,
   "batect": {


### PR DESCRIPTION
See [1]. This is a preparation for release automation including release
notes. At the same time, configure Renovate to use "deps" as the type
and no scope at all, see [2].

[1]: https://www.conventionalcommits.org/
[2]: https://docs.renovatebot.com/semantic-commits/

Co-authored-by: Martin Nonnenmacher <martin.nonnenmacher@gmail.com>
Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>