### PR TITLE
build(Gradle): Simplify the version constant for Logback

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ kotlinxSerialization = "1.5.0"
 ktor = "2.2.4"
 log4jApi = "2.20.0"
 log4jApiKotlin = "1.2.0"
-logbackImpl = "1.4.5"
+logback = "1.4.5"
 maven = "3.9.0"
 # @pin this version as it needs to be aligned with "maven".
 mavenResolver = "1.9.4"
@@ -126,7 +126,7 @@ ktorClientOkHttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor"
 log4jApi = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4jApi" }
 log4jApiKotlin = { module = "org.apache.logging.log4j:log4j-api-kotlin", version.ref = "log4jApiKotlin" }
 log4jApiToSlf4j = { module = "org.apache.logging.log4j:log4j-to-slf4j", version.ref = "log4jApi" }
-logbackClassic = { module = "ch.qos.logback:logback-classic", version.ref = "logbackImpl" }
+logbackClassic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 mavenCompat = { module = "org.apache.maven:maven-compat", version.ref = "maven" }
 mavenCore = { module = "org.apache.maven:maven-core", version.ref = "maven" }
 mavenResolverConnectorBasic = { module = "org.apache.maven.resolver:maven-resolver-connector-basic", version.ref = "mavenResolver" }


### PR DESCRIPTION
Strip the "Impl" suffix as there is nothing else than the (logback-classic) implementation.