### PR TITLE
feat(Analyzer): Support Pub dependencies from Git

### DIFF
--- a/analyzer/src/main/kotlin/managers/utils/PubCacheReader.kt
+++ b/analyzer/src/main/kotlin/managers/utils/PubCacheReader.kt
@@ -93,9 +93,12 @@ internal class PubCacheReader {
             // Packages with source set to "git" and a "resolved-ref" key in description set to a gitHash.
             // These packages do not define a packageName in the packageInfo, but by definition the path resolves to
             // the project name as given from the VcsHost and to the resolvedRef.
-            val projectName = VcsHost.fromUrl(url)?.getProject(url) ?: return null
-
-            "git/$projectName-$resolvedRef"
+            val projectName = VcsHost.getProject(url) ?: return null
+            if (resolvedPath.isNotEmpty()) {
+                "git/$projectName-$resolvedRef/$resolvedPath"
+            } else {
+                "git/$projectName-$resolvedRef"
+            }
         } else {
             logger.error { "Could not find projectRoot of '$packageName'." }
 

--- a/downloader/src/main/kotlin/VcsHost.kt
+++ b/downloader/src/main/kotlin/VcsHost.kt
@@ -318,6 +318,7 @@ enum class VcsHost(
         private val SVN_BRANCH_OR_TAG_PATTERN = Regex("(.*svn.*)/(branches|tags)/([^/]+)/?(.*)")
         private val SVN_TRUNK_PATTERN = Regex("(.*svn.*)/(trunk)/?(.*)")
         private val GIT_REVISION_FRAGMENT = Regex("git.+#[a-fA-F0-9]{7,}")
+        private val GIT_PROJECT_NAME = Regex("/([^/]+)\\.git")
 
         /**
          * Return the applicable [VcsHost] for the given [url], or null if no applicable host is found.
@@ -445,6 +446,16 @@ enum class VcsHost(
                 val vcsInfo = host.toVcsInfoInternal(it)
                 host.toRawDownloadUrlInternal(userOrOrg, project, vcsInfo)
             }.getOrNull()
+        }
+
+        /**
+         * Return the project's name, with generic handling of unknown VCS hosts (those not covered by the enumeration,
+         * e.g. an on-premises Git server).
+         */
+        fun getProject(projectUrl: String): String? {
+            val host = values().find { it.isApplicable(projectUrl) }
+                ?: return GIT_PROJECT_NAME.find(projectUrl)?.groupValues?.getOrNull(1)
+            return projectUrl.toUri { host.getProjectInternal(it) }.getOrNull()
         }
     }
 

--- a/downloader/src/test/kotlin/VcsHostTest.kt
+++ b/downloader/src/test/kotlin/VcsHostTest.kt
@@ -481,4 +481,38 @@ class VcsHostTest : WordSpec({
             VcsHost.fromUrl("https://host.tld/path/to/repo") should beNull()
         }
     }
+
+    "Getting the project from a URL" should {
+        "work for an Azure DevOps URL" {
+            VcsHost.getProject("https://dev.azure.com/oss-review-toolkit/kotlin-devs/_git/ort") shouldBe "ort"
+        }
+
+        "work for a GitHub URL" {
+            VcsHost.getProject("https://github.com/oss-review-toolkit/ort") shouldBe "ort"
+        }
+
+        "work for a GitLab URL" {
+            VcsHost.getProject("https://gitlab.com/gitlab-org/gitlab") shouldBe "gitlab"
+        }
+
+        "work for a Bitbucket URL" {
+            VcsHost.getProject("https://bitbucket.org/yevster/spdxtraxample") shouldBe "spdxtraxample"
+        }
+
+        "work for a SourceHut URL to a Git repository" {
+            VcsHost.getProject("https://git.sr.ht/~sircmpwn/sourcehut.org") shouldBe "sourcehut.org"
+        }
+
+        "work for a SourceHut URL to a Mercurial repository" {
+            VcsHost.getProject("https://hg.sr.ht/~sircmpwn/invertbucket") shouldBe "invertbucket"
+        }
+
+        "work for a generic URL to a Git repository" {
+            VcsHost.getProject("ssh://git@gitlab.custom.com:group/project.git") shouldBe "project"
+        }
+
+        "handle an unknown URL" {
+            VcsHost.fromUrl("https://host.tld/path/to/repo") should beNull()
+        }
+    }
 })


### PR DESCRIPTION
Support Pub dependencies which are loaded from a Git repository.

This implements part of https://github.com/oss-review-toolkit/ort/issues/5268 (only Git packages, but Pub supports additional sources).