### PR TITLE
VulnerableCode: Uses aliases instead of internal vulnerability IDs

### DIFF
--- a/advisor/src/test/assets/__files/vulnerable-code/response_junit.json
+++ b/advisor/src/test/assets/__files/vulnerable-code/response_junit.json
@@ -1,0 +1,71 @@
+[
+  {
+    "url": "http://public.vulnerablecode.io/api/packages/168702",
+    "purl": "pkg:maven/junit/junit@4.12",
+    "type": "maven",
+    "namespace": "junit",
+    "name": "junit",
+    "version": "4.12",
+    "qualifiers": {},
+    "subpath": "",
+    "affected_by_vulnerabilities": [
+      {
+        "url": "http://public.vulnerablecode.io/api/vulnerabilities/1265",
+        "vulnerability_id": "VCID-e1bu-4uh4-aaac",
+        "summary": "",
+        "fixed_packages": [
+          {
+            "url": "http://public.vulnerablecode.io/api/packages/99502",
+            "purl": "pkg:maven/junit/junit@4.13.1",
+            "is_vulnerable": false
+          }
+        ]
+      }
+    ],
+    "fixing_vulnerabilities": [],
+    "unresolved_vulnerabilities": [
+      {
+        "url": "http://public.vulnerablecode.io/api/vulnerabilities/1265",
+        "vulnerability_id": "VCID-e1bu-4uh4-aaac",
+        "summary": "",
+        "references": [
+          {
+            "reference_url": "http://people.canonical.com/~ubuntu-security/cve/2020/CVE-2020-15250.html",
+            "reference_id": "",
+            "scores": [
+              {
+                "value": "Medium",
+                "scoring_system": "generic_textual",
+                "scoring_elements": ""
+              }
+            ],
+            "url": "http://people.canonical.com/~ubuntu-security/cve/2020/CVE-2020-15250.html"
+          },
+          {
+            "reference_url": "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2020-15250.json",
+            "reference_id": "",
+            "scores": [
+              {
+                "value": "4.0",
+                "scoring_system": "cvssv3",
+                "scoring_elements": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+              }
+            ],
+            "url": "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2020-15250.json"
+          }
+        ],
+        "aliases": [
+           "CVE-2020-15250",
+            "GHSA-269g-pwp5-87pp"
+        ],
+        "fixed_packages": [
+          {
+            "url": "http://public.vulnerablecode.io/api/packages/99502",
+            "purl": "pkg:maven/junit/junit@4.13.1",
+            "is_vulnerable": false
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/advisor/src/test/assets/__files/vulnerable-code/response_log4j.json
+++ b/advisor/src/test/assets/__files/vulnerable-code/response_log4j.json
@@ -1,0 +1,52 @@
+[
+  {
+    "url": "http://public.vulnerablecode.io/api/packages/124759",
+    "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.17.0",
+    "type": "maven",
+    "namespace": "org.apache.logging.log4j",
+    "name": "log4j-core",
+    "version": "2.17.0",
+    "qualifiers": {},
+    "subpath": "",
+    "unresolved_vulnerabilities": [
+      {
+        "url": "http://public.vulnerablecode.io/api/vulnerabilities/8905",
+        "vulnerability_id": "VCID-bk15-3vac-aaaj",
+        "summary": "Remote code injection in Log4j",
+        "references": [
+          {
+            "reference_url": "http://ref.com/files/165225/Apache-Log4j2-2.14.1-Remote-Code-Execution.html",
+            "reference_id": "",
+            "scores": [],
+            "url": "http://ref.com/files/165225/Apache-Log4j2-2.14.1-Remote-Code-Execution.html"
+          }
+        ],
+        "aliases": [
+          "GHSA-jfh8-c2jp-5v3q"
+        ]
+      },
+      {
+        "url": "http://public.vulnerablecode.io/api/vulnerabilities/8994",
+        "vulnerability_id": "VCID-y1c6-8gmx-aaar",
+        "summary": "Improper Input Validation and Injection in Apache Log4j2",
+        "references": [
+          {
+            "reference_url": "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-44832.json",
+            "reference_id": "",
+            "scores": [
+              {
+                "value": "6.6",
+                "scoring_system": "cvssv3",
+                "scoring_elements": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H"
+              }
+            ],
+            "url": "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-44832.json"
+          }
+        ],
+        "aliases": [
+          "CVE-2021-44832"
+        ]
+      }
+    ]
+  }
+]

--- a/advisor/src/test/kotlin/advisors/VulnerableCodeTest.kt
+++ b/advisor/src/test/kotlin/advisors/VulnerableCodeTest.kt
@@ -76,7 +76,7 @@ class VulnerableCodeTest : WordSpec({
         "return vulnerability information" {
             server.stubPackagesRequest("response_packages.json")
             val vulnerableCode = createVulnerableCode(server)
-            val packagesToAdvise = inputPackages()
+            val packagesToAdvise = inputPackagesFromAnalyzerResult()
 
             val result = vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
@@ -142,6 +142,69 @@ class VulnerableCodeTest : WordSpec({
             strutsResults.flatMap { it.vulnerabilities } should containExactlyInAnyOrder(expStrutsVulnerabilities)
         }
 
+        "extract the CVE ID from an alias" {
+            server.stubPackagesRequest("response_junit.json", request = generatePackagesRequest(idJUnit))
+            val vulnerableCode = createVulnerableCode(server)
+            val packagesToAdvise = inputPackagesFromIdentifiers(idJUnit)
+
+            val result = vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            val junitResults = result.getValue(idJUnit)
+
+            val expJunitVulnerability = Vulnerability(
+                id = "CVE-2020-15250",
+                references = listOf(
+                    VulnerabilityReference(
+                        URI("http://people.canonical.com/~ubuntu-security/cve/2020/CVE-2020-15250.html"),
+                        scoringSystem = "generic_textual",
+                        severity = "Medium"
+                    ),
+                    VulnerabilityReference(
+                        URI("https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2020-15250.json"),
+                        scoringSystem = "cvssv3",
+                        severity = "4.0"
+                    )
+                )
+            )
+
+            junitResults.flatMap { it.vulnerabilities } should containExactly(expJunitVulnerability)
+        }
+
+        "extract other official identifiers from aliases" {
+            server.stubPackagesRequest("response_log4j.json", generatePackagesRequest(idLog4j))
+            val vulnerableCode = createVulnerableCode(server)
+            val packagesToAdvise = inputPackagesFromIdentifiers(idLog4j)
+
+            val result = vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
+
+            val log4jResults = result.getValue(idLog4j)
+
+            val expLog4jVulnerabilities = listOf(
+                Vulnerability(
+                    id = "GHSA-jfh8-c2jp-5v3q",
+                    references = listOf(
+                        VulnerabilityReference(
+                            URI("http://ref.com/files/165225/Apache-Log4j2-2.14.1-Remote-Code-Execution.html"),
+                            scoringSystem = null,
+                            severity = null
+                        )
+                    )
+                ),
+                Vulnerability(
+                    id = "CVE-2021-44832",
+                    references = listOf(
+                        VulnerabilityReference(
+                            URI("https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-44832.json"),
+                            scoringSystem = "cvssv3",
+                            severity = "6.6"
+                        )
+                    )
+                )
+            )
+
+            log4jResults.flatMap { it.vulnerabilities } should containExactlyInAnyOrder(expLog4jVulnerabilities)
+        }
+
         "handle a failure response from the server" {
             server.stubFor(
                 post(urlPathEqualTo("/api/packages/bulk_search/"))
@@ -150,7 +213,7 @@ class VulnerableCodeTest : WordSpec({
                     )
             )
             val vulnerableCode = createVulnerableCode(server)
-            val packagesToAdvise = inputPackages()
+            val packagesToAdvise = inputPackagesFromAnalyzerResult()
 
             val result = vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
@@ -173,7 +236,7 @@ class VulnerableCodeTest : WordSpec({
         "filter out packages without vulnerabilities" {
             server.stubPackagesRequest("response_packages_no_vulnerabilities.json")
             val vulnerableCode = createVulnerableCode(server)
-            val packagesToAdvise = inputPackages()
+            val packagesToAdvise = inputPackagesFromAnalyzerResult()
 
             val result = vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
@@ -183,7 +246,7 @@ class VulnerableCodeTest : WordSpec({
         "handle unexpected packages in the query result" {
             server.stubPackagesRequest("response_unexpected_packages.json")
             val vulnerableCode = createVulnerableCode(server)
-            val packagesToAdvise = inputPackages()
+            val packagesToAdvise = inputPackagesFromAnalyzerResult()
 
             val result = vulnerableCode.retrievePackageFindings(packagesToAdvise).mapKeys { it.key.id }
 
@@ -211,6 +274,7 @@ private val idText = Identifier("Maven:org.apache.commons:commons-text:1.1")
 private val idStruts = Identifier("Maven:org.apache.struts:struts2-assembly:2.5.14.1")
 private val idJUnit = Identifier("Maven:junit:junit:4.12")
 private val idHamcrest = Identifier("Maven:org.hamcrest:hamcrest-core:1.3")
+private val idLog4j = Identifier("Maven:org.apache.logging.log4j:log4j-core:2.17.0")
 
 /**
  * The list with the identifiers of packages that are referenced in the test result file.
@@ -228,13 +292,13 @@ private val packages = packageIdentifiers.map { it.toPurl() }
 private val packagesRequestJson = generatePackagesRequest()
 
 /**
- * Prepare this server to expect a bulk request for the test packages and to answer it with the given [responseFile].
+ * Prepare this server to expect a bulk [request] for the test packages and to answer it with the given [responseFile].
  */
-private fun WireMockServer.stubPackagesRequest(responseFile: String) {
+private fun WireMockServer.stubPackagesRequest(responseFile: String, request: String = packagesRequestJson) {
     stubFor(
         post(urlPathEqualTo("/api/packages/bulk_search"))
             .withRequestBody(
-                equalToJson(packagesRequestJson, /* ignoreArrayOrder = */ true, /* ignoreExtraElements = */ false)
+                equalToJson(request, /* ignoreArrayOrder = */ true, /* ignoreExtraElements = */ false)
             )
             .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
             .willReturn(
@@ -266,12 +330,24 @@ private fun resultFile(): File = File(TEST_FILES_ROOT, TEST_RESULT_NAME)
 /**
  * Return a list with [Package]s from the analyzer result file that serve as input for the [VulnerableCode] advisor.
  */
-private fun inputPackages(): Set<Package> =
+private fun inputPackagesFromAnalyzerResult(): Set<Package> =
     resultFile().readValue<OrtResult>().getPackages().mapTo(mutableSetOf()) { it.metadata }
 
 /**
- * Generate the JSON body of the request to query information about packages. It mainly consists of an array with the
- * package URLs.
+ * Return a set with [Package]s to be used as input for the [VulnerableCode] advisor derived from the given
+ * [identifiers].
  */
-private fun generatePackagesRequest(): String =
-    packages.joinToString(prefix = "{ \"purls\": [", postfix = "] }") { "\"$it\"" }
+private fun inputPackagesFromIdentifiers(vararg identifiers: Identifier): Set<Package> =
+    identifiers.map { Package.EMPTY.copy(id = it, purl = it.toPurl()) }.toSet()
+
+/**
+ * Generate the JSON body of the request to query information about the packages identified by the given [purls].
+ * The request mainly consists of an array with the package URLs.
+ */
+private fun generatePackagesRequest(purls: Collection<String> = packages): String =
+    purls.joinToString(prefix = "{ \"purls\": [", postfix = "] }") { "\"$it\"" }
+
+/**
+ * Generate the JSON body of the request to query vulnerability information about the [Package] with the given [id].
+ */
+private fun generatePackagesRequest(id: Identifier): String = generatePackagesRequest(listOf(id.toPurl()))

--- a/clients/vulnerable-code/src/main/kotlin/VulnerableCodeService.kt
+++ b/clients/vulnerable-code/src/main/kotlin/VulnerableCodeService.kt
@@ -112,12 +112,20 @@ interface VulnerableCodeService {
      */
     @Serializable
     data class Vulnerability(
-        /** A URL with information about the vulnerability. */
+        /** The VulnerableCode-specific identifier for this vulnerability. */
         @SerialName("vulnerability_id")
         val vulnerabilityId: String,
 
         /** A list with [VulnerabilityReference]s pointing to sources of information about this vulnerability. */
-        val references: List<VulnerabilityReference>
+        val references: List<VulnerabilityReference>,
+
+        /**
+         * A list with strings representing alias identifiers for this vulnerability as they are used by other
+         * databases. VulnerableCode here returns plain strings without further context information; therefore, it is
+         * currently only possible to determine the source of a specific identifier from its structure, e.g. if it has
+         * a well-known prefix like CVE or GHSA.
+         */
+        val aliases: List<String> = emptyList()
     )
 
     /**


### PR DESCRIPTION
While older versions of VulnerableCode used to return official identifiers (like CVEs) for vulnerabilities, this is no longer the case. Instead, internal IDs are used. There is, however, information about aliases which contains such official identifiers. This PR evaluates this information and tries to generate more meaningful IDs for vulnerabilities to be displayed in reports.
_Note_: The presence of alias information in query results is a rather new feature which is not yet part of the latest release of VulnerableCode. There is a related issue [1]. So, there may still be changes in the final release version. The results used by the tests are obtained from the public VulnerableCode instance which already includes this information. The changes in the PR are compatible with older versions, since alias information is optional.

[1] https://github.com/nexB/vulnerablecode/issues/1090