### PR TITLE
Introduce issue switch & blank template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,13 @@
+---
+name: Blank issue (Bug, Feature request)
+about: You found a bug, or want to create a feature request? Go here.
+title: ""
+assignees: ''
+
+---
+
+## Motivation
+
+## Action items
+
+## Context

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+contact_links:
+    - name: ORT Discussion Forum
+      url: https://github.com/oss-review-toolkit/ort/discussions
+      about: You did not find a bug but have a more open question or want to discuss support-style questions? Please be welcome to our discussion forum!
+    - name: ORT FAQ (Frequently Asked Questions)
+      url: https://github.com/oss-review-toolkit/ort/discussions/categories/q-a
+      about: This is our interactive FAQ section in the discussion forum. Think Stack Overflow meets Wiki.
+    - name: ORT Slack channel
+      url: https://ort-talk.slack.com/join/shared_invite/zt-1c7yi4sj6-mk7R1fAa6ZdW5MQ6DfAVRg#/shared-invite/email
+      about: Do you need a more sync & interactive discussion medium (chat)? Please sign up for our Slack channel.


### PR DESCRIPTION
This introduces an issue switch to direct people to either the 
 - proper issue section
 - the general discussion forum
 - the Q&A section as FAQ
 - or our Slack instance

`config.yml` does the last the 3 offers, `bug.md` does the first one. 
I added some minimal structure to the bug ticket template, commit suggestions more than welcome here. We used none of that so far, maybe a context would be useful, but given the rather technical audience of ORT probably shouldn't overdo it with a template here.

And this will fix #6540 if merged.