### PR TITLE
Gradle: Upgrade the SPDX license list to version 3.19

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ kotlin.code.style = official
 
 # The version of the SPDX license list which is used to import license texts and generate SPDX enums. Must be a valid
 # tag, see https://github.com/spdx/license-list-data/tags.
-spdxLicenseListVersion = 3.18
+spdxLicenseListVersion = 3.19

--- a/utils/spdx/src/main/kotlin/SpdxLicense.kt
+++ b/utils/spdx/src/main/kotlin/SpdxLicense.kt
@@ -188,6 +188,7 @@ enum class SpdxLicense(
     CERN_OHL_P_2_0("CERN-OHL-P-2.0", "CERN Open Hardware Licence Version 2 - Permissive"),
     CERN_OHL_S_2_0("CERN-OHL-S-2.0", "CERN Open Hardware Licence Version 2 - Strongly Reciprocal"),
     CERN_OHL_W_2_0("CERN-OHL-W-2.0", "CERN Open Hardware Licence Version 2 - Weakly Reciprocal"),
+    CHECKMK("checkmk", "Checkmk License"),
     CLARTISTIC("ClArtistic", "Clarified Artistic License"),
     CNRI_JYTHON("CNRI-Jython", "CNRI Jython License"),
     CNRI_PYTHON("CNRI-Python", "CNRI Python License"),
@@ -240,6 +241,7 @@ enum class SpdxLicense(
     FSFAP("FSFAP", "FSF All Permissive License"),
     FSFUL("FSFUL", "FSF Unlimited License"),
     FSFULLR("FSFULLR", "FSF Unlimited License (with License Retention)"),
+    FSFULLRWD("FSFULLRWD", "FSF Unlimited License (With License Retention    and Warranty Disclaimer)"),
     FTL("FTL", "Freetype Project License"),
     GD("GD", "GD License"),
     GFDL_1_1("GFDL-1.1", "GNU Free Documentation License v1.1", true),
@@ -311,6 +313,7 @@ enum class SpdxLicense(
     JASPER_2_0("JasPer-2.0", "JasPer License"),
     JPNIC("JPNIC", "Japan Network Information Center License"),
     JSON("JSON", "JSON License"),
+    KNUTH_CTAN("Knuth-CTAN", "Knuth CTAN License"),
     LAL_1_2("LAL-1.2", "Licence Art Libre 1.2"),
     LAL_1_3("LAL-1.3", "Licence Art Libre 1.3"),
     LATEX2E("Latex2e", "Latex2e License"),
@@ -332,6 +335,7 @@ enum class SpdxLicense(
     LIBPNG_2_0("libpng-2.0", "PNG Reference Library version 2"),
     LIBSELINUX_1_0("libselinux-1.0", "libselinux public domain notice"),
     LIBTIFF("libtiff", "libtiff License"),
+    LIBUTIL_DAVID_NUGENT("libutil-David-Nugent", "libutil David Nugent License"),
     LILIQ_P_1_1("LiLiQ-P-1.1", "Licence Libre du Québec – Permissive version 1.1"),
     LILIQ_RPLUS_1_1("LiLiQ-Rplus-1.1", "Licence Libre du Québec – Réciprocité forte version 1.1"),
     LILIQ_R_1_1("LiLiQ-R-1.1", "Licence Libre du Québec – Réciprocité version 1.1"),
@@ -545,7 +549,7 @@ enum class SpdxLicense(
         /**
          * The version of the license list.
          */
-        const val LICENSE_LIST_VERSION = "3.18"
+        const val LICENSE_LIST_VERSION = "3.19"
 
         /**
          * Return the enum value for the given [id], or null if it is no SPDX license id.

--- a/utils/spdx/src/main/kotlin/SpdxLicenseException.kt
+++ b/utils/spdx/src/main/kotlin/SpdxLicenseException.kt
@@ -88,6 +88,7 @@ enum class SpdxLicenseException(
     UNIVERSAL_FOSS_EXCEPTION_1_0("Universal-FOSS-exception-1.0", "Universal FOSS Exception, Version 1.0"),
     U_BOOT_EXCEPTION_2_0("u-boot-exception-2.0", "U-Boot exception 2.0"),
     WXWINDOWS_EXCEPTION_3_1("WxWindows-exception-3.1", "WxWindows Library Exception 3.1"),
+    X11VNC_OPENSSL_EXCEPTION("x11vnc-openssl-exception", "x11vnc OpenSSL Exception"),
     _389_EXCEPTION("389-exception", "389 Directory Server Exception");
 
     companion object {

--- a/utils/spdx/src/main/resources/exceptions/x11vnc-openssl-exception
+++ b/utils/spdx/src/main/resources/exceptions/x11vnc-openssl-exception
@@ -1,0 +1,14 @@
+The OpenSSL Exception:
+
+In addition, as a special exception, the copyright holders give
+permission to link the code of portions of this program with the
+OpenSSL library under certain conditions as described in each
+individual source file, and distribute linked combinations
+including the two.
+You must obey the GNU General Public License in all respects
+for all of the code used other than OpenSSL.  If you modify
+file(s) with this exception, you may extend this exception to your
+version of the file(s), but you are not obligated to do so.  If you
+do not wish to do so, delete this exception statement from your
+version.  If you delete this exception statement from all source
+files in the program, then also delete it here.

--- a/utils/spdx/src/main/resources/licenses/FSFULLRWD
+++ b/utils/spdx/src/main/resources/licenses/FSFULLRWD
@@ -1,0 +1,8 @@
+This file is free software; the Free Software Foundation gives
+unlimited permission to copy and/or distribute it, with or without
+modifications, as long as this notice is preserved.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE.

--- a/utils/spdx/src/main/resources/licenses/Knuth-CTAN
+++ b/utils/spdx/src/main/resources/licenses/Knuth-CTAN
@@ -1,0 +1,5 @@
+This software is copyrighted. Unlimited copying and redistribution
+of this package and/or its individual files are permitted
+as long as there are no modifications. Modifications, and
+redistribution of modifications, are also permitted, but
+only if the resulting package and/or files are renamed.

--- a/utils/spdx/src/main/resources/licenses/checkmk
+++ b/utils/spdx/src/main/resources/licenses/checkmk
@@ -1,0 +1,7 @@
+Redistribution of this program in any form, with or without
+modifications, is permitted, provided that the above copyright is
+retained in distributions of this program in source form.
+
+(This is a free, non-copyleft license compatible with pretty much any
+other free or proprietary license, including the GPL. It's essentially
+a scaled-down version of the "modified" BSD license.)

--- a/utils/spdx/src/main/resources/licenses/libutil-David-Nugent
+++ b/utils/spdx/src/main/resources/licenses/libutil-David-Nugent
@@ -1,0 +1,15 @@
+Redistribution and use in source and binary forms, with or without
+modification, is permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice immediately at the beginning of the file, without modification,
+   this list of conditions, and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. This work was done expressly for inclusion into FreeBSD. Other use
+   is permitted provided this notation is included.
+4. Absolutely no warranty of function or purpose is made by the author
+   David Nugent.
+5. Modifications may be freely made to this file providing the above
+   conditions are met.


### PR DESCRIPTION
Generated files were updated by running `./gradlew generateSpdxEnums`.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>