### PR TITLE
docs: Fix minor missing quotes in `reference.yml`

### DIFF
--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -33,7 +33,7 @@ ort:
 
   licenseFilePatterns:
     licenseFilenames: ['license*']
-    patentFilenames: [patents]
+    patentFilenames: ['patents']
     rootLicenseFilenames: ['readme*']
 
   # Providers are listed from highest to lower priority. Technically, they are applied in reverse order: The provider


### PR DESCRIPTION
a very small change