### PR TITLE
fix(ImportCopyrightGarbageCommand): Stop using `Locale` constructors

### DIFF
--- a/helper-cli/src/main/kotlin/commands/ImportCopyrightGarbageCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ImportCopyrightGarbageCommand.kt
@@ -65,7 +65,8 @@ internal class ImportCopyrightGarbageCommand : CliktCommand(
             emptySet<String>()
         }
 
-        val collator = Collator.getInstance(Locale("en", "US.utf-8", "POSIX"))
+        val locale = Locale.Builder().setLanguage("en").setRegion("US.utf-8").setVariant("POSIX").build()
+        val collator = Collator.getInstance(locale)
         CopyrightGarbage((entriesToImport + existingCopyrightGarbage).toSortedSet(collator)).let {
             createYamlMapper().writeValue(outputCopyrightGarbageFile, it)
         }


### PR DESCRIPTION
`Locale` constructors are deprecated as of Java 19. Alternatives are the `Builder` class or the static `of` method [1], but the latter is only available as of Java 19. So use the former `Builder` approach for compatibility. Resolves #6631.

[1]: https://simplelocalize.io/blog/posts/java-internationalization/#locale-class-changes