### PR TITLE
feat(Npm): Group related lines when parsing issues

### DIFF
--- a/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/external/git-repo-expected-output.yml
@@ -4095,18 +4095,26 @@ analyzer:
       NPM::isarray:2.0.5:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "NPM"
-        message: "The package-lock.json file was created with an old version of npm,\n\
-          so supplemental metadata must be fetched from the registry.\nThis is a one-time\
-          \ fix-up, please be patient...\nminimatch@0.3.0: Please update to minimatch\
-          \ 3.0.2 or higher to avoid a RegExp DoS issue"
+        message: "The package-lock.json file was created with an old version of npm,\
+          \ so supplemental metadata must be fetched from the registry. This is a\
+          \ one-time fix-up, please be patient..."
+        severity: "WARNING"
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "NPM"
+        message: "deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or\
+          \ higher to avoid a RegExp DoS issue"
         severity: "WARNING"
       NPM::npm-test-project:1.0.0:
       - timestamp: "1970-01-01T00:00:00Z"
         source: "NPM"
-        message: "The package-lock.json file was created with an old version of npm,\n\
-          so supplemental metadata must be fetched from the registry.\nThis is a one-time\
-          \ fix-up, please be patient...\ncoffee-script@1.12.7: CoffeeScript on NPM\
-          \ has moved to \"coffeescript\" (no hyphen)"
+        message: "The package-lock.json file was created with an old version of npm,\
+          \ so supplemental metadata must be fetched from the registry. This is a\
+          \ one-time fix-up, please be patient..."
+        severity: "WARNING"
+      - timestamp: "1970-01-01T00:00:00Z"
+        source: "NPM"
+        message: "deprecated coffee-script@1.12.7: CoffeeScript on NPM has moved to\
+          \ \"coffeescript\" (no hyphen)"
         severity: "WARNING"
       'NPM::submodules/test-data-npm/long.js/package.json:':
       - timestamp: "1970-01-01T00:00:00Z"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -7770,11 +7770,22 @@ packages:
 issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "NPM"
-  message: "urix@0.1.0: Please see https://github.com/lydell/urix#deprecated\nresolve-url@0.2.1:\
-    \ https://github.com/lydell/resolve-url#deprecated\nchokidar@1.7.0: Chokidar 2\
-    \ will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.\n\
-    core-js@2.6.12: core-js@<3.3 is no longer maintained and not recommended for usage\
-    \ due to the number of issues. Because of the V8 engine whims, feature detection\
-    \ in old core-js versions could cause a slowdown up to 100x even if nothing is\
-    \ polyfilled. Please, upgrade your dependencies to the actual version of core-js."
+  message: "deprecated chokidar@1.7.0: Chokidar 2 will break on node v14+. Upgrade\
+    \ to chokidar 3 with 15x less dependencies."
+  severity: "WARNING"
+- timestamp: "1970-01-01T00:00:00Z"
+  source: "NPM"
+  message: "deprecated core-js@2.6.12: core-js@<3.3 is no longer maintained and not\
+    \ recommended for usage due to the number of issues. Because of the V8 engine\
+    \ whims, feature detection in old core-js versions could cause a slowdown up to\
+    \ 100x even if nothing is polyfilled. Please, upgrade your dependencies to the\
+    \ actual version of core-js."
+  severity: "WARNING"
+- timestamp: "1970-01-01T00:00:00Z"
+  source: "NPM"
+  message: "deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated"
+  severity: "WARNING"
+- timestamp: "1970-01-01T00:00:00Z"
+  source: "NPM"
+  message: "deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated"
   severity: "WARNING"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-scope-excludes.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-scope-excludes.yml
@@ -1153,8 +1153,12 @@ packages:
 issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "NPM"
