### PR TITLE
docs: Fix the name for a package configurations file

### DIFF
--- a/docs/config-file-package-configuration-yml.md
+++ b/docs/config-file-package-configuration-yml.md
@@ -125,7 +125,7 @@ cli/build/install/ort/bin/ort report
   --package-configuration-file $ORT_CONFIG_DIR/packages.yml
 ```
 
-The code below shows an example for `packages.yml`:
+The code below shows an example for `package-configurations.yml`:
 
 ```yaml
 - id: "Pip::example-package:0.0.1"


### PR DESCRIPTION
Note that the corresponding command line option should also be renamed to plural form, so that it matches this filename.


