### PR TITLE
GoMod: Fix analyzing projects without deps

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-no-deps-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-no-deps-expected-output.yml
@@ -1,0 +1,23 @@
+---
+project:
+  id: "GoMod::gomod_no_deps:<REPLACE_REVISION>"
+  definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
+  declared_licenses: []
+  declared_licenses_processed: {}
+  vcs:
+    type: "Git"
+    url: "<REPLACE_URL>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  vcs_processed:
+    type: "Git"
+    url: "<REPLACE_URL>"
+    revision: "<REPLACE_REVISION>"
+    path: "<REPLACE_PATH>"
+  homepage_url: ""
+  scopes:
+  - name: "main"
+    dependencies: []
+  - name: "vendor"
+    dependencies: []
+packages: []

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-no-deps/go.mod
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-no-deps/go.mod
@@ -1,0 +1,3 @@
+module gomod_no_deps
+
+go 1.19

--- a/analyzer/src/funTest/kotlin/managers/GoModFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoModFunTest.kt
@@ -52,6 +52,15 @@ class GoModFunTest : StringSpec({
 
         result.toYaml() shouldBe patchExpectedResult(definitionFile, expectedResultFile)
     }
+
+    "Project dependencies are detected correctly if there are no dependencies" {
+        val definitionFile = testDir.resolve("gomod-no-deps/go.mod")
+        val expectedResultFile = testDir.resolve("gomod-no-deps-expected-output.yml")
+
+        val result = createGoMod().resolveSingleProject(definitionFile)
+
+        result.toYaml() shouldBe patchExpectedResult(definitionFile, expectedResultFile)
+    }
 })
 
 private fun createGoMod() = GoMod("GoMod", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -212,7 +212,7 @@ class GoMod(
 
     private fun ModuleInfo.toId(): Identifier =
         Identifier(
-            type = managerName.takeIf { version.isBlank() } ?: "Go",
+            type = managerName.takeIf { main } ?: "Go",
             namespace = "",
             name = path,
             version = normalizeModuleVersion(version)

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -170,7 +170,8 @@ class GoMod(
                 moduleInfo(moduleName).toId()
             }
 
-        var graph = Graph()
+        val mainModuleId = moduleInfoForModuleName.values.single { it.main }.toId()
+        var graph = Graph(mutableMapOf(mainModuleId to emptySet()))
 
         val edges = runGo("mod", "graph", workingDir = projectDir)
 


### PR DESCRIPTION
See individual commits.

This is part of #6615. For that issue to be fixed GoMod needs to work in case of:
- unused dependencies + used dependencies
- only unused dependencies
- no dependencies at all
