### PR TITLE
fix(PackageCuration): Don't apply curations with different version

### DIFF
--- a/model/src/main/kotlin/PackageCuration.kt
+++ b/model/src/main/kotlin/PackageCuration.kt
@@ -70,10 +70,7 @@ data class PackageCuration(
      */
     private fun isApplicableIvyVersion(pkgId: Identifier) =
         runCatching {
-            if (Semver.isValid(id.version)) {
-                // If the curation is for a valid semver, do not coerce the package version, as it also has to be valid.
-                return id.version == pkgId.version
-            }
+            if (id.version == pkgId.version) return true
 
             if (id.version.isVersionRange()) {
                 // `Semver.satisfies(String)` requires a valid version range to work as expected, see:
@@ -86,8 +83,7 @@ data class PackageCuration(
                 return Semver.coerce(pkgId.version).satisfies(range)
             }
 
-            // `id.version` is invalid, but also not a version range. Therefore, coerce valid versions.
-            Semver.coerce(pkgId.version).satisfies(Semver.coerce(id.version).version)
+            return false
         }.onFailure {
             logger.warn {
                 "Failed to check if package curation version '${id.version}' is applicable to package version " +

--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -435,6 +435,12 @@ class PackageCurationTest : WordSpec({
             }
         }
 
+        "work for invalid semvers" {
+            packageCurationForVersion("3.0.3.jre11").isApplicable(identifierForVersion("3.0.3.jre11")) shouldBe true
+            packageCurationForVersion("3.0.3.jre11").isApplicable(identifierForVersion("3.0.3.jre8")) shouldBe false
+            packageCurationForVersion("1.2.3.4").isApplicable(identifierForVersion("1.2.3.9")) shouldBe false
+        }
+
         "not apply for invalid version ranges" {
             packageCurationForVersion("[2.0.0, 2.1.0]").isApplicable(identifierForVersion("2.0.0")) shouldBe false
         }


### PR DESCRIPTION
Neither the package's nor the curation's version are guaranteed to use
valid semvers. Semver4j's `coerce()` function creates a valid semver in
cases when this is not wanted, e.g. 1.2.3.4 is parsed as 1.2.3 and
therefore a package curation for 1.2.3.9 would be seen as applicable.

Remove the coercing to valid semvers to avoid applying incorrect package
curations.