### PR TITLE
Allow to match Copyright garbage by `Regex` patterns

### DIFF
--- a/docs/config-file-copyright-garbage-yml.md
+++ b/docs/config-file-copyright-garbage-yml.md
@@ -1,18 +1,14 @@
 # The `copyright-garbage.yml` file
 
-The `copyright-garbage.yml` file allows for removal of incorrect copyright holder detections from the _reporter_ output.
-
-You can use the [copyright-garbage.yml example](../examples/copyright-garbage.yml) as the base file for your scans.
-
-### When to Use
-
-No scanner is perfect and many detect code statements or binary code as copyright holders, `copyright-garbage.yml`
-provides a way to clean up such errors across all scans.
+The `copyright-garbage.yml` file allows to define which Copyright statements are to be considered as garbage, like any
+invalid findings from a scanner. This can be done by literal strings or regular expression patterns. The _evaluator_ and
+_reporter_ take the file as optional input. See the [copyright-garbage.yml example](../examples/copyright-garbage.yml)
+as a base to get started.
 
 ## Command Line
 
-To use the `copyright-garbage.yml` file put it to `$ORT_CONFIG_DIR/copyright-garbage.yml` or pass it to the
-`--copyright-garbage-file` option of the _reporter_:
+Either create a file at the default location at `$ORT_CONFIG_DIR/copyright-garbage.yml`, or pass a custom file via the
+`--copyright-garbage-file` option of the _evaluator_ or _reporter_. For example:
 
 ```bash
 cli/build/install/ort/bin/ort report

--- a/examples/copyright-garbage.yml
+++ b/examples/copyright-garbage.yml
@@ -130,3 +130,5 @@ items:
 - "VuSS vaa (c) Ac"
 - "Xz eaaeuyATNRU (c) Ijr"
 - "Y2oex (c) A1"
+patterns:
+- "^\\(c\\) https?://stackoverflow\\.com/questions/.+$"

--- a/model/src/main/kotlin/config/CopyrightGarbage.kt
+++ b/model/src/main/kotlin/config/CopyrightGarbage.kt
@@ -21,6 +21,14 @@ package org.ossreviewtoolkit.model.config
 
 import java.util.SortedSet
 
-data class CopyrightGarbage(val items: SortedSet<String> = sortedSetOf())
+/**
+ * A class that defines which Copyright statements are to be considered as garbage instead of real findings.
+ */
+data class CopyrightGarbage(
+    /**
+     * A set of literal strings that identify garbage Copyright findings.
+     */
+    val items: SortedSet<String> = sortedSetOf()
+)
 
 fun CopyrightGarbage?.orEmpty(): CopyrightGarbage = this ?: CopyrightGarbage()

--- a/model/src/main/kotlin/config/CopyrightGarbage.kt
+++ b/model/src/main/kotlin/config/CopyrightGarbage.kt
@@ -21,8 +21,6 @@ package org.ossreviewtoolkit.model.config
 
 import java.util.SortedSet
 
-data class CopyrightGarbage(val items: SortedSet<String> = sortedSetOf()) {
-    constructor(vararg items: String) : this(items.toSortedSet())
-}
+data class CopyrightGarbage(val items: SortedSet<String> = sortedSetOf())
 
 fun CopyrightGarbage?.orEmpty(): CopyrightGarbage = this ?: CopyrightGarbage()

--- a/model/src/main/kotlin/config/CopyrightGarbage.kt
+++ b/model/src/main/kotlin/config/CopyrightGarbage.kt
@@ -27,6 +27,11 @@ data class CopyrightGarbage(
      * A set of literal strings that identify garbage Copyright findings.
      */
     val items: Set<String> = emptySet()
-)
+) {
+    /**
+     * Return whether the [statement] is garbage.
+     */
+    operator fun contains(statement: String): Boolean = statement in items
+}
 
 fun CopyrightGarbage?.orEmpty(): CopyrightGarbage = this ?: CopyrightGarbage()

--- a/model/src/main/kotlin/config/CopyrightGarbage.kt
+++ b/model/src/main/kotlin/config/CopyrightGarbage.kt
@@ -19,8 +19,6 @@
 
 package org.ossreviewtoolkit.model.config
 
-import java.util.SortedSet
-
 /**
  * A class that defines which Copyright statements are to be considered as garbage instead of real findings.
  */
@@ -28,7 +26,7 @@ data class CopyrightGarbage(
     /**
      * A set of literal strings that identify garbage Copyright findings.
      */
-    val items: SortedSet<String> = sortedSetOf()
+    val items: Set<String> = emptySet()
 )
 
 fun CopyrightGarbage?.orEmpty(): CopyrightGarbage = this ?: CopyrightGarbage()

--- a/model/src/main/kotlin/config/CopyrightGarbage.kt
+++ b/model/src/main/kotlin/config/CopyrightGarbage.kt
@@ -26,12 +26,20 @@ data class CopyrightGarbage(
     /**
      * A set of literal strings that identify garbage Copyright findings.
      */
-    val items: Set<String> = emptySet()
+    val items: Set<String> = emptySet(),
+
+    /**
+     * A set of [Regex] patterns that identify garbage Copyright findings.
+     */
+    val patterns: Set<String> = emptySet()
 ) {
+    private val regexes by lazy { patterns.map { it.toRegex() } }
+
     /**
      * Return whether the [statement] is garbage.
      */
-    operator fun contains(statement: String): Boolean = statement in items
+    operator fun contains(statement: String): Boolean =
+        statement in items || regexes.any { it.matches(statement) }
 }
 
 fun CopyrightGarbage?.orEmpty(): CopyrightGarbage = this ?: CopyrightGarbage()

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -167,12 +167,12 @@ class LicenseInfoResolver(
     private fun DetectedLicenseInfo.filterCopyrightGarbage(
         copyrightGarbageFindings: MutableMap<Provenance, Set<CopyrightFinding>>
     ): DetectedLicenseInfo {
-        val filteredFindings = findings.map {
-            val (copyrightGarbage, copyrightFindings) = it.copyrights.partition { copyrightFinding ->
+        val filteredFindings = findings.map { finding ->
+            val (copyrightGarbage, copyrightFindings) = finding.copyrights.partition { copyrightFinding ->
                 copyrightFinding.statement in copyrightGarbage.items
             }
-            copyrightGarbageFindings[it.provenance] = copyrightGarbage.toSet()
-            it.copy(copyrights = copyrightFindings.toSet())
+            copyrightGarbageFindings[finding.provenance] = copyrightGarbage.toSet()
+            finding.copy(copyrights = copyrightFindings.toSet())
         }
         return DetectedLicenseInfo(filteredFindings)
     }

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -169,7 +169,7 @@ class LicenseInfoResolver(
     ): DetectedLicenseInfo {
         val filteredFindings = findings.map { finding ->
             val (copyrightGarbage, copyrightFindings) = finding.copyrights.partition { copyrightFinding ->
-                copyrightFinding.statement in copyrightGarbage.items
+                copyrightFinding.statement in copyrightGarbage
             }
             copyrightGarbageFindings[finding.provenance] = copyrightGarbage.toSet()
             finding.copy(copyrights = copyrightFindings.toSet())

--- a/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
+++ b/model/src/main/kotlin/licenses/LicenseInfoResolver.kt
@@ -168,11 +168,11 @@ class LicenseInfoResolver(
         copyrightGarbageFindings: MutableMap<Provenance, Set<CopyrightFinding>>
     ): DetectedLicenseInfo {
         val filteredFindings = findings.map {
-            val partitionedFindings = it.copyrights.partition { copyrightFinding ->
+            val (copyrightGarbage, copyrightFindings) = it.copyrights.partition { copyrightFinding ->
                 copyrightFinding.statement in copyrightGarbage.items
             }
-            copyrightGarbageFindings[it.provenance] = partitionedFindings.first.toSet()
-            it.copy(copyrights = partitionedFindings.second.toSet())
+            copyrightGarbageFindings[it.provenance] = copyrightGarbage.toSet()
+            it.copy(copyrights = copyrightFindings.toSet())
         }
         return DetectedLicenseInfo(filteredFindings)
     }


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.