### PR TITLE
refactor(PdfTemplateReporter): Make setting attribute values more compact

### DIFF
--- a/reporter/src/main/kotlin/reporters/freemarker/asciidoc/AsciiDocTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/asciidoc/AsciiDocTemplateReporter.kt
@@ -60,6 +60,10 @@ open class AsciiDocTemplateReporter(private val backend: String, override val ty
 
     private val asciidoctor by lazy { Asciidoctor.Factory.create() }
 
+    /**
+     * Turn recognized [options] into [Attributes] and remove them from [options] afterwards to mark them as processed.
+     * By default no [options] are processed and the returned [Attributes] are empty.
+     */
     protected open fun processTemplateOptions(outputDir: File, options: MutableMap<String, String>): Attributes =
         Attributes.builder().build()
 

--- a/reporter/src/main/kotlin/reporters/freemarker/asciidoc/AsciiDocTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/asciidoc/AsciiDocTemplateReporter.kt
@@ -86,12 +86,10 @@ open class AsciiDocTemplateReporter(private val backend: String, override val ty
     private fun generateAsciiDocFiles(
         input: ReporterInput,
         outputDir: File,
-        options: Map<String, String> = emptyMap()
+        options: MutableMap<String, String>
     ): List<File> {
-        val templateOptions = options.toMutableMap()
-
-        if (FreemarkerTemplateProcessor.OPTION_TEMPLATE_PATH !in templateOptions) {
-            templateOptions.putIfAbsent(
+        if (FreemarkerTemplateProcessor.OPTION_TEMPLATE_PATH !in options) {
+            options.putIfAbsent(
                 FreemarkerTemplateProcessor.OPTION_TEMPLATE_ID,
                 buildString {
                     append(DISCLOSURE_TEMPLATE_ID)
@@ -103,7 +101,7 @@ open class AsciiDocTemplateReporter(private val backend: String, override val ty
             )
         }
 
-        return templateProcessor.processTemplates(input, outputDir, templateOptions)
+        return templateProcessor.processTemplates(input, outputDir, options)
     }
 
     /**

--- a/reporter/src/main/kotlin/reporters/freemarker/asciidoc/PdfTemplateReporter.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/asciidoc/PdfTemplateReporter.kt
@@ -62,12 +62,10 @@ class PdfTemplateReporter : AsciiDocTemplateReporter("pdf", "PdfTemplate") {
 
     override fun processTemplateOptions(outputDir: File, options: MutableMap<String, String>): Attributes =
         Attributes.builder().apply {
-            val pdfThemeAttribute = options.remove(OPTION_PDF_THEME_FILE)?.let {
-                val pdfThemeFile = File(it).absoluteFile
-
-                require(pdfThemeFile.isFile) { "Could not find PDF theme file at '$pdfThemeFile'." }
-
-                pdfThemeFile.path
+            val pdfTheme = options.remove(OPTION_PDF_THEME_FILE)?.let { option ->
+                File(option).absoluteFile.also {
+                    require(it.isFile) { "Could not find PDF theme file at '$it'." }
+                }.path
             } ?: run {
                 // Images are being looked up relative to the themes directory. As images currently are the only use for
                 // the themes directory, point it at the images directory. However, the themes directory does not
@@ -81,17 +79,15 @@ class PdfTemplateReporter : AsciiDocTemplateReporter("pdf", "PdfTemplate") {
                 "uri:classloader:/templates/asciidoc/pdf-theme.yml"
             }
 
-            attribute("pdf-theme", pdfThemeAttribute)
+            attribute("pdf-theme", pdfTheme)
 
-            val pdfFontsDirAttribute = options.remove(OPTION_PDF_FONTS_DIR)?.let {
-                val pdfFontsDir = File(it).absoluteFile
-
-                require(pdfFontsDir.isDirectory) { "Could not find PDF fonts directory at '$pdfFontsDir'." }
-
-                pdfFontsDir.path
+            val pdfFontsDir = options.remove(OPTION_PDF_FONTS_DIR)?.let { option ->
+                File(option).absoluteFile.also {
+                    require(it.isDirectory) { "Could not find PDF fonts directory at '$it'." }
+                }.path
             } ?: "uri:classloader:/fonts"
 
-            attribute("pdf-fontsdir", "$pdfFontsDirAttribute,GEM_FONTS_DIR")
+            attribute("pdf-fontsdir", "$pdfFontsDir,GEM_FONTS_DIR")
         }.build()
 
     private fun extractImageResources(targetDir: File) {


### PR DESCRIPTION
Also shorten some variable names as these are not full attributes but only their values, and use `toString()` instead of `path` to better express that a string is needed here (although both calls internally do the same thing).