### PR TITLE
build(detekt-rules): Fix `OrtPackageNaming` on Windows

### DIFF
--- a/detekt-rules/src/main/kotlin/OrtPackageNaming.kt
+++ b/detekt-rules/src/main/kotlin/OrtPackageNaming.kt
@@ -60,7 +60,7 @@ class OrtPackageNaming(config: Config) : Rule(config) {
         val projectDir = pathPrefix.name
         val projectGroup = pathPrefix.parent
             ?.let { ".$it" }
-            ?.replace("/", ".")
+            ?.replace(forwardOrBackwardSlashPattern, ".")
             ?.replace("-", "")
             .orEmpty()
 


### PR DESCRIPTION
This is a fixup for b718e97.