### PR TITLE
docs(README): Note to disable Gradle's "configuration on demand"

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ external tools to be installed.
 # Development
 
 ORT is written in [Kotlin](https://kotlinlang.org/) and uses [Gradle](https://gradle.org/) as the build system, with
-[Kotlin script](https://docs.gradle.org/current/userguide/kotlin_dsl.html) instead of Groovy as the DSL.
+[Kotlin script](https://docs.gradle.org/current/userguide/kotlin_dsl.html) instead of Groovy as the DSL. Please ensure to have Gradle's incubating [configuration on demand](https://docs.gradle.org/current/userguide/multi_project_configuration_and_execution.html#sec:configuration_on_demand) feature disabled as it is currently [incompatible with ORT](https://github.com/gradle/gradle/issues/4823).
 
 When developing on the command line, use the committed
 [Gradle wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html) to bootstrap Gradle in the configured


### PR DESCRIPTION
Unfortunately, it does not work to enforce this by adding

    org.gradle.configureondemand = false

to the project's `gradle.properties` as any global property would take precedence, see [1].

[1]: https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties