### PR TITLE
fix(clients/osv): Support latest vulnerability schema version 1.4.0

### DIFF
--- a/clients/osv/src/main/kotlin/Model.kt
+++ b/clients/osv/src/main/kotlin/Model.kt
@@ -78,6 +78,7 @@ data class Affected(
     @SerialName("package")
     val pkg: Package,
     val ranges: List<Range> = emptyList(),
+    val severity: Set<Severity> = emptySet(),
     val versions: List<String> = emptyList(),
     @SerialName("ecosystem_specific")
     val ecosystemSpecific: JsonObject? = null,


### PR DESCRIPTION
The API recently started returning data using schema version 1.4.0, see [1]. So, incorporate the changes as per change log [2] to ensure that deserialization still works.

Fixes: #6708.

[1]: https://github.com/oss-review-toolkit/ort/pull/6681/commits/4301c660c339be92e1a747f30bb0e31d02e23139
[2]: https://ossf.github.io/osv-schema/#change-log


