### PR TITLE
Migrate remaining test code to `patchExpectedResult2()`

### DIFF
--- a/analyzer/src/funTest/assets/projects/synthetic/glide-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/glide-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "GoDep::<REPLACE_GITHUB_PROJECT>/analyzer/src/funtest/assets/projects/synthetic/godep/glide:<REPLACE_REVISION>"
+  id: "GoDep::github.com/oss-review-toolkit/ort/analyzer/src/funtest/assets/projects/synthetic/godep/glide:<REPLACE_REVISION>"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/godep/glide/glide.yaml"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/godep-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/godep-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "GoDep::<REPLACE_GITHUB_PROJECT>/analyzer/src/funtest/assets/projects/synthetic/godep/lockfile:<REPLACE_REVISION>"
+  id: "GoDep::github.com/oss-review-toolkit/ort/analyzer/src/funtest/assets/projects/synthetic/godep/lockfile:<REPLACE_REVISION>"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/godep/lockfile/Gopkg.toml"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/assets/projects/synthetic/godeps-expected-output.yml
+++ b/analyzer/src/funTest/assets/projects/synthetic/godeps-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "GoDep::<REPLACE_GITHUB_PROJECT>/analyzer/src/funtest/assets/projects/synthetic/godep/godeps/godeps:<REPLACE_REVISION>"
+  id: "GoDep::github.com/oss-review-toolkit/ort/analyzer/src/funtest/assets/projects/synthetic/godep/godeps/godeps:<REPLACE_REVISION>"
   definition_file_path: "analyzer/src/funTest/assets/projects/synthetic/godep/godeps/Godeps/Godeps.json"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/analyzer/src/funTest/kotlin/managers/GoDepFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/GoDepFunTest.kt