-  message: "The <REPLACE_LOCKFILE_NAME> file was created with an old version of npm,\n\
-    so supplemental metadata must be fetched from the registry.\nThis is a one-time\
-    \ fix-up, please be patient...\ncoffee-script@1.12.7: CoffeeScript on NPM has\
-    \ moved to \"coffeescript\" (no hyphen)"
+  message: "The <REPLACE_LOCKFILE_NAME> file was created with an old version of npm, so\
+    \ supplemental metadata must be fetched from the registry. This is a one-time\
+    \ fix-up, please be patient..."
+  severity: "WARNING"
+- timestamp: "1970-01-01T00:00:00Z"
+  source: "NPM"
+  message: "deprecated coffee-script@1.12.7: CoffeeScript on NPM has moved to \"coffeescript\"\
+    \ (no hyphen)"
   severity: "WARNING"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
@@ -1189,8 +1189,12 @@ packages:
 issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "NPM"
-  message: "The <REPLACE_LOCKFILE_NAME> file was created with an old version of npm,\n\
-    so supplemental metadata must be fetched from the registry.\nThis is a one-time\
-    \ fix-up, please be patient...\ncoffee-script@1.12.7: CoffeeScript on NPM has\
-    \ moved to \"coffeescript\" (no hyphen)"
+  message: "The <REPLACE_LOCKFILE_NAME> file was created with an old version of npm, so\
+    \ supplemental metadata must be fetched from the registry. This is a one-time\
+    \ fix-up, please be patient..."
+  severity: "WARNING"
+- timestamp: "1970-01-01T00:00:00Z"
+  source: "NPM"
+  message: "deprecated coffee-script@1.12.7: CoffeeScript on NPM has moved to \"coffeescript\"\
+    \ (no hyphen)"
   severity: "WARNING"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
@@ -5151,13 +5151,33 @@ packages:
 issues:
 - timestamp: "1970-01-01T00:00:00Z"
   source: "NPM"
-  message: "The package-lock.json file was created with an old version of npm,\nso\
-    \ supplemental metadata must be fetched from the registry.\nThis is a one-time\
-    \ fix-up, please be patient...\ngulp-header@1.8.12: Removed event-stream from\
-    \ gulp-header\nurix@0.1.0: Please see https://github.com/lydell/urix#deprecated\n\
-    resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated\nsource-map-resolve@0.5.3:\
-    \ See https://github.com/lydell/source-map-resolve#deprecated\nsource-map-url@0.4.0:\
-    \ See https://github.com/lydell/source-map-url#deprecated\nmkdirp@0.5.1: Legacy\
-    \ versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note\
-    \ that the API surface has changed to use Promises in 1.x.)"
+  message: "The package-lock.json file was created with an old version of npm, so\
+    \ supplemental metadata must be fetched from the registry. This is a one-time\
+    \ fix-up, please be patient..."
+  severity: "WARNING"
+- timestamp: "1970-01-01T00:00:00Z"
+  source: "NPM"
+  message: "deprecated gulp-header@1.8.12: Removed event-stream from gulp-header"
+  severity: "WARNING"
+- timestamp: "1970-01-01T00:00:00Z"
+  source: "NPM"
+  message: "deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated"
+  severity: "WARNING"
+- timestamp: "1970-01-01T00:00:00Z"
+  source: "NPM"
+  message: "deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated"
+  severity: "WARNING"
+- timestamp: "1970-01-01T00:00:00Z"
+  source: "NPM"
+  message: "deprecated source-map-resolve@0.5.3: See https://github.com/lydell/source-map-resolve#deprecated"
+  severity: "WARNING"
+- timestamp: "1970-01-01T00:00:00Z"
+  source: "NPM"
+  message: "deprecated source-map-url@0.4.0: See https://github.com/lydell/source-map-url#deprecated"
+  severity: "WARNING"
+- timestamp: "1970-01-01T00:00:00Z"
+  source: "NPM"
+  message: "deprecated mkdirp@0.5.1: Legacy versions of mkdirp are no longer supported.\
+    \ Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises\
+    \ in 1.x.)"
   severity: "WARNING"

