### PR TITLE
feat(FreeMarkerTemplateReporter): Pass `statistics` to the templates

### DIFF
--- a/reporter/src/main/kotlin/ReporterInput.kt
+++ b/reporter/src/main/kotlin/ReporterInput.kt
@@ -32,6 +32,7 @@ import org.ossreviewtoolkit.model.licenses.LicenseInfoResolver
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.model.utils.PackageConfigurationProvider
 import org.ossreviewtoolkit.model.utils.ResolutionProvider
+import org.ossreviewtoolkit.reporter.StatisticsCalculator.getStatistics
 
 /**
  * A bundle of input to be used by [Reporter] implementations.
@@ -88,4 +89,10 @@ data class ReporterInput(
      * A [HowToFixTextProvider], can be used to integrate how to fix texts for [Issue]s into reports.
      */
     val howToFixTextProvider: HowToFixTextProvider = HowToFixTextProvider.NONE
-)
+) {
+    /**
+     * Statistics for [ortResult].
+     */
+    @Suppress("UNUSED") // This can be used from templates.
+    val statistics: Statistics by lazy { getStatistics(ortResult, resolutionProvider, licenseInfoResolver) }
+}

--- a/reporter/src/main/kotlin/Statistics.kt
+++ b/reporter/src/main/kotlin/Statistics.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.reporter.reporters.evaluatedmodel
+package org.ossreviewtoolkit.reporter
 
 import java.util.SortedMap
 import java.util.SortedSet

--- a/reporter/src/main/kotlin/StatisticsCalculator.kt
+++ b/reporter/src/main/kotlin/StatisticsCalculator.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.ossreviewtoolkit.reporter.reporters.evaluatedmodel
+package org.ossreviewtoolkit.reporter
 
 import java.util.SortedMap
 

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModel.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModel.kt
@@ -46,6 +46,7 @@ import org.ossreviewtoolkit.model.config.VulnerabilityResolution
 import org.ossreviewtoolkit.model.mapperConfig
 import org.ossreviewtoolkit.reporter.Reporter
 import org.ossreviewtoolkit.reporter.ReporterInput
+import org.ossreviewtoolkit.reporter.Statistics
 import org.ossreviewtoolkit.reporter.reporters.WebAppReporter
 
 /**

--- a/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/evaluatedmodel/EvaluatedModelMapper.kt
@@ -46,7 +46,7 @@ import org.ossreviewtoolkit.model.utils.FindingsMatcher
 import org.ossreviewtoolkit.model.utils.RootLicenseMatcher
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.reporter.ReporterInput
-import org.ossreviewtoolkit.reporter.reporters.evaluatedmodel.StatisticsCalculator.getStatistics
+import org.ossreviewtoolkit.reporter.StatisticsCalculator.getStatistics
 import org.ossreviewtoolkit.utils.ort.ProcessedDeclaredLicense
 
 /**


### PR DESCRIPTION
This can be useful for outputting a short summary, e.g. for an ORT run on CI.
See individual commits.