### PR TITLE
Advisors: Ensure only non-empty PURLs are used in requests

### DIFF
--- a/advisor/src/main/kotlin/advisors/NexusIq.kt
+++ b/advisor/src/main/kotlin/advisors/NexusIq.kt
@@ -83,7 +83,7 @@ class NexusIq(name: String, private val nexusIqConfig: NexusIqConfiguration) : A
     override suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, List<AdvisorResult>> {
         val startTime = Instant.now()
 
-        val components = packages.map { pkg ->
+        val components = packages.filter { it.purl.isNotEmpty() }.map { pkg ->
             val packageUrl = buildString {
                 append(pkg.purl)
 

--- a/advisor/src/main/kotlin/advisors/OssIndex.kt
+++ b/advisor/src/main/kotlin/advisors/OssIndex.kt
@@ -71,7 +71,7 @@ class OssIndex(name: String, serverUrl: String? = null) : AdviceProvider(name) {
     override suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, List<AdvisorResult>> {
         val startTime = Instant.now()
 
-        val purls = packages.map { it.purl }
+        val purls = packages.mapNotNull { pkg -> pkg.purl.takeUnless { it.isEmpty() } }
 
         return try {
             val componentReports = mutableMapOf<String, OssIndexService.ComponentReport>()

--- a/advisor/src/main/kotlin/advisors/VulnerableCode.kt
+++ b/advisor/src/main/kotlin/advisors/VulnerableCode.kt
@@ -87,7 +87,7 @@ class VulnerableCode(name: String, vulnerableCodeConfiguration: VulnerableCodeCo
         packages: List<Package>,
         startTime: Instant
     ): Map<Package, List<AdvisorResult>> {
-        val packageMap = packages.associateBy { it.purl }
+        val packageMap = packages.filter { it.purl.isNotEmpty() }.associateBy { it.purl }
         val packageVulnerabilities = service.getPackageVulnerabilities(PackagesWrapper(packageMap.keys))
 
         return packageVulnerabilities.filter { it.unresolvedVulnerabilities.isNotEmpty() }.mapNotNull { pv ->


### PR DESCRIPTION
It is possible that a package declares an empty string as PURL, e.g. for non-published packages. This results in a `Bad Request`. Avoid this by filtering the packages, before requesting the package details.
