### PR TITLE
refactor(Analyzer)!: Improve package curation ordering

### DIFF
--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -120,6 +120,10 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
         return ManagedFileInfo(absoluteProjectPath, managedFiles, repositoryConfiguration)
     }
 
+    /**
+     * Return the result of analyzing the given [managed file][info]. The given [curationProviders] must be ordered
+     * highest-priority-first.
+     */
     @JvmOverloads
     fun analyze(
         info: ManagedFileInfo,
@@ -344,6 +348,10 @@ private class PackageManagerRunner(
     }
 }
 
+/**
+ * Return the resolved configuration for the given [analyzerResult]. The [curationProviders] must be ordered
+ * highest-priority-first.
+ */
 private fun resolveConfiguration(
     analyzerResult: AnalyzerResult,
     curationProviders: List<Pair<String, PackageCurationProvider>>

--- a/analyzer/src/main/kotlin/PackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/PackageCurationProvider.kt
@@ -36,9 +36,8 @@ interface PackageCurationProviderFactory<CONFIG> : ConfigurablePluginFactory<Pac
 
         /**
          * Return a new (identifier, provider instance) tuple for each
-         * [enabled][PackageCurationProviderConfiguration.enabled] provider configuration in [configurations]. The given
-         * [configurations] must be ordered highest-priority first while the returned providers are ordered
-         * lowest-priority first, which is the order in which the corresponding curations must be applied.
+         * [enabled][PackageCurationProviderConfiguration.enabled] provider configuration in [configurations] ordered
+         * highest-priority first. The given [configurations] must be ordered highest-priority first as well.
          */
         fun create(
             configurations: List<PackageCurationProviderConfiguration>
@@ -47,7 +46,7 @@ interface PackageCurationProviderFactory<CONFIG> : ConfigurablePluginFactory<Pac
                 it.enabled
             }.map {
                 it.id to ALL.getValue(it.type).create(it.config)
-            }.asReversed().apply {
+            }.apply {
                 require(none { (id, _) -> id.isBlank() }) {
                     "The configuration contains a package curations provider with a blank ID which is not allowed."
                 }

--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -189,8 +189,6 @@ class AnalyzerCommand : OrtCommand(
         val analyzer = Analyzer(analyzerConfiguration, labels)
 
         val enabledCurationProviders = buildList {
-            addAll(PackageCurationProviderFactory.create(ortConfig.packageCurationProviders))
-
             val repositoryPackageCurations = repositoryConfiguration.curations.packages
 
             if (ortConfig.enableRepositoryPackageCurations) {
@@ -201,6 +199,8 @@ class AnalyzerCommand : OrtCommand(
                             "because the feature is disabled."
                 }
             }
+
+            addAll(PackageCurationProviderFactory.create(ortConfig.packageCurationProviders))
         }
 
         println("The following package curation providers are enabled:")

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -529,6 +529,11 @@ data class OrtResult(
         }
 }
 
+/**
+ * Return a set containing exactly one [CuratedPackage] for each given [Package], derived from applying all
+ * given [curations] to the packages they apply to. The given [curations] must be ordered highest-priority-first, which
+ * is the inverse order of their application.
+ */
 private fun applyPackageCurations(
     packages: Collection<Package>,
     curations: List<PackageCuration>
@@ -543,7 +548,7 @@ private fun applyPackageCurations(
     )
 
     return packages.mapTo(mutableSetOf()) { pkg ->
-        curationsForId[pkg.id].orEmpty().fold(pkg.toCuratedPackage()) { cur, packageCuration ->
+        curationsForId[pkg.id].orEmpty().asReversed().fold(pkg.toCuratedPackage()) { cur, packageCuration ->
             OrtResult.logger.debug {
                 "Applying curation '$packageCuration' to package '${pkg.id.toCoordinates()}'."
             }

--- a/model/src/main/kotlin/ResolvedConfiguration.kt
+++ b/model/src/main/kotlin/ResolvedConfiguration.kt
@@ -29,7 +29,8 @@ import com.fasterxml.jackson.annotation.JsonInclude
  */
 data class ResolvedConfiguration(
     /**
-     * All package curations applicable to the packages contained in the enclosing [OrtResult].
+     * All package curations applicable to the packages contained in the enclosing [OrtResult] ordered
+     * highest-priority-first.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val packageCurations: List<PackageCuration> = emptyList()


### PR DESCRIPTION
Conistently order the package curations or the providers repsectively by higherst-priority first. This avoids confusion compared to dealing with inconsistent ordering. This way only the logic which actually applies the curations needs to reverse the curations.

Add or update the KDoc of all releated functions and properties so that the order is always specified.

BREAKING CHANGE: There is no backwards compatibility for de-serializing ORT files prior to this change. Deserialization is possible, but leads to reversing the curation order. Note that recently deserialization has been broken anyway and very soon there will be another breaking change. So, it does not really matter whether this change is breaking as we decided for breaking it anyway.
