### PR TITLE
FreemarkerTemplateProcessor: Improve the code a bit

### DIFF
--- a/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
@@ -111,12 +111,9 @@ class FreemarkerTemplateProcessor(
             }
         }
 
-        return processTemplatesInternal(
-            input = input.deduplicateProjectScanResults(projectsAsPackages),
-            outputDir = outputDir,
-            options = options,
-            projectsAsPackages = projectsAsPackages
-        )
+        val dataModel = createDataModel(input.deduplicateProjectScanResults(projectsAsPackages), projectsAsPackages)
+
+        return processTemplatesInternal(dataModel, outputDir, options)
     }
 
     /**
@@ -124,13 +121,10 @@ class FreemarkerTemplateProcessor(
      * generated files.
      */
     private fun processTemplatesInternal(
-        input: ReporterInput,
+        dataModel: Map<String, Any>,
         outputDir: File,
-        options: Map<String, String>,
-        projectsAsPackages: Set<Identifier>
+        options: Map<String, String>
     ): List<File> {
-        val dataModel = createDataModel(input, projectsAsPackages)
-
         val templatePaths = options[OPTION_TEMPLATE_PATH]?.split(',').orEmpty()
         val templateIds = options[OPTION_TEMPLATE_ID]?.split(',').orEmpty()
 

--- a/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
@@ -409,14 +409,6 @@ class FreemarkerTemplateProcessor(
 }
 
 /**
- * A list of the enum classes that are made available to templates.
- */
-private val ENUM_CLASSES = listOf(
-    AdvisorCapability::class.java,
-    Severity::class.java
-)
-
-/**
  * Return a map with wrapper beans for the enum classes that are relevant for templates.These enums can then be
  * referenced directly by templates.
  * See https://freemarker.apache.org/docs/pgui_misc_beanwrapper.html#jdk_15_enums.
@@ -425,7 +417,10 @@ private fun enumModel(): Map<String, Any> {
     val beansWrapper = BeansWrapperBuilder(Configuration.VERSION_2_3_30).build()
     val enumModels = beansWrapper.enumModels
 
-    return ENUM_CLASSES.associate { it.simpleName to enumModels.get(it.name) }
+    return listOf(
+        AdvisorCapability::class.java,
+        Severity::class.java
+    ).associate { it.simpleName to enumModels.get(it.name) }
 }
 
 private fun List<ResolvedLicense>.merge(): ResolvedLicense {

--- a/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
@@ -190,18 +190,6 @@ class FreemarkerTemplateProcessor(
     }
 
     /**
-     * Return a map with wrapper beans for the enum classes that are relevant for templates.These enums can then be
-     * referenced directly by templates.
-     * See https://freemarker.apache.org/docs/pgui_misc_beanwrapper.html#jdk_15_enums.
-     */
-    private fun enumModel(): Map<String, Any> {
-        val beansWrapper = BeansWrapperBuilder(Configuration.VERSION_2_3_30).build()
-        val enumModels = beansWrapper.enumModels
-
-        return ENUM_CLASSES.associate { it.simpleName to enumModels.get(it.name) }
-    }
-
-    /**
      * License information for a single package or project.
      */
     class PackageModel(
@@ -427,6 +415,18 @@ private val ENUM_CLASSES = listOf(
     AdvisorCapability::class.java,
     Severity::class.java
 )
+
+/**
+ * Return a map with wrapper beans for the enum classes that are relevant for templates.These enums can then be
+ * referenced directly by templates.
+ * See https://freemarker.apache.org/docs/pgui_misc_beanwrapper.html#jdk_15_enums.
+ */
+private fun enumModel(): Map<String, Any> {
+    val beansWrapper = BeansWrapperBuilder(Configuration.VERSION_2_3_30).build()
+    val enumModels = beansWrapper.enumModels
+
+    return ENUM_CLASSES.associate { it.simpleName to enumModels.get(it.name) }
+}
 
 private fun List<ResolvedLicense>.merge(): ResolvedLicense {
     require(isNotEmpty()) { "Cannot merge an empty list." }


### PR DESCRIPTION
Prepare for a further refactoring mainly focusing on reducing the size of `processTemplatesInternal()` to
make things easier to grasp.

See individual commits.

Context: #6569.