@@ -34,7 +34,6 @@ import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
-import org.ossreviewtoolkit.utils.common.replaceCredentialsInUri
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.getAssetFile
@@ -48,8 +47,6 @@ class GoDepFunTest : WordSpec() {
     private val vcsRevision = vcsDir.getRevision()
 
     private val normalizedVcsUrl = normalizeVcsUrl(vcsUrl)
-    private val gitHubProject = normalizedVcsUrl.replaceCredentialsInUri()
-        .substringAfter("://").substringBefore(".git")
 
     init {
         "GoDep" should {
@@ -63,8 +60,7 @@ class GoDepFunTest : WordSpec() {
                     projectsDir.resolve("synthetic/godep-expected-output.yml"),
                     urlProcessed = normalizedVcsUrl,
                     revision = vcsRevision,
-                    path = vcsPath,
-                    custom = mapOf("<REPLACE_GITHUB_PROJECT>" to gitHubProject)
+                    path = vcsPath
                 )
 
                 result.toYaml() shouldBe expectedResult
@@ -106,8 +102,7 @@ class GoDepFunTest : WordSpec() {
                     projectsDir.resolve("synthetic/glide-expected-output.yml"),
                     urlProcessed = normalizedVcsUrl,
                     revision = vcsRevision,
-                    path = vcsPath,
-                    custom = mapOf("<REPLACE_GITHUB_PROJECT>" to gitHubProject)
+                    path = vcsPath
                 )
 
                 result.toYaml() shouldBe expectedResult
@@ -123,8 +118,7 @@ class GoDepFunTest : WordSpec() {
                     projectsDir.resolve("synthetic/godeps-expected-output.yml"),
                     urlProcessed = normalizedVcsUrl,
                     revision = vcsRevision,
-                    path = vcsPath,
-                    custom = mapOf("<REPLACE_GITHUB_PROJECT>" to gitHubProject)
+                    path = vcsPath
                 )
 
                 result.toYaml() shouldBe expectedResult

--- a/analyzer/src/funTest/kotlin/managers/NpmFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmFunTest.kt
@@ -26,8 +26,6 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 
-import java.time.Instant
-
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
@@ -155,7 +153,3 @@ private fun createNpm(
     repoConfig: RepositoryConfiguration = RepositoryConfiguration()
 ) =
     Npm("NPM", USER_DIR, analyzerConfig, repoConfig)
-
-private fun ProjectAnalyzerResult.withInvariantIssues() =
-    // Account for different NPM versions to return issues in different order.
-    copy(issues = issues.sortedBy { it.message }.map { it.copy(timestamp = Instant.EPOCH) })

--- a/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
@@ -24,8 +24,6 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
-import java.time.Instant
-
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
@@ -51,7 +49,3 @@ class NpmVersionUrlFunTest : WordSpec({
 
 private fun createNpm() =
     Npm("NPM", USER_DIR, AnalyzerConfiguration(allowDynamicVersions = true), RepositoryConfiguration())
-
-private fun ProjectAnalyzerResult.withInvariantIssues() =
-    // Account for different NPM versions to return issues in different order.
-    copy(issues = issues.sortedBy { it.message }.map { it.copy(timestamp = Instant.EPOCH) })

--- a/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
@@ -45,7 +45,6 @@ class NpmVersionUrlFunTest : WordSpec({
     "NPM" should {
         "resolve dependencies with URLs as versions correctly" {
             val definitionFile = projectDir.resolve("package.json")
-            val config = AnalyzerConfiguration(allowDynamicVersions = true)
             val vcsPath = vcsDir.getPathToRoot(projectDir)
             val expectedResultYaml = patchExpectedResult(
                 projectDir.resolveSibling("npm-version-urls-expected-output.yml"),
@@ -56,14 +55,15 @@ class NpmVersionUrlFunTest : WordSpec({
             )
             val expectedResult = yamlMapper.readValue<ProjectAnalyzerResult>(expectedResultYaml)
 
-            val actualResult = createNpm(config).resolveSingleProject(definitionFile, resolveScopes = true)
+            val actualResult = createNpm().resolveSingleProject(definitionFile, resolveScopes = true)
 
             actualResult.withInvariantIssues() shouldBe expectedResult.withInvariantIssues()
         }
     }
 })
 
-private fun createNpm(config: AnalyzerConfiguration) = Npm("NPM", USER_DIR, config, RepositoryConfiguration())
+private fun createNpm() =
+    Npm("NPM", USER_DIR, AnalyzerConfiguration(allowDynamicVersions = true), RepositoryConfiguration())
 
 private fun ProjectAnalyzerResult.withInvariantIssues() =
     // Account for different NPM versions to return issues in different order.

--- a/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NpmVersionUrlFunTest.kt
@@ -26,37 +26,24 @@ import io.kotest.matchers.shouldBe
 
 import java.time.Instant
 
-import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.yamlMapper
-import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.getAssetFile
-import org.ossreviewtoolkit.utils.test.patchExpectedResult
+import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 
 class NpmVersionUrlFunTest : WordSpec({
-    val projectDir = getAssetFile("projects/synthetic/npm-version-urls")
-    val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
-    val vcsUrl = vcsDir.getRemoteUrl()
-    val vcsRevision = vcsDir.getRevision()
-
     "NPM" should {
         "resolve dependencies with URLs as versions correctly" {
-            val definitionFile = projectDir.resolve("package.json")
-            val vcsPath = vcsDir.getPathToRoot(projectDir)
-            val expectedResultYaml = patchExpectedResult(
-                projectDir.resolveSibling("npm-version-urls-expected-output.yml"),
-                definitionFilePath = "$vcsPath/package.json",
-                urlProcessed = normalizeVcsUrl(vcsUrl),
-                revision = vcsRevision,
-                path = vcsPath
-            )
-            val expectedResult = yamlMapper.readValue<ProjectAnalyzerResult>(expectedResultYaml)
+            val definitionFile = getAssetFile("projects/synthetic/npm-version-urls/package.json")
+            val expectedResultFile = getAssetFile("projects/synthetic/npm-version-urls-expected-output.yml")
+            val expectedResult = patchExpectedResult2(expectedResultFile, definitionFile).let {
+                yamlMapper.readValue<ProjectAnalyzerResult>(it)
+            }
 
             val actualResult = createNpm().resolveSingleProject(definitionFile, resolveScopes = true)
-
             actualResult.withInvariantIssues() shouldBe expectedResult.withInvariantIssues()
         }
     }

--- a/analyzer/src/funTest/kotlin/managers/NuGetFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/NuGetFunTest.kt
@@ -26,23 +26,17 @@ import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetDependency
 import org.ossreviewtoolkit.analyzer.managers.utils.NuGetSupport.Companion.OPTION_DIRECT_DEPENDENCIES_ONLY
-import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
-import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchActualResult
-import org.ossreviewtoolkit.utils.test.patchExpectedResult
+import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class NuGetFunTest : StringSpec({
-    val projectDir = getAssetFile("projects/synthetic/nuget")
-    val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
-    val vcsUrl = vcsDir.getRemoteUrl()
-    val vcsRevision = vcsDir.getRevision()
-    val definitionFile = projectDir.resolve("packages.config")
+    val definitionFile = getAssetFile("projects/synthetic/nuget/packages.config")
 
     "Definition file is correctly read" {
         val reader = NuGetPackageFileReader()
@@ -67,29 +61,19 @@ class NuGetFunTest : StringSpec({
     }
 
     "Project dependencies are detected correctly" {
-        val vcsPath = vcsDir.getPathToRoot(projectDir)
-        val expectedResult = patchExpectedResult(
-            projectDir.resolveSibling("nuget-expected-output.yml"),
-            urlProcessed = normalizeVcsUrl(vcsUrl),
-            revision = vcsRevision,
-            path = vcsPath
-        )
+        val expectedResultFile = getAssetFile("projects/synthetic/nuget-expected-output.yml")
+
         val result = createNuGet().resolveSingleProject(definitionFile)
 
-        patchActualResult(result.toYaml()) shouldBe expectedResult
+        patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
     }
 
     "Direct project dependencies are detected correctly" {
-        val vcsPath = vcsDir.getPathToRoot(projectDir)
-        val expectedResult = patchExpectedResult(
-            projectDir.resolveSibling("nuget-direct-dependencies-only-expected-output.yml"),
-            urlProcessed = normalizeVcsUrl(vcsUrl),
-            revision = vcsRevision,
-            path = vcsPath
-        )
+        val expectedResultFile = getAssetFile("projects/synthetic/nuget-direct-dependencies-only-expected-output.yml")
+
         val result = createNuGet(directDependenciesOnly = true).resolveSingleProject(definitionFile)
 
-        patchActualResult(result.toYaml()) shouldBe expectedResult
+        patchActualResult(result.toYaml()) shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
     }
 })
 

--- a/analyzer/src/funTest/kotlin/managers/SpdxDocumentFileFunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/SpdxDocumentFileFunTest.kt
@@ -42,42 +42,28 @@ import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.getAssetFile
-import org.ossreviewtoolkit.utils.test.patchExpectedResult
+import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class SpdxDocumentFileFunTest : WordSpec({
     "resolveDependencies()" should {
         "succeed if a project with inline packages is provided" {
-            val definitionFile = projectDir.resolve("inline-packages/project-xyz.spdx.yml")
-            val expectedResult = patchExpectedResult(
-                projectDir.resolveSibling("spdx-project-xyz-expected-output.yml"),
-                definitionFilePath = vcsDir.getPathToRoot(definitionFile),
-                path = vcsDir.getPathToRoot(definitionFile.parentFile),
-                url = vcsUrl,
-                urlProcessed = normalizeVcsUrl(vcsUrl),
-                revision = vcsRevision
-            )
+            val definitionFile = getAssetFile("projects/synthetic/spdx/inline-packages/project-xyz.spdx.yml")
+            val expectedResultFile = getAssetFile("projects/synthetic/spdx-project-xyz-expected-output.yml")
 
             val actualResult = createSpdxDocumentFile().resolveSingleProject(definitionFile).toYaml()
 
-            actualResult shouldBe expectedResult
+            actualResult shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
 
         "succeed if a project with package references is provided" {
-            val definitionFile = projectDir.resolve("package-references/project-xyz.spdx.yml")
-            val expectedResult = patchExpectedResult(
-                projectDir.resolveSibling("spdx-project-xyz-expected-output.yml"),
-                definitionFilePath = vcsDir.getPathToRoot(definitionFile),
-                path = vcsDir.getPathToRoot(definitionFile.parentFile),
-                url = vcsUrl,
-                urlProcessed = normalizeVcsUrl(vcsUrl),
-                revision = vcsRevision
-            )
+            val definitionFile = getAssetFile("projects/synthetic/spdx/package-references/project-xyz.spdx.yml")
+            val expectedResultFile = getAssetFile("projects/synthetic/spdx-project-xyz-expected-output.yml")
 
             val actualResult = createSpdxDocumentFile().resolveSingleProject(definitionFile).toYaml()
 
-            actualResult shouldBe expectedResult
+            actualResult shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
 
         "succeed if no project is provided" {
@@ -192,23 +178,18 @@ class SpdxDocumentFileFunTest : WordSpec({
         }
 
         "resolve dependencies from other package managers" {
-            val testProjectDir = projectDir.resolve("subproject-conan")
-            val definitionFile = testProjectDir.resolve("project-xyz.spdx.yml")
-            val expectedResult = patchExpectedResult(
-                projectDir.resolveSibling("spdx-project-xyz-expected-output-subproject-conan.yml"),
-                definitionFilePath = vcsDir.getPathToRoot(definitionFile),
-                url = vcsUrl,
-                urlProcessed = normalizeVcsUrl(vcsUrl),
-                revision = vcsRevision
+            val definitionFile = getAssetFile("projects/synthetic/spdx/subproject-conan/project-xyz.spdx.yml")
+            val expectedResultFile = getAssetFile(
+                "projects/synthetic/spdx-project-xyz-expected-output-subproject-conan.yml"
             )
 
             val analyzer = Analyzer(AnalyzerConfiguration(allowDynamicVersions = true))
-            val managedFiles = analyzer.findManagedFiles(testProjectDir)
+            val managedFiles = analyzer.findManagedFiles(definitionFile.parentFile)
 
             val analyzerRun = analyzer.analyze(managedFiles).analyzer.shouldNotBeNull()
             val analyzerResult = analyzerRun.result.withResolvedScopes()
 
-            analyzerResult.toYaml() shouldBe expectedResult
+            analyzerResult.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
     }
 

--- a/analyzer/src/funTest/kotlin/managers/Yarn2FunTest.kt
+++ b/analyzer/src/funTest/kotlin/managers/Yarn2FunTest.kt
@@ -74,17 +74,14 @@ private fun resolveDependencies(
     definitionFile: File,
     analyzerConfig: AnalyzerConfiguration = AnalyzerConfiguration(),
     repositoryConfig: RepositoryConfiguration = RepositoryConfiguration()
-): String {
-    val result = createYarn2(analyzerConfig, repositoryConfig)
+): String =
+    createYarn2(analyzerConfig, repositoryConfig)
         .resolveSingleProject(definitionFile, resolveScopes = true)
-    return result.toYaml()
-}
+        .toYaml()
 
-private fun resolveMultipleDependencies(definitionFile: File): String {
-     val result = createYarn2().collateMultipleProjects(definitionFile)
+private fun resolveMultipleDependencies(definitionFile: File): String =
     // Remove the dependency graph and add scope information.
-    return result.withResolvedScopes().toYaml()
-}
+    createYarn2().collateMultipleProjects(definitionFile).withResolvedScopes().toYaml()
 
 private fun createYarn2(
     analyzerConfig: AnalyzerConfiguration = AnalyzerConfiguration(),

--- a/analyzer/src/testFixtures/kotlin/Extensions.kt
+++ b/analyzer/src/testFixtures/kotlin/Extensions.kt
@@ -25,6 +25,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 
 import java.io.File
+import java.time.Instant
 
 import org.ossreviewtoolkit.analyzer.AnalyzerResultBuilder
 import org.ossreviewtoolkit.analyzer.PackageManager
@@ -92,3 +93,7 @@ private fun Project.filterReferencedPackages(allPackages: Set<Package>): Set<Pac
     val projectDependencies = DependencyTreeNavigator.projectDependencies(this)
     return allPackages.filterTo(mutableSetOf()) { it.id in projectDependencies }
 }
+
+fun ProjectAnalyzerResult.withInvariantIssues() =
+    // Account for different NPM versions to return issues in different order.
+    copy(issues = issues.sortedBy { it.message }.map { it.copy(timestamp = Instant.EPOCH) })

--- a/cli/src/funTest/assets/git-repo-expected-output.yml
+++ b/cli/src/funTest/assets/git-repo-expected-output.yml
@@ -3,12 +3,12 @@ repository:
   vcs:
     type: "GitRepo"
     url: "https://github.com/oss-review-toolkit/ort-test-data-git-repo?manifest=manifest.xml"
-    revision: "<REPLACE_REVISION>"
+    revision: "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
     path: ""
   vcs_processed:
     type: "GitRepo"
     url: "https://github.com/oss-review-toolkit/ort-test-data-git-repo.git?manifest=manifest.xml"
-    revision: "<REPLACE_REVISION>"
+    revision: "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
     path: ""
   nested_repositories:
     spdx-tools:
@@ -378,7 +378,7 @@ analyzer:
         path: ""
       homepage_url: ""
       scopes: []
-    - id: "Unmanaged:manifest.xml:manifest:<REPLACE_REVISION>"
+    - id: "Unmanaged:manifest.xml:manifest:31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
       definition_file_path: ""
       declared_licenses: []
       declared_licenses_processed: {}
@@ -390,7 +390,7 @@ analyzer:
       vcs_processed:
         type: "GitRepo"
         url: "https://github.com/oss-review-toolkit/ort-test-data-git-repo?manifest=manifest.xml"
-        revision: "<REPLACE_REVISION>"
+        revision: "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
         path: ""
       homepage_url: ""
       scopes: []

--- a/cli/src/funTest/kotlin/AnalyzerFunTest.kt
+++ b/cli/src/funTest/kotlin/AnalyzerFunTest.kt
@@ -75,11 +75,7 @@ class AnalyzerFunTest : WordSpec({
 
             GitRepo().download(pkg, outputDir)
 
-            val expectedResult = patchExpectedResult(
-                getAssetFile("git-repo-expected-output.yml"),
-                revision = revision,
-                path = outputDir.invariantSeparatorsPath
-            )
+            val expectedResult = patchExpectedResult(getAssetFile("git-repo-expected-output.yml"))
 
             val ortResult = Analyzer(AnalyzerConfiguration()).run {
                 analyze(findManagedFiles(outputDir))

--- a/cli/src/funTest/kotlin/AnalyzerFunTest.kt
+++ b/cli/src/funTest/kotlin/AnalyzerFunTest.kt
@@ -67,23 +67,21 @@ class AnalyzerFunTest : WordSpec({
 
     "VcsInfo for git-repo projects" should {
         "be correctly reported" {
-            val url = "https://github.com/oss-review-toolkit/ort-test-data-git-repo?manifest=manifest.xml"
-            val revision = "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
-            val vcs = VcsInfo(VcsType.GIT_REPO, url, revision)
-            val pkg = Package.EMPTY.copy(vcsProcessed = vcs)
-            val outputDir = createTestTempDir()
+            val expectedResultFile = getAssetFile("git-repo-expected-output.yml")
+            val pkg = Package.EMPTY.copy(
+                vcsProcessed = VcsInfo(
+                    type = VcsType.GIT_REPO,
+                    url = "https://github.com/oss-review-toolkit/ort-test-data-git-repo?manifest=manifest.xml",
+                    revision = "31588aa8f8555474e1c3c66a359ec99e4cd4b1fa"
+                )
+            )
+            val outputDir = createTestTempDir().also { GitRepo().download(pkg, it) }
 
-            GitRepo().download(pkg, outputDir)
-
-            val expectedResult = patchExpectedResult(getAssetFile("git-repo-expected-output.yml"))
-
-            val ortResult = Analyzer(AnalyzerConfiguration()).run {
+            val result = Analyzer(AnalyzerConfiguration()).run {
                 analyze(findManagedFiles(outputDir))
-            }
+            }.withResolvedScopes().toYaml()
 
-            val actualResult = ortResult.withResolvedScopes().toYaml()
-
-            patchActualResult(actualResult, patchStartAndEndTime = true) shouldBe expectedResult
+            patchActualResult(result, patchStartAndEndTime = true) shouldBe patchExpectedResult(expectedResultFile)
         }
     }
 })

--- a/cli/src/funTest/kotlin/OrtMainFunTest.kt
+++ b/cli/src/funTest/kotlin/OrtMainFunTest.kt
@@ -184,7 +184,7 @@ class OrtMainFunTest : StringSpec() {
         }
 
         "Output formats are deduplicated" {
-            val inputDir = projectDir.resolve("gradle")
+            val inputDir = createTestTempDir()
 
             val stdout = runMain(
                 "-c", configFile.path,

--- a/cli/src/funTest/kotlin/OrtMainFunTest.kt
+++ b/cli/src/funTest/kotlin/OrtMainFunTest.kt
@@ -34,7 +34,6 @@ import io.kotest.matchers.shouldBe
 import java.io.File
 
 import org.ossreviewtoolkit.analyzer.PackageManager
-import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.OrtConfigurationWrapper
@@ -44,23 +43,17 @@ import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.writeValue
 import org.ossreviewtoolkit.utils.common.EnvironmentVariableFilter
 import org.ossreviewtoolkit.utils.common.redirectStdout
-import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.createSpecTempFile
 import org.ossreviewtoolkit.utils.test.createTestTempDir
 import org.ossreviewtoolkit.utils.test.getAssetFile
 import org.ossreviewtoolkit.utils.test.patchActualResult
-import org.ossreviewtoolkit.utils.test.patchExpectedResult
+import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 /**
  * A test for the main entry point of the application.
  */
 class OrtMainFunTest : StringSpec() {
-    private val projectDir = File("../plugins/package-managers/gradle/src/funTest/assets/projects/synthetic")
-    private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
-    private val vcsUrl = vcsDir.getRemoteUrl()
-    private val vcsRevision = vcsDir.getRevision()
-
     private lateinit var configFile: File
     private lateinit var outputDir: File
 
@@ -200,19 +193,18 @@ class OrtMainFunTest : StringSpec() {
         }
 
         "Analyzer creates correct output" {
-            val expectedResult = patchExpectedResult(
-                getAssetFile("gradle-all-dependencies-expected-result-with-curations.yml"),
-                url = vcsUrl,
-                revision = vcsRevision,
-                urlProcessed = normalizeVcsUrl(vcsUrl)
+            val definitionFile = File(
+                "../plugins/package-managers/gradle/src/funTest/assets/projects/synthetic/gradle/build.gradle"
             )
+            val expectedResultFile = getAssetFile("gradle-all-dependencies-expected-result-with-curations.yml")
+            val expectedResult = patchExpectedResult2(expectedResultFile, definitionFile)
 
             @Suppress("IgnoredReturnValue")
             runMain(
                 "-c", configFile.path,
                 "-P", "ort.analyzer.enabledPackageManagers=Gradle",
                 "analyze",
-                "-i", projectDir.resolve("gradle").absolutePath,
+                "-i", definitionFile.parentFile.absolutePath,
                 "-o", outputDir.path
             )
 

--- a/plugins/package-managers/carthage/src/funTest/assets/projects/synthetic/carthage-expected-output.yml
+++ b/plugins/package-managers/carthage/src/funTest/assets/projects/synthetic/carthage-expected-output.yml
@@ -1,6 +1,6 @@
 ---
 project:
-  id: "Carthage:<REPLACE_GITHUB_PROJECT>:<REPLACE_REVISION>"
+  id: "Carthage:oss-review-toolkit:ort:<REPLACE_REVISION>"
   definition_file_path: "<REPLACE_DEFINITION_FILE_PATH>"
   declared_licenses: []
   declared_licenses_processed: {}

--- a/plugins/package-managers/carthage/src/funTest/kotlin/CarthageFunTest.kt
+++ b/plugins/package-managers/carthage/src/funTest/kotlin/CarthageFunTest.kt
@@ -39,7 +39,6 @@ class CarthageFunTest : StringSpec() {
     private val vcsRevision = vcsDir.getRevision()
 
     private val normalizedVcsUrl = normalizeVcsUrl(vcsUrl)
-    private val gitHubProject = normalizedVcsUrl.split('/', '.').dropLast(1).takeLast(2).joinToString(":")
 
     init {
         "Project dependencies are detected correctly" {
@@ -50,8 +49,7 @@ class CarthageFunTest : StringSpec() {
                 definitionFilePath = "$vcsPath/Cartfile.resolved",
                 path = vcsPath,
                 revision = vcsRevision,
-                urlProcessed = normalizedVcsUrl,
-                custom = mapOf("<REPLACE_GITHUB_PROJECT>" to gitHubProject)
+                urlProcessed = normalizedVcsUrl
             )
 
             val result = createCarthage().resolveSingleProject(cartfileResolved)

--- a/plugins/package-managers/carthage/src/funTest/kotlin/CarthageFunTest.kt
+++ b/plugins/package-managers/carthage/src/funTest/kotlin/CarthageFunTest.kt
@@ -23,38 +23,22 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
 import org.ossreviewtoolkit.analyzer.managers.resolveSingleProject
-import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
-import org.ossreviewtoolkit.utils.ort.normalizeVcsUrl
 import org.ossreviewtoolkit.utils.test.USER_DIR
 import org.ossreviewtoolkit.utils.test.getAssetFile
-import org.ossreviewtoolkit.utils.test.patchExpectedResult
+import org.ossreviewtoolkit.utils.test.patchExpectedResult2
 import org.ossreviewtoolkit.utils.test.toYaml
 
 class CarthageFunTest : StringSpec() {
-    private val projectDir = getAssetFile("projects/synthetic/carthage")
-    private val vcsDir = VersionControlSystem.forDirectory(projectDir)!!
-    private val vcsUrl = vcsDir.getRemoteUrl()
-    private val vcsRevision = vcsDir.getRevision()
-
-    private val normalizedVcsUrl = normalizeVcsUrl(vcsUrl)
-
     init {
         "Project dependencies are detected correctly" {
-            val cartfileResolved = projectDir.resolve("Cartfile.resolved")
-            val vcsPath = vcsDir.getPathToRoot(projectDir)
-            val expectedResult = patchExpectedResult(
-                projectDir.resolveSibling("carthage-expected-output.yml"),
-                definitionFilePath = "$vcsPath/Cartfile.resolved",
-                path = vcsPath,
-                revision = vcsRevision,
-                urlProcessed = normalizedVcsUrl
-            )
+            val definitionFile = getAssetFile("projects/synthetic/carthage/Cartfile.resolved")
+            val expectedResultFile = getAssetFile("projects/synthetic/carthage-expected-output.yml")
 
-            val result = createCarthage().resolveSingleProject(cartfileResolved)
+            val result = createCarthage().resolveSingleProject(definitionFile)
 
-            result.toYaml() shouldBe expectedResult
+            result.toYaml() shouldBe patchExpectedResult2(expectedResultFile, definitionFile)
         }
     }
 


### PR DESCRIPTION
See individual commits.

`GoDepFunTest` is still left as todo for a future PR.  