### PR TITLE
Address some vulnerabilities reported for ORT using resolutions in .ort.yml

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -57,6 +57,14 @@ resolutions:
     comment: >-
       This is a duplicate for CVE-2022-22965 reported by Sonatype NexusIQ, as Sonatype reported this issue before a
       CVE ID was officially released.
+  - id: "CVE-2016-7954"
+    reason: "INEFFECTIVE_VULNERABILITY"
+    comment: >-
+      This vulnerability is reported for the JRuby dependencies used within the Analyzer and the Reporter. The CVE is
+      actually assigned to Bundler which is shipped with JRuby. It is about a possibility to inject malicious code for
+      gems hosted on GitHub by deploying packages with same names on RubyGems.org. For the usage in the Reporter, this
+      is completely irrelevant. For the Analyzer, the issue does not affect ORT itself, but applications analyzed by
+      ORT that use Bundler as package manager.
 curations:
   license_findings:
   - path: "README.md"

--- a/.ort.yml
+++ b/.ort.yml
@@ -72,6 +72,32 @@ resolutions:
       related to the CGI gem. The version of the gem bundled with JRuby is greater than 0.3.1 and is therefore not
       affected. Since ORT does not use Ruby gems to implement server functionality, this vulnerability is ineffective
       anyway.
+  - id: "CVE-2022-40149"
+    reason: "INEFFECTIVE_VULNERABILITY"
+    comment: >-
+      This vulnerability is reported for the jettison package which is a dependency of the Atlassian Jira client used
+      by the notifier. The component is vulnerable to Denial of Service attacks causing stack overflow for specially
+      crafted parser input. Since it is used here only to parse responses of valid Jira servers, this is not an issue.
+  - id: "CVE-2022-40150"
+    reason: "INEFFECTIVE_VULNERABILITY"
+    comment: >-
+      This vulnerability is reported for the jettison package which is a dependency of the Atlassian Jira client used
+      by the notifier. The component is vulnerable to Denial of Service attacks causing out of memory errors for
+      specially crafted parser input. Since it is used here only to parse responses of valid Jira servers, this is not
+      an issue.
+  - id: "CVE-2022-45685"
+    reason: "INEFFECTIVE_VULNERABILITY"
+    comment: >-
+      This vulnerability is reported for the jettison package which is a dependency of the Atlassian Jira client used
+      by the notifier. The component is vulnerable to Denial of Service attacks due to Uncontrolled Recursion for
+      specially crafted parser input. Since it is used here only to parse responses of valid Jira servers, this is not
+      an issue.
+  - id: "CVE-2022-45693"
+    reason: "INEFFECTIVE_VULNERABILITY"
+    comment: >-
+      This vulnerability is reported for the jettison package which is a dependency of the Atlassian Jira client used
+      by the notifier. The component is vulnerable to Denial of Service attacks causing stack overflow for specially
+      crafted parser input. Since it is used here only to parse responses of valid Jira servers, this is not an issue.
   - id: "CVE-2021-28965"
     reason: "INVALID_MATCH_VULNERABILITY"
     comment: >-

--- a/.ort.yml
+++ b/.ort.yml
@@ -65,6 +65,27 @@ resolutions:
       gems hosted on GitHub by deploying packages with same names on RubyGems.org. For the usage in the Reporter, this
       is completely irrelevant. For the Analyzer, the issue does not affect ORT itself, but applications analyzed by
       ORT that use Bundler as package manager.
+  - id: "CVE-2021-41819"
+    reason: "INEFFECTIVE_VULNERABILITY"
+    comment: >-
+      This vulnerability is reported for the JRuby dependencies used within the Analyzer and the Reporter. It is
+      related to the CGI gem. The version of the gem bundled with JRuby is greater than 0.3.1 and is therefore not
+      affected. Since ORT does not use Ruby gems to implement server functionality, this vulnerability is ineffective
+      anyway.
+  - id: "CVE-2021-28965"
+    reason: "INVALID_MATCH_VULNERABILITY"
+    comment: >-
+      This vulnerability is reported for the JRuby dependencies used within the Analyzer and the Reporter. It is
+      related to the RXML gem in versions prior to 3.2.5. According to
+      https://github.com/jruby/jruby/blob/9.4.0.0/lib/pom.rb, the version of JRuby in use already bundles version
+      3.2.5 of this gem.
+  - id: "CVE-2021-31799"
+    reason: "INVALID_MATCH_VULNERABILITY"
+    comment: >-
+      This vulnerability is reported for the JRuby dependencies used within the Analyzer and the Reporter. It is
+      related to the RDoc gem in versions prior to 6.3.0. According to
+      https://github.com/jruby/jruby/blob/9.4.0.0/lib/pom.rb, the version of JRuby in use already bundles a higher
+      version of this gem.
 curations:
   license_findings:
   - path: "README.md"

--- a/.ort.yml
+++ b/.ort.yml
@@ -31,6 +31,10 @@ excludes:
     reason: "DEV_DEPENDENCY_OF"
     comment: >-
       Packages for development only. Not part of released artifacts.
+  - pattern: "dokka.*"
+    reason: "BUILD_DEPENDENCY_OF"
+    comment: >-
+      Packages used to build artifacts. Not part of released artifacts.
 resolutions:
   issues:
   - message: "ERROR: Timeout after 300 seconds while scanning file 'reporter-web-app/public/index.html'."

--- a/.ort.yml
+++ b/.ort.yml
@@ -41,6 +41,18 @@ resolutions:
     reason: "SCANNER_ISSUE"
     comment: >-
       This file contains test data. Contained licenses do not apply to the OSS Review Toolkit.
+  vulnerabilities:
+  - id: "CVE-2022-22965"
+    reason: "INEFFECTIVE_VULNERABILITY"
+    comment: >-
+      This vulnerability is triggered by the org.springframework:spring-beans package which comes as a transitive
+      dependency of the Jira REST client used by the notifier. The vulnerability applies only to Spring MVC or Spring
+      WebFlux applications; so it is ineffective for the current usage scenario.
+  - id: "sonatype-2022-1764"
+    reason: "INEFFECTIVE_VULNERABILITY"
+    comment: >-
+      This is a duplicate for CVE-2022-22965 reported by Sonatype NexusIQ, as Sonatype reported this issue before a
+      CVE ID was officially released.
 curations:
   license_findings:
   - path: "README.md"


### PR DESCRIPTION
This PR is in the context of scanning ORT with ORT. Sonatype NexusIQ which we use currently as advisor issues a number of vulnerabilities for ORT. In this PR I try to address some of them by resolutions in `.ort.yml` that (according to my analysis and understanding) should not affect ORT in the way it is using the affected components.

There are other vulnerabilities though which probably cannot be handled by such resolutions in general, since they may depend on the concrete context or environment in which ORT is used.