### PR TITLE
fix(Gradle): Stop using deprecated constructs in Kotlin DSL

### DIFF
--- a/scanner/build.gradle.kts
+++ b/scanner/build.gradle.kts
@@ -70,7 +70,7 @@ tasks.withType<KotlinCompile>().configureEach {
         "-opt-in=kotlinx.serialization.ExperimentalSerializationApi"
     )
 
-    if ("test" in name.toLowerCase()) {
+    if ("test" in name.lowercase()) {
         kotlinOptions {
             freeCompilerArgs = freeCompilerArgs + customCompilerArgs
         }

--- a/utils/spdx/build.gradle.kts
+++ b/utils/spdx/build.gradle.kts
@@ -134,7 +134,7 @@ fun getLicenseHeader(year: Int = 2017) =
     """.trimMargin()
 
 fun licenseToEnumEntry(info: LicenseInfo): String {
-    var enumEntry = info.id.toUpperCase().replace(Regex("[-.]"), "_").replace("+", "PLUS")
+    var enumEntry = info.id.uppercase().replace(Regex("[-.]"), "_").replace("+", "PLUS")
     if (enumEntry.first().isDigit()) {
         enumEntry = "_$enumEntry"
     }
@@ -330,7 +330,7 @@ val generateSpdxLicenseEnum by tasks.registering(Download::class) {
         providers.mapNotNull { it.getLicenseUrl(info) }.first() to info.id
     }
 
-    src(licenseUrlMap.keys.sortedBy { it.toString().toLowerCase() })
+    src(licenseUrlMap.keys.sortedBy { it.toString().lowercase() })
     dest("src/main/resources/$licensesResourcePath")
     eachFile { name = licenseUrlMap[sourceURL] }
 
@@ -363,7 +363,7 @@ val generateSpdxLicenseExceptionEnum by tasks.registering(Download::class) {
         providers.mapNotNull { it.getLicenseUrl(info) }.first() to info.id
     }
 
-    src(licenseExceptionUrlMap.keys.sortedBy { it.toString().toLowerCase() })
+    src(licenseExceptionUrlMap.keys.sortedBy { it.toString().lowercase() })
     dest("src/main/resources/$exceptionsResourcePath")
     eachFile { name = licenseExceptionUrlMap[sourceURL] }
 


### PR DESCRIPTION
Gradle 8 started to ship with Kotlin 1.8, which deprecated several constructs. Replace these with their current counterparts.