### PR TITLE
fix(Npm): Correctly parse the output of the 'npm' command

### DIFF
--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -597,11 +597,12 @@ open class Npm(
         )
 
         fun mapLinesToOrtIssues(prefix: String, severity: Severity) {
-            val issueLines = lines.takeWhile { it.startsWith(prefix) }.mapNotNull { line ->
-                line.removePrefix(prefix).let {
-                    commonSecondaryPrefixes.fold(it) { remainder, prefix -> remainder.removePrefix(prefix) }
-                }.takeUnless { it.isBlank() }
-            }
+            val issueLines = lines.dropWhile { !it.startsWith(prefix) }
+                .takeWhile { it.startsWith(prefix) }.mapNotNull { line ->
+                    line.removePrefix(prefix).let {
+                        commonSecondaryPrefixes.fold(it) { remainder, prefix -> remainder.removePrefix(prefix) }
+                    }.takeUnless { it.isBlank() }
+                }
 
             if (issueLines.isNotEmpty()) {
                 issues += OrtIssue(

--- a/analyzer/src/test/assets/npm-err.txt
+++ b/analyzer/src/test/assets/npm-err.txt
@@ -1,0 +1,17 @@
+npm notice
+npm notice New major version of npm available! 8.15.1 -> 9.4.0
+npm notice Changelog: <https://github.com/npm/cli/releases/tag/v9.4.0>
+npm notice Run `npm install -g npm@9.4.0` to update!
+npm notice
+npm ERR! code ENOTFOUND
+npm ERR! syscall getaddrinfo
+npm ERR! errno ENOTFOUND
+npm ERR! network request to https://example.com/artifactory/api/npm/npm-repo/zone.js/-/zone.js-0.11.6.tgz failed, reason: getaddrinfo ENOTFOUND example.com
+npm ERR! network This is a problem related to network connectivity.
+npm ERR! network In most cases you are behind a proxy or have bad network settings.
+npm ERR! network
+npm ERR! network If you are behind a proxy, please make sure that the
+npm ERR! network 'proxy' config is set properly.  See: 'npm help config'
+
+npm ERR! A complete log of this run can be found in:
+npm ERR!     /home/ort/.npm/_logs/2023-01-31T07_29_19_725Z-debug-0.log

--- a/analyzer/src/test/assets/test-package-no-deps.json
+++ b/analyzer/src/test/assets/test-package-no-deps.json
@@ -1,0 +1,38 @@
+{
+  "name": "bonjour",
+  "version": "3.5.0",
+  "description": "A Bonjour/Zeroconf implementation in pure JavaScript (local)",
+  "main": "index.js",
+  "dependencies": {},
+  "devDependencies": {},
+  "scripts": {
+    "test": "standard && tape test/*.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/watson/bonjour.git"
+  },
+  "keywords": [
+    "bonjour",
+    "zeroconf",
+    "zero",
+    "configuration",
+    "mdns",
+    "dns",
+    "service",
+    "discovery",
+    "multicast",
+    "broadcast",
+    "dns-sd"
+  ],
+  "author": "Thomas Watson Steen <w@tson.dk> (https://twitter.com/wa7son)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/local/watson/bonjour/issues"
+  },
+  "homepage": "https://github.com/watson/bonjour/local",
+  "coordinates": [
+    55.68250900965318,
+    12.586377442991648
+  ]
+}

--- a/analyzer/src/test/kotlin/managers/NpmTest.kt
+++ b/analyzer/src/test/kotlin/managers/NpmTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import io.mockk.EqMatcher
+import io.mockk.VarargMatcher
+import io.mockk.every
+import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
+
+import java.io.File
+
+import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
+import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
+import org.ossreviewtoolkit.model.config.RepositoryConfiguration
+import org.ossreviewtoolkit.utils.common.ProcessCapture
+import org.ossreviewtoolkit.utils.test.createTestTempDir
+
+class NpmTest : StringSpec({
+    "The output of the npm command should be parsed correctly" {
+        val workingDir = createTestTempDir()
+        val definitionFileSrc = File("src/test/assets/test-package-no-deps.json")
+        val definitionFile = workingDir.resolve("package.json")
+        definitionFileSrc.copyTo(definitionFile)
+
+        val errorFile = File("src/test/assets/npm-err.txt")
+        val errorText = errorFile.readText()
+
+        mockkConstructor(ProcessCapture::class)
+        try {
+            every {
+                constructedWith<ProcessCapture>(
+                    EqMatcher(workingDir),
+                    VarargMatcher(
+                        all = true,
+                        matcher = { true },
+                        prefix = listOf(
+                            EqMatcher("npm"),
+                            EqMatcher("install"),
+                            EqMatcher("--ignore-scripts"),
+                            EqMatcher("--no-audit"),
+                            EqMatcher("--legacy-peer-deps")
+                        )
+                    )
+                ).stderr
+            } returns errorText
+
+            val analyzerName = "test-npm"
+            val npmOptions = mapOf("legacyPeerDeps" to "true")
+            val npmConfig = PackageManagerConfiguration(options = npmOptions)
+            val analyzerConfig =
+                AnalyzerConfiguration(allowDynamicVersions = true, packageManagers = mapOf(analyzerName to npmConfig))
+            val npm = Npm(analyzerName, workingDir, analyzerConfig, RepositoryConfiguration())
+
+            val results = npm.resolveDependencies(definitionFile, emptyMap())
+
+            results shouldHaveSize 1
+
+            with(results[0]) {
+                packages should beEmpty()
+                issues shouldHaveSize 1
+                issues[0].severity shouldBe Severity.ERROR
+            }
+        } finally {
+            unmockkConstructor(ProcessCapture::class)
+        }
+    }
+})


### PR DESCRIPTION
When parsing the output of the command to install NPM dependencies, do not expect that the output starts with the expected error level, but read the whole text if necessary. Otherwise, important error information can be missed if the output starts with a hint.