### PR TITLE
Make more use of getAssetFile() and getAssetAsString() in functional tests

### DIFF
--- a/advisor/src/funTest/kotlin/OsvFunTest.kt
+++ b/advisor/src/funTest/kotlin/OsvFunTest.kt
@@ -24,7 +24,6 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 
-import java.io.File
 import java.time.Instant
 
 import org.ossreviewtoolkit.advisor.advisors.Osv
@@ -33,6 +32,7 @@ import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
 import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.utils.test.getAssetFile
 
 class OsvFunTest : StringSpec({
     "retrievePackageFindings() returns vulnerabilities for the supported ecosystems" {
@@ -60,7 +60,7 @@ class OsvFunTest : StringSpec({
     }
 
     "retrievePackageFindings() returns the expected result for the given package(s)" {
-        val expectedResult = File("src/funTest/assets/retrieve-package-findings-expected-result.json")
+        val expectedResult = getAssetFile("retrieve-package-findings-expected-result.json")
             .readValue<Map<Identifier, List<AdvisorResult>>>()
         val osv = createOsv()
         // The following packages have been chosen because they have only one vulnerability with the oldest possible

--- a/analyzer/src/funTest/kotlin/GitRepoFunTest.kt
+++ b/analyzer/src/funTest/kotlin/GitRepoFunTest.kt
@@ -35,6 +35,7 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.ORT_NAME
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
@@ -67,7 +68,7 @@ class GitRepoFunTest : StringSpec({
 
         val actualResult = ortResult.withResolvedScopes().toYaml()
         val expectedResult = patchExpectedResult(
-            File("src/funTest/assets/projects/external/git-repo-expected-output.yml"),
+            getAssetFile("projects/external/git-repo-expected-output.yml"),
             revision = REPO_REV,
             path = outputDir.invariantSeparatorsPath
         )

--- a/analyzer/src/funTest/kotlin/managers/BabelFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/BabelFunTest.kt
@@ -22,18 +22,17 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class BabelFunTest : WordSpec({
-    val projectDir = File("src/funTest/assets/projects/synthetic/npm-babel").absoluteFile
+    val projectDir = getAssetFile("projects/synthetic/npm-babel").absoluteFile
     val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     val vcsUrl = vcsDir.getRemoteUrl()
     val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/BowerFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/BowerFunTest.kt
@@ -22,17 +22,16 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class BowerFunTest : StringSpec() {
-    private val projectDir = File("src/funTest/assets/projects/synthetic/bower").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/bower").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/BundlerFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/BundlerFunTest.kt
@@ -34,10 +34,11 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class BundlerFunTest : WordSpec() {
-    private val projectsDir = File("src/funTest/assets/projects/synthetic/bundler").absoluteFile
+    private val projectsDir = getAssetFile("projects/synthetic/bundler").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
     private val vcsRevision = vcsDir.getRevision()
     private val vcsUrl = vcsDir.getRemoteUrl()

--- a/analyzer/src/funTest/kotlin/managers/CargoFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/CargoFunTest.kt
@@ -22,17 +22,16 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class CargoFunTest : StringSpec() {
-    private val projectDir = File("src/funTest/assets/projects/synthetic/cargo").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/cargo").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/CargoSubcrateFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/CargoSubcrateFunTest.kt
@@ -22,17 +22,16 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class CargoSubcrateFunTest : StringSpec() {
-    private val projectDir = File("src/funTest/assets/projects/synthetic/cargo-subcrate").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/cargo-subcrate").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/CarthageFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/CarthageFunTest.kt
@@ -22,17 +22,16 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class CarthageFunTest : StringSpec() {
-    private val projectDir = File("src/funTest/assets/projects/synthetic/carthage").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/carthage").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/CocoaPodsFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/CocoaPodsFunTest.kt
@@ -32,9 +32,10 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
-private val SYNTHETIC_PROJECTS_DIR = File("src/funTest/assets/projects/synthetic")
+private val SYNTHETIC_PROJECTS_DIR = getAssetFile("projects/synthetic")
 
 class CocoaPodsFunTest : WordSpec({
     "resolveSingleProject()" should {

--- a/analyzer/src/funTest/kotlin/managers/ComposerFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/ComposerFunTest.kt
@@ -25,18 +25,17 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.haveSubstring
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class ComposerFunTest : StringSpec() {
-    private val projectsDir = File("src/funTest/assets/projects/synthetic/composer").absoluteFile
+    private val projectsDir = getAssetFile("projects/synthetic/composer").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
     private val vcsRevision = vcsDir.getRevision()
     private val vcsUrl = vcsDir.getRemoteUrl()

--- a/analyzer/src/funTest/kotlin/managers/ConanFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/ConanFunTest.kt
@@ -22,8 +22,6 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
@@ -31,16 +29,17 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class ConanFunTest : StringSpec() {
-    private val projectsDirTxt = File("src/funTest/assets/projects/synthetic/conan-txt").absoluteFile
+    private val projectsDirTxt = getAssetFile("projects/synthetic/conan-txt").absoluteFile
     private val vcsDirTxt = VersionControlSystem.forDirectory(projectsDirTxt)!!
     private val vcsRevisionTxt = vcsDirTxt.getRevision()
     private val vcsUrlTxt = vcsDirTxt.getRemoteUrl()
 
-    private val projectsDirPy = File("src/funTest/assets/projects/synthetic/conan-py").absoluteFile
+    private val projectsDirPy = getAssetFile("projects/synthetic/conan-py").absoluteFile
     private val vcsDirPy = VersionControlSystem.forDirectory(projectsDirPy)!!
     private val vcsRevisionPy = vcsDirPy.getRevision()
     private val vcsUrlPy = vcsDirPy.getRemoteUrl()

--- a/analyzer/src/funTest/kotlin/managers/DotNetFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/DotNetFunTest.kt
@@ -34,11 +34,12 @@ import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class DotNetFunTest : StringSpec() {
-    private val projectDir = File("src/funTest/assets/projects/synthetic/dotnet").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/dotnet").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/GoDepFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoDepFunTest.kt
@@ -37,10 +37,11 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class GoDepFunTest : WordSpec() {
-    private val projectsDir = File("src/funTest/assets/projects").absoluteFile
+    private val projectsDir = getAssetFile("projects").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/GoModFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoModFunTest.kt
@@ -29,10 +29,11 @@ import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class GoModFunTest : StringSpec({
-    val testDir = File("src/funTest/assets/projects/synthetic").absoluteFile
+    val testDir = getAssetFile("projects/synthetic").absoluteFile
 
     "Project dependencies are detected correctly" {
         val definitionFile = testDir.resolve("gomod/go.mod")

--- a/analyzer/src/funTest/kotlin/managers/GradleAndroidFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleAndroidFunTest.kt
@@ -22,8 +22,6 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
@@ -31,10 +29,11 @@ import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.AndroidTag
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class GradleAndroidFunTest : StringSpec() {
-    private val projectDir = File("src/funTest/assets/projects/synthetic/gradle-android").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/gradle-android").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()
@@ -80,7 +79,7 @@ class GradleAndroidFunTest : StringSpec() {
         }
 
         "Cyclic dependencies over multiple libraries can be handled".config(tags = setOf(AndroidTag, ExpensiveTag)) {
-            val cyclicProjectDir = File("src/funTest/assets/projects/synthetic/gradle-android-cyclic").absoluteFile
+            val cyclicProjectDir = getAssetFile("projects/synthetic/gradle-android-cyclic").absoluteFile
             val definitionFile = cyclicProjectDir.resolve("app/build.gradle")
             val expectedResult = patchExpectedResult(
                 projectDir.resolveSibling("gradle-android-cyclic-expected-output-app.yml"),

--- a/analyzer/src/funTest/kotlin/managers/GradleBomFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleBomFunTest.kt
@@ -22,17 +22,16 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class GradleBomFunTest : StringSpec() {
-    private val projectDir = File("src/funTest/assets/projects/synthetic/gradle-bom").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/gradle-bom").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/GradleCompositeFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleCompositeFunTest.kt
@@ -22,17 +22,16 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class GradleCompositeFunTest : StringSpec() {
-    private val projectDir = File("src/funTest/assets/projects/synthetic/gradle-composite").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/gradle-composite").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/GradleFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleFunTest.kt
@@ -27,8 +27,6 @@ import io.kotest.data.row
 import io.kotest.data.table
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.downloader.vcs.Git
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
@@ -41,11 +39,12 @@ import org.ossreviewtoolkit.utils.common.ProcessCapture
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.ExpensiveTag
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class GradleFunTest : StringSpec() {
-    private val projectDir = File("src/funTest/assets/projects/synthetic/gradle").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/gradle").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/GradleKotlinScriptFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleKotlinScriptFunTest.kt
@@ -22,17 +22,16 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class GradleKotlinScriptFunTest : StringSpec() {
-    private val projectDir = File("src/funTest/assets/projects/synthetic/multi-kotlin-project").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/multi-kotlin-project").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/GradleLibraryFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GradleLibraryFunTest.kt
@@ -22,17 +22,16 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class GradleLibraryFunTest : StringSpec() {
-    private val projectDir = File("src/funTest/assets/projects/synthetic/gradle-library").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/gradle-library").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/MavenFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/MavenFunTest.kt
@@ -25,8 +25,6 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.Excludes
@@ -37,11 +35,12 @@ import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class MavenFunTest : StringSpec() {
-    private val projectDir = File("src/funTest/assets/projects/synthetic/maven").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/maven").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()
@@ -117,7 +116,7 @@ class MavenFunTest : StringSpec() {
                 .resolve(".m2/repository/org/springframework/boot/spring-boot-starter-parent/1.5.3.RELEASE")
                 .safeDeleteRecursively(force = true)
 
-            val projectDir = File("src/funTest/assets/projects/synthetic/maven-parent").absoluteFile
+            val projectDir = getAssetFile("projects/synthetic/maven-parent").absoluteFile
             val pomFile = projectDir.resolve("pom.xml")
             val expectedResult = patchExpectedResult(
                 projectDir.resolveSibling("maven-parent-expected-output-root.yml"),
@@ -131,7 +130,7 @@ class MavenFunTest : StringSpec() {
         }
 
         "Maven Wagon extensions can be loaded" {
-            val projectDir = File("src/funTest/assets/projects/synthetic/maven-wagon").absoluteFile
+            val projectDir = getAssetFile("projects/synthetic/maven-wagon").absoluteFile
             val pomFile = projectDir.resolve("pom.xml")
             val expectedResult = patchExpectedResult(
                 projectDir.resolveSibling("maven-wagon-expected-output.yml"),

--- a/analyzer/src/funTest/kotlin/managers/NpmFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmFunTest.kt
@@ -24,8 +24,6 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
@@ -36,11 +34,12 @@ import org.ossreviewtoolkit.model.config.ScopeExcludeReason
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.createTestTempDir
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class NpmFunTest : WordSpec() {
-    private val projectsDir = File("src/funTest/assets/projects/synthetic/npm").absoluteFile
+    private val projectsDir = getAssetFile("projects/synthetic/npm").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
 import java.time.Instant
 
 import org.ossreviewtoolkit.downloader.VersionControlSystem
@@ -34,10 +33,11 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class NpmVersionUrlFunTest : WordSpec() {
-    private val projectDir = File("src/funTest/assets/projects/synthetic/npm-version-urls").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/npm-version-urls").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/NuGetFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NuGetFunTest.kt
@@ -24,8 +24,6 @@ import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetDependency
 import org.ossreviewtoolkit.analyzer.managers.utils.OPTION_DIRECT_DEPENDENCIES_ONLY
 import org.ossreviewtoolkit.downloader.VersionControlSystem
@@ -34,11 +32,12 @@ import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class NuGetFunTest : StringSpec({
-    val projectDir = File("src/funTest/assets/projects/synthetic/nuget").absoluteFile
+    val projectDir = getAssetFile("projects/synthetic/nuget").absoluteFile
     val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     val vcsUrl = vcsDir.getRemoteUrl()
     val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/PipFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PipFunTest.kt
@@ -24,8 +24,6 @@ import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
@@ -34,10 +32,11 @@ import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.createTestTempFile
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class PipFunTest : WordSpec({
-    val projectsDir = File("src/funTest/assets/projects").absoluteFile
+    val projectsDir = getAssetFile("projects").absoluteFile
     val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
     val vcsUrl = vcsDir.getRemoteUrl()
     val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/PipenvFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PipenvFunTest.kt
@@ -22,17 +22,16 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class PipenvFunTest : WordSpec() {
-    private val projectsDir = File("src/funTest/assets/projects").absoluteFile
+    private val projectsDir = getAssetFile("projects").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/PnpmFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PnpmFunTest.kt
@@ -30,13 +30,14 @@ import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class PnpmFunTest : WordSpec({
     "Pnpm" should {
         "resolve dependencies correctly in a simple project" {
-            val projectDir = File("src/funTest/assets/projects/synthetic/pnpm").absoluteFile
+            val projectDir = getAssetFile("projects/synthetic/pnpm").absoluteFile
 
             val result = resolveDependencies(projectDir)
             val expectedResult = getExpectedResult(projectDir, "pnpm-expected-output.yml")
@@ -45,7 +46,7 @@ class PnpmFunTest : WordSpec({
         }
 
         "resolve dependencies correctly in a workspaces project" {
-            val rootProjectDir = File("src/funTest/assets/projects/synthetic/pnpm-workspaces").absoluteFile
+            val rootProjectDir = getAssetFile("projects/synthetic/pnpm-workspaces").absoluteFile
 
             val ortResult = Analyzer(AnalyzerConfiguration()).run {
                 analyze(findManagedFiles(rootProjectDir, setOf(Pnpm.Factory())))

--- a/analyzer/src/funTest/kotlin/managers/PoetryFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PoetryFunTest.kt
@@ -22,17 +22,16 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class PoetryFunTest : WordSpec() {
-    private val projectsDir = File("src/funTest/assets/projects").absoluteFile
+    private val projectsDir = getAssetFile("projects").absoluteFile
     private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/SbtFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/SbtFunTest.kt
@@ -33,9 +33,10 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class SbtFunTest : StringSpec({
     "Dependencies of the external 'sbt-multi-project-example' multi-project should be detected correctly" {
-        val projectName = "sbt-multi-project-example"
-        val projectDir = getAssetFile("projects/external/$projectName").absoluteFile
-        val expectedResult = patchExpectedResult(projectDir.resolveSibling("$projectName-expected-output.yml"))
+        val projectDir = getAssetFile("projects/external/sbt-multi-project-example").absoluteFile
+        val expectedResult = patchExpectedResult(
+            projectDir.resolveSibling("sbt-multi-project-example-expected-output.yml")
+        )
 
         // Clean any previously generated POM files / target directories.
         Git().run(projectDir, "clean", "-fd")
@@ -48,13 +49,12 @@ class SbtFunTest : StringSpec({
     }
 
     "Dependencies of the synthetic 'http4s-template' project should be detected correctly" {
-        val projectName = "sbt-http4s-template"
-        val projectDir = getAssetFile("projects/synthetic/$projectName").absoluteFile
+        val projectDir = getAssetFile("projects/synthetic/sbt-http4s-template").absoluteFile
         val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
         val vcsUrl = vcsDir.getRemoteUrl()
         val vcsRevision = vcsDir.getRevision()
         val expectedResult = patchExpectedResult(
-            projectDir.resolveSibling("$projectName-expected-output.yml"),
+            projectDir.resolveSibling("sbt-http4s-template-expected-output.yml"),
             url = vcsUrl,
             revision = vcsRevision,
             urlProcessed = normalizeVcsUrl(vcsUrl)

--- a/analyzer/src/funTest/kotlin/managers/SbtFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/SbtFunTest.kt
@@ -22,20 +22,19 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.analyzer.Analyzer
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.downloader.vcs.Git
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class SbtFunTest : StringSpec({
     "Dependencies of the external 'sbt-multi-project-example' multi-project should be detected correctly" {
         val projectName = "sbt-multi-project-example"
-        val projectDir = File("src/funTest/assets/projects/external/$projectName").absoluteFile
+        val projectDir = getAssetFile("projects/external/$projectName").absoluteFile
         val expectedResult = patchExpectedResult(projectDir.resolveSibling("$projectName-expected-output.yml"))
 
         // Clean any previously generated POM files / target directories.
@@ -50,7 +49,7 @@ class SbtFunTest : StringSpec({
 
     "Dependencies of the synthetic 'http4s-template' project should be detected correctly" {
         val projectName = "sbt-http4s-template"
-        val projectDir = File("src/funTest/assets/projects/synthetic/$projectName").absoluteFile
+        val projectDir = getAssetFile("projects/synthetic/$projectName").absoluteFile
         val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
         val vcsUrl = vcsDir.getRemoteUrl()
         val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/SpdxDocumentFileFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/SpdxDocumentFileFunTest.kt
@@ -29,8 +29,6 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.analyzer.Analyzer
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Identifier
@@ -43,6 +41,7 @@ import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
@@ -262,7 +261,7 @@ class SpdxDocumentFileFunTest : WordSpec({
     }
 })
 
-private val projectDir = File("src/funTest/assets/projects/synthetic/spdx").absoluteFile
+private val projectDir = getAssetFile("projects/synthetic/spdx").absoluteFile
 private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
 private val vcsUrl = vcsDir.getRemoteUrl()
 private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/StackFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/StackFunTest.kt
@@ -22,12 +22,11 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 
 class StackFunTest : StringSpec({
     "Dependencies should be resolved correctly for quickcheck-state-machine" {
@@ -46,7 +45,7 @@ class StackFunTest : StringSpec({
     }
 })
 
-private val projectsDir = File("src/funTest/assets/projects").absoluteFile
+private val projectsDir = getAssetFile("projects").absoluteFile
 
 private fun createStack() =
     Stack("Stack", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())

--- a/analyzer/src/funTest/kotlin/managers/Yarn2FunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/Yarn2FunTest.kt
@@ -32,12 +32,13 @@ import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.config.ScopeExcludeReason
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class Yarn2FunTest : WordSpec({
     "Yarn 2" should {
         "resolve dependencies correctly" {
-            val projectDir = File("src/funTest/assets/projects/synthetic/yarn2").absoluteFile
+            val projectDir = getAssetFile("projects/synthetic/yarn2").absoluteFile
 
             val result = resolveDependencies(projectDir)
 
@@ -46,7 +47,7 @@ class Yarn2FunTest : WordSpec({
         }
 
         "exclude scopes if configured" {
-            val projectDir = File("src/funTest/assets/projects/synthetic/yarn2").absoluteFile
+            val projectDir = getAssetFile("projects/synthetic/yarn2").absoluteFile
 
             val analyzerConfig = AnalyzerConfiguration(skipExcluded = true)
             val scopeExclude = ScopeExclude("devDependencies", ScopeExcludeReason.TEST_DEPENDENCY_OF)
@@ -60,7 +61,7 @@ class Yarn2FunTest : WordSpec({
         }
 
         "resolve workspace dependencies correctly" {
-            val projectDir = File("src/funTest/assets/projects/synthetic/yarn2-workspaces").absoluteFile
+            val projectDir = getAssetFile("projects/synthetic/yarn2-workspaces").absoluteFile
 
             val result = resolveMultipleDependencies(projectDir)
 

--- a/analyzer/src/funTest/kotlin/managers/YarnFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/YarnFunTest.kt
@@ -29,6 +29,7 @@ import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class YarnFunTest : WordSpec() {
@@ -58,7 +59,7 @@ class YarnFunTest : WordSpec() {
     init {
         "yarn" should {
             "resolve dependencies correctly" {
-                val projectDir = File("src/funTest/assets/projects/synthetic/yarn").absoluteFile
+                val projectDir = getAssetFile("projects/synthetic/yarn").absoluteFile
 
                 val result = resolveDependencies(projectDir)
 
@@ -69,7 +70,7 @@ class YarnFunTest : WordSpec() {
             "resolve workspace dependencies correctly" {
                 // This test case illustrates the lack of Yarn workspaces support, in particular not all workspace
                 // dependencies get assigned to a scope.
-                val projectDir = File("src/funTest/assets/projects/synthetic/yarn-workspaces").absoluteFile
+                val projectDir = getAssetFile("projects/synthetic/yarn-workspaces").absoluteFile
 
                 val result = resolveDependencies(projectDir)
 

--- a/analyzer/src/funTest/kotlin/managers/utils/PythonInspectorFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/utils/PythonInspectorFunTest.kt
@@ -23,12 +23,11 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.should
 
-import java.io.File
-
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
+import org.ossreviewtoolkit.utils.test.getAssetFile
 
 class PythonInspectorFunTest : StringSpec({
-    val projectsDir = File("src/funTest/assets/projects").absoluteFile
+    val projectsDir = getAssetFile("projects").absoluteFile
 
     "python-inspector output can be deserialized" {
         val definitionFile = projectsDir.resolve("synthetic/pip/requirements.txt")

--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -63,6 +63,7 @@ import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
 import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
 import org.ossreviewtoolkit.utils.spdx.toSpdx
 import org.ossreviewtoolkit.utils.test.createSpecTempDir
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class ExamplesFunTest : StringSpec() {
@@ -138,7 +139,7 @@ class ExamplesFunTest : StringSpec() {
         }
 
         "The rules script can be run" {
-            val resultFile = File("src/funTest/assets/semver4j-ort-result.yml")
+            val resultFile = getAssetFile("semver4j-ort-result.yml")
             val licenseFile = File("../examples/license-classifications.yml")
             val ortResult = resultFile.readValue<OrtResult>()
             val evaluator = Evaluator(

--- a/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
+++ b/clients/clearly-defined/src/funTest/kotlin/ClearlyDefinedServiceFunTest.kt
@@ -31,20 +31,19 @@ import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.include
 import io.kotest.matchers.string.shouldStartWith
 
-import java.io.File
-
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.decodeFromStream
 
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionInfo
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionPatch
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.Server
+import org.ossreviewtoolkit.utils.test.getAssetFile
 
 class ClearlyDefinedServiceFunTest : WordSpec({
     "A contribution patch" should {
         "be correctly deserialized when using empty facet arrays" {
             // See https://github.com/clearlydefined/curated-data/blob/0b2db78/curations/maven/mavencentral/com.google.code.gson/gson.yaml#L10-L11.
-            val curation = File("src/funTest/assets/gson.json").inputStream().use {
+            val curation = getAssetFile("gson.json").inputStream().use {
                 ClearlyDefinedService.JSON.decodeFromStream<Curation>(it)
             }
 

--- a/downloader/src/funTest/kotlin/vcs/CvsWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/CvsWorkingTreeFunTest.kt
@@ -26,20 +26,19 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.beEmpty
 
-import java.io.File
-
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.common.unpack
 import org.ossreviewtoolkit.utils.ort.ortDataDirectory
 import org.ossreviewtoolkit.utils.test.createSpecTempDir
+import org.ossreviewtoolkit.utils.test.getAssetFile
 
 class CvsWorkingTreeFunTest : StringSpec({
     val cvs = Cvs()
     val zipContentDir = createSpecTempDir()
 
     beforeSpec {
-        val zipFile = File("src/funTest/assets/jhove-2019-12-11-cvs.zip")
+        val zipFile = getAssetFile("jhove-2019-12-11-cvs.zip")
         println("Extracting '$zipFile' to '$zipContentDir'...")
         zipFile.unpack(zipContentDir)
     }

--- a/downloader/src/funTest/kotlin/vcs/GitWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/GitWorkingTreeFunTest.kt
@@ -33,13 +33,14 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.common.unpack
 import org.ossreviewtoolkit.utils.ort.ortDataDirectory
 import org.ossreviewtoolkit.utils.test.createSpecTempDir
+import org.ossreviewtoolkit.utils.test.getAssetFile
 
 class GitWorkingTreeFunTest : StringSpec({
     val git = Git()
     val zipContentDir = createSpecTempDir()
 
     beforeSpec {
-        val zipFile = File("src/funTest/assets/pipdeptree-2018-01-03-git.zip")
+        val zipFile = getAssetFile("pipdeptree-2018-01-03-git.zip")
         println("Extracting '$zipFile' to '$zipContentDir'...")
         zipFile.unpack(zipContentDir)
     }

--- a/downloader/src/funTest/kotlin/vcs/MercurialWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/MercurialWorkingTreeFunTest.kt
@@ -26,20 +26,19 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.beEmpty
 
-import java.io.File
-
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.common.unpack
 import org.ossreviewtoolkit.utils.ort.ortDataDirectory
 import org.ossreviewtoolkit.utils.test.createSpecTempDir
+import org.ossreviewtoolkit.utils.test.getAssetFile
 
 class MercurialWorkingTreeFunTest : StringSpec({
     val hg = Mercurial()
     val zipContentDir = createSpecTempDir()
 
     beforeSpec {
-        val zipFile = File("src/funTest/assets/lz4revlog-2018-01-03-hg.zip")
+        val zipFile = getAssetFile("lz4revlog-2018-01-03-hg.zip")
         println("Extracting '$zipFile' to '$zipContentDir'...")
         zipFile.unpack(zipContentDir)
     }

--- a/downloader/src/funTest/kotlin/vcs/SubversionWorkingTreeFunTest.kt
+++ b/downloader/src/funTest/kotlin/vcs/SubversionWorkingTreeFunTest.kt
@@ -26,20 +26,19 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.beEmpty
 
-import java.io.File
-
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.utils.common.unpack
 import org.ossreviewtoolkit.utils.ort.ortDataDirectory
 import org.ossreviewtoolkit.utils.test.createSpecTempDir
+import org.ossreviewtoolkit.utils.test.getAssetFile
 
 class SubversionWorkingTreeFunTest : StringSpec({
     val svn = Subversion()
     val zipContentDir = createSpecTempDir()
 
     beforeSpec {
-        val zipFile = File("src/funTest/assets/docutils-2018-01-03-svn-trunk.zip")
+        val zipFile = getAssetFile("docutils-2018-01-03-svn-trunk.zip")
         print("Extracting '$zipFile' to '$zipContentDir'... ")
         zipFile.unpack(zipContentDir)
         println("done.")

--- a/reporter/src/funTest/kotlin/reporters/CycloneDxReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/CycloneDxReporterFunTest.kt
@@ -29,8 +29,6 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 
-import java.io.File
-
 import org.cyclonedx.parsers.JsonParser
 import org.cyclonedx.parsers.XmlParser
 
@@ -39,6 +37,7 @@ import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.patchCycloneDxResult
 import org.ossreviewtoolkit.utils.common.normalizeLineBreaks
 import org.ossreviewtoolkit.utils.test.createSpecTempDir
+import org.ossreviewtoolkit.utils.test.getAssetAsString
 
 class CycloneDxReporterFunTest : WordSpec({
     val defaultSchemaVersion = CycloneDxReporter.DEFAULT_SCHEMA_VERSION.versionString
@@ -66,7 +65,7 @@ class CycloneDxReporterFunTest : WordSpec({
         }
 
         "create the expected XML file" {
-            val expectedBom = File("src/funTest/assets/cyclonedx-reporter-expected-result.xml").readText()
+            val expectedBom = getAssetAsString("cyclonedx-reporter-expected-result.xml")
             val xmlOptions = optionSingle + mapOf("output.file.formats" to "xml")
 
             val bomFile = CycloneDxReporter().generateReport(ReporterInput(ORT_RESULT), outputDir, xmlOptions).single()
@@ -86,7 +85,7 @@ class CycloneDxReporterFunTest : WordSpec({
         }
 
         "create the expected JSON file" {
-            val expectedBom = File("src/funTest/assets/cyclonedx-reporter-expected-result.json").readText()
+            val expectedBom = getAssetAsString("cyclonedx-reporter-expected-result.json")
             val jsonOptions = optionSingle + mapOf("output.file.formats" to "json")
 
             val bomFile = CycloneDxReporter().generateReport(ReporterInput(ORT_RESULT), outputDir, jsonOptions).single()
@@ -149,11 +148,10 @@ class CycloneDxReporterFunTest : WordSpec({
         }
 
         "generate expected JSON files" {
-            val expectedBomWithFindings =
-                File("src/funTest/assets/cyclonedx-reporter-expected-result-with-findings.json").readText()
-            val expectedBomWithoutFindings =
-                File("src/funTest/assets/cyclonedx-reporter-expected-result-without-findings.json")
-                    .readText()
+            val expectedBomWithFindings = getAssetAsString("cyclonedx-reporter-expected-result-with-findings.json")
+            val expectedBomWithoutFindings = getAssetAsString(
+                "cyclonedx-reporter-expected-result-without-findings.json"
+            )
             val jsonOptions = optionMulti + mapOf("output.file.formats" to "json")
 
             val (bomProjectWithFindings, bomProjectWithoutFindings) = CycloneDxReporter()

--- a/reporter/src/funTest/kotlin/reporters/StaticHtmlReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/StaticHtmlReporterFunTest.kt
@@ -23,8 +23,6 @@ import io.kotest.core.TestConfiguration
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import javax.xml.transform.TransformerFactory
 
 import org.ossreviewtoolkit.model.OrtResult
@@ -33,6 +31,7 @@ import org.ossreviewtoolkit.reporter.HowToFixTextProvider
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.ort.Environment
 import org.ossreviewtoolkit.utils.test.createTestTempDir
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.readOrtResult
 
@@ -59,7 +58,7 @@ class StaticHtmlReporterFunTest : WordSpec({
             val actualReport = generateReport(ortResult).replace(timeStampPattern, "<REPLACE_TIMESTAMP>")
 
             val expectedReport = patchExpectedResult(
-                File("src/funTest/assets/static-html-reporter-test-expected-output.html"),
+                getAssetFile("static-html-reporter-test-expected-output.html"),
                 mapOf("<REPLACE_ORT_VERSION>" to Environment.ORT_VERSION)
             )
 

--- a/reporter/src/funTest/kotlin/reporters/ctrlx/CtrlXAutomationReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/ctrlx/CtrlXAutomationReporterFunTest.kt
@@ -24,18 +24,17 @@ import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.should
 
-import java.io.File
-
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.reporters.ctrlx.CtrlXAutomationReporter.Companion.REPORT_FILENAME
 import org.ossreviewtoolkit.utils.test.createTestTempDir
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class CtrlXAutomationReporterFunTest : StringSpec({
     "The official sample file can be deserialized" {
-        val fossInfoFile = File("src/funTest/assets/sample.fossinfo.json")
+        val fossInfoFile = getAssetFile("sample.fossinfo.json")
         val fossInfo = fossInfoFile.readValue<FossInfo>()
 
         fossInfo.components shouldNotBeNull {

--- a/reporter/src/funTest/kotlin/reporters/freemarker/NoticeTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/freemarker/NoticeTemplateReporterFunTest.kt
@@ -53,7 +53,6 @@ class NoticeTemplateReporterFunTest : WordSpec({
         "generate the correct license notes with archived license files" {
             val expectedText =
                 File("src/funTest/assets/notice-template-reporter-expected-results-with-license-files").readText()
-
             val archiveDir = File("src/funTest/assets/archive")
             val config = OrtConfiguration(
                 scanner = ScannerConfiguration(

--- a/reporter/src/funTest/kotlin/reporters/freemarker/NoticeTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/freemarker/NoticeTemplateReporterFunTest.kt
@@ -23,8 +23,6 @@ import io.kotest.core.TestConfiguration
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.FileArchiverConfiguration
@@ -39,11 +37,13 @@ import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.utils.test.createTestTempDir
+import org.ossreviewtoolkit.utils.test.getAssetAsString
+import org.ossreviewtoolkit.utils.test.getAssetFile
 
 class NoticeTemplateReporterFunTest : WordSpec({
     "The default template" should {
         "generate the correct license notes" {
-            val expectedText = File("src/funTest/assets/notice-template-reporter-expected-results").readText()
+            val expectedText = getAssetAsString("notice-template-reporter-expected-results")
 
             val report = generateReport(ORT_RESULT)
 
@@ -51,9 +51,8 @@ class NoticeTemplateReporterFunTest : WordSpec({
         }
 
         "generate the correct license notes with archived license files" {
-            val expectedText =
-                File("src/funTest/assets/notice-template-reporter-expected-results-with-license-files").readText()
-            val archiveDir = File("src/funTest/assets/archive")
+            val expectedText = getAssetAsString("notice-template-reporter-expected-results-with-license-files")
+            val archiveDir = getAssetFile("archive")
             val config = OrtConfiguration(
                 scanner = ScannerConfiguration(
                     archive = FileArchiverConfiguration(
@@ -75,7 +74,7 @@ class NoticeTemplateReporterFunTest : WordSpec({
 
     "The summary template" should {
         "generate the correct license notes" {
-            val expectedText = File("src/funTest/assets/notice-template-reporter-expected-results-summary").readText()
+            val expectedText = getAssetAsString("notice-template-reporter-expected-results-summary")
 
             val report = generateReport(ORT_RESULT, options = mapOf("template.id" to "summary"))
 

--- a/reporter/src/funTest/kotlin/reporters/freemarker/asciidoc/AdocTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/freemarker/asciidoc/AdocTemplateReporterFunTest.kt
@@ -22,16 +22,15 @@ package org.ossreviewtoolkit.reporter.reporters.freemarker.asciidoc
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.patchAsciiDocTemplateResult
 import org.ossreviewtoolkit.utils.test.createTestTempDir
+import org.ossreviewtoolkit.utils.test.getAssetAsString
 
 class AdocTemplateReporterFunTest : StringSpec({
     "AsciiDoc files are created from default template" {
-        val expectedText = File("src/funTest/assets/asciidoc-template-reporter-expected-result.adoc").readText()
+        val expectedText = getAssetAsString("asciidoc-template-reporter-expected-result.adoc")
 
         val reportContent =
             AdocTemplateReporter().generateReport(ReporterInput(ORT_RESULT), createTestTempDir()).single()

--- a/reporter/src/funTest/kotlin/reporters/freemarker/asciidoc/DocBookTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/freemarker/asciidoc/DocBookTemplateReporterFunTest.kt
@@ -22,16 +22,15 @@ package org.ossreviewtoolkit.reporter.reporters.freemarker.asciidoc
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.patchAsciiDocTemplateResult
 import org.ossreviewtoolkit.utils.test.createTestTempDir
+import org.ossreviewtoolkit.utils.test.getAssetAsString
 
 class DocBookTemplateReporterFunTest : StringSpec({
     "DocBook report is created from default template" {
-        val expectedText = File("src/funTest/assets/docbook-template-reporter-expected-result.xml").readText()
+        val expectedText = getAssetAsString("docbook-template-reporter-expected-result.xml")
 
         val reportContent =
             DocBookTemplateReporter().generateReport(ReporterInput(ORT_RESULT), createTestTempDir()).single().readText()

--- a/reporter/src/funTest/kotlin/reporters/freemarker/asciidoc/HtmlTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/freemarker/asciidoc/HtmlTemplateReporterFunTest.kt
@@ -22,16 +22,15 @@ package org.ossreviewtoolkit.reporter.reporters.freemarker.asciidoc
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.patchAsciiDocTemplateResult
 import org.ossreviewtoolkit.utils.test.createTestTempDir
+import org.ossreviewtoolkit.utils.test.getAssetAsString
 
 class HtmlTemplateReporterFunTest : StringSpec({
     "HTML report is created from default template" {
-        val expectedText = File("src/funTest/assets/html-template-reporter-expected-result.html").readText()
+        val expectedText = getAssetAsString("html-template-reporter-expected-result.html")
 
         val reportContent =
             HtmlTemplateReporter().generateReport(ReporterInput(ORT_RESULT), createTestTempDir()).single().readText()

--- a/reporter/src/funTest/kotlin/reporters/freemarker/asciidoc/ManPageTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/freemarker/asciidoc/ManPageTemplateReporterFunTest.kt
@@ -22,16 +22,15 @@ package org.ossreviewtoolkit.reporter.reporters.freemarker.asciidoc
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.patchAsciiDocTemplateResult
 import org.ossreviewtoolkit.utils.test.createTestTempDir
+import org.ossreviewtoolkit.utils.test.getAssetAsString
 
 class ManPageTemplateReporterFunTest : StringSpec({
     "ManPage report is created from default template" {
-        val expectedText = File("src/funTest/assets/manpage-template-reporter-expected-result.1").readText()
+        val expectedText = getAssetAsString("manpage-template-reporter-expected-result.1")
 
         val reportContent =
             ManPageTemplateReporter().generateReport(ReporterInput(ORT_RESULT), createTestTempDir()).single().readText()

--- a/reporter/src/funTest/kotlin/reporters/freemarker/asciidoc/XHtmlTemplateReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/freemarker/asciidoc/XHtmlTemplateReporterFunTest.kt
@@ -22,16 +22,15 @@ package org.ossreviewtoolkit.reporter.reporters.freemarker.asciidoc
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.reporter.ORT_RESULT
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.reporter.patchAsciiDocTemplateResult
 import org.ossreviewtoolkit.utils.test.createTestTempDir
+import org.ossreviewtoolkit.utils.test.getAssetAsString
 
 class XHtmlTemplateReporterFunTest : StringSpec({
     "XHTML report is created from default template" {
-        val expectedText = File("src/funTest/assets/xhtml-template-reporter-expected-result.xhtml").readText()
+        val expectedText = getAssetAsString("xhtml-template-reporter-expected-result.xhtml")
 
         val reportContent =
             XHtmlTemplateReporter().generateReport(ReporterInput(ORT_RESULT), createTestTempDir()).single().readText()

--- a/reporter/src/funTest/kotlin/reporters/gitlab/GitLabLicenseModelReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/gitlab/GitLabLicenseModelReporterFunTest.kt
@@ -23,8 +23,6 @@ import io.kotest.core.TestConfiguration
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.AnalyzerRun
 import org.ossreviewtoolkit.model.Identifier
@@ -44,6 +42,7 @@ import org.ossreviewtoolkit.model.config.ScopeExcludeReason
 import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.normalizeLineBreaks
 import org.ossreviewtoolkit.utils.test.createTestTempDir
+import org.ossreviewtoolkit.utils.test.getAssetAsString
 
 class GitLabLicenseModelReporterFunTest : WordSpec({
     "GitLabLicenseModelReporter" should {
@@ -65,7 +64,7 @@ class GitLabLicenseModelReporterFunTest : WordSpec({
     }
 })
 
-private fun expectedOutput(assetName: String): String = File("src/funTest/assets/$assetName").readText()
+private fun expectedOutput(assetName: String): String = getAssetAsString("$assetName")
 
 private fun TestConfiguration.generateReport(ortResult: OrtResult, skipExcluded: Boolean): String =
     GitLabLicenseModelReporter().generateReport(

--- a/reporter/src/funTest/kotlin/reporters/gitlab/GitLabLicenseModelReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/gitlab/GitLabLicenseModelReporterFunTest.kt
@@ -51,7 +51,7 @@ class GitLabLicenseModelReporterFunTest : WordSpec({
 
             val jsonLicenseModel = generateReport(ortResult = ortResult, skipExcluded = true) + "\n"
 
-            jsonLicenseModel shouldBe expectedOutput("gitlab-license-model-test-skip-excluded-expected-output.json")
+            jsonLicenseModel shouldBe getAssetAsString("gitlab-license-model-test-skip-excluded-expected-output.json")
         }
 
         "create the expected JSON license model containing all packages referenced by any project " {
@@ -59,12 +59,10 @@ class GitLabLicenseModelReporterFunTest : WordSpec({
 
             val jsonLicenseModel = generateReport(ortResult = ortResult, skipExcluded = false) + "\n"
 
-            jsonLicenseModel shouldBe expectedOutput("gitlab-license-model-test-expected-output.json")
+            jsonLicenseModel shouldBe getAssetAsString("gitlab-license-model-test-expected-output.json")
         }
     }
 })
-
-private fun expectedOutput(assetName: String): String = getAssetAsString("$assetName")
 
 private fun TestConfiguration.generateReport(ortResult: OrtResult, skipExcluded: Boolean): String =
     GitLabLicenseModelReporter().generateReport(

--- a/reporter/src/funTest/kotlin/reporters/spdx/SpdxDocumentReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/spdx/SpdxDocumentReporterFunTest.kt
@@ -67,6 +67,7 @@ import org.ossreviewtoolkit.utils.spdx.SpdxModelMapper.fromYaml
 import org.ossreviewtoolkit.utils.spdx.model.SpdxDocument
 import org.ossreviewtoolkit.utils.spdx.toSpdx
 import org.ossreviewtoolkit.utils.test.createTestTempDir
+import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class SpdxDocumentReporterFunTest : WordSpec({
@@ -77,7 +78,7 @@ class SpdxDocumentReporterFunTest : WordSpec({
                 .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
                 .objectMapper(FileFormat.JSON.mapper)
                 .build()
-                .getSchema(File("src/funTest/assets/spdx-schema.json").toURI())
+                .getSchema(getAssetFile("spdx-schema.json").toURI())
 
             val jsonSpdxDocument = generateReport(ortResult, FileFormat.JSON)
             val errors = schema.validate(jsonMapper.readTree(jsonSpdxDocument))


### PR DESCRIPTION
See individual commits.