### PR TITLE
docs(README): Remove the hint about `ort.jar` from JitPack

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,6 @@ Gradle and download all required dependencies).
 
 Depending on how ORT was installed, it can be run in the following ways:
 
-- If the binary was downloaded from JitPack, use
-
-      java -jar ort.jar --help
-
 - If the Docker image was built, use
 
       docker run ort --help


### PR DESCRIPTION
The fat JAR build was removed in [1], so there is no more `ort.jar` being built by JitPack. Also see [2] for some context.

[1]: https://github.com/oss-review-toolkit/ort/pull/6322
[2]: https://github.com/oss-review-toolkit/ort/issues/6512