### PR TITLE
fix(analyzer): Correctly determine the project name from Windows paths

### DIFF
--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.analyzer.managers
 
 import java.io.File
+import java.net.URI
 
 import org.apache.logging.log4j.kotlin.Logging
 
@@ -101,10 +102,12 @@ class Unmanaged(
 
             else -> {
                 // For all non-GitRepo VCSes derive the name from the VCS URL.
+                val fileUrl = File(vcsInfo.url).takeIf { it.exists() } ?: File(URI(vcsInfo.url))
+
                 Identifier(
                     type = managerName,
                     namespace = "",
-                    name = vcsInfo.url.split('/').last().removeSuffix(".git"),
+                    name = fileUrl.name.removeSuffix(".git"),
                     version = vcsInfo.revision
                 )
             }


### PR DESCRIPTION
Fixes #2900.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>