### PR TITLE
Fallback project names

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "Bundler::lockfile:"
+  id: "Bundler::src/funTest/assets/projects/synthetic/bundler/lockfile/Gemfile:"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/bundler/lockfile/Gemfile"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -232,6 +232,13 @@ abstract class PackageManager(
          */
         private fun Excludes.isPathExcluded(root: Path, path: Path): Boolean =
             isPathExcluded(root.relativize(path).pathString)
+
+        /**
+         * Get a fallback project name from the [definitionFile] path relative to the [analysisRoot]. This function
+         * should be used if the project name cannot be determined from the project's metadata.
+         */
+        fun getFallbackProjectName(analysisRoot: File, definitionFile: File) =
+            definitionFile.relativeTo(analysisRoot).invariantSeparatorsPath
     }
 
     /**

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -204,7 +204,7 @@ class Bundler(
 
         val gemSpecs = resolveGemsMetadata(workingDir)
 
-        return with(parseProject(workingDir, gemSpecs)) {
+        return with(parseProject(definitionFile, gemSpecs)) {
             val projectId = Identifier(managerName, "", name, version)
             val groupedDeps = getDependencyGroups(workingDir)
 
@@ -310,12 +310,12 @@ class Bundler(
         return gemSpecs
     }
 
-    private fun parseProject(workingDir: File, gemSpecs: MutableMap<String, GemSpec>) =
-        getGemspecFile(workingDir)?.let { gemspecFile ->
+    private fun parseProject(definitionFile: File, gemSpecs: MutableMap<String, GemSpec>) =
+        getGemspecFile(definitionFile.parentFile)?.let { gemspecFile ->
             // Project is a Gem, i.e. a library.
             gemSpecs[gemspecFile.nameWithoutExtension]
         } ?: GemSpec(
-            name = workingDir.name,
+            name = getFallbackProjectName(analysisRoot, definitionFile),
             version = "",
             homepageUrl = "",
             authors = emptySet(),

--- a/analyzer/src/main/kotlin/managers/Carthage.kt
+++ b/analyzer/src/main/kotlin/managers/Carthage.kt
@@ -69,7 +69,7 @@ class Carthage(
         // Transitive dependencies are only supported if the dependency itself uses Carthage.
         // See: https://github.com/Carthage/Carthage#nested-dependencies
         val workingDir = definitionFile.parentFile
-        val projectInfo = getProjectInfoFromVcs(workingDir)
+        val projectInfo = getProjectInfoFromVcs(definitionFile)
 
         return listOf(
             ProjectAnalyzerResult(
@@ -96,8 +96,8 @@ class Carthage(
     /**
      * As the "Carthage.resolved" file does not provide any project information, trying to retrieve some from VCS.
      */
-    private fun getProjectInfoFromVcs(workingDir: File): ProjectInfo {
-        val workingTree = VersionControlSystem.forDirectory(workingDir)
+    private fun getProjectInfoFromVcs(definitionFile: File): ProjectInfo {
+        val workingTree = VersionControlSystem.forDirectory(definitionFile.parentFile)
         val vcsInfo = workingTree?.getInfo().orEmpty()
         val normalizedVcsUrl = normalizeVcsUrl(vcsInfo.url)
         val vcsHost = VcsHost.fromUrl(normalizedVcsUrl)
@@ -105,7 +105,7 @@ class Carthage(
         return ProjectInfo(
             namespace = vcsHost?.getUserOrOrganization(normalizedVcsUrl),
             projectName = vcsHost?.getProject(normalizedVcsUrl)
-                ?: workingDir.relativeTo(analysisRoot).invariantSeparatorsPath,
+                ?: getFallbackProjectName(analysisRoot, definitionFile),
             revision = vcsInfo.revision
         )
     }

--- a/analyzer/src/main/kotlin/managers/CocoaPods.kt
+++ b/analyzer/src/main/kotlin/managers/CocoaPods.kt
@@ -156,7 +156,7 @@ class CocoaPods(
                 id = Identifier(
                     type = managerName,
                     namespace = "",
-                    name = definitionFile.relativeTo(analysisRoot).invariantSeparatorsPath,
+                    name = getFallbackProjectName(analysisRoot, definitionFile),
                     version = ""
                 ),
                 definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -161,7 +161,7 @@ class GoDep(
                 .filterNot { it.isEmpty() }
                 .joinToString(separator = "/")
                 .lowercase()
-        }.getOrDefault(projectDir.name)
+        }.getOrDefault(getFallbackProjectName(analysisRoot, definitionFile))
 
         // TODO Keeping this between scans would speed things up considerably.
         gopath.safeDeleteRecursively(force = true)

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -289,7 +289,7 @@ class NuGetSupport(
             id = Identifier(
                 type = managerName,
                 namespace = "",
-                name = spec?.metadata?.id ?: definitionFile.relativeTo(analysisRoot).invariantSeparatorsPath,
+                name = spec?.metadata?.id ?: PackageManager.getFallbackProjectName(analysisRoot, definitionFile),
                 version = spec?.metadata?.version.orEmpty()
             ),
             definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,

--- a/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
+++ b/analyzer/src/main/kotlin/managers/utils/PythonInspector.kt
@@ -245,7 +245,7 @@ private fun PythonInspector.Result.resolveIdentifier(
         hasSetupName && !hasRequirementsName -> setupName
         // In case of only a requirements file without further metadata, use the relative path to the analyzer
         // root as a unique project name.
-        !hasSetupName && hasRequirementsName -> definitionFile.relativeTo(analysisRoot).invariantSeparatorsPath
+        !hasSetupName && hasRequirementsName -> PackageManager.getFallbackProjectName(analysisRoot, definitionFile)
         hasSetupName && hasRequirementsName -> "$setupName-requirements$requirementsSuffix"
         else -> throw IllegalArgumentException("Unable to determine a project name for '$definitionFile'.")
     }


### PR DESCRIPTION
Align the fallback project names that are used when the name cannot be determined from the project's metadata. This also reduces the risk of duplicate identifiers for some package managers. See the commit messages for details.

**Breaking change:**
Project names could change for the Bundler, Carthage, and GoDep package managers.