### PR TITLE
Conan: Allow wildcards in definition file names

### DIFF
--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -87,7 +87,7 @@ class Conan(
     }
 
     class Factory : AbstractPackageManagerFactory<Conan>("Conan") {
-        override val globsForDefinitionFiles = listOf("conanfile.txt", "conanfile.py")
+        override val globsForDefinitionFiles = listOf("conanfile*.txt", "conanfile*.py")
 
         override fun create(
             analysisRoot: File,


### PR DESCRIPTION
Change the globs to match Conan definition files to contain a wildcard after `conanfile` to also find files named like `conanfile-xyz.py`.