### PR TITLE
fix(VulnerableCode): Handle invalid URLs in references

### DIFF
--- a/advisor/src/test/assets/__files/vulnerable-code/response_invalid_uri.json
+++ b/advisor/src/test/assets/__files/vulnerable-code/response_invalid_uri.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "commons-lang3",
+    "namespace": "org.apache.commons",
+    "purl": "pkg:maven/org.apache.commons/commons-lang3@3.5",
+    "qualifiers": {},
+    "resolved_vulnerabilities": [],
+    "subpath": "",
+    "type": "maven",
+    "version": "3.5",
+    "url": "http://testserver/api/packages/3467",
+    "unresolved_vulnerabilities": [
+      {
+        "references": [
+          {
+            "reference_id": "",
+            "scores": [],
+            "source": "",
+            "url": "https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe:2.3:a:oracle:siebel_engineering_-_installer_\\&_deployment:*:*:*:*:*:*:*:*"
+          }
+        ],
+        "url": "http://testserver/api/vulnerabilities/60",
+        "vulnerability_id": "CVE-2014-8242"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
There are some packages for which VulnerableCode returns vulnerabilities with URL references that cannot be converted to URIs, since they contain invalid characters. In such cases, no meaningful advisor result was generated. Prevent this by handling exceptions when converting to URIs.
