### PR TITLE
Address some more vulnerabilities findings

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -35,6 +35,10 @@ excludes:
     reason: "BUILD_DEPENDENCY_OF"
     comment: >-
       Packages for the Dokka documentation engine.
+  - pattern: "graphql.*"
+    reason: "BUILD_DEPENDENCY_OF"
+    comment: >-
+      Packages for the generation of GraphQL clients by the GraphQL Kotlin build plugin.
 resolutions:
   issues:
   - message: "ERROR: Timeout after 300 seconds while scanning file 'reporter-web-app/public/index.html'."

--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -72,7 +72,13 @@ dependencies {
     implementation(libs.kotlinxSerialization)
     implementation(libs.semver4j)
     implementation(libs.sw360Client)
+
     implementation(libs.toml4j)
+    constraints {
+        implementation("com.google.code.gson:gson:2.8.9") {
+            because("Earlier versions have vulnerabilities.")
+        }
+    }
 
     testImplementation(libs.mockk)
     testImplementation(libs.wiremock)


### PR DESCRIPTION
This is a follow-up of #6338. It suppresses some more vulnerabilities by excluding a scope for generation of GraphQL clients and adding a constraint to enforce a higher version of a transitive gson dependency.