### PR TITLE
fix(SpdxDocumentModelMapper): Only reset concluded licenses for sources

### DIFF
--- a/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
+++ b/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
@@ -59,7 +59,7 @@
     "filesAnalyzed" : true,
     "homepage" : "first package's homepage URL",
     "licenseConcluded" : "NOASSERTION",
-    "licenseDeclared" : "NOASSERTION",
+    "licenseDeclared" : "BSD-3-Clause AND (MIT OR GPL-2.0-only)",
     "licenseInfoFromFiles" : [ "Apache-2.0", "BSD-2-Clause" ],
     "name" : "first-package",
     "packageVerificationCode" : {
@@ -79,7 +79,7 @@
     "filesAnalyzed" : true,
     "homepage" : "first package's homepage URL",
     "licenseConcluded" : "NOASSERTION",
-    "licenseDeclared" : "NOASSERTION",
+    "licenseDeclared" : "BSD-3-Clause AND (MIT OR GPL-2.0-only)",
     "licenseInfoFromFiles" : [ "Apache-2.0", "BSD-2-Clause" ],
     "name" : "first-package",
     "packageVerificationCode" : {

--- a/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
+++ b/reporter/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
@@ -73,7 +73,7 @@ packages:
   filesAnalyzed: true
   homepage: "first package's homepage URL"
   licenseConcluded: "NOASSERTION"
-  licenseDeclared: "NOASSERTION"
+  licenseDeclared: "BSD-3-Clause AND (MIT OR GPL-2.0-only)"
   licenseInfoFromFiles:
   - "Apache-2.0"
   - "BSD-2-Clause"
@@ -96,7 +96,7 @@ packages:
   filesAnalyzed: true
   homepage: "first package's homepage URL"
   licenseConcluded: "NOASSERTION"
-  licenseDeclared: "NOASSERTION"
+  licenseDeclared: "BSD-3-Clause AND (MIT OR GPL-2.0-only)"
   licenseInfoFromFiles:
   - "Apache-2.0"
   - "BSD-2-Clause"

--- a/reporter/src/main/kotlin/reporters/spdx/SpdxDocumentModelMapper.kt
+++ b/reporter/src/main/kotlin/reporters/spdx/SpdxDocumentModelMapper.kt
@@ -119,8 +119,8 @@ object SpdxDocumentModelMapper {
                     spdxId = "${binaryPackage.spdxId}-vcs",
                     filesAnalyzed = filesAnalyzed,
                     downloadLocation = pkg.vcsProcessed.toSpdxDownloadLocation(provenance?.resolvedRevision),
+                    // Clear the concluded license as it might need to be different for the VCS location.
                     licenseConcluded = SpdxConstants.NOASSERTION,
-                    licenseDeclared = SpdxConstants.NOASSERTION,
                     packageVerificationCode = packageVerificationCode
                 )
 
@@ -151,8 +151,8 @@ object SpdxDocumentModelMapper {
                     spdxId = "${binaryPackage.spdxId}-source-artifact",
                     filesAnalyzed = filesAnalyzed,
                     downloadLocation = curatedPackage.metadata.sourceArtifact.url.nullOrBlankToSpdxNone(),
+                    // Clear the concluded license as it might need to be different for the source artifact.
                     licenseConcluded = SpdxConstants.NOASSERTION,
-                    licenseDeclared = SpdxConstants.NOASSERTION,
                     packageVerificationCode = packageVerificationCode
                 )
 


### PR DESCRIPTION
As a single SPDX package cannot capture the same amount of metadata as an
ORT package can, the `SpdxDocumentModelMapper` creates up to three SPDX
packages for a single ORT package: A binary package, a VCS source package,
and a source artifact package. The latter two copy all properties from the
binary package while adjusting esp. the `downloadLocation`. As part of
these adjustments, the licenses were reset to `NOASSERTION` until now.

However, that is inconsistent and misleading, as there has been an attempt
made to determine the declared license from metadata, and metadata is
usually stored in definition files along with the source code. Thus,
source packages should contain `licenseDeclared` from the binary package
at least as a subset.

Note that detected licenses, if any, would go into the separate
`licenseInfoFromFiles` property, also see the currently pending #6757.