### PR TITLE
fix(ArchiveUtils): Correct the entry name when packing a single file

### DIFF
--- a/utils/common/src/main/kotlin/ArchiveUtils.kt
+++ b/utils/common/src/main/kotlin/ArchiveUtils.kt
@@ -344,7 +344,7 @@ fun File.packZip(
         }.filter {
             Files.isRegularFile(it.toPath(), LinkOption.NOFOLLOW_LINKS) && fileFilter(it) && it != targetFile
         }.forEach { file ->
-            val packPath = prefix + file.toRelativeString(this)
+            val packPath = prefix + file.toRelativeString(takeUnless { it.isFile } ?: parentFile)
             val entry = ZipArchiveEntry(file, packPath)
             output.putArchiveEntry(entry)
             file.inputStream().use { input -> input.copyTo(output) }

--- a/utils/common/src/test/kotlin/ArchiveUtilsTest.kt
+++ b/utils/common/src/test/kotlin/ArchiveUtilsTest.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.utils.common
 
+import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.core.test.TestCase
@@ -418,6 +419,18 @@ class ArchiveUtilsTest : WordSpec() {
         }
 
         "packZip" should {
+            "be able to zip a single file" {
+                val file = createTestTempFile().apply { writeText("Hello World!") }
+
+                val zipFile = file.packZip(outputDir.resolve("archive.zip"))
+
+                zipFile shouldBe aFile()
+                shouldNotThrow<IOException> {
+                    zipFile.unpackZip(outputDir)
+                    outputDir.resolve(file.name).readText() shouldBe "Hello World!"
+                }
+            }
+
             "not follow symbolic links".config(enabled = Os.isLinux) {
                 val inputDir = createTestTempDir()
                 val parentDir = inputDir.resolve("parent").safeMkdirs()


### PR DESCRIPTION
Previously, the determined `ZipArchiveEntry` name was empty when packing a single file. Fix this by calculating the relative path correctly in that case.