### PR TITLE
Migrate the Opossum reporter to the dependency navigator

### DIFF
--- a/reporter/src/main/kotlin/reporters/opossum/OpossumReporter.kt
+++ b/reporter/src/main/kotlin/reporters/opossum/OpossumReporter.kt
@@ -333,22 +333,6 @@ class OpossumReporter : Reporter {
             }
         }
 
-        private fun addDependencyScope(
-            scope: Scope,
-            ortResult: OrtResult,
-            relRoot: String = "/"
-        ) {
-            val name = scope.name
-            logger.debug { "$relRoot - $name - DependencyScope" }
-
-            val rootForScope = resolvePath(relRoot, name)
-            if (scope.dependencies.isNotEmpty()) addAttributionBreakpoint(rootForScope)
-
-            scope.dependencies.forEach { dependency ->
-                addDependency(dependency, ortResult, rootForScope)
-            }
-        }
-
         private fun getRootForProject(project: Project, relRoot: String): String {
             val vcsPath = resolvePath(relRoot, project.vcs.path)
             val definitionFilePath = resolvePath(relRoot, project.definitionFilePath)
@@ -388,7 +372,15 @@ class OpossumReporter : Reporter {
             project.scopes
                 .filterNot { ortResult.getExcludes().isScopeExcluded(it.name) }
                 .forEach { scope ->
-                    addDependencyScope(scope, ortResult, definitionFilePath)
+                    val name = scope.name
+                    logger.debug { "$definitionFilePath - $name - DependencyScope" }
+
+                    val rootForScope = resolvePath(definitionFilePath, name)
+                    if (scope.dependencies.isNotEmpty()) addAttributionBreakpoint(rootForScope)
+
+                    scope.dependencies.forEach { dependency ->
+                        addDependency(dependency, ortResult, rootForScope)
+                    }
                 }
         }
 

--- a/reporter/src/main/kotlin/reporters/opossum/OpossumReporter.kt
+++ b/reporter/src/main/kotlin/reporters/opossum/OpossumReporter.kt
@@ -296,12 +296,12 @@ class OpossumReporter : Reporter {
             }
         }
 
-        private fun signalFromPkg(pkg: Package, id: Identifier = pkg.id): OpossumSignal {
+        private fun signalFromPkg(pkg: Package): OpossumSignal {
             val source = addExternalAttributionSource("ORT-Package", "ORT-Package", 180)
 
             return OpossumSignal(
                 source,
-                id = id,
+                id = pkg.id,
                 url = pkg.homepageUrl,
                 license = pkg.concludedLicense ?: pkg.declaredLicensesProcessed.spdxExpression,
                 preselected = true
@@ -320,10 +320,11 @@ class OpossumReporter : Reporter {
 
             val dependencyPath =
                 resolvePath(listOf(relRoot, dependencyId.namespace, "${dependencyId.name}@${dependencyId.version}"))
-            val dependencyPackage = ortResult.getPackage(dependencyId)?.metadata ?: Package.EMPTY
+            val dependencyPackage = ortResult.getPackage(dependencyId)?.metadata
+                ?: Package.EMPTY.copy(id = dependencyId)
 
             addPackageRoot(dependencyId, dependencyPath, level, dependencyPackage.vcsProcessed)
-            addSignal(signalFromPkg(dependencyPackage, dependencyId), sortedSetOf(dependencyPath))
+            addSignal(signalFromPkg(dependencyPackage), sortedSetOf(dependencyPath))
 
             val dependencies = dependency.getDependencies()
 

--- a/reporter/src/main/kotlin/reporters/opossum/OpossumReporter.kt
+++ b/reporter/src/main/kotlin/reporters/opossum/OpossumReporter.kt
@@ -526,19 +526,15 @@ class OpossumReporter : Reporter {
             opossumInput.frequentLicenses += OpossumFrequentLicense(it.id, it.fullName, licenseText)
         }
 
-        val analyzerResult = ortResult.analyzer?.result ?: return opossumInput
-        val analyzerResultProjects = analyzerResult.projects
-        val analyzerResultPackages = analyzerResult.packages
-
-        analyzerResultProjects.forEach { project ->
+        ortResult.getProjects().forEach { project ->
             opossumInput.addProject(project, ortResult)
         }
 
         if (ortResult.getExcludes().scopes.isEmpty()) {
-            opossumInput.addPackagesThatAreRootless(analyzerResultPackages)
+            opossumInput.addPackagesThatAreRootless(ortResult.getPackages())
         }
 
-        analyzerResult.issues.entries.forEach { (id, issues) ->
+        ortResult.analyzer?.result?.issues.orEmpty().forEach { (id, issues) ->
             issues.forEach { issue ->
                 val source = opossumInput.addExternalAttributionSource(
                     key = "ORT-Analyzer-Issues",

--- a/reporter/src/test/kotlin/reporters/opossum/OpossumReporterTest.kt
+++ b/reporter/src/test/kotlin/reporters/opossum/OpossumReporterTest.kt
@@ -176,8 +176,9 @@ class OpossumReporterTest : WordSpec({
             }
         }
 
-        val opossumInputJson = opossumInput.toJson()
         "create an opossumInput JSON with expected top level entries" {
+            val opossumInputJson = opossumInput.toJson()
+
             opossumInputJson.keys should containExactlyInAnyOrder(
                 "attributionBreakpoints",
                 "baseUrlsForSources",


### PR DESCRIPTION
Mainly, migrate from accessing the legacy dependency representation to using the dependency navigator, to remove technical debt and to enable and make further simplifications.

See individual commits.

