### PR TITLE
refactor(analyzer): Make all constants for option key names public

### DIFF
--- a/analyzer/src/funTest/kotlin/managers/DotNetFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/DotNetFunTest.kt
@@ -27,7 +27,7 @@ import io.kotest.matchers.shouldBe
 import java.io.File
 
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetDependency
-import org.ossreviewtoolkit.analyzer.managers.utils.OPTION_DIRECT_DEPENDENCIES_ONLY
+import org.ossreviewtoolkit.analyzer.managers.utils.NuGetSupport.Companion.OPTION_DIRECT_DEPENDENCIES_ONLY
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.PackageManagerConfiguration

--- a/analyzer/src/funTest/kotlin/managers/NuGetFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NuGetFunTest.kt
@@ -25,7 +25,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetDependency
-import org.ossreviewtoolkit.analyzer.managers.utils.OPTION_DIRECT_DEPENDENCIES_ONLY
+import org.ossreviewtoolkit.analyzer.managers.utils.NuGetSupport.Companion.OPTION_DIRECT_DEPENDENCIES_ONLY
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.PackageManagerConfiguration

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -63,6 +63,11 @@ import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 /**
+ * The name of the option to specify the Bundler version.
+ */
+const val OPTION_BUNDLER_VERSION = "bundlerVersion"
+
+/**
  * The path to the helper script resource that resolves a `Gemfile`'s top-level dependencies with group information.
  */
 private const val ROOT_DEPENDENCIES_SCRIPT = "scripts/bundler_root_dependencies.rb"
@@ -76,11 +81,6 @@ private const val RESOLVE_DEPENDENCIES_SCRIPT = "scripts/bundler_resolve_depende
  * The name of the Bundler Gem.
  */
 private const val BUNDLER_GEM_NAME = "bundler"
-
-/**
- * The name of the option to specify the Bundler version.
- */
-private const val OPTION_BUNDLER_VERSION = "bundlerVersion"
 
 /**
  * The name of the file where Bundler stores locked down dependency information.

--- a/analyzer/src/main/kotlin/managers/Bundler.kt
+++ b/analyzer/src/main/kotlin/managers/Bundler.kt
@@ -63,11 +63,6 @@ import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.ort.showStackTrace
 
 /**
- * The name of the option to specify the Bundler version.
- */
-const val OPTION_BUNDLER_VERSION = "bundlerVersion"
-
-/**
  * The path to the helper script resource that resolves a `Gemfile`'s top-level dependencies with group information.
  */
 private const val ROOT_DEPENDENCIES_SCRIPT = "scripts/bundler_root_dependencies.rb"
@@ -140,7 +135,12 @@ class Bundler(
     analyzerConfig: AnalyzerConfiguration,
     repoConfig: RepositoryConfiguration
 ) : PackageManager(name, analysisRoot, analyzerConfig, repoConfig) {
-    companion object : Logging
+    companion object : Logging {
+        /**
+         * The name of the option to specify the Bundler version.
+         */
+        const val OPTION_BUNDLER_VERSION = "bundlerVersion"
+    }
 
     class Factory : AbstractPackageManagerFactory<Bundler>("Bundler") {
         override val globsForDefinitionFiles = listOf("Gemfile")

--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -61,11 +61,6 @@ import org.semver4j.RangesList
 import org.semver4j.RangesListFactory
 
 /**
- * The name of the option to specify the name of the lockfile.
- */
-const val OPTION_LOCKFILE_NAME = "lockfileName"
-
-/**
  * The [Conan](https://conan.io/) package manager for C / C++.
  *
  * This package manager supports the following [options][PackageManagerConfiguration.options]:
@@ -81,6 +76,11 @@ class Conan(
     repoConfig: RepositoryConfiguration
 ) : PackageManager(name, analysisRoot, analyzerConfig, repoConfig), CommandLineTool {
     companion object : Logging {
+        /**
+         * The name of the option to specify the name of the lockfile.
+         */
+        const val OPTION_LOCKFILE_NAME = "lockfileName"
+
         private val DUMMY_COMPILER_SETTINGS = arrayOf(
             "-s", "compiler=gcc",
             "-s", "compiler.libcxx=libstdc++",

--- a/analyzer/src/main/kotlin/managers/Conan.kt
+++ b/analyzer/src/main/kotlin/managers/Conan.kt
@@ -63,7 +63,7 @@ import org.semver4j.RangesListFactory
 /**
  * The name of the option to specify the name of the lockfile.
  */
-private const val OPTION_LOCKFILE_NAME = "lockfileName"
+const val OPTION_LOCKFILE_NAME = "lockfileName"
 
 /**
  * The [Conan](https://conan.io/) package manager for C / C++.

--- a/analyzer/src/main/kotlin/managers/DotNet.kt
+++ b/analyzer/src/main/kotlin/managers/DotNet.kt
@@ -31,7 +31,7 @@ import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetDependency
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetSupport
-import org.ossreviewtoolkit.analyzer.managers.utils.OPTION_DIRECT_DEPENDENCIES_ONLY
+import org.ossreviewtoolkit.analyzer.managers.utils.NuGetSupport.Companion.OPTION_DIRECT_DEPENDENCIES_ONLY
 import org.ossreviewtoolkit.analyzer.managers.utils.XmlPackageFileReader
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration

--- a/analyzer/src/main/kotlin/managers/Gradle.kt
+++ b/analyzer/src/main/kotlin/managers/Gradle.kt
@@ -61,11 +61,6 @@ import org.ossreviewtoolkit.utils.common.splitOnWhitespace
 import org.ossreviewtoolkit.utils.common.temporaryProperties
 import org.ossreviewtoolkit.utils.ort.createOrtTempFile
 
-/**
- * The name of the option to specify the Gradle version.
- */
-const val OPTION_GRADLE_VERSION = "gradleVersion"
-
 private val GRADLE_USER_HOME = Os.env["GRADLE_USER_HOME"]?.let { File(it) } ?: Os.userHomeDirectory.resolve(".gradle")
 
 private val GRADLE_BUILD_FILES = listOf("build.gradle", "build.gradle.kts")
@@ -87,7 +82,12 @@ class Gradle(
     analyzerConfig: AnalyzerConfiguration,
     repoConfig: RepositoryConfiguration
 ) : PackageManager(name, analysisRoot, analyzerConfig, repoConfig) {
-    companion object : Logging
+    companion object : Logging {
+        /**
+         * The name of the option to specify the Gradle version.
+         */
+        const val OPTION_GRADLE_VERSION = "gradleVersion"
+    }
 
     class Factory : AbstractPackageManagerFactory<Gradle>("Gradle") {
         // Gradle prefers Groovy ".gradle" files over Kotlin ".gradle.kts" files, but "build" files have to come before

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -83,9 +83,6 @@ import org.ossreviewtoolkit.utils.common.withoutPrefix
 import org.semver4j.RangesList
 import org.semver4j.RangesListFactory
 
-/** Name of the configuration option to toggle legacy peer dependency support. */
-const val OPTION_LEGACY_PEER_DEPS = "legacyPeerDeps"
-
 /** Name of the scope with the regular dependencies. */
 private const val DEPENDENCIES_SCOPE = "dependencies"
 
@@ -110,7 +107,10 @@ open class Npm(
     analyzerConfig: AnalyzerConfiguration,
     repoConfig: RepositoryConfiguration
 ) : PackageManager(name, analysisRoot, analyzerConfig, repoConfig), CommandLineTool {
-    companion object : Logging
+    companion object : Logging {
+        /** Name of the configuration option to toggle legacy peer dependency support. */
+        const val OPTION_LEGACY_PEER_DEPS = "legacyPeerDeps"
+    }
 
     class Factory : AbstractPackageManagerFactory<Npm>("NPM") {
         override val globsForDefinitionFiles = listOf("package.json")

--- a/analyzer/src/main/kotlin/managers/Npm.kt
+++ b/analyzer/src/main/kotlin/managers/Npm.kt
@@ -83,6 +83,18 @@ import org.ossreviewtoolkit.utils.common.withoutPrefix
 import org.semver4j.RangesList
 import org.semver4j.RangesListFactory
 
+/** Name of the configuration option to toggle legacy peer dependency support. */
+const val OPTION_LEGACY_PEER_DEPS = "legacyPeerDeps"
+
+/** Name of the scope with the regular dependencies. */
+private const val DEPENDENCIES_SCOPE = "dependencies"
+
+/** Name of the scope with optional dependencies. */
+private const val OPTIONAL_DEPENDENCIES_SCOPE = "optionalDependencies"
+
+/** Name of the scope with development dependencies. */
+private const val DEV_DEPENDENCIES_SCOPE = "devDependencies"
+
 /**
  * The [Node package manager](https://www.npmjs.com/) for JavaScript.
  *
@@ -669,15 +681,3 @@ open class Npm(
         return ProcessCapture(workingDir, command(workingDir), subcommand, *options.toTypedArray())
     }
 }
-
-/** Name of the configuration option to toggle legacy peer dependency support. */
-private const val OPTION_LEGACY_PEER_DEPS = "legacyPeerDeps"
-
-/** Name of the scope with the regular dependencies. */
-private const val DEPENDENCIES_SCOPE = "dependencies"
-
-/** Name of the scope with optional dependencies. */
-private const val OPTIONAL_DEPENDENCIES_SCOPE = "optionalDependencies"
-
-/** Name of the scope with development dependencies. */
-private const val DEV_DEPENDENCIES_SCOPE = "devDependencies"

--- a/analyzer/src/main/kotlin/managers/NuGet.kt
+++ b/analyzer/src/main/kotlin/managers/NuGet.kt
@@ -31,7 +31,7 @@ import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetDependency
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetSupport
-import org.ossreviewtoolkit.analyzer.managers.utils.OPTION_DIRECT_DEPENDENCIES_ONLY
+import org.ossreviewtoolkit.analyzer.managers.utils.NuGetSupport.Companion.OPTION_DIRECT_DEPENDENCIES_ONLY
 import org.ossreviewtoolkit.analyzer.managers.utils.XmlPackageFileReader
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -44,11 +44,9 @@ object Python : CommandLineTool {
     override fun transformVersion(output: String) = output.removePrefix("Python ")
 }
 
-const val OPTION_OPERATING_SYSTEM = "operatingSystem"
 private const val OPTION_OPERATING_SYSTEM_DEFAULT = "linux"
 private val OPERATING_SYSTEMS = listOf(OPTION_OPERATING_SYSTEM_DEFAULT, "macos", "windows")
 
-const val OPTION_PYTHON_VERSION = "pythonVersion"
 private const val OPTION_PYTHON_VERSION_DEFAULT = "3.10"
 private val PYTHON_VERSIONS = listOf("2.7", "3.6", "3.7", "3.8", "3.9", OPTION_PYTHON_VERSION_DEFAULT)
 
@@ -68,7 +66,10 @@ class Pip(
     analyzerConfig: AnalyzerConfiguration,
     repoConfig: RepositoryConfiguration
 ) : PackageManager(name, analysisRoot, analyzerConfig, repoConfig) {
-    companion object : Logging
+    companion object : Logging {
+        const val OPTION_OPERATING_SYSTEM = "operatingSystem"
+        const val OPTION_PYTHON_VERSION = "pythonVersion"
+    }
 
     class Factory : AbstractPackageManagerFactory<Pip>("PIP") {
         override val globsForDefinitionFiles = listOf("*requirements*.txt", "setup.py")

--- a/analyzer/src/main/kotlin/managers/Pip.kt
+++ b/analyzer/src/main/kotlin/managers/Pip.kt
@@ -44,11 +44,11 @@ object Python : CommandLineTool {
     override fun transformVersion(output: String) = output.removePrefix("Python ")
 }
 
-private const val OPTION_OPERATING_SYSTEM = "operatingSystem"
+const val OPTION_OPERATING_SYSTEM = "operatingSystem"
 private const val OPTION_OPERATING_SYSTEM_DEFAULT = "linux"
 private val OPERATING_SYSTEMS = listOf(OPTION_OPERATING_SYSTEM_DEFAULT, "macos", "windows")
 
-private const val OPTION_PYTHON_VERSION = "pythonVersion"
+const val OPTION_PYTHON_VERSION = "pythonVersion"
 private const val OPTION_PYTHON_VERSION_DEFAULT = "3.10"
 private val PYTHON_VERSIONS = listOf("2.7", "3.6", "3.7", "3.8", "3.9", OPTION_PYTHON_VERSION_DEFAULT)
 

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -72,7 +72,7 @@ import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.semver4j.RangesList
 import org.semver4j.RangesListFactory
 
-private const val OPTION_PUB_DEPENDENCIES_ONLY = "pubDependenciesOnly"
+const val OPTION_PUB_DEPENDENCIES_ONLY = "pubDependenciesOnly"
 
 private const val GRADLE_VERSION = "7.3"
 private const val PUBSPEC_YAML = "pubspec.yaml"

--- a/analyzer/src/main/kotlin/managers/Pub.kt
+++ b/analyzer/src/main/kotlin/managers/Pub.kt
@@ -32,6 +32,7 @@ import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.analyzer.PackageManagerDependencyResult
 import org.ossreviewtoolkit.analyzer.PackageManagerResult
+import org.ossreviewtoolkit.analyzer.managers.Gradle.Companion.OPTION_GRADLE_VERSION
 import org.ossreviewtoolkit.analyzer.managers.utils.PackageManagerDependencyHandler
 import org.ossreviewtoolkit.analyzer.managers.utils.PubCacheReader
 import org.ossreviewtoolkit.analyzer.parseAuthorString
@@ -72,8 +73,6 @@ import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.semver4j.RangesList
 import org.semver4j.RangesListFactory
 
-const val OPTION_PUB_DEPENDENCIES_ONLY = "pubDependenciesOnly"
-
 private const val GRADLE_VERSION = "7.3"
 private const val PUBSPEC_YAML = "pubspec.yaml"
 private const val PUB_LOCK_FILE = "pubspec.lock"
@@ -109,7 +108,9 @@ class Pub(
     analyzerConfig: AnalyzerConfiguration,
     repoConfig: RepositoryConfiguration
 ) : PackageManager(name, analysisRoot, analyzerConfig, repoConfig), CommandLineTool {
-    companion object : Logging
+    companion object : Logging {
+        const val OPTION_PUB_DEPENDENCIES_ONLY = "pubDependenciesOnly"
+    }
 
     class Factory : AbstractPackageManagerFactory<Pub>("Pub") {
         override val globsForDefinitionFiles = listOf(PUBSPEC_YAML)

--- a/analyzer/src/main/kotlin/managers/Yarn2.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn2.kt
@@ -73,8 +73,6 @@ import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.semver4j.RangesList
 import org.semver4j.RangesListFactory
 
-const val OPTION_DISABLE_REGISTRY_CERTIFICATE_VERIFICATION = "disableRegistryCertificateVerification"
-
 // The various Yarn dependency types supported by this package manager.
 private enum class YarnDependencyType(val type: String) {
     DEPENDENCIES("dependencies"),
@@ -96,6 +94,11 @@ class Yarn2(
     repoConfig: RepositoryConfiguration
 ) : PackageManager(name, analysisRoot, analyzerConfig, repoConfig), CommandLineTool {
     companion object : Logging {
+        /**
+         * The name of the option to disable HTTPS server certificate verification.
+         */
+        const val OPTION_DISABLE_REGISTRY_CERTIFICATE_VERIFICATION = "disableRegistryCertificateVerification"
+
         /**
          * The name of Yarn 2+ resource file.
          */

--- a/analyzer/src/main/kotlin/managers/Yarn2.kt
+++ b/analyzer/src/main/kotlin/managers/Yarn2.kt
@@ -73,7 +73,7 @@ import org.ossreviewtoolkit.utils.ort.showStackTrace
 import org.semver4j.RangesList
 import org.semver4j.RangesListFactory
 
-internal const val OPTION_DISABLE_REGISTRY_CERTIFICATE_VERIFICATION = "disableRegistryCertificateVerification"
+const val OPTION_DISABLE_REGISTRY_CERTIFICATE_VERIFICATION = "disableRegistryCertificateVerification"
 
 // The various Yarn dependency types supported by this package manager.
 private enum class YarnDependencyType(val type: String) {

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -59,7 +59,7 @@ import org.ossreviewtoolkit.utils.common.searchUpwardsForFile
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.ort.downloadText
 
-internal const val OPTION_DIRECT_DEPENDENCIES_ONLY = "directDependenciesOnly"
+const val OPTION_DIRECT_DEPENDENCIES_ONLY = "directDependenciesOnly"
 
 // See https://docs.microsoft.com/en-us/nuget/api/overview.
 private const val DEFAULT_SERVICE_INDEX_URL = "https://api.nuget.org/v3/index.json"

--- a/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
+++ b/analyzer/src/main/kotlin/managers/utils/NuGetSupport.kt
@@ -59,8 +59,6 @@ import org.ossreviewtoolkit.utils.common.searchUpwardsForFile
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 import org.ossreviewtoolkit.utils.ort.downloadText
 
-const val OPTION_DIRECT_DEPENDENCIES_ONLY = "directDependenciesOnly"
-
 // See https://docs.microsoft.com/en-us/nuget/api/overview.
 private const val DEFAULT_SERVICE_INDEX_URL = "https://api.nuget.org/v3/index.json"
 private const val REGISTRATIONS_BASE_URL_TYPE = "RegistrationsBaseUrl/3.6.0"
@@ -76,6 +74,8 @@ class NuGetSupport(
     private val reader: XmlPackageFileReader
 ) {
     companion object : Logging {
+        const val OPTION_DIRECT_DEPENDENCIES_ONLY = "directDependenciesOnly"
+
         val XML_MAPPER = XmlMapper(
             XmlFactory().apply {
                 // Work-around for https://github.com/FasterXML/jackson-module-kotlin/issues/138.


### PR DESCRIPTION
These are useful for programmatic use of the package managers.

Where it is offered, also slightly rearrange related code blocks of constants to they are at the top of the file, with public ones going first.