### PR TITLE
chore(build.gradle): Explicitly disable standard streams in tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -311,6 +311,7 @@ subprojects {
         testLogging {
             events = setOf(TestLogEvent.STARTED, TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
             exceptionFormat = TestExceptionFormat.FULL
+            showStandardStreams = false
         }
 
         useJUnitPlatform()


### PR DESCRIPTION
The change is non-functional as the default value is `false`. However, it simplifies enabling the streams during development.


