### PR TITLE
analyzer: Move `CurationProvider` to the `model` module

### DIFF
--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -52,6 +52,7 @@ import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.Excludes
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.orEmpty
+import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES

--- a/analyzer/src/main/kotlin/PackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/PackageCurationProvider.kt
@@ -21,61 +21,6 @@ package org.ossreviewtoolkit.analyzer
 
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCuration
-import org.ossreviewtoolkit.model.config.PackageCurationProviderConfiguration
-import org.ossreviewtoolkit.utils.common.ConfigurablePluginFactory
-import org.ossreviewtoolkit.utils.common.Plugin
-import org.ossreviewtoolkit.utils.common.getDuplicates
-
-/**
- * The extension point for [PackageCurationProvider]s.
- */
-interface PackageCurationProviderFactory<CONFIG> : ConfigurablePluginFactory<PackageCurationProvider> {
-    companion object {
-        val ALL = Plugin.getAll<PackageCurationProviderFactory<*>>()
-        const val REPOSITORY_CONFIGURATION_PROVIDER_ID = "RepositoryConfiguration"
-
-        /**
-         * Return a new (identifier, provider instance) tuple for each
-         * [enabled][PackageCurationProviderConfiguration.enabled] provider configuration in [configurations] ordered
-         * highest-priority first. The given [configurations] must be ordered highest-priority first as well.
-         */
-        fun create(
-            configurations: List<PackageCurationProviderConfiguration>
-        ): List<Pair<String, PackageCurationProvider>> =
-            configurations.filter {
-                it.enabled
-            }.map {
-                it.id to ALL.getValue(it.type).create(it.config)
-            }.apply {
-                require(none { (id, _) -> id.isBlank() }) {
-                    "The configuration contains a package curations provider with a blank ID which is not allowed."
-                }
-
-                val duplicateIds = getDuplicates { (id, _) -> id }.keys
-                require(duplicateIds.isEmpty()) {
-                    "Found multiple package curation providers for the IDs ${duplicateIds.joinToString()}, which is " +
-                            "not allowed. Please configure a unique ID for each package curation provider."
-                }
-
-                require(none { (id, _) -> id == REPOSITORY_CONFIGURATION_PROVIDER_ID }) {
-                    "Found a package curation provider which uses '$REPOSITORY_CONFIGURATION_PROVIDER_ID' as its id " +
-                            "which is reserved and not allowed."
-                }
-            }
-    }
-
-    override fun create(config: Map<String, String>): PackageCurationProvider = create(parseConfig(config))
-
-    /**
-     * Create a new [PackageCurationProvider] with [config].
-     */
-    fun create(config: CONFIG): PackageCurationProvider
-
-    /**
-     * Parse the [config] map into an object.
-     */
-    fun parseConfig(config: Map<String, String>): CONFIG
-}
 
 /**
  * A provider for [PackageCuration]s.

--- a/analyzer/src/main/kotlin/PackageCurationProviderFactory.kt
+++ b/analyzer/src/main/kotlin/PackageCurationProviderFactory.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2017 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer
+
+import org.ossreviewtoolkit.model.config.PackageCurationProviderConfiguration
+import org.ossreviewtoolkit.utils.common.ConfigurablePluginFactory
+import org.ossreviewtoolkit.utils.common.Plugin
+import org.ossreviewtoolkit.utils.common.getDuplicates
+
+/**
+ * The extension point for [PackageCurationProvider]s.
+ */
+interface PackageCurationProviderFactory<CONFIG> : ConfigurablePluginFactory<PackageCurationProvider> {
+    companion object {
+        val ALL = Plugin.getAll<PackageCurationProviderFactory<*>>()
+        const val REPOSITORY_CONFIGURATION_PROVIDER_ID = "RepositoryConfiguration"
+
+        /**
+         * Return a new (identifier, provider instance) tuple for each
+         * [enabled][PackageCurationProviderConfiguration.enabled] provider configuration in [configurations] ordered
+         * highest-priority first. The given [configurations] must be ordered highest-priority first as well.
+         */
+        fun create(
+            configurations: List<PackageCurationProviderConfiguration>
+        ): List<Pair<String, PackageCurationProvider>> =
+            configurations.filter {
+                it.enabled
+            }.map {
+                it.id to ALL.getValue(it.type).create(it.config)
+            }.apply {
+                require(none { (id, _) -> id.isBlank() }) {
+                    "The configuration contains a package curations provider with a blank ID which is not allowed."
+                }
+
+                val duplicateIds = getDuplicates { (id, _) -> id }.keys
+                require(duplicateIds.isEmpty()) {
+                    "Found multiple package curation providers for the IDs ${duplicateIds.joinToString()}, which is " +
+                            "not allowed. Please configure a unique ID for each package curation provider."
+                }
+
+                require(none { (id, _) -> id == REPOSITORY_CONFIGURATION_PROVIDER_ID }) {
+                    "Found a package curation provider which uses '$REPOSITORY_CONFIGURATION_PROVIDER_ID' as its id " +
+                            "which is reserved and not allowed."
+                }
+            }
+    }
+
+    override fun create(config: Map<String, String>): PackageCurationProvider = create(parseConfig(config))
+
+    /**
+     * Create a new [PackageCurationProvider] with [config].
+     */
+    fun create(config: CONFIG): PackageCurationProvider
+
+    /**
+     * Parse the [config] map into an object.
+     */
+    fun parseConfig(config: Map<String, String>): CONFIG
+}

--- a/analyzer/src/main/kotlin/PackageCurationProviderFactory.kt
+++ b/analyzer/src/main/kotlin/PackageCurationProviderFactory.kt
@@ -20,6 +20,7 @@
 package org.ossreviewtoolkit.analyzer
 
 import org.ossreviewtoolkit.model.config.PackageCurationProviderConfiguration
+import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.utils.common.ConfigurablePluginFactory
 import org.ossreviewtoolkit.utils.common.Plugin
 import org.ossreviewtoolkit.utils.common.getDuplicates

--- a/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/ClearlyDefinedPackageCurationProvider.kt
@@ -27,7 +27,6 @@ import okhttp3.OkHttpClient
 
 import org.apache.logging.log4j.kotlin.Logging
 
-import org.ossreviewtoolkit.analyzer.PackageCurationProvider
 import org.ossreviewtoolkit.analyzer.PackageCurationProviderFactory
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
@@ -43,6 +42,7 @@ import org.ossreviewtoolkit.model.PackageCurationData
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.VcsInfoCurationData
 import org.ossreviewtoolkit.model.VcsType
+import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.model.utils.toClearlyDefinedTypeAndProvider
 import org.ossreviewtoolkit.utils.common.collectMessages
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper

--- a/analyzer/src/main/kotlin/curation/FilePackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/FilePackageCurationProvider.kt
@@ -24,11 +24,11 @@ import java.io.IOException
 
 import org.apache.logging.log4j.kotlin.Logging
 
-import org.ossreviewtoolkit.analyzer.PackageCurationProvider
 import org.ossreviewtoolkit.analyzer.PackageCurationProviderFactory
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.utils.common.getDuplicates
 import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CURATIONS_DIRNAME
 import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CURATIONS_FILENAME

--- a/analyzer/src/main/kotlin/curation/OrtConfigPackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/OrtConfigPackageCurationProvider.kt
@@ -24,7 +24,6 @@ import java.io.IOException
 
 import org.apache.logging.log4j.kotlin.Logging
 
-import org.ossreviewtoolkit.analyzer.PackageCurationProvider
 import org.ossreviewtoolkit.analyzer.PackageCurationProviderFactory
 import org.ossreviewtoolkit.downloader.vcs.Git
 import org.ossreviewtoolkit.model.Identifier
@@ -33,6 +32,7 @@ import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.utils.common.encodeOr
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.ort.ortDataDirectory

--- a/analyzer/src/main/kotlin/curation/SimplePackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/SimplePackageCurationProvider.kt
@@ -19,9 +19,9 @@
 
 package org.ossreviewtoolkit.analyzer.curation
 
-import org.ossreviewtoolkit.analyzer.PackageCurationProvider
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCuration
+import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 
 /**
  * A [PackageCurationProvider] that provides the specified [packageCurations].

--- a/analyzer/src/main/kotlin/curation/Sw360PackageCurationProvider.kt
+++ b/analyzer/src/main/kotlin/curation/Sw360PackageCurationProvider.kt
@@ -32,7 +32,6 @@ import org.eclipse.sw360.clients.rest.resource.releases.SW360Release
 import org.eclipse.sw360.http.HttpClientFactoryImpl
 import org.eclipse.sw360.http.config.HttpClientConfig
 
-import org.ossreviewtoolkit.analyzer.PackageCurationProvider
 import org.ossreviewtoolkit.analyzer.PackageCurationProviderFactory
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.HashAlgorithm
@@ -44,6 +43,7 @@ import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.config.Sw360StorageConfiguration
 import org.ossreviewtoolkit.model.jsonMapper
 import org.ossreviewtoolkit.model.orEmpty
+import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.utils.ort.DeclaredLicenseProcessor
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -272,8 +272,8 @@ class EvaluatorCommand : OrtCommand(
         }
 
         if (packageCurationsDir != null || packageCurationsFile != null) {
-            val curations = FilePackageCurationProvider(packageCurationsFile, packageCurationsDir).packageCurations
-            ortResultInput = ortResultInput.replacePackageCurations(curations)
+            val provider = FilePackageCurationProvider(packageCurationsFile, packageCurationsDir)
+            ortResultInput = ortResultInput.replacePackageCurations(provider)
         }
 
         val packageConfigurationProvider = if (ortConfig.enableRepositoryPackageConfigurations) {

--- a/helper-cli/src/main/kotlin/commands/packagecuration/SetCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/packagecuration/SetCommand.kt
@@ -57,9 +57,9 @@ class SetCommand : CliktCommand(
         .convert { it.absoluteFile.normalize() }
 
     override fun run() {
-        val curations = FilePackageCurationProvider(packageCurationsFile, packageCurationsDir).packageCurations
+        val provider = FilePackageCurationProvider(packageCurationsFile, packageCurationsDir)
 
-        val ortResult = readOrtResult(ortFile).replacePackageCurations(curations)
+        val ortResult = readOrtResult(ortFile).replacePackageCurations(provider)
 
         writeOrtResult(ortResult, ortFile)
     }

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -29,6 +29,7 @@ import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.Resolutions
 import org.ossreviewtoolkit.model.config.orEmpty
+import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.utils.common.zipWithCollections
 import org.ossreviewtoolkit.utils.spdx.model.SpdxLicenseChoice
 
@@ -318,12 +319,12 @@ data class OrtResult(
     fun replaceConfig(config: RepositoryConfiguration): OrtResult = copy(repository = repository.copy(config = config))
 
     /**
-     * Return a copy of this [OrtResult] with the [PackageCuration]s replaced by the given [curations].
+     * Return a copy of this [OrtResult] with the [PackageCuration]s replaced by the ones from the given [provider].
      */
-    fun replacePackageCurations(curations: Collection<PackageCuration>): OrtResult {
-        val packageIds = getPackages().map { it.metadata.id }
-        val applicableCurations = curations.filter { curation ->
-            packageIds.any { curation.isApplicable(it) }
+    fun replacePackageCurations(provider: PackageCurationProvider): OrtResult {
+        val packages = analyzer?.result?.packages.orEmpty()
+        val applicableCurations = provider.getCurationsFor(packages).filter { curation ->
+            packages.any { curation.isApplicable(it.id) }
         }
 
         return copy(

--- a/model/src/main/kotlin/utils/PackageCurationProvider.kt
+++ b/model/src/main/kotlin/utils/PackageCurationProvider.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.analyzer
+package org.ossreviewtoolkit.model.utils
 
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCuration


### PR DESCRIPTION
Simplify adding provider IDs to `OrtResult` in a following PR. 
Note that the provider now lives next to `PackageConfigurationProvider`.

See individual commits.