### PR TITLE
Implement generic config resolution

### DIFF
--- a/model/src/main/kotlin/OrtConfigFile.kt
+++ b/model/src/main/kotlin/OrtConfigFile.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+import org.ossreviewtoolkit.utils.ort.ORT_CONFIG_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_COPYRIGHT_GARBAGE_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_CUSTOM_LICENSE_TEXTS_DIRNAME
+import org.ossreviewtoolkit.utils.ort.ORT_EVALUATOR_RULES_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_HOW_TO_FIX_TEXT_PROVIDER_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_LICENSE_CLASSIFICATIONS_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_NOTIFIER_SCRIPT_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CONFIGURATIONS_DIRNAME
+import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CONFIGURATION_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CURATIONS_DIRNAME
+import org.ossreviewtoolkit.utils.ort.ORT_PACKAGE_CURATIONS_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
+
+/**
+ * An enum representing the different ORT configuration files.
+ */
+enum class OrtConfigFile(
+    /**
+     * The default name of the config file.
+     */
+    val defaultFilename: String,
+
+    /**
+     * The default name of the config directory, if the config can be read from multiple files inside a directory.
+     */
+    val defaultDirectoryName: String? = null,
+
+    /**
+     * The [OrtConfigType]s provided by the config file.
+     */
+    val providedTypes: Set<OrtConfigType>
+) {
+    COPYRIGHT_GARBAGE(
+        defaultFilename = ORT_COPYRIGHT_GARBAGE_FILENAME,
+        providedTypes = setOf(OrtConfigType.COPYRIGHT_GARBAGE)
+    ),
+
+    CUSTOM_LICENSE_TEXTS(
+        defaultFilename = ORT_CUSTOM_LICENSE_TEXTS_DIRNAME,
+        providedTypes = setOf(OrtConfigType.CUSTOM_LICENSE_TEXTS)
+    ),
+
+    EVALUATOR_RULES(
+        defaultFilename = ORT_EVALUATOR_RULES_FILENAME,
+        providedTypes = setOf(OrtConfigType.EVALUATOR_RULES)
+    ),
+
+    HOW_TO_FIX_TEXT_PROVIDER(
+        defaultFilename = ORT_HOW_TO_FIX_TEXT_PROVIDER_FILENAME,
+        providedTypes = setOf(OrtConfigType.HOW_TO_FIX_TEXTS)
+    ),
+
+    LICENSE_CLASSIFICATIONS(
+        defaultFilename = ORT_LICENSE_CLASSIFICATIONS_FILENAME,
+        providedTypes = setOf(OrtConfigType.LICENSE_CLASSIFICATIONS)
+    ),
+
+    NOTIFIER_SCRIPT(
+        defaultFilename = ORT_NOTIFIER_SCRIPT_FILENAME,
+        providedTypes = setOf(OrtConfigType.NOTIFIER_RULES)
+    ),
+
+    ORT_CONFIG(
+        defaultFilename = ORT_CONFIG_FILENAME,
+        providedTypes = setOf(OrtConfigType.ORT_CONFIG)
+    ),
+
+    PACKAGE_CONFIGURATIONS(
+        defaultFilename = ORT_PACKAGE_CONFIGURATION_FILENAME,
+        defaultDirectoryName = ORT_PACKAGE_CONFIGURATIONS_DIRNAME,
+        providedTypes = setOf(OrtConfigType.PACKAGE_CONFIGURATIONS)
+    ),
+
+    PACKAGE_CURATIONS(
+        defaultFilename = ORT_PACKAGE_CURATIONS_FILENAME,
+        defaultDirectoryName = ORT_PACKAGE_CURATIONS_DIRNAME,
+        providedTypes = setOf(OrtConfigType.PACKAGE_CURATIONS)
+    ),
+
+    REPOSITORY_CONFIGURATION(
+        defaultFilename = ORT_REPO_CONFIG_FILENAME,
+        providedTypes = setOf(
+            OrtConfigType.LICENSE_CHOICES,
+            OrtConfigType.ORT_CONFIG,
+            OrtConfigType.PACKAGE_CONFIGURATIONS,
+            OrtConfigType.PACKAGE_CURATIONS,
+            OrtConfigType.RESOLUTIONS
+        )
+    ),
+
+    RESOLUTIONS(
+        defaultFilename = ORT_RESOLUTIONS_FILENAME,
+        providedTypes = setOf(OrtConfigType.RESOLUTIONS)
+    )
+}

--- a/model/src/main/kotlin/OrtConfigType.kt
+++ b/model/src/main/kotlin/OrtConfigType.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+/**
+ * An enum representing the different kinds of configuration the ORT tools consume.
+ */
+enum class OrtConfigType(val resolvable: Boolean) {
+    COPYRIGHT_GARBAGE(resolvable = false),
+    CUSTOM_LICENSE_TEXTS(resolvable = false),
+    EVALUATOR_RULES(resolvable = false),
+    HOW_TO_FIX_TEXTS(resolvable = false),
+    LICENSE_CHOICES(resolvable = false),
+    LICENSE_CLASSIFICATIONS(resolvable = false),
+    NOTIFIER_RULES(resolvable = false),
+    ORT_CONFIG(resolvable = false),
+    PACKAGE_CONFIGURATIONS(resolvable = true),
+    PACKAGE_CURATIONS(resolvable = true),
+    RESOLUTIONS(resolvable = true);
+
+    fun resolvableTypes() = values().filter { it.resolvable }
+}

--- a/model/src/main/kotlin/OrtTool.kt
+++ b/model/src/main/kotlin/OrtTool.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model
+
+/**
+ * An enum representing the different ORT tools and how they depend on each other.
+ */
+enum class OrtTool(
+    /**
+     * Tools whose output is required to run this tool.
+     */
+    val requiredInput: Set<OrtTool>,
+
+    /**
+     * Tools whose output is used if it is available.
+     */
+    val optionalInput: Set<OrtTool>,
+
+    /**
+     * The different [OrtConfigType]s consumed by the tool.
+     */
+    val consumedConfig: Set<OrtConfigType>
+) {
+    ANALYZER(
+        requiredInput = emptySet(),
+        optionalInput = emptySet(),
+        consumedConfig = setOf(
+            OrtConfigType.ORT_CONFIG,
+            OrtConfigType.PACKAGE_CURATIONS,
+            OrtConfigType.RESOLUTIONS
+        )
+    ),
+
+    ADVISOR(
+        requiredInput = setOf(ANALYZER),
+        optionalInput = emptySet(),
+        consumedConfig = setOf(
+            OrtConfigType.ORT_CONFIG,
+            OrtConfigType.RESOLUTIONS
+        )
+    ),
+
+    SCANNER(
+        requiredInput = setOf(ANALYZER),
+        optionalInput = emptySet(),
+        consumedConfig = setOf(
+            OrtConfigType.ORT_CONFIG,
+            OrtConfigType.RESOLUTIONS
+        )
+    ),
+
+    EVALUATOR(
+        requiredInput = setOf(ANALYZER),
+        optionalInput = setOf(ADVISOR, SCANNER),
+        consumedConfig = setOf(
+            OrtConfigType.COPYRIGHT_GARBAGE,
+            OrtConfigType.EVALUATOR_RULES,
+            OrtConfigType.LICENSE_CHOICES,
+            OrtConfigType.LICENSE_CLASSIFICATIONS,
+            OrtConfigType.ORT_CONFIG,
+            OrtConfigType.PACKAGE_CONFIGURATIONS,
+            OrtConfigType.PACKAGE_CURATIONS,
+            OrtConfigType.RESOLUTIONS
+        )
+    ),
+
+    REPORTER(
+        requiredInput = setOf(ANALYZER),
+        optionalInput = setOf(ADVISOR, SCANNER, EVALUATOR),
+        consumedConfig = setOf(
+            OrtConfigType.COPYRIGHT_GARBAGE,
+            OrtConfigType.CUSTOM_LICENSE_TEXTS,
+            OrtConfigType.HOW_TO_FIX_TEXTS,
+            OrtConfigType.LICENSE_CHOICES,
+            OrtConfigType.LICENSE_CLASSIFICATIONS,
+            OrtConfigType.ORT_CONFIG,
+            OrtConfigType.PACKAGE_CONFIGURATIONS,
+            OrtConfigType.PACKAGE_CURATIONS,
+            OrtConfigType.RESOLUTIONS
+        )
+    ),
+
+    NOTIFIER(
+        requiredInput = setOf(ANALYZER),
+        optionalInput = setOf(ADVISOR, SCANNER, EVALUATOR),
+        consumedConfig = setOf(
+            OrtConfigType.COPYRIGHT_GARBAGE,
+            OrtConfigType.CUSTOM_LICENSE_TEXTS,
+            OrtConfigType.LICENSE_CHOICES,
+            OrtConfigType.LICENSE_CLASSIFICATIONS,
+            OrtConfigType.ORT_CONFIG,
+            OrtConfigType.PACKAGE_CONFIGURATIONS,
+            OrtConfigType.PACKAGE_CURATIONS,
+            OrtConfigType.RESOLUTIONS
+        )
+    );
+
+    val alias = name.lowercase()
+    val input = requiredInput + optionalInput
+}


### PR DESCRIPTION
Add a model for the different ORT tools, how they depend on each other, and which configuration they consume. Use it to implement a generic function to resolve configuration and warn if re-resolving a previously resolved configuration can lead to inconsistencies in the result.

This is an early draft and by no means complete, no need to review yet.