### PR TITLE
tests: Continue moving to `patchExpectedResult2()`

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-scope-excludes.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-scope-excludes.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "NPM::npm-project:1.0.0"
+  id: "NPM::npm-shrinkwrap:1.0.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   authors:
   - "The Author"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "NPM::npm-project:1.0.0"
+  id: "NPM::<REPLACE_PROJECT_NAME>:1.0.0"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   authors:
   - "The Author"

--- a/analyzer/src/funTest/kotlin/managers/ConanFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/ConanFunTest.kt
@@ -22,60 +22,34 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.common.Os
-import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchActualResult
-import org.ossreviewtoolkit.utils.test.patchExpectedResult
+import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class ConanFunTest : StringSpec() {
-    private val projectsDirTxt = getAssetFile("projects/synthetic/conan-txt")
-    private val vcsDirTxt = VersionControlSystem.forDirectory(projectsDirTxt)!!
-    private val vcsRevisionTxt = vcsDirTxt.getRevision()
-    private val vcsUrlTxt = vcsDirTxt.getRemoteUrl()
-
-    private val projectsDirPy = getAssetFile("projects/synthetic/conan-py")
-    private val vcsDirPy = VersionControlSystem.forDirectory(projectsDirPy)!!
-    private val vcsRevisionPy = vcsDirPy.getRevision()
-    private val vcsUrlPy = vcsDirPy.getRemoteUrl()
-
     init {
         "Project dependencies are detected correctly for conanfile.txt" {
-            val definitionFile = projectsDirTxt.resolve("conanfile.txt")
-            val vcsPath = vcsDirTxt.getPathToRoot(projectsDirTxt)
-            val expectedResult = patchExpectedResult(
-                projectsDirTxt.resolveSibling("conan-expected-output-txt.yml"),
-                definitionFilePath = "$vcsPath/conanfile.txt",
-                path = vcsPath,
-                revision = vcsRevisionTxt,
-                url = normalizeVcsUrl(vcsUrlTxt)
-            )
+            val definitionFile = getAssetFile("projects/synthetic/conan-txt/conanfile.txt")
+            val expectedResultFile = getAssetFile("projects/synthetic/conan-expected-output-txt.yml")
 
             val result = createConanDynamicVersions().resolveSingleProject(definitionFile)
 
-            patchActualResult(result.toYaml()) shouldBe expectedResult
+            patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
 
         "Project dependencies are detected correctly for conanfile.py" {
-            val definitionFile = projectsDirPy.resolve("conanfile.py")
-            val vcsPath = vcsDirPy.getPathToRoot(projectsDirPy)
-            val expectedResult = patchExpectedResult(
-                projectsDirPy.resolveSibling("conan-expected-output-py.yml"),
-                definitionFilePath = "$vcsPath/conanfile.py",
-                path = vcsPath,
-                revision = vcsRevisionPy,
-                url = normalizeVcsUrl(vcsUrlPy)
-            )
+            val definitionFile = getAssetFile("projects/synthetic/conan-py/conanfile.py")
+            val expectedResultFile = getAssetFile("projects/synthetic/conan-expected-output-py.yml")
 
             val result = createConanDynamicVersions().resolveSingleProject(definitionFile)
 
-            patchActualResult(result.toYaml()) shouldBe expectedResult
+            patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
 
         /**
@@ -83,19 +57,12 @@ class ConanFunTest : StringSpec() {
          * system. The `package id` is set to the one calculated on Linux.
          */
         "Project dependencies are detected correctly with the lockfile".config(enabled = Os.isLinux) {
-            val definitionFile = projectsDirPy.resolve("conanfile.py")
-            val vcsPath = vcsDirPy.getPathToRoot(projectsDirPy)
-            val expectedResult = patchExpectedResult(
-                projectsDirPy.parentFile.resolve("conan-expected-output-py.yml"),
-                definitionFilePath = "$vcsPath/conanfile.py",
-                path = vcsPath,
-                revision = vcsRevisionPy,
-                url = normalizeVcsUrl(vcsUrlPy)
-            )
+            val definitionFile = getAssetFile("projects/synthetic/conan-py/conanfile.py")
+            val expectedResultFile = getAssetFile("projects/synthetic/conan-expected-output-py.yml")
 
             val result = createConanWithLockFile().resolveSingleProject(definitionFile)
 
-            patchActualResult(result.toYaml()) shouldBe expectedResult
+            patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
     }
 

--- a/analyzer/src/funTest/kotlin/managers/ConanFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/ConanFunTest.kt
@@ -32,56 +32,54 @@ import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
-class ConanFunTest : StringSpec() {
-    init {
-        "Project dependencies are detected correctly for conanfile.txt" {
-            val definitionFile = getAssetFile("projects/synthetic/conan-txt/conanfile.txt")
-            val expectedResultFile = getAssetFile("projects/synthetic/conan-expected-output-txt.yml")
+class ConanFunTest : StringSpec({
+    "Project dependencies are detected correctly for conanfile.txt" {
+        val definitionFile = getAssetFile("projects/synthetic/conan-txt/conanfile.txt")
+        val expectedResultFile = getAssetFile("projects/synthetic/conan-expected-output-txt.yml")
 
-            val result = createConanDynamicVersions().resolveSingleProject(definitionFile)
+        val result = createConanDynamicVersions().resolveSingleProject(definitionFile)
 
-            patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-        }
-
-        "Project dependencies are detected correctly for conanfile.py" {
-            val definitionFile = getAssetFile("projects/synthetic/conan-py/conanfile.py")
-            val expectedResultFile = getAssetFile("projects/synthetic/conan-expected-output-py.yml")
-
-            val result = createConanDynamicVersions().resolveSingleProject(definitionFile)
-
-            patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-        }
-
-        /**
-         * This test cannot complete successfully when you run it locally as `package id` differs depending on operating
-         * system. The `package id` is set to the one calculated on Linux.
-         */
-        "Project dependencies are detected correctly with the lockfile".config(enabled = Os.isLinux) {
-            val definitionFile = getAssetFile("projects/synthetic/conan-py/conanfile.py")
-            val expectedResultFile = getAssetFile("projects/synthetic/conan-expected-output-py.yml")
-
-            val result = createConanWithLockFile().resolveSingleProject(definitionFile)
-
-            patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-        }
+        patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
     }
 
-    private fun createConanDynamicVersions() =
-        Conan("Conan", USER_DIR, AnalyzerConfiguration(true), RepositoryConfiguration())
+    "Project dependencies are detected correctly for conanfile.py" {
+        val definitionFile = getAssetFile("projects/synthetic/conan-py/conanfile.py")
+        val expectedResultFile = getAssetFile("projects/synthetic/conan-expected-output-py.yml")
 
-    private fun createConanWithLockFile() =
-        Conan(
-            "Conan",
-            USER_DIR,
-            AnalyzerConfiguration().copy(
-                packageManagers = mapOf(
-                    "Conan" to PackageManagerConfiguration(
-                        options = mapOf(
-                            "lockfileName" to "lockfile.lock"
-                        )
+        val result = createConanDynamicVersions().resolveSingleProject(definitionFile)
+
+        patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
+    }
+
+    /**
+     * This test cannot complete successfully when you run it locally as `package id` differs depending on operating
+     * system. The `package id` is set to the one calculated on Linux.
+     */
+    "Project dependencies are detected correctly with the lockfile".config(enabled = Os.isLinux) {
+        val definitionFile = getAssetFile("projects/synthetic/conan-py/conanfile.py")
+        val expectedResultFile = getAssetFile("projects/synthetic/conan-expected-output-py.yml")
+
+        val result = createConanWithLockFile().resolveSingleProject(definitionFile)
+
+        patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
+    }
+})
+
+private fun createConanDynamicVersions() =
+    Conan("Conan", USER_DIR, AnalyzerConfiguration(true), RepositoryConfiguration())
+
+private fun createConanWithLockFile() =
+    Conan(
+        "Conan",
+        USER_DIR,
+        AnalyzerConfiguration().copy(
+            packageManagers = mapOf(
+                "Conan" to PackageManagerConfiguration(
+                    options = mapOf(
+                        "lockfileName" to "lockfile.lock"
                     )
                 )
-            ),
-            RepositoryConfiguration()
-        )
-}
+            )
+        ),
+        RepositoryConfiguration()
+    )

--- a/analyzer/src/funTest/kotlin/managers/ConanFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/ConanFunTest.kt
@@ -83,7 +83,7 @@ class ConanFunTest : StringSpec() {
          * system. The `package id` is set to the one calculated on Linux.
          */
         "Project dependencies are detected correctly with the lockfile".config(enabled = Os.isLinux) {
-            val packageFile = projectsDirPy.resolve("conanfile.py")
+            val definitionFile = projectsDirPy.resolve("conanfile.py")
             val vcsPath = vcsDirPy.getPathToRoot(projectsDirPy)
             val expectedResult = patchExpectedResult(
                 projectsDirPy.parentFile.resolve("conan-expected-output-py.yml"),
@@ -93,7 +93,7 @@ class ConanFunTest : StringSpec() {
                 url = normalizeVcsUrl(vcsUrlPy)
             )
 
-            val result = createConanWithLockFile().resolveSingleProject(packageFile)
+            val result = createConanWithLockFile().resolveSingleProject(definitionFile)
 
             patchActualResult(result.toYaml()) shouldBe expectedResult
         }

--- a/analyzer/src/funTest/kotlin/managers/DotNetFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/DotNetFunTest.kt
@@ -35,74 +35,72 @@ import org.ossreviewtoolkit.utils.test.patchActualResult
 import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
-class DotNetFunTest : StringSpec() {
-    init {
-        "Definition file is correctly read" {
-            val definitionFile = getAssetFile("projects/synthetic/dotnet/subProjectTest/test.csproj")
-            val reader = DotNetPackageFileReader()
-            val result = reader.getDependencies(definitionFile)
+class DotNetFunTest : StringSpec({
+    "Definition file is correctly read" {
+        val definitionFile = getAssetFile("projects/synthetic/dotnet/subProjectTest/test.csproj")
+        val reader = DotNetPackageFileReader()
+        val result = reader.getDependencies(definitionFile)
 
-            result should containExactlyInAnyOrder(
-                NuGetDependency(name = "System.Globalization", version = "4.3.0", targetFramework = "netcoreapp3.1"),
-                NuGetDependency(name = "System.Threading", version = "4.0.11", targetFramework = "netcoreapp3.1"),
-                NuGetDependency(
-                    name = "System.Threading.Tasks.Extensions",
-                    version = "4.5.4",
-                    targetFramework = "net45"
-                ),
-                NuGetDependency(
-                    name = "WebGrease",
-                    version = "1.5.2",
-                    targetFramework = "netcoreapp3.1",
-                    developmentDependency = true
-                ),
-                NuGetDependency(name = "foobar", version = "1.2.3", targetFramework = "netcoreapp3.1")
-            )
-        }
-
-        "Project dependencies are detected correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/dotnet/subProjectTest/test.csproj")
-            val expectedResultFile = getAssetFile("projects/synthetic/dotnet-expected-output.yml")
-
-            val result = createDotNet().resolveSingleProject(definitionFile)
-
-            patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-        }
-
-        "Direct project dependencies are detected correctly" {
-            val definitionFile = getAssetFile("projects/synthetic/dotnet/subProjectTest/test.csproj")
-            val expectedResultFile = getAssetFile(
-                "projects/synthetic/dotnet-direct-dependencies-only-expected-output.yml"
-            )
-
-            val result = createDotNet(directDependenciesOnly = true).resolveSingleProject(definitionFile)
-
-            patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-        }
-
-        "Project metadata is correctly extracted from a .nuspec file" {
-            val definitionFile = getAssetFile("projects/synthetic/dotnet/subProjectTestWithNuspec/test.csproj")
-            val expectedResultFile = getAssetFile("projects/synthetic/dotnet-expected-output-with-nuspec.yml")
-
-            val result = createDotNet().resolveSingleProject(definitionFile)
-
-            patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-        }
+        result should containExactlyInAnyOrder(
+            NuGetDependency(name = "System.Globalization", version = "4.3.0", targetFramework = "netcoreapp3.1"),
+            NuGetDependency(name = "System.Threading", version = "4.0.11", targetFramework = "netcoreapp3.1"),
+            NuGetDependency(
+                name = "System.Threading.Tasks.Extensions",
+                version = "4.5.4",
+                targetFramework = "net45"
+            ),
+            NuGetDependency(
+                name = "WebGrease",
+                version = "1.5.2",
+                targetFramework = "netcoreapp3.1",
+                developmentDependency = true
+            ),
+            NuGetDependency(name = "foobar", version = "1.2.3", targetFramework = "netcoreapp3.1")
+        )
     }
 
-    private fun createDotNet(directDependenciesOnly: Boolean = false) =
-        DotNet(
-            "DotNet",
-            USER_DIR,
-            AnalyzerConfiguration().copy(
-                packageManagers = mapOf(
-                    "DotNet" to PackageManagerConfiguration(
-                        options = mapOf(
-                            OPTION_DIRECT_DEPENDENCIES_ONLY to "$directDependenciesOnly"
-                        )
+    "Project dependencies are detected correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/dotnet/subProjectTest/test.csproj")
+        val expectedResultFile = getAssetFile("projects/synthetic/dotnet-expected-output.yml")
+
+        val result = createDotNet().resolveSingleProject(definitionFile)
+
+        patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
+    }
+
+    "Direct project dependencies are detected correctly" {
+        val definitionFile = getAssetFile("projects/synthetic/dotnet/subProjectTest/test.csproj")
+        val expectedResultFile = getAssetFile(
+            "projects/synthetic/dotnet-direct-dependencies-only-expected-output.yml"
+        )
+
+        val result = createDotNet(directDependenciesOnly = true).resolveSingleProject(definitionFile)
+
+        patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
+    }
+
+    "Project metadata is correctly extracted from a .nuspec file" {
+        val definitionFile = getAssetFile("projects/synthetic/dotnet/subProjectTestWithNuspec/test.csproj")
+        val expectedResultFile = getAssetFile("projects/synthetic/dotnet-expected-output-with-nuspec.yml")
+
+        val result = createDotNet().resolveSingleProject(definitionFile)
+
+        patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
+    }
+})
+
+private fun createDotNet(directDependenciesOnly: Boolean = false) =
+    DotNet(
+        "DotNet",
+        USER_DIR,
+        AnalyzerConfiguration().copy(
+            packageManagers = mapOf(
+                "DotNet" to PackageManagerConfiguration(
+                    options = mapOf(
+                        OPTION_DIRECT_DEPENDENCIES_ONLY to "$directDependenciesOnly"
                     )
                 )
-            ),
-            RepositoryConfiguration()
-        )
-}
+            )
+        ),
+        RepositoryConfiguration()
+    )

--- a/analyzer/src/funTest/kotlin/managers/GoDepFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoDepFunTest.kt
@@ -54,10 +54,10 @@ class GoDepFunTest : WordSpec() {
     init {
         "GoDep" should {
             "resolve dependencies from a lockfile correctly" {
-                val manifestFile = projectsDir.resolve("synthetic/godep/lockfile/Gopkg.toml")
-                val vcsPath = vcsDir.getPathToRoot(manifestFile.parentFile)
+                val definitionFile = projectsDir.resolve("synthetic/godep/lockfile/Gopkg.toml")
+                val vcsPath = vcsDir.getPathToRoot(definitionFile.parentFile)
 
-                val result = createGoDep().resolveSingleProject(manifestFile)
+                val result = createGoDep().resolveSingleProject(definitionFile)
 
                 val expectedResult = patchExpectedResult(
                     projectsDir.resolve("synthetic/godep-expected-output.yml"),
@@ -71,8 +71,8 @@ class GoDepFunTest : WordSpec() {
             }
 
             "show error if no lockfile is present" {
-                val manifestFile = projectsDir.resolve("synthetic/godep/no-lockfile/Gopkg.toml")
-                val result = createGoDep().resolveSingleProject(manifestFile)
+                val definitionFile = projectsDir.resolve("synthetic/godep/no-lockfile/Gopkg.toml")
+                val result = createGoDep().resolveSingleProject(definitionFile)
 
                 with(result) {
                     project.id shouldBe
@@ -86,9 +86,9 @@ class GoDepFunTest : WordSpec() {
             }
 
             "invoke the dependency solver if no lockfile is present and allowDynamicVersions is set" {
-                val manifestFile = projectsDir.resolve("synthetic/godep/no-lockfile/Gopkg.toml")
+                val definitionFile = projectsDir.resolve("synthetic/godep/no-lockfile/Gopkg.toml")
                 val config = AnalyzerConfiguration(allowDynamicVersions = true)
-                val result = createGoDep(config).resolveSingleProject(manifestFile)
+                val result = createGoDep(config).resolveSingleProject(definitionFile)
 
                 with(result) {
                     project shouldNotBe Project.EMPTY
@@ -97,10 +97,10 @@ class GoDepFunTest : WordSpec() {
             }
 
             "import dependencies from Glide" {
-                val manifestFile = projectsDir.resolve("synthetic/godep/glide/glide.yaml")
-                val vcsPath = vcsDir.getPathToRoot(manifestFile.parentFile)
+                val definitionFile = projectsDir.resolve("synthetic/godep/glide/glide.yaml")
+                val vcsPath = vcsDir.getPathToRoot(definitionFile.parentFile)
 
-                val result = createGoDep().resolveSingleProject(manifestFile)
+                val result = createGoDep().resolveSingleProject(definitionFile)
 
                 val expectedResult = patchExpectedResult(
                     projectsDir.resolve("synthetic/glide-expected-output.yml"),
@@ -114,10 +114,10 @@ class GoDepFunTest : WordSpec() {
             }
 
             "import dependencies from godeps" {
-                val manifestFile = projectsDir.resolve("synthetic/godep/godeps/Godeps/Godeps.json")
-                val vcsPath = vcsDir.getPathToRoot(manifestFile.parentFile.parentFile)
+                val definitionFile = projectsDir.resolve("synthetic/godep/godeps/Godeps/Godeps.json")
+                val vcsPath = vcsDir.getPathToRoot(definitionFile.parentFile.parentFile)
 
-                val result = createGoDep().resolveSingleProject(manifestFile)
+                val result = createGoDep().resolveSingleProject(definitionFile)
 
                 val expectedResult = patchExpectedResult(
                     projectsDir.resolve("synthetic/godeps-expected-output.yml"),

--- a/analyzer/src/funTest/kotlin/managers/GoModFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoModFunTest.kt
@@ -22,15 +22,11 @@ package org.ossreviewtoolkit.analyzer.managers
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-import java.io.File
-
-import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
-import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.getAssetFile
-import org.ossreviewtoolkit.utils.test.patchExpectedResult
+import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class GoModFunTest : StringSpec({
@@ -42,7 +38,7 @@ class GoModFunTest : StringSpec({
 
         val result = createGoMod().resolveSingleProject(definitionFile)
 
-        result.toYaml() shouldBe patchExpectedResult(definitionFile, expectedResultFile)
+        result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
     }
 
     "Project dependencies are detected correctly if the main package does not contain any code" {
@@ -51,7 +47,7 @@ class GoModFunTest : StringSpec({
 
         val result = createGoMod().resolveSingleProject(definitionFile)
 
-        result.toYaml() shouldBe patchExpectedResult(definitionFile, expectedResultFile)
+        result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
     }
 
     "Project dependencies are detected correctly if there are no dependencies" {
@@ -60,7 +56,7 @@ class GoModFunTest : StringSpec({
 
         val result = createGoMod().resolveSingleProject(definitionFile)
 
-        result.toYaml() shouldBe patchExpectedResult(definitionFile, expectedResultFile)
+        result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
     }
 
     "Unused dependencies are not contained in the result" {
@@ -69,27 +65,8 @@ class GoModFunTest : StringSpec({
 
         val result = createGoMod().resolveSingleProject(definitionFile)
 
-        result.toYaml() shouldBe patchExpectedResult(definitionFile, expectedResultFile)
+        result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
     }
 })
 
 private fun createGoMod() = GoMod("GoMod", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())
-
-private fun patchExpectedResult(
-    definitionFile: File,
-    expectedResultFile: File
-): String {
-    val projectDir = definitionFile.parentFile
-    val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
-    val vcsUrl = vcsDir.getRemoteUrl()
-    val vcsRevision = vcsDir.getRevision()
-    val vcsPath = vcsDir.getPathToRoot(projectDir)
-
-    return patchExpectedResult(
-        expectedResultFile,
-        definitionFilePath = "$vcsPath/go.mod",
-        path = vcsPath,
-        revision = vcsRevision,
-        url = normalizeVcsUrl(vcsUrl)
-    )
-}

--- a/analyzer/src/funTest/kotlin/managers/MavenFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/MavenFunTest.kt
@@ -48,21 +48,21 @@ class MavenFunTest : StringSpec() {
 
     init {
         "Root project dependencies are detected correctly" {
-            val pomFile = projectDir.resolve("pom.xml")
+            val definitionFile = projectDir.resolve("pom.xml")
             val expectedResult = patchExpectedResult(
                 projectDir.resolveSibling("maven-expected-output-root.yml"),
                 url = normalizeVcsUrl(vcsUrl),
                 revision = vcsRevision
             )
 
-            val result = createMaven().resolveSingleProject(pomFile, resolveScopes = true)
+            val result = createMaven().resolveSingleProject(definitionFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
 
         "Project dependencies are detected correctly" {
-            val pomFileApp = projectDir.resolve("app/pom.xml")
-            val pomFileLib = projectDir.resolve("lib/pom.xml")
+            val definitionFileApp = projectDir.resolve("app/pom.xml")
+            val definitionFileLib = projectDir.resolve("lib/pom.xml")
             val expectedResult = patchExpectedResult(
                 projectDir.resolveSibling("maven-expected-output-app.yml"),
                 url = normalizeVcsUrl(vcsUrl),
@@ -72,8 +72,12 @@ class MavenFunTest : StringSpec() {
             // app depends on lib, so we also have to pass the pom.xml of lib to resolveDependencies so that it is
             // available in the Maven.projectsByIdentifier cache. Otherwise, resolution of transitive dependencies would
             // not work.
-            val managerResult = createMaven().resolveDependencies(listOf(pomFileApp, pomFileLib), emptyMap())
-            val result = managerResult.projectResults[pomFileApp]
+            val managerResult = createMaven().resolveDependencies(
+                listOf(definitionFileApp, definitionFileLib),
+                emptyMap()
+            )
+
+            val result = managerResult.projectResults[definitionFileApp]
 
             result.shouldNotBeNull()
             result should haveSize(1)
@@ -81,20 +85,20 @@ class MavenFunTest : StringSpec() {
         }
 
         "External dependencies are detected correctly" {
-            val pomFile = projectDir.resolve("lib/pom.xml")
+            val definitionFile = projectDir.resolve("lib/pom.xml")
             val expectedResult = patchExpectedResult(
                 projectDir.resolveSibling("maven-expected-output-lib.yml"),
                 url = normalizeVcsUrl(vcsUrl),
                 revision = vcsRevision
             )
 
-            val result = createMaven().resolveSingleProject(pomFile, resolveScopes = true)
+            val result = createMaven().resolveSingleProject(definitionFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
 
         "Scopes can be excluded" {
-            val pomFile = projectDir.resolve("lib/pom.xml")
+            val definitionFile = projectDir.resolve("lib/pom.xml")
             val expectedResult = patchExpectedResult(
                 projectDir.resolveSibling("maven-expected-output-scope-excludes.yml"),
                 url = normalizeVcsUrl(vcsUrl),
@@ -106,7 +110,7 @@ class MavenFunTest : StringSpec() {
             val repoConfig = RepositoryConfiguration(excludes = Excludes(scopes = listOf(scopeExclude)))
 
             val result = createMaven(analyzerConfig, repoConfig)
-                .resolveSingleProject(pomFile, resolveScopes = true)
+                .resolveSingleProject(definitionFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
@@ -118,28 +122,28 @@ class MavenFunTest : StringSpec() {
                 .safeDeleteRecursively(force = true)
 
             val projectDir = getAssetFile("projects/synthetic/maven-parent")
-            val pomFile = projectDir.resolve("pom.xml")
+            val definitionFile = projectDir.resolve("pom.xml")
             val expectedResult = patchExpectedResult(
                 projectDir.resolveSibling("maven-parent-expected-output-root.yml"),
                 url = normalizeVcsUrl(vcsUrl),
                 revision = vcsRevision
             )
 
-            val result = createMaven().resolveSingleProject(pomFile, resolveScopes = true)
+            val result = createMaven().resolveSingleProject(definitionFile, resolveScopes = true)
 
             result.toYaml() shouldBe expectedResult
         }
 
         "Maven Wagon extensions can be loaded" {
             val projectDir = getAssetFile("projects/synthetic/maven-wagon")
-            val pomFile = projectDir.resolve("pom.xml")
+            val definitionFile = projectDir.resolve("pom.xml")
             val expectedResult = patchExpectedResult(
                 projectDir.resolveSibling("maven-wagon-expected-output.yml"),
                 url = normalizeVcsUrl(vcsUrl),
                 revision = vcsRevision
             )
 
-            val result = createMaven().resolveSingleProject(pomFile, resolveScopes = true)
+            val result = createMaven().resolveSingleProject(definitionFile, resolveScopes = true)
 
             patchActualResult(result.toYaml(), patchStartAndEndTime = true) shouldBe expectedResult
         }

--- a/analyzer/src/funTest/kotlin/managers/NpmFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmFunTest.kt
@@ -62,7 +62,7 @@ class NpmFunTest : WordSpec() {
                 val expectedResult = patchExpectedResult(
                     projectsDir.resolveSibling("npm-expected-output.yml"),
                     custom = mapOf(
-                        "npm-project" to "npm-${workingDir.name}",
+                        "<REPLACE_PROJECT_NAME>" to "npm-${workingDir.name}",
                         "<REPLACE_LOCKFILE_NAME>" to "npm-shrinkwrap.json"
                     ),
                     definitionFilePath = "$vcsPath/package.json",
@@ -107,7 +107,7 @@ class NpmFunTest : WordSpec() {
                 val expectedResult = patchExpectedResult(
                     projectsDir.resolveSibling("npm-expected-output.yml"),
                     custom = mapOf(
-                        "npm-project" to "npm-${workingDir.name}",
+                        "<REPLACE_PROJECT_NAME>" to "npm-${workingDir.name}",
                         "<REPLACE_LOCKFILE_NAME>" to "package-lock.json"
                     ),
                     definitionFilePath = "$vcsPath/package.json",
@@ -160,7 +160,7 @@ class NpmFunTest : WordSpec() {
                 val expectedResult = patchExpectedResult(
                     projectsDir.resolveSibling("npm-expected-output.yml"),
                     custom = mapOf(
-                        "npm-project" to "npm-${workingDir.name}",
+                        "<REPLACE_PROJECT_NAME>" to "npm-${workingDir.name}",
                         "<REPLACE_LOCKFILE_NAME>" to "package-lock.json"
                     ),
                     definitionFilePath = "$vcsPath/package.json",

--- a/analyzer/src/funTest/kotlin/managers/NpmFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmFunTest.kt
@@ -130,7 +130,6 @@ class NpmFunTest : WordSpec() {
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                     projectsDir.resolveSibling("npm-expected-output-no-lockfile.yml"),
-                    custom = mapOf("npm-project" to "npm-${workingDir.name}"),
                     definitionFilePath = "$vcsPath/package.json",
                     url = normalizeVcsUrl(vcsUrl),
                     revision = vcsRevision,

--- a/analyzer/src/funTest/kotlin/managers/NpmFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmFunTest.kt
@@ -88,10 +88,7 @@ class NpmFunTest : WordSpec() {
                 val vcsPath = vcsDir.getPathToRoot(workingDir)
                 val expectedResult = patchExpectedResult(
                     projectsDir.resolveSibling("npm-expected-output-scope-excludes.yml"),
-                    custom = mapOf(
-                        "npm-project" to "npm-${workingDir.name}",
-                        "<REPLACE_LOCKFILE_NAME>" to "npm-shrinkwrap.json"
-                    ),
+                    custom = mapOf("<REPLACE_LOCKFILE_NAME>" to "npm-shrinkwrap.json"),
                     definitionFilePath = "$vcsPath/package.json",
                     url = normalizeVcsUrl(vcsUrl),
                     revision = vcsRevision,

--- a/plugins/package-managers/python/src/funTest/kotlin/PipenvFunTest.kt
+++ b/plugins/package-managers/python/src/funTest/kotlin/PipenvFunTest.kt
@@ -23,55 +23,34 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.analyzer.managers.resolveSingleProject
-import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
-import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.getAssetFile
-import org.ossreviewtoolkit.utils.test.patchExpectedResult
+import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class PipenvFunTest : WordSpec() {
-    private val projectsDir = getAssetFile("projects")
-    private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
-    private val vcsUrl = vcsDir.getRemoteUrl()
-    private val vcsRevision = vcsDir.getRevision()
-
     init {
         "Python 2" should {
             "resolve dependencies correctly" {
-                val definitionFile = projectsDir.resolve("synthetic/pipenv/Pipfile.lock")
-                val vcsPath = vcsDir.getPathToRoot(definitionFile.parentFile)
-
-                val expectedResult = patchExpectedResult(
-                    projectsDir.resolve("synthetic/pipenv-expected-output.yml"),
-                    url = normalizeVcsUrl(vcsUrl),
-                    revision = vcsRevision,
-                    path = vcsPath
-                )
+                val definitionFile = getAssetFile("projects/synthetic/pipenv/Pipfile.lock")
+                val expectedResultFile = getAssetFile("projects/synthetic/pipenv-expected-output.yml")
 
                 val result = createPipenv().resolveSingleProject(definitionFile)
 
-                result.toYaml() shouldBe expectedResult
+                result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
             }
         }
 
         "Python 3" should {
             "resolve dependencies correctly for a Django project" {
-                val definitionFile = projectsDir.resolve("synthetic/pipenv-python3/Pipfile.lock")
-                val vcsPath = vcsDir.getPathToRoot(definitionFile.parentFile)
+                val definitionFile = getAssetFile("projects/synthetic/pipenv-python3/Pipfile.lock")
+                val expectedResultFile = getAssetFile("projects/synthetic/pipenv-python3-expected-output.yml")
 
                 val result = createPipenv().resolveSingleProject(definitionFile)
-                val expectedResultFile = projectsDir.resolve("synthetic/pipenv-python3-expected-output.yml")
-                val expectedResult = patchExpectedResult(
-                    expectedResultFile,
-                    url = normalizeVcsUrl(vcsUrl),
-                    revision = vcsRevision,
-                    path = vcsPath
-                )
 
-                result.toYaml() shouldBe expectedResult
+                result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
             }
         }
     }

--- a/plugins/package-managers/python/src/funTest/kotlin/PipenvFunTest.kt
+++ b/plugins/package-managers/python/src/funTest/kotlin/PipenvFunTest.kt
@@ -30,31 +30,28 @@ import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
-class PipenvFunTest : WordSpec() {
-    init {
-        "Python 2" should {
-            "resolve dependencies correctly" {
-                val definitionFile = getAssetFile("projects/synthetic/pipenv/Pipfile.lock")
-                val expectedResultFile = getAssetFile("projects/synthetic/pipenv-expected-output.yml")
+class PipenvFunTest : WordSpec({
+    "Python 2" should {
+        "resolve dependencies correctly" {
+            val definitionFile = getAssetFile("projects/synthetic/pipenv/Pipfile.lock")
+            val expectedResultFile = getAssetFile("projects/synthetic/pipenv-expected-output.yml")
 
-                val result = createPipenv().resolveSingleProject(definitionFile)
+            val result = createPipenv().resolveSingleProject(definitionFile)
 
-                result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-            }
-        }
-
-        "Python 3" should {
-            "resolve dependencies correctly for a Django project" {
-                val definitionFile = getAssetFile("projects/synthetic/pipenv-python3/Pipfile.lock")
-                val expectedResultFile = getAssetFile("projects/synthetic/pipenv-python3-expected-output.yml")
-
-                val result = createPipenv().resolveSingleProject(definitionFile)
-
-                result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-            }
+            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
     }
 
-    private fun createPipenv() =
-        Pipenv("Pipenv", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())
-}
+    "Python 3" should {
+        "resolve dependencies correctly for a Django project" {
+            val definitionFile = getAssetFile("projects/synthetic/pipenv-python3/Pipfile.lock")
+            val expectedResultFile = getAssetFile("projects/synthetic/pipenv-python3-expected-output.yml")
+
+            val result = createPipenv().resolveSingleProject(definitionFile)
+
+            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
+        }
+    }
+})
+
+private fun createPipenv() = Pipenv("Pipenv", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())

--- a/plugins/package-managers/python/src/funTest/kotlin/PoetryFunTest.kt
+++ b/plugins/package-managers/python/src/funTest/kotlin/PoetryFunTest.kt
@@ -30,20 +30,17 @@ import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
-class PoetryFunTest : WordSpec() {
-    init {
-        "Python 3" should {
-            "resolve dependencies correctly" {
-                val definitionFile = getAssetFile("projects/synthetic/poetry/poetry.lock")
-                val expectedResultFile = getAssetFile("projects/synthetic/poetry-expected-output.yml")
+class PoetryFunTest : WordSpec({
+    "Python 3" should {
+        "resolve dependencies correctly" {
+            val definitionFile = getAssetFile("projects/synthetic/poetry/poetry.lock")
+            val expectedResultFile = getAssetFile("projects/synthetic/poetry-expected-output.yml")
 
-                val result = createPoetry().resolveSingleProject(definitionFile)
+            val result = createPoetry().resolveSingleProject(definitionFile)
 
-                result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
-            }
+            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
     }
+})
 
-    private fun createPoetry() =
-        Poetry("Poetry", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())
-}
+private fun createPoetry() = Poetry("Poetry", USER_DIR, AnalyzerConfiguration(), RepositoryConfiguration())

--- a/plugins/package-managers/python/src/funTest/kotlin/PoetryFunTest.kt
+++ b/plugins/package-managers/python/src/funTest/kotlin/PoetryFunTest.kt
@@ -23,37 +23,23 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.analyzer.managers.resolveSingleProject
-import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
-import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.getAssetFile
-import org.ossreviewtoolkit.utils.test.patchExpectedResult
+import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class PoetryFunTest : WordSpec() {
-    private val projectsDir = getAssetFile("projects")
-    private val vcsDir = VersionControlSystem.forDirectory(projectsDir)!!
-    private val vcsUrl = vcsDir.getRemoteUrl()
-    private val vcsRevision = vcsDir.getRevision()
-
     init {
         "Python 3" should {
             "resolve dependencies correctly" {
-                val definitionFile = projectsDir.resolve("synthetic/poetry/poetry.lock")
-                val vcsPath = vcsDir.getPathToRoot(definitionFile.parentFile)
+                val definitionFile = getAssetFile("projects/synthetic/poetry/poetry.lock")
+                val expectedResultFile = getAssetFile("projects/synthetic/poetry-expected-output.yml")
 
                 val result = createPoetry().resolveSingleProject(definitionFile)
-                val expectedResultFile = projectsDir.resolve("synthetic/poetry-expected-output.yml")
-                val expectedResult = patchExpectedResult(
-                    expectedResultFile,
-                    url = normalizeVcsUrl(vcsUrl),
-                    revision = vcsRevision,
-                    path = vcsPath
-                )
 
-                result.toYaml() shouldBe expectedResult
+                result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
             }
         }
     }

--- a/utils/test/src/main/kotlin/Utils.kt
+++ b/utils/test/src/main/kotlin/Utils.kt
@@ -80,7 +80,11 @@ fun patchExpectedResult(
         .replaceIfNotNull("<REPLACE_URL_PROCESSED>", urlProcessed)
 }
 
-fun patchExpectedResult2(expectedResultFile: File, definitionFile: File): String {
+fun patchExpectedResult2(
+    expectedResultFile: File,
+    definitionFile: File,
+    custom: Map<String, String> = emptyMap()
+): String {
     val projectDir = definitionFile.parentFile
     val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
     val vcsUrl = vcsDir.getRemoteUrl()
@@ -93,7 +97,8 @@ fun patchExpectedResult2(expectedResultFile: File, definitionFile: File): String
         absoluteDefinitionFilePath = definitionFile.absolutePath,
         path = vcsPath,
         revision = vcsRevision,
-        url = normalizeVcsUrl(vcsUrl)
+        url = normalizeVcsUrl(vcsUrl),
+        custom = custom
     )
 }
 


### PR DESCRIPTION
See individual commits.