### PR TITLE
fix(commitlint): Raise the max length of footer

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -9,6 +9,10 @@ rules:
     - 2
     - always
     - 75
+  footer-max-line-length:
+    - 2
+    - always
+    - 120
   footer-leading-blank:
     - 2
     - always


### PR DESCRIPTION
Commitlint extends the config set from
https://www.npmjs.com/package/@commitlint/config-conventional, which has validation entries for footer as well.

Signed-off-by: Helio Chissini de Castro <heliocastro@gmail.com>

