### PR TITLE
fix(plugins): Include dependencies in POM files of platform projects

### DIFF
--- a/plugins/package-curation-providers/build.gradle.kts
+++ b/plugins/package-curation-providers/build.gradle.kts
@@ -39,6 +39,8 @@ configure<PublishingExtension> {
         create<MavenPublication>(name) {
             groupId = "org.ossreviewtoolkit.plugins"
 
+            from(components["javaPlatform"])
+
             pom {
                 licenses {
                     license {

--- a/plugins/package-managers/build.gradle.kts
+++ b/plugins/package-managers/build.gradle.kts
@@ -41,6 +41,8 @@ configure<PublishingExtension> {
         create<MavenPublication>(name) {
             groupId = "org.ossreviewtoolkit.plugins"
 
+            from(components["javaPlatform"])
+
             pom {
                 licenses {
                     license {


### PR DESCRIPTION
Add the missing configuration to include the dependencies of the `package-curation-providers` and `package-managers` platform projects in the generated POM files.