### PR TITLE
ORT plugin renamings

### DIFF
--- a/advisor/src/main/kotlin/AdviceProviderFactory.kt
+++ b/advisor/src/main/kotlin/AdviceProviderFactory.kt
@@ -23,7 +23,7 @@ import java.util.ServiceLoader
 
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
 import org.ossreviewtoolkit.model.config.Options
-import org.ossreviewtoolkit.utils.common.NamedPlugin
+import org.ossreviewtoolkit.utils.common.Plugin
 import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
 
@@ -31,7 +31,7 @@ import org.ossreviewtoolkit.utils.ort.ortConfigDirectory
  * A common interface for use with [ServiceLoader] that all [AbstractAdviceProviderFactory] classes need to
  * implement.
  */
-interface AdviceProviderFactory : NamedPlugin {
+interface AdviceProviderFactory : Plugin {
     /**
      * Create an [AdviceProvider] using the specified [config].
      */

--- a/advisor/src/main/kotlin/AdviceProviderFactory.kt
+++ b/advisor/src/main/kotlin/AdviceProviderFactory.kt
@@ -42,7 +42,7 @@ interface AdviceProviderFactory : Plugin {
  * A generic factory class for an [AdviceProvider].
  */
 abstract class AbstractAdviceProviderFactory<out T : AdviceProvider>(
-    override val name: String
+    override val type: String
 ) : AdviceProviderFactory {
     abstract override fun create(config: AdvisorConfiguration): T
 
@@ -52,7 +52,7 @@ abstract class AbstractAdviceProviderFactory<out T : AdviceProvider>(
      */
     protected fun <T : Any> AdvisorConfiguration.forProvider(select: AdvisorConfiguration.() -> T?): T =
         requireNotNull(select()) {
-            "No configuration for '$name' found in '${ortConfigDirectory.resolve(ORT_CONFIG_FILENAME)}'."
+            "No configuration for '$type' found in '${ortConfigDirectory.resolve(ORT_CONFIG_FILENAME)}'."
         }
 
     /**
@@ -60,11 +60,11 @@ abstract class AbstractAdviceProviderFactory<out T : AdviceProvider>(
      * available.
      */
     protected fun AdvisorConfiguration.providerOptions(): Options =
-        options.orEmpty()[name].orEmpty()
+        options.orEmpty()[type].orEmpty()
 
     /**
      * Return the provider's name here to allow Clikt to display something meaningful when listing the advisors which
      * are enabled by default via their factories.
      */
-    override fun toString() = name
+    override fun toString() = type
 }

--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -34,7 +34,7 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
-import org.ossreviewtoolkit.utils.common.NamedPlugin
+import org.ossreviewtoolkit.utils.common.Plugin
 import org.ossreviewtoolkit.utils.ort.Environment
 
 /**
@@ -49,7 +49,7 @@ class Advisor(
         /**
          * All [advice provider factories][AdviceProviderFactory] available in the classpath, associated by their names.
          */
-        val ALL by lazy { NamedPlugin.getAll<AdviceProviderFactory>() }
+        val ALL by lazy { Plugin.getAll<AdviceProviderFactory>() }
     }
 
     /**

--- a/advisor/src/main/kotlin/advisors/GitHubDefects.kt
+++ b/advisor/src/main/kotlin/advisors/GitHubDefects.kt
@@ -90,7 +90,7 @@ class GitHubDefects(name: String, gitHubConfiguration: GitHubDefectsConfiguratio
     }
 
     class Factory : AbstractAdviceProviderFactory<GitHubDefects>("GitHubDefects") {
-        override fun create(config: AdvisorConfiguration) = GitHubDefects(name, config.forProvider { gitHubDefects })
+        override fun create(config: AdvisorConfiguration) = GitHubDefects(type, config.forProvider { gitHubDefects })
     }
 
     /**

--- a/advisor/src/main/kotlin/advisors/NexusIq.kt
+++ b/advisor/src/main/kotlin/advisors/NexusIq.kt
@@ -64,7 +64,7 @@ class NexusIq(name: String, private val nexusIqConfig: NexusIqConfiguration) : A
     companion object : Logging
 
     class Factory : AbstractAdviceProviderFactory<NexusIq>("NexusIQ") {
-        override fun create(config: AdvisorConfiguration) = NexusIq(name, config.forProvider { nexusIq })
+        override fun create(config: AdvisorConfiguration) = NexusIq(type, config.forProvider { nexusIq })
     }
 
     override val details: AdvisorDetails = AdvisorDetails(providerName, enumSetOf(AdvisorCapability.VULNERABILITIES))

--- a/advisor/src/main/kotlin/advisors/OssIndex.kt
+++ b/advisor/src/main/kotlin/advisors/OssIndex.kt
@@ -56,7 +56,7 @@ class OssIndex(name: String, serverUrl: String? = null) : AdviceProvider(name) {
     class Factory : AbstractAdviceProviderFactory<OssIndex>("OssIndex") {
         override fun create(config: AdvisorConfiguration) =
             // The OSS Index does not require any configuration.
-            OssIndex(name)
+            OssIndex(type)
     }
 
     override val details = AdvisorDetails(providerName, enumSetOf(AdvisorCapability.VULNERABILITIES))

--- a/advisor/src/main/kotlin/advisors/Osv.kt
+++ b/advisor/src/main/kotlin/advisors/Osv.kt
@@ -57,7 +57,7 @@ class Osv(name: String, advisorConfiguration: AdvisorConfiguration) : AdviceProv
     class Factory : AbstractAdviceProviderFactory<Osv>("OSV") {
         override fun create(config: AdvisorConfiguration) =
             // OSV does not require any dedicated configuration to be present.
-            Osv(name, config)
+            Osv(type, config)
     }
 
     override val details: AdvisorDetails = AdvisorDetails(providerName, enumSetOf(AdvisorCapability.VULNERABILITIES))

--- a/advisor/src/main/kotlin/advisors/VulnerableCode.kt
+++ b/advisor/src/main/kotlin/advisors/VulnerableCode.kt
@@ -50,7 +50,7 @@ private const val BULK_REQUEST_SIZE = 100
  */
 class VulnerableCode(name: String, vulnerableCodeConfiguration: VulnerableCodeConfiguration) : AdviceProvider(name) {
     class Factory : AbstractAdviceProviderFactory<VulnerableCode>("VulnerableCode") {
-        override fun create(config: AdvisorConfiguration) = VulnerableCode(name, config.forProvider { vulnerableCode })
+        override fun create(config: AdvisorConfiguration) = VulnerableCode(type, config.forProvider { vulnerableCode })
     }
 
     /**

--- a/advisor/src/test/kotlin/AbstractAdviceProviderFactoryTest.kt
+++ b/advisor/src/test/kotlin/AbstractAdviceProviderFactoryTest.kt
@@ -38,7 +38,7 @@ class AbstractAdviceProviderFactoryTest : WordSpec({
             val factory = object : AbstractAdviceProviderFactory<AdviceProvider>(PROVIDER_NAME) {
                 override fun create(config: AdvisorConfiguration): AdviceProvider {
                     config.forProvider { vulnerableCode } shouldBe VULNERABLE_CODE_CONFIG
-                    return VulnerableCode(name, VULNERABLE_CODE_CONFIG)
+                    return VulnerableCode(type, VULNERABLE_CODE_CONFIG)
                 }
             }
 
@@ -54,7 +54,7 @@ class AbstractAdviceProviderFactoryTest : WordSpec({
 
                     exception.message shouldContain PROVIDER_NAME
 
-                    return VulnerableCode(name, VULNERABLE_CODE_CONFIG)
+                    return VulnerableCode(type, VULNERABLE_CODE_CONFIG)
                 }
             }
 
@@ -71,7 +71,7 @@ class AbstractAdviceProviderFactoryTest : WordSpec({
                 override fun create(config: AdvisorConfiguration): AdviceProvider {
                     config.providerOptions() shouldBe providerOptions
 
-                    return VulnerableCode(name, VULNERABLE_CODE_CONFIG)
+                    return VulnerableCode(type, VULNERABLE_CODE_CONFIG)
                 }
             }
 
@@ -86,7 +86,7 @@ class AbstractAdviceProviderFactoryTest : WordSpec({
                 override fun create(config: AdvisorConfiguration): AdviceProvider {
                     config.providerOptions() should beEmpty()
 
-                    return VulnerableCode(name, VULNERABLE_CODE_CONFIG)
+                    return VulnerableCode(type, VULNERABLE_CODE_CONFIG)
                 }
             }
 
@@ -98,7 +98,7 @@ class AbstractAdviceProviderFactoryTest : WordSpec({
                 override fun create(config: AdvisorConfiguration): AdviceProvider {
                     config.providerOptions() should beEmpty()
 
-                    return VulnerableCode(name, VULNERABLE_CODE_CONFIG)
+                    return VulnerableCode(type, VULNERABLE_CODE_CONFIG)
                 }
             }
 

--- a/analyzer/src/funTest/kotlin/managers/PipFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PipFunTest.kt
@@ -134,7 +134,7 @@ private fun createPip(pythonVersion: String = "3.10") =
 private fun createAnalyzerConfiguration(pythonVersion: String) =
     AnalyzerConfiguration(
         packageManagers = mapOf(
-            Pip.Factory().name to PackageManagerConfiguration(
+            Pip.Factory().type to PackageManagerConfiguration(
                 options = mapOf("pythonVersion" to pythonVersion)
             )
         )

--- a/analyzer/src/main/kotlin/PackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/PackageCurationProvider.kt
@@ -35,7 +35,7 @@ interface PackageCurationProviderFactory<CONFIG> : ConfigurablePluginFactory<Pac
         fun create(configurations: List<PackageCurationProviderConfiguration>) =
             // Reverse the list so that curations from providers with higher priority are applied later and can
             // overwrite curations from providers with lower priority.
-            configurations.filter { it.enabled }.map { ALL.getValue(it.name).create(it.config) }.asReversed()
+            configurations.filter { it.enabled }.map { ALL.getValue(it.type).create(it.config) }.asReversed()
     }
 
     override fun create(config: Map<String, String>): PackageCurationProvider = create(parseConfig(config))

--- a/analyzer/src/main/kotlin/PackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/PackageCurationProvider.kt
@@ -23,14 +23,14 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.config.PackageCurationProviderConfiguration
 import org.ossreviewtoolkit.utils.common.ConfigurablePluginFactory
-import org.ossreviewtoolkit.utils.common.NamedPlugin
+import org.ossreviewtoolkit.utils.common.Plugin
 
 /**
  * The extension point for [PackageCurationProvider]s.
  */
 interface PackageCurationProviderFactory<CONFIG> : ConfigurablePluginFactory<PackageCurationProvider> {
     companion object {
-        val ALL = NamedPlugin.getAll<PackageCurationProviderFactory<*>>()
+        val ALL = Plugin.getAll<PackageCurationProviderFactory<*>>()
 
         fun create(configurations: List<PackageCurationProviderConfiguration>) =
             // Reverse the list so that curations from providers with higher priority are applied later and can

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -45,7 +45,7 @@ import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
-import org.ossreviewtoolkit.utils.common.NamedPlugin
+import org.ossreviewtoolkit.utils.common.Plugin
 import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.common.isSymbolicLink
@@ -70,7 +70,7 @@ abstract class PackageManager(
         /**
          * All [package manager factories][PackageManagerFactory] available in the classpath, associated by their names.
          */
-        val ALL by lazy { NamedPlugin.getAll<PackageManagerFactory>() }
+        val ALL by lazy { Plugin.getAll<PackageManagerFactory>() }
 
         private val PACKAGE_MANAGER_DIRECTORIES = listOf(
             // Ignore intermediate build system directories.

--- a/analyzer/src/main/kotlin/PackageManagerFactory.kt
+++ b/analyzer/src/main/kotlin/PackageManagerFactory.kt
@@ -52,7 +52,7 @@ interface PackageManagerFactory : Plugin {
  * A generic factory class for a [PackageManager].
  */
 abstract class AbstractPackageManagerFactory<out T : PackageManager>(
-    override val name: String
+    override val type: String
 ) : PackageManagerFactory {
     /**
      * The prioritized list of glob patterns of definition files supported by this package manager. Only all matches of
@@ -76,5 +76,5 @@ abstract class AbstractPackageManagerFactory<out T : PackageManager>(
      * Return the package manager's name here to allow Clikt to display something meaningful when listing the
      * package managers which are enabled by default via their factories.
      */
-    override fun toString() = name
+    override fun toString() = type
 }

--- a/analyzer/src/main/kotlin/PackageManagerFactory.kt
+++ b/analyzer/src/main/kotlin/PackageManagerFactory.kt
@@ -26,12 +26,12 @@ import java.util.ServiceLoader
 
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
-import org.ossreviewtoolkit.utils.common.NamedPlugin
+import org.ossreviewtoolkit.utils.common.Plugin
 
 /**
  * A common interface for use with [ServiceLoader] that all [AbstractPackageManagerFactory] classes need to implement.
  */
-interface PackageManagerFactory : NamedPlugin {
+interface PackageManagerFactory : Plugin {
     /**
      * The glob matchers for all definition files.
      */

--- a/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
@@ -66,7 +66,7 @@ class ClearlyDefinedPackageCurationProviderConfig(
 
 class ClearlyDefinedPackageCurationProviderFactory :
     PackageCurationProviderFactory<ClearlyDefinedPackageCurationProviderConfig> {
-    override val name = "ClearlyDefined"
+    override val type = "ClearlyDefined"
 
     override fun create(config: ClearlyDefinedPackageCurationProviderConfig) =
         ClearlyDefinedPackageCurationProvider(config)

--- a/analyzer/src/main/kotlin/curation/FilePackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/FilePackageCurationProvider.kt
@@ -47,7 +47,7 @@ class FilePackageCurationProviderConfig(
 )
 
 open class FilePackageCurationProviderFactory : PackageCurationProviderFactory<FilePackageCurationProviderConfig> {
-    override val name = "File"
+    override val type = "File"
 
     override fun create(config: FilePackageCurationProviderConfig) =
         FilePackageCurationProvider(config)
@@ -60,7 +60,7 @@ open class FilePackageCurationProviderFactory : PackageCurationProviderFactory<F
 }
 
 class DefaultFilePackageCurationProviderFactory : FilePackageCurationProviderFactory() {
-    override val name = "DefaultFile"
+    override val type = "DefaultFile"
 
     override fun parseConfig(config: Map<String, String>) =
         FilePackageCurationProviderConfig(
@@ -70,7 +70,7 @@ class DefaultFilePackageCurationProviderFactory : FilePackageCurationProviderFac
 }
 
 class DefaultDirPackageCurationProviderFactory : FilePackageCurationProviderFactory() {
-    override val name = "DefaultDir"
+    override val type = "DefaultDir"
 
     override fun parseConfig(config: Map<String, String>) =
         FilePackageCurationProviderConfig(

--- a/analyzer/src/main/kotlin/curation/OrtConfigPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/OrtConfigPackageCurationProvider.kt
@@ -40,7 +40,7 @@ private const val ORT_CONFIG_REPOSITORY_BRANCH = "main"
 private const val ORT_CONFIG_REPOSITORY_URL = "https://github.com/oss-review-toolkit/ort-config.git"
 
 class OrtConfigPackageCurationProviderFactory : PackageCurationProviderFactory<Unit> {
-    override val name = "OrtConfig"
+    override val type = "OrtConfig"
 
     override fun create(config: Unit) = OrtConfigPackageCurationProvider()
 

--- a/analyzer/src/main/kotlin/curation/Sw360PackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/Sw360PackageCurationProvider.kt
@@ -47,7 +47,7 @@ import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
 class Sw360PackageCurationProviderFactory : PackageCurationProviderFactory<Sw360StorageConfiguration> {
-    override val name = "SW360"
+    override val type = "SW360"
 
     override fun create(config: Sw360StorageConfiguration) = Sw360PackageCurationProvider(config)
 

--- a/analyzer/src/main/kotlin/managers/Bower.kt
+++ b/analyzer/src/main/kotlin/managers/Bower.kt
@@ -221,7 +221,7 @@ class Bower(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Bower(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Bower(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = if (Os.isWindows) "bower.cmd" else "bower"

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -149,7 +149,7 @@ class Bundler(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Bundler(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Bundler(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     override fun beforeResolution(definitionFiles: List<File>) {

--- a/analyzer/src/main/kotlin/managers/Cargo.kt
+++ b/analyzer/src/main/kotlin/managers/Cargo.kt
@@ -74,7 +74,7 @@ class Cargo(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Cargo(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Cargo(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = "cargo"

--- a/analyzer/src/main/kotlin/managers/Carthage.kt
+++ b/analyzer/src/main/kotlin/managers/Carthage.kt
@@ -62,7 +62,7 @@ class Carthage(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Carthage(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Carthage(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     override fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult> {

--- a/analyzer/src/main/kotlin/managers/CocoaPods.kt
+++ b/analyzer/src/main/kotlin/managers/CocoaPods.kt
@@ -87,7 +87,7 @@ class CocoaPods(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = CocoaPods(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = CocoaPods(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     private val podspecCache = mutableMapOf<String, Podspec>()

--- a/analyzer/src/main/kotlin/managers/Composer.kt
+++ b/analyzer/src/main/kotlin/managers/Composer.kt
@@ -87,7 +87,7 @@ class Composer(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Composer(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Composer(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) =

--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -88,7 +88,7 @@ class Conan(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Conan(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Conan(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     private val conanHome = Os.userHomeDirectory.resolve(".conan")

--- a/analyzer/src/main/kotlin/managers/DotNet.kt
+++ b/analyzer/src/main/kotlin/managers/DotNet.kt
@@ -58,7 +58,7 @@ class DotNet(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = DotNet(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = DotNet(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     private val directDependenciesOnly = options[OPTION_DIRECT_DEPENDENCIES_ONLY].toBoolean()

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -87,7 +87,7 @@ class GoDep(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = GoDep(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = GoDep(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = "dep"

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -79,7 +79,7 @@ class GoMod(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = GoMod(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = GoMod(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = "go"

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -90,7 +90,7 @@ class Gradle(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Gradle(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Gradle(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     /**

--- a/analyzer/src/main/kotlin/managers/Maven.kt
+++ b/analyzer/src/main/kotlin/managers/Maven.kt
@@ -65,7 +65,7 @@ class Maven(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Maven(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Maven(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     private inner class LocalProjectWorkspaceReader : WorkspaceReader {

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -106,7 +106,7 @@ open class Npm(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Npm(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Npm(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     private val legacyPeerDeps = options[OPTION_LEGACY_PEER_DEPS].toBoolean()

--- a/analyzer/src/main/kotlin/managers/NuGet.kt
+++ b/analyzer/src/main/kotlin/managers/NuGet.kt
@@ -57,7 +57,7 @@ class NuGet(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = NuGet(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = NuGet(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     private val directDependenciesOnly = options[OPTION_DIRECT_DEPENDENCIES_ONLY].toBoolean()

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -78,7 +78,7 @@ class Pip(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Pip(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Pip(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     private val operatingSystemOption = (options[OPTION_OPERATING_SYSTEM] ?: OPTION_OPERATING_SYSTEM_DEFAULT)

--- a/analyzer/src/main/kotlin/managers/Pipenv.kt
+++ b/analyzer/src/main/kotlin/managers/Pipenv.kt
@@ -55,7 +55,7 @@ class Pipenv(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Pipenv(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Pipenv(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = "pipenv"

--- a/analyzer/src/main/kotlin/managers/Pnpm.kt
+++ b/analyzer/src/main/kotlin/managers/Pnpm.kt
@@ -48,7 +48,7 @@ class Pnpm(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Pnpm(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Pnpm(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     /**

--- a/analyzer/src/main/kotlin/managers/Poetry.kt
+++ b/analyzer/src/main/kotlin/managers/Poetry.kt
@@ -49,7 +49,7 @@ class Poetry(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Poetry(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Poetry(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = "poetry"

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -109,7 +109,7 @@ class Pub(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Pub(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Pub(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     private data class ParsePackagesResult(
@@ -200,7 +200,7 @@ class Pub(
         // If there are any Gradle definition files which seem to be associated to a Pub Flutter project, it is likely
         // that Pub needs to run before Gradle, because Pub generates the required local.properties file which contains
         // the path to the Android SDK.
-        val gradle = managedFiles.keys.find { it.managerName == Gradle.Factory().name }
+        val gradle = managedFiles.keys.find { it.managerName == Gradle.Factory().type }
         val mustRunBefore = if (gradle != null && findGradleDefinitionFiles(managedFiles.getValue(this)).isNotEmpty()) {
             setOf(gradle.managerName)
         } else {
@@ -237,7 +237,7 @@ class Pub(
             val gradleDefinitionFiles = gradleDefinitionFilesForPubDefinitionFiles.getValue(definitionFile).toList()
 
             if (gradleDefinitionFiles.isNotEmpty()) {
-                val gradleName = Gradle.Factory().name
+                val gradleName = Gradle.Factory().type
                 val gradleDependencies = gradleDefinitionFiles.map {
                     PackageManagerDependencyHandler.createPackageManagerDependency(
                         packageManager = gradleName,

--- a/analyzer/src/main/kotlin/managers/Sbt.kt
+++ b/analyzer/src/main/kotlin/managers/Sbt.kt
@@ -91,7 +91,7 @@ class Sbt(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Sbt(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Sbt(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     override fun command(workingDir: File?) = if (Os.isWindows) "sbt.bat" else "sbt"

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -273,7 +273,7 @@ class SpdxDocumentFile(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = SpdxDocumentFile(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = SpdxDocumentFile(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     private val spdxDocumentCache = SpdxDocumentCache()
@@ -367,7 +367,7 @@ class SpdxDocumentFile(
                     // TODO: The data from the spdxPackage is currently ignored, check if some fields need to be
                     //       preserved somehow.
                     return PackageManagerDependencyHandler.createPackageManagerDependency(
-                        packageManager = factory.name,
+                        packageManager = factory.type,
                         definitionFile = VersionControlSystem.getPathInfo(packageFile).path,
                         scope = scope,
                         linkage = PackageLinkage.PROJECT_STATIC // TODO: Set linkage based on SPDX reference type.

--- a/analyzer/src/main/kotlin/managers/Stack.kt
+++ b/analyzer/src/main/kotlin/managers/Stack.kt
@@ -78,7 +78,7 @@ class Stack(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Stack(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Stack(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -58,7 +58,7 @@ class Unmanaged(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Unmanaged(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Unmanaged(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     /**

--- a/analyzer/src/main/kotlin/managers/Yarn.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn.kt
@@ -65,7 +65,7 @@ class Yarn(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Yarn(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Yarn(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     override fun hasLockFile(projectDir: File) = hasYarnLockFile(projectDir)

--- a/analyzer/src/main/kotlin/managers/Yarn2.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn2.kt
@@ -124,7 +124,7 @@ class Yarn2(
             analysisRoot: File,
             analyzerConfig: AnalyzerConfiguration,
             repoConfig: RepositoryConfiguration
-        ) = Yarn2(name, analysisRoot, analyzerConfig, repoConfig)
+        ) = Yarn2(type, analysisRoot, analyzerConfig, repoConfig)
     }
 
     /**

--- a/analyzer/src/test/kotlin/PackageManagerTest.kt
+++ b/analyzer/src/test/kotlin/PackageManagerTest.kt
@@ -89,9 +89,9 @@ class PackageManagerTest : WordSpec({
             }
 
             // The keys in expected and actual maps of definition files are different instances of package manager
-            // factories. So to compare values use the package manager names as keys instead.
+            // factories. So to compare values use the package manager types as keys instead.
             val managedFilesByName = managedFiles.map { (manager, files) ->
-                manager.name to files.map { it.relativeTo(projectDir).invariantSeparatorsPath }
+                manager.type to files.map { it.relativeTo(projectDir).invariantSeparatorsPath }
             }.toMap()
 
             assertSoftly {
@@ -145,9 +145,9 @@ class PackageManagerTest : WordSpec({
             managedFiles.size shouldBe 3
 
             // The keys in expected and actual maps of definition files are different instances of package manager
-            // factories. So to compare values use the package manager names as keys instead.
+            // factories. So to compare values use the package manager types as keys instead.
             val managedFilesByName = managedFiles.map { (manager, files) ->
-                manager.name to files.map { it.relativeTo(projectDir).invariantSeparatorsPath }
+                manager.type to files.map { it.relativeTo(projectDir).invariantSeparatorsPath }
             }.toMap()
 
             managedFilesByName["Gradle"] should containExactlyInAnyOrder(

--- a/cli/src/funTest/kotlin/OrtMainFunTest.kt
+++ b/cli/src/funTest/kotlin/OrtMainFunTest.kt
@@ -69,7 +69,7 @@ class OrtMainFunTest : StringSpec() {
                 OrtConfiguration(
                     packageCurationProviders = listOf(
                         PackageCurationProviderConfiguration(
-                            name = "File",
+                            type = "File",
                             config = mapOf("path" to projectDir.resolve("gradle/curations.yml").path)
                         )
                     )

--- a/cli/src/funTest/kotlin/OrtMainFunTest.kt
+++ b/cli/src/funTest/kotlin/OrtMainFunTest.kt
@@ -117,10 +117,10 @@ class OrtMainFunTest : StringSpec() {
                 if (iterator.next() == "The following package managers are enabled:") break
             }
 
-            val expectedPackageManagers = PackageManager.ALL.values.filterNot { it.name == "Gradle" }
+            val expectedPackageManagers = PackageManager.ALL.values.filterNot { it.type == "Gradle" }
 
             iterator.hasNext() shouldBe true
-            iterator.next() shouldBe "\t${expectedPackageManagers.joinToString { it.name }}"
+            iterator.next() shouldBe "\t${expectedPackageManagers.joinToString { it.type }}"
         }
 
         "Disabling a package manager overrides enabling it" {

--- a/cli/src/main/kotlin/OrtCommand.kt
+++ b/cli/src/main/kotlin/OrtCommand.kt
@@ -34,5 +34,5 @@ abstract class OrtCommand(name: String, help: String) : CliktCommand(name = name
         val ALL by lazy { Plugin.getAll<OrtCommand>() }
     }
 
-    override val name = commandName
+    override val type = commandName
 }

--- a/cli/src/main/kotlin/OrtCommand.kt
+++ b/cli/src/main/kotlin/OrtCommand.kt
@@ -21,17 +21,17 @@ package org.ossreviewtoolkit.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
 
-import org.ossreviewtoolkit.utils.common.NamedPlugin
+import org.ossreviewtoolkit.utils.common.Plugin
 
 /**
  * An interface for [CliktCommand]-based ORT commands that come as named plugins.
  */
-abstract class OrtCommand(name: String, help: String) : CliktCommand(name = name, help = help), NamedPlugin {
+abstract class OrtCommand(name: String, help: String) : CliktCommand(name = name, help = help), Plugin {
     companion object {
         /**
          * All ORT commands available in the classpath, associated by their names.
          */
-        val ALL by lazy { NamedPlugin.getAll<OrtCommand>() }
+        val ALL by lazy { Plugin.getAll<OrtCommand>() }
     }
 
     override val name = commandName

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -272,10 +272,10 @@ class ReporterCommand : OrtCommand(
                 reportFormats.map { reporter ->
                     async {
                         val threadName = Thread.currentThread().name
-                        println("Generating the '${reporter.name}' report in thread '$threadName'...")
+                        println("Generating the '${reporter.type}' report in thread '$threadName'...")
 
                         reporter to measureTimedValue {
-                            val options = reportOptionsMap[reporter.name].orEmpty()
+                            val options = reportOptionsMap[reporter.type].orEmpty()
                             runCatching { reporter.generateReport(input, outputDir, options) }
                         }
                     }
@@ -286,7 +286,7 @@ class ReporterCommand : OrtCommand(
         var failureCount = 0
 
         reportDurationMap.value.forEach { (reporter, timedValue) ->
-            val name = reporter.name
+            val name = reporter.type
 
             timedValue.value.onSuccess { files ->
                 val fileList = files.joinToString { "'$it'" }

--- a/model/src/main/kotlin/config/PackageCurationProviderConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageCurationProviderConfiguration.kt
@@ -19,13 +19,16 @@
 
 package org.ossreviewtoolkit.model.config
 
+import com.sksamuel.hoplite.ConfigAlias
+
 import org.ossreviewtoolkit.utils.common.Plugin
 
 data class PackageCurationProviderConfiguration(
     /**
-     * The [name][Plugin.type] of the package curation provider.
+     * The [type][Plugin.type] of the package curation provider.
      */
-    val name: String,
+    @ConfigAlias("name")
+    val type: String,
 
     /**
      * Whether this curation provider is enabled.

--- a/model/src/main/kotlin/config/PackageCurationProviderConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageCurationProviderConfiguration.kt
@@ -19,11 +19,11 @@
 
 package org.ossreviewtoolkit.model.config
 
-import org.ossreviewtoolkit.utils.common.NamedPlugin
+import org.ossreviewtoolkit.utils.common.Plugin
 
 data class PackageCurationProviderConfiguration(
     /**
-     * The [name][NamedPlugin.name] of the package curation provider.
+     * The [name][Plugin.name] of the package curation provider.
      */
     val name: String,
 

--- a/model/src/main/kotlin/config/PackageCurationProviderConfiguration.kt
+++ b/model/src/main/kotlin/config/PackageCurationProviderConfiguration.kt
@@ -23,7 +23,7 @@ import org.ossreviewtoolkit.utils.common.Plugin
 
 data class PackageCurationProviderConfiguration(
     /**
-     * The [name][Plugin.name] of the package curation provider.
+     * The [name][Plugin.type] of the package curation provider.
      */
     val name: String,
 

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -39,23 +39,23 @@ ort:
   # Providers are listed from highest to lower priority. Technically, they are applied in reverse order: The provider
   # with the highest priority is applied last, so it can overwrite any previously applied curations.
   packageCurationProviders:
-    - name: DefaultFile
-    - name: DefaultDir
-    - name: File
+    - type: DefaultFile
+    - type: DefaultDir
+    - type: File
       config:
         path: '/some-path/curations.yml'
         mustExist: true
-    - name: File
+    - type: File
       config:
         path: '/some-path/curations-dir'
         mustExist: false
-    - name: OrtConfig
+    - type: OrtConfig
       enabled: '${USE_ORT_CONFIG_CURATIONS:-true}'
-    - name: ClearlyDefined
+    - type: ClearlyDefined
       config:
         serverUrl: 'https://api.clearlydefined.io'
         minTotalLicenseScore: 80
-    - name: SW360
+    - type: SW360
       config:
         restUrl: 'https://your-sw360-rest-url'
         authUrl: 'https://your-authentication-url'

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -64,23 +64,23 @@ class OrtConfigurationTest : WordSpec({
             }
 
             ortConfig.packageCurationProviders should containExactly(
-                PackageCurationProviderConfiguration(name = "DefaultFile"),
-                PackageCurationProviderConfiguration(name = "DefaultDir"),
+                PackageCurationProviderConfiguration(type = "DefaultFile"),
+                PackageCurationProviderConfiguration(type = "DefaultDir"),
                 PackageCurationProviderConfiguration(
-                    name = "File",
+                    type = "File",
                     config = mapOf("path" to "/some-path/curations.yml", "mustExist" to "true")
                 ),
                 PackageCurationProviderConfiguration(
-                    name = "File",
+                    type = "File",
                     config = mapOf("path" to "/some-path/curations-dir", "mustExist" to "false")
                 ),
-                PackageCurationProviderConfiguration(name = "OrtConfig", enabled = true),
+                PackageCurationProviderConfiguration(type = "OrtConfig", enabled = true),
                 PackageCurationProviderConfiguration(
-                    name = "ClearlyDefined",
+                    type = "ClearlyDefined",
                     config = mapOf("serverUrl" to "https://api.clearlydefined.io", "minTotalLicenseScore" to "80")
                 ),
                 PackageCurationProviderConfiguration(
-                    name = "SW360",
+                    type = "SW360",
                     config = mapOf(
                         "restUrl" to "https://your-sw360-rest-url",
                         "authUrl" to "https://your-authentication-url",

--- a/reporter/src/main/kotlin/Reporter.kt
+++ b/reporter/src/main/kotlin/Reporter.kt
@@ -24,18 +24,18 @@ import java.io.File
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.config.ScopeExclude
-import org.ossreviewtoolkit.utils.common.NamedPlugin
+import org.ossreviewtoolkit.utils.common.Plugin
 import org.ossreviewtoolkit.utils.common.joinNonBlank
 
 /**
  * A reporter that creates a human-readable report from a given [OrtResult].
  */
-interface Reporter : NamedPlugin {
+interface Reporter : Plugin {
     companion object {
         /**
          * All [reporters][Reporter] available in the classpath, associated by their names.
          */
-        val ALL by lazy { NamedPlugin.getAll<Reporter>() }
+        val ALL by lazy { Plugin.getAll<Reporter>() }
     }
 
     /**

--- a/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
+++ b/reporter/src/main/kotlin/reporters/CycloneDxReporter.kt
@@ -69,7 +69,7 @@ class CycloneDxReporter : Reporter {
         const val OPTION_OUTPUT_FILE_FORMATS = "output.file.formats"
     }
 
-    override val name = "CycloneDx"
+    override val type = "CycloneDx"
 
     private val base64Encoder = Base64.getEncoder()
 

--- a/reporter/src/main/kotlin/reporters/ExcelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ExcelReporter.kt
@@ -67,7 +67,7 @@ private const val OPTION_EXTRA_COLUMNS = "extraColumns"
  * - *extraColumns*: A comma separated list of columns that are added to each sheet.
  */
 class ExcelReporter : Reporter {
-    override val name = "Excel"
+    override val type = "Excel"
 
     private val reportFilename = "scan-report.xlsx"
 

--- a/reporter/src/main/kotlin/reporters/OpossumReporter.kt
+++ b/reporter/src/main/kotlin/reporters/OpossumReporter.kt
@@ -503,7 +503,7 @@ class OpossumReporter : Reporter {
         }
     }
 
-    override val name = "Opossum"
+    override val type = "Opossum"
 
     private fun writeReport(outputFile: File, opossumInput: OpossumInput) {
         FileOutputStream(outputFile, /* append = */ false).use { outputStream ->

--- a/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
+++ b/reporter/src/main/kotlin/reporters/StaticHtmlReporter.kt
@@ -67,7 +67,7 @@ import org.ossreviewtoolkit.utils.spdx.SpdxLicenseWithExceptionExpression
 
 @Suppress("LargeClass", "TooManyFunctions")
 class StaticHtmlReporter : Reporter {
-    override val name = "StaticHtml"
+    override val type = "StaticHtml"
 
     private val reportFilename = "scan-report.html"
     private val css = javaClass.getResource("/static-html-reporter.css").readText()

--- a/reporter/src/main/kotlin/reporters/WebAppReporter.kt
+++ b/reporter/src/main/kotlin/reporters/WebAppReporter.kt
@@ -45,7 +45,7 @@ class WebAppReporter : Reporter {
         const val OPTION_DEDUPLICATE_DEPENDENCY_TREE = "deduplicateDependencyTree"
     }
 
-    override val name = "WebApp"
+    override val type = "WebApp"
 
     private val reportFilename = "scan-report-web-app.html"
 

--- a/reporter/src/main/kotlin/reporters/ctrlx/CtrlXAutomationReporter.kt
+++ b/reporter/src/main/kotlin/reporters/ctrlx/CtrlXAutomationReporter.kt
@@ -39,7 +39,7 @@ class CtrlXAutomationReporter : Reporter {
         )
     }
 
-    override val name = "CtrlXAutomation"
+    override val type = "CtrlXAutomation"
 
     override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
         val reportFile = outputDir.resolve(REPORT_FILENAME)

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelReporter.kt
@@ -40,7 +40,7 @@ class EvaluatedModelReporter : Reporter {
         const val OPTION_DEDUPLICATE_DEPENDENCY_TREE = "deduplicateDependencyTree"
     }
 
-    override val name = "EvaluatedModel"
+    override val type = "EvaluatedModel"
 
     override fun generateReport(
         input: ReporterInput,

--- a/reporter/src/main/kotlin/reporters/fossid/FossIdReporter.kt
+++ b/reporter/src/main/kotlin/reporters/fossid/FossIdReporter.kt
@@ -66,7 +66,7 @@ class FossIdReporter : Reporter {
         const val SCAN_CODE_KEY = "scancode"
     }
 
-    override val name = "FossId"
+    override val type = "FossId"
 
     override fun generateReport(input: ReporterInput, outputDir: File, options: Map<String, String>): List<File> {
         val serverUrl = requireNotNull(options[SERVER_URL_PROPERTY]) {

--- a/reporter/src/main/kotlin/reporters/freemarker/NoticeTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/NoticeTemplateReporter.kt
@@ -47,7 +47,7 @@ class NoticeTemplateReporter : Reporter {
         private const val DEFAULT_TEMPLATE_ID = "default"
     }
 
-    override val name = "NoticeTemplate"
+    override val type = "NoticeTemplate"
 
     private val templateProcessor = FreemarkerTemplateProcessor(
         NOTICE_FILE_PREFIX,

--- a/reporter/src/main/kotlin/reporters/freemarker/asciidoc/AsciiDocTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/asciidoc/AsciiDocTemplateReporter.kt
@@ -41,7 +41,7 @@ import org.ossreviewtoolkit.utils.ort.createOrtTempDir
  * [3]: https://github.com/asciidoctor/asciidoctorj
  * [4]: https://docs.asciidoctor.org/asciidoctor/latest/convert/available
  */
-open class AsciiDocTemplateReporter(private val backend: String, override val name: String) : Reporter {
+open class AsciiDocTemplateReporter(private val backend: String, override val type: String) : Reporter {
     companion object {
         private const val ASCII_DOC_FILE_PREFIX = "AsciiDoc_"
         private const val ASCII_DOC_FILE_EXTENSION = "adoc"

--- a/reporter/src/main/kotlin/reporters/gitlab/GitLabLicenseModelReporter.kt
+++ b/reporter/src/main/kotlin/reporters/gitlab/GitLabLicenseModelReporter.kt
@@ -40,7 +40,7 @@ class GitLabLicenseModelReporter : Reporter {
         const val OPTION_SKIP_EXCLUDED = "skip.excluded"
     }
 
-    override val name = "GitLabLicenseModel"
+    override val type = "GitLabLicenseModel"
 
     private val reportFilename = "gl-license-scanning-report.json"
 

--- a/reporter/src/main/kotlin/reporters/spdx/SpdxDocumentReporter.kt
+++ b/reporter/src/main/kotlin/reporters/spdx/SpdxDocumentReporter.kt
@@ -51,7 +51,7 @@ class SpdxDocumentReporter : Reporter {
         private const val DOCUMENT_NAME_DEFAULT_VALUE = "Unnamed document"
     }
 
-    override val name = "SpdxDocument"
+    override val type = "SpdxDocument"
 
     override fun generateReport(
         input: ReporterInput,

--- a/scanner/src/main/kotlin/ScannerWrapper.kt
+++ b/scanner/src/main/kotlin/ScannerWrapper.kt
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.utils.common.NamedPlugin
+import org.ossreviewtoolkit.utils.common.Plugin
 
 /**
  * The base interface for all types of scanners.
@@ -39,7 +39,7 @@ sealed interface ScannerWrapper {
         /**
          * All [scanner wrapper factories][ScannerWrapperFactory] available in the classpath, associated by their names.
          */
-        val ALL by lazy { NamedPlugin.getAll<ScannerWrapperFactory>() }
+        val ALL by lazy { Plugin.getAll<ScannerWrapperFactory>() }
     }
 
     /**

--- a/scanner/src/main/kotlin/ScannerWrapperFactory.kt
+++ b/scanner/src/main/kotlin/ScannerWrapperFactory.kt
@@ -23,12 +23,12 @@ import java.util.ServiceLoader
 
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
-import org.ossreviewtoolkit.utils.common.NamedPlugin
+import org.ossreviewtoolkit.utils.common.Plugin
 
 /**
  * A common interface for use with [ServiceLoader] that all [ScannerWrapperFactory] classes need to implement.
  */
-interface ScannerWrapperFactory : NamedPlugin {
+interface ScannerWrapperFactory : Plugin {
     /**
      * Create a [ScannerWrapper] using the specified [scannerConfig] and [downloaderConfig].
      */

--- a/scanner/src/main/kotlin/ScannerWrapperFactory.kt
+++ b/scanner/src/main/kotlin/ScannerWrapperFactory.kt
@@ -39,7 +39,7 @@ interface ScannerWrapperFactory : Plugin {
  * A generic factory class for a [ScannerWrapper].
  */
 abstract class AbstractScannerWrapperFactory<out T : ScannerWrapper>(
-    override val name: String
+    override val type: String
 ) : ScannerWrapperFactory {
     abstract override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration): T
 
@@ -47,5 +47,5 @@ abstract class AbstractScannerWrapperFactory<out T : ScannerWrapper>(
      * Return the scanner wrapper's name here to allow Clikt to display something meaningful when listing the scanners
      * which are enabled by default via their factories.
      */
-    override fun toString() = name
+    override fun toString() = type
 }

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -48,7 +48,7 @@ class Askalono internal constructor(
 
     class Factory : AbstractScannerWrapperFactory<Askalono>("Askalono") {
         override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
-            Askalono(name, scannerConfig)
+            Askalono(type, scannerConfig)
     }
 
     override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -55,7 +55,7 @@ class BoyterLc internal constructor(
 
     class Factory : AbstractScannerWrapperFactory<BoyterLc>("BoyterLc") {
         override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
-            BoyterLc(name, scannerConfig)
+            BoyterLc(type, scannerConfig)
     }
 
     override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -50,7 +50,7 @@ class Licensee internal constructor(
 
     class Factory : AbstractScannerWrapperFactory<Licensee>("Licensee") {
         override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
-            Licensee(name, scannerConfig)
+            Licensee(type, scannerConfig)
     }
 
     override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -147,7 +147,7 @@ class FossId internal constructor(
 
     class Factory : AbstractScannerWrapperFactory<FossId>("FossId") {
         override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
-            FossId(name, scannerConfig, FossIdConfig.create(scannerConfig))
+            FossId(type, scannerConfig, FossIdConfig.create(scannerConfig))
     }
 
     /**

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCode.kt
@@ -95,7 +95,7 @@ class ScanCode internal constructor(
 
     class Factory : AbstractScannerWrapperFactory<ScanCode>(SCANNER_NAME) {
         override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
-            ScanCode(name, scannerConfig)
+            ScanCode(type, scannerConfig)
     }
 
     override val criteria by lazy { ScannerCriteria.fromConfig(details, scannerConfig) }

--- a/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
+++ b/scanner/src/main/kotlin/scanners/scanoss/ScanOss.kt
@@ -58,7 +58,7 @@ class ScanOss internal constructor(
 
     class Factory : AbstractScannerWrapperFactory<ScanOss>("SCANOSS") {
         override fun create(scannerConfig: ScannerConfiguration, downloaderConfig: DownloaderConfiguration) =
-            ScanOss(name, scannerConfig)
+            ScanOss(type, scannerConfig)
     }
 
     private val config = ScanOssConfig.create(scannerConfig).also {

--- a/utils/common/src/main/kotlin/PluginManager.kt
+++ b/utils/common/src/main/kotlin/PluginManager.kt
@@ -27,14 +27,14 @@ import java.util.ServiceLoader
 inline fun <reified T : Any> getLoaderFor(): ServiceLoader<T> = ServiceLoader.load(T::class.java)
 
 /**
- * An interface to be implemented by plugins that have a name.
+ * An interface to be implemented by any ORT plugin.
  */
-interface NamedPlugin {
+interface Plugin {
     companion object {
         /**
-         * Return instances for all named plugins of type [T].
+         * Return instances for all ORT plugins of type [T].
          */
-        inline fun <reified T : NamedPlugin> getAll() = getLoaderFor<T>()
+        inline fun <reified T : Plugin> getAll() = getLoaderFor<T>()
             .iterator()
             .asSequence()
             .associateByTo(sortedMapOf(String.CASE_INSENSITIVE_ORDER)) {
@@ -52,7 +52,7 @@ interface NamedPlugin {
  * An interface to be implemented by plugin factories. Plugin factories are required if a plugin needs configuration
  * on initialization and can therefore not be created directly by the [ServiceLoader].
  */
-interface ConfigurablePluginFactory<out PLUGIN> : NamedPlugin {
+interface ConfigurablePluginFactory<out PLUGIN> : Plugin {
     /**
      * Create a new instance of [PLUGIN] from [config].
      */

--- a/utils/common/src/main/kotlin/PluginManager.kt
+++ b/utils/common/src/main/kotlin/PluginManager.kt
@@ -38,14 +38,14 @@ interface Plugin {
             .iterator()
             .asSequence()
             .associateByTo(sortedMapOf(String.CASE_INSENSITIVE_ORDER)) {
-                it.name
+                it.type
             }
     }
 
     /**
-     * The name of the plugin.
+     * The type of the plugin.
      */
-    val name: String
+    val type: String
 }
 
 /**


### PR DESCRIPTION
Call the interface for ORT plugins `OrtPlugin` and renamed its property `name` to `type`.
Also, align another property name in `OrtConfiguration` for consistency.
Also see individual commits.

Breaking change:

1. The ORT plugin interface has been renamed, so plugins must implement `org.ossreviewtoolkit.utils.common.Plugin` instead of `org.ossreviewtoolkit.utils.common.Plugin`.
2. The property `Plugin.name` has been renamed to `Plugin.type`, so plugin implementations must align with that new property name.
3. `OrtConfiguration`s, e.g. `~/.ort/config/config.yml` which define `PackageCurationProviders` should align the respective property names from `name` to `type`.