--- a/analyzer/src/funTest/kotlin/managers/BabelFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/BabelFunTest.kt
@@ -61,12 +61,6 @@ class BabelFunTest : WordSpec({
 
 private fun createNPM() = Npm("NPM", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())
 
-private fun ProjectAnalyzerResult.withInvariantIssues() = copy(
-    issues = issues.map {
-        it.copy(
-            timestamp = Instant.EPOCH,
-            // Account for different NPM versions to return issues in different order.
-            message = it.message.lines().sorted().joinToString("\n")
-        )
-    }
-)
+private fun ProjectAnalyzerResult.withInvariantIssues() =
+    // Account for different NPM versions to return issues in different order.
+    copy(issues = issues.sortedBy { it.message }.map { it.copy(timestamp = Instant.EPOCH) })

--- a/analyzer/src/funTest/kotlin/managers/BabelFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/BabelFunTest.kt
@@ -40,12 +40,12 @@ class BabelFunTest : WordSpec({
     "Babel dependencies" should {
         "be correctly analyzed" {
             val definitionFile = projectDir.resolve("package.json")
-
             val expectedResult = patchExpectedResult(
                 projectDir.resolveSibling("npm-babel-expected-output.yml"),
                 url = normalizeVcsUrl(vcsUrl),
                 revision = vcsRevision
             )
+
             val actualResult = createNPM().resolveSingleProject(definitionFile, resolveScopes = true)
 
             patchActualResult(actualResult.toYaml()) shouldBe expectedResult

--- a/analyzer/src/funTest/kotlin/managers/NpmFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmFunTest.kt
@@ -112,11 +112,7 @@ class NpmFunTest : WordSpec() {
                     path = vcsPath
                 )
 
-                patchActualResult(
-                    result.toYaml(),
-                    // Deal with wrapping depending on the lockfile name length.
-                    custom = mapOf("so\\\n    \\ supplemental metadata" to "\\\n    so supplemental metadata")
-                ) shouldBe expectedResult
+                patchActualResult(result.toYaml()) shouldBe expectedResult
             }
 
             "show an error if no lockfile is present" {
@@ -170,11 +166,7 @@ class NpmFunTest : WordSpec() {
                     path = vcsPath
                 )
 
-                patchActualResult(
-                    result.toYaml(),
-                    // Deal with wrapping depending on the lockfile name length.
-                    custom = mapOf("so\\\n    \\ supplemental metadata" to "\\\n    so supplemental metadata")
-                ) shouldBe expectedResult
+                patchActualResult(result.toYaml()) shouldBe expectedResult
             }
         }
     }

--- a/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
@@ -45,9 +45,7 @@ class NpmVersionUrlFunTest : WordSpec({
     "NPM" should {
         "resolve dependencies with URLs as versions correctly" {
             val definitionFile = projectDir.resolve("package.json")
-
             val config = AnalyzerConfiguration(allowDynamicVersions = true)
-            val result = createNpm(config).resolveSingleProject(definitionFile, resolveScopes = true)
             val vcsPath = vcsDir.getPathToRoot(projectDir)
             val expectedResultYaml = patchExpectedResult(
                 projectDir.resolveSibling("npm-version-urls-expected-output.yml"),
@@ -58,7 +56,9 @@ class NpmVersionUrlFunTest : WordSpec({
             )
             val expectedResult = yamlMapper.readValue<ProjectAnalyzerResult>(expectedResultYaml)
 
-            result.withInvariantIssues() shouldBe expectedResult.withInvariantIssues()
+            val actualResult = createNpm(config).resolveSingleProject(definitionFile, resolveScopes = true)
+
+            actualResult.withInvariantIssues() shouldBe expectedResult.withInvariantIssues()
         }
     }
 })

--- a/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
@@ -63,18 +63,16 @@ class NpmVersionUrlFunTest : WordSpec() {
             }
         }
     }
-
-    private fun createNpm(config: AnalyzerConfiguration) =
-        Npm("NPM", USER_DIR, config, RepositoryConfiguration())
-
-    private fun ProjectAnalyzerResult.withInvariantIssues() =
-        copy(
-            issues = issues.map {
-                it.copy(
-                    timestamp = Instant.EPOCH,
-                    // Account for different NPM versions to return issues in different order.
-                    message = it.message.lines().sorted().joinToString("\n")
-                )
-            }
-        )
 }
+
+private fun createNpm(config: AnalyzerConfiguration) = Npm("NPM", USER_DIR, config, RepositoryConfiguration())
+
+private fun ProjectAnalyzerResult.withInvariantIssues() = copy(
+    issues = issues.map {
+        it.copy(
+            timestamp = Instant.EPOCH,
+            // Account for different NPM versions to return issues in different order.
+            message = it.message.lines().sorted().joinToString("\n")
+        )
+    }
+)

--- a/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
@@ -36,34 +36,32 @@ import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
-class NpmVersionUrlFunTest : WordSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/npm-version-urls").absoluteFile
-    private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
-    private val vcsUrl = vcsDir.getRemoteUrl()
-    private val vcsRevision = vcsDir.getRevision()
+class NpmVersionUrlFunTest : WordSpec({
+    val projectDir = getAssetFile("projects/synthetic/npm-version-urls").absoluteFile
+    val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
+    val vcsUrl = vcsDir.getRemoteUrl()
+    val vcsRevision = vcsDir.getRevision()
 
-    init {
-        "NPM" should {
-            "resolve dependencies with URLs as versions correctly" {
-                val definitionFile = projectDir.resolve("package.json")
+    "NPM" should {
+        "resolve dependencies with URLs as versions correctly" {
+            val definitionFile = projectDir.resolve("package.json")
 
-                val config = AnalyzerConfiguration(allowDynamicVersions = true)
-                val result = createNpm(config).resolveSingleProject(definitionFile, resolveScopes = true)
-                val vcsPath = vcsDir.getPathToRoot(projectDir)
-                val expectedResultYaml = patchExpectedResult(
-                    projectDir.resolveSibling("npm-version-urls-expected-output.yml"),
-                    definitionFilePath = "$vcsPath/package.json",
-                    url = normalizeVcsUrl(vcsUrl),
-                    revision = vcsRevision,
-                    path = vcsPath
-                )
-                val expectedResult = yamlMapper.readValue<ProjectAnalyzerResult>(expectedResultYaml)
+            val config = AnalyzerConfiguration(allowDynamicVersions = true)
+            val result = createNpm(config).resolveSingleProject(definitionFile, resolveScopes = true)
+            val vcsPath = vcsDir.getPathToRoot(projectDir)
+            val expectedResultYaml = patchExpectedResult(
+                projectDir.resolveSibling("npm-version-urls-expected-output.yml"),
+                definitionFilePath = "$vcsPath/package.json",
+                url = normalizeVcsUrl(vcsUrl),
+                revision = vcsRevision,
+                path = vcsPath
+            )
+            val expectedResult = yamlMapper.readValue<ProjectAnalyzerResult>(expectedResultYaml)
 
-                result.withInvariantIssues() shouldBe expectedResult.withInvariantIssues()
-            }
+            result.withInvariantIssues() shouldBe expectedResult.withInvariantIssues()
         }
     }
-}
+})
 
 private fun createNpm(config: AnalyzerConfiguration) = Npm("NPM", USER_DIR, config, RepositoryConfiguration())
 

--- a/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
@@ -65,12 +65,6 @@ class NpmVersionUrlFunTest : WordSpec({
 
 private fun createNpm(config: AnalyzerConfiguration) = Npm("NPM", USER_DIR, config, RepositoryConfiguration())
 
-private fun ProjectAnalyzerResult.withInvariantIssues() = copy(
-    issues = issues.map {
-        it.copy(
-            timestamp = Instant.EPOCH,
-            // Account for different NPM versions to return issues in different order.
-            message = it.message.lines().sorted().joinToString("\n")
-        )
-    }
-)
+private fun ProjectAnalyzerResult.withInvariantIssues() =
+    // Account for different NPM versions to return issues in different order.
+    copy(issues = issues.sortedBy { it.message }.map { it.copy(timestamp = Instant.EPOCH) })


### PR DESCRIPTION
This improves the logic added in 5311dcd by grouping on arbitrary secondary prefix instead of hard-coding them. This also creates a separate issue for each deprecated packages for a better overview.