### PR TITLE
Refactor default resolution provider

### DIFF
--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -217,7 +217,7 @@ class ReporterCommand : OrtCommand(
 
         val resolutionProvider =
             ortResult.resolvedConfiguration.resolutions.takeUnless { refreshResolutions }?.let { resolutions ->
-                DefaultResolutionProvider().add(resolutions)
+                DefaultResolutionProvider(resolutions)
             } ?: DefaultResolutionProvider.create(ortResult, resolutionsFile)
 
         val licenseTextDirectories = listOfNotNull(customLicenseTextsDir.takeIf { it.isDirectory })

--- a/model/src/main/kotlin/utils/DefaultResolutionProvider.kt
+++ b/model/src/main/kotlin/utils/DefaultResolutionProvider.kt
@@ -29,7 +29,7 @@ import org.ossreviewtoolkit.model.config.Resolutions
 import org.ossreviewtoolkit.model.readValue
 
 /**
- * A provider of previously added resolutions for [Issue]s and [RuleViolation]s.
+ * A [ResolutionProvider] that provides previously added resolutions.
  */
 class DefaultResolutionProvider : ResolutionProvider {
     companion object {

--- a/model/src/main/kotlin/utils/DefaultResolutionProvider.kt
+++ b/model/src/main/kotlin/utils/DefaultResolutionProvider.kt
@@ -29,24 +29,20 @@ import org.ossreviewtoolkit.model.config.Resolutions
 import org.ossreviewtoolkit.model.readValue
 
 /**
- * A [ResolutionProvider] that provides previously added resolutions.
+ * A [ResolutionProvider] that provides the given [resolutions].
  */
-class DefaultResolutionProvider(private var resolutions: Resolutions = Resolutions()) : ResolutionProvider {
+class DefaultResolutionProvider(private val resolutions: Resolutions = Resolutions()) : ResolutionProvider {
     companion object {
         /**
          * Create a [DefaultResolutionProvider] and add the resolutions from the [ortResult] and the [resolutionsFile].
          */
-        fun create(ortResult: OrtResult? = null, resolutionsFile: File? = null): DefaultResolutionProvider =
-            DefaultResolutionProvider().apply {
-                ortResult?.let { add(it.getResolutions()) }
-                resolutionsFile?.takeIf { it.isFile }?.readValue<Resolutions>()?.let { add(it) }
-            }
-    }
+        fun create(ortResult: OrtResult? = null, resolutionsFile: File? = null): DefaultResolutionProvider {
+            val resolutionsFromOrtResult = ortResult?.getResolutions() ?: Resolutions()
+            val resolutionsFromFile = resolutionsFile?.takeIf { it.isFile }?.readValue() ?: Resolutions()
 
-    /**
-     * Add [other] resolutions that get merged with the existing resolutions.
-     */
-    fun add(other: Resolutions) = apply { resolutions = resolutions.merge(other) }
+            return DefaultResolutionProvider(resolutionsFromOrtResult.merge(resolutionsFromFile))
+        }
+    }
 
     override fun getIssueResolutionsFor(issue: Issue) = resolutions.issues.filter { it.matches(issue) }
 

--- a/model/src/main/kotlin/utils/DefaultResolutionProvider.kt
+++ b/model/src/main/kotlin/utils/DefaultResolutionProvider.kt
@@ -31,7 +31,7 @@ import org.ossreviewtoolkit.model.readValue
 /**
  * A [ResolutionProvider] that provides previously added resolutions.
  */
-class DefaultResolutionProvider : ResolutionProvider {
+class DefaultResolutionProvider(private var resolutions: Resolutions = Resolutions()) : ResolutionProvider {
     companion object {
         /**
          * Create a [DefaultResolutionProvider] and add the resolutions from the [ortResult] and the [resolutionsFile].
@@ -42,8 +42,6 @@ class DefaultResolutionProvider : ResolutionProvider {
                 resolutionsFile?.takeIf { it.isFile }?.readValue<Resolutions>()?.let { add(it) }
             }
     }
-
-    private var resolutions = Resolutions()
 
     /**
      * Add [other] resolutions that get merged with the existing resolutions.

--- a/reporter/src/funTest/kotlin/reporters/opossum/OpossumReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/opossum/OpossumReporterFunTest.kt
@@ -61,7 +61,7 @@ class OpossumReporterFunTest : WordSpec({
 private fun TestConfiguration.generateReport(ortResult: OrtResult): String {
     val input = ReporterInput(
         ortResult = ortResult,
-        resolutionProvider = DefaultResolutionProvider().add(ortResult.getResolutions()),
+        resolutionProvider = DefaultResolutionProvider(ortResult.getResolutions()),
         howToFixTextProvider = { "Some how to fix text." }
     )
 


### PR DESCRIPTION
Please see the commit messages for details.

**Breaking API change:**
The `add()` function of the `DefaultResolutionProvider` was removed.