### PR TITLE
refactor(OrtResult): Use getUncuratedPackages() again

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -339,7 +339,7 @@ data class OrtResult(
      */
     fun replacePackageCurations(provider: PackageCurationProvider, providerId: String): OrtResult {
         val packageCurations = ConfigurationResolver.resolvePackageCurations(
-            packages = analyzer?.result?.packages.orEmpty(),
+            packages = getUncuratedPackages(),
             curationProviders = listOf(providerId to provider)
         )
 


### PR DESCRIPTION
This is a fix-up for 57e6dce.
