### PR TITLE
revert(SpdxExpression): Revert changes to the license choice

### DIFF
--- a/utils/spdx/src/main/kotlin/SpdxExpression.kt
+++ b/utils/spdx/src/main/kotlin/SpdxExpression.kt
@@ -310,29 +310,24 @@ class SpdxCompoundExpression(
         right.validate(strictness)
     }
 
-    override fun validChoicesForDnf(): Set<SpdxExpression> {
-        val validChoicesLeft = when (left) {
-            is SpdxCompoundExpression -> left.validChoicesForDnf()
-            else -> left.validChoices()
-        }
+    override fun validChoicesForDnf(): Set<SpdxExpression> =
+        when (operator) {
+            SpdxOperator.AND -> setOf(decompose().reduce(SpdxExpression::and))
 
-        val validChoicesRight = when (right) {
-            is SpdxCompoundExpression -> right.validChoicesForDnf()
-            else -> right.validChoices()
-        }
+            SpdxOperator.OR -> {
+                val validChoicesLeft = when (left) {
+                    is SpdxCompoundExpression -> left.validChoicesForDnf()
+                    else -> left.validChoices()
+                }
 
-        return when (operator) {
-            SpdxOperator.AND -> {
-                validChoicesLeft.map { leftChoice ->
-                    validChoicesRight.map { rightChoice ->
-                        if (leftChoice == rightChoice) leftChoice else leftChoice and rightChoice
-                    }
-                }.flatten().toSet()
+                val validChoicesRight = when (right) {
+                    is SpdxCompoundExpression -> right.validChoicesForDnf()
+                    else -> right.validChoices()
+                }
+
+                validChoicesLeft + validChoicesRight
             }
-
-            SpdxOperator.OR -> validChoicesLeft + validChoicesRight
         }
-    }
 
     override fun offersChoice(): Boolean =
         when (operator) {

--- a/utils/spdx/src/test/kotlin/SpdxExpressionTest.kt
+++ b/utils/spdx/src/test/kotlin/SpdxExpressionTest.kt
@@ -439,15 +439,6 @@ class SpdxExpressionTest : WordSpec() {
             "not contain duplicate valid choice different left and right expressions" {
                 "a AND a AND b".toSpdx().validChoices() should containExactly("a AND b".toSpdx())
             }
-
-            "return the correct choices for a mixed expression" {
-                val spdxExpression = "a AND (a OR b)".toSpdx()
-
-                spdxExpression.validChoices() should containExactlyInAnyOrder(
-                    "a".toSpdx(),
-                    "a AND b".toSpdx()
-                )
-            }
         }
 
         "offersChoice()" should {


### PR DESCRIPTION
This reverts commit 2ce43220f4e8dce5d6421b4527c7ab513dd8345d. In some circumstances, the new license choice implementation leads to infinite loop during Evaluator runs.

