### PR TITLE
fix(commitlint): Disable `scope-case` checks

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -25,14 +25,7 @@ rules:
     - always
     - 75
   scope-case:
-    - 2
-    - always
-    - - camel-case
-      - kebab-case
-      - lower-case
-      - pascal-case
-      - snake-case
-      - upper-case
+    - 0
   subject-case:
     - 1
     - always


### PR DESCRIPTION
Scopes with mixed case like "FossID" should be allowed, but they seem to match none of the supported case styles [1], so simply disable the rule completely, even if that allows unwanted spaces in the scope name.

[1]: https://github.com/conventional-changelog/commitlint/blob/master/docs/reference-rules.md#scope-case

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>