### PR TITLE
refactor(GitHubService): Make `ENDPOINT` a `String`

### DIFF
--- a/advisor/src/main/kotlin/advisors/GitHubDefects.kt
+++ b/advisor/src/main/kotlin/advisors/GitHubDefects.kt
@@ -112,7 +112,7 @@ class GitHubDefects(name: String, gitHubConfiguration: GitHubDefectsConfiguratio
     private val service by lazy {
         GitHubService.create(
             token = gitHubConfiguration.token.orEmpty(),
-            url = gitHubConfiguration.endpointUrl?.let { URI(it) } ?: GitHubService.ENDPOINT,
+            url = gitHubConfiguration.endpointUrl ?: GitHubService.ENDPOINT,
             client = HttpClient(OkHttp)
         )
     }

--- a/advisor/src/test/kotlin/advisors/GitHubDefectsTest.kt
+++ b/advisor/src/test/kotlin/advisors/GitHubDefectsTest.kt
@@ -305,14 +305,14 @@ class GitHubDefectsTest : WordSpec({
 
     "the GitHubService instance" should {
         "use the configured endpoint URI" {
-            val endpointUri = URI("https://www.example.org/alternative/endpoint")
-            createGitHubServiceMock(endpointUri).configureResults(emptyList(), emptyList())
+            val url = "https://www.example.org/alternative/endpoint"
+            createGitHubServiceMock(url).configureResults(emptyList(), emptyList())
 
-            val advisor = createAdvisor(url = endpointUri.toString())
+            val advisor = createAdvisor(url = url)
             advisor.retrievePackageFindings(setOf(createPackage()))
 
             verify {
-                GitHubService.create(GITHUB_TOKEN, endpointUri, any())
+                GitHubService.create(GITHUB_TOKEN, url, any())
             }
         }
     }
@@ -416,7 +416,7 @@ private val PACKAGE_ID =
  * Create a mock for the [GitHubService] and prepare the static factory method to return this mock, expecting the
  * provided [url].
  */
-private fun createGitHubServiceMock(url: URI = GitHubService.ENDPOINT): GitHubService {
+private fun createGitHubServiceMock(url: String = GitHubService.ENDPOINT): GitHubService {
     val service = mockk<GitHubService>()
 
     mockkObject(GitHubService)

--- a/clients/github-graphql/src/main/kotlin/GitHubService.kt
+++ b/clients/github-graphql/src/main/kotlin/GitHubService.kt
@@ -29,7 +29,7 @@ import io.ktor.client.HttpClientConfig
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.header
 
-import java.net.URI
+import java.net.URL
 
 import kotlin.time.measureTimedValue
 
@@ -66,14 +66,14 @@ class GitHubService private constructor(
         /**
          * The default endpoint URL for accessing the GitHub GraphQL API.
          */
-        val ENDPOINT = URI("https://api.github.com/graphql")
+        const val ENDPOINT = "https://api.github.com/graphql"
 
         /**
          * Create a new [GitHubService] instance that uses the given [token] to authenticate against the GitHub API.
          * Optionally, the [url] for the GitHub GraphQL endpoint can be configured, and an HTTP [client] can be
          * specified.
          */
-        fun create(token: String, url: URI = ENDPOINT, client: HttpClient? = null): GitHubService {
+        fun create(token: String, url: String = ENDPOINT, client: HttpClient? = null): GitHubService {
             val clientConfig: HttpClientConfig<*>.() -> Unit = {
                 defaultRequest {
                     header("Authorization", "Bearer $token")
@@ -82,7 +82,7 @@ class GitHubService private constructor(
 
             val httpClient = client?.config(clientConfig) ?: HttpClient(clientConfig)
 
-            return GitHubService(GraphQLKtorClient(url.toURL(), httpClient))
+            return GitHubService(GraphQLKtorClient(URL(url), httpClient))
         }
     }
 

--- a/clients/github-graphql/src/test/kotlin/GitHubServiceTest.kt
+++ b/clients/github-graphql/src/test/kotlin/GitHubServiceTest.kt
@@ -45,7 +45,6 @@ import io.ktor.client.plugins.ClientRequestException
 import java.io.File
 import java.net.ConnectException
 import java.net.ServerSocket
-import java.net.URI
 import java.util.regex.Pattern
 
 import kotlinx.coroutines.Dispatchers
@@ -91,7 +90,7 @@ class GitHubServiceTest : WordSpec({
             val port = withContext(Dispatchers.IO) { ServerSocket(0).use { it.localPort } }
             val serverUrl = "http://localhost:$port"
 
-            val service = GitHubService.create(TOKEN, URI(serverUrl))
+            val service = GitHubService.create(TOKEN, serverUrl)
 
             val issuesResult = service.repositoryIssues(REPO_OWNER, REPO_NAME)
 
@@ -238,7 +237,7 @@ private const val PAGE_SIZE = 32
  * Create a [GitHubService] instance that is configured to access the given mock [server].
  */
 private fun createService(server: WireMockServer): GitHubService =
-    GitHubService.create(TOKEN, URI("http://localhost:${server.port()}$ENDPOINT"))
+    GitHubService.create(TOKEN, "http://localhost:${server.port()}$ENDPOINT")
 
 /**
  * Prepare this mock server to answer a GraphQL read from [queryFileName] containing variables matched by


### PR DESCRIPTION
This simplifies the current code as well as some upcoming further refactoring.