### PR TITLE
refactor: Introduce a lazy `PackageManager.ENABLED_BY_DEFAULT` property

### DIFF
--- a/analyzer/src/main/kotlin/Analyzer.kt
+++ b/analyzer/src/main/kotlin/Analyzer.kt
@@ -69,7 +69,7 @@ class Analyzer(private val config: AnalyzerConfiguration, private val labels: Ma
     @JvmOverloads
     fun findManagedFiles(
         absoluteProjectPath: File,
-        packageManagers: Collection<PackageManagerFactory> = PackageManager.ALL.values,
+        packageManagers: Collection<PackageManagerFactory> = PackageManager.ENABLED_BY_DEFAULT,
         repositoryConfiguration: RepositoryConfiguration = RepositoryConfiguration()
     ): ManagedFileInfo {
         require(absoluteProjectPath.isAbsolute)

--- a/analyzer/src/main/kotlin/PackageManager.kt
+++ b/analyzer/src/main/kotlin/PackageManager.kt
@@ -74,6 +74,11 @@ abstract class PackageManager(
          */
         val ALL by lazy { Plugin.getAll<PackageManagerFactory>() }
 
+        /**
+         * The available [package manager factories][PackageManagerFactory] that are enabled by default.
+         */
+        val ENABLED_BY_DEFAULT by lazy { ALL.values.filter { it.isEnabledByDefault } }
+
         private val PACKAGE_MANAGER_DIRECTORIES = listOf(
             // Ignore intermediate build system directories.
             ".gradle",

--- a/analyzer/src/testFixtures/kotlin/Extensions.kt
+++ b/analyzer/src/testFixtures/kotlin/Extensions.kt
@@ -106,7 +106,7 @@ fun ProjectAnalyzerResult.withInvariantIssues() =
 fun Spec.analyze(
     projectDir: File,
     allowDynamicVersions: Boolean = false,
-    packageManagers: Collection<PackageManagerFactory> = PackageManager.ALL.values
+    packageManagers: Collection<PackageManagerFactory> = PackageManager.ENABLED_BY_DEFAULT
 ): OrtResult {
     val config = AnalyzerConfiguration(allowDynamicVersions)
     val analyzer = Analyzer(config)

--- a/cli/src/funTest/kotlin/OrtMainFunTest.kt
+++ b/cli/src/funTest/kotlin/OrtMainFunTest.kt
@@ -113,7 +113,7 @@ class OrtMainFunTest : StringSpec() {
                 if (iterator.next() == "The following package managers are enabled:") break
             }
 
-            val expectedPackageManagers = PackageManager.ALL.values.filterNot { it.type == "Gradle" }
+            val expectedPackageManagers = PackageManager.ENABLED_BY_DEFAULT.filterNot { it.type == "Gradle" }
 
             iterator.hasNext() shouldBe true
             iterator.next() shouldBe "\t${expectedPackageManagers.joinToString { it.type }}"

--- a/cli/src/funTest/kotlin/PackageManagerFunTest.kt
+++ b/cli/src/funTest/kotlin/PackageManagerFunTest.kt
@@ -87,7 +87,7 @@ class PackageManagerFunTest : WordSpec({
 
             // The test project contains at least one file per package manager, so the result should also contain an
             // entry for each package manager.
-            managedFiles.keys shouldContainExactlyInAnyOrder PackageManager.ALL.values.filterNot {
+            managedFiles.keys shouldContainExactlyInAnyOrder PackageManager.ENABLED_BY_DEFAULT.filterNot {
                 it is Unmanaged.Factory
             }
 

--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -162,7 +162,7 @@ class AnalyzerCommand : OrtCommand(
         println("\t" + configurationInfo)
 
         val enabledPackageManagers = if (enabledPackageManagers != null || disabledPackageManagers != null) {
-            (enabledPackageManagers ?: PackageManager.ALL.values.filter { it.isEnabledByDefault }).toSet() -
+            (enabledPackageManagers ?: PackageManager.ENABLED_BY_DEFAULT).toSet() -
                     disabledPackageManagers.orEmpty().toSet()
         } else {
             ortConfig.analyzer.determineEnabledPackageManagers()
@@ -252,8 +252,7 @@ class AnalyzerCommand : OrtCommand(
 }
 
 private fun AnalyzerConfiguration.determineEnabledPackageManagers(): Set<PackageManagerFactory> {
-    val enabled = enabledPackageManagers?.mapNotNull { PackageManager.ALL[it] }
-        ?: PackageManager.ALL.values.filter { it.isEnabledByDefault }
+    val enabled = enabledPackageManagers?.mapNotNull { PackageManager.ALL[it] } ?: PackageManager.ENABLED_BY_DEFAULT
     val disabled = disabledPackageManagers?.mapNotNull { PackageManager.ALL[it] }.orEmpty()
 
     return enabled.toSet() - disabled.toSet()

--- a/helper-cli/src/main/kotlin/utils/Extensions.kt
+++ b/helper-cli/src/main/kotlin/utils/Extensions.kt
@@ -257,7 +257,7 @@ internal fun OrtResult.getScanIssues(omitExcluded: Boolean = false): List<Issue>
  * Return all path excludes from this [OrtResult] represented as [RepositoryPathExcludes].
  */
 internal fun OrtResult.getRepositoryPathExcludes(): RepositoryPathExcludes {
-    fun isDefinitionsFile(pathExclude: PathExclude) = PackageManager.ALL.values.any {
+    fun isDefinitionsFile(pathExclude: PathExclude) = PackageManager.ENABLED_BY_DEFAULT.any {
         it.matchersForDefinitionFiles.any { matcher ->
             pathExclude.pattern.endsWith(matcher.toString())
         }


### PR DESCRIPTION
Use that property in places where `PackageManager.All.values` was accessed directly as otherwise some tests would start failing as soon as the first package manager is introduced that is disabled by default.