### PR TITLE
Add DoubleOpen as license classification provider

### DIFF
--- a/helper-cli/src/main/kotlin/commands/classifications/ImportCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/classifications/ImportCommand.kt
@@ -81,6 +81,9 @@ private data class EclipseLicenses(
 )
 
 private enum class LicenseClassificationProvider(val url: String) : Logging {
+    DOUBLE_OPEN("https://github.com/doubleopen-project/policy-configuration/raw/main/license-classifications.yml") {
+        override fun getClassifications(): LicenseClassifications = yamlMapper.readValue(URL(url))
+    },
     ECLIPSE("https://www.eclipse.org/legal/licenses.json") {
         override fun getClassifications(): LicenseClassifications {
             val json = jsonMapper.readValue<EclipseLicenses>(URL(url))

--- a/helper-cli/src/main/kotlin/commands/classifications/ImportCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/classifications/ImportCommand.kt
@@ -105,7 +105,7 @@ private enum class LicenseClassificationProvider(val url: String) : Logging {
             )
         }
     },
-    LDBCOLLECTOR("https://github.com/maxhbr/LDBcollector/raw/generated/ort/license-classifications.yml") {
+    LDB_COLLECTOR("https://github.com/maxhbr/LDBcollector/raw/generated/ort/license-classifications.yml") {
         override fun getClassifications(): LicenseClassifications = yamlMapper.readValue(URL(url))
     };
 


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.