### PR TITLE
feat(renovate): Use the existing "dependencies" label

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,7 @@
     "**/src/funTest/assets/**",
     "**/src/test/assets/**"
   ],
+  "labels": ["dependencies"],
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
Configure the renovate-bot to use the existing "dependencies" label on PRs that update dependencies as another way to filter for these PRs.