### PR TITLE
Gracefully handle package curations when replacing repository configurations or curations

### DIFF
--- a/analyzer/src/main/kotlin/PackageCurationProviderFactory.kt
+++ b/analyzer/src/main/kotlin/PackageCurationProviderFactory.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.analyzer
 
+import org.ossreviewtoolkit.model.ResolvedPackageCurations.Companion.REPOSITORY_CONFIGURATION_PROVIDER_ID
 import org.ossreviewtoolkit.model.config.PackageCurationProviderConfiguration
 import org.ossreviewtoolkit.model.utils.PackageCurationProvider
 import org.ossreviewtoolkit.utils.common.ConfigurablePluginFactory
@@ -31,7 +32,6 @@ import org.ossreviewtoolkit.utils.common.getDuplicates
 interface PackageCurationProviderFactory<CONFIG> : ConfigurablePluginFactory<PackageCurationProvider> {
     companion object {
         val ALL = Plugin.getAll<PackageCurationProviderFactory<*>>()
-        const val REPOSITORY_CONFIGURATION_PROVIDER_ID = "RepositoryConfiguration"
 
         /**
          * Return a new (identifier, provider instance) tuple for each

--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -40,7 +40,6 @@ import kotlin.time.toKotlinDuration
 
 import org.ossreviewtoolkit.analyzer.Analyzer
 import org.ossreviewtoolkit.analyzer.PackageCurationProviderFactory
-import org.ossreviewtoolkit.analyzer.PackageCurationProviderFactory.Companion.REPOSITORY_CONFIGURATION_PROVIDER_ID
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.analyzer.PackageManagerFactory
 import org.ossreviewtoolkit.analyzer.curation.SimplePackageCurationProvider
@@ -52,6 +51,7 @@ import org.ossreviewtoolkit.cli.utils.logger
 import org.ossreviewtoolkit.cli.utils.outputGroup
 import org.ossreviewtoolkit.cli.utils.writeOrtResult
 import org.ossreviewtoolkit.model.FileFormat
+import org.ossreviewtoolkit.model.ResolvedPackageCurations.Companion.REPOSITORY_CONFIGURATION_PROVIDER_ID
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -355,13 +355,17 @@ data class OrtResult(
      * associated with the given [providerId].
      */
     fun replacePackageCurations(provider: PackageCurationProvider, providerId: String): OrtResult {
-        val packageCurations = ConfigurationResolver.resolvePackageCurations(
+        require(providerId != REPOSITORY_CONFIGURATION_PROVIDER_ID) {
+            "Cannot replace curations for id '$REPOSITORY_CONFIGURATION_PROVIDER_ID' which is reserved and not allowed."
+        }
+
+        val packageCurations = resolvedConfiguration.packageCurations.find {
+            it.provider.id == REPOSITORY_CONFIGURATION_PROVIDER_ID
+        }.let { listOfNotNull(it) } + ConfigurationResolver.resolvePackageCurations(
             packages = getUncuratedPackages(),
             curationProviders = listOf(providerId to provider)
         )
 
-        // TODO: Implement replacing curations for a particular provider ID, without losing the curations from the
-        //       repository configuration if applicable.
         return copy(
             resolvedConfiguration = resolvedConfiguration.copy(
                 packageCurations = packageCurations

--- a/model/src/main/kotlin/ResolvedConfiguration.kt
+++ b/model/src/main/kotlin/ResolvedConfiguration.kt
@@ -72,7 +72,12 @@ data class ResolvedPackageCurations(
         val id: String
 
         // TODO: Add the attributes `type` and `config` from the provider configuration.
-    )
+    ) companion object {
+        /**
+         * The provider ID to associate with package curations coming from the repository configuration.
+         */
+        const val REPOSITORY_CONFIGURATION_PROVIDER_ID = "RepositoryConfiguration"
+    }
 }
 
 private fun Collection<Any>.joinToStringSingleQuoted() = joinToString(prefix = "'", separator = "','", postfix = "'")


### PR DESCRIPTION
This PR finally implements support for package curations in repository configurations, for the use case of re-running the evaluator after making local changes to both, local and global package curations. 

See individual commits.