### PR TITLE
build(Gradle): Change version logging to `lifecycle`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ if (version == Project.DEFAULT_VERSION) {
     }
 }
 
-logger.quiet("Building ORT version $version.")
+logger.lifecycle("Building ORT version $version.")
 
 // Note that Gradle's Java toolchain mechanism cannot be used here as that only applies to the Java version used in
 // compile tasks. But already ORT's build scripts, like the compilation of this file itself, depend on Java 11 due to


### PR DESCRIPTION
This way running

    ./gradlew -q :cli:run --args="--generate-completion=bash" > \
        integrations/completions/ort-completion.bash

does not write the "Building ORT version" string to the file.