### PR TITLE
fix(Unmanaged): Fix ID generation for unmanaged projects

### DIFF
--- a/analyzer/src/main/kotlin/managers/Unmanaged.kt
+++ b/analyzer/src/main/kotlin/managers/Unmanaged.kt
@@ -20,7 +20,6 @@
 package org.ossreviewtoolkit.analyzer.managers
 
 import java.io.File
-import java.net.URI
 
 import org.apache.logging.log4j.kotlin.Logging
 
@@ -102,12 +101,10 @@ class Unmanaged(
 
             else -> {
                 // For all non-GitRepo VCSes derive the name from the VCS URL.
-                val fileUrl = File(vcsInfo.url).takeIf { it.exists() } ?: File(URI(vcsInfo.url))
-
                 Identifier(
                     type = managerName,
                     namespace = "",
-                    name = fileUrl.name.removeSuffix(".git"),
+                    name = vcsInfo.url.split('/').last().removeSuffix(".git"),
                     version = vcsInfo.revision
                 )
             }


### PR DESCRIPTION
This is a fix for 07c8633a in #6402 which changed the way the name for unmanaged projects was generated. This approach threw an IllegalArgumentException for all VCS URLs not of type file://. To fix this, obtain the project name from the path of the VCS URI.

I could successfully test the new way to obtain the project name in our setup; however, I am not sure how this looks like under Windows.