### PR TITLE
fix(Gradle): Make an ANTRL task dependency explicit

### DIFF
--- a/utils/spdx/build.gradle.kts
+++ b/utils/spdx/build.gradle.kts
@@ -40,6 +40,12 @@ tasks.withType<AntlrTask>().configureEach {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
+    // Ensure "generateGrammarSource" is called before "compileKotlin".
+    dependsOn(tasks.withType<AntlrTask>())
+}
+
+tasks.withType<Jar>().configureEach {
+    // Ensure "generateGrammarSource" is called before "sourcesJar".
     dependsOn(tasks.withType<AntlrTask>())
 }
 


### PR DESCRIPTION
Starting with Gradle 8, it became an error to rely on implicit task dependencies like the one of "sourcesJar" on "generateGrammarSource" (see [1]). Make that dependency explicit in the same way as already for "compileKotlin" to fix the JitPack build of sources artifacts (see [2]). Also align code comments while at it.

[1]: https://github.com/gradle/gradle/issues/19555
[2]: https://jitpack.io/com/github/oss-review-toolkit/ort/90858686d8/build.log