### PR TITLE
feat(reporter): Improve handling of unmapped licenses in SPDX reporter

### DIFF
--- a/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
+++ b/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
@@ -96,7 +96,7 @@
     "filesAnalyzed" : false,
     "homepage" : "NONE",
     "licenseConcluded" : "NOASSERTION",
-    "licenseDeclared" : "MIT",
+    "licenseDeclared" : "MIT AND NOASSERTION",
     "name" : "fourth-package",
     "summary" : "A package with partially mapped declared license.",
     "versionInfo" : "0.0.1"

--- a/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
+++ b/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
@@ -108,7 +108,7 @@ packages:
   filesAnalyzed: false
   homepage: "NONE"
   licenseConcluded: "NOASSERTION"
-  licenseDeclared: "MIT"
+  licenseDeclared: "MIT AND NOASSERTION"
   name: "fourth-package"
   summary: "A package with partially mapped declared license."
   versionInfo: "0.0.1"


### PR DESCRIPTION
If a package has unmapped declared licenses, always append `NOASSERTION` to the declared license SPDX expression. Previously, `NOASSERTION` was only added if the SPDX expression was null or blank. This did hide the fact that there are unmapped licenses if the expression was not empty.