### PR TITLE
OrtResult: Associate package curations with provider IDs

### DIFF
--- a/advisor/src/test/assets/ort-analyzer-result.yml
+++ b/advisor/src/test/assets/ort-analyzer-result.yml
@@ -571,4 +571,8 @@ analyzer:
 scanner: null
 advisor: null
 evaluator: null
-resolved_configuration: {}
+resolved_configuration:
+  package_curations:
+  - provider:
+      id: "DefaultDir"
+    curations: []

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -361,7 +361,7 @@ private fun resolveConfiguration(
 
     curationProviders.forEach { (id, curationProvider) ->
         val (curations, duration) = measureTimedValue {
-            curationProvider.getCurationsFor(analyzerResult.packages).distinct()
+            curationProvider.getCurationsFor(analyzerResult.packages)
         }
 
         packageCurations += curations

--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -365,7 +365,18 @@ private fun resolveConfiguration(
             curationProvider.getCurationsFor(analyzerResult.packages)
         }
 
-        packageCurations[id] = curations
+        val (applicableCurations, nonApplicableCurations) = curations.partition { curation ->
+            analyzerResult.packages.any { pkg -> curation.isApplicable(pkg.id) }
+        }.let { it.first.toSet() to it.second.toSet() }
+
+        if (nonApplicableCurations.isNotEmpty()) {
+            Analyzer.logger.warn {
+                "The provider '$id' returned the following non-applicable curations: " +
+                        "${nonApplicableCurations.joinToString()}."
+            }
+        }
+
+        packageCurations[id] = applicableCurations
 
         Analyzer.logger().info { "Getting ${curations.size} package curation(s) from provider '$id' took $duration." }
     }

--- a/cli/src/funTest/assets/gradle-all-dependencies-expected-result-with-curations.yml
+++ b/cli/src/funTest/assets/gradle-all-dependencies-expected-result-with-curations.yml
@@ -462,11 +462,14 @@ advisor: null
 evaluator: null
 resolved_configuration:
   package_curations:
-  - id: "Maven:org.hamcrest::"
+  - provider:
+      id: "File"
     curations:
-      comment: "Use the actual homepage instead of the GitHub page."
-      homepage_url: "http://hamcrest.org/JavaHamcrest/"
-  - id: "Maven:org.hamcrest:hamcrest-core:"
-    curations:
-      comment: "Fix description."
-      description: "Curated description."
+    - id: "Maven:org.hamcrest:hamcrest-core:"
+      curations:
+        comment: "Fix description."
+        description: "Curated description."
+    - id: "Maven:org.hamcrest::"
+      curations:
+        comment: "Use the actual homepage instead of the GitHub page."
+        homepage_url: "http://hamcrest.org/JavaHamcrest/"

--- a/cli/src/funTest/assets/semver4j-ort-result.yml
+++ b/cli/src/funTest/assets/semver4j-ort-result.yml
@@ -345,4 +345,8 @@ advisor:
             severity: "5.5"
     has_issues: false
 evaluator: null
-resolved_configuration: {}
+resolved_configuration:
+  package_curations:
+  - provider:
+      id: "DefaultDir"
+    curations: []

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -273,7 +273,7 @@ class EvaluatorCommand : OrtCommand(
 
         if (packageCurationsDir != null || packageCurationsFile != null) {
             val provider = FilePackageCurationProvider(packageCurationsFile, packageCurationsDir)
-            ortResultInput = ortResultInput.replacePackageCurations(provider)
+            ortResultInput = ortResultInput.replacePackageCurations(provider, providerId = "EvaluatorCommandOption")
         }
 
         val packageConfigurationProvider = if (ortConfig.enableRepositoryPackageConfigurations) {

--- a/helper-cli/src/main/kotlin/commands/packagecuration/SetCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packagecuration/SetCommand.kt
@@ -59,7 +59,7 @@ class SetCommand : CliktCommand(
     override fun run() {
         val provider = FilePackageCurationProvider(packageCurationsFile, packageCurationsDir)
 
-        val ortResult = readOrtResult(ortFile).replacePackageCurations(provider)
+        val ortResult = readOrtResult(ortFile).replacePackageCurations(provider, providerId = "SetCommandOption")
 
         writeOrtResult(ortResult, ortFile)
     }

--- a/model/src/main/kotlin/ResolvedConfiguration.kt
+++ b/model/src/main/kotlin/ResolvedConfiguration.kt
@@ -36,7 +36,7 @@ data class ResolvedConfiguration(
      * each enabled provider.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val packageCurations: List<PackageCurationsEntry> = emptyList(),
+    val packageCurations: List<ResolvedPackageCurations> = emptyList(),
 ) {
     init {
         val duplicateProviderIds = packageCurations.getDuplicates().map { it.provider.id }
@@ -53,7 +53,7 @@ data class ResolvedConfiguration(
     fun getAllPackageCurations(): List<PackageCuration> = packageCurations.flatMap { it.curations }
 }
 
-data class PackageCurationsEntry(
+data class ResolvedPackageCurations(
     /**
      * All enabled providers ordered highest-priority-first.
      */

--- a/model/src/main/kotlin/utils/ConfigurationResolver.kt
+++ b/model/src/main/kotlin/utils/ConfigurationResolver.kt
@@ -27,8 +27,8 @@ import org.apache.logging.log4j.kotlin.logger
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCuration
-import org.ossreviewtoolkit.model.PackageCurationsEntry
 import org.ossreviewtoolkit.model.ResolvedConfiguration
+import org.ossreviewtoolkit.model.ResolvedPackageCurations
 
 object ConfigurationResolver : Logging {
     /**
@@ -50,7 +50,7 @@ object ConfigurationResolver : Logging {
     fun resolvePackageCurations(
         packages: Collection<Package>,
         curationProviders: List<Pair<String, PackageCurationProvider>>
-    ): List<PackageCurationsEntry> {
+    ): List<ResolvedPackageCurations> {
         val packageCurations = mutableMapOf<String, Set<PackageCuration>>()
 
         curationProviders.forEach { (id, curationProvider) ->
@@ -75,8 +75,8 @@ object ConfigurationResolver : Logging {
         }
 
         return packageCurations.map { (providerId, curations) ->
-            PackageCurationsEntry(
-                provider = PackageCurationsEntry.Provider(providerId),
+            ResolvedPackageCurations(
+                provider = ResolvedPackageCurations.Provider(providerId),
                 curations = curations
             )
         }

--- a/model/src/main/kotlin/utils/ConfigurationResolver.kt
+++ b/model/src/main/kotlin/utils/ConfigurationResolver.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.utils
+
+import kotlin.time.measureTimedValue
+
+import org.apache.logging.log4j.kotlin.Logging
+import org.apache.logging.log4j.kotlin.logger
+
+import org.ossreviewtoolkit.model.AnalyzerResult
+import org.ossreviewtoolkit.model.PackageCuration
+import org.ossreviewtoolkit.model.PackageCurationsEntry
+import org.ossreviewtoolkit.model.ResolvedConfiguration
+
+object ConfigurationResolver : Logging {
+    /**
+     * Return the resolved configuration for the given [analyzerResult]. The [curationProviders] must be ordered
+     * highest-priority-first.
+     */
+    fun resolveConfiguration(
+        analyzerResult: AnalyzerResult,
+        curationProviders: List<Pair<String, PackageCurationProvider>>
+    ): ResolvedConfiguration {
+        val packageCurations = mutableMapOf<String, Set<PackageCuration>>()
+
+        curationProviders.forEach { (id, curationProvider) ->
+            val (curations, duration) = measureTimedValue {
+                curationProvider.getCurationsFor(analyzerResult.packages)
+            }
+
+            val (applicableCurations, nonApplicableCurations) = curations.partition { curation ->
+                analyzerResult.packages.any { pkg -> curation.isApplicable(pkg.id) }
+            }.let { it.first.toSet() to it.second.toSet() }
+
+            if (nonApplicableCurations.isNotEmpty()) {
+                logger.warn {
+                    "The provider '$id' returned the following non-applicable curations: " +
+                            "${nonApplicableCurations.joinToString()}."
+                }
+            }
+
+            packageCurations[id] = applicableCurations
+
+            logger().info { "Getting ${curations.size} package curation(s) from provider '$id' took $duration." }
+        }
+
+        return ResolvedConfiguration(
+            packageCurations = packageCurations.map { (providerId, curations) ->
+                PackageCurationsEntry(
+                    provider = PackageCurationsEntry.Provider(providerId),
+                    curations = curations
+                )
+            }
+        )
+    }
+}

--- a/model/src/test/assets/analyzer-result-with-dependency-graph.yml
+++ b/model/src/test/assets/analyzer-result-with-dependency-graph.yml
@@ -177,15 +177,18 @@ advisor: null
 evaluator: null
 resolved_configuration:
   package_curations:
-  - id: "Maven:junit:junit:4.12"
+  - provider:
+      id: "DefaultDir"
     curations:
-      comment: "ScanCode claims to find some NOASSERTION and Apache-2.0 in the FAQ\
-        \ and the pom.xml, both are false-positives."
-      concluded_license: "EPL-1.0"
-      vcs:
-        type: "Git"
-        url: "https://github.com/junit-team/junit4.git"
-        revision: "r4.12"
+    - id: "Maven:junit:junit:4.12"
+      curations:
+        comment: "ScanCode claims to find some NOASSERTION and Apache-2.0 in the FAQ\
+          \ and the pom.xml, both are false-positives."
+        concluded_license: "EPL-1.0"
+        vcs:
+          type: "Git"
+          url: "https://github.com/junit-team/junit4.git"
+          revision: "r4.12"
 labels:
   applicationCategory: "BT05 Client application"
   projectName: "Semver4jNewDependencyGraphShared"

--- a/model/src/test/assets/gradle-all-dependencies-expected-result.yml
+++ b/model/src/test/assets/gradle-all-dependencies-expected-result.yml
@@ -459,4 +459,8 @@ analyzer:
 scanner: null
 advisor: null
 evaluator: null
-resolved_configuration: {}
+resolved_configuration:
+  package_curations:
+  - provider:
+      id: "DefaultDir"
+    curations: []

--- a/model/src/test/assets/result-with-issues-graph-old.yml
+++ b/model/src/test/assets/result-with-issues-graph-old.yml
@@ -1310,4 +1310,8 @@ analyzer:
 scanner: null
 advisor: null
 evaluator: null
-resolved_configuration: {}
+resolved_configuration:
+  package_curations:
+  - provider:
+      id: "DefaultDir"
+    curations: []

--- a/model/src/test/assets/result-with-issues-graph.yml
+++ b/model/src/test/assets/result-with-issues-graph.yml
@@ -1339,4 +1339,8 @@ analyzer:
 scanner: null
 advisor: null
 evaluator: null
-resolved_configuration: {}
+resolved_configuration:
+  package_curations:
+  - provider:
+      id: "DefaultDir"
+    curations: []

--- a/model/src/test/assets/result-with-issues-scopes.yml
+++ b/model/src/test/assets/result-with-issues-scopes.yml
@@ -1306,4 +1306,8 @@ analyzer:
 scanner: null
 advisor: null
 evaluator: null
-resolved_configuration: {}
+resolved_configuration:
+  package_curations:
+  - provider:
+      id: "DefaultDir"
+    curations: []

--- a/model/src/test/assets/sbt-multi-project-example-graph-old.yml
+++ b/model/src/test/assets/sbt-multi-project-example-graph-old.yml
@@ -1300,4 +1300,8 @@ analyzer:
 scanner: null
 advisor: null
 evaluator: null
-resolved_configuration: {}
+resolved_configuration:
+  package_curations:
+  - provider:
+      id: "DefaultDir"
+    curations: []

--- a/model/src/test/assets/sbt-multi-project-example-graph.yml
+++ b/model/src/test/assets/sbt-multi-project-example-graph.yml
@@ -1329,4 +1329,8 @@ analyzer:
 scanner: null
 advisor: null
 evaluator: null
-resolved_configuration: {}
+resolved_configuration:
+  package_curations:
+  - provider:
+      id: "DefaultDir"
+    curations: []

--- a/reporter/src/funTest/assets/gradle-all-dependencies-result.yml
+++ b/reporter/src/funTest/assets/gradle-all-dependencies-result.yml
@@ -536,4 +536,8 @@ analyzer:
 scanner: null
 advisor: null
 evaluator: null
-resolved_configuration: {}
+resolved_configuration:
+  package_curations:
+  - provider:
+      id: "DefaultDir"
+    curations: []

--- a/reporter/src/funTest/assets/static-html-reporter-test-input.yml
+++ b/reporter/src/funTest/assets/static-html-reporter-test-input.yml
@@ -639,14 +639,17 @@ evaluator:
       \ that overflow:scroll is working as expected.\n```"
 resolved_configuration:
   package_curations:
-  - id: "Maven:com.foobar:foobar:1.0"
+  - provider:
+      id: "DefaultDir"
     curations:
-      comment: "Foobar is an imaginary dependency and offers a license choice"
-      concluded_license: "GPL-2.0-only OR MIT"
-  - id: "Maven:com.h2database:h2:1.4.200"
-    curations:
-      comment: "H2 database offers a license choice"
-      concluded_license: "MPL-2.0 OR EPL-1.0"
+    - id: "Maven:com.foobar:foobar:1.0"
+      curations:
+        comment: "Foobar is an imaginary dependency and offers a license choice"
+        concluded_license: "GPL-2.0-only OR MIT"
+    - id: "Maven:com.h2database:h2:1.4.200"
+      curations:
+        comment: "H2 database offers a license choice"
+        concluded_license: "MPL-2.0 OR EPL-1.0"
 labels:
   job_parameters.JOB_PARAM_1: "label job param 1"
   job_parameters.JOB_PARAM_2: "label job param 2"

--- a/scanner/src/funTest/assets/analyzer-result.yml
+++ b/scanner/src/funTest/assets/analyzer-result.yml
@@ -184,4 +184,8 @@ analyzer:
 scanner: null
 advisor: null
 evaluator: null
-resolved_configuration: {}
+resolved_configuration:
+  package_curations:
+  - provider:
+      id: "DefaultDir"
+    curations: []

--- a/scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
+++ b/scanner/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
@@ -369,4 +369,8 @@ scanner:
   has_issues: true
 advisor: null
 evaluator: null
-resolved_configuration: {}
+resolved_configuration:
+  package_curations:
+  - provider:
+      id: "DefaultDir"
+    curations: []


### PR DESCRIPTION
Keep the association between curations and providers (IDs) in the `OrtResult` to enable

1. Tracability of curations back to providers
2. supporting additional use cases
    - replace curations for specific provider with given ones
    - re-request curations for given provider IDs

See individual commits.

BREAKING CHANGE: No backwards compatibility for de-serializing ORT files. This is ok as backwards compatibility has been broken very recently, so it's not a big deal to extend this by a couple of days. The file format change is limited to `OrtResult.resolvedConfiguration`.

