### PR TITLE
fix(conan): Do not hard-code the VCS type to "Git"

### DIFF
--- a/cli/src/funTest/assets/projects/synthetic/spdx-project-xyz-expected-output-subproject-conan.yml
+++ b/cli/src/funTest/assets/projects/synthetic/spdx-project-xyz-expected-output-subproject-conan.yml
@@ -11,7 +11,7 @@ projects:
     - "The Boost Software License 1.0"
   vcs:
     type: "Git"
-    url: "http://github.com/ossreviewtoolkit/ort"
+    url: "http://github.com/ossreviewtoolkit/ort.git"
     revision: ""
     path: ""
   vcs_processed:

--- a/plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan-expected-output-py.yml
+++ b/plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan-expected-output-py.yml
@@ -11,7 +11,7 @@ project:
     - "The Boost Software License 1.0"
   vcs:
     type: "Git"
-    url: "http://github.com/pocoproject/conan-poco"
+    url: "http://github.com/pocoproject/conan-poco.git"
     revision: ""
     path: ""
   vcs_processed:

--- a/plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan-expected-output-txt.yml
+++ b/plugins/package-managers/conan/src/funTest/assets/projects/synthetic/conan-expected-output-txt.yml
@@ -5,7 +5,7 @@ project:
   declared_licenses: []
   declared_licenses_processed: {}
   vcs:
-    type: "Git"
+    type: ""
     url: ""
     revision: ""
     path: ""

--- a/plugins/package-managers/conan/src/main/kotlin/Conan.kt
+++ b/plugins/package-managers/conan/src/main/kotlin/Conan.kt
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.kotlin.Logging
 import org.ossreviewtoolkit.analyzer.AbstractPackageManagerFactory
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.analyzer.parseAuthorString
+import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
@@ -40,7 +41,6 @@ import org.ossreviewtoolkit.model.ProjectAnalyzerResult
 import org.ossreviewtoolkit.model.RemoteArtifact
 import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.VcsInfo
-import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
@@ -376,12 +376,12 @@ class Conan(
     /**
      * Return the [VcsInfo] contained in [node].
      */
-    private fun parseVcsInfo(node: JsonNode) =
-        VcsInfo(
-            type = VcsType.GIT,
-            url = node["url"].textValueOrEmpty(),
-            revision = node["revision"].textValueOrEmpty().takeUnless { it == "0" }.orEmpty()
-        )
+    private fun parseVcsInfo(node: JsonNode): VcsInfo {
+        val revision = node["revision"].textValueOrEmpty()
+        val url = node["url"].textValueOrEmpty()
+        val vcsInfo = VcsHost.parseUrl(url)
+        return if (revision == "0") vcsInfo else vcsInfo.copy(revision = revision)
+    }
 
     /**
      * Return the value of [field] from the output of `conan inspect --raw` for the package in [node].


### PR DESCRIPTION
Fixes #6827.