### PR TITLE
fix(PythonInspector): Improve the way project names are derived

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/example-python-flask-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "PIP::src/funTest/assets/projects/external/example-python-flask/requirements.txt:0773991e36a4c69b121cdb05146d6140347d4065"
+  id: "PIP::example-python-flask:0773991e36a4c69b121cdb05146d6140347d4065"
   definition_file_path: "requirements.txt"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "PIP::Example-App-requirements:2.4.0"
+  id: "PIP::Example-App-with-requirements-pip:2.4.0"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/pip/requirements.txt"
   declared_licenses:
   - "MIT License"

--- a/analyzer/src/funTest/assets/projects/synthetic/pip-python3-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pip-python3-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "PIP::src/funTest/assets/projects/synthetic/pip-python3/requirements.txt:<REPLACE_REVISION>"
+  id: "PIP::pip-python3:<REPLACE_REVISION>"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/pip-python3/requirements.txt"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "Pipenv::src/funTest/assets/projects/synthetic/pipenv/requirements-from-pipenv.txt:<REPLACE_REVISION>"
+  id: "Pipenv::pipenv-from-pipenv:<REPLACE_REVISION>"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/pipenv/requirements-from-pipenv.txt"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/pipenv-python3-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pipenv-python3-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "Pipenv::src/funTest/assets/projects/synthetic/pipenv-python3/requirements-from-pipenv.txt:<REPLACE_REVISION>"
+  id: "Pipenv::pipenv-python3-from-pipenv:<REPLACE_REVISION>"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/pipenv-python3/requirements-from-pipenv.txt"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/poetry-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/poetry-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "Poetry::src/funTest/assets/projects/synthetic/poetry/requirements-from-poetry.txt:<REPLACE_REVISION>"
+  id: "Poetry::poetry-from-poetry:<REPLACE_REVISION>"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/poetry/requirements-from-poetry.txt"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/python-inspector-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/python-inspector-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "PIP::src/funTest/assets/projects/synthetic/python-inspector/requirements.txt:<REPLACE_REVISION>"
+  id: "PIP::python-inspector:<REPLACE_REVISION>"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/python-inspector/requirements.txt"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
+++ b/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
@@ -247,7 +247,7 @@ private fun PythonInspector.Result.resolveIdentifier(
         // root as a unique project name.
         !hasSetupName && hasRequirementsName -> PackageManager.getFallbackProjectName(analysisRoot, definitionFile)
         hasSetupName && hasRequirementsName -> "$setupName-requirements$requirementsSuffix"
-        else -> throw IllegalArgumentException("Unable to determine a project name for '$definitionFile'.")
+        else -> PackageManager.getFallbackProjectName(analysisRoot, definitionFile)
     }
 
     val projectVersion = setupVersion.takeIf { it.isNotEmpty() } ?: requirementsVersion


### PR DESCRIPTION
Actually use `requirementsName` if there is no `setupName`, improve the project name if there are both, and always use the relative path to the analyzer as a fallback.

Fixes #6524.

> **Note**
> This is a **breaking change** under some circumstances Python projects my get assigned different ids than before, which might affect existing curations.