### PR TITLE
Make the use of replace patterns consistent

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-py.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-py.yml
@@ -16,7 +16,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-txt.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/conan-expected-output-txt.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-direct-dependencies-only-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-direct-dependencies-only-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output-with-nuspec.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output-with-nuspec.yml
@@ -17,7 +17,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/dotnet-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/glide-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/glide-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/godep-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/godep-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/godeps-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/godeps-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-expected-output.yml
@@ -6,12 +6,12 @@ project:
   declared_licenses_processed: {}
   vcs:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-no-deps-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-no-deps-expected-output.yml
@@ -6,12 +6,12 @@ project:
   declared_licenses_processed: {}
   vcs:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-subpkg-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-subpkg-expected-output.yml
@@ -6,12 +6,12 @@ project:
   declared_licenses_processed: {}
   vcs:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/gomod-unused-deps-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/gomod-unused-deps-expected-output.yml
@@ -6,12 +6,12 @@ project:
   declared_licenses_processed: {}
   vcs:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-app.yml
@@ -18,7 +18,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/maven/app"
   homepage_url: "http://maven.apache.org"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-lib.yml
@@ -18,7 +18,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/maven/lib"
   homepage_url: "http://maven.apache.org"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-root.yml
@@ -18,7 +18,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/maven"
   homepage_url: "http://maven.apache.org"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-scope-excludes.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-expected-output-scope-excludes.yml
@@ -18,7 +18,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/maven/lib"
   homepage_url: "http://maven.apache.org"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-parent-expected-output-root.yml
@@ -18,7 +18,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/maven-parent"
   homepage_url: "http://maven.apache.org"

--- a/analyzer/src/funTest/assets/projects/synthetic/maven-wagon-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/maven-wagon-expected-output.yml
@@ -15,7 +15,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/maven-wagon"
   homepage_url: "http://maven.apache.org"

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-babel-expected-output.yml
@@ -13,7 +13,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/npm-babel"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-no-lockfile.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-no-lockfile.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-scope-excludes.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output-scope-excludes.yml
@@ -15,7 +15,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-expected-output.yml
@@ -15,7 +15,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/npm-version-urls-expected-output.yml
@@ -13,7 +13,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-direct-dependencies-only-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-direct-dependencies-only-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/nuget-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/pnpm-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pnpm-expected-output.yml
@@ -13,7 +13,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces-expected-output.yml
@@ -2,7 +2,7 @@
 repository:
   vcs:
     type: "Git"
-    url: "<REPLACE_RAW_URL>"
+    url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces"
   vcs_processed:
@@ -625,7 +625,7 @@ analyzer:
           algorithm: ""
       vcs:
         type: "Git"
-        url: "<REPLACE_RAW_URL>"
+        url: "<REPLACE_URL>"
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces"
       vcs_processed:
@@ -776,7 +776,7 @@ analyzer:
           algorithm: ""
       vcs:
         type: "Git"
-        url: "<REPLACE_RAW_URL>"
+        url: "<REPLACE_URL>"
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/src/packages/package-a"
       vcs_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces-expected-output.yml
@@ -7,7 +7,7 @@ repository:
     path: "analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces"
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   config: {}
@@ -42,7 +42,7 @@ analyzer:
         path: ""
       vcs_processed:
         type: "Git"
-        url: "<REPLACE_URL>"
+        url: "<REPLACE_URL_PROCESSED>"
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces"
       homepage_url: ""
@@ -114,7 +114,7 @@ analyzer:
         path: ""
       vcs_processed:
         type: "Git"
-        url: "<REPLACE_URL>"
+        url: "<REPLACE_URL_PROCESSED>"
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/src/non-workspace/package-c"
       homepage_url: ""
@@ -630,7 +630,7 @@ analyzer:
         path: "analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces"
       vcs_processed:
         type: "Git"
-        url: "<REPLACE_URL>"
+        url: "<REPLACE_URL_PROCESSED>"
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces"
     - id: "NPM::require-uncached:2.0.0"
@@ -781,7 +781,7 @@ analyzer:
         path: "analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/src/packages/package-a"
       vcs_processed:
         type: "Git"
-        url: "<REPLACE_URL>"
+        url: "<REPLACE_URL_PROCESSED>"
         revision: "<REPLACE_REVISION>"
         path: "analyzer/src/funTest/assets/projects/synthetic/pnpm-workspaces/src/packages/package-a"
     has_issues: false

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-expected-output.yml
@@ -13,7 +13,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces-expected-output.yml
@@ -77,7 +77,7 @@ packages:
       algorithm: ""
   vcs:
     type: "Git"
-    url: "<REPLACE_RAW_URL>"
+    url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg2"
   vcs_processed:
@@ -165,7 +165,7 @@ packages:
       algorithm: ""
   vcs:
     type: "Git"
-    url: "<REPLACE_RAW_URL>"
+    url: "<REPLACE_URL>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg1"
   vcs_processed:

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces-expected-output.yml
@@ -13,7 +13,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces"
   homepage_url: ""
@@ -82,7 +82,7 @@ packages:
     path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg2"
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg2"
 - id: "NPM:@here:harp-fetch:0.3.6"
@@ -170,6 +170,6 @@ packages:
     path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg1"
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/yarn-workspaces/packages/pkg1"

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn2-expected-output-scope-excludes.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn2-expected-output-scope-excludes.yml
@@ -13,7 +13,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn2-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn2-expected-output.yml
@@ -13,7 +13,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/analyzer/src/funTest/assets/projects/synthetic/yarn2-workspaces-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/yarn2-workspaces-expected-output.yml
@@ -13,7 +13,7 @@ projects:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/yarn2-workspaces"
   homepage_url: ""
@@ -36,7 +36,7 @@ projects:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/yarn2-workspaces"
   homepage_url: ""
@@ -54,7 +54,7 @@ projects:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "analyzer/src/funTest/assets/projects/synthetic/yarn2-workspaces"
   homepage_url: ""

--- a/analyzer/src/funTest/kotlin/managers/GoDepFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoDepFunTest.kt
@@ -61,7 +61,7 @@ class GoDepFunTest : WordSpec() {
 
                 val expectedResult = patchExpectedResult(
                     projectsDir.resolve("synthetic/godep-expected-output.yml"),
-                    url = normalizedVcsUrl,
+                    urlProcessed = normalizedVcsUrl,
                     revision = vcsRevision,
                     path = vcsPath,
                     custom = mapOf("<REPLACE_GITHUB_PROJECT>" to gitHubProject)
@@ -104,7 +104,7 @@ class GoDepFunTest : WordSpec() {
 
                 val expectedResult = patchExpectedResult(
                     projectsDir.resolve("synthetic/glide-expected-output.yml"),
-                    url = normalizedVcsUrl,
+                    urlProcessed = normalizedVcsUrl,
                     revision = vcsRevision,
                     path = vcsPath,
                     custom = mapOf("<REPLACE_GITHUB_PROJECT>" to gitHubProject)
@@ -121,7 +121,7 @@ class GoDepFunTest : WordSpec() {
 
                 val expectedResult = patchExpectedResult(
                     projectsDir.resolve("synthetic/godeps-expected-output.yml"),
-                    url = normalizedVcsUrl,
+                    urlProcessed = normalizedVcsUrl,
                     revision = vcsRevision,
                     path = vcsPath,
                     custom = mapOf("<REPLACE_GITHUB_PROJECT>" to gitHubProject)

--- a/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
@@ -50,7 +50,7 @@ class NpmVersionUrlFunTest : WordSpec({
             val expectedResultYaml = patchExpectedResult(
                 projectDir.resolveSibling("npm-version-urls-expected-output.yml"),
                 definitionFilePath = "$vcsPath/package.json",
-                url = normalizeVcsUrl(vcsUrl),
+                urlProcessed = normalizeVcsUrl(vcsUrl),
                 revision = vcsRevision,
                 path = vcsPath
             )

--- a/analyzer/src/funTest/kotlin/managers/NuGetFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NuGetFunTest.kt
@@ -70,7 +70,7 @@ class NuGetFunTest : StringSpec({
         val vcsPath = vcsDir.getPathToRoot(projectDir)
         val expectedResult = patchExpectedResult(
             projectDir.resolveSibling("nuget-expected-output.yml"),
-            url = normalizeVcsUrl(vcsUrl),
+            urlProcessed = normalizeVcsUrl(vcsUrl),
             revision = vcsRevision,
             path = vcsPath
         )
@@ -83,7 +83,7 @@ class NuGetFunTest : StringSpec({
         val vcsPath = vcsDir.getPathToRoot(projectDir)
         val expectedResult = patchExpectedResult(
             projectDir.resolveSibling("nuget-direct-dependencies-only-expected-output.yml"),
-            url = normalizeVcsUrl(vcsUrl),
+            urlProcessed = normalizeVcsUrl(vcsUrl),
             revision = vcsRevision,
             path = vcsPath
         )

--- a/analyzer/src/funTest/kotlin/managers/PnpmFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PnpmFunTest.kt
@@ -79,9 +79,9 @@ private fun getExpectedResult(projectDir: File, expectedResultTemplateFile: Stri
     return patchExpectedResult(
         result = expectedOutputTemplate,
         definitionFilePath = "$vcsPath/package.json",
+        url = vcsUrl,
         urlProcessed = normalizeVcsUrl(vcsUrl),
         revision = vcsRevision,
-        path = vcsPath,
-        custom = mapOf("<REPLACE_RAW_URL>" to vcsUrl)
+        path = vcsPath
     )
 }

--- a/analyzer/src/funTest/kotlin/managers/PnpmFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/PnpmFunTest.kt
@@ -79,7 +79,7 @@ private fun getExpectedResult(projectDir: File, expectedResultTemplateFile: Stri
     return patchExpectedResult(
         result = expectedOutputTemplate,
         definitionFilePath = "$vcsPath/package.json",
-        url = normalizeVcsUrl(vcsUrl),
+        urlProcessed = normalizeVcsUrl(vcsUrl),
         revision = vcsRevision,
         path = vcsPath,
         custom = mapOf("<REPLACE_RAW_URL>" to vcsUrl)

--- a/analyzer/src/funTest/kotlin/managers/Yarn2FunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/Yarn2FunTest.kt
@@ -85,10 +85,10 @@ private fun getExpectedResult(projectDir: File, expectedResultTemplateFile: Stri
     return patchExpectedResult(
         result = expectedOutputTemplate,
         definitionFilePath = "$vcsPath/package.json",
+        url = vcsUrl,
         urlProcessed = normalizeVcsUrl(vcsUrl),
         revision = vcsRevision,
-        path = vcsPath,
-        custom = mapOf("<REPLACE_RAW_URL>" to vcsUrl)
+        path = vcsPath
     )
 }
 

--- a/analyzer/src/funTest/kotlin/managers/Yarn2FunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/Yarn2FunTest.kt
@@ -85,7 +85,7 @@ private fun getExpectedResult(projectDir: File, expectedResultTemplateFile: Stri
     return patchExpectedResult(
         result = expectedOutputTemplate,
         definitionFilePath = "$vcsPath/package.json",
-        url = normalizeVcsUrl(vcsUrl),
+        urlProcessed = normalizeVcsUrl(vcsUrl),
         revision = vcsRevision,
         path = vcsPath,
         custom = mapOf("<REPLACE_RAW_URL>" to vcsUrl)

--- a/analyzer/src/funTest/kotlin/managers/YarnFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/YarnFunTest.kt
@@ -44,10 +44,10 @@ class YarnFunTest : WordSpec() {
         return patchExpectedResult(
             result = expectedOutputTemplate,
             definitionFilePath = "$vcsPath/package.json",
+            url = vcsUrl,
             urlProcessed = normalizeVcsUrl(vcsUrl),
             revision = vcsRevision,
-            path = vcsPath,
-            custom = mapOf("<REPLACE_RAW_URL>" to vcsUrl)
+            path = vcsPath
         )
     }
 

--- a/analyzer/src/funTest/kotlin/managers/YarnFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/YarnFunTest.kt
@@ -44,7 +44,7 @@ class YarnFunTest : WordSpec() {
         return patchExpectedResult(
             result = expectedOutputTemplate,
             definitionFilePath = "$vcsPath/package.json",
-            url = normalizeVcsUrl(vcsUrl),
+            urlProcessed = normalizeVcsUrl(vcsUrl),
             revision = vcsRevision,
             path = vcsPath,
             custom = mapOf("<REPLACE_RAW_URL>" to vcsUrl)

--- a/plugins/package-managers/bower/src/funTest/assets/projects/synthetic/bower-expected-output.yml
+++ b/plugins/package-managers/bower/src/funTest/assets/projects/synthetic/bower-expected-output.yml
@@ -16,7 +16,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: "https://github.com/oss-review-toolkit/ort"

--- a/plugins/package-managers/bundler/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
+++ b/plugins/package-managers/bundler/src/funTest/assets/projects/synthetic/bundler-expected-output-gemspec.yml
@@ -13,7 +13,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/bundler/src/funTest/assets/projects/synthetic/gemspec"
   homepage_url: ""

--- a/plugins/package-managers/bundler/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
+++ b/plugins/package-managers/bundler/src/funTest/assets/projects/synthetic/bundler-expected-output-lockfile.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/plugins/package-managers/cargo/src/funTest/assets/projects/synthetic/cargo-expected-output.yml
+++ b/plugins/package-managers/cargo/src/funTest/assets/projects/synthetic/cargo-expected-output.yml
@@ -18,7 +18,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: "https://example.org"

--- a/plugins/package-managers/cargo/src/funTest/assets/projects/synthetic/cargo-subcrate-client-expected-output.yml
+++ b/plugins/package-managers/cargo/src/funTest/assets/projects/synthetic/cargo-subcrate-client-expected-output.yml
@@ -13,7 +13,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/plugins/package-managers/cargo/src/funTest/assets/projects/synthetic/cargo-subcrate-integration-expected-output.yml
+++ b/plugins/package-managers/cargo/src/funTest/assets/projects/synthetic/cargo-subcrate-integration-expected-output.yml
@@ -13,7 +13,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/plugins/package-managers/cargo/src/funTest/assets/projects/synthetic/cargo-subcrate-lib-expected-output.yml
+++ b/plugins/package-managers/cargo/src/funTest/assets/projects/synthetic/cargo-subcrate-lib-expected-output.yml
@@ -14,7 +14,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: "https://example.org"

--- a/plugins/package-managers/carthage/src/funTest/assets/projects/synthetic/carthage-expected-output.yml
+++ b/plugins/package-managers/carthage/src/funTest/assets/projects/synthetic/carthage-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/plugins/package-managers/carthage/src/funTest/kotlin/CarthageFunTest.kt
+++ b/plugins/package-managers/carthage/src/funTest/kotlin/CarthageFunTest.kt
@@ -50,7 +50,7 @@ class CarthageFunTest : StringSpec() {
                 definitionFilePath = "$vcsPath/Cartfile.resolved",
                 path = vcsPath,
                 revision = vcsRevision,
-                url = normalizedVcsUrl,
+                urlProcessed = normalizedVcsUrl,
                 custom = mapOf("<REPLACE_GITHUB_PROJECT>" to gitHubProject)
             )
 

--- a/plugins/package-managers/cocoapods/src/funTest/assets/projects/synthetic/dep-tree-expected-output.yml
+++ b/plugins/package-managers/cocoapods/src/funTest/assets/projects/synthetic/dep-tree-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/plugins/package-managers/cocoapods/src/funTest/assets/projects/synthetic/no-lockfile-expected-output.yml
+++ b/plugins/package-managers/cocoapods/src/funTest/assets/projects/synthetic/no-lockfile-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/plugins/package-managers/cocoapods/src/funTest/assets/projects/synthetic/regular-expected-output.yml
+++ b/plugins/package-managers/cocoapods/src/funTest/assets/projects/synthetic/regular-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/plugins/package-managers/composer/src/funTest/assets/projects/synthetic/composer-expected-output-no-deps.yml
+++ b/plugins/package-managers/composer/src/funTest/assets/projects/synthetic/composer-expected-output-no-deps.yml
@@ -17,7 +17,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: "https://github.com/oss-review-toolkit/ort"

--- a/plugins/package-managers/composer/src/funTest/assets/projects/synthetic/composer-expected-output-with-provide.yml
+++ b/plugins/package-managers/composer/src/funTest/assets/projects/synthetic/composer-expected-output-with-provide.yml
@@ -14,7 +14,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: "https://github.com/oss-review-toolkit/ort"

--- a/plugins/package-managers/composer/src/funTest/assets/projects/synthetic/composer-expected-output-with-replace.yml
+++ b/plugins/package-managers/composer/src/funTest/assets/projects/synthetic/composer-expected-output-with-replace.yml
@@ -14,7 +14,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: "https://github.com/oss-review-toolkit/ort"

--- a/plugins/package-managers/composer/src/funTest/assets/projects/synthetic/composer-expected-output.yml
+++ b/plugins/package-managers/composer/src/funTest/assets/projects/synthetic/composer-expected-output.yml
@@ -14,7 +14,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: "https://github.com/oss-review-toolkit/ort"

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-android-cyclic-expected-output-app.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-android-cyclic-expected-output-app.yml
@@ -13,7 +13,7 @@ project_results:
         path: ""
       vcs_processed:
         type: "Git"
-        url: "<REPLACE_URL>"
+        url: "<REPLACE_URL_PROCESSED>"
         revision: "<REPLACE_REVISION>"
         path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-android-cyclic/app"
       homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-android-expected-output-app.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-android/app"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-android-expected-output-lib.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-android/lib"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-android-expected-output-root.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-android"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-bom-expected-output.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-bom-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-bom"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-composite-expected-output.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-composite-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-composite/project1"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-app-2.14.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle/app"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-app-3.4.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle/app"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-app.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle/app"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-lib-without-repo.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle/lib-without-repo"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-lib.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle/lib"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-root.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-scopes-excludes.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-scopes-excludes.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle/app"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-expected-output-unsupported-version.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-unsupported-version"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-library-expected-output-app.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-library/app"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-library-expected-output-lib.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-library/lib"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-library-expected-output-root.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-library-expected-output-root.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle-library"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/multi-kotlin-project-expected-output-cli.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/multi-kotlin-project-expected-output-cli.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/multi-kotlin-project/cli"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/multi-kotlin-project-expected-output-core.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/multi-kotlin-project-expected-output-core.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/multi-kotlin-project/core"
   homepage_url: ""

--- a/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/multi-kotlin-project-expected-output-root.yml
+++ b/plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/multi-kotlin-project-expected-output-root.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/multi-kotlin-project"
   homepage_url: ""

--- a/plugins/package-managers/pub/src/funTest/assets/projects/synthetic/pub-expected-output-any-version.yml
+++ b/plugins/package-managers/pub/src/funTest/assets/projects/synthetic/pub-expected-output-any-version.yml
@@ -14,7 +14,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: "http://oss-review-toolkit.org/"

--- a/plugins/package-managers/pub/src/funTest/assets/projects/synthetic/pub-expected-output-multi-module.yml
+++ b/plugins/package-managers/pub/src/funTest/assets/projects/synthetic/pub-expected-output-multi-module.yml
@@ -13,7 +13,7 @@ projects:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: "https://ossreviewtoolkit.org/"
@@ -38,7 +38,7 @@ projects:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>/subproject"
   homepage_url: "https://ossreviewtoolkit.org/"

--- a/plugins/package-managers/pub/src/funTest/assets/projects/synthetic/pub-expected-output-with-flutter-android-and-cocoapods.yml
+++ b/plugins/package-managers/pub/src/funTest/assets/projects/synthetic/pub-expected-output-with-flutter-android-and-cocoapods.yml
@@ -11,7 +11,7 @@ projects:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "plugins/package-managers/pub/src/funTest/assets/projects/synthetic/flutter-project-with-android-and-cocoapods"
   homepage_url: ""

--- a/plugins/package-managers/pub/src/funTest/kotlin/PubFunTest.kt
+++ b/plugins/package-managers/pub/src/funTest/kotlin/PubFunTest.kt
@@ -125,7 +125,7 @@ class PubFunTest : WordSpec() {
 
         return patchExpectedResult(
             expectedResultDir.resolve(expectedResultFilename),
-            url = normalizeVcsUrl(vcsUrl),
+            urlProcessed = normalizeVcsUrl(vcsUrl),
             revision = vcsRevision,
             path = vcsPath
         )

--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pip-expected-output.yml
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pip-expected-output.yml
@@ -15,7 +15,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: "https://example.org/app"

--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pip-python3-expected-output.yml
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pip-python3-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pipenv-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pipenv-python3-expected-output.yml
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/pipenv-python3-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/poetry-expected-output.yml
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/poetry-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/plugins/package-managers/python/src/funTest/assets/projects/synthetic/python-inspector-expected-output.yml
+++ b/plugins/package-managers/python/src/funTest/assets/projects/synthetic/python-inspector-expected-output.yml
@@ -11,7 +11,7 @@ project:
     path: ""
   vcs_processed:
     type: "Git"
-    url: "<REPLACE_URL>"
+    url: "<REPLACE_URL_PROCESSED>"
     revision: "<REPLACE_REVISION>"
     path: "<REPLACE_PATH>"
   homepage_url: ""

--- a/utils/test/src/main/kotlin/Utils.kt
+++ b/utils/test/src/main/kotlin/Utils.kt
@@ -97,7 +97,8 @@ fun patchExpectedResult2(
         absoluteDefinitionFilePath = definitionFile.absolutePath,
         path = vcsPath,
         revision = vcsRevision,
-        url = normalizeVcsUrl(vcsUrl),
+        url = vcsUrl,
+        urlProcessed = normalizeVcsUrl(vcsUrl),
         custom = custom
     )
 }


### PR DESCRIPTION
Align on using `<REPLACE_URL>` for inserting raw URLs and `<REPLACE_URL_PROCESSED>` for inserting processed URLs.
Eliminate `<REPLACE_RAW_URL>` and use `<REPLACE_URL>` instead.