### PR TITLE
fix(Gradle): Change client projects to be implementation dependencies

### DIFF
--- a/advisor/build.gradle.kts
+++ b/advisor/build.gradle.kts
@@ -23,12 +23,13 @@ plugins {
 }
 
 dependencies {
-    api(project(":clients:nexus-iq"))
-    api(project(":clients:oss-index"))
-    api(project(":clients:osv"))
-    api(project(":clients:vulnerable-code"))
-    api(project(":clients:github-graphql"))
     api(project(":model"))
+
+    implementation(project(":clients:nexus-iq"))
+    implementation(project(":clients:oss-index"))
+    implementation(project(":clients:osv"))
+    implementation(project(":clients:vulnerable-code"))
+    implementation(project(":clients:github-graphql"))
 
     implementation(libs.cvssCalculator)
     implementation(libs.kotlinxCoroutines)

--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -51,9 +51,9 @@ repositories {
 }
 
 dependencies {
-    api(project(":clients:clearly-defined"))
     api(project(":model"))
 
+    implementation(project(":clients:clearly-defined"))
     implementation(project(":downloader"))
     implementation(project(":utils:ort-utils"))
     implementation(project(":utils:spdx-utils"))


### PR DESCRIPTION
The projects from the clients sub-directory are used for the low-level implementations only. An exception is the "model" project where conversion functions use ClearlyDefined classes as part of their API.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>