### PR TITLE
refactor(init.gradle): Do not hard-code an interface name

### DIFF
--- a/analyzer/src/main/resources/scripts/init.gradle
+++ b/analyzer/src/main/resources/scripts/init.gradle
@@ -156,7 +156,7 @@ class AbstractDependencyTreePlugin<T> implements Plugin<T> {
 
         @Override
         boolean canBuild(String modelName) {
-            return modelName == 'DependencyTreeModel'
+            return modelName == DependencyTreeModel.name
         }
 
         @Override


### PR DESCRIPTION
This is safer in case the interface name changes and makes more clear where the name comes from.