### PR TITLE
AnalyzerConfiguration: Make properties nullable

### DIFF
--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -359,7 +359,7 @@ abstract class PackageManager(
     abstract fun resolveDependencies(definitionFile: File, labels: Map<String, String>): List<ProjectAnalyzerResult>
 
     protected fun requireLockfile(workingDir: File, condition: () -> Boolean) {
-        require(analyzerConfig.allowDynamicVersions || condition()) {
+        require(analyzerConfig.allowDynamicVersions == true || condition()) {
             val relativePathString = workingDir.relativeTo(analysisRoot).invariantSeparatorsPath
                 .takeUnless { it.isEmpty() } ?: "."
 

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -224,7 +224,7 @@ abstract class PackageManager(
          * object. This means that all dependencies are collected, and excludes are applied later on the report level.
          */
         internal fun AnalyzerConfiguration.excludes(repositoryConfiguration: RepositoryConfiguration): Excludes =
-            repositoryConfiguration.excludes.takeIf { skipExcluded } ?: Excludes.EMPTY
+            repositoryConfiguration.excludes.takeIf { skipExcluded == true } ?: Excludes.EMPTY
 
         /**
          * Check whether the given [path] interpreted relatively against [root] is matched by a path exclude in this

--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -232,11 +232,10 @@ class GoDep(
 
     private fun parseProjects(workingDir: File, gopath: File): List<Map<String, String>> {
         val lockfile = workingDir.resolve("Gopkg.lock")
-        if (!lockfile.isFile) {
-            require(analyzerConfig.allowDynamicVersions) {
-                "No lockfile found in ${workingDir.invariantSeparatorsPath}, dependency versions are unstable."
-            }
 
+        requireLockfile(workingDir) { lockfile.isFile }
+
+        if (!lockfile.isFile) {
             logger.debug { "Running 'dep ensure' to generate missing lockfile in $workingDir" }
 
             run("ensure", workingDir = workingDir, environment = mapOf("GOPATH" to gopath.path))

--- a/model/src/main/kotlin/config/AnalyzerConfiguration.kt
+++ b/model/src/main/kotlin/config/AnalyzerConfiguration.kt
@@ -27,10 +27,10 @@ data class AnalyzerConfiguration(
      * Enable the analysis of projects that use version ranges to declare their dependencies. If set to true,
      * dependencies of exactly the same project might change with another scan done at a later time if any of the
      * (transitive) dependencies are declared using version ranges and a new version of such a dependency was
-     * published in the meantime. If set to false, analysis of projects that use version ranges will fail. Defaults to
-     * false.
+     * published in the meantime. If set to false or null, analysis of projects that use version ranges will fail.
+     * Defaults to null.
      */
-    val allowDynamicVersions: Boolean = false,
+    val allowDynamicVersions: Boolean? = null,
 
     /**
      * A list of the case-insensitive names of package managers that are enabled. Disabling a package manager in
@@ -107,7 +107,7 @@ data class AnalyzerConfiguration(
         }
 
         return AnalyzerConfiguration(
-            allowDynamicVersions = other.allowDynamicVersions,
+            allowDynamicVersions = other.allowDynamicVersions ?: allowDynamicVersions,
             enabledPackageManagers = other.enabledPackageManagers ?: enabledPackageManagers,
             disabledPackageManagers = other.disabledPackageManagers ?: disabledPackageManagers,
             packageManagers = mergedPackageManagers,

--- a/model/src/main/kotlin/config/AnalyzerConfiguration.kt
+++ b/model/src/main/kotlin/config/AnalyzerConfiguration.kt
@@ -51,9 +51,10 @@ data class AnalyzerConfiguration(
     val packageManagers: Map<String, PackageManagerConfiguration>? = null,
 
     /**
-     * A flag to control whether excluded scopes and paths should be skipped during the analysis.
+     * A flag to control whether excluded scopes and paths should be skipped during the analysis. If set to false or
+     * null, excluded scopes and paths are also analyzed. Defaults to null.
      */
-    val skipExcluded: Boolean = false
+    val skipExcluded: Boolean? = null
 ) {
     /**
      * A copy of [packageManagers] with case-insensitive keys.

--- a/model/src/test/kotlin/config/AnalyzerConfigurationTest.kt
+++ b/model/src/test/kotlin/config/AnalyzerConfigurationTest.kt
@@ -70,11 +70,13 @@ class AnalyzerConfigurationTest : WordSpec({
 
         "keep values which are null in other" {
             val self = AnalyzerConfiguration(
+                allowDynamicVersions = true,
                 enabledPackageManagers = listOf("Gradle"),
                 disabledPackageManagers = listOf("NPM")
             )
 
             val other = AnalyzerConfiguration(
+                allowDynamicVersions = null,
                 enabledPackageManagers = null,
                 disabledPackageManagers = null
             )

--- a/model/src/test/kotlin/config/AnalyzerConfigurationTest.kt
+++ b/model/src/test/kotlin/config/AnalyzerConfigurationTest.kt
@@ -50,7 +50,8 @@ class AnalyzerConfigurationTest : WordSpec({
             val self = AnalyzerConfiguration(
                 allowDynamicVersions = false,
                 enabledPackageManagers = listOf("Gradle"),
-                disabledPackageManagers = listOf("NPM")
+                disabledPackageManagers = listOf("NPM"),
+                skipExcluded = false
             )
 
             val other = AnalyzerConfiguration(
@@ -72,13 +73,15 @@ class AnalyzerConfigurationTest : WordSpec({
             val self = AnalyzerConfiguration(
                 allowDynamicVersions = true,
                 enabledPackageManagers = listOf("Gradle"),
-                disabledPackageManagers = listOf("NPM")
+                disabledPackageManagers = listOf("NPM"),
+                skipExcluded = true
             )
 
             val other = AnalyzerConfiguration(
                 allowDynamicVersions = null,
                 enabledPackageManagers = null,
-                disabledPackageManagers = null
+                disabledPackageManagers = null,
+                skipExcluded = null
             )
 
             self.merge(other) shouldBe self


### PR DESCRIPTION
Make some propertties nullable to fix merging global and local configuration. See the commit messages for details:

**Breaking API change:**
* The `allowDynamicVersions` and `skipExcluded` properties of the `AnalyzerConfiguration` are now nullable and the default value was changed from `false` to `null`.