### PR TITLE
fix(analyzer): Only use values configured in repository configuration

### DIFF
--- a/model/src/main/kotlin/config/RepositoryAnalyzerConfiguration.kt
+++ b/model/src/main/kotlin/config/RepositoryAnalyzerConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,39 +21,51 @@ package org.ossreviewtoolkit.model.config
 
 import com.fasterxml.jackson.annotation.JsonInclude
 
+/**
+ * [AnalyzerConfiguration] options that can be configured in the [RepositoryConfiguration].
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-data class AnalyzerConfiguration(
+data class RepositoryAnalyzerConfiguration(
     /**
      * Enable the analysis of projects that use version ranges to declare their dependencies. If set to true,
      * dependencies of exactly the same project might change with another scan done at a later time if any of the
      * (transitive) dependencies are declared using version ranges and a new version of such a dependency was
-     * published in the meantime. If set to false, analysis of projects that use version ranges will fail. Defaults to
-     * false.
+     * published in the meantime. If set to false, analysis of projects that use version ranges will fail.
+     *
+     * If set to null, the global configuration from [AnalyzerConfiguration.allowDynamicVersions] will be used.
      */
-    val allowDynamicVersions: Boolean = false,
+    val allowDynamicVersions: Boolean? = null,
 
     /**
      * A list of the case-insensitive names of package managers that are enabled. Disabling a package manager in
      * [disabledPackageManagers] overrides enabling it here.
+     *
+     * If set to null, the global configuration from [AnalyzerConfiguration.enabledPackageManagers] will be used.
      */
     val enabledPackageManagers: List<String>? = null,
 
     /**
      * A list of the case-insensitive names of package managers that are disabled. Disabling a package manager in this
      * list overrides [enabledPackageManagers].
+     *
+     * If set to null, the global configuration from [AnalyzerConfiguration.disabledPackageManagers] will be used.
      */
     val disabledPackageManagers: List<String>? = null,
 
     /**
      * Package manager specific configurations. The key needs to match the name of the package manager class, e.g.
      * "NuGet" for the NuGet package manager.
+     *
+     * If set to null, the global configuration from [AnalyzerConfiguration.packageManagers] will be used.
      */
     val packageManagers: Map<String, PackageManagerConfiguration>? = null,
 
     /**
      * A flag to control whether excluded scopes and paths should be skipped during the analysis.
+     *
+     * If set to null, the global configuration from [AnalyzerConfiguration.skipExcluded] will be used.
      */
-    val skipExcluded: Boolean = false
+    val skipExcluded: Boolean? = null
 ) {
     /**
      * A copy of [packageManagers] with case-insensitive keys.
@@ -75,43 +87,4 @@ data class AnalyzerConfiguration(
      * [packageManager] can be case-insensitive.
      */
     fun getPackageManagerConfiguration(packageManager: String) = packageManagersCaseInsensitive?.get(packageManager)
-
-    /**
-     * Merge this [AnalyzerConfiguration] with [other]. Values of [other] take precedence.
-     */
-    fun merge(other: RepositoryAnalyzerConfiguration): AnalyzerConfiguration {
-        val mergedPackageManagers = when {
-            packageManagers == null -> other.packageManagers
-            other.packageManagers == null -> packageManagers
-            else -> {
-                val keys = sortedSetOf(String.CASE_INSENSITIVE_ORDER).apply {
-                    addAll(packageManagers.keys)
-                    addAll(other.packageManagers.keys)
-                }
-
-                val result = sortedMapOf<String, PackageManagerConfiguration>(String.CASE_INSENSITIVE_ORDER)
-
-                keys.forEach { key ->
-                    val configSelf = getPackageManagerConfiguration(key)
-                    val configOther = other.getPackageManagerConfiguration(key)
-
-                    result[key] = when {
-                        configSelf == null -> configOther
-                        configOther == null -> configSelf
-                        else -> configSelf.merge(configOther)
-                    }
-                }
-
-                result
-            }
-        }
-
-        return AnalyzerConfiguration(
-            allowDynamicVersions = other.allowDynamicVersions ?: allowDynamicVersions,
-            enabledPackageManagers = other.enabledPackageManagers ?: enabledPackageManagers,
-            disabledPackageManagers = other.disabledPackageManagers ?: disabledPackageManagers,
-            packageManagers = mergedPackageManagers,
-            skipExcluded = other.skipExcluded ?: skipExcluded
-        )
-    }
 }

--- a/model/src/main/kotlin/config/RepositoryConfiguration.kt
+++ b/model/src/main/kotlin/config/RepositoryConfiguration.kt
@@ -32,7 +32,7 @@ data class RepositoryConfiguration(
      * The configuration for the analyzer. Values in this configuration take precedence over global configuration.
      */
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    val analyzer: AnalyzerConfiguration? = null,
+    val analyzer: RepositoryAnalyzerConfiguration? = null,
 
     /**
      * Defines which parts of the repository will be excluded. Note that excluded parts will still be analyzed and

--- a/model/src/test/kotlin/config/AnalyzerConfigurationTest.kt
+++ b/model/src/test/kotlin/config/AnalyzerConfigurationTest.kt
@@ -53,7 +53,7 @@ class AnalyzerConfigurationTest : WordSpec({
                 disabledPackageManagers = listOf("NPM")
             )
 
-            val other = AnalyzerConfiguration(
+            val other = RepositoryAnalyzerConfiguration(
                 allowDynamicVersions = true,
                 enabledPackageManagers = listOf("Maven"),
                 disabledPackageManagers = listOf("SBT"),
@@ -70,13 +70,17 @@ class AnalyzerConfigurationTest : WordSpec({
 
         "keep values which are null in other" {
             val self = AnalyzerConfiguration(
+                allowDynamicVersions = true,
                 enabledPackageManagers = listOf("Gradle"),
-                disabledPackageManagers = listOf("NPM")
+                disabledPackageManagers = listOf("NPM"),
+                skipExcluded = true
             )
 
-            val other = AnalyzerConfiguration(
+            val other = RepositoryAnalyzerConfiguration(
+                allowDynamicVersions = null,
                 enabledPackageManagers = null,
-                disabledPackageManagers = null
+                disabledPackageManagers = null,
+                skipExcluded = null
             )
 
             self.merge(other) shouldBe self
@@ -92,7 +96,7 @@ class AnalyzerConfigurationTest : WordSpec({
                 )
             )
 
-            val other = AnalyzerConfiguration(
+            val other = RepositoryAnalyzerConfiguration(
                 packageManagers = mapOf(
                     "gradle" to PackageManagerConfiguration(
                         mustRunAfter = listOf("NPM"),


### PR DESCRIPTION
Add a `RepositoryAnalyzerConfiguration` class that contains the same properties as `AnalyzerConfiguration` with the difference that they are all nullable. This fixes the merging of the global analyzer configuration with the analyzer configuration from the repository configuration, because now all properties can be ignored if they are null.

Previously, if any analyzer property was set in the repository configuration, `allowDynamicVersions` and `skipExcluded` were initialized with their default values and overwrote the global configuration.