### PR TITLE
test(ClearlyDefined): Reduce the duration of simulated timeouts

### DIFF
--- a/analyzer/src/test/kotlin/curation/ClearlyDefinedPackageCurationProviderTest.kt
+++ b/analyzer/src/test/kotlin/curation/ClearlyDefinedPackageCurationProviderTest.kt
@@ -62,10 +62,10 @@ class ClearlyDefinedPackageCurationProviderTest : WordSpec({
         "handle a SocketTimeoutException" {
             server.stubFor(
                 get(anyUrl())
-                    .willReturn(aResponse().withFixedDelay(2000))
+                    .willReturn(aResponse().withFixedDelay(100))
             )
             val client = OkHttpClientHelper.buildClient {
-                readTimeout(Duration.ofSeconds(1))
+                readTimeout(Duration.ofMillis(1))
             }
 
             val provider = ClearlyDefinedPackageCurationProvider("http://localhost:${server.port()}", client)

--- a/scanner/src/test/kotlin/storages/ClearlyDefinedStorageTest.kt
+++ b/scanner/src/test/kotlin/storages/ClearlyDefinedStorageTest.kt
@@ -228,10 +228,10 @@ class ClearlyDefinedStorageTest : WordSpec({
         "handle a SocketTimeoutException" {
             server.stubFor(
                 get(anyUrl())
-                    .willReturn(aResponse().withFixedDelay(2000))
+                    .willReturn(aResponse().withFixedDelay(100))
             )
             val client = OkHttpClientHelper.buildClient {
-                readTimeout(Duration.ofSeconds(1))
+                readTimeout(Duration.ofMillis(1))
             }
 
             val storage = ClearlyDefinedStorage("http://localhost:${server.port()}", client)


### PR DESCRIPTION
This should reduce the overall runtime of these tests a bit.