### PR TITLE
Rename `OrtIssue` to `Issue`

### DIFF
--- a/advisor/src/main/kotlin/advisors/GitHubDefects.kt
+++ b/advisor/src/main/kotlin/advisors/GitHubDefects.kt
@@ -185,7 +185,7 @@ class GitHubDefects(name: String, gitHubConfiguration: GitHubDefectsConfiguratio
         logger.debug { "Found ${gitHubIssues.size} issues for package '${pkg.original.id.toCoordinates()}'." }
 
         val defects = if (ortIssues.isEmpty()) {
-            issuesForRelease(pkg, gitHubIssues.applyLabelFilters(), releases, ortIssues).also {
+            createIssuesForReleases(pkg, gitHubIssues.applyLabelFilters(), releases, ortIssues).also {
                 logger.debug { "Found ${it.size} defects for package '${pkg.original.id.toCoordinates()}'." }
             }
         } else {
@@ -207,7 +207,7 @@ class GitHubDefects(name: String, gitHubConfiguration: GitHubDefectsConfiguratio
      * Filter the list of [gitHubIssues] for defects affecting the version of the given [package][pkg]. Use [releases]
      * for the version match. Add an entry to [issues] if the release for the package cannot be determined.
      */
-    private fun issuesForRelease(
+    private fun createIssuesForReleases(
         pkg: GitHubPackage,
         gitHubIssues: List<GitHubIssue>,
         releases: List<Release>,

--- a/advisor/src/main/kotlin/advisors/GitHubDefects.kt
+++ b/advisor/src/main/kotlin/advisors/GitHubDefects.kt
@@ -205,17 +205,17 @@ class GitHubDefects(name: String, gitHubConfiguration: GitHubDefectsConfiguratio
 
     /**
      * Filter the list of [gitHubIssues] for defects affecting the version of the given [package][pkg]. Use [releases]
-     * for the version match. Add an entry to [ortIssues] if the release for the package cannot be determined.
+     * for the version match. Add an entry to [issues] if the release for the package cannot be determined.
      */
     private fun issuesForRelease(
         pkg: GitHubPackage,
         gitHubIssues: List<GitHubIssue>,
         releases: List<Release>,
-        ortIssues: MutableList<Issue>
+        issues: MutableList<Issue>
     ): List<Defect> {
         val releaseDate = findReleaseFor(pkg.original, releases)?.publishedAt?.let(Instant::parse)
             ?: Instant.now().also {
-                ortIssues += createAndLogIssue(
+                issues += createAndLogIssue(
                     providerName,
                     "Could not determine release date for package '${pkg.original.id.toCoordinates()}'.",
                     Severity.HINT

--- a/advisor/src/main/kotlin/advisors/GitHubDefects.kt
+++ b/advisor/src/main/kotlin/advisors/GitHubDefects.kt
@@ -177,15 +177,15 @@ class GitHubDefects(name: String, gitHubConfiguration: GitHubDefectsConfiguratio
 
         logger.debug { "Found ${releases.size} releases for package '${pkg.original.id.toCoordinates()}'." }
 
-        val issues = handleError(
+        val gitHubIssues = handleError(
             fetchAll(maxDefects) { service.repositoryIssues(pkg.repoOwner, pkg.repoName, it) },
             "issues"
         )
 
-        logger.debug { "Found ${issues.size} issues for package '${pkg.original.id.toCoordinates()}'." }
+        logger.debug { "Found ${gitHubIssues.size} issues for package '${pkg.original.id.toCoordinates()}'." }
 
         val defects = if (ortIssues.isEmpty()) {
-            issuesForRelease(pkg, issues.applyLabelFilters(), releases, ortIssues).also {
+            issuesForRelease(pkg, gitHubIssues.applyLabelFilters(), releases, ortIssues).also {
                 logger.debug { "Found ${it.size} defects for package '${pkg.original.id.toCoordinates()}'." }
             }
         } else {
@@ -204,12 +204,12 @@ class GitHubDefects(name: String, gitHubConfiguration: GitHubDefectsConfiguratio
     }
 
     /**
-     * Filter the list of [issues] for defects affecting the version of the given [package][pkg]. Use [releases] for
-     * the version match. Add an entry to [ortIssues] if the release for the package cannot be determined.
+     * Filter the list of [gitHubIssues] for defects affecting the version of the given [package][pkg]. Use [releases]
+     * for the version match. Add an entry to [ortIssues] if the release for the package cannot be determined.
      */
     private fun issuesForRelease(
         pkg: GitHubPackage,
-        issues: List<GitHubIssue>,
+        gitHubIssues: List<GitHubIssue>,
         releases: List<Release>,
         ortIssues: MutableList<OrtIssue>
     ): List<Defect> {
@@ -223,7 +223,7 @@ class GitHubDefects(name: String, gitHubConfiguration: GitHubDefectsConfiguratio
             }
 
         logger.debug { "Assuming release date $releaseDate for package '${pkg.original.id.toCoordinates()}'." }
-        return issues.filter { it.closedAfter(releaseDate) }.map { it.toDefect(releases) }
+        return gitHubIssues.filter { it.closedAfter(releaseDate) }.map { it.toDefect(releases) }
     }
 
     /**

--- a/advisor/src/main/kotlin/advisors/GitHubDefects.kt
+++ b/advisor/src/main/kotlin/advisors/GitHubDefects.kt
@@ -39,7 +39,7 @@ import org.ossreviewtoolkit.clients.github.DateTime
 import org.ossreviewtoolkit.clients.github.GitHubService
 import org.ossreviewtoolkit.clients.github.Paging
 import org.ossreviewtoolkit.clients.github.QueryResult
-import org.ossreviewtoolkit.clients.github.issuesquery.Issue
+import org.ossreviewtoolkit.clients.github.issuesquery.Issue as GitHubIssue
 import org.ossreviewtoolkit.clients.github.labels
 import org.ossreviewtoolkit.clients.github.releasesquery.Release
 import org.ossreviewtoolkit.model.AdvisorCapability
@@ -209,7 +209,7 @@ class GitHubDefects(name: String, gitHubConfiguration: GitHubDefectsConfiguratio
      */
     private fun issuesForRelease(
         pkg: GitHubPackage,
-        issues: List<Issue>,
+        issues: List<GitHubIssue>,
         releases: List<Release>,
         ortIssues: MutableList<OrtIssue>
     ): List<Defect> {
@@ -229,7 +229,7 @@ class GitHubDefects(name: String, gitHubConfiguration: GitHubDefectsConfiguratio
     /**
      * Return a filtered list of [Issue]s according to the label filters defined in the configuration.
      */
-    private fun List<Issue>.applyLabelFilters(): List<Issue> = filter { issue ->
+    private fun List<GitHubIssue>.applyLabelFilters(): List<GitHubIssue> = filter { issue ->
         val labels = issue.labels()
         labelFilters.find { it.matches(labels) }?.including ?: false
     }
@@ -301,7 +301,7 @@ private val REGEX_FILTER_WILDCARDS = "(?<=[*])|(?=[*])".toRegex()
 /**
  * Convert this [Issue] to a [Defect], using [releases] to determine the fix release.
  */
-private fun Issue.toDefect(releases: List<Release>): Defect =
+private fun GitHubIssue.toDefect(releases: List<Release>): Defect =
     Defect(
         id = url.substringAfterLast('/'),
         url = URI(url),
@@ -319,7 +319,7 @@ private fun Issue.toDefect(releases: List<Release>): Defect =
  * Return a flag whether this issue was closed after the given [time]. This is used to compare the time when an issue
  * was closed with a release date to find the issues affecting a release.
  */
-private fun Issue.closedAfter(time: Instant): Boolean =
+private fun GitHubIssue.closedAfter(time: Instant): Boolean =
     !closed || closedAt == null || Instant.parse(closedAt).isAfter(time)
 
 /**

--- a/advisor/src/main/kotlin/advisors/GitHubDefects.kt
+++ b/advisor/src/main/kotlin/advisors/GitHubDefects.kt
@@ -47,7 +47,7 @@ import org.ossreviewtoolkit.model.AdvisorDetails
 import org.ossreviewtoolkit.model.AdvisorResult
 import org.ossreviewtoolkit.model.AdvisorSummary
 import org.ossreviewtoolkit.model.Defect
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
@@ -156,7 +156,7 @@ class GitHubDefects(name: String, gitHubConfiguration: GitHubDefectsConfiguratio
         logger.info { "Finding defects for package '${pkg.original.id.toCoordinates()}'." }
 
         val startTime = Instant.now()
-        val ortIssues = mutableListOf<OrtIssue>()
+        val ortIssues = mutableListOf<Issue>()
 
         fun <T> handleError(result: Result<List<T>>, itemType: String): List<T> =
             result.onFailure { exception ->
@@ -211,7 +211,7 @@ class GitHubDefects(name: String, gitHubConfiguration: GitHubDefectsConfiguratio
         pkg: GitHubPackage,
         gitHubIssues: List<GitHubIssue>,
         releases: List<Release>,
-        ortIssues: MutableList<OrtIssue>
+        ortIssues: MutableList<Issue>
     ): List<Defect> {
         val releaseDate = findReleaseFor(pkg.original, releases)?.publishedAt?.let(Instant::parse)
             ?: Instant.now().also {

--- a/advisor/src/test/kotlin/advisors/GitHubDefectsTest.kt
+++ b/advisor/src/test/kotlin/advisors/GitHubDefectsTest.kt
@@ -130,7 +130,7 @@ class GitHubDefectsTest : WordSpec({
             )
         }
 
-        "create an OrtIssue for a package if the release cannot be matched" {
+        "create an Issue for a package if the release cannot be matched" {
             val pkg = createPackage()
             val issues = listOf(createIssue(index = 1, closedTime = time(2, 2)))
 

--- a/analyzer/src/main/kotlin/AnalyzerResultBuilder.kt
+++ b/analyzer/src/main/kotlin/AnalyzerResultBuilder.kt
@@ -26,7 +26,7 @@ import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.DependencyGraph
 import org.ossreviewtoolkit.model.DependencyGraphNavigator
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
@@ -40,7 +40,7 @@ class AnalyzerResultBuilder {
 
     private val projects = mutableSetOf<Project>()
     private val packages = mutableSetOf<Package>()
-    private val issues = mutableMapOf<Identifier, List<OrtIssue>>()
+    private val issues = mutableMapOf<Identifier, List<Issue>>()
     private val dependencyGraphs = mutableMapOf<String, DependencyGraph>()
 
     fun build(): AnalyzerResult {

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -42,7 +42,7 @@ import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageReference
 import org.ossreviewtoolkit.model.Project
@@ -200,7 +200,7 @@ class Bundler(
         requireLockfile(workingDir) { workingDir.resolve(BUNDLER_LOCKFILE_NAME).isFile }
 
         val scopes = mutableSetOf<Scope>()
-        val issues = mutableListOf<OrtIssue>()
+        val issues = mutableListOf<Issue>()
 
         val gemSpecs = resolveGemsMetadata(workingDir)
 
@@ -236,7 +236,7 @@ class Bundler(
 
     private fun parseScope(
         workingDir: File, projectId: Identifier, groupName: String, dependencyList: List<String>,
-        scopes: MutableSet<Scope>, gemSpecs: MutableMap<String, GemSpec>, issues: MutableList<OrtIssue>
+        scopes: MutableSet<Scope>, gemSpecs: MutableMap<String, GemSpec>, issues: MutableList<Issue>
     ) {
         logger.debug {
             "Parsing scope '$groupName' with top-level dependencies $dependencyList for project " +
@@ -254,7 +254,7 @@ class Bundler(
 
     private fun parseDependency(
         workingDir: File, projectId: Identifier, gemName: String, gemSpecs: MutableMap<String, GemSpec>,
-        scopeDependencies: MutableSet<PackageReference>, issues: MutableList<OrtIssue>
+        scopeDependencies: MutableSet<PackageReference>, issues: MutableList<Issue>
     ) {
         logger.debug { "Parsing dependency '$gemName'." }
 

--- a/analyzer/src/main/kotlin/managers/CocoaPods.kt
+++ b/analyzer/src/main/kotlin/managers/CocoaPods.kt
@@ -37,7 +37,7 @@ import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageReference
 import org.ossreviewtoolkit.model.Project
@@ -134,7 +134,7 @@ class CocoaPods(
 
         val scopes = sortedSetOf<Scope>()
         val packages = mutableSetOf<Package>()
-        val issues = mutableListOf<OrtIssue>()
+        val issues = mutableListOf<Issue>()
 
         if (lockfile.isFile) {
             val dependencies = getPackageReferences(lockfile)

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.analyzer.managers.utils.normalizeModuleVersion
 import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.PackageReference
@@ -118,7 +118,7 @@ class GoDep(
             val revision = project.getValue("revision")
             val version = project.getValue("version")
 
-            val issues = mutableListOf<OrtIssue>()
+            val issues = mutableListOf<Issue>()
 
             val vcsProcessed = try {
                 resolveVcsInfo(name, revision, gopath)

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -46,7 +46,7 @@ import org.ossreviewtoolkit.analyzer.managers.utils.identifier
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.DependencyGraph
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.Severity
@@ -266,7 +266,7 @@ class Gradle(
                     scopeNames = graphBuilder.scopesFor(projectId)
                 )
 
-                val issues = mutableListOf<OrtIssue>()
+                val issues = mutableListOf<Issue>()
 
                 dependencyTreeModel.errors.mapTo(issues) {
                     createAndLogIssue(source = managerName, message = it, severity = Severity.ERROR)

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -54,7 +54,7 @@ import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.DependencyGraph
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
@@ -581,14 +581,14 @@ open class Npm(
     /**
      * Install dependencies using the given package manager command.
      */
-    private fun installDependencies(workingDir: File): List<OrtIssue> {
+    private fun installDependencies(workingDir: File): List<Issue> {
         requireLockfile(workingDir) { hasLockFile(workingDir) }
 
         // Install all NPM dependencies to enable NPM to list dependencies.
         val process = runInstall(workingDir)
 
         val lines = process.stderr.lines()
-        val issues = mutableListOf<OrtIssue>()
+        val issues = mutableListOf<Issue>()
         val commonSecondaryPrefixes = listOf(
             "JSON.parse ",
             "deprecated ",
@@ -605,7 +605,7 @@ open class Npm(
                 }
 
             if (issueLines.isNotEmpty()) {
-                issues += OrtIssue(
+                issues += Issue(
                     source = managerName,
                     message = issueLines.joinToString("\n"),
                     severity = severity

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -596,7 +596,7 @@ open class Npm(
             "old lockfile "
         )
 
-        fun mapLinesToOrtIssues(prefix: String, severity: Severity) {
+        fun mapLinesToIssues(prefix: String, severity: Severity) {
             val issueLines = lines.dropWhile { !it.startsWith(prefix) }
                 .takeWhile { it.startsWith(prefix) }.mapNotNull { line ->
                     line.removePrefix(prefix).let {
@@ -613,8 +613,8 @@ open class Npm(
             }
         }
 
-        mapLinesToOrtIssues("npm WARN ", Severity.WARNING)
-        mapLinesToOrtIssues("npm ERR! ", Severity.ERROR)
+        mapLinesToIssues("npm WARN ", Severity.WARNING)
+        mapLinesToIssues("npm ERR! ", Severity.ERROR)
 
         return issues
     }

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -39,7 +39,7 @@ import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.EMPTY_JSON_NODE
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.PackageReference
@@ -114,7 +114,7 @@ class Pub(
 
     private data class ParsePackagesResult(
         val packages: Map<Identifier, Package>,
-        val issues: List<OrtIssue>
+        val issues: List<Issue>
     )
 
     private val reader = PubCacheReader()
@@ -220,7 +220,7 @@ class Pub(
 
         val packages = mutableMapOf<Identifier, Package>()
         val scopes = sortedSetOf<Scope>()
-        val issues = mutableListOf<OrtIssue>()
+        val issues = mutableListOf<Issue>()
         val projectAnalyzerResults = mutableListOf<ProjectAnalyzerResult>()
 
         if (hasDependencies) {
@@ -461,7 +461,7 @@ class Pub(
         logger.info { "Parsing installed Pub packages..." }
 
         val packages = mutableMapOf<Identifier, Package>()
-        val issues = mutableListOf<OrtIssue>()
+        val issues = mutableListOf<Issue>()
 
         // Flag if the project is a flutter project.
         var containsFlutter = false

--- a/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
+++ b/analyzer/src/main/kotlin/managers/SpdxDocumentFile.kt
@@ -35,7 +35,7 @@ import org.ossreviewtoolkit.analyzer.managers.utils.SpdxResolvedDocument
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.PackageReference
@@ -337,7 +337,7 @@ class SpdxDocumentFile(
         packages: MutableSet<Package>
     ): SortedSet<PackageReference> =
         getDependencies(pkgId, doc, packages, SpdxRelationship.Type.DEPENDENCY_OF) { target ->
-            val issues = mutableListOf<OrtIssue>()
+            val issues = mutableListOf<Issue>()
             getPackageManagerDependency(target, doc) ?: doc.getSpdxPackageForId(target, issues)?.let { dependency ->
                 packages += dependency.toPackage(doc.getDefinitionFile(target), doc)
 
@@ -392,7 +392,7 @@ class SpdxDocumentFile(
         dependsOnCase: (String) -> PackageReference? = { null }
     ): SortedSet<PackageReference> =
         doc.relationships.mapNotNullTo(sortedSetOf()) { (source, relation, target, _) ->
-            val issues = mutableListOf<OrtIssue>()
+            val issues = mutableListOf<Issue>()
 
             val isDependsOnRelation = relation == SpdxRelationship.Type.DEPENDS_ON || hasDefaultScopeLinkage(
                 source, target, relation, doc.relationships

--- a/analyzer/src/main/kotlin/managers/Yarn2.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn2.kt
@@ -48,7 +48,7 @@ import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.DependencyGraph
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.Project
@@ -148,7 +148,7 @@ class Yarn2(
     private val allProjects = mutableMapOf<Identifier, Project>()
 
     // The issues that have been found when resolving the dependencies.
-    private val issues = mutableListOf<OrtIssue>()
+    private val issues = mutableListOf<Issue>()
 
     override fun command(workingDir: File?): String {
         if (workingDir == null) return ""
@@ -718,7 +718,7 @@ class Yarn2(
         override fun linkageFor(dependency: YarnModuleInfo): PackageLinkage =
             if (dependency.pkg == null) PackageLinkage.PROJECT_DYNAMIC else PackageLinkage.DYNAMIC
 
-        override fun createPackage(dependency: YarnModuleInfo, issues: MutableList<OrtIssue>): Package? = dependency.pkg
+        override fun createPackage(dependency: YarnModuleInfo, issues: MutableList<Issue>): Package? = dependency.pkg
     }
 
     /**

--- a/analyzer/src/main/kotlin/managers/utils/GradleDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/utils/GradleDependencyHandler.kt
@@ -29,7 +29,7 @@ import org.eclipse.aether.artifact.DefaultArtifact
 import org.eclipse.aether.repository.RemoteRepository
 
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.Severity
@@ -67,7 +67,7 @@ class GradleDependencyHandler(
 
     override fun dependenciesFor(dependency: Dependency): Collection<Dependency> = dependency.dependencies
 
-    override fun issuesForDependency(dependency: Dependency): Collection<OrtIssue> =
+    override fun issuesForDependency(dependency: Dependency): Collection<Issue> =
         listOfNotNull(
             dependency.error?.let {
                 createAndLogIssue(
@@ -89,7 +89,7 @@ class GradleDependencyHandler(
     override fun linkageFor(dependency: Dependency): PackageLinkage =
         if (dependency.isProjectDependency()) PackageLinkage.PROJECT_DYNAMIC else PackageLinkage.DYNAMIC
 
-    override fun createPackage(dependency: Dependency, issues: MutableList<OrtIssue>): Package? {
+    override fun createPackage(dependency: Dependency, issues: MutableList<Issue>): Package? {
         // Only look for a package if there was no error resolving the dependency and it is no project dependency.
         if (dependency.error != null || dependency.isProjectDependency()) return null
 

--- a/analyzer/src/main/kotlin/managers/utils/MavenDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/utils/MavenDependencyHandler.kt
@@ -26,7 +26,7 @@ import org.eclipse.aether.graph.DependencyNode
 
 import org.ossreviewtoolkit.analyzer.managers.Maven
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.createAndLogIssue
@@ -90,7 +90,7 @@ class MavenDependencyHandler(
      * Create a [Package] representing a [dependency] if possible, recording any [issues]. Inter-project
      * dependencies are skipped.
      */
-    override fun createPackage(dependency: DependencyNode, issues: MutableList<OrtIssue>): Package? {
+    override fun createPackage(dependency: DependencyNode, issues: MutableList<Issue>): Package? {
         if (isLocalProject(dependency)) return null
 
         return runCatching {

--- a/analyzer/src/main/kotlin/managers/utils/NpmDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NpmDependencyHandler.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.runBlocking
 
 import org.ossreviewtoolkit.analyzer.managers.Npm
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.utils.DependencyHandler
@@ -80,7 +80,7 @@ class NpmDependencyHandler(private val npm: Npm) : DependencyHandler<NpmModuleIn
 
     override fun linkageFor(dependency: NpmModuleInfo): PackageLinkage = PackageLinkage.DYNAMIC
 
-    override fun createPackage(dependency: NpmModuleInfo, issues: MutableList<OrtIssue>): Package =
+    override fun createPackage(dependency: NpmModuleInfo, issues: MutableList<Issue>): Package =
         runBlocking {
             npm.parsePackage(dependency.workingDir, dependency.packageFile).second
         }

--- a/analyzer/src/main/kotlin/managers/utils/NpmSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NpmSupport.kt
@@ -366,7 +366,7 @@ fun parseNpmLicenses(json: JsonNode): Set<String> {
             declaredLicense == "UNLICENSED" -> SpdxConstants.NONE
 
             // NPM allows declaring non-SPDX licenses only by referencing a license file. Avoid reporting an
-            // [OrtIssue] by mapping this to a valid license identifier.
+            // [Issue] by mapping this to a valid license identifier.
             declaredLicense.startsWith("SEE LICENSE IN ") -> SpdxConstants.NOASSERTION
 
             else -> declaredLicense.takeUnless { it.isBlank() }

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -44,7 +44,7 @@ import org.ossreviewtoolkit.analyzer.PackageManager.Companion.processPackageVcs
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageReference
 import org.ossreviewtoolkit.model.Project
@@ -125,8 +125,8 @@ class NuGetSupport(
     private fun getAllPackageData(
         directDependencies: Collection<Identifier>,
         registrationsBaseUrls: Collection<String>,
-    ): Pair<Map<Identifier, AllPackageData>, Set<OrtIssue>> {
-        val issues = mutableSetOf<OrtIssue>()
+    ): Pair<Map<Identifier, AllPackageData>, Set<Issue>> {
+        val issues = mutableSetOf<Issue>()
         val result = mutableMapOf<Identifier, AllPackageData>()
         val queue = LinkedList(directDependencies)
 

--- a/analyzer/src/main/kotlin/managers/utils/PackageManagerDependencyHandler.kt
+++ b/analyzer/src/main/kotlin/managers/utils/PackageManagerDependencyHandler.kt
@@ -30,7 +30,7 @@ import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.DependencyGraphNavigator
 import org.ossreviewtoolkit.model.DependencyNode
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.PackageReference
@@ -80,7 +80,7 @@ class PackageManagerDependencyHandler(
 
     private val navigator = DependencyGraphNavigator(analyzerResult.dependencyGraphs)
 
-    override fun createPackage(dependency: ResolvableDependencyNode, issues: MutableList<OrtIssue>): Package? =
+    override fun createPackage(dependency: ResolvableDependencyNode, issues: MutableList<Issue>): Package? =
         analyzerResult.packages.find { it.id == dependency.id }
 
     override fun dependenciesFor(dependency: ResolvableDependencyNode): Collection<ResolvableDependencyNode> =
@@ -94,7 +94,7 @@ class PackageManagerDependencyHandler(
 
     override fun identifierFor(dependency: ResolvableDependencyNode): Identifier = dependency.id
 
-    override fun issuesForDependency(dependency: ResolvableDependencyNode): Collection<OrtIssue> = dependency.issues
+    override fun issuesForDependency(dependency: ResolvableDependencyNode): Collection<Issue> = dependency.issues
 
     override fun linkageFor(dependency: ResolvableDependencyNode): PackageLinkage = dependency.linkage
 
@@ -164,7 +164,7 @@ sealed class ResolvableDependencyNode : DependencyNode
 class ProjectScopeDependencyNode(
     override val id: Identifier,
     override val linkage: PackageLinkage,
-    override val issues: List<OrtIssue>,
+    override val issues: List<Issue>,
     private val dependencies: Sequence<DependencyNode>
 ) : ResolvableDependencyNode() {
     override fun <T> visitDependencies(block: (Sequence<DependencyNode>) -> T): T = block(dependencies)

--- a/analyzer/src/main/kotlin/managers/utils/SpdxResolvedDocument.kt
+++ b/analyzer/src/main/kotlin/managers/utils/SpdxResolvedDocument.kt
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.kotlin.Logging
 
 import org.ossreviewtoolkit.analyzer.managers.SpdxDocumentFile
 import org.ossreviewtoolkit.model.Hash
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.utils.common.collectMessages
@@ -57,7 +57,7 @@ internal data class SpdxResolvedDocument(
 
     /**
      * The name of the package manager that uses this document. This is mainly used to fill the source in generated
-     * [OrtIssue]s.
+     * [Issue]s.
      */
     val managerName: String,
 
@@ -84,14 +84,14 @@ internal data class SpdxResolvedDocument(
      * A map storing issues that were encountered when resolving external document references. These issues are also
      * assigned to [SpdxPackage]s defined in the corresponding external documents.
      */
-    private val issuesByReferenceId: Map<String, OrtIssue>
+    private val issuesByReferenceId: Map<String, Issue>
 ) {
     companion object : Logging {
         fun load(cache: SpdxDocumentCache, rootDocumentFile: File, managerName: String): SpdxResolvedDocument {
             val rootDocument = cache.load(rootDocumentFile).getOrThrow()
 
             val references = mutableMapOf<SpdxExternalDocumentReference, ResolvedSpdxDocument>()
-            val issues = mutableMapOf<String, OrtIssue>()
+            val issues = mutableMapOf<String, Issue>()
             resolveAllReferences(
                 cache,
                 managerName,
@@ -117,7 +117,7 @@ internal data class SpdxResolvedDocument(
      * Get the [SpdxPackage] for the given [identifier] by resolving against packages or external document references
      * contained in this document. If the package cannot be resolved, add an issue to [issues].
      */
-    fun getSpdxPackageForId(identifier: String, issues: MutableList<OrtIssue>): SpdxPackage? {
+    fun getSpdxPackageForId(identifier: String, issues: MutableList<Issue>): SpdxPackage? {
         val pkg = packagesById[identifier]
         val issue = issuesByReferenceId[identifier.substringBefore(':', "")]
 
@@ -178,7 +178,7 @@ private fun resolveAllReferences(
     document: SpdxDocument,
     baseUri: URI,
     references: MutableMap<SpdxExternalDocumentReference, ResolvedSpdxDocument>,
-    issues: MutableMap<String, OrtIssue>,
+    issues: MutableMap<String, Issue>,
     knownUris: MutableSet<URI>
 ) {
     document.resolveReferences(cache, baseUri, managerName).forEach { (ref, resolvedDoc) ->
@@ -229,7 +229,7 @@ private fun collectAndQualifyRelations(
 
 /**
  * A data class to hold the result of an operation to resolve an [SpdxDocument] from an external reference. Resolving
- * of the document may fail, then the document is *null*, and a corresponding [OrtIssue] is present.
+ * of the document may fail, then the document is *null*, and a corresponding [Issue] is present.
  */
 internal data class ResolutionResult(
     /**
@@ -244,7 +244,7 @@ internal data class ResolutionResult(
      * An issue that occurred while resolving the document. If the document could not be resolved, this gives details
      * about the underlying error. It could also be a warning.
      */
-    val issue: OrtIssue?
+    val issue: Issue?
 )
 
 /**
@@ -291,7 +291,7 @@ internal fun SpdxExternalDocumentReference.resolve(
 
 /**
  * Resolve this [SpdxExternalDocumentReference] from [uri] if it points to a file on the local file system. Use
- * [cache] to load the file. In case of a failure, create an [OrtIssue] whose message includes [baseUri], and
+ * [cache] to load the file. In case of a failure, create an [Issue] whose message includes [baseUri], and
  * [managerName].
  */
 private fun SpdxExternalDocumentReference.resolveFromFile(
@@ -326,7 +326,7 @@ private fun SpdxExternalDocumentReference.resolveFromFile(
 
 /**
  * Resolve this [SpdxExternalDocumentReference] from [uri] if it requires a download from a server. Use [cache] to
- * parse the document after it has been downloaded. In case of a failure, create an [OrtIssue] whose message includes
+ * parse the document after it has been downloaded. In case of a failure, create an [Issue] whose message includes
  * [baseUri], and [managerName].
  */
 private fun SpdxExternalDocumentReference.resolveFromDownload(
@@ -382,9 +382,9 @@ private fun SpdxExternalDocumentReference.resolveFromDownload(
 
 /**
  * Verify that the resolved or downloaded [file] this [SpdxExternalDocumentReference] refers to matches the expected
- * checksum. If not, return an [OrtIssue] based on the document [uri] and [managerName].
+ * checksum. If not, return an [Issue] based on the document [uri] and [managerName].
  */
-private fun SpdxExternalDocumentReference.verifyChecksum(file: File, uri: URI, managerName: String): OrtIssue? {
+private fun SpdxExternalDocumentReference.verifyChecksum(file: File, uri: URI, managerName: String): Issue? {
     val hash = Hash.create(checksum.checksumValue, checksum.algorithm.name)
     if (hash.verify(file)) return null
 

--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -37,7 +37,7 @@ import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.DependencyGraph
 import org.ossreviewtoolkit.model.DependencyReference
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.PackageReference
@@ -49,11 +49,11 @@ import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class AnalyzerResultBuilderTest : WordSpec() {
-    private val issue1 = OrtIssue(source = "source-1", message = "message-1")
-    private val issue2 = OrtIssue(source = "source-2", message = "message-2")
-    private val issue3 = OrtIssue(source = "source-3", message = "message-3")
-    private val issue4 = OrtIssue(source = "source-4", message = "message-4")
-    private val issue5 = OrtIssue(source = "source-5", message = "message-5")
+    private val issue1 = Issue(source = "source-1", message = "message-1")
+    private val issue2 = Issue(source = "source-2", message = "message-2")
+    private val issue3 = Issue(source = "source-3", message = "message-3")
+    private val issue4 = Issue(source = "source-4", message = "message-4")
+    private val issue5 = Issue(source = "source-5", message = "message-5")
 
     private val package1 = Package.EMPTY.copy(id = Identifier("type-1", "namespace-1", "package-1", "version-1"))
     private val package2 = Package.EMPTY.copy(id = Identifier("type-2", "namespace-2", "package-2", "version-2"))

--- a/analyzer/src/test/kotlin/managers/utils/GradleDependencyHandlerTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/GradleDependencyHandlerTest.kt
@@ -50,7 +50,7 @@ import org.eclipse.aether.repository.RemoteRepository
 
 import org.ossreviewtoolkit.analyzer.managers.Gradle
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageReference
 import org.ossreviewtoolkit.model.RemoteArtifact
@@ -310,7 +310,7 @@ class GradleDependencyHandlerTest : WordSpec({
             val maven = mockk<MavenSupport>()
             val exception = ProjectBuildingException("project", "Could not build.", IOException("Download exception"))
             val dep = createDependency("org.apache.commons", "commons-lang3", "3.11")
-            val issues = mutableListOf<OrtIssue>()
+            val issues = mutableListOf<Issue>()
 
             every { maven.parsePackage(any(), any(), any()) } throws exception
             val handler = GradleDependencyHandler(NAME, maven)

--- a/analyzer/src/test/kotlin/managers/utils/MavenDependencyHandlerTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/MavenDependencyHandlerTest.kt
@@ -43,7 +43,7 @@ import org.eclipse.aether.graph.DependencyNode
 import org.eclipse.aether.repository.RemoteRepository
 
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.Severity
@@ -137,7 +137,7 @@ class MavenDependencyHandlerTest : WordSpec({
             val artifact = dependency.artifact
             val repos = listOf(createRepository(), createRepository())
             val pkg = createPackage(IDENTIFIER)
-            val issues = mutableListOf<OrtIssue>()
+            val issues = mutableListOf<Issue>()
 
             val handler = createHandler()
 
@@ -153,7 +153,7 @@ class MavenDependencyHandlerTest : WordSpec({
             val artifact = dependency.artifact
             val repos = listOf(createRepository())
             val pkg = createPackage(IDENTIFIER)
-            val issues = mutableListOf<OrtIssue>()
+            val issues = mutableListOf<Issue>()
 
             val handler = createHandler(sbtMode = true)
 
@@ -166,7 +166,7 @@ class MavenDependencyHandlerTest : WordSpec({
 
         "return null for a project dependency" {
             val projectDependency = createDependency(PROJECT_ID)
-            val issues = mutableListOf<OrtIssue>()
+            val issues = mutableListOf<Issue>()
 
             val handler = createHandler()
 
@@ -212,7 +212,7 @@ class MavenDependencyHandlerTest : WordSpec({
             val dependency = createDependency(IDENTIFIER)
             val artifact = dependency.artifact
             val repos = listOf(createRepository())
-            val issues = mutableListOf<OrtIssue>()
+            val issues = mutableListOf<Issue>()
 
             val handler = createHandler()
 

--- a/analyzer/src/test/kotlin/managers/utils/SpdxResolvedDocumentTest.kt
+++ b/analyzer/src/test/kotlin/managers/utils/SpdxResolvedDocumentTest.kt
@@ -44,7 +44,7 @@ import io.kotest.matchers.types.beTheSameInstanceAs
 import java.io.File
 import java.net.URI
 
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.utils.common.calculateHash
 import org.ossreviewtoolkit.utils.common.encodeHex
@@ -179,7 +179,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
             "return a package from the root document" {
                 val resolvedDoc = SpdxResolvedDocument.load(SpdxDocumentCache(), BASE_DOCUMENT_FILE, MANAGER_NAME)
 
-                val issues = mutableListOf<OrtIssue>()
+                val issues = mutableListOf<Issue>()
                 resolvedDoc.getSpdxPackageForId("SPDXRef-Package-xyz", issues) shouldNotBeNull {
                     name shouldBe "xyz"
                     versionInfo shouldBe "0.1.0"
@@ -199,7 +199,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
 
                 val resolvedDoc = SpdxResolvedDocument.load(SpdxDocumentCache(), rootFile, MANAGER_NAME)
 
-                val issues = mutableListOf<OrtIssue>()
+                val issues = mutableListOf<Issue>()
                 resolvedDoc.getSpdxPackageForId(pkgId, issues) shouldBe externalPackage
 
                 issues should beEmpty()
@@ -209,7 +209,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
                 val identifier = "unknownPackageId"
                 val resolvedDoc = SpdxResolvedDocument.load(SpdxDocumentCache(), BASE_DOCUMENT_FILE, MANAGER_NAME)
 
-                val issues = mutableListOf<OrtIssue>()
+                val issues = mutableListOf<Issue>()
                 resolvedDoc.getSpdxPackageForId(identifier, issues) should beNull()
 
                 with(issues.single()) {
@@ -226,7 +226,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
 
                 val resolvedDoc = SpdxResolvedDocument.load(SpdxDocumentCache(), doc, MANAGER_NAME)
 
-                val issues = mutableListOf<OrtIssue>()
+                val issues = mutableListOf<Issue>()
                 resolvedDoc.getSpdxPackageForId(identifier, issues) should beNull()
 
                 with(issues.single()) {
@@ -244,7 +244,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
 
                 val resolvedDoc = SpdxResolvedDocument.load(SpdxDocumentCache(), doc, MANAGER_NAME)
 
-                val issues = mutableListOf<OrtIssue>()
+                val issues = mutableListOf<Issue>()
                 resolvedDoc.getSpdxPackageForId(identifier, issues) should beNull()
 
                 with(issues.single()) {
@@ -265,7 +265,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
 
                 val resolvedDoc = SpdxResolvedDocument.load(SpdxDocumentCache(), rootDoc, MANAGER_NAME)
 
-                val issues = mutableListOf<OrtIssue>()
+                val issues = mutableListOf<Issue>()
                 resolvedDoc.getSpdxPackageForId(identifier, issues) shouldBe externalPackage
 
                 with(issues.single()) {
@@ -296,7 +296,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
 
                 val resolvedDoc = SpdxResolvedDocument.load(SpdxDocumentCache(), rootDoc, MANAGER_NAME)
 
-                val issues = mutableListOf<OrtIssue>()
+                val issues = mutableListOf<Issue>()
                 resolvedDoc.getSpdxPackageForId(identifier, issues) shouldBe externalPackage
 
                 issues should beEmpty()
@@ -321,7 +321,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
 
                 val resolvedDoc = SpdxResolvedDocument.load(SpdxDocumentCache(), rootDoc, MANAGER_NAME)
 
-                val issues = mutableListOf<OrtIssue>()
+                val issues = mutableListOf<Issue>()
                 resolvedDoc.getSpdxPackageForId(identifier, issues) shouldBe externalPackage
 
                 with(issues.single()) {
@@ -349,7 +349,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
 
                 val resolvedDoc = SpdxResolvedDocument.load(SpdxDocumentCache(), rootDoc, MANAGER_NAME)
 
-                val issues = mutableListOf<OrtIssue>()
+                val issues = mutableListOf<Issue>()
                 resolvedDoc.getSpdxPackageForId(identifier, issues) should beNull()
 
                 with(issues.single()) {
@@ -487,7 +487,7 @@ class SpdxResolvedDocumentTest : WordSpec() {
 
                 val resolvedDoc = SpdxResolvedDocument.load(SpdxDocumentCache(), doc1, MANAGER_NAME)
 
-                val issues = mutableListOf<OrtIssue>()
+                val issues = mutableListOf<Issue>()
                 resolvedDoc.relationships.forEach { relation ->
                     resolvedDoc.getSpdxPackageForId(relation.spdxElementId, issues) shouldNotBeNull {
                         spdxId shouldBe relation.spdxElementId.substringAfter(':')

--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -43,7 +43,7 @@ import org.ossreviewtoolkit.evaluator.Evaluator
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.AnalyzerRun
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.Severity
@@ -196,7 +196,7 @@ class ExamplesFunTest : StringSpec() {
         "how-to-fix-text-provider.kts provides the expected how-to-fix text" {
             val script = takeExampleFile("how-to-fix-text-provider.kts").readText()
             val howToFixTextProvider = HowToFixTextProvider.fromKotlinScript(script, OrtResult.EMPTY)
-            val issue = OrtIssue(
+            val issue = Issue(
                 message = "ERROR: Timeout after 360 seconds while scanning file 'src/res/data.json'.",
                 source = "ScanCode",
                 severity = Severity.ERROR,
@@ -220,7 +220,7 @@ private fun createOrtResultWithIssue() =
             result = AnalyzerResult.EMPTY.copy(
                 issues = mapOf(
                     Identifier("Maven:org.oss-review-toolkit:example:1.0") to listOf(
-                        OrtIssue(source = "", message = "issue")
+                        Issue(source = "", message = "issue")
                     )
                 )
             )

--- a/cli/src/main/kotlin/utils/SeverityStats.kt
+++ b/cli/src/main/kotlin/utils/SeverityStats.kt
@@ -21,7 +21,7 @@ package org.ossreviewtoolkit.cli.utils
 
 import com.github.ajalt.clikt.core.ProgramResult
 
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.Severity
 
@@ -40,8 +40,8 @@ internal sealed class SeverityStats(
 
     companion object {
         fun createFromIssues(
-            resolvedIssues: Collection<OrtIssue>,
-            unresolvedIssues: Collection<OrtIssue>
+            resolvedIssues: Collection<Issue>,
+            unresolvedIssues: Collection<Issue>
         ) =
             IssueSeverityStats(
                 resolvedCounts = resolvedIssues.groupingBy { it.severity }.eachCount(),

--- a/evaluator/src/main/kotlin/Rule.kt
+++ b/evaluator/src/main/kotlin/Rule.kt
@@ -22,8 +22,8 @@ package org.ossreviewtoolkit.evaluator
 import org.apache.logging.log4j.kotlin.Logging
 
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.LicenseSource
-import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.Severity
@@ -118,7 +118,7 @@ abstract class Rule(
         }
 
     /**
-     * Return a string to be used as [source][OrtIssue.source] for issues generated in [hint], [warning], and [error].
+     * Return a string to be used as [source][Issue.source] for issues generated in [hint], [warning], and [error].
      */
     abstract fun issueSource(): String
 

--- a/examples/how-to-fix-text-provider.kts
+++ b/examples/how-to-fix-text-provider.kts
@@ -1,7 +1,7 @@
 object : HowToFixTextProvider {
-    fun OrtIssue.matchesMessage(pattern: String): Boolean = pattern.toRegex().matches(message)
+    fun Issue.matchesMessage(pattern: String): Boolean = pattern.toRegex().matches(message)
 
-    override fun getHowToFixText(issue: OrtIssue): String? {
+    override fun getHowToFixText(issue: Issue): String? {
         // How-to-fix instruction Markdown for scan timeout errors.
         if (issue.matchesMessage("ERROR: Timeout after .* seconds while scanning file.*")) {
             return """

--- a/examples/notifications/src/main/resources/example.notifications.kts
+++ b/examples/notifications/src/main/resources/example.notifications.kts
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-val issues: Map<Identifier, Set<OrtIssue>> = ortResult.collectIssues()
+val issues: Map<Identifier, Set<Issue>> = ortResult.collectIssues()
 
 if (issues.isNotEmpty()) {
     mailClient.sendMail(

--- a/helper-cli/src/main/kotlin/utils/Extensions.kt
+++ b/helper-cli/src/main/kotlin/utils/Extensions.kt
@@ -40,7 +40,7 @@ import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.downloader.Downloader
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCuration
@@ -239,8 +239,8 @@ internal fun OrtResult.getProvenance(id: Identifier): Provenance? = getScanResul
  * Return all issues from scan results. Issues for excludes [Project]s or [Package]s are not returned if and only if
  * the given [omitExcluded] is true.
  */
-internal fun OrtResult.getScanIssues(omitExcluded: Boolean = false): List<OrtIssue> {
-    val result = mutableListOf<OrtIssue>()
+internal fun OrtResult.getScanIssues(omitExcluded: Boolean = false): List<Issue> {
+    val result = mutableListOf<Issue>()
 
     scanner?.scanResults?.forEach { (id, results) ->
         if (!omitExcluded || !isExcluded(id)) {

--- a/model/src/main/kotlin/AdvisorRecord.kt
+++ b/model/src/main/kotlin/AdvisorRecord.kt
@@ -67,8 +67,8 @@ data class AdvisorRecord(
         }
     }
 
-    fun collectIssues(): Map<Identifier, Set<OrtIssue>> {
-        val collectedIssues = mutableMapOf<Identifier, MutableSet<OrtIssue>>()
+    fun collectIssues(): Map<Identifier, Set<Issue>> {
+        val collectedIssues = mutableMapOf<Identifier, MutableSet<Issue>>()
 
         advisorResults.forEach { (id, results) ->
             results.forEach { result ->
@@ -82,7 +82,7 @@ data class AdvisorRecord(
     }
 
     /**
-     * True if any of the [advisorResults] contain [OrtIssue]s.
+     * True if any of the [advisorResults] contain [Issue]s.
      */
     val hasIssues by lazy { collectIssues().isNotEmpty() }
 

--- a/model/src/main/kotlin/AdvisorSummary.kt
+++ b/model/src/main/kotlin/AdvisorSummary.kt
@@ -43,5 +43,5 @@ data class AdvisorSummary(
      * issues at all, [AdvisorRecord.hasIssues] already contains that information.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val issues: List<OrtIssue> = emptyList()
+    val issues: List<Issue> = emptyList()
 )

--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -45,14 +45,14 @@ data class AnalyzerResult(
     val packages: Set<Package>,
 
     /**
-     * The lists of [OrtIssue]s that occurred within the analyzed projects themselves. Issues related to project
+     * The lists of [Issue]s that occurred within the analyzed projects themselves. Issues related to project
      * dependencies are contained in the dependencies of the project's scopes.
      * This property is not serialized if the map is empty to reduce the size of the result file. If there are no issues
      * at all, [AnalyzerResult.hasIssues] already contains that information.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyOrder(alphabetic = true)
-    val issues: Map<Identifier, List<OrtIssue>> = emptyMap(),
+    val issues: Map<Identifier, List<Issue>> = emptyMap(),
 
     /**
      * A map with [DependencyGraph]s keyed by the name of the package manager that created this graph. Package
@@ -76,9 +76,9 @@ data class AnalyzerResult(
     }
 
     /**
-     * Return a map of all de-duplicated [OrtIssue]s associated by [Identifier].
+     * Return a map of all de-duplicated [Issue]s associated by [Identifier].
      */
-    fun collectIssues(): Map<Identifier, Set<OrtIssue>> {
+    fun collectIssues(): Map<Identifier, Set<Issue>> {
         val collectedIssues = issues.mapValuesTo(mutableMapOf()) { it.value.toMutableSet() }
 
         // Collecting issues from projects is necessary only if they use the dependency tree format; otherwise, the

--- a/model/src/main/kotlin/DependencyGraph.kt
+++ b/model/src/main/kotlin/DependencyGraph.kt
@@ -222,12 +222,12 @@ data class DependencyGraph(
         }
 
     /**
-     * Return a map of all de-duplicated [OrtIssue]s associated by [Identifier].
+     * Return a map of all de-duplicated [Issue]s associated by [Identifier].
      */
-    fun collectIssues(): Map<Identifier, Set<OrtIssue>> {
-        val collectedIssues = mutableMapOf<Identifier, MutableSet<OrtIssue>>()
+    fun collectIssues(): Map<Identifier, Set<Issue>> {
+        val collectedIssues = mutableMapOf<Identifier, MutableSet<Issue>>()
 
-        fun addIssues(pkg: Int, issues: Collection<OrtIssue>) {
+        fun addIssues(pkg: Int, issues: Collection<Issue>) {
             if (issues.isNotEmpty()) {
                 collectedIssues.getOrPut(packages[pkg]) { mutableSetOf() } += issues
             }
@@ -324,9 +324,9 @@ class DependencyReference(
     val linkage: PackageLinkage = PackageLinkage.DYNAMIC,
 
     /**
-     * A list of [OrtIssue]s that occurred handling this dependency.
+     * A list of [Issue]s that occurred handling this dependency.
      */
-    val issues: List<OrtIssue> = emptyList()
+    val issues: List<Issue> = emptyList()
 ) : Comparable<DependencyReference> {
     /**
      * Define an order on [DependencyReference] instances. Instances are ordered by their indices and fragment indices.
@@ -369,9 +369,9 @@ data class DependencyGraphNode(
     val linkage: PackageLinkage = PackageLinkage.DYNAMIC,
 
     /**
-     * A list of [OrtIssue]s that occurred handling this dependency.
+     * A list of [Issue]s that occurred handling this dependency.
      */
-    val issues: List<OrtIssue> = emptyList()
+    val issues: List<Issue> = emptyList()
 )
 
 /**

--- a/model/src/main/kotlin/DependencyGraphNavigator.kt
+++ b/model/src/main/kotlin/DependencyGraphNavigator.kt
@@ -147,7 +147,7 @@ private class DependencyRefCursor(
     override val linkage: PackageLinkage
         get() = current.linkage
 
-    override val issues: List<OrtIssue>
+    override val issues: List<Issue>
         get() = current.issues
 
     override fun <T> visitDependencies(block: (Sequence<DependencyNode>) -> T): T =

--- a/model/src/main/kotlin/DependencyNavigator.kt
+++ b/model/src/main/kotlin/DependencyNavigator.kt
@@ -60,11 +60,11 @@ interface DependencyNavigator {
             values.flatMapTo(mutableSetOf()) { it }
 
         /**
-         * Return a map with all [OrtIssue]s found in the dependency graph spawned by [dependencies] grouped by their
+         * Return a map with all [Issue]s found in the dependency graph spawned by [dependencies] grouped by their
          * [Identifier]s.
          */
-        fun collectIssues(dependencies: Sequence<DependencyNode>): Map<Identifier, Set<OrtIssue>> {
-            val collectedIssues = mutableMapOf<Identifier, MutableSet<OrtIssue>>()
+        fun collectIssues(dependencies: Sequence<DependencyNode>): Map<Identifier, Set<Issue>> {
+            val collectedIssues = mutableMapOf<Identifier, MutableSet<Issue>>()
 
             fun addIssues(nodes: Sequence<DependencyNode>) {
                 nodes.forEach { node ->
@@ -171,9 +171,9 @@ interface DependencyNavigator {
         getTreeDepthRecursive(directDependencies(project, scopeName))
 
     /**
-     * Return a map of all de-duplicated [OrtIssue]s associated by [Identifier] for the given [project].
+     * Return a map of all de-duplicated [Issue]s associated by [Identifier] for the given [project].
      */
-    fun projectIssues(project: Project): Map<Identifier, Set<OrtIssue>> =
+    fun projectIssues(project: Project): Map<Identifier, Set<Issue>> =
         collectIssues(scopeNames(project).asSequence().flatMap { directDependencies(project, it) })
 
     /**

--- a/model/src/main/kotlin/DependencyNode.kt
+++ b/model/src/main/kotlin/DependencyNode.kt
@@ -45,7 +45,7 @@ interface DependencyNode {
     val linkage: PackageLinkage
 
     /** A list with issues that occurred while resolving this dependency. */
-    val issues: List<OrtIssue>
+    val issues: List<Issue>
 
     /**
      * Visit the direct dependencies of this [DependencyNode] by calling the specified [block] with a sequence of all

--- a/model/src/main/kotlin/Issue.kt
+++ b/model/src/main/kotlin/Issue.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.common.normalizeLineBreaks
 /**
  * An issue that occurred while executing ORT.
  */
-data class OrtIssue(
+data class Issue(
     /**
      * The timestamp of the issue.
      */
@@ -68,15 +68,15 @@ class NormalizeLineBreaksSerializer : StdSerializer<String>(String::class.java) 
 }
 
 /**
- * Create an [OrtIssue] and log the message. The log level is aligned with the [severity].
+ * Create an [Issue] and log the message. The log level is aligned with the [severity].
  */
 inline fun <reified T : Logging> T.createAndLogIssue(
     source: String,
     message: String,
     severity: Severity? = null
-): OrtIssue {
-    val issue = severity?.let { OrtIssue(source = source, message = message, severity = it) }
-        ?: OrtIssue(source = source, message = message)
+): Issue {
+    val issue = severity?.let { Issue(source = source, message = message, severity = it) }
+        ?: Issue(source = source, message = message)
     logger.log(issue.severity.toLog4jLevel()) { message }
     return issue
 }

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -186,9 +186,9 @@ data class OrtResult(
     }
 
     /**
-     * Return a map of all de-duplicated [OrtIssue]s associated by [Identifier].
+     * Return a map of all de-duplicated [Issue]s associated by [Identifier].
      */
-    fun collectIssues(): Map<Identifier, Set<OrtIssue>> {
+    fun collectIssues(): Map<Identifier, Set<Issue>> {
         val analyzerIssues = analyzer?.result?.collectIssues().orEmpty()
         val scannerIssues = scanner?.collectIssues().orEmpty()
         val advisorIssues = advisor?.results?.collectIssues().orEmpty()

--- a/model/src/main/kotlin/Package.kt
+++ b/model/src/main/kotlin/Package.kt
@@ -187,7 +187,7 @@ data class Package(
     fun toReference(
         linkage: PackageLinkage? = null,
         dependencies: SortedSet<PackageReference>? = null,
-        issues: List<OrtIssue>? = null
+        issues: List<Issue>? = null
     ): PackageReference {
         var ref = PackageReference(id)
 

--- a/model/src/main/kotlin/PackageReference.kt
+++ b/model/src/main/kotlin/PackageReference.kt
@@ -59,9 +59,9 @@ data class PackageReference(
     val dependencies: SortedSet<PackageReference> = sortedSetOf(),
 
     /**
-     * A list of [OrtIssue]s that occurred handling this [PackageReference].
+     * A list of [Issue]s that occurred handling this [PackageReference].
      */
-    override val issues: List<OrtIssue> = emptyList()
+    override val issues: List<Issue> = emptyList()
 ) : Comparable<PackageReference>, DependencyNode {
     /**
      * Return the set of [Identifier]s the package referred by this [PackageReference] transitively depends on,

--- a/model/src/main/kotlin/ProjectAnalyzerResult.kt
+++ b/model/src/main/kotlin/ProjectAnalyzerResult.kt
@@ -46,5 +46,5 @@ data class ProjectAnalyzerResult(
      * even if this class is not serialized as part of an [OrtResult].
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val issues: List<OrtIssue> = emptyList()
+    val issues: List<Issue> = emptyList()
 )

--- a/model/src/main/kotlin/ScanSummary.kt
+++ b/model/src/main/kotlin/ScanSummary.kt
@@ -72,7 +72,7 @@ data class ScanSummary(
      * information.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val issues: List<OrtIssue> = emptyList()
+    val issues: List<Issue> = emptyList()
 ) {
     companion object {
         /**

--- a/model/src/main/kotlin/ScannerRun.kt
+++ b/model/src/main/kotlin/ScannerRun.kt
@@ -78,10 +78,10 @@ data class ScannerRun(
     }
 
     /**
-     * Return a map of all de-duplicated [OrtIssue]s associated by [Identifier].
+     * Return a map of all de-duplicated [Issue]s associated by [Identifier].
      */
-    fun collectIssues(): Map<Identifier, Set<OrtIssue>> {
-        val collectedIssues = mutableMapOf<Identifier, MutableSet<OrtIssue>>()
+    fun collectIssues(): Map<Identifier, Set<Issue>> {
+        val collectedIssues = mutableMapOf<Identifier, MutableSet<Issue>>()
 
         scanResults.forEach { (id, results) ->
             results.forEach { result ->
@@ -95,7 +95,7 @@ data class ScannerRun(
     }
 
     /**
-     * True if any of the [scanResults] contain [OrtIssue]s.
+     * True if any of the [scanResults] contain [Issue]s.
      */
     val hasIssues by lazy { collectIssues().isNotEmpty() }
 }

--- a/model/src/main/kotlin/config/IssueResolution.kt
+++ b/model/src/main/kotlin/config/IssueResolution.kt
@@ -19,11 +19,11 @@
 
 package org.ossreviewtoolkit.model.config
 
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.utils.common.collapseWhitespace
 
 /**
- * Defines the resolution of an [OrtIssue]. This can be used to silence false positives, or issues that have been
+ * Defines the resolution of an [Issue]. This can be used to silence false positives, or issues that have been
  * identified as not being relevant.
  */
 data class IssueResolution(
@@ -48,5 +48,5 @@ data class IssueResolution(
     /**
      * True if [message] matches the message of [issue].
      */
-    fun matches(issue: OrtIssue) = regex.matches(issue.message.collapseWhitespace())
+    fun matches(issue: Issue) = regex.matches(issue.message.collapseWhitespace())
 }

--- a/model/src/main/kotlin/config/IssueResolutionReason.kt
+++ b/model/src/main/kotlin/config/IssueResolutionReason.kt
@@ -19,10 +19,10 @@
 
 package org.ossreviewtoolkit.model.config
 
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 
 /**
- * Possible reasons for resolving an [OrtIssue] using a [IssueResolution].
+ * Possible reasons for resolving an [Issue] using a [IssueResolution].
  */
 enum class IssueResolutionReason {
     /**

--- a/model/src/main/kotlin/utils/DefaultResolutionProvider.kt
+++ b/model/src/main/kotlin/utils/DefaultResolutionProvider.kt
@@ -21,7 +21,7 @@ package org.ossreviewtoolkit.model.utils
 
 import java.io.File
 
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.Vulnerability
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.model.config.Resolutions
 import org.ossreviewtoolkit.model.readValue
 
 /**
- * A provider of previously added resolutions for [OrtIssue]s and [RuleViolation]s.
+ * A provider of previously added resolutions for [Issue]s and [RuleViolation]s.
  */
 class DefaultResolutionProvider : ResolutionProvider {
     companion object {
@@ -50,7 +50,7 @@ class DefaultResolutionProvider : ResolutionProvider {
      */
     fun add(other: Resolutions) = apply { resolutions = resolutions.merge(other) }
 
-    override fun getIssueResolutionsFor(issue: OrtIssue) = resolutions.issues.filter { it.matches(issue) }
+    override fun getIssueResolutionsFor(issue: Issue) = resolutions.issues.filter { it.matches(issue) }
 
     override fun getRuleViolationResolutionsFor(violation: RuleViolation) =
         resolutions.ruleViolations.filter { it.matches(violation) }

--- a/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphBuilder.kt
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.model.DependencyGraphEdge
 import org.ossreviewtoolkit.model.DependencyGraphNode
 import org.ossreviewtoolkit.model.DependencyReference
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.RootDependencyIndex
@@ -276,7 +276,7 @@ class DependencyGraphBuilder<D>(
      * to the data managed by this instance, resolve the package, and update the [issues] if necessary. Return the
      * numeric index for this dependency.
      */
-    private fun updateDependencyMappingAndPackages(id: Identifier, dependency: D, issues: MutableList<OrtIssue>): Int {
+    private fun updateDependencyMappingAndPackages(id: Identifier, dependency: D, issues: MutableList<Issue>): Int {
         val dependencyIndex = dependencyIndexMapping[id]
         if (dependencyIndex != null) return dependencyIndex
 
@@ -345,7 +345,7 @@ class DependencyGraphBuilder<D>(
         index: Int,
         scopeName: String,
         dependency: D,
-        issues: List<OrtIssue>,
+        issues: List<Issue>,
         transitive: Boolean,
         processed: Set<D>
     ): DependencyReference? {
@@ -368,7 +368,7 @@ class DependencyGraphBuilder<D>(
         index: RootDependencyIndex,
         scopeName: String,
         dependency: D,
-        issues: List<OrtIssue>,
+        issues: List<Issue>,
         transitive: Boolean,
         processed: Set<D>
     ): DependencyReference? {
@@ -408,7 +408,7 @@ class DependencyGraphBuilder<D>(
      * available, nothing has to be done. Otherwise, create a new one and add it to the set managed by this object. If
      * this fails, record a corresponding message in [issues].
      */
-    private fun updateResolvedPackages(id: Identifier, dependency: D, issues: MutableList<OrtIssue>) {
+    private fun updateResolvedPackages(id: Identifier, dependency: D, issues: MutableList<Issue>) {
         resolvedPackages.compute(id) { _, pkg -> pkg ?: dependencyHandler.createPackage(dependency, issues) }
     }
 

--- a/model/src/main/kotlin/utils/DependencyGraphConverter.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphConverter.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.model.utils
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.DependencyGraph
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.PackageReference
@@ -112,9 +112,9 @@ object DependencyGraphConverter {
 
         override fun linkageFor(dependency: PackageReference): PackageLinkage = dependency.linkage
 
-        override fun createPackage(dependency: PackageReference, issues: MutableList<OrtIssue>): Package? = null
+        override fun createPackage(dependency: PackageReference, issues: MutableList<Issue>): Package? = null
 
-        override fun issuesForDependency(dependency: PackageReference): Collection<OrtIssue> =
+        override fun issuesForDependency(dependency: PackageReference): Collection<Issue> =
             dependency.issues
     }
 }

--- a/model/src/main/kotlin/utils/DependencyHandler.kt
+++ b/model/src/main/kotlin/utils/DependencyHandler.kt
@@ -20,7 +20,7 @@
 package org.ossreviewtoolkit.model.utils
 
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 
@@ -57,12 +57,12 @@ interface DependencyHandler<D> {
      * the provided [issues] list. If the [dependency] does not map to a package, an implementation should return
      * *null*.
      */
-    fun createPackage(dependency: D, issues: MutableList<OrtIssue>): Package?
+    fun createPackage(dependency: D, issues: MutableList<Issue>): Package?
 
     /**
      * Return a collection with known issues for the given [dependency]. Some package manager implementations may
      * already encounter problems when obtaining dependency representations. These can be reported here. This base
      * implementation returns an empty collection.
      */
-    fun issuesForDependency(dependency: D): Collection<OrtIssue> = emptyList()
+    fun issuesForDependency(dependency: D): Collection<Issue> = emptyList()
 }

--- a/model/src/main/kotlin/utils/ResolutionProvider.kt
+++ b/model/src/main/kotlin/utils/ResolutionProvider.kt
@@ -19,7 +19,7 @@
 
 package org.ossreviewtoolkit.model.utils
 
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.Vulnerability
@@ -29,13 +29,13 @@ import org.ossreviewtoolkit.model.config.RuleViolationResolution
 import org.ossreviewtoolkit.model.config.VulnerabilityResolution
 
 /**
- * An interface to provide resolutions for [OrtIssue]s, [RuleViolation]s and [Vulnerability]s .
+ * An interface to provide resolutions for [Issue]s, [RuleViolation]s and [Vulnerability]s .
  */
 interface ResolutionProvider {
     /**
      * Get all issue resolutions that match [issue].
      */
-    fun getIssueResolutionsFor(issue: OrtIssue): List<IssueResolution>
+    fun getIssueResolutionsFor(issue: Issue): List<IssueResolution>
 
     /**
      * Get all rule violation resolutions that match [violation].
@@ -48,7 +48,7 @@ interface ResolutionProvider {
     fun getVulnerabilityResolutionsFor(vulnerability: Vulnerability): List<VulnerabilityResolution>
 
     /**
-     * Get a [Resolutions] object that contains all resolutions which apply to [OrtIssue]s or [RuleViolation]s contained
+     * Get a [Resolutions] object that contains all resolutions which apply to [Issue]s or [RuleViolation]s contained
      * in [ortResult].
      */
     fun getResolutionsFor(ortResult: OrtResult): Resolutions
@@ -56,7 +56,7 @@ interface ResolutionProvider {
     /**
      * Return true if there is at least one issue resolution that matches [issue].
      */
-    fun isResolved(issue: OrtIssue): Boolean = getIssueResolutionsFor(issue).isNotEmpty()
+    fun isResolved(issue: Issue): Boolean = getIssueResolutionsFor(issue).isNotEmpty()
 
     /**
      * Return true if there is at least one rule violation resolution that matches [violation].

--- a/model/src/test/kotlin/AbstractDependencyNavigatorTest.kt
+++ b/model/src/test/kotlin/AbstractDependencyNavigatorTest.kt
@@ -352,14 +352,14 @@ abstract class AbstractDependencyNavigatorTest : WordSpec() {
 
                     issues should containExactlyEntries(
                         Identifier("Maven:org.scala-lang.modules:scala-java8-compat_2.12:0.8.0") to setOf(
-                            OrtIssue(
+                            Issue(
                                 Instant.EPOCH,
                                 "Gradle",
                                 "Test issue 1"
                             )
                         ),
                         Identifier("Maven:org.scalactic:scalactic_2.12:3.0.4") to setOf(
-                            OrtIssue(
+                            Issue(
                                 Instant.EPOCH,
                                 "Gradle",
                                 "Test issue 2"

--- a/model/src/test/kotlin/AdvisorRecordTest.kt
+++ b/model/src/test/kotlin/AdvisorRecordTest.kt
@@ -46,7 +46,7 @@ class AdvisorRecordTest : WordSpec({
             val record = advisorRecordOf(
                 queryId to listOf(
                     createResult(
-                        issues = listOf(OrtIssue(source = "Advisor", message = "Failure"))
+                        issues = listOf(Issue(source = "Advisor", message = "Failure"))
                     )
                 )
             )
@@ -67,9 +67,9 @@ class AdvisorRecordTest : WordSpec({
         }
 
         "return a map with all issues in the record" {
-            val issue1 = OrtIssue(source = "Advisor", message = "Failure1")
-            val issue2 = OrtIssue(source = "Advisor", message = "Failure2")
-            val issue3 = OrtIssue(source = "Advisor", message = "Warning", severity = Severity.WARNING)
+            val issue1 = Issue(source = "Advisor", message = "Failure1")
+            val issue2 = Issue(source = "Advisor", message = "Failure2")
+            val issue3 = Issue(source = "Advisor", message = "Warning", severity = Severity.WARNING)
             val record = advisorRecordOf(
                 langId to listOf(createResult(issues = listOf(issue3))),
                 queryId to listOf(createResult(issues = listOf(issue1, issue2)))
@@ -233,7 +233,7 @@ class AdvisorRecordTest : WordSpec({
         "provide a predefined filter for results with issues" {
             val result1 = createResult(
                 advisorIndex = 1,
-                issues = listOf(OrtIssue(source = "test", message = "test message", severity = Severity.HINT))
+                issues = listOf(Issue(source = "test", message = "test message", severity = Severity.HINT))
             )
             val result2 = createResult(advisorIndex = 2)
 
@@ -251,11 +251,11 @@ class AdvisorRecordTest : WordSpec({
         "provide a predefined filter for results with issues that have a minimum severity" {
             val result1 = createResult(
                 advisorIndex = 1,
-                issues = listOf(OrtIssue(source = "test", message = "test message", severity = Severity.ERROR))
+                issues = listOf(Issue(source = "test", message = "test message", severity = Severity.ERROR))
             )
             val result2 = createResult(
                 advisorIndex = 2,
-                issues = listOf(OrtIssue(source = "test", message = "test message", severity = Severity.WARNING)),
+                issues = listOf(Issue(source = "test", message = "test message", severity = Severity.WARNING)),
                 capability = AdvisorCapability.DEFECTS
             )
 
@@ -273,11 +273,11 @@ class AdvisorRecordTest : WordSpec({
         "provide a predefined filter for results with issues for a given advisor capability" {
             val result1 = createResult(
                 advisorIndex = 1,
-                issues = listOf(OrtIssue(source = "test", message = "test message", severity = Severity.ERROR))
+                issues = listOf(Issue(source = "test", message = "test message", severity = Severity.ERROR))
             )
             val result2 = createResult(
                 advisorIndex = 2,
-                issues = listOf(OrtIssue(source = "test", message = "test message", severity = Severity.WARNING)),
+                issues = listOf(Issue(source = "test", message = "test message", severity = Severity.WARNING)),
                 capability = AdvisorCapability.DEFECTS
             )
 
@@ -340,7 +340,7 @@ private fun createDefect(id: String): Defect =
  */
 private fun createResult(
     advisorIndex: Int = 1,
-    issues: List<OrtIssue> = emptyList(),
+    issues: List<Issue> = emptyList(),
     vulnerabilities: List<Vulnerability> = emptyList(),
     defects: List<Defect> = emptyList(),
     capability: AdvisorCapability = AdvisorCapability.VULNERABILITIES

--- a/model/src/test/kotlin/DependencyGraphTest.kt
+++ b/model/src/test/kotlin/DependencyGraphTest.kt
@@ -169,7 +169,7 @@ class DependencyGraphTest : WordSpec({
                 id("org.apache.commons", "commons-lang3", "3.10"),
                 id("org.apache.commons", "commons-collections4", "4.4")
             )
-            val issue = OrtIssue(source = "analyzer", message = "Could not analyze :-(")
+            val issue = Issue(source = "analyzer", message = "Could not analyze :-(")
             val refLang = DependencyReference(0, linkage = PackageLinkage.PROJECT_DYNAMIC)
             val refCol = DependencyReference(1, issues = listOf(issue), dependencies = sortedSetOf(refLang))
             val trees = sortedSetOf(refCol)

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -168,8 +168,8 @@ class OrtResultTest : WordSpec({
                         issues = mapOf(
                             Identifier("Maven:org.oss-review-toolkit:example:1.0") to
                                     listOf(
-                                        OrtIssue(message = "Issue message to resolve", source = ""),
-                                        OrtIssue(message = "Non-resolved issue", source = "")
+                                        Issue(message = "Issue message to resolve", source = ""),
+                                        Issue(message = "Non-resolved issue", source = "")
                                     )
                         )
                     )
@@ -193,12 +193,12 @@ class OrtResultTest : WordSpec({
                         issues = mapOf(
                             Identifier("Maven:org.oss-review-toolkit:example:1.0") to
                                     listOf(
-                                        OrtIssue(
+                                        Issue(
                                             message = "Issue with severity 'warning'",
                                             source = "",
                                             severity = Severity.WARNING
                                         ),
-                                        OrtIssue(
+                                        Issue(
                                             message = "Issue with severity 'hint'.",
                                             source = "",
                                             severity = Severity.HINT
@@ -243,9 +243,9 @@ class OrtResultTest : WordSpec({
                         packages = emptySet(),
                         issues = mapOf(
                             Identifier("Maven:org.oss-review-toolkit:excluded:1.0") to
-                                    listOf(OrtIssue(message = "Excluded issue", source = "")),
+                                    listOf(Issue(message = "Excluded issue", source = "")),
                             Identifier("Maven:org.oss-review-toolkit:included:1.0") to
-                                    listOf(OrtIssue(message = "Included issue", source = ""))
+                                    listOf(Issue(message = "Included issue", source = ""))
                         )
                     )
                 )

--- a/model/src/test/kotlin/PackageReferenceTest.kt
+++ b/model/src/test/kotlin/PackageReferenceTest.kt
@@ -72,7 +72,7 @@ class PackageReferenceTest : WordSpec() {
                     val name = "${it.id.name}_suffix"
                     it.copy(
                         id = it.id.copy(name = name),
-                        issues = listOf(OrtIssue(source = "test", message = "issue $name"))
+                        issues = listOf(Issue(source = "test", message = "issue $name"))
                     )
                 }
 

--- a/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
+++ b/model/src/test/kotlin/utils/DependencyGraphBuilderTest.kt
@@ -36,7 +36,7 @@ import java.util.SortedSet
 import org.ossreviewtoolkit.model.DependencyGraph
 import org.ossreviewtoolkit.model.DependencyGraphEdge
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.PackageReference
@@ -242,7 +242,7 @@ class DependencyGraphBuilderTest : WordSpec({
         "take issues into account when checking for illegal references" {
             val depLang = createDependency("org.apache.commons", "commons-lang3", "3.11")
             val depIssuesPkg = createDependency(NO_PACKAGE_NAMESPACE, "errors", "1.2").copy(
-                issues = listOf(OrtIssue(source = "test", message = "test issue"))
+                issues = listOf(Issue(source = "test", message = "test issue"))
             )
             val depLog =
                 createDependency("commons-logging", "commons-logging", "1.2", dependencies = listOf(depIssuesPkg))
@@ -364,10 +364,10 @@ private object PackageRefDependencyHandler : DependencyHandler<PackageReference>
 
     override fun linkageFor(dependency: PackageReference): PackageLinkage = dependency.linkage
 
-    override fun createPackage(dependency: PackageReference, issues: MutableList<OrtIssue>): Package? =
+    override fun createPackage(dependency: PackageReference, issues: MutableList<Issue>): Package? =
         Package.EMPTY.copy(id = dependency.id).takeUnless { dependency.id.namespace == NO_PACKAGE_NAMESPACE }
 
-    override fun issuesForDependency(dependency: PackageReference): Collection<OrtIssue> =
+    override fun issuesForDependency(dependency: PackageReference): Collection<Issue> =
         dependency.issues
 }
 

--- a/model/src/test/kotlin/utils/DependencyGraphConverterTest.kt
+++ b/model/src/test/kotlin/utils/DependencyGraphConverterTest.kt
@@ -35,7 +35,7 @@ import java.util.SortedSet
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.DependencyGraphNode
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageReference
@@ -113,7 +113,7 @@ class DependencyGraphConverterTest : WordSpec({
             val convertedResult = DependencyGraphConverter.convert(result)
 
             val graph = convertedResult.dependencyGraphs.getValue("Maven")
-            val issues = mutableListOf<OrtIssue>()
+            val issues = mutableListOf<Issue>()
 
             fun collectIssues(node: DependencyGraphNode) {
                 issues += node.issues
@@ -187,9 +187,9 @@ private fun createDependencies(managerName: String, startIndex: Int, count: Int)
 /**
  * Create a list with issues for a test dependency based on its [index].
  */
-private fun createIssues(index: Int): List<OrtIssue> =
-    emptyList<OrtIssue>().takeIf { index % 2 == 0 } ?: listOf(
-        OrtIssue(source = "test", message = "Test issue $index.")
+private fun createIssues(index: Int): List<Issue> =
+    emptyList<Issue>().takeIf { index % 2 == 0 } ?: listOf(
+        Issue(source = "test", message = "Test issue $index.")
     )
 
 /**

--- a/reporter/src/main/kotlin/HowToFixTextProvider.kt
+++ b/reporter/src/main/kotlin/HowToFixTextProvider.kt
@@ -25,17 +25,17 @@ import kotlin.script.experimental.api.constructorArgs
 import kotlin.script.experimental.api.scriptsInstancesSharing
 import kotlin.script.experimental.jvmhost.createJvmCompilationConfigurationFromTemplate
 
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.utils.scripting.ScriptRunner
 
 /**
- * Provides how-to-fix texts in Markdown format for any given [OrtIssue].
+ * Provides how-to-fix texts in Markdown format for any given [Issue].
  */
 fun interface HowToFixTextProvider {
     companion object {
         /**
-         * A [HowToFixTextProvider] which returns null for any given [OrtIssue].
+         * A [HowToFixTextProvider] which returns null for any given [Issue].
          */
         val NONE = HowToFixTextProvider { null }
 
@@ -50,7 +50,7 @@ fun interface HowToFixTextProvider {
      * Return a Markdown text describing how to fix the given [issue]. Non-null return values override the default
      * how-to-fix texts, while a null value keeps the default.
      */
-    fun getHowToFixText(issue: OrtIssue): String?
+    fun getHowToFixText(issue: Issue): String?
 }
 
 private class HowToFixScriptRunner(ortResult: OrtResult) : ScriptRunner() {

--- a/reporter/src/main/kotlin/ReportTableModelMapper.kt
+++ b/reporter/src/main/kotlin/ReportTableModelMapper.kt
@@ -21,8 +21,8 @@ package org.ossreviewtoolkit.reporter
 
 import org.ossreviewtoolkit.model.DependencyNavigator
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.LicenseSource
-import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.RuleViolation
@@ -68,13 +68,13 @@ private fun Project.getScopesForDependencies(
 }
 
 /**
- * A mapper which converts an [OrtIssue] to a [ReportTableModel] view model.
+ * A mapper which converts an [Issue] to a [ReportTableModel] view model.
  */
 class ReportTableModelMapper(
     private val resolutionProvider: ResolutionProvider,
     private val howToFixTextProvider: HowToFixTextProvider
 ) {
-    private fun OrtIssue.toResolvableIssue(): ResolvableIssue {
+    private fun Issue.toResolvableIssue(): ResolvableIssue {
         val resolutions = resolutionProvider.getIssueResolutionsFor(this)
         return ResolvableIssue(
             source = this@toResolvableIssue.source,

--- a/reporter/src/main/kotlin/ReporterInput.kt
+++ b/reporter/src/main/kotlin/ReporterInput.kt
@@ -19,7 +19,7 @@
 
 package org.ossreviewtoolkit.reporter
 
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
@@ -53,7 +53,7 @@ data class ReporterInput(
     val packageConfigurationProvider: PackageConfigurationProvider = PackageConfigurationProvider.EMPTY,
 
     /**
-     * A [ResolutionProvider], can be used to check which [OrtIssue]s and [RuleViolation]s are resolved.
+     * A [ResolutionProvider], can be used to check which [Issue]s and [RuleViolation]s are resolved.
      */
     val resolutionProvider: ResolutionProvider = DefaultResolutionProvider(),
 
@@ -85,7 +85,7 @@ data class ReporterInput(
     val licenseClassifications: LicenseClassifications = LicenseClassifications(),
 
     /**
-     * A [HowToFixTextProvider], can be used to integrate how to fix texts for [OrtIssue]s into reports.
+     * A [HowToFixTextProvider], can be used to integrate how to fix texts for [Issue]s into reports.
      */
     val howToFixTextProvider: HowToFixTextProvider = HowToFixTextProvider.NONE
 )

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/DependencyTreeNode.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/DependencyTreeNode.kt
@@ -42,7 +42,7 @@ data class DependencyTreeNode(
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val scopeExcludes: List<ScopeExclude> = emptyList(),
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val issues: List<EvaluatedOrtIssue> = emptyList(),
+    val issues: List<EvaluatedIssue> = emptyList(),
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val children: List<DependencyTreeNode>
 )

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedIssue.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedIssue.kt
@@ -31,7 +31,7 @@ import org.ossreviewtoolkit.model.config.IssueResolution
 /**
  * The evaluated form of a [Issue] used by the [EvaluatedModel].
  */
-data class EvaluatedOrtIssue(
+data class EvaluatedIssue(
     val timestamp: Instant,
     val type: EvaluatedIssueType,
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedIssueType.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedIssueType.kt
@@ -20,7 +20,7 @@
 package org.ossreviewtoolkit.reporter.reporters.evaluatedmodel
 
 /**
- * The possible types of an [EvaluatedOrtIssue].
+ * The possible types of an [EvaluatedIssue].
  */
 enum class EvaluatedIssueType {
     ADVISOR, ANALYZER, SCANNER

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedIssueType.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedIssueType.kt
@@ -22,6 +22,6 @@ package org.ossreviewtoolkit.reporter.reporters.evaluatedmodel
 /**
  * The possible types of an [EvaluatedOrtIssue].
  */
-enum class EvaluatedOrtIssueType {
+enum class EvaluatedIssueType {
     ADVISOR, ANALYZER, SCANNER
 }

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModel.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModel.kt
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 
 import java.io.Writer
 
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Repository
 import org.ossreviewtoolkit.model.RuleViolation
@@ -53,7 +53,7 @@ import org.ossreviewtoolkit.reporter.reporters.WebAppReporter
  * information contained in the [ReporterInput] is applied to the [OrtResult]:
  *
  * * [PathExclude]s and [ScopeExclude]s from the [RepositoryConfiguration] are applied.
- * * [IssueResolution]s from the [ReporterInput.resolutionProvider] are matched against all [OrtIssue]s contained in the
+ * * [IssueResolution]s from the [ReporterInput.resolutionProvider] are matched against all [Issue]s contained in the
  *   result.
  * * [RuleViolationResolution]s from the [ReporterInput.resolutionProvider] are matched against all [RuleViolation]s.
  *
@@ -62,7 +62,7 @@ import org.ossreviewtoolkit.reporter.reporters.WebAppReporter
  * * [LicenseFindingCuration]s are not yet applied to the model.
  *
  * The model also contains useful containers to easily access some content of the [OrtResult], for example a list of
- * all [OrtIssue]s in their [evaluated form][EvaluatedOrtIssue] which contains back-references to its source.
+ * all [Issue]s in their [evaluated form][EvaluatedOrtIssue] which contains back-references to its source.
  *
  * The model can be serialized to with the helper functions [toJson] and [toYaml]. It uses a special [JsonMapper] that
  * de-duplicates objects in the result. For this it uses Jackson's [JsonIdentityInfo] to automatically generate [Int]

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModel.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModel.kt
@@ -62,7 +62,7 @@ import org.ossreviewtoolkit.reporter.reporters.WebAppReporter
  * * [LicenseFindingCuration]s are not yet applied to the model.
  *
  * The model also contains useful containers to easily access some content of the [OrtResult], for example a list of
- * all [Issue]s in their [evaluated form][EvaluatedOrtIssue] which contains back-references to its source.
+ * all [Issue]s in their [evaluated form][EvaluatedIssue] which contains back-references to its source.
  *
  * The model can be serialized to with the helper functions [toJson] and [toYaml]. It uses a special [JsonMapper] that
  * de-duplicates objects in the result. For this it uses Jackson's [JsonIdentityInfo] to automatically generate [Int]
@@ -86,8 +86,8 @@ import org.ossreviewtoolkit.reporter.reporters.WebAppReporter
  * * When modifying the model make sure that the objects are serialized at the right place. By default, Jackson
  *   serializes an Object with [ObjectIdInfo] the first time the serializer sees the object. If this is not desired
  *   because the object shall be serialized as the generated ID, the [JsonIdentityReference] annotation can be used to
- *   enforce this. For example, the list of [EvaluatedOrtIssue]s is serialized before the list of [EvaluatedPackage]s.
- *   Therefore [EvaluatedOrtIssue.pkg] is annotated with [JsonIdentityReference].
+ *   enforce this. For example, the list of [EvaluatedIssue]s is serialized before the list of [EvaluatedPackage]s.
+ *   Therefore [EvaluatedIssue.pkg] is annotated with [JsonIdentityReference].
  */
 data class EvaluatedModel(
     val pathExcludes: List<PathExclude>,
@@ -96,7 +96,7 @@ data class EvaluatedModel(
     val licenses: List<LicenseId>,
     val scopes: List<EvaluatedScope>,
     val issueResolutions: List<IssueResolution>,
-    val issues: List<EvaluatedOrtIssue>,
+    val issues: List<EvaluatedIssue>,
     val scanResults: List<EvaluatedScanResult>,
     val packages: List<EvaluatedPackage>,
     val paths: List<EvaluatedPackagePath>,
@@ -123,7 +123,7 @@ data class EvaluatedModel(
     companion object {
         private val INT_ID_TYPES = listOf(
             CopyrightStatement::class.java,
-            EvaluatedOrtIssue::class.java,
+            EvaluatedIssue::class.java,
             EvaluatedPackage::class.java,
             EvaluatedPackagePath::class.java,
             EvaluatedRuleViolation::class.java,

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelMapper.kt
@@ -355,7 +355,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         val result = mutableListOf<EvaluatedOrtIssue>()
 
         input.ortResult.analyzer?.result?.issues?.get(id)?.let { analyzerIssues ->
-            result += addIssues(analyzerIssues, EvaluatedOrtIssueType.ANALYZER, pkg, null, null)
+            result += addIssues(analyzerIssues, EvaluatedIssueType.ANALYZER, pkg, null, null)
         }
 
         return result
@@ -390,7 +390,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             addVulnerability(pkg, vulnerability)
         }
 
-        addIssues(result.summary.issues, EvaluatedOrtIssueType.ADVISOR, pkg, null, null)
+        addIssues(result.summary.issues, EvaluatedIssueType.ADVISOR, pkg, null, null)
     }
 
     private fun addVulnerability(pkg: EvaluatedPackage, vulnerability: Vulnerability) {
@@ -435,7 +435,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
 
         issues += addIssues(
             result.summary.issues,
-            EvaluatedOrtIssueType.SCANNER,
+            EvaluatedIssueType.SCANNER,
             pkg,
             actualScanResult,
             null
@@ -487,7 +487,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
 
             if (this.issues.isNotEmpty()) {
                 paths += packagePath
-                issues += addIssues(this.issues, EvaluatedOrtIssueType.ANALYZER, dependency, null, packagePath)
+                issues += addIssues(this.issues, EvaluatedIssueType.ANALYZER, dependency, null, packagePath)
             }
 
             visitedNodes += getInternalId() to createDependencyNode(dependency, linkage, issues)
@@ -585,7 +585,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
 
     private fun addIssues(
         issues: List<Issue>,
-        type: EvaluatedOrtIssueType,
+        type: EvaluatedIssueType,
         pkg: EvaluatedPackage,
         scanResult: EvaluatedScanResult?,
         path: EvaluatedPackagePath?

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelMapper.kt
@@ -23,7 +23,7 @@ import org.ossreviewtoolkit.model.AdvisorResult
 import org.ossreviewtoolkit.model.CuratedPackage
 import org.ossreviewtoolkit.model.DependencyNode
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.Provenance
@@ -584,7 +584,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     }
 
     private fun addIssues(
-        issues: List<OrtIssue>,
+        issues: List<Issue>,
         type: EvaluatedOrtIssueType,
         pkg: EvaluatedPackage,
         scanResult: EvaluatedScanResult?,
@@ -612,7 +612,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         return evaluatedIssues
     }
 
-    private fun addResolutions(issue: OrtIssue): List<IssueResolution> {
+    private fun addResolutions(issue: Issue): List<IssueResolution> {
         val matchingResolutions = input.resolutionProvider.getIssueResolutionsFor(issue)
 
         return issueResolutions.addIfRequired(matchingResolutions)

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelMapper.kt
@@ -60,7 +60,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
     private val copyrights = mutableListOf<CopyrightStatement>()
     private val licenses = mutableListOf<LicenseId>()
     private val scopes = mutableMapOf<String, EvaluatedScope>()
-    private val issues = mutableListOf<EvaluatedOrtIssue>()
+    private val issues = mutableListOf<EvaluatedIssue>()
     private val issueResolutions = mutableListOf<IssueResolution>()
     private val pathExcludes = mutableListOf<PathExclude>()
     private val scopeExcludes = mutableListOf<ScopeExclude>()
@@ -236,7 +236,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         val detectedLicenses = mutableSetOf<LicenseId>()
         val detectedExcludedLicenses = mutableSetOf<LicenseId>()
         val findings = mutableListOf<EvaluatedFinding>()
-        val issues = mutableListOf<EvaluatedOrtIssue>()
+        val issues = mutableListOf<EvaluatedIssue>()
 
         val applicablePathExcludes = input.ortResult.getExcludes().findPathExcludes(project, input.ortResult)
         val evaluatedPathExcludes = pathExcludes.addIfRequired(applicablePathExcludes)
@@ -293,7 +293,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         val detectedLicenses = mutableSetOf<LicenseId>()
         val detectedExcludedLicenses = mutableSetOf<LicenseId>()
         val findings = mutableListOf<EvaluatedFinding>()
-        val issues = mutableListOf<EvaluatedOrtIssue>()
+        val issues = mutableListOf<EvaluatedIssue>()
 
         val excludeInfo = packageExcludeInfo.getValue(pkg.id)
 
@@ -351,8 +351,8 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         detectedExcludedLicenses += detectedLicenses - includedDetectedLicenses
     }
 
-    private fun addAnalyzerIssues(id: Identifier, pkg: EvaluatedPackage): List<EvaluatedOrtIssue> {
-        val result = mutableListOf<EvaluatedOrtIssue>()
+    private fun addAnalyzerIssues(id: Identifier, pkg: EvaluatedPackage): List<EvaluatedIssue> {
+        val result = mutableListOf<EvaluatedIssue>()
 
         input.ortResult.analyzer?.result?.issues?.get(id)?.let { analyzerIssues ->
             result += addIssues(analyzerIssues, EvaluatedIssueType.ANALYZER, pkg, null, null)
@@ -420,7 +420,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         findings: MutableList<EvaluatedFinding>,
         pkg: EvaluatedPackage
     ): EvaluatedScanResult {
-        val issues = mutableListOf<EvaluatedOrtIssue>()
+        val issues = mutableListOf<EvaluatedIssue>()
 
         val evaluatedScanResult = EvaluatedScanResult(
             provenance = result.provenance,
@@ -456,7 +456,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         fun createDependencyNode(
             dependency: EvaluatedPackage,
             linkage: PackageLinkage,
-            issues: List<EvaluatedOrtIssue>,
+            issues: List<EvaluatedIssue>,
             children: List<DependencyTreeNode> = emptyList()
         ) =
             DependencyTreeNode(
@@ -474,7 +474,7 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
             path: List<EvaluatedPackage>
         ): DependencyTreeNode {
             val dependency = packages.getOrPut(id) { createEmptyPackage(id) }
-            val issues = mutableListOf<EvaluatedOrtIssue>()
+            val issues = mutableListOf<EvaluatedIssue>()
             val packagePath = EvaluatedPackagePath(
                 pkg = dependency,
                 project = pkg,
@@ -589,11 +589,11 @@ internal class EvaluatedModelMapper(private val input: ReporterInput) {
         pkg: EvaluatedPackage,
         scanResult: EvaluatedScanResult?,
         path: EvaluatedPackagePath?
-    ): List<EvaluatedOrtIssue> {
+    ): List<EvaluatedIssue> {
         val evaluatedIssues = issues.map { issue ->
             val resolutions = addResolutions(issue)
 
-            EvaluatedOrtIssue(
+            EvaluatedIssue(
                 timestamp = issue.timestamp,
                 type = type,
                 source = issue.source,

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedOrtIssue.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedOrtIssue.kt
@@ -24,12 +24,12 @@ import com.fasterxml.jackson.annotation.JsonInclude
 
 import java.time.Instant
 
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.IssueResolution
 
 /**
- * The evaluated form of a [OrtIssue] used by the [EvaluatedModel].
+ * The evaluated form of a [Issue] used by the [EvaluatedModel].
  */
 data class EvaluatedOrtIssue(
     val timestamp: Instant,

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedOrtIssue.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedOrtIssue.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.model.config.IssueResolution
  */
 data class EvaluatedOrtIssue(
     val timestamp: Instant,
-    val type: EvaluatedOrtIssueType,
+    val type: EvaluatedIssueType,
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val source: String,
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedPackage.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedPackage.kt
@@ -81,5 +81,5 @@ data class EvaluatedPackage(
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val scopeExcludes: List<ScopeExclude>,
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val issues: List<EvaluatedOrtIssue>
+    val issues: List<EvaluatedIssue>
 )

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedScanResult.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedScanResult.kt
@@ -39,5 +39,5 @@ data class EvaluatedScanResult(
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val packageVerificationCode: String,
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val issues: List<EvaluatedOrtIssue>
+    val issues: List<EvaluatedIssue>
 )

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/Statistics.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/Statistics.kt
@@ -22,7 +22,7 @@ package org.ossreviewtoolkit.reporter.reporters.evaluatedmodel
 import java.util.SortedMap
 import java.util.SortedSet
 
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Project
@@ -48,7 +48,7 @@ data class Statistics(
     val repositoryConfiguration: RepositoryConfigurationStatistics,
 
     /**
-     * The number of [OrtIssue]s by severity which are not resolved and not excluded.
+     * The number of [Issue]s by severity which are not resolved and not excluded.
      */
     val openIssues: IssueStatistics,
 

--- a/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
@@ -35,7 +35,7 @@ import org.ossreviewtoolkit.model.AdvisorRecord
 import org.ossreviewtoolkit.model.AdvisorResult
 import org.ossreviewtoolkit.model.AdvisorResultFilter
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.RepositoryProvenance
@@ -323,7 +323,7 @@ class FreemarkerTemplateProcessor(
         fun isLicensePresent(license: ResolvedLicense): Boolean = SpdxConstants.isPresent(license.license.toString())
 
         /**
-         * Return `true` if there are any unresolved and non-excluded [OrtIssue]s whose severity is equal to or greater
+         * Return `true` if there are any unresolved and non-excluded [Issue]s whose severity is equal to or greater
          * than the [threshold], or `false` otherwise.
          */
         @JvmOverloads

--- a/reporter/src/main/kotlin/reporters/opossum/OpossumReporter.kt
+++ b/reporter/src/main/kotlin/reporters/opossum/OpossumReporter.kt
@@ -40,7 +40,7 @@ import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.model.CuratedPackage
 import org.ossreviewtoolkit.model.DependencyNode
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Project
@@ -468,7 +468,7 @@ class OpossumReporter : Reporter {
             results.forEach { addScannerResult(id, it, maxDepth) }
         }
 
-        fun addIssue(issue: OrtIssue, id: Identifier, source: String) {
+        fun addIssue(issue: Issue, id: Identifier, source: String) {
             val roots = packageToRoot[id]
 
             val paths = if (roots.isNullOrEmpty()) {

--- a/reporter/src/test/kotlin/reporters/freemarker/FreeMarkerTemplateProcessorTest.kt
+++ b/reporter/src/test/kotlin/reporters/freemarker/FreeMarkerTemplateProcessorTest.kt
@@ -46,9 +46,9 @@ import org.ossreviewtoolkit.model.AnalyzerRun
 import org.ossreviewtoolkit.model.CopyrightFinding
 import org.ossreviewtoolkit.model.Defect
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.LicenseSource
-import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Project
@@ -238,7 +238,7 @@ private fun advisorRun(results: SortedMap<Identifier, List<AdvisorResult>>): Adv
  */
 private fun advisorResult(
     details: AdvisorDetails = ADVISOR_DETAILS,
-    issues: List<OrtIssue> = emptyList(),
+    issues: List<Issue> = emptyList(),
     vulnerabilities: List<Vulnerability> = emptyList(),
     defects: List<Defect> = emptyList()
 ): AdvisorResult =
@@ -434,7 +434,7 @@ class FreeMarkerTemplateProcessorTest : WordSpec({
         }
 
         "return true if there are issues for an advisor with the provided capability" {
-            val issue = OrtIssue(source = ADVISOR_DETAILS.name, message = "An error occurred")
+            val issue = Issue(source = ADVISOR_DETAILS.name, message = "An error occurred")
             val advisorResult = advisorResult(issues = listOf(issue))
 
             val advisorRun = advisorRun(sortedMapOf(idSubProject to listOf(advisorResult)))
@@ -451,7 +451,7 @@ class FreeMarkerTemplateProcessorTest : WordSpec({
             val advisorResult1 = advisorResult(vulnerabilities = listOf(vulnerability))
 
             val details2 = AdvisorDetails("anotherAdvisor", enumSetOf(AdvisorCapability.DEFECTS))
-            val issue = OrtIssue(source = details2.name, message = "Error when loading defects")
+            val issue = Issue(source = details2.name, message = "Error when loading defects")
             val advisorResult2 = advisorResult(details = details2, issues = listOf(issue))
 
             val advisorRun = advisorRun(
@@ -467,7 +467,7 @@ class FreeMarkerTemplateProcessorTest : WordSpec({
 
         "ignore issues with a lower severity" {
             val issue =
-                OrtIssue(source = ADVISOR_DETAILS.name, message = "A warning occurred", severity = Severity.WARNING)
+                Issue(source = ADVISOR_DETAILS.name, message = "A warning occurred", severity = Severity.WARNING)
             val advisorResult = advisorResult(issues = listOf(issue))
 
             val advisorRun = advisorRun(sortedMapOf(idSubProject to listOf(advisorResult)))
@@ -482,7 +482,7 @@ class FreeMarkerTemplateProcessorTest : WordSpec({
 
     "advisorResultsWithIssues" should {
         "return the correct results" {
-            val issue = OrtIssue(source = ADVISOR_DETAILS.name, message = "An error occurred")
+            val issue = Issue(source = ADVISOR_DETAILS.name, message = "An error occurred")
             val advisorResult = advisorResult(issues = listOf(issue))
 
             val advisorRun = advisorRun(
@@ -504,7 +504,7 @@ class FreeMarkerTemplateProcessorTest : WordSpec({
 
         "ignore advisor results with other capabilities" {
             val details2 = AdvisorDetails("anotherAdvisor", enumSetOf(AdvisorCapability.DEFECTS))
-            val issue = OrtIssue(source = details2.name, message = "Error when loading defects")
+            val issue = Issue(source = details2.name, message = "Error when loading defects")
 
             val vulnerability = mockk<Vulnerability>()
             val advisorResult1 = advisorResult(vulnerabilities = listOf(vulnerability), issues = listOf(issue))
@@ -526,7 +526,7 @@ class FreeMarkerTemplateProcessorTest : WordSpec({
 
         "ignore issues with a lower severity" {
             val issue =
-                OrtIssue(source = ADVISOR_DETAILS.name, message = "A warning occurred", severity = Severity.WARNING)
+                Issue(source = ADVISOR_DETAILS.name, message = "A warning occurred", severity = Severity.WARNING)
             val advisorResult = advisorResult(issues = listOf(issue))
 
             val advisorRun = advisorRun(sortedMapOf(idSubProject to listOf(advisorResult)))

--- a/reporter/src/test/kotlin/reporters/opossum/OpossumReporterTest.kt
+++ b/reporter/src/test/kotlin/reporters/opossum/OpossumReporterTest.kt
@@ -38,8 +38,8 @@ import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.CopyrightFinding
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.LicenseFinding
-import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageReference
@@ -207,7 +207,7 @@ class OpossumReporterTest : WordSpec({
                     "https://github.com/path/first-package-repo/tree/master/project-path/{path}"
         }
 
-        "create ortIssues containing all issues" {
+        "create issues containing all issues" {
             val issuesFromFirstPackage =
                 opossumInput.getSignalsForFile("/pom.xml/compile/first-package-group/first-package@0.0.1")
                     .filter { it.comment?.contains(Regex("Source-.*Message-")) == true }
@@ -419,17 +419,17 @@ private fun createOrtResult(): OrtResult {
                 ),
                 issues = mapOf(
                     Identifier("Maven:first-package-group:first-package:0.0.1") to listOf(
-                        OrtIssue(
+                        Issue(
                             source = "Source-1",
                             message = "Message-1"
                         ),
-                        OrtIssue(
+                        Issue(
                             source = "Source-2",
                             message = "Message-2"
                         )
                     ),
                     Identifier("unknown-identifier") to listOf(
-                        OrtIssue(
+                        Issue(
                             source = "Source-3",
                             message = "Message-3"
                         )
@@ -504,11 +504,11 @@ private fun createOrtResult(): OrtResult {
                                 )
                             ),
                             issues = listOf(
-                                OrtIssue(
+                                Issue(
                                     source = "Source-4",
                                     message = "Message-4"
                                 ),
-                                OrtIssue(
+                                Issue(
                                     source = "Source-5",
                                     message = "Message-5"
                                 )

--- a/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
+++ b/scanner/src/funTest/kotlin/storages/AbstractStorageFunTest.kt
@@ -35,8 +35,8 @@ import java.time.Instant
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.LicenseFinding
-import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.RepositoryProvenance
@@ -108,8 +108,8 @@ abstract class AbstractStorageFunTest(vararg listeners: TestListener) : WordSpec
             LicenseFinding("license-1.2", DUMMY_TEXT_LOCATION)
         ),
         issues = mutableListOf(
-            OrtIssue(source = "source-1", message = "error-1"),
-            OrtIssue(source = "source-2", message = "error-2")
+            Issue(source = "source-1", message = "error-1"),
+            Issue(source = "source-2", message = "error-2")
         )
     )
 

--- a/scanner/src/main/kotlin/ScanController.kt
+++ b/scanner/src/main/kotlin/ScanController.kt
@@ -22,8 +22,8 @@ package org.ossreviewtoolkit.scanner
 import java.time.Instant
 
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.KnownProvenance
-import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
@@ -55,16 +55,16 @@ class ScanController(
     val config: ScannerConfiguration
 ) {
     /**
-     * A map of package [Identifier]s to a list of [OrtIssue]s that occurred during provenance resolution for the
+     * A map of package [Identifier]s to a list of [Issue]s that occurred during provenance resolution for the
      * respective package.
      */
-    private val provenanceResolutionIssues = mutableMapOf<Identifier, MutableList<OrtIssue>>()
+    private val provenanceResolutionIssues = mutableMapOf<Identifier, MutableList<Issue>>()
 
     /**
-     * A map of [Identifier]s associated with a list of [OrtIssue]s that occurred during a scan besides the issues
+     * A map of [Identifier]s associated with a list of [Issue]s that occurred during a scan besides the issues
      * created by the scanners themselves as part of the [ScanSummary].
      */
-    private val issues = mutableMapOf<Identifier, MutableList<OrtIssue>>()
+    private val issues = mutableMapOf<Identifier, MutableList<Issue>>()
 
     /**
      * A map of [KnownProvenance]s to their resolved [NestedProvenance]s.
@@ -88,11 +88,11 @@ class ScanController(
      */
     private val scanResults = mutableMapOf<ScannerWrapper, MutableMap<KnownProvenance, MutableList<ScanResult>>>()
 
-    fun addProvenanceResolutionIssue(id: Identifier, issue: OrtIssue) {
+    fun addProvenanceResolutionIssue(id: Identifier, issue: Issue) {
         provenanceResolutionIssues.getOrPut(id) { mutableListOf() } += issue
     }
 
-    fun addIssue(id: Identifier, issue: OrtIssue) {
+    fun addIssue(id: Identifier, issue: Issue) {
         issues.getOrPut(id) { mutableListOf() } += issue
     }
 
@@ -287,7 +287,7 @@ class ScanController(
 
     private fun buildNestedProvenanceScanResult(
         root: KnownProvenance,
-        issues: List<OrtIssue>
+        issues: List<Issue>
     ): NestedProvenanceScanResult? {
         val nestedProvenance = nestedProvenances[root] ?: return null
 

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -36,8 +36,8 @@ import org.apache.logging.log4j.kotlin.Logging
 import org.ossreviewtoolkit.downloader.DownloadException
 import org.ossreviewtoolkit.model.AccessStatistics
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.KnownProvenance
-import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageType
@@ -183,7 +183,7 @@ class Scanner(
                 }.onFailure {
                     controller.addProvenanceResolutionIssue(
                         pkg.id,
-                        OrtIssue(
+                        Issue(
                             source = TOOL_NAME,
                             severity = Severity.ERROR,
                             message = "Could not resolve provenance for package '${pkg.id.toCoordinates()}': " +
@@ -216,7 +216,7 @@ class Scanner(
                     controller.getPackagesForProvenanceWithoutVcsPath(provenance).forEach { id ->
                         controller.addProvenanceResolutionIssue(
                             id,
-                            OrtIssue(
+                            Issue(
                                 source = TOOL_NAME,
                                 severity = Severity.ERROR,
                                 message = "Could not resolve nested provenance for package " +
@@ -603,7 +603,7 @@ class Scanner(
                 }.onFailure {
                     controller.addIssue(
                         pkg.id,
-                        OrtIssue(
+                        Issue(
                             source = "Downloader",
                             message = "Could not create file archive for " +
                                     "'${pkg.id.toCoordinates()}': ${it.collectMessages()}",

--- a/scanner/src/main/kotlin/scanners/Askalono.kt
+++ b/scanner/src/main/kotlin/scanners/Askalono.kt
@@ -24,8 +24,8 @@ import java.time.Instant
 
 import org.apache.logging.log4j.kotlin.Logging
 
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.LicenseFinding
-import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
@@ -108,7 +108,7 @@ class Askalono internal constructor(
             licenseFindings = licenseFindings,
             copyrightFindings = sortedSetOf(),
             issues = listOf(
-                OrtIssue(
+                Issue(
                     source = name,
                     message = "This scanner is not capable of detecting copyright statements.",
                     severity = Severity.HINT

--- a/scanner/src/main/kotlin/scanners/BoyterLc.kt
+++ b/scanner/src/main/kotlin/scanners/BoyterLc.kt
@@ -24,8 +24,8 @@ import java.time.Instant
 
 import org.apache.logging.log4j.kotlin.Logging
 
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.LicenseFinding
-import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
@@ -118,7 +118,7 @@ class BoyterLc internal constructor(
             licenseFindings = licenseFindings,
             copyrightFindings = sortedSetOf(),
             issues = listOf(
-                OrtIssue(
+                Issue(
                     source = name,
                     message = "This scanner is not capable of detecting copyright statements.",
                     severity = Severity.HINT

--- a/scanner/src/main/kotlin/scanners/Licensee.kt
+++ b/scanner/src/main/kotlin/scanners/Licensee.kt
@@ -24,8 +24,8 @@ import java.time.Instant
 
 import org.apache.logging.log4j.kotlin.Logging
 
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.LicenseFinding
-import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.TextLocation
@@ -107,7 +107,7 @@ class Licensee internal constructor(
             licenseFindings = licenseFindings,
             copyrightFindings = sortedSetOf(),
             issues = listOf(
-                OrtIssue(
+                Issue(
                     source = name,
                     message = "This scanner is not capable of detecting copyright statements.",
                     severity = Severity.HINT

--- a/scanner/src/main/kotlin/scanners/fossid/FossId.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossId.kt
@@ -55,7 +55,7 @@ import org.ossreviewtoolkit.clients.fossid.model.rules.RuleType
 import org.ossreviewtoolkit.clients.fossid.model.status.DownloadStatus
 import org.ossreviewtoolkit.clients.fossid.model.status.ScanStatus
 import org.ossreviewtoolkit.clients.fossid.runScan
-import org.ossreviewtoolkit.model.OrtIssue
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
@@ -204,7 +204,7 @@ class FossId internal constructor(
 
     override fun scanPackage(pkg: Package, context: ScanContext): ScanResult {
         val (result, duration) = measureTimedValue {
-            fun createSingleIssueResult(issue: OrtIssue, provenance: Provenance): ScanResult {
+            fun createSingleIssueResult(issue: Issue, provenance: Provenance): ScanResult {
                 val time = Instant.now()
                 val summary = ScanSummary(time, time, "", sortedSetOf(), sortedSetOf(), listOf(issue))
                 return ScanResult(provenance, details, summary)
@@ -691,7 +691,7 @@ class FossId internal constructor(
     ): ScanResult {
         // TODO: Maybe get issues from FossID (see has_failed_scan_files, get_failed_files and maybe get_scan_log).
         val issues = rawResults.listPendingFiles.mapTo(mutableListOf()) {
-            OrtIssue(source = name, message = "Pending identification for '$it'.", severity = Severity.HINT)
+            Issue(source = name, message = "Pending identification for '$it'.", severity = Severity.HINT)
         }
 
         val ignoredFiles = rawResults.listIgnoredFiles.associateBy { it.path }

--- a/scanner/src/main/kotlin/scanners/fossid/FossIdScanResults.kt
+++ b/scanner/src/main/kotlin/scanners/fossid/FossIdScanResults.kt
@@ -24,8 +24,8 @@ import org.ossreviewtoolkit.clients.fossid.model.identification.ignored.IgnoredF
 import org.ossreviewtoolkit.clients.fossid.model.identification.markedAsIdentified.MarkedAsIdentifiedFile
 import org.ossreviewtoolkit.clients.fossid.model.summary.Summarizable
 import org.ossreviewtoolkit.model.CopyrightFinding
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.LicenseFinding
-import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.TextLocation
 import org.ossreviewtoolkit.model.createAndLogIssue
 import org.ossreviewtoolkit.utils.common.collectMessages
@@ -53,7 +53,7 @@ internal data class FindingsContainer(
  */
 internal fun <T : Summarizable> List<T>.mapSummary(
     ignoredFiles: Map<String, IgnoredFile>,
-    issues: MutableList<OrtIssue>,
+    issues: MutableList<Issue>,
     detectedLicenseMapping: Map<String, String>
 ): FindingsContainer {
     val licenseFindings = mutableListOf<LicenseFinding>()

--- a/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
+++ b/scanner/src/main/kotlin/scanners/scancode/ScanCodeResultParser.kt
@@ -29,8 +29,8 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 import org.ossreviewtoolkit.model.CopyrightFinding
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.LicenseFinding
-import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerDetails
 import org.ossreviewtoolkit.model.TextLocation
@@ -281,14 +281,14 @@ private fun getCopyrightFindings(result: JsonNode): List<CopyrightFinding> {
 }
 
 /**
- * Get the list of [OrtIssue]s for scanned files.
+ * Get the list of [Issue]s for scanned files.
  */
-private fun getIssues(result: JsonNode): List<OrtIssue> {
+private fun getIssues(result: JsonNode): List<Issue> {
     val input = getInputPath(result)
     return result["files"]?.flatMap { file ->
         val path = file["path"].textValue().removePrefix(input)
         file["scan_errors"].map {
-            OrtIssue(
+            Issue(
                 source = ScanCode.SCANNER_NAME,
                 message = "${it.textValue()} (File: $path)"
             )
@@ -300,7 +300,7 @@ private fun getIssues(result: JsonNode): List<OrtIssue> {
  * Map messages about timeout errors to a more compact form. Return true if solely timeout errors occurred, return false
  * otherwise.
  */
-internal fun mapTimeoutErrors(issues: MutableList<OrtIssue>): Boolean {
+internal fun mapTimeoutErrors(issues: MutableList<Issue>): Boolean {
     if (issues.isEmpty()) return false
 
     var onlyTimeoutErrors = true
@@ -328,7 +328,7 @@ internal fun mapTimeoutErrors(issues: MutableList<OrtIssue>): Boolean {
  * Map messages about unknown issues to a more compact form. Return true if solely memory errors occurred, return false
  * otherwise.
  */
-internal fun mapUnknownIssues(issues: MutableList<OrtIssue>): Boolean {
+internal fun mapUnknownIssues(issues: MutableList<Issue>): Boolean {
     if (issues.isEmpty()) return false
 
     var onlyMemoryErrors = true

--- a/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
+++ b/scanner/src/test/kotlin/scanners/fossid/FossIdTest.kt
@@ -78,8 +78,8 @@ import org.ossreviewtoolkit.clients.fossid.model.status.UnversionedScanDescripti
 import org.ossreviewtoolkit.clients.fossid.runScan
 import org.ossreviewtoolkit.model.CopyrightFinding
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.LicenseFinding
-import org.ossreviewtoolkit.model.OrtIssue
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageType
 import org.ossreviewtoolkit.model.ScanResult
@@ -330,7 +330,7 @@ class FossIdTest : WordSpec({
             val summary = fossId.scan(createPackage(pkgId, vcsInfo)).summary
 
             val expectedIssues = listOf(createPendingFile(4), createPendingFile(5)).map {
-                OrtIssue(Instant.EPOCH, "FossId", "Pending identification for '$it'.", Severity.HINT)
+                Issue(Instant.EPOCH, "FossId", "Pending identification for '$it'.", Severity.HINT)
             }
 
             summary.issues.map { it.copy(timestamp = Instant.EPOCH) } shouldBe expectedIssues


### PR DESCRIPTION
Rename `OrtIssue` to just `Issue` for consistency with e.g. `RuleViolation`

BREAKING CHANGE: This change is only breaking for programmatic use of ORT, which may require to align the type name.
The interface towards 'ort-config' also changes slightly, see e.g. https://github.com/oss-review-toolkit/ort-config/pull/95.