### PR TITLE
refactor(analyzer): Consistently use constants for option key names

### DIFF
--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -61,6 +61,11 @@ import org.semver4j.RangesList
 import org.semver4j.RangesListFactory
 
 /**
+ * The name of the option to specify the name of the lockfile.
+ */
+private const val OPTION_LOCKFILE_NAME = "lockfileName"
+
+/**
  * The [Conan](https://conan.io/) package manager for C / C++.
  *
  * This package manager supports the following [options][PackageManagerConfiguration.options]:
@@ -148,7 +153,7 @@ class Conan(
             configureRemoteAuthentication(conanConfig)
 
             // TODO: Support lockfiles which are located in a different directory than the definition file.
-            val lockfileName = options["lockfileName"]
+            val lockfileName = options[OPTION_LOCKFILE_NAME]
             requireLockfile(workingDir) { lockfileName?.let { hasLockFile(workingDir.resolve(it).path) } ?: false }
 
             val jsonFile = createOrtTempDir().resolve("info.json")

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -61,6 +61,11 @@ import org.ossreviewtoolkit.utils.common.splitOnWhitespace
 import org.ossreviewtoolkit.utils.common.temporaryProperties
 import org.ossreviewtoolkit.utils.ort.createOrtTempFile
 
+/**
+ * The name of the option to specify the Gradle version.
+ */
+const val OPTION_GRADLE_VERSION = "gradleVersion"
+
 private val GRADLE_USER_HOME = Os.env["GRADLE_USER_HOME"]?.let { File(it) } ?: Os.userHomeDirectory.resolve(".gradle")
 
 private val GRADLE_BUILD_FILES = listOf("build.gradle", "build.gradle.kts")
@@ -173,7 +178,7 @@ class Gradle(
 
         val gradleConnector = GradleConnector.newConnector()
 
-        val gradleVersion = options["gradleVersion"]
+        val gradleVersion = options[OPTION_GRADLE_VERSION]
         if (gradleVersion != null) {
             gradleConnector.useGradleVersion(gradleVersion)
         }

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -408,7 +408,7 @@ class Pub(
         if (gradleFactory == null || !definitionFile.isFile) return emptyList()
 
         return analyzerResultCacheAndroid.getOrPut(packageName) {
-            val pubGradleVersion = options["gradleVersion"] ?: GRADLE_VERSION
+            val pubGradleVersion = options[OPTION_GRADLE_VERSION] ?: GRADLE_VERSION
 
             logger.info {
                 "Analyzing Android dependencies for package '$packageName' using Gradle version $pubGradleVersion."
@@ -416,7 +416,7 @@ class Pub(
 
             val gradleAnalyzerConfig = analyzerConfig.withPackageManagerOption(
                 "Gradle",
-                "gradleVersion",
+                OPTION_GRADLE_VERSION,
                 pubGradleVersion
             )
 


### PR DESCRIPTION
Note that `OPTION_GRADLE_VERSION` is public for use in `Pub`. Actually, all option constants should be public for programmatic use of the package managers classes. However, that requires a bit more refactoring to avoid clashes between any option constant names and will be done at a later time.