### PR TITLE
build(analyzer): Fix `funTest` to see the text fixtures

### DIFF
--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -47,6 +47,9 @@ dependencies {
         }
     }
 
+    // Only the Java plugin's built-in "test" source set automatically depends on the test fixtures.
+    funTestImplementation(testFixtures(project(":analyzer")))
+
     testImplementation(libs.mockk)
     testImplementation(libs.wiremock)
 

--- a/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-txt.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-txt.yml
@@ -28,7 +28,7 @@ project:
     dependencies:
     - id: "Conan::libcurl:7.85.0"
       dependencies:
-      - id: "Conan::openssl:1.1.1s"
+      - id: "Conan::openssl:1.1.1t"
       - id: "Conan::zlib:1.2.13"
     - id: "Conan::zlib:1.2.13"
 packages:
@@ -146,8 +146,8 @@ packages:
     revision: ""
     path: ""
   is_modified: true
-- id: "Conan::openssl:1.1.1s"
-  purl: "pkg:conan/openssl@1.1.1s"
+- id: "Conan::openssl:1.1.1t"
+  purl: "pkg:conan/openssl@1.1.1t"
   declared_licenses:
   - "OpenSSL"
   declared_licenses_processed:
@@ -161,9 +161,9 @@ packages:
       value: ""
       algorithm: ""
   source_artifact:
-    url: "https://www.openssl.org/source/openssl-1.1.1s.tar.gz"
+    url: "https://www.openssl.org/source/openssl-1.1.1t.tar.gz"
     hash:
-      value: "c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa"
+      value: "8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b"
       algorithm: "SHA-256"
   vcs:
     type: "Git"


### PR DESCRIPTION
This is necessary now due to `test` dependencies no more leaking into `funTest` as of 508701e.