### PR TITLE
Change the curation provider API to take packages instead of ids

### DIFF
--- a/analyzer/src/funTest/kotlin/curation/ClearlyDefinedPackageCurationProviderFunTest.kt
+++ b/analyzer/src/funTest/kotlin/curation/ClearlyDefinedPackageCurationProviderFunTest.kt
@@ -28,6 +28,7 @@ import io.kotest.matchers.shouldNot
 
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.utils.spdx.toSpdx
 
 class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
@@ -35,9 +36,9 @@ class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
         val provider = ClearlyDefinedPackageCurationProvider()
 
         "return an existing curation for the javax.servlet-api Maven package" {
-            val identifier = Identifier("Maven:javax.servlet:javax.servlet-api:3.1.0")
+            val packages = createPackagesFromIds("Maven:javax.servlet:javax.servlet-api:3.1.0")
 
-            val curations = provider.getCurationsFor(listOf(identifier))
+            val curations = provider.getCurationsFor(packages)
 
             curations should haveSize(1)
             curations.values.flatten().first().data.concludedLicense shouldBe
@@ -45,18 +46,18 @@ class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
         }
 
         "return an existing curation for the slf4j-log4j12 Maven package" {
-            val identifier = Identifier("Maven:org.slf4j:slf4j-log4j12:1.7.30")
+            val packages = createPackagesFromIds("Maven:org.slf4j:slf4j-log4j12:1.7.30")
 
-            val curations = provider.getCurationsFor(listOf(identifier))
+            val curations = provider.getCurationsFor(packages)
 
             curations should haveSize(1)
             curations.values.flatten().first().data.vcs?.revision shouldBe "0b97c416e42a184ff9728877b461c616187c58f7"
         }
 
         "return no curation for a non-existing dummy NPM package" {
-            val identifier = Identifier("NPM:@scope:name:1.2.3")
+            val packages = createPackagesFromIds("NPM:@scope:name:1.2.3")
 
-            val curations = provider.getCurationsFor(listOf(identifier))
+            val curations = provider.getCurationsFor(packages)
 
             curations should beEmpty()
         }
@@ -66,18 +67,18 @@ class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
         val provider = ClearlyDefinedPackageCurationProvider(Server.DEVELOPMENT)
 
         "return an existing curation for the platform-express NPM package" {
-            val identifier = Identifier("NPM:@nestjs:platform-express:6.2.3")
+            val packages = createPackagesFromIds("NPM:@nestjs:platform-express:6.2.3")
 
-            val curations = provider.getCurationsFor(listOf(identifier))
+            val curations = provider.getCurationsFor(packages)
 
             curations should haveSize(1)
             curations.values.flatten().first().data.concludedLicense shouldBe "Apache-1.0".toSpdx()
         }
 
         "return no curation for a non-existing dummy Maven package" {
-            val identifier = Identifier("Maven:group:name:1.2.3")
+            val packages = createPackagesFromIds("Maven:group:name:1.2.3")
 
-            val curations = provider.getCurationsFor(listOf(identifier))
+            val curations = provider.getCurationsFor(packages)
 
             curations should beEmpty()
         }
@@ -92,20 +93,23 @@ class ClearlyDefinedPackageCurationProviderFunTest : WordSpec({
             val provider = ClearlyDefinedPackageCurationProvider(config)
 
             // Use an id which is known to have non-empty results from an earlier test.
-            val identifier = Identifier("Maven:org.slf4j:slf4j-log4j12:1.7.30")
+            val packages = createPackagesFromIds("Maven:org.slf4j:slf4j-log4j12:1.7.30")
 
-            val curations = provider.getCurationsFor(listOf(identifier))
+            val curations = provider.getCurationsFor(packages)
 
             curations should beEmpty()
         }
 
         "be retrieved for packages without a namespace" {
             val provider = ClearlyDefinedPackageCurationProvider()
-            val identifier = Identifier("NPM::acorn:0.6.0")
+            val packages = createPackagesFromIds("NPM::acorn:0.6.0")
 
-            val curations = provider.getCurationsFor(listOf(identifier))
+            val curations = provider.getCurationsFor(packages)
 
             curations shouldNot beEmpty()
         }
     }
 })
+
+private fun createPackagesFromIds(vararg ids: String) =
+    ids.map { Package.EMPTY.copy(id = Identifier(it)) }

