### PR TITLE
Start adressing redundancy in the callers of `patchExpectedResult()`

### DIFF
--- a/analyzer/src/funTest/kotlin/managers/BabelFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/BabelFunTest.kt
@@ -37,7 +37,7 @@ import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class BabelFunTest : WordSpec({
-    val projectDir = getAssetFile("projects/synthetic/npm-babel").absoluteFile
+    val projectDir = getAssetFile("projects/synthetic/npm-babel")
     val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     val vcsUrl = vcsDir.getRemoteUrl()
     val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/ConanFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/ConanFunTest.kt
@@ -35,12 +35,12 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class ConanFunTest : StringSpec() {
-    private val projectsDirTxt = getAssetFile("projects/synthetic/conan-txt").absoluteFile
+    private val projectsDirTxt = getAssetFile("projects/synthetic/conan-txt")
     private val vcsDirTxt = VersionControlSystem.forDirectory(projectsDirTxt)!!
     private val vcsRevisionTxt = vcsDirTxt.getRevision()
     private val vcsUrlTxt = vcsDirTxt.getRemoteUrl()
 
-    private val projectsDirPy = getAssetFile("projects/synthetic/conan-py").absoluteFile
+    private val projectsDirPy = getAssetFile("projects/synthetic/conan-py")
     private val vcsDirPy = VersionControlSystem.forDirectory(projectsDirPy)!!
     private val vcsRevisionPy = vcsDirPy.getRevision()
     private val vcsUrlPy = vcsDirPy.getRemoteUrl()

--- a/analyzer/src/funTest/kotlin/managers/DotNetFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/DotNetFunTest.kt
@@ -40,7 +40,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class DotNetFunTest : StringSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/dotnet").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/dotnet")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/GoDepFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoDepFunTest.kt
@@ -42,7 +42,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class GoDepFunTest : WordSpec() {
-    private val projectsDir = getAssetFile("projects").absoluteFile
+    private val projectsDir = getAssetFile("projects")
     private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/GoModFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoModFunTest.kt
@@ -34,7 +34,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class GoModFunTest : StringSpec({
-    val testDir = getAssetFile("projects/synthetic").absoluteFile
+    val testDir = getAssetFile("projects/synthetic")
 
     "Project dependencies are detected correctly" {
         val definitionFile = testDir.resolve("gomod/go.mod")

--- a/analyzer/src/funTest/kotlin/managers/MavenFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/MavenFunTest.kt
@@ -41,7 +41,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class MavenFunTest : StringSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/maven").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/maven")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()
@@ -117,7 +117,7 @@ class MavenFunTest : StringSpec() {
                 .resolve(".m2/repository/org/springframework/boot/spring-boot-starter-parent/1.5.3.RELEASE")
                 .safeDeleteRecursively(force = true)
 
-            val projectDir = getAssetFile("projects/synthetic/maven-parent").absoluteFile
+            val projectDir = getAssetFile("projects/synthetic/maven-parent")
             val pomFile = projectDir.resolve("pom.xml")
             val expectedResult = patchExpectedResult(
                 projectDir.resolveSibling("maven-parent-expected-output-root.yml"),
@@ -131,7 +131,7 @@ class MavenFunTest : StringSpec() {
         }
 
         "Maven Wagon extensions can be loaded" {
-            val projectDir = getAssetFile("projects/synthetic/maven-wagon").absoluteFile
+            val projectDir = getAssetFile("projects/synthetic/maven-wagon")
             val pomFile = projectDir.resolve("pom.xml")
             val expectedResult = patchExpectedResult(
                 projectDir.resolveSibling("maven-wagon-expected-output.yml"),

--- a/analyzer/src/funTest/kotlin/managers/NpmFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmFunTest.kt
@@ -40,7 +40,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class NpmFunTest : WordSpec() {
-    private val projectsDir = getAssetFile("projects/synthetic/npm").absoluteFile
+    private val projectsDir = getAssetFile("projects/synthetic/npm")
     private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
@@ -37,7 +37,7 @@ import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class NpmVersionUrlFunTest : WordSpec({
-    val projectDir = getAssetFile("projects/synthetic/npm-version-urls").absoluteFile
+    val projectDir = getAssetFile("projects/synthetic/npm-version-urls")
     val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     val vcsUrl = vcsDir.getRemoteUrl()
     val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/NuGetFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NuGetFunTest.kt
@@ -38,7 +38,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class NuGetFunTest : StringSpec({
-    val projectDir = getAssetFile("projects/synthetic/nuget").absoluteFile
+    val projectDir = getAssetFile("projects/synthetic/nuget")
     val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     val vcsUrl = vcsDir.getRemoteUrl()
     val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/PnpmFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PnpmFunTest.kt
@@ -38,7 +38,7 @@ import org.ossreviewtoolkit.utils.test.toYaml
 class PnpmFunTest : WordSpec({
     "Pnpm" should {
         "resolve dependencies correctly in a simple project" {
-            val projectDir = getAssetFile("projects/synthetic/pnpm").absoluteFile
+            val projectDir = getAssetFile("projects/synthetic/pnpm")
 
             val result = resolveDependencies(projectDir)
             val expectedResult = getExpectedResult(projectDir, "pnpm-expected-output.yml")
@@ -47,7 +47,7 @@ class PnpmFunTest : WordSpec({
         }
 
         "resolve dependencies correctly in a workspaces project" {
-            val rootProjectDir = getAssetFile("projects/synthetic/pnpm-workspaces").absoluteFile
+            val rootProjectDir = getAssetFile("projects/synthetic/pnpm-workspaces")
 
             val ortResult = Analyzer(AnalyzerConfiguration()).run {
                 analyze(findManagedFiles(rootProjectDir, setOf(Pnpm.Factory())))

--- a/analyzer/src/funTest/kotlin/managers/SbtFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/SbtFunTest.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 
 class SbtFunTest : StringSpec({
     "Dependencies of the external 'sbt-multi-project-example' multi-project should be detected correctly" {
-        val projectDir = getAssetFile("projects/external/sbt-multi-project-example").absoluteFile
+        val projectDir = getAssetFile("projects/external/sbt-multi-project-example")
         val expectedResult = patchExpectedResult(
             projectDir.resolveSibling("sbt-multi-project-example-expected-output.yml")
         )
@@ -49,7 +49,7 @@ class SbtFunTest : StringSpec({
     }
 
     "Dependencies of the synthetic 'http4s-template' project should be detected correctly" {
-        val projectDir = getAssetFile("projects/synthetic/sbt-http4s-template").absoluteFile
+        val projectDir = getAssetFile("projects/synthetic/sbt-http4s-template")
         val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
         val vcsUrl = vcsDir.getRemoteUrl()
         val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/SpdxDocumentFileFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/SpdxDocumentFileFunTest.kt
@@ -262,7 +262,7 @@ class SpdxDocumentFileFunTest : WordSpec({
     }
 })
 
-private val projectDir = getAssetFile("projects/synthetic/spdx").absoluteFile
+private val projectDir = getAssetFile("projects/synthetic/spdx")
 private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
 private val vcsUrl = vcsDir.getRemoteUrl()
 private val vcsRevision = vcsDir.getRevision()

--- a/analyzer/src/funTest/kotlin/managers/StackFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/StackFunTest.kt
@@ -46,7 +46,7 @@ class StackFunTest : StringSpec({
     }
 })
 
-private val projectsDir = getAssetFile("projects").absoluteFile
+private val projectsDir = getAssetFile("projects")
 
 private fun createStack() =
     Stack("Stack", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())

--- a/analyzer/src/funTest/kotlin/managers/Yarn2FunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/Yarn2FunTest.kt
@@ -39,7 +39,7 @@ import org.ossreviewtoolkit.utils.test.toYaml
 class Yarn2FunTest : WordSpec({
     "Yarn 2" should {
         "resolve dependencies correctly" {
-            val projectDir = getAssetFile("projects/synthetic/yarn2").absoluteFile
+            val projectDir = getAssetFile("projects/synthetic/yarn2")
 
             val result = resolveDependencies(projectDir)
 
@@ -48,7 +48,7 @@ class Yarn2FunTest : WordSpec({
         }
 
         "exclude scopes if configured" {
-            val projectDir = getAssetFile("projects/synthetic/yarn2").absoluteFile
+            val projectDir = getAssetFile("projects/synthetic/yarn2")
 
             val analyzerConfig = AnalyzerConfiguration(skipExcluded = true)
             val scopeExclude = ScopeExclude("devDependencies", ScopeExcludeReason.TEST_DEPENDENCY_OF)
@@ -62,7 +62,7 @@ class Yarn2FunTest : WordSpec({
         }
 
         "resolve workspace dependencies correctly" {
-            val projectDir = getAssetFile("projects/synthetic/yarn2-workspaces").absoluteFile
+            val projectDir = getAssetFile("projects/synthetic/yarn2-workspaces")
 
             val result = resolveMultipleDependencies(projectDir)
 

--- a/analyzer/src/funTest/kotlin/managers/YarnFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/YarnFunTest.kt
@@ -60,7 +60,7 @@ class YarnFunTest : WordSpec() {
     init {
         "yarn" should {
             "resolve dependencies correctly" {
-                val projectDir = getAssetFile("projects/synthetic/yarn").absoluteFile
+                val projectDir = getAssetFile("projects/synthetic/yarn")
 
                 val result = resolveDependencies(projectDir)
 
@@ -71,7 +71,7 @@ class YarnFunTest : WordSpec() {
             "resolve workspace dependencies correctly" {
                 // This test case illustrates the lack of Yarn workspaces support, in particular not all workspace
                 // dependencies get assigned to a scope.
-                val projectDir = getAssetFile("projects/synthetic/yarn-workspaces").absoluteFile
+                val projectDir = getAssetFile("projects/synthetic/yarn-workspaces")
 
                 val result = resolveDependencies(projectDir)
 

--- a/plugins/package-managers/bower/src/funTest/kotlin/BowerFunTest.kt
+++ b/plugins/package-managers/bower/src/funTest/kotlin/BowerFunTest.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class BowerFunTest : StringSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/bower").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/bower")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/plugins/package-managers/bower/src/funTest/kotlin/BowerFunTest.kt
+++ b/plugins/package-managers/bower/src/funTest/kotlin/BowerFunTest.kt
@@ -30,18 +30,15 @@ import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
-class BowerFunTest : StringSpec() {
-     init {
-        "Project dependencies are detected correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/bower/bower.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/bower-expected-output.yml")
+class BowerFunTest : StringSpec({
+    "Project dependencies are detected correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/bower/bower.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/bower-expected-output.yml")
 
-            val result = createBower().resolveSingleProject(definitionFile)
+        val result = createBower().resolveSingleProject(definitionFile)
 
-            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-        }
+        result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
     }
+})
 
-    private fun createBower() =
-        Bower("Bower", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())
-}
+private fun createBower() = Bower("Bower", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())

--- a/plugins/package-managers/bower/src/funTest/kotlin/BowerFunTest.kt
+++ b/plugins/package-managers/bower/src/funTest/kotlin/BowerFunTest.kt
@@ -23,36 +23,22 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.analyzer.managers.resolveSingleProject
-import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
-import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.getAssetFile
-import org.ossreviewtoolkit.utils.test.patchExpectedResult
+import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class BowerFunTest : StringSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/bower")
-    private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
-    private val vcsUrl = vcsDir.getRemoteUrl()
-    private val vcsRevision = vcsDir.getRevision()
-
-    init {
+     init {
         "Project dependencies are detected correctly" {
-            val definitionFile = projectDir.resolve("bower.json")
-            val vcsPath = vcsDir.getPathToRoot(projectDir)
-            val expectedResult = patchExpectedResult(
-                projectDir.resolveSibling("bower-expected-output.yml"),
-                definitionFilePath = "$vcsPath/bower.json",
-                path = vcsPath,
-                revision = vcsRevision,
-                url = normalizeVcsUrl(vcsUrl)
-            )
+            val definitionFile = getAssetFile("projects/synthetic/bower/bower.json")
+            val expectedResultFile = getAssetFile("projects/synthetic/bower-expected-output.yml")
 
             val result = createBower().resolveSingleProject(definitionFile)
 
-            result.toYaml() shouldBe expectedResult
+            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
     }
 

--- a/plugins/package-managers/bundler/src/funTest/kotlin/BundlerFunTest.kt
+++ b/plugins/package-managers/bundler/src/funTest/kotlin/BundlerFunTest.kt
@@ -25,8 +25,6 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.haveSubstring
 
-import java.io.File
-
 import org.ossreviewtoolkit.analyzer.managers.resolveSingleProject
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
@@ -48,7 +46,7 @@ class BundlerFunTest : WordSpec({
 
                 actualResult.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
             } finally {
-                File(definitionFile.parentFile, ".bundle").safeDeleteRecursively(force = true)
+                definitionFile.resolveSibling(".bundle").safeDeleteRecursively(force = true)
             }
         }
 
@@ -76,7 +74,7 @@ class BundlerFunTest : WordSpec({
 
                 actualResult.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
             } finally {
-                File(definitionFile.parentFile, ".bundle").safeDeleteRecursively(force = true)
+                definitionFile.resolveSibling(".bundle").safeDeleteRecursively(force = true)
             }
         }
     }

--- a/plugins/package-managers/bundler/src/funTest/kotlin/BundlerFunTest.kt
+++ b/plugins/package-managers/bundler/src/funTest/kotlin/BundlerFunTest.kt
@@ -37,52 +37,50 @@ import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
-class BundlerFunTest : WordSpec() {
-    init {
-        "Bundler" should {
-            "resolve dependencies correctly" {
-                val definitionFile = getAssetFile("projects/synthetic/lockfile/Gemfile")
-                val expectedResultFile = getAssetFile("projects/synthetic/bundler-expected-output-lockfile.yml")
+class BundlerFunTest : WordSpec({
+    "Bundler" should {
+        "resolve dependencies correctly" {
+            val definitionFile = getAssetFile("projects/synthetic/lockfile/Gemfile")
+            val expectedResultFile = getAssetFile("projects/synthetic/bundler-expected-output-lockfile.yml")
 
-                try {
-                    val actualResult = createBundler().resolveSingleProject(definitionFile)
-
-                    actualResult.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-                } finally {
-                    File(definitionFile.parentFile, ".bundle").safeDeleteRecursively(force = true)
-                }
-            }
-
-            "show error if no lockfile is present" {
-                val definitionFile = getAssetFile("projects/synthetic/no-lockfile/Gemfile")
+            try {
                 val actualResult = createBundler().resolveSingleProject(definitionFile)
 
-                with(actualResult) {
-                    project.id shouldBe
-                            Identifier("Bundler::src/funTest/assets/projects/synthetic/no-lockfile/Gemfile:")
-                    project.definitionFilePath shouldBe
-                            "plugins/package-managers/bundler/src/funTest/assets/projects/synthetic/no-lockfile/Gemfile"
-                    packages should beEmpty()
-                    issues.size shouldBe 1
-                    issues.first().message should haveSubstring("IllegalArgumentException: No lockfile found in")
-                }
+                actualResult.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
+            } finally {
+                File(definitionFile.parentFile, ".bundle").safeDeleteRecursively(force = true)
             }
+        }
 
-            "resolve dependencies correctly when the project is a Gem" {
-                val definitionFile = getAssetFile("projects/synthetic/gemspec/Gemfile")
-                val expectedResultFile = getAssetFile("projects/synthetic/bundler-expected-output-gemspec.yml")
+        "show error if no lockfile is present" {
+            val definitionFile = getAssetFile("projects/synthetic/no-lockfile/Gemfile")
+            val actualResult = createBundler().resolveSingleProject(definitionFile)
 
-                try {
-                    val actualResult = createBundler().resolveSingleProject(definitionFile)
+            with(actualResult) {
+                project.id shouldBe
+                        Identifier("Bundler::src/funTest/assets/projects/synthetic/no-lockfile/Gemfile:")
+                project.definitionFilePath shouldBe
+                        "plugins/package-managers/bundler/src/funTest/assets/projects/synthetic/no-lockfile/Gemfile"
+                packages should beEmpty()
+                issues.size shouldBe 1
+                issues.first().message should haveSubstring("IllegalArgumentException: No lockfile found in")
+            }
+        }
 
-                    actualResult.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-                } finally {
-                    File(definitionFile.parentFile, ".bundle").safeDeleteRecursively(force = true)
-                }
+        "resolve dependencies correctly when the project is a Gem" {
+            val definitionFile = getAssetFile("projects/synthetic/gemspec/Gemfile")
+            val expectedResultFile = getAssetFile("projects/synthetic/bundler-expected-output-gemspec.yml")
+
+            try {
+                val actualResult = createBundler().resolveSingleProject(definitionFile)
+
+                actualResult.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
+            } finally {
+                File(definitionFile.parentFile, ".bundle").safeDeleteRecursively(force = true)
             }
         }
     }
+})
 
-    private fun createBundler() =
-        Bundler("Bundler", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())
-}
+private fun createBundler() =
+    Bundler("Bundler", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())

--- a/plugins/package-managers/bundler/src/funTest/kotlin/BundlerFunTest.kt
+++ b/plugins/package-managers/bundler/src/funTest/kotlin/BundlerFunTest.kt
@@ -75,12 +75,10 @@ class BundlerFunTest : WordSpec({
     }
 })
 
-private fun createBundler() =
-    Bundler("Bundler", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())
-
 private fun resolveSingleProject(definitionFile: File): ProjectAnalyzerResult =
     try {
-        createBundler().resolveSingleProject(definitionFile)
+        val bundler = Bundler("Bundler", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())
+        bundler.resolveSingleProject(definitionFile)
     } finally {
         definitionFile.resolveSibling(".bundle").safeDeleteRecursively(force = true)
     }

--- a/plugins/package-managers/bundler/src/funTest/kotlin/BundlerFunTest.kt
+++ b/plugins/package-managers/bundler/src/funTest/kotlin/BundlerFunTest.kt
@@ -40,7 +40,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class BundlerFunTest : WordSpec() {
-    private val projectsDir = getAssetFile("projects/synthetic").absoluteFile
+    private val projectsDir = getAssetFile("projects/synthetic")
     private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
     private val vcsRevision = vcsDir.getRevision()
     private val vcsUrl = vcsDir.getRemoteUrl()

--- a/plugins/package-managers/bundler/src/funTest/kotlin/BundlerFunTest.kt
+++ b/plugins/package-managers/bundler/src/funTest/kotlin/BundlerFunTest.kt
@@ -25,8 +25,11 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.haveSubstring
 
+import java.io.File
+
 import org.ossreviewtoolkit.analyzer.managers.resolveSingleProject
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
@@ -41,18 +44,14 @@ class BundlerFunTest : WordSpec({
             val definitionFile = getAssetFile("projects/synthetic/lockfile/Gemfile")
             val expectedResultFile = getAssetFile("projects/synthetic/bundler-expected-output-lockfile.yml")
 
-            try {
-                val actualResult = createBundler().resolveSingleProject(definitionFile)
+            val actualResult = resolveSingleProject(definitionFile)
 
-                actualResult.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-            } finally {
-                definitionFile.resolveSibling(".bundle").safeDeleteRecursively(force = true)
-            }
+            actualResult.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
 
         "show error if no lockfile is present" {
             val definitionFile = getAssetFile("projects/synthetic/no-lockfile/Gemfile")
-            val actualResult = createBundler().resolveSingleProject(definitionFile)
+            val actualResult = resolveSingleProject(definitionFile)
 
             with(actualResult) {
                 project.id shouldBe
@@ -69,16 +68,19 @@ class BundlerFunTest : WordSpec({
             val definitionFile = getAssetFile("projects/synthetic/gemspec/Gemfile")
             val expectedResultFile = getAssetFile("projects/synthetic/bundler-expected-output-gemspec.yml")
 
-            try {
-                val actualResult = createBundler().resolveSingleProject(definitionFile)
+            val actualResult = resolveSingleProject(definitionFile)
 
-                actualResult.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-            } finally {
-                definitionFile.resolveSibling(".bundle").safeDeleteRecursively(force = true)
-            }
+            actualResult.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
     }
 })
 
 private fun createBundler() =
     Bundler("Bundler", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())
+
+private fun resolveSingleProject(definitionFile: File): ProjectAnalyzerResult =
+    try {
+        createBundler().resolveSingleProject(definitionFile)
+    } finally {
+        definitionFile.resolveSibling(".bundle").safeDeleteRecursively(force = true)
+    }

--- a/plugins/package-managers/cargo/src/funTest/kotlin/CargoFunTest.kt
+++ b/plugins/package-managers/cargo/src/funTest/kotlin/CargoFunTest.kt
@@ -23,36 +23,22 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.analyzer.managers.resolveSingleProject
-import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
-import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.getAssetFile
-import org.ossreviewtoolkit.utils.test.patchExpectedResult
+import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class CargoFunTest : StringSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/cargo")
-    private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
-    private val vcsUrl = vcsDir.getRemoteUrl()
-    private val vcsRevision = vcsDir.getRevision()
-
     init {
         "Projects dependencies are detected correctly" {
-            val definitionFile = projectDir.resolve("Cargo.toml")
-            val vcsPath = vcsDir.getPathToRoot(projectDir)
-            val expectedResult = patchExpectedResult(
-                projectDir.resolveSibling("cargo-expected-output.yml"),
-                definitionFilePath = "$vcsPath/Cargo.toml",
-                path = vcsPath,
-                revision = vcsRevision,
-                url = normalizeVcsUrl(vcsUrl)
-            )
+            val definitionFile = getAssetFile("projects/synthetic/cargo/Cargo.toml")
+            val expectedResultFile = getAssetFile("projects/synthetic/cargo-expected-output.yml")
 
             val result = createCargo().resolveSingleProject(definitionFile)
 
-            result.toYaml() shouldBe expectedResult
+            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
     }
 

--- a/plugins/package-managers/cargo/src/funTest/kotlin/CargoFunTest.kt
+++ b/plugins/package-managers/cargo/src/funTest/kotlin/CargoFunTest.kt
@@ -30,18 +30,15 @@ import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
-class CargoFunTest : StringSpec() {
-    init {
-        "Projects dependencies are detected correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/cargo/Cargo.toml")
-            val expectedResultFile = getAssetFile("projects/synthetic/cargo-expected-output.yml")
+class CargoFunTest : StringSpec({
+    "Projects dependencies are detected correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/cargo/Cargo.toml")
+        val expectedResultFile = getAssetFile("projects/synthetic/cargo-expected-output.yml")
 
-            val result = createCargo().resolveSingleProject(definitionFile)
+        val result = createCargo().resolveSingleProject(definitionFile)
 
-            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-        }
+        result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
     }
+})
 
-    private fun createCargo() =
-        Cargo("Cargo", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())
-}
+private fun createCargo() = Cargo("Cargo", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())

--- a/plugins/package-managers/cargo/src/funTest/kotlin/CargoFunTest.kt
+++ b/plugins/package-managers/cargo/src/funTest/kotlin/CargoFunTest.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class CargoFunTest : StringSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/cargo").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/cargo")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/plugins/package-managers/cargo/src/funTest/kotlin/CargoSubcrateFunTest.kt
+++ b/plugins/package-managers/cargo/src/funTest/kotlin/CargoSubcrateFunTest.kt
@@ -23,70 +23,40 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.analyzer.managers.resolveSingleProject
-import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
-import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.getAssetFile
-import org.ossreviewtoolkit.utils.test.patchExpectedResult
+import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class CargoSubcrateFunTest : StringSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/cargo-subcrate")
-    private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
-    private val vcsUrl = vcsDir.getRemoteUrl()
-    private val vcsRevision = vcsDir.getRevision()
-
     init {
         "Lib project dependencies are detected correctly" {
-            val definitionFile = projectDir.resolve("Cargo.toml")
-            val vcsPath = vcsDir.getPathToRoot(projectDir)
-            val expectedResult = patchExpectedResult(
-                projectDir.resolveSibling("cargo-subcrate-lib-expected-output.yml"),
-                definitionFilePath = "$vcsPath/Cargo.toml",
-                path = vcsPath,
-                revision = vcsRevision,
-                url = normalizeVcsUrl(vcsUrl)
-            )
+            val definitionFile = getAssetFile("projects/synthetic/cargo-subcrate/Cargo.toml")
+            val expectedResultFile = getAssetFile("projects/synthetic/cargo-subcrate-lib-expected-output.yml")
 
             val result = createCargo().resolveSingleProject(definitionFile)
 
-            result.toYaml() shouldBe expectedResult
+            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
 
         "Integration sub-project dependencies are detected correctly" {
-            val integrationProjectDir = projectDir.resolve("integration")
-            val definitionFile = integrationProjectDir.resolve("Cargo.toml")
-            val vcsPath = vcsDir.getPathToRoot(integrationProjectDir)
-            val expectedResult = patchExpectedResult(
-                projectDir.resolveSibling("cargo-subcrate-integration-expected-output.yml"),
-                definitionFilePath = "$vcsPath/Cargo.toml",
-                path = vcsPath,
-                revision = vcsRevision,
-                url = normalizeVcsUrl(vcsUrl)
-            )
+            val definitionFile = getAssetFile("projects/synthetic/cargo-subcrate/integration/Cargo.toml")
+            val expectedResultFile = getAssetFile("projects/synthetic/cargo-subcrate-integration-expected-output.yml")
 
             val result = createCargo().resolveSingleProject(definitionFile)
 
-            result.toYaml() shouldBe expectedResult
+            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
 
         "Client sub-project dependencies are detected correctly" {
-            val clientProjectDir = projectDir.resolve("client")
-            val definitionFile = clientProjectDir.resolve("Cargo.toml")
-            val vcsPath = vcsDir.getPathToRoot(clientProjectDir)
-            val expectedResult = patchExpectedResult(
-                projectDir.resolveSibling("cargo-subcrate-client-expected-output.yml"),
-                definitionFilePath = "$vcsPath/Cargo.toml",
-                path = vcsPath,
-                revision = vcsRevision,
-                url = normalizeVcsUrl(vcsUrl)
-            )
+            val definitionFile = getAssetFile("projects/synthetic/cargo-subcrate/client/Cargo.toml")
+            val expectedResultFile = getAssetFile("projects/synthetic/cargo-subcrate-client-expected-output.yml")
 
             val result = createCargo().resolveSingleProject(definitionFile)
 
-            result.toYaml() shouldBe expectedResult
+            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
     }
 

--- a/plugins/package-managers/cargo/src/funTest/kotlin/CargoSubcrateFunTest.kt
+++ b/plugins/package-managers/cargo/src/funTest/kotlin/CargoSubcrateFunTest.kt
@@ -30,36 +30,34 @@ import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
-class CargoSubcrateFunTest : StringSpec() {
-    init {
-        "Lib project dependencies are detected correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/cargo-subcrate/Cargo.toml")
-            val expectedResultFile = getAssetFile("projects/synthetic/cargo-subcrate-lib-expected-output.yml")
+class CargoSubcrateFunTest : StringSpec({
+    "Lib project dependencies are detected correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/cargo-subcrate/Cargo.toml")
+        val expectedResultFile = getAssetFile("projects/synthetic/cargo-subcrate-lib-expected-output.yml")
 
-            val result = createCargo().resolveSingleProject(definitionFile)
+        val result = createCargo().resolveSingleProject(definitionFile)
 
-            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-        }
-
-        "Integration sub-project dependencies are detected correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/cargo-subcrate/integration/Cargo.toml")
-            val expectedResultFile = getAssetFile("projects/synthetic/cargo-subcrate-integration-expected-output.yml")
-
-            val result = createCargo().resolveSingleProject(definitionFile)
-
-            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-        }
-
-        "Client sub-project dependencies are detected correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/cargo-subcrate/client/Cargo.toml")
-            val expectedResultFile = getAssetFile("projects/synthetic/cargo-subcrate-client-expected-output.yml")
-
-            val result = createCargo().resolveSingleProject(definitionFile)
-
-            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-        }
+        result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
     }
 
-    private fun createCargo() =
-        Cargo("Cargo", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())
-}
+    "Integration sub-project dependencies are detected correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/cargo-subcrate/integration/Cargo.toml")
+        val expectedResultFile = getAssetFile("projects/synthetic/cargo-subcrate-integration-expected-output.yml")
+
+        val result = createCargo().resolveSingleProject(definitionFile)
+
+        result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
+    }
+
+    "Client sub-project dependencies are detected correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/cargo-subcrate/client/Cargo.toml")
+        val expectedResultFile = getAssetFile("projects/synthetic/cargo-subcrate-client-expected-output.yml")
+
+        val result = createCargo().resolveSingleProject(definitionFile)
+
+        result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
+    }
+})
+
+private fun createCargo() =
+    Cargo("Cargo", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())

--- a/plugins/package-managers/cargo/src/funTest/kotlin/CargoSubcrateFunTest.kt
+++ b/plugins/package-managers/cargo/src/funTest/kotlin/CargoSubcrateFunTest.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class CargoSubcrateFunTest : StringSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/cargo-subcrate").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/cargo-subcrate")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/plugins/package-managers/carthage/src/funTest/kotlin/CarthageFunTest.kt
+++ b/plugins/package-managers/carthage/src/funTest/kotlin/CarthageFunTest.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class CarthageFunTest : StringSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/carthage").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/carthage")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/plugins/package-managers/composer/src/funTest/kotlin/ComposerFunTest.kt
+++ b/plugins/package-managers/composer/src/funTest/kotlin/ComposerFunTest.kt
@@ -26,39 +26,27 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.haveSubstring
 
 import org.ossreviewtoolkit.analyzer.managers.resolveSingleProject
-import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
-import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.getAssetFile
-import org.ossreviewtoolkit.utils.test.patchExpectedResult
+import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class ComposerFunTest : StringSpec() {
-    private val projectsDir = getAssetFile("projects/synthetic")
-    private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
-    private val vcsRevision = vcsDir.getRevision()
-    private val vcsUrl = vcsDir.getRemoteUrl()
-
     init {
         "Project dependencies are detected correctly" {
-            val definitionFile = projectsDir.resolve("lockfile/composer.json")
+            val definitionFile = getAssetFile("projects/synthetic/lockfile/composer.json")
+            val expectedResultFile = getAssetFile("projects/synthetic/composer-expected-output.yml")
 
             val result = createComposer().resolveSingleProject(definitionFile)
-            val expectedResults = patchExpectedResult(
-                projectsDir.resolve("composer-expected-output.yml"),
-                url = normalizeVcsUrl(vcsUrl),
-                revision = vcsRevision,
-                path = vcsDir.getPathToRoot(definitionFile.parentFile)
-            )
 
-            result.toYaml() shouldBe expectedResults
+            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
 
         "Error is shown when no lockfile is present" {
-            val definitionFile = projectsDir.resolve("no-lockfile/composer.json")
+            val definitionFile = getAssetFile("projects/synthetic/no-lockfile/composer.json")
             val result = createComposer().resolveSingleProject(definitionFile)
 
             with(result) {
@@ -74,61 +62,39 @@ class ComposerFunTest : StringSpec() {
         }
 
         "No composer.lock is required for projects without dependencies" {
-            val definitionFile = projectsDir.resolve("no-deps/composer.json")
+            val definitionFile = getAssetFile("projects/synthetic/no-deps/composer.json")
+            val expectedResultFile = getAssetFile("projects/synthetic/composer-expected-output-no-deps.yml")
 
             val result = createComposer().resolveSingleProject(definitionFile)
-            val expectedResults = patchExpectedResult(
-                projectsDir.resolve("composer-expected-output-no-deps.yml"),
-                definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
-                url = normalizeVcsUrl(vcsUrl),
-                revision = vcsRevision,
-                path = vcsDir.getPathToRoot(definitionFile.parentFile)
-            )
 
-            result.toYaml() shouldBe expectedResults
+            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
 
         "No composer.lock is required for projects with empty dependencies" {
-            val definitionFile = projectsDir.resolve("empty-deps/composer.json")
+            val definitionFile = getAssetFile("projects/synthetic/empty-deps/composer.json")
+            val expectedResultFile = getAssetFile("projects/synthetic/composer-expected-output-no-deps.yml")
 
             val result = createComposer().resolveSingleProject(definitionFile)
-            val expectedResults = patchExpectedResult(
-                projectsDir.resolve("composer-expected-output-no-deps.yml"),
-                definitionFilePath = VersionControlSystem.getPathInfo(definitionFile).path,
-                url = normalizeVcsUrl(vcsUrl),
-                revision = vcsRevision,
-                path = vcsDir.getPathToRoot(definitionFile.parentFile)
-            )
 
-            result.toYaml() shouldBe expectedResults
+            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
 
         "Packages defined as provided are not reported as missing" {
-            val definitionFile = projectsDir.resolve("with-provide/composer.json")
+            val definitionFile = getAssetFile("projects/synthetic/with-provide/composer.json")
+            val expectedResultFile = getAssetFile("projects/synthetic/composer-expected-output-with-provide.yml")
 
             val result = createComposer().resolveSingleProject(definitionFile)
-            val expectedResults = patchExpectedResult(
-                projectsDir.resolve("composer-expected-output-with-provide.yml"),
-                url = normalizeVcsUrl(vcsUrl),
-                revision = vcsRevision,
-                path = vcsDir.getPathToRoot(definitionFile.parentFile)
-            )
 
-            result.toYaml() shouldBe expectedResults
+            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
 
         "Packages defined as replaced are not reported as missing" {
-            val definitionFile = projectsDir.resolve("with-replace/composer.json")
+            val definitionFile = getAssetFile("projects/synthetic/with-replace/composer.json")
+            val expectedResultFile = getAssetFile("projects/synthetic/composer-expected-output-with-replace.yml")
 
             val result = createComposer().resolveSingleProject(definitionFile)
-            val expectedResults = patchExpectedResult(
-                projectsDir.resolve("composer-expected-output-with-replace.yml"),
-                url = normalizeVcsUrl(vcsUrl),
-                revision = vcsRevision,
-                path = vcsDir.getPathToRoot(definitionFile.parentFile)
-            )
 
-            result.toYaml() shouldBe expectedResults
+            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
     }
 

--- a/plugins/package-managers/composer/src/funTest/kotlin/ComposerFunTest.kt
+++ b/plugins/package-managers/composer/src/funTest/kotlin/ComposerFunTest.kt
@@ -37,7 +37,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class ComposerFunTest : StringSpec() {
-    private val projectsDir = getAssetFile("projects/synthetic").absoluteFile
+    private val projectsDir = getAssetFile("projects/synthetic")
     private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
     private val vcsRevision = vcsDir.getRevision()
     private val vcsUrl = vcsDir.getRemoteUrl()

--- a/plugins/package-managers/composer/src/funTest/kotlin/ComposerFunTest.kt
+++ b/plugins/package-managers/composer/src/funTest/kotlin/ComposerFunTest.kt
@@ -34,70 +34,68 @@ import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
-class ComposerFunTest : StringSpec() {
-    init {
-        "Project dependencies are detected correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/lockfile/composer.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/composer-expected-output.yml")
+class ComposerFunTest : StringSpec({
+    "Project dependencies are detected correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/lockfile/composer.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/composer-expected-output.yml")
 
-            val result = createComposer().resolveSingleProject(definitionFile)
+        val result = createComposer().resolveSingleProject(definitionFile)
 
-            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-        }
+        result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
+    }
 
-        "Error is shown when no lockfile is present" {
-            val definitionFile = getAssetFile("projects/synthetic/no-lockfile/composer.json")
-            val result = createComposer().resolveSingleProject(definitionFile)
+    "Error is shown when no lockfile is present" {
+        val definitionFile = getAssetFile("projects/synthetic/no-lockfile/composer.json")
+        val result = createComposer().resolveSingleProject(definitionFile)
 
-            with(result) {
-                project.id shouldBe Identifier(
-                    "Composer::src/funTest/assets/projects/synthetic/no-lockfile/composer.json:"
-                )
-                project.definitionFilePath shouldBe "plugins/package-managers/composer/src/funTest/assets/projects/" +
-                        "synthetic/no-lockfile/composer.json"
-                packages should beEmpty()
-                issues.size shouldBe 1
-                issues.first().message should haveSubstring("IllegalArgumentException: No lockfile found in")
-            }
-        }
-
-        "No composer.lock is required for projects without dependencies" {
-            val definitionFile = getAssetFile("projects/synthetic/no-deps/composer.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/composer-expected-output-no-deps.yml")
-
-            val result = createComposer().resolveSingleProject(definitionFile)
-
-            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-        }
-
-        "No composer.lock is required for projects with empty dependencies" {
-            val definitionFile = getAssetFile("projects/synthetic/empty-deps/composer.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/composer-expected-output-no-deps.yml")
-
-            val result = createComposer().resolveSingleProject(definitionFile)
-
-            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-        }
-
-        "Packages defined as provided are not reported as missing" {
-            val definitionFile = getAssetFile("projects/synthetic/with-provide/composer.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/composer-expected-output-with-provide.yml")
-
-            val result = createComposer().resolveSingleProject(definitionFile)
-
-            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-        }
-
-        "Packages defined as replaced are not reported as missing" {
-            val definitionFile = getAssetFile("projects/synthetic/with-replace/composer.json")
-            val expectedResultFile = getAssetFile("projects/synthetic/composer-expected-output-with-replace.yml")
-
-            val result = createComposer().resolveSingleProject(definitionFile)
-
-            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
+        with(result) {
+            project.id shouldBe Identifier(
+                "Composer::src/funTest/assets/projects/synthetic/no-lockfile/composer.json:"
+            )
+            project.definitionFilePath shouldBe "plugins/package-managers/composer/src/funTest/assets/projects/" +
+                    "synthetic/no-lockfile/composer.json"
+            packages should beEmpty()
+            issues.size shouldBe 1
+            issues.first().message should haveSubstring("IllegalArgumentException: No lockfile found in")
         }
     }
 
-    private fun createComposer() =
-        Composer("Composer", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())
-}
+    "No composer.lock is required for projects without dependencies" {
+        val definitionFile = getAssetFile("projects/synthetic/no-deps/composer.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/composer-expected-output-no-deps.yml")
+
+        val result = createComposer().resolveSingleProject(definitionFile)
+
+        result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
+    }
+
+    "No composer.lock is required for projects with empty dependencies" {
+        val definitionFile = getAssetFile("projects/synthetic/empty-deps/composer.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/composer-expected-output-no-deps.yml")
+
+        val result = createComposer().resolveSingleProject(definitionFile)
+
+        result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
+    }
+
+    "Packages defined as provided are not reported as missing" {
+        val definitionFile = getAssetFile("projects/synthetic/with-provide/composer.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/composer-expected-output-with-provide.yml")
+
+        val result = createComposer().resolveSingleProject(definitionFile)
+
+        result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
+    }
+
+    "Packages defined as replaced are not reported as missing" {
+        val definitionFile = getAssetFile("projects/synthetic/with-replace/composer.json")
+        val expectedResultFile = getAssetFile("projects/synthetic/composer-expected-output-with-replace.yml")
+
+        val result = createComposer().resolveSingleProject(definitionFile)
+
+        result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
+    }
+})
+
+private fun createComposer() =
+    Composer("Composer", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())

--- a/plugins/package-managers/gradle/src/funTest/kotlin/GradleAndroidFunTest.kt
+++ b/plugins/package-managers/gradle/src/funTest/kotlin/GradleAndroidFunTest.kt
@@ -35,7 +35,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class GradleAndroidFunTest : StringSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/gradle-android").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/gradle-android")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()
@@ -81,7 +81,7 @@ class GradleAndroidFunTest : StringSpec() {
         }
 
         "Cyclic dependencies over multiple libraries can be handled".config(tags = setOf(AndroidTag, ExpensiveTag)) {
-            val cyclicProjectDir = getAssetFile("projects/synthetic/gradle-android-cyclic").absoluteFile
+            val cyclicProjectDir = getAssetFile("projects/synthetic/gradle-android-cyclic")
             val definitionFile = cyclicProjectDir.resolve("app/build.gradle")
             val expectedResult = patchExpectedResult(
                 projectDir.resolveSibling("gradle-android-cyclic-expected-output-app.yml"),

--- a/plugins/package-managers/gradle/src/funTest/kotlin/GradleBomFunTest.kt
+++ b/plugins/package-managers/gradle/src/funTest/kotlin/GradleBomFunTest.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class GradleBomFunTest : StringSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/gradle-bom").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/gradle-bom")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/plugins/package-managers/gradle/src/funTest/kotlin/GradleCompositeFunTest.kt
+++ b/plugins/package-managers/gradle/src/funTest/kotlin/GradleCompositeFunTest.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class GradleCompositeFunTest : StringSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/gradle-composite").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/gradle-composite")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/plugins/package-managers/gradle/src/funTest/kotlin/GradleFunTest.kt
+++ b/plugins/package-managers/gradle/src/funTest/kotlin/GradleFunTest.kt
@@ -46,7 +46,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class GradleFunTest : StringSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/gradle").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/gradle")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/plugins/package-managers/gradle/src/funTest/kotlin/GradleKotlinScriptFunTest.kt
+++ b/plugins/package-managers/gradle/src/funTest/kotlin/GradleKotlinScriptFunTest.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class GradleKotlinScriptFunTest : StringSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/multi-kotlin-project").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/multi-kotlin-project")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/plugins/package-managers/gradle/src/funTest/kotlin/GradleLibraryFunTest.kt
+++ b/plugins/package-managers/gradle/src/funTest/kotlin/GradleLibraryFunTest.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class GradleLibraryFunTest : StringSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/gradle-library").absoluteFile
+    private val projectDir = getAssetFile("projects/synthetic/gradle-library")
     private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/plugins/package-managers/pub/src/funTest/kotlin/PubFunTest.kt
+++ b/plugins/package-managers/pub/src/funTest/kotlin/PubFunTest.kt
@@ -42,8 +42,8 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class PubFunTest : WordSpec() {
-    private val projectsDir = getAssetFile("projects/synthetic").absoluteFile
-    private val projectsDirExternal = getAssetFile("projects/external").absoluteFile
+    private val projectsDir = getAssetFile("projects/synthetic")
+    private val projectsDirExternal = getAssetFile("projects/external")
     private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/plugins/package-managers/python/src/funTest/kotlin/PipFunTest.kt
+++ b/plugins/package-managers/python/src/funTest/kotlin/PipFunTest.kt
@@ -38,7 +38,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class PipFunTest : WordSpec({
-    val projectsDir = getAssetFile("projects").absoluteFile
+    val projectsDir = getAssetFile("projects")
     val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
     val vcsUrl = vcsDir.getRemoteUrl()
     val vcsRevision = vcsDir.getRevision()

--- a/plugins/package-managers/python/src/funTest/kotlin/PipenvFunTest.kt
+++ b/plugins/package-managers/python/src/funTest/kotlin/PipenvFunTest.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class PipenvFunTest : WordSpec() {
-    private val projectsDir = getAssetFile("projects").absoluteFile
+    private val projectsDir = getAssetFile("projects")
     private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/plugins/package-managers/python/src/funTest/kotlin/PoetryFunTest.kt
+++ b/plugins/package-managers/python/src/funTest/kotlin/PoetryFunTest.kt
@@ -33,7 +33,7 @@ import org.ossreviewtoolkit.utils.test.patchExpectedResult
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class PoetryFunTest : WordSpec() {
-    private val projectsDir = getAssetFile("projects").absoluteFile
+    private val projectsDir = getAssetFile("projects")
     private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
     private val vcsUrl = vcsDir.getRemoteUrl()
     private val vcsRevision = vcsDir.getRevision()

--- a/plugins/package-managers/python/src/funTest/kotlin/utils/PythonInspectorFunTest.kt
+++ b/plugins/package-managers/python/src/funTest/kotlin/utils/PythonInspectorFunTest.kt
@@ -27,7 +27,7 @@ import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.test.getAssetFile
 
 class PythonInspectorFunTest : StringSpec({
-    val projectsDir = getAssetFile("projects").absoluteFile
+    val projectsDir = getAssetFile("projects")
 
     "python-inspector output can be deserialized" {
         val definitionFile = projectsDir.resolve("synthetic/pip/requirements.txt")

--- a/utils/test/build.gradle.kts
+++ b/utils/test/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     api(libs.kotestAssertionsCore)
     api(libs.kotestFrameworkApi)
 
+    implementation(project(":downloader"))
     implementation(project(":utils:ort-utils"))
 
     implementation(libs.jacksonModuleKotlin)

--- a/utils/test/src/main/kotlin/Utils.kt
+++ b/utils/test/src/main/kotlin/Utils.kt
@@ -47,9 +47,9 @@ private val TIMESTAMP_REGEX = Regex("(timestamp): \".*\"")
 fun getAssetAsString(path: String): String = getAssetFile(path).readText()
 
 /**
- * Return the fun test asset file located under [path] relative to the 'assets' directory.
+ * Return the absolute file for the functional test assets at the given [path].
  */
-fun getAssetFile(path: String) = File("src/funTest/assets", path)
+fun getAssetFile(path: String): File = File("src/funTest/assets", path).absoluteFile
 
 fun patchExpectedResult(
     result: File,

--- a/utils/test/src/main/kotlin/Utils.kt
+++ b/utils/test/src/main/kotlin/Utils.kt
@@ -28,9 +28,11 @@ import io.kotest.matchers.neverNullMatcher
 import java.io.File
 import java.time.Instant
 
+import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.mapper
 import org.ossreviewtoolkit.model.yamlMapper
+import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 
 val USER_DIR = File(System.getProperty("user.dir"))
 
@@ -73,6 +75,22 @@ fun patchExpectedResult(
         .replaceIfNotNull("<REPLACE_REVISION>", revision)
         .replaceIfNotNull("<REPLACE_PATH>", path)
         .replaceIfNotNull("<REPLACE_URL_PROCESSED>", urlProcessed)
+}
+
+fun patchExpectedResult2(expectedResultFile: File, definitionFile: File): String {
+    val projectDir = definitionFile.parentFile
+    val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
+    val vcsUrl = vcsDir.getRemoteUrl()
+    val vcsRevision = vcsDir.getRevision()
+    val vcsPath = vcsDir.getPathToRoot(projectDir)
+
+    return patchExpectedResult(
+        expectedResultFile,
+        definitionFilePath = "$vcsPath/${definitionFile.name}",
+        path = vcsPath,
+        revision = vcsRevision,
+        url = normalizeVcsUrl(vcsUrl)
+    )
 }
 
 fun patchActualResult(

--- a/utils/test/src/main/kotlin/Utils.kt
+++ b/utils/test/src/main/kotlin/Utils.kt
@@ -47,7 +47,7 @@ private val TIMESTAMP_REGEX = Regex("(timestamp): \".*\"")
 fun getAssetAsString(path: String): String = getAssetFile(path).readText()
 
 /**
- * Return the fun test asset file located  under [path] relative to the 'assets' directory.
+ * Return the fun test asset file located under [path] relative to the 'assets' directory.
  */
 fun getAssetFile(path: String) = File("src/funTest/assets", path)
 


### PR DESCRIPTION
Introduce `patchExpectedResult2()` and start migrating to it.