### PR TITLE
refactor(GoMod): Extract the `Graph` class and improve it a bit

### DIFF
--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -168,7 +168,7 @@ class GoMod(
             }
 
         val mainModuleId = moduleInfoForModuleName.values.single { it.main }.toId()
-        var graph = Graph(mutableMapOf(mainModuleId to emptySet()))
+        var graph = Graph().apply { addNode(mainModuleId) }
 
         val edges = runGo("mod", "graph", workingDir = projectDir)
 

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -197,9 +197,9 @@ class GoMod(
         }.toMap()
 
         val vendorModules = getVendorModules(graph, projectDir, replacedModules)
-        if (vendorModules.size < graph.size()) {
+        if (vendorModules.size < graph.size) {
             logger.debug {
-                "Removing ${graph.size() - vendorModules.size} non-vendor modules from the dependency graph."
+                "Removing ${graph.size - vendorModules.size} non-vendor modules from the dependency graph."
             }
 
             graph = graph.subgraph(vendorModules)

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -372,19 +372,6 @@ private class Graph(private val nodeMap: MutableMap<Identifier, Set<Identifier>>
             }
         )
 
-    /**
-     * Search for the single package that represents the main project. This is the only package without a version. Fail
-     * if no single package with this criterion can be found.
-     */
-    fun projectId(): Identifier =
-        nodes().filter { it.version.isBlank() }.let { idsWithoutVersion ->
-            require(idsWithoutVersion.size == 1) {
-                "Expected exactly one unique package without version but got ${idsWithoutVersion.joinToString()}."
-            }
-
-            idsWithoutVersion.first()
-        }
-
     private enum class NodeColor { WHITE, GRAY, BLACK }
 
     /**
@@ -514,6 +501,19 @@ private data class ModuleInfoFile(
         val subdir: String? = null
     )
 }
+
+/**
+ * Search for the single package that represents the main project. This is the only package without a version. Fail
+ * if no single package with this criterion can be found.
+ */
+private fun Graph.projectId(): Identifier =
+    nodes().filter { it.version.isBlank() }.let { idsWithoutVersion ->
+        require(idsWithoutVersion.size == 1) {
+            "Expected exactly one unique package without version but got ${idsWithoutVersion.joinToString()}."
+        }
+
+        idsWithoutVersion.first()
+    }
 
 private fun ModuleInfo.toVcsInfo(): VcsInfo? {
     val info = jsonMapper.readValue<ModuleInfoFile>(File(goMod).resolveSibling("$version.info"))

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -25,20 +25,17 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.readValues
 
 import java.io.File
-import java.util.LinkedList
-import java.util.SortedSet
 
 import org.apache.logging.log4j.kotlin.Logging
 
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
+import org.ossreviewtoolkit.analyzer.managers.utils.Graph
 import org.ossreviewtoolkit.analyzer.managers.utils.normalizeModuleVersion
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Package
-import org.ossreviewtoolkit.model.PackageLinkage
-import org.ossreviewtoolkit.model.PackageReference
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.RemoteArtifact
@@ -333,115 +330,6 @@ class GoMod(
 
     private fun runGo(vararg args: CharSequence, workingDir: File? = null) =
         run(args = args, workingDir = workingDir, environment = environment)
-}
-
-/**
- * A class to represent a graph with dependencies. This representation is basically an adjacency list implemented by a
- * map whose keys are package identifiers and whose values are the identifiers of packages these packages depend on.
- */
-private class Graph(private val nodeMap: MutableMap<Identifier, Set<Identifier>> = mutableMapOf()) {
-    companion object : Logging
-
-    /**
-     * Return a set with all nodes (i.e. package identifiers) contained in this graph.
-     */
-    fun nodes(): Set<Identifier> = nodeMap.keys
-
-    /**
-     * Return the size of this graph. This is the number of nodes it contains.
-     */
-    fun size() = nodeMap.size
-
-    /**
-     * Add an edge (i.e. a dependency relation) from [source] to [target] to this dependency graph. Add missing nodes if
-     * necessary.
-     */
-    fun addEdge(source: Identifier, target: Identifier) {
-        nodeMap.merge(source, setOf(target)) { set, _ -> set + target }
-        nodeMap.getOrPut(target) { emptySet() }
-    }
-
-    /**
-     * Return a subgraph of this [Graph] that contains only nodes from the given set of [subNodes]. This can be used to
-     * construct graphs for specific scopes.
-     */
-    fun subgraph(subNodes: Set<Identifier>): Graph =
-        Graph(
-            nodeMap.filter { it.key in subNodes }.mapValuesTo(mutableMapOf()) { e ->
-                e.value.filterTo(mutableSetOf()) { it in subNodes }
-            }
-        )
-
-    private enum class NodeColor { WHITE, GRAY, BLACK }
-
-    /**
-     * Return a copy of this Graph with edges removed so that no circle remains.
-     * TODO: The code has been copied from DependencyGraphBuilder as a temporary solutions. Once GoMod is migrated to
-     * use the dependency graph, this function can be dropped and the one from DependencyGraphBuilder can be re-used,
-     * see also https://github.com/oss-review-toolkit/ort/issues/4249.
-     */
-    fun breakCycles(): Graph {
-        val outgoingEdgesForNodes = nodeMap.mapValuesTo(mutableMapOf()) { it.value.toMutableSet() }
-        val color = outgoingEdgesForNodes.keys.associateWithTo(mutableMapOf()) { NodeColor.WHITE }
-
-        fun visit(u: Identifier) {
-            color[u] = NodeColor.GRAY
-
-            val nodesClosingCircle = mutableSetOf<Identifier>()
-
-            outgoingEdgesForNodes[u].orEmpty().forEach { v ->
-                if (color[v] == NodeColor.WHITE) {
-                    visit(v)
-                } else if (color[v] == NodeColor.GRAY) {
-                    nodesClosingCircle += v
-                }
-            }
-
-            outgoingEdgesForNodes[u]?.removeAll(nodesClosingCircle)
-            nodesClosingCircle.forEach { v ->
-                logger.debug { "Removing edge: ${u.toCoordinates()} -> ${v.toCoordinates()}}." }
-            }
-
-            color[u] = NodeColor.BLACK
-        }
-
-        val queue = LinkedList(outgoingEdgesForNodes.keys)
-
-        while (queue.isNotEmpty()) {
-            val v = queue.removeFirst()
-
-            if (color.getValue(v) != NodeColor.WHITE) continue
-
-            visit(v)
-        }
-
-        return Graph(outgoingEdgesForNodes.mapValuesTo(mutableMapOf()) { it.value.toSet() })
-    }
-
-    /**
-     * Convert this [Graph] to a set of [PackageReference]s that spawn the dependency trees of the direct dependencies
-     * of the given [root] package. The graph must not contain any cycles, so [breakCycles] should be called before.
-     */
-    fun toPackageReferenceForest(root: Identifier): SortedSet<PackageReference> {
-        fun getPackageReference(id: Identifier): PackageReference {
-            val dependencies = nodeMap.getValue(id).mapTo(sortedSetOf()) {
-                getPackageReference(it)
-            }
-
-            return PackageReference(
-                id = id,
-                linkage = PackageLinkage.PROJECT_STATIC,
-                dependencies = dependencies
-            )
-        }
-
-        return dependencies(root).mapTo(sortedSetOf()) { getPackageReference(it) }
-    }
-
-    /**
-     * Return the identifiers of the direct dependencies of the package denoted by [id].
-     */
-    private fun dependencies(id: Identifier): Set<Identifier> = nodeMap[id].orEmpty()
 }
 
 /** Separator string indicating that data of a new package follows in the output of the go mod why command. */

--- a/analyzer/src/main/kotlin/managers/GoMod.kt
+++ b/analyzer/src/main/kotlin/managers/GoMod.kt
@@ -114,12 +114,12 @@ class GoMod(
             val moduleInfoForModuleName = getModuleInfos(projectDir)
             val graph = getModuleGraph(projectDir, moduleInfoForModuleName)
             val projectId = graph.projectId()
-            val packageIds = graph.nodes() - projectId
+            val packageIds = graph.nodes - projectId
             val packages = packageIds.mapTo(mutableSetOf()) { moduleInfoForModuleName.getValue(it.name).toPackage() }
             val projectVcs = processProjectVcs(projectDir)
 
             val dependenciesScopePackageIds = getTransitiveMainModuleDependencies(projectDir).let { moduleNames ->
-                graph.nodes().filterTo(mutableSetOf()) { it.name in moduleNames }
+                graph.nodes.filterTo(mutableSetOf()) { it.name in moduleNames }
             }
 
             val scopes = sortedSetOf(
@@ -253,7 +253,7 @@ class GoMod(
     ): Set<Identifier> {
         val vendorModuleNames = mutableSetOf(graph.projectId().name)
 
-        graph.nodes().chunked(WHY_CHUNK_SIZE).forEach { ids ->
+        graph.nodes.chunked(WHY_CHUNK_SIZE).forEach { ids ->
             // Use the names of replaced modules, because `go mod why` returns only results for those.
             val moduleNames = ids.map { replacedModules[it.name] ?: it.name }.toTypedArray()
             // Use the ´-m´ switch to use module names because the graph also uses module names, not package names.
@@ -263,7 +263,7 @@ class GoMod(
             vendorModuleNames += parseWhyOutput(why.stdout)
         }
 
-        return graph.nodes().filterTo(mutableSetOf()) { (replacedModules[it.name] ?: it.name) in vendorModuleNames }
+        return graph.nodes.filterTo(mutableSetOf()) { (replacedModules[it.name] ?: it.name) in vendorModuleNames }
     }
 
     /**
@@ -395,7 +395,7 @@ private data class ModuleInfoFile(
  * if no single package with this criterion can be found.
  */
 private fun Graph.projectId(): Identifier =
-    nodes().filter { it.version.isBlank() }.let { idsWithoutVersion ->
+    nodes.filter { it.version.isBlank() }.let { idsWithoutVersion ->
         require(idsWithoutVersion.size == 1) {
             "Expected exactly one unique package without version but got ${idsWithoutVersion.joinToString()}."
         }

--- a/analyzer/src/main/kotlin/managers/utils/Graph.kt
+++ b/analyzer/src/main/kotlin/managers/utils/Graph.kt
@@ -45,7 +45,7 @@ internal class Graph private constructor(private val nodeMap: MutableMap<Identif
     /**
      * Return the size of this graph. This is the number of nodes it contains.
      */
-    fun size() = nodeMap.size
+    val size: Int get() = nodeMap.size
 
     /**
      * Add an edge (i.e. a dependency relation) from [source] to [target] to this dependency graph. Add missing nodes if

--- a/analyzer/src/main/kotlin/managers/utils/Graph.kt
+++ b/analyzer/src/main/kotlin/managers/utils/Graph.kt
@@ -51,7 +51,14 @@ internal class Graph(private val nodeMap: MutableMap<Identifier, Set<Identifier>
      */
     fun addEdge(source: Identifier, target: Identifier) {
         nodeMap.merge(source, setOf(target)) { set, _ -> set + target }
-        nodeMap.getOrPut(target) { emptySet() }
+        addNode(target)
+    }
+
+    /**
+     * Add a node to this dependency graph.
+     */
+    fun addNode(node: Identifier) {
+        nodeMap.getOrPut(node) { mutableSetOf() }
     }
 
     /**

--- a/analyzer/src/main/kotlin/managers/utils/Graph.kt
+++ b/analyzer/src/main/kotlin/managers/utils/Graph.kt
@@ -40,7 +40,7 @@ internal class Graph private constructor(private val nodeMap: MutableMap<Identif
     /**
      * Return a set with all nodes (i.e. package identifiers) contained in this graph.
      */
-    fun nodes(): Set<Identifier> = nodeMap.keys
+    val nodes: Set<Identifier> get() = nodeMap.keys
 
     /**
      * Return the size of this graph. This is the number of nodes it contains.

--- a/analyzer/src/main/kotlin/managers/utils/Graph.kt
+++ b/analyzer/src/main/kotlin/managers/utils/Graph.kt
@@ -65,8 +65,6 @@ internal class Graph(private val nodeMap: MutableMap<Identifier, Set<Identifier>
             }
         )
 
-    private enum class NodeColor { WHITE, GRAY, BLACK }
-
     /**
      * Return a copy of this Graph with edges removed so that no circle remains.
      * TODO: The code has been copied from DependencyGraphBuilder as a temporary solutions. Once GoMod is migrated to
@@ -136,3 +134,5 @@ internal class Graph(private val nodeMap: MutableMap<Identifier, Set<Identifier>
      */
     private fun dependencies(id: Identifier): Set<Identifier> = nodeMap[id].orEmpty()
 }
+
+private enum class NodeColor { WHITE, GRAY, BLACK }

--- a/analyzer/src/main/kotlin/managers/utils/Graph.kt
+++ b/analyzer/src/main/kotlin/managers/utils/Graph.kt
@@ -32,8 +32,10 @@ import org.ossreviewtoolkit.model.PackageReference
  * A class to represent a graph with dependencies. This representation is basically an adjacency list implemented by a
  * map whose keys are package identifiers and whose values are the identifiers of packages these packages depend on.
  */
-internal class Graph(private val nodeMap: MutableMap<Identifier, Set<Identifier>> = mutableMapOf()) {
+internal class Graph private constructor(private val nodeMap: MutableMap<Identifier, MutableSet<Identifier>>) {
     companion object : Logging
+
+    constructor() : this(mutableMapOf())
 
     /**
      * Return a set with all nodes (i.e. package identifiers) contained in this graph.
@@ -50,7 +52,7 @@ internal class Graph(private val nodeMap: MutableMap<Identifier, Set<Identifier>
      * necessary.
      */
     fun addEdge(source: Identifier, target: Identifier) {
-        nodeMap.merge(source, setOf(target)) { set, _ -> set + target }
+        nodeMap.getOrPut(source) { mutableSetOf() } += target
         addNode(target)
     }
 
@@ -113,7 +115,7 @@ internal class Graph(private val nodeMap: MutableMap<Identifier, Set<Identifier>
             visit(v)
         }
 
-        return Graph(outgoingEdgesForNodes.mapValuesTo(mutableMapOf()) { it.value.toSet() })
+        return Graph(outgoingEdgesForNodes.mapValuesTo(mutableMapOf()) { it.value.toMutableSet() })
     }
 
     /**

--- a/analyzer/src/main/kotlin/managers/utils/Graph.kt
+++ b/analyzer/src/main/kotlin/managers/utils/Graph.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.analyzer.managers.utils
+
+import java.util.LinkedList
+import java.util.SortedSet
+
+import org.apache.logging.log4j.kotlin.Logging
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.PackageLinkage
+import org.ossreviewtoolkit.model.PackageReference
+
+/**
+ * A class to represent a graph with dependencies. This representation is basically an adjacency list implemented by a
+ * map whose keys are package identifiers and whose values are the identifiers of packages these packages depend on.
+ */
+internal class Graph(private val nodeMap: MutableMap<Identifier, Set<Identifier>> = mutableMapOf()) {
+    companion object : Logging
+
+    /**
+     * Return a set with all nodes (i.e. package identifiers) contained in this graph.
+     */
+    fun nodes(): Set<Identifier> = nodeMap.keys
+
+    /**
+     * Return the size of this graph. This is the number of nodes it contains.
+     */
+    fun size() = nodeMap.size
+
+    /**
+     * Add an edge (i.e. a dependency relation) from [source] to [target] to this dependency graph. Add missing nodes if
+     * necessary.
+     */
+    fun addEdge(source: Identifier, target: Identifier) {
+        nodeMap.merge(source, setOf(target)) { set, _ -> set + target }
+        nodeMap.getOrPut(target) { emptySet() }
+    }
+
+    /**
+     * Return a subgraph of this [Graph] that contains only nodes from the given set of [subNodes]. This can be used to
+     * construct graphs for specific scopes.
+     */
+    fun subgraph(subNodes: Set<Identifier>): Graph =
+        Graph(
+            nodeMap.filter { it.key in subNodes }.mapValuesTo(mutableMapOf()) { e ->
+                e.value.filterTo(mutableSetOf()) { it in subNodes }
+            }
+        )
+
+    private enum class NodeColor { WHITE, GRAY, BLACK }
+
+    /**
+     * Return a copy of this Graph with edges removed so that no circle remains.
+     * TODO: The code has been copied from DependencyGraphBuilder as a temporary solutions. Once GoMod is migrated to
+     * use the dependency graph, this function can be dropped and the one from DependencyGraphBuilder can be re-used,
+     * see also https://github.com/oss-review-toolkit/ort/issues/4249.
+     */
+    fun breakCycles(): Graph {
+        val outgoingEdgesForNodes = nodeMap.mapValuesTo(mutableMapOf()) { it.value.toMutableSet() }
+        val color = outgoingEdgesForNodes.keys.associateWithTo(mutableMapOf()) { NodeColor.WHITE }
+
+        fun visit(u: Identifier) {
+            color[u] = NodeColor.GRAY
+
+            val nodesClosingCircle = mutableSetOf<Identifier>()
+
+            outgoingEdgesForNodes[u].orEmpty().forEach { v ->
+                if (color[v] == NodeColor.WHITE) {
+                    visit(v)
+                } else if (color[v] == NodeColor.GRAY) {
+                    nodesClosingCircle += v
+                }
+            }
+
+            outgoingEdgesForNodes[u]?.removeAll(nodesClosingCircle)
+            nodesClosingCircle.forEach { v ->
+                logger.debug { "Removing edge: ${u.toCoordinates()} -> ${v.toCoordinates()}}." }
+            }
+
+            color[u] = NodeColor.BLACK
+        }
+
+        val queue = LinkedList(outgoingEdgesForNodes.keys)
+
+        while (queue.isNotEmpty()) {
+            val v = queue.removeFirst()
+
+            if (color.getValue(v) != NodeColor.WHITE) continue
+
+            visit(v)
+        }
+
+        return Graph(outgoingEdgesForNodes.mapValuesTo(mutableMapOf()) { it.value.toSet() })
+    }
+
+    /**
+     * Convert this [Graph] to a set of [PackageReference]s that spawn the dependency trees of the direct dependencies
+     * of the given [root] package. The graph must not contain any cycles, so [breakCycles] should be called before.
+     */
+    fun toPackageReferenceForest(root: Identifier): SortedSet<PackageReference> {
+        fun getPackageReference(id: Identifier): PackageReference {
+            val dependencies = nodeMap.getValue(id).mapTo(sortedSetOf()) {
+                getPackageReference(it)
+            }
+
+            return PackageReference(
+                id = id,
+                linkage = PackageLinkage.PROJECT_STATIC,
+                dependencies = dependencies
+            )
+        }
+
+        return dependencies(root).mapTo(sortedSetOf()) { getPackageReference(it) }
+    }
+
+    /**
+     * Return the identifiers of the direct dependencies of the package denoted by [id].
+     */
+    private fun dependencies(id: Identifier): Set<Identifier> = nodeMap[id].orEmpty()
+}


### PR DESCRIPTION
The `GoMod` class was quite large and extracting the `Graph` class to a separate file removes a bit of distraction for the reader.

