### PR TITLE
chore(Gradle): Also specifiy the type for "dependencies" tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -422,7 +422,7 @@ subprojects {
 // all dependencies at once is beneficial, e.g. for debugging version conflict resolution.
 // [1]: https://docs.gradle.org/current/userguide/viewing_debugging_dependencies.html#sec:listing_dependencies
 tasks.register("allDependencies").configure {
-    val dependenciesTasks = allprojects.map { it.tasks.named("dependencies") }
+    val dependenciesTasks = allprojects.map { it.tasks.named<DependencyReportTask>("dependencies") }
     dependsOn(dependenciesTasks)
 
     // Ensure deterministic output by requiring to run tasks after each other in always the same order.


### PR DESCRIPTION
Be on the safe side and only gather "dependencies" tasks whose type is `DependencyReportTask`.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>