### PR TITLE
Scanner: Fail early on misconfigured criteria and version

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -79,6 +79,15 @@ class Scanner(
         require(scannerWrappers.isNotEmpty() && scannerWrappers.any { it.value.isNotEmpty() }) {
             "At least one ScannerWrapper must be provided."
         }
+
+        scannerWrappers.values.flatten().distinct().forEach { scannerWrapper ->
+            scannerWrapper.criteria?.let { criteria ->
+                require(criteria.matches(scannerWrapper.details)) {
+                    "The scanner details of scanner '${scannerWrapper.details.name}' must satisfy the configured " +
+                        "criteria for looking up scan storage entries."
+                }
+            }
+        }
     }
 
     private val archiver = scannerConfig.archive.createFileArchiver()

--- a/scanner/src/main/kotlin/ScannerCriteria.kt
+++ b/scanner/src/main/kotlin/ScannerCriteria.kt
@@ -82,16 +82,19 @@ data class ScannerCriteria(
 
         /**
          * The name of the property defining the regular expression for the scanner name as part of [ScannerCriteria].
+         * The [scanner details][ScannerDetails] of the corresponding scanner must match the criteria.
          */
         const val PROP_CRITERIA_NAME = "regScannerName"
 
         /**
-         * The name of the property defining the minimum version of the scanner as part of [ScannerCriteria].
+         * The name of the property defining the minimum version of the scanner as part of [ScannerCriteria]. The
+         * [scanner details][ScannerDetails] of the corresponding scanner must match the criteria.
          */
         const val PROP_CRITERIA_MIN_VERSION = "minVersion"
 
         /**
-         * The name of the property defining the maximum version of the scanner as part of [ScannerCriteria].
+         * The name of the property defining the maximum version of the scanner as part of [ScannerCriteria]. The
+         * [scanner details][ScannerDetails] of the corresponding scanner must match the criteria.
          */
         const val PROP_CRITERIA_MAX_VERSION = "maxVersion"
 


### PR DESCRIPTION
**To be merged after** #6665.

Fixes #6581.

BREAKING CHANGE:
- The scanner will now fail hard if this mis-configuration accurs instead of tolerating it with caching "disabled".