### PR TITLE
fix(model): Handle vulnerability resolutions in `DefaultResolutionProvider`

### DIFF
--- a/model/src/main/kotlin/utils/DefaultResolutionProvider.kt
+++ b/model/src/main/kotlin/utils/DefaultResolutionProvider.kt
@@ -61,6 +61,10 @@ class DefaultResolutionProvider(private val resolutions: Resolutions = Resolutio
             resolutions.ruleViolations.filter { resolution -> violations.any { resolution.matches(it) } }
         }.orEmpty()
 
-        return Resolutions(issueResolutions, ruleViolationResolutions)
+        val vulnerabilityResolutions = ortResult.getVulnerabilities().values.flatten().let { vulnerabilities ->
+            resolutions.vulnerabilities.filter { resolution -> vulnerabilities.any { resolution.matches(it) } }
+        }
+
+        return Resolutions(issueResolutions, ruleViolationResolutions, vulnerabilityResolutions)
     }
 }


### PR DESCRIPTION
Add the missing handling of vulnerability resolutions to `DefaultResolutionProvider.getResolutions()`.