### PR TITLE
AnalyzerCommand: Fix a file path in the log output

### DIFF
--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -197,8 +197,8 @@ class AnalyzerCommand : OrtCommand(
                 add(ORT_YML_PROVIDER_ID to SimplePackageCurationProvider(repositoryPackageCurations))
             } else if (repositoryPackageCurations.isNotEmpty()) {
                 logger.warn {
-                    "Existing package curations from '$ORT_REPO_CONFIG_FILENAME' are not applied because the feature " +
-                            "is disabled."
+                    "Existing package curations from '${repositoryConfigurationFile.absolutePath}' are not applied " +
+                            "because the feature is disabled."
                 }
             }
         }


### PR DESCRIPTION
Log the file path of the actually use repository configuration instead of the default file location.
