### PR TITLE
fix(Gradle): Avoid a runtime warning with JDK 17

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -30,6 +30,10 @@ plugins {
 
 application {
     applicationName = "ort"
+    applicationDefaultJvmArgs = listOf(
+        "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
+        "--add-opens", "java.base/java.io=ALL-UNNAMED"
+    )
     mainClass.set("org.ossreviewtoolkit.cli.OrtMainKt")
 }
 

--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -27,6 +27,10 @@ plugins {
 
 application {
     applicationName = "orth"
+    applicationDefaultJvmArgs = listOf(
+        "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
+        "--add-opens", "java.base/java.io=ALL-UNNAMED"
+    )
     mainClass.set("org.ossreviewtoolkit.helper.HelperMainKt")
 }
 


### PR DESCRIPTION
Avoid

    WARN FilenoUtil : Native subprocess control requires open access to
    the JDK IO subsystem

by adding the required options to the runtime JVM arguments.