### PR TITLE
OrtMainFunTest: Inline a variable

### DIFF
--- a/cli/src/funTest/kotlin/OrtMainFunTest.kt
+++ b/cli/src/funTest/kotlin/OrtMainFunTest.kt
@@ -214,10 +214,9 @@ class OrtMainFunTest : StringSpec() {
                 "-o", outputDir.path
             )
 
-            val analyzerResult = outputDir.resolve("analyzer-result.yml").readValue<OrtResult>()
-            val resolvedResult = analyzerResult.withResolvedScopes()
+            val ortResult = outputDir.resolve("analyzer-result.yml").readValue<OrtResult>().withResolvedScopes()
 
-            patchActualResult(resolvedResult, patchStartAndEndTime = true) shouldBe expectedResult
+            patchActualResult(ortResult, patchStartAndEndTime = true) shouldBe expectedResult
         }
 
         "Passing mutually exclusive evaluator options fails" {


### PR DESCRIPTION
Also rename the result variable to fit the code to a single line and for consistency with other test cases in this file.

