### PR TITLE
build(Gradle): Decouple `maven-core` from `maven-compat`

### DIFF
--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -30,7 +30,10 @@ dependencies {
     implementation(project(":utils:ort-utils"))
     implementation(project(":utils:spdx-utils"))
 
-    implementation(libs.bundles.maven)
+    implementation(libs.mavenCore)
+
+    // TODO: Remove this once https://issues.apache.org/jira/browse/MNG-6561 is resolved.
+    implementation(libs.mavenCompat)
 
     // The classes from the maven-resolver dependencies are not used directly but initialized by the Plexus IoC
     // container automatically. They are required on the classpath for Maven dependency resolution to work.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -157,5 +157,4 @@ xz = { module = "org.tukaani:xz", version.ref = "xz" }
 exposed = ["exposedCore", "exposedDao", "exposedJdbc", "exposedJavaTime"]
 hoplite = ["hopliteCore", "hopliteYaml"]
 kotlinxSerialization = ["kotlinxSerializationCore", "kotlinxSerializationJson"]
-maven = ["mavenCore", "mavenCompat"]
 mavenResolver = ["mavenResolverConnectorBasic", "mavenResolverTransportFile", "mavenResolverTransportHttp", "mavenResolverTransportWagon"]

--- a/plugins/package-managers/gradle/build.gradle.kts
+++ b/plugins/package-managers/gradle/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     implementation(project(":plugins:package-managers:gradle-model"))
 
     implementation("org.gradle:gradle-tooling-api:${gradle.gradleVersion}")
-    implementation(libs.bundles.maven)
+    implementation(libs.mavenCore)
 
     funTestImplementation(testFixtures(project(":analyzer")))
 


### PR DESCRIPTION
Perspectively, the Maven-2-compatibility-layer should not be used with a
Maven 3 core, see [1], so prepare for that split for more fine-grained
dependencies.
    
[1]: https://issues.apache.org/jira/browse/MNG-6561