### PR TITLE
Revert "deps: update dependency org.antlr:antlr4 to v4.12.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ kotlinPlugin = "1.8.10"
 versionCatalogUpdatePlugin = "0.7.0"
 versionsPlugin = "0.45.0"
 
-antlr = "4.12.0"
+antlr = "4.11.1"
 asciidoctorj = "2.5.7"
 asciidoctorjPdf = "2.3.4"
 clikt = "3.5.1"


### PR DESCRIPTION
This reverts commit fec5dc5 due to an "illegal unicode escape" issue [1].

[1]: https://github.com/antlr/antlr4/issues/2569#issuecomment-1437290697