### PR TITLE
Improve Advisor API

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,6 +1,14 @@
 # Commitlint configuration.
 # See: https://github.com/conventional-changelog/commitlint/blob/master/docs/reference-rules.md
 ---
+parserPreset:
+  parserOpts:
+    headerPattern: '^(\w*)(?:\((.*)\))?!?: (.*)$'
+    breakingHeaderPattern: '^(\w*)(?:\((.*)\))?!: (.*)$'
+    headerCorrespondence: ['type', 'scope', 'subject']
+    noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE']
+    revertPattern: '/^(?:Revert|revert:)\s"?([\s\S]+?)"?\s*This reverts commit (\w*)\./i'
+    revertCorrespondence: ['header', 'hash']
 rules:
   body-leading-blank:
     - 2

--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -6,7 +6,7 @@ parserPreset:
     headerPattern: '^(\w*)(?:\((.*)\))?!?: (.*)$'
     breakingHeaderPattern: '^(\w*)(?:\((.*)\))?!: (.*)$'
     headerCorrespondence: ['type', 'scope', 'subject']
-    noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE', '\[\d+\]:']
+    noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE', '\[\d+\]:', 'Signed-off-by:']
     revertPattern: '/^(?:Revert|revert:)\s"?([\s\S]+?)"?\s*This reverts commit (\w*)\./i'
     revertCorrespondence: ['header', 'hash']
 rules:

--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -6,7 +6,7 @@ parserPreset:
     headerPattern: '^(\w*)(?:\((.*)\))?!?: (.*)$'
     breakingHeaderPattern: '^(\w*)(?:\((.*)\))?!: (.*)$'
     headerCorrespondence: ['type', 'scope', 'subject']
-    noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE']
+    noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE', '\[\d+\]:']
     revertPattern: '/^(?:Revert|revert:)\s"?([\s\S]+?)"?\s*This reverts commit (\w*)\./i'
     revertCorrespondence: ['header', 'hash']
 rules:

--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -51,6 +51,10 @@ class Advisor(
         val ALL by lazy { NamedPlugin.getAll<AdviceProviderFactory>() }
     }
 
+    /**
+     * Query the [advice providers][providerFactories] and add the result to the provided [ortResult]. Excluded packages
+     * can optionally be [skipped][skipExcluded].
+     */
     @JvmOverloads
     fun advise(ortResult: OrtResult, skipExcluded: Boolean = false): OrtResult {
         if (ortResult.analyzer == null) {
@@ -67,6 +71,9 @@ class Advisor(
         return ortResult.copy(advisor = advisorRun)
     }
 
+    /**
+     * Query the [advice providers][providerFactories] for the provided [packages].
+     */
     fun advise(packages: Set<Package>): AdvisorRun {
         val startTime = Instant.now()
 

--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -51,7 +51,7 @@ class Advisor(
     }
 
     @JvmOverloads
-    fun retrieveFindings(ortResult: OrtResult, skipExcluded: Boolean = false): OrtResult {
+    fun advise(ortResult: OrtResult, skipExcluded: Boolean = false): OrtResult {
         val startTime = Instant.now()
 
         if (ortResult.analyzer == null) {

--- a/advisor/src/test/kotlin/AdvisorTest.kt
+++ b/advisor/src/test/kotlin/AdvisorTest.kt
@@ -48,7 +48,7 @@ class AdvisorTest : WordSpec({
 
             val advisor = createAdvisor(listOf(provider))
 
-            advisor.retrieveFindings(OrtResult.EMPTY) should beTheSameInstanceAs(OrtResult.EMPTY)
+            advisor.advise(OrtResult.EMPTY) should beTheSameInstanceAs(OrtResult.EMPTY)
 
             coVerify(exactly = 0) {
                 provider.retrievePackageFindings(any())
@@ -61,7 +61,7 @@ class AdvisorTest : WordSpec({
 
             val advisor = createAdvisor(listOf(provider))
 
-            val result = advisor.retrieveFindings(originResult)
+            val result = advisor.advise(originResult)
 
             result.advisor shouldNotBeNull {
                 results.advisorResults should beEmpty()
@@ -101,7 +101,7 @@ class AdvisorTest : WordSpec({
 
             val advisor = createAdvisor(listOf(provider1, provider2))
 
-            val result = advisor.retrieveFindings(originResult)
+            val result = advisor.advise(originResult)
 
             result.advisor shouldNotBeNull {
                 results.advisorResults shouldBe expectedResults

--- a/cli/src/main/kotlin/commands/AdvisorCommand.kt
+++ b/cli/src/main/kotlin/commands/AdvisorCommand.kt
@@ -127,7 +127,7 @@ class AdvisorCommand : OrtCommand(
         val advisor = Advisor(distinctProviders, ortConfig.advisor)
 
         val ortResultInput = readOrtResult(ortFile)
-        val ortResultOutput = advisor.retrieveFindings(ortResultInput, skipExcluded).mergeLabels(labels)
+        val ortResultOutput = advisor.advise(ortResultInput, skipExcluded).mergeLabels(labels)
 
         outputDir.safeMkdirs()
         writeOrtResult(ortResultOutput, outputFiles, "advisor")


### PR DESCRIPTION
Add an `advise` function that is easier to use programmatically, see the commit messages for details.

**Breaking change:**
The function `Advisor.retrieveFindings()` was renamed to `Advisor.advise()`.