### PR TITLE
refactor(PackageCurationProvider): Align on camel case IDs

### DIFF
--- a/analyzer/src/main/kotlin/PackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/PackageCurationProvider.kt
@@ -59,8 +59,8 @@ interface PackageCurationProviderFactory<CONFIG> : ConfigurablePluginFactory<Pac
                 }
 
                 require(none { (id, _) -> id == REPOSITORY_CONFIGURATION_PROVIDER_ID }) {
-                    "Found package curation provider which uses '$REPOSITORY_CONFIGURATION_PROVIDER_ID' as id which " +
-                             "is reserved and not allowed."
+                    "Found a package curation provider which uses '$REPOSITORY_CONFIGURATION_PROVIDER_ID' as its id " +
+                            "which is reserved and not allowed."
                 }
             }
     }

--- a/analyzer/src/main/kotlin/PackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/PackageCurationProvider.kt
@@ -32,7 +32,7 @@ import org.ossreviewtoolkit.utils.common.getDuplicates
 interface PackageCurationProviderFactory<CONFIG> : ConfigurablePluginFactory<PackageCurationProvider> {
     companion object {
         val ALL = Plugin.getAll<PackageCurationProviderFactory<*>>()
-        const val ORT_YML_PROVIDER_ID = "ort-yml"
+        const val ORT_YML_PROVIDER_ID = "OrtYml"
 
         /**
          * Return a new (identifier, provider instance) tuple for each

--- a/analyzer/src/main/kotlin/PackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/PackageCurationProvider.kt
@@ -32,7 +32,7 @@ import org.ossreviewtoolkit.utils.common.getDuplicates
 interface PackageCurationProviderFactory<CONFIG> : ConfigurablePluginFactory<PackageCurationProvider> {
     companion object {
         val ALL = Plugin.getAll<PackageCurationProviderFactory<*>>()
-        const val ORT_YML_PROVIDER_ID = "OrtYml"
+        const val REPOSITORY_CONFIGURATION_PROVIDER_ID = "RepositoryConfiguration"
 
         /**
          * Return a new (identifier, provider instance) tuple for each
@@ -58,9 +58,9 @@ interface PackageCurationProviderFactory<CONFIG> : ConfigurablePluginFactory<Pac
                             "not allowed. Please configure a unique ID for each package curation provider."
                 }
 
-                require(none { (id, _) -> id == ORT_YML_PROVIDER_ID }) {
-                    "Found package curation provider which uses '$ORT_YML_PROVIDER_ID' as id which is reserved and " +
-                            "not allowed."
+                require(none { (id, _) -> id == REPOSITORY_CONFIGURATION_PROVIDER_ID }) {
+                    "Found package curation provider which uses '$REPOSITORY_CONFIGURATION_PROVIDER_ID' as id which " +
+                             "is reserved and not allowed."
                 }
             }
     }

--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -40,7 +40,7 @@ import kotlin.time.toKotlinDuration
 
 import org.ossreviewtoolkit.analyzer.Analyzer
 import org.ossreviewtoolkit.analyzer.PackageCurationProviderFactory
-import org.ossreviewtoolkit.analyzer.PackageCurationProviderFactory.Companion.ORT_YML_PROVIDER_ID
+import org.ossreviewtoolkit.analyzer.PackageCurationProviderFactory.Companion.REPOSITORY_CONFIGURATION_PROVIDER_ID
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.analyzer.PackageManagerFactory
 import org.ossreviewtoolkit.analyzer.curation.SimplePackageCurationProvider
@@ -194,7 +194,7 @@ class AnalyzerCommand : OrtCommand(
             val repositoryPackageCurations = repositoryConfiguration.curations.packages
 
             if (ortConfig.enableRepositoryPackageCurations) {
-                add(ORT_YML_PROVIDER_ID to SimplePackageCurationProvider(repositoryPackageCurations))
+                add(REPOSITORY_CONFIGURATION_PROVIDER_ID to SimplePackageCurationProvider(repositoryPackageCurations))
             } else if (repositoryPackageCurations.isNotEmpty()) {
                 logger.warn {
                     "Existing package curations from '${repositoryConfigurationFile.absolutePath}' are not applied " +

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -42,12 +42,12 @@ ort:
     - type: DefaultFile
     - type: DefaultDir
     - type: File
-      id: some-curations-file
+      id: SomeCurationsFile
       config:
         path: '/some-path/curations.yml'
         mustExist: true
     - type: File
-      id: some-curations-dir
+      id: SomeCurationsDir
       config:
         path: '/some-path/curations-dir'
         mustExist: false

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -68,12 +68,12 @@ class OrtConfigurationTest : WordSpec({
                 PackageCurationProviderConfiguration(type = "DefaultDir"),
                 PackageCurationProviderConfiguration(
                     type = "File",
-                    id = "some-curations-file",
+                    id = "SomeCurationsFile",
                     config = mapOf("path" to "/some-path/curations.yml", "mustExist" to "true")
                 ),
                 PackageCurationProviderConfiguration(
                     type = "File",
-                    id = "some-curations-dir",
+                    id = "SomeCurationsDir",
                     config = mapOf("path" to "/some-path/curations-dir", "mustExist" to "false")
                 ),
                 PackageCurationProviderConfiguration(type = "OrtConfig", enabled = true),


### PR DESCRIPTION
The values of the IDs default to the values of `type` which are all in camel case. So, consistently use camel case for all IDs.
