### PR TITLE
Let `GradleInspector` filter all dependencies metadata configurations

### DIFF
--- a/plugins/package-managers/gradle-plugin/src/main/kotlin/GradleModelExtensions.kt
+++ b/plugins/package-managers/gradle-plugin/src/main/kotlin/GradleModelExtensions.kt
@@ -44,7 +44,10 @@ internal fun Configuration.isRelevant(): Boolean {
     val isDeprecatedConfiguration = GradleVersion.current() >= GradleVersion.version("6.0")
             && this is DeprecatableConfiguration && resolutionAlternatives != null
 
-    return canBeResolved && !isDeprecatedConfiguration
+    // Do not try to resolve dependencies metadata configurations as there often cause failures with Gradle itself.
+    val isDependenciesMetadata = name.endsWith("DependenciesMetadata")
+
+    return canBeResolved && !isDeprecatedConfiguration && !isDependenciesMetadata
 }
 
 /**

--- a/plugins/package-managers/gradle-plugin/src/main/kotlin/GradleModelExtensions.kt
+++ b/plugins/package-managers/gradle-plugin/src/main/kotlin/GradleModelExtensions.kt
@@ -36,8 +36,11 @@ internal fun AttributeContainer.getValueByName(name: String): Any? =
  * Return whether this Gradle configuration is relevant for ORT's dependency resolution.
  */
 internal fun Configuration.isRelevant(): Boolean {
+    // Configurations can be resolved and / or consumed, but not neither, see the table at
+    // https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:resolvable-consumable-configs
     val canBeResolved = GradleVersion.current() < GradleVersion.version("3.3") || isCanBeResolved
 
+    // Check if a configuration is deprecated in favor of alternatives.
     val isDeprecatedConfiguration = GradleVersion.current() >= GradleVersion.version("6.0")
             && this is DeprecatableConfiguration && resolutionAlternatives != null
 

--- a/plugins/package-managers/gradle-plugin/src/main/kotlin/OrtModelBuilder.kt
+++ b/plugins/package-managers/gradle-plugin/src/main/kotlin/OrtModelBuilder.kt
@@ -65,18 +65,7 @@ internal class OrtModelBuilder : ToolingModelBuilder {
     override fun buildAll(modelName: String, project: Project): OrtDependencyTreeModel {
         repositories = project.repositories.associate { it.name to (it as? UrlArtifactRepository)?.url?.toString() }
 
-        val resolvableConfigurations = project.configurations.filter { it.isRelevant() }.run {
-            if (project.isAndroidProject()) {
-                // Filter out dependencies metadata configuration as created by the Android Gradle plugin 4.0.0 and
-                // higher, see [1]. Also see [2] for valuable information in this context.
-                //
-                // [1]: https://developer.android.com/studio/past-releases/past-agp-releases/agp-4-0-0-release-notes#dependency-metadata
-                // [2]: https://gist.github.com/h0tk3y/41c73d1f822378f52f1e6cce8dcf56aa#orgjetbrainskotlinplatformtype
-                filterNot { it.name.endsWith("DependenciesMetadata") }
-            } else {
-                this
-            }
-        }
+        val resolvableConfigurations = project.configurations.filter { it.isRelevant() }
 
         val ortConfigurations = resolvableConfigurations.mapNotNull { config ->
             // Explicitly resolve all POM files and their parents, as the latter otherwise may get resolved in Gradle's


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 