### PR TITLE
build: Fix executing tests

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -27,7 +27,7 @@ import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
 
-import kotlin.io.path.pathString
+import kotlin.io.path.invariantSeparatorsPathString
 import kotlin.time.measureTime
 
 import org.apache.logging.log4j.kotlin.Logging
@@ -231,7 +231,7 @@ abstract class PackageManager(
          * [Excludes] object.
          */
         private fun Excludes.isPathExcluded(root: Path, path: Path): Boolean =
-            isPathExcluded(root.relativize(path).pathString)
+            isPathExcluded(root.relativize(path).invariantSeparatorsPathString)
 
         /**
          * Get a fallback project name from the [definitionFile] path relative to the [analysisRoot]. This function

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -191,6 +191,11 @@ subprojects {
 
     testing {
         suites {
+            @Suppress("UnusedPrivateMember")
+            val test by getting(JvmTestSuite::class) {
+                useJUnitJupiter()
+            }
+
             register<JvmTestSuite>("funTest") {
                 sources {
                     kotlin {

--- a/helper-cli/src/main/kotlin/utils/PathExcludeGenerator.kt
+++ b/helper-cli/src/main/kotlin/utils/PathExcludeGenerator.kt
@@ -187,7 +187,6 @@ private val PATH_EXCLUDES_REASON_FOR_DIR_NAME = listOf(
 
 /** Case-sensitive glob patterns matched against filenames. */
 private val PATH_EXCLUDE_REASON_FOR_FILENAME = listOf(
-    ORT_REPO_CONFIG_FILENAME to BUILD_TOOL_OF,
     "*.bazel" to BUILD_TOOL_OF,
     "*.cmake" to BUILD_TOOL_OF,
     "*.cmakein" to BUILD_TOOL_OF,
@@ -204,6 +203,7 @@ private val PATH_EXCLUDE_REASON_FOR_FILENAME = listOf(
     "*_test.go" to TEST_OF,
     "*coverage*.sh" to BUILD_TOOL_OF,
     ".editorconfig" to PathExcludeReason.OTHER,
+    ORT_REPO_CONFIG_FILENAME to BUILD_TOOL_OF,
     ".travis.yml" to BUILD_TOOL_OF,
     "BUILD" to BUILD_TOOL_OF, // Bazel
     "Build.PL" to BUILD_TOOL_OF,


### PR DESCRIPTION
Since 33fdca9 test from the `test` source sets were not executed
anymore, because no test framework was configured. Fix this by
configuring JUnit Jupiter as test framework.

Note that it is not necessary to declare the test framework for the
`funTest` suite because additional test suites use JUnit Jupiter by
default [1].

[1]: https://docs.gradle.org/8.0/userguide/jvm_test_suite_plugin.html#sec:declare_an_additional_test_suite