### PR TITLE
Fix an issue with CuratedPackage.toUncuratedPackage()

### DIFF
--- a/cli/src/main/kotlin/commands/UploadResultToSw360Command.kt
+++ b/cli/src/main/kotlin/commands/UploadResultToSw360Command.kt
@@ -194,7 +194,7 @@ class UploadResultToSw360Command : OrtCommand(
         ortResult.getProjects(omitExcluded = true).associateWith { project ->
             // Upload the uncurated packages because SW360 also is a package curation provider.
             ortResult.dependencyNavigator.projectDependencies(project)
-                .mapNotNull { ortResult.getUncuratedPackageById(it) }
+                .mapNotNull { ortResult.getUncuratedPackageOrProject(it) }
         }
 
     private fun createReleaseName(pkgId: Identifier) =

--- a/evaluator/src/main/kotlin/PackageRule.kt
+++ b/evaluator/src/main/kotlin/PackageRule.kt
@@ -52,7 +52,7 @@ open class PackageRule(
     private val licenseRules = mutableListOf<LicenseRule>()
 
     @Suppress("UNUSED") // This is intended to be used by rule implementations.
-    val uncuratedPkg by lazy { pkg.toUncuratedPackage() }
+    val uncuratedPkg by lazy { ruleSet.ortResult.getUncuratedPackageById(pkg.metadata.id) }
 
     override val description = "Evaluating rule '$name' for package '${pkg.metadata.id.toCoordinates()}'."
 

--- a/evaluator/src/main/kotlin/PackageRule.kt
+++ b/evaluator/src/main/kotlin/PackageRule.kt
@@ -52,7 +52,7 @@ open class PackageRule(
     private val licenseRules = mutableListOf<LicenseRule>()
 
     @Suppress("UNUSED") // This is intended to be used by rule implementations.
-    val uncuratedPkg by lazy { ruleSet.ortResult.getUncuratedPackageById(pkg.metadata.id) }
+    val uncuratedPkg by lazy { ruleSet.ortResult.getUncuratedPackageOrProject(pkg.metadata.id) }
 
     override val description = "Evaluating rule '$name' for package '${pkg.metadata.id.toCoordinates()}'."
 

--- a/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListLicensesCommand.kt
@@ -39,7 +39,6 @@ import org.ossreviewtoolkit.helper.utils.PackageConfigurationOption
 import org.ossreviewtoolkit.helper.utils.createProvider
 import org.ossreviewtoolkit.helper.utils.fetchScannedSources
 import org.ossreviewtoolkit.helper.utils.getLicenseFindingsById
-import org.ossreviewtoolkit.helper.utils.getPackageOrProject
 import org.ossreviewtoolkit.helper.utils.getViolatedRulesByLicense
 import org.ossreviewtoolkit.helper.utils.readOrtResult
 import org.ossreviewtoolkit.helper.utils.replaceConfig

--- a/helper-cli/src/main/kotlin/utils/Extensions.kt
+++ b/helper-cli/src/main/kotlin/utils/Extensions.kt
@@ -231,12 +231,6 @@ internal fun OrtResult.getViolatedRulesByLicense(
         .mapValues { (_, ruleViolations) -> ruleViolations.map { it.rule } }
 
 /**
- * Return the Package with the given [id] denoting either a [Project] or a [Package].
- */
-internal fun OrtResult.getPackageOrProject(id: Identifier): Package? =
-    getProject(id)?.toPackage() ?: getPackage(id)?.metadata
-
-/**
  * Return the [Provenance] of the first scan result matching the given [id] or null if there is no match.
  */
 internal fun OrtResult.getProvenance(id: Identifier): Provenance? = getScanResultsForId(id).firstOrNull()?.provenance

--- a/helper-cli/src/main/kotlin/utils/Extensions.kt
+++ b/helper-cli/src/main/kotlin/utils/Extensions.kt
@@ -102,7 +102,7 @@ internal fun List<ScopeExclude>.minimize(projectScopes: List<String>): List<Scop
 internal fun OrtResult.fetchScannedSources(id: Identifier): File {
     val tempDir = createTempDirectory(Paths.get("."), ORTH_NAME).toFile()
 
-    val pkg = getPackageOrProject(id)!!.let {
+    val pkg = getPackageOrProject(id)!!.metadata.let {
         if (getProvenance(id) is ArtifactProvenance) {
             it.copy(vcs = VcsInfo.EMPTY, vcsProcessed = VcsInfo.EMPTY)
         } else {

--- a/model/src/main/kotlin/CuratedPackage.kt
+++ b/model/src/main/kotlin/CuratedPackage.kt
@@ -21,7 +21,6 @@ package org.ossreviewtoolkit.model
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 
-import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
 /**
@@ -39,23 +38,6 @@ data class CuratedPackage(
      */
     val curations: List<PackageCurationResult> = emptyList()
 ) {
-    /**
-     * Return a [Package] representing the same package as this one but which does not have any curations applied.
-     */
-    fun toUncuratedPackage() =
-        curations.reversed().fold(this) { current, curation ->
-            curation.base.apply(current)
-        }.metadata.copy(
-            // The declared license mapping cannot be reversed as it is additive.
-            declaredLicensesProcessed = DeclaredLicenseProcessor.process(metadata.declaredLicenses),
-
-            // It is not possible to derive the original concluded license value with the above reversed application
-            // of the base curations, even if the function Package.diff() was extended to handle the concluded license,
-            // see also https://github.com/oss-review-toolkit/ort/issues/5637. Until this is fixed just set the
-            // concluded license to null, because an un-curated package cannot have a non-null concluded license.
-            concludedLicense = null
-        )
-
     @JsonIgnore
     fun getDeclaredLicenseMapping(): Map<String, SpdxExpression> =
         buildMap {

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -338,6 +338,12 @@ data class OrtResult(
     fun getPackage(id: Identifier): CuratedPackage? = packages[id]?.curatedPackage
 
     /**
+     * Return the Package with the given [id] denoting either a [Project] or a [Package].
+     */
+    fun getPackageOrProject(id: Identifier): Package? =
+        getProject(id)?.toPackage() ?: getPackage(id)?.metadata
+
+    /**
      * Return all [Package]s contained in this [OrtResult] or only the non-excluded ones if [omitExcluded] is true.
      */
     @JsonIgnore

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -518,7 +518,10 @@ data class OrtResult(
         }
 }
 
-private fun applyPackageCurations(packages: Set<Package>, curations: List<PackageCuration>): Set<CuratedPackage> {
+private fun applyPackageCurations(
+    packages: Collection<Package>,
+    curations: List<PackageCuration>
+): Set<CuratedPackage> {
     val curationsForId = packages.associateBy(
         keySelector = { pkg -> pkg.id },
         valueTransform = { pkg ->

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -341,7 +341,7 @@ data class OrtResult(
      * Return the Package with the given [id] denoting either a [Project] or a [Package].
      */
     fun getPackageOrProject(id: Identifier): CuratedPackage? =
-        getProject(id)?.toPackage()?.toCuratedPackage() ?: getPackage(id)
+        getPackage(id) ?: getProject(id)?.toPackage()?.toCuratedPackage()
 
     /**
      * Return all [Package]s contained in this [OrtResult] or only the non-excluded ones if [omitExcluded] is true.

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -235,7 +235,7 @@ data class OrtResult(
         return vendorPackages
     }
 
-    fun getUncuratedPackageById(id: Identifier): Package? =
+    fun getUncuratedPackageOrProject(id: Identifier): Package? =
         packages[id]?.pkg ?: getProject(id)?.toPackage()
 
     /**

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -340,8 +340,8 @@ data class OrtResult(
     /**
      * Return the Package with the given [id] denoting either a [Project] or a [Package].
      */
-    fun getPackageOrProject(id: Identifier): Package? =
-        getProject(id)?.toPackage() ?: getPackage(id)?.metadata
+    fun getPackageOrProject(id: Identifier): CuratedPackage? =
+        getProject(id)?.toPackage()?.toCuratedPackage() ?: getPackage(id)
 
     /**
      * Return all [Package]s contained in this [OrtResult] or only the non-excluded ones if [omitExcluded] is true.


### PR DESCRIPTION
Get rid of the "not always correctly working" [1] `toUncuratedPackage()` by utilizing the original uncurated packages from the `OrtResult`. While at it, do a couple of clean-ups for related `OrtResult` getters and their callers.

[1] https://github.com/oss-review-toolkit/ort/issues/5637.

BREAKING CHANGE: Only for programmatic use of ORT:
1. uncurated packages should be obtained now from the `OrtResult` instead of from the removed `toUncuratedPackage()`.
2. Some API functions get renamed, so the name change must be reflected.