### PR TITLE
refactor(PackageCurationData)!: Drop support for legacy property name

### DIFF
--- a/model/src/main/kotlin/PackageCurationData.kt
+++ b/model/src/main/kotlin/PackageCurationData.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.model
 
-import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonInclude
 
 import org.ossreviewtoolkit.utils.common.zip
@@ -88,7 +87,6 @@ data class PackageCurationData(
     /**
      * Whether the package is metadata only.
      */
-    @JsonAlias("is_meta_data_only")
     val isMetadataOnly: Boolean? = null,
 
     /**


### PR DESCRIPTION
The property has been renamed five month ago [^1] and it's easy to make the needed alignments, see [^2]. So, drop this last remaining `@JsonAlias` annotation to eliminate technical debt.

[^1]: https://github.com/oss-review-toolkit/ort/commit/b9e8b63ace7215f042a80b41f5c8b5fcbedaebea
[^2]: https://github.com/oss-review-toolkit/ort-config/pull/96

BREAKING CHANGE: Align your `ort-config` curations as illustrated in [^2].

**Note: Should be merged after [^2].**