### PR TITLE
fix(Dependency graph): Do not drop packages during graph conversion

### DIFF
--- a/model/src/main/kotlin/utils/DependencyGraphConverter.kt
+++ b/model/src/main/kotlin/utils/DependencyGraphConverter.kt
@@ -58,7 +58,7 @@ object DependencyGraphConverter {
         val filteredPackages = if (excludes.scopes.isEmpty()) {
             result.packages
         } else {
-            filterExcludedPackages(graphs.values, result.packages)
+            filterExcludedPackages(allGraphs.values, result.packages)
         }
 
         return result.copy(


### PR DESCRIPTION
This is fix for 09285cb4. When filtering out excluded packages, the packages detected by managers already supporting the dependency graph format natively were dropped accidentally.
