### PR TITLE
fix(OrtResult): Suppress an unused warning

### DIFF
--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -426,6 +426,7 @@ data class OrtResult(
     /**
      * Return the list of [AdvisorResult]s for the given [id].
      */
+    @Suppress("UNUSED")
     fun getAdvisorResultsForId(id: Identifier): List<AdvisorResult> = advisorResultsById[id].orEmpty()
 
     /**


### PR DESCRIPTION
It makes sense to keep this function for programatic use of ORT, for consistency with `getScanResultsForId()`.