--- a/analyzer/src/funTest/kotlin/curation/OrtConfigPackageCurationProviderFunTest.kt
+++ b/analyzer/src/funTest/kotlin/curation/OrtConfigPackageCurationProviderFunTest.kt
@@ -27,13 +27,15 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
 
 class OrtConfigPackageCurationProviderFunTest : StringSpec({
     "provider can load curations from the ort-config repository" {
         val azureCore = Identifier("NuGet::Azure.Core:1.22.0")
         val azureCoreAmqp = Identifier("NuGet::Azure.Core.Amqp:1.2.0")
+        val packages = createPackagesFromIds(azureCore, azureCoreAmqp)
 
-        val curations = OrtConfigPackageCurationProvider().getCurationsFor(listOf(azureCore, azureCoreAmqp))
+        val curations = OrtConfigPackageCurationProvider().getCurationsFor(packages)
 
         curations.shouldContainKeys(azureCore, azureCoreAmqp)
         curations.getValue(azureCore) shouldNot beEmpty()
@@ -41,10 +43,13 @@ class OrtConfigPackageCurationProviderFunTest : StringSpec({
     }
 
     "provider does not fail for packages which have no curations" {
-        val id = Identifier("Some:Bogus:Package:Id")
+        val packages = createPackagesFromIds(Identifier("Some:Bogus:Package:Id"))
 
-        val curations = OrtConfigPackageCurationProvider().getCurationsFor(listOf(id))
+        val curations = OrtConfigPackageCurationProvider().getCurationsFor(packages)
 
         curations should beEmptyMap()
     }
 })
+
+private fun createPackagesFromIds(vararg ids: Identifier) =
+    ids.map { Package.EMPTY.copy(id = it) }

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -348,12 +348,11 @@ private fun resolveConfiguration(
     analyzerResult: AnalyzerResult,
     curationProviders: List<Pair<String, PackageCurationProvider>>
 ): ResolvedConfiguration {
-    val packageIds = analyzerResult.packages.mapTo(mutableSetOf()) { it.id }
     val packageCurations = mutableListOf<PackageCuration>()
 
     curationProviders.forEach { (id, curationProvider) ->
         val (curations, duration) = measureTimedValue {
-            curationProvider.getCurationsFor(packageIds).values.flatten().distinct()
+            curationProvider.getCurationsFor(analyzerResult.packages).values.flatten().distinct()
         }
 
         packageCurations += curations

--- a/analyzer/src/main/kotlin/PackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/PackageCurationProvider.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.analyzer
 
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.config.PackageCurationProviderConfiguration
 import org.ossreviewtoolkit.utils.common.ConfigurablePluginFactory
@@ -83,10 +84,10 @@ interface PackageCurationProviderFactory<CONFIG> : ConfigurablePluginFactory<Pac
  */
 fun interface PackageCurationProvider {
     /**
-     * Return all available [PackageCuration]s for the provided [pkgIds], associated by the package's [Identifier]. Each
-     * list of curations must be non-empty; if no curation is available for a package, the returned map must not contain
-     * a key for that package's identifier at all.
+     * Return all available [PackageCuration]s for the provided [packages], associated by the package's [Identifier].
+     * Each list of curations must be non-empty; if no curation is available for a package, the returned map must not
+     * contain a key for that package's identifier at all.
      */
     // TODO: Maybe make this a suspend function, then all implementing classes could deal with coroutines more easily.
-    fun getCurationsFor(pkgIds: Collection<Identifier>): Map<Identifier, List<PackageCuration>>
+    fun getCurationsFor(packages: Collection<Package>): Map<Identifier, List<PackageCuration>>
 }

--- a/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
@@ -38,6 +38,7 @@ import org.ossreviewtoolkit.clients.clearlydefined.getCurationsChunked
 import org.ossreviewtoolkit.clients.clearlydefined.getDefinitionsChunked
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.PackageCurationData
 import org.ossreviewtoolkit.model.RemoteArtifact
@@ -97,11 +98,11 @@ class ClearlyDefinedPackageCurationProvider(
         ClearlyDefinedService.create(config.serverUrl, client ?: OkHttpClientHelper.buildClient())
     }
 
-    override fun getCurationsFor(pkgIds: Collection<Identifier>): Map<Identifier, List<PackageCuration>> {
-        val coordinatesToIds = pkgIds.mapNotNull { pkgId ->
-            pkgId.toClearlyDefinedTypeAndProvider()?.let { (type, provider) ->
-                val namespace = pkgId.namespace.takeUnless { it.isEmpty() }
-                Coordinates(type, provider, namespace, pkgId.name, pkgId.version) to pkgId
+    override fun getCurationsFor(packages: Collection<Package>): Map<Identifier, List<PackageCuration>> {
+        val coordinatesToIds = packages.mapNotNull { pkg ->
+            pkg.toClearlyDefinedTypeAndProvider()?.let { (type, provider) ->
+                val namespace = pkg.id.namespace.takeUnless { it.isEmpty() }
+                Coordinates(type, provider, namespace, pkg.id.name, pkg.id.version) to pkg.id
             }
         }.toMap()
 

--- a/analyzer/src/main/kotlin/curation/OrtConfigPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/OrtConfigPackageCurationProvider.kt
@@ -28,6 +28,7 @@ import org.ossreviewtoolkit.analyzer.PackageCurationProvider
 import org.ossreviewtoolkit.analyzer.PackageCurationProviderFactory
 import org.ossreviewtoolkit.downloader.vcs.Git
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
@@ -60,9 +61,9 @@ open class OrtConfigPackageCurationProvider : PackageCurationProvider {
         }
     }
 
-    override fun getCurationsFor(pkgIds: Collection<Identifier>) =
-        pkgIds.mapNotNull { pkgId ->
-            getCurationsFor(pkgId).takeUnless { it.isEmpty() }?.let { pkgId to it }
+    override fun getCurationsFor(packages: Collection<Package>) =
+        packages.mapNotNull { pkg ->
+            getCurationsFor(pkg.id).takeUnless { it.isEmpty() }?.let { pkg.id to it }
         }.toMap()
 
     private fun getCurationsFor(pkgId: Identifier): List<PackageCuration> {

--- a/analyzer/src/main/kotlin/curation/SimplePackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/SimplePackageCurationProvider.kt
@@ -20,15 +20,15 @@
 package org.ossreviewtoolkit.analyzer.curation
 
 import org.ossreviewtoolkit.analyzer.PackageCurationProvider
-import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCuration
 
 /**
  * A [PackageCurationProvider] that provides the specified [packageCurations].
  */
 open class SimplePackageCurationProvider(val packageCurations: List<PackageCuration>) : PackageCurationProvider {
-    override fun getCurationsFor(pkgIds: Collection<Identifier>) =
-        pkgIds.mapNotNull { pkgId ->
-            packageCurations.filter { it.isApplicable(pkgId) }.takeUnless { it.isEmpty() }?.let { pkgId to it }
+    override fun getCurationsFor(packages: Collection<Package>) =
+        packages.mapNotNull { pkg ->
+            packageCurations.filter { it.isApplicable(pkg.id) }.takeUnless { it.isEmpty() }?.let { pkg.id to it }
         }.toMap()
 }

--- a/analyzer/src/main/kotlin/curation/Sw360PackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/Sw360PackageCurationProvider.kt
@@ -37,6 +37,7 @@ import org.ossreviewtoolkit.analyzer.PackageCurationProviderFactory
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.HashAlgorithm
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.PackageCurationData
 import org.ossreviewtoolkit.model.RemoteArtifact
@@ -97,9 +98,9 @@ class Sw360PackageCurationProvider(config: Sw360StorageConfiguration) : PackageC
     private val connectionFactory = createConnection(config)
     private val releaseClient = connectionFactory.releaseAdapter
 
-    override fun getCurationsFor(pkgIds: Collection<Identifier>) =
-        pkgIds.mapNotNull { pkgId ->
-            getCurationsFor(pkgId).takeUnless { it.isEmpty() }?.let { pkgId to it }
+    override fun getCurationsFor(packages: Collection<Package>) =
+        packages.mapNotNull { pkg ->
+            getCurationsFor(pkg.id).takeUnless { it.isEmpty() }?.let { pkg.id to it }
         }.toMap()
 
     private fun getCurationsFor(pkgId: Identifier): List<PackageCuration> {

--- a/analyzer/src/test/kotlin/curation/ClearlyDefinedPackageCurationProviderTest.kt
+++ b/analyzer/src/test/kotlin/curation/ClearlyDefinedPackageCurationProviderTest.kt
@@ -32,6 +32,7 @@ import io.kotest.matchers.should
 import java.time.Duration
 
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 
 /**
@@ -68,9 +69,10 @@ class ClearlyDefinedPackageCurationProviderTest : WordSpec({
             }
 
             val provider = ClearlyDefinedPackageCurationProvider("http://localhost:${server.port()}", client)
-            val ids = listOf(Identifier("Maven:some-ns:some-component:1.2.3"))
+            val id = Identifier("Maven:some-ns:some-component:1.2.3")
+            val packages = listOf(Package.EMPTY.copy(id = id))
 
-            provider.getCurationsFor(ids) should beEmpty()
+            provider.getCurationsFor(packages) should beEmpty()
         }
     }
 })

--- a/model/src/main/kotlin/utils/Extensions.kt
+++ b/model/src/main/kotlin/utils/Extensions.kt
@@ -36,12 +36,12 @@ internal fun TextLocation.prependPath(prefix: String): String =
     if (prefix.isBlank()) path else "${prefix.removeSuffix("/")}/$path"
 
 /**
- * Map an [Identifier] to a ClearlyDefined [ComponentType] and [Provider]. Note that an
+ * Map an [Package] to a ClearlyDefined [ComponentType] and [Provider]. Note that an
  * [identifier's type][Identifier.type] in ORT currently implies a default provider. Return null if a mapping is not
  * possible.
  */
-fun Identifier.toClearlyDefinedTypeAndProvider(): Pair<ComponentType, Provider>? =
-    when (type) {
+fun Package.toClearlyDefinedTypeAndProvider(): Pair<ComponentType, Provider>? =
+    when (id.type) {
         "Bower" -> ComponentType.GIT to Provider.GITHUB
         "CocoaPods" -> ComponentType.POD to Provider.COCOAPODS
         "Composer" -> ComponentType.COMPOSER to Provider.PACKAGIST
@@ -57,24 +57,24 @@ fun Identifier.toClearlyDefinedTypeAndProvider(): Pair<ComponentType, Provider>?
     }
 
 /**
- * Map an ORT [Identifier] to ClearlyDefined [Coordinates], or to null if mapping is not possible.
+ * Map an ORT [Package] to ClearlyDefined [Coordinates], or to null if mapping is not possible.
  */
-fun Identifier.toClearlyDefinedCoordinates(): Coordinates? =
+fun Package.toClearlyDefinedCoordinates(): Coordinates? =
     toClearlyDefinedTypeAndProvider()?.let { (type, provider) ->
         Coordinates(
             type = type,
             provider = provider,
-            namespace = namespace.takeUnless { it.isEmpty() },
-            name = name,
-            revision = version.takeUnless { it.isEmpty() }
+            namespace = id.namespace.takeUnless { it.isEmpty() },
+            name = id.name,
+            revision = id.version.takeUnless { it.isEmpty() }
         )
     }
 
 /**
- * Create a ClearlyDefined [SourceLocation] from an [Identifier]. Prefer a [VcsInfoCurationData], but eventually fall
+ * Create a ClearlyDefined [SourceLocation] from a [Package]. Prefer a [VcsInfoCurationData], but eventually fall
  * back to a [RemoteArtifact], or return null if not enough information is available.
  */
-fun Identifier.toClearlyDefinedSourceLocation(
+fun Package.toClearlyDefinedSourceLocation(
     vcs: VcsInfoCurationData?,
     sourceArtifact: RemoteArtifact?
 ): SourceLocation? {
@@ -100,10 +100,10 @@ fun Identifier.toClearlyDefinedSourceLocation(
         sourceArtifact != null -> {
             toClearlyDefinedTypeAndProvider()?.let { (_, provider) ->
                 SourceLocation(
-                    name = name,
-                    namespace = namespace.takeUnless { it.isEmpty() },
+                    name = id.name,
+                    namespace = id.namespace.takeUnless { it.isEmpty() },
                     provider = provider,
-                    revision = version,
+                    revision = id.version,
                     type = ComponentType.SOURCE_ARCHIVE,
                     url = sourceArtifact.url
                 )

--- a/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
+++ b/scanner/src/main/kotlin/storages/ClearlyDefinedStorage.kt
@@ -76,8 +76,8 @@ private fun VcsInfo.toVcsInfoCurationData(): VcsInfoCurationData = VcsInfoCurati
 private fun packageCoordinates(pkg: Package): Coordinates {
     val vcs = pkg.vcs.takeUnless { it.url.isEmpty() }
     val sourceArtifact = pkg.sourceArtifact.takeUnless { it.url.isEmpty() }
-    val sourceLocation = pkg.id.toClearlyDefinedSourceLocation(vcs?.toVcsInfoCurationData(), sourceArtifact)
-    return sourceLocation?.toCoordinates() ?: pkg.id.toClearlyDefinedCoordinates()
+    val sourceLocation = pkg.toClearlyDefinedSourceLocation(vcs?.toVcsInfoCurationData(), sourceArtifact)
+    return sourceLocation?.toCoordinates() ?: pkg.toClearlyDefinedCoordinates()
         ?: throw IllegalArgumentException("Unable to create ClearlyDefined coordinates for $pkg.")
 }
 


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.

> **Note**
> This is a **breaking change** in the sense that the `PackageCurationProvider` interface now takes a collection of `Package`s instead of `Identifiers`.