### PR TITLE
`OrtResult` function renamings

### DIFF
--- a/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
+++ b/analyzer/src/test/kotlin/AnalyzerResultBuilderTest.kt
@@ -213,7 +213,7 @@ class AnalyzerResultBuilderTest : WordSpec() {
                     .addDependencyGraph("foo", graph2)
                     .build()
 
-                analyzerResult.collectIssues() should containExactly(
+                analyzerResult.getAllIssues() should containExactly(
                     package1.id to setOf(issue1),
                     package3.id to setOf(issue2),
                     project1.id to setOf(issue3, issue4),

--- a/cli/src/funTest/kotlin/ExamplesFunTest.kt
+++ b/cli/src/funTest/kotlin/ExamplesFunTest.kt
@@ -190,7 +190,7 @@ class ExamplesFunTest : StringSpec({
 
         actualBody shouldContain "Content-Type: text/html; charset=UTF-8"
         actualBody shouldContain "Content-Type: text/plain; charset=UTF-8" // Fallback
-        actualBody shouldContain "Number of issues found: ${ortResult.collectIssues().size}"
+        actualBody shouldContain "Number of issues found: ${ortResult.getIssues().size}"
 
         greenMail.stop()
     }

--- a/cli/src/main/kotlin/commands/AdvisorCommand.kt
+++ b/cli/src/main/kotlin/commands/AdvisorCommand.kt
@@ -146,7 +146,7 @@ class AdvisorCommand : OrtCommand(
         }
 
         val resolutionProvider = DefaultResolutionProvider.create(ortResultOutput, resolutionsFile)
-        val (resolvedIssues, unresolvedIssues) = advisorRun.results.collectIssues().flatMap { it.value }
+        val (resolvedIssues, unresolvedIssues) = advisorRun.results.getIssues().flatMap { it.value }
             .partition { resolutionProvider.isResolved(it) }
         val severityStats = SeverityStats.createFromIssues(resolvedIssues, unresolvedIssues)
 

--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -243,7 +243,7 @@ class AnalyzerCommand : OrtCommand(
         println("Applied $curationCount curation(s) from ${enabledCurationProviders.size} provider(s).")
 
         val resolutionProvider = DefaultResolutionProvider.create(ortResult, resolutionsFile)
-        val (resolvedIssues, unresolvedIssues) = analyzerRun.result.collectIssues().flatMap { it.value }
+        val (resolvedIssues, unresolvedIssues) = analyzerRun.result.getAllIssues().flatMap { it.value }
             .partition { resolutionProvider.isResolved(it) }
         val severityStats = SeverityStats.createFromIssues(resolvedIssues, unresolvedIssues)
 

--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -162,7 +162,7 @@ class ScannerCommand : OrtCommand(
         println("The scan took $duration.")
 
         val resolutionProvider = DefaultResolutionProvider.create(ortResult, resolutionsFile)
-        val (resolvedIssues, unresolvedIssues) = scannerRun.collectIssues().flatMap { it.value }
+        val (resolvedIssues, unresolvedIssues) = scannerRun.getIssues().flatMap { it.value }
             .partition { resolutionProvider.isResolved(it) }
         val severityStats = SeverityStats.createFromIssues(resolvedIssues, unresolvedIssues)
 

--- a/examples/notifications/src/main/resources/example.notifications.kts
+++ b/examples/notifications/src/main/resources/example.notifications.kts
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-val issues: Map<Identifier, Set<Issue>> = ortResult.collectIssues()
+val issues: Map<Identifier, Set<Issue>> = ortResult.getIssues()
 
 if (issues.isNotEmpty()) {
     mailClient.sendMail(

--- a/helper-cli/src/main/kotlin/commands/ListPackagesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/ListPackagesCommand.kt
@@ -86,7 +86,7 @@ class ListPackagesCommand : CliktCommand(
             it.severity in offendingSeverities
         }.mapNotNullTo(mutableSetOf()) { it.pkg }
 
-        val packages = ortResult.collectProjectsAndPackages().filter { id ->
+        val packages = ortResult.getProjectsAndPackages().filter { id ->
             (ortResult.isPackage(id) && PACKAGE in type) || (ortResult.isProject(id) && PROJECT in type)
         }.filter { id ->
             matchDetectedLicenses.isEmpty() || (matchDetectedLicenses - getDetectedLicenses(id)).isEmpty()

--- a/helper-cli/src/main/kotlin/commands/repoconfig/RemoveEntriesCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/repoconfig/RemoveEntriesCommand.kt
@@ -109,7 +109,7 @@ internal class RemoveEntriesCommand : CliktCommand(
         }
 
         val resolutionProvider = DefaultResolutionProvider.create(resolutionsFile = resolutionsFile)
-        val notGloballyResolvedIssues = ortResult.collectIssues().values.flatten().filterNot {
+        val notGloballyResolvedIssues = ortResult.getIssues().values.flatten().filterNot {
             resolutionProvider.isResolved(it)
         }
         val issueResolutions = ortResult.getResolutions().issues.filter { resolution ->

--- a/helper-cli/src/main/kotlin/utils/Extensions.kt
+++ b/helper-cli/src/main/kotlin/utils/Extensions.kt
@@ -134,7 +134,7 @@ internal fun OrtResult.processAllCopyrightStatements(
         addAuthorsToCopyrights = addAuthorsToCopyrights
     )
 
-    collectProjectsAndPackages().forEach { id ->
+    getProjectsAndPackages().forEach { id ->
         licenseInfoResolver.resolveLicenseInfo(id).forEach inner@{ resolvedLicense ->
             if (omitExcluded && resolvedLicense.isDetectedExcluded) return@inner
 

--- a/helper-cli/src/main/kotlin/utils/Extensions.kt
+++ b/helper-cli/src/main/kotlin/utils/Extensions.kt
@@ -184,7 +184,7 @@ internal fun OrtResult.getLicenseFindingsById(
 
     fun getLicenseFindingsCurations(provenance: Provenance): List<LicenseFindingCuration> =
         if (isProject(id)) {
-            getLicenseFindingsCurations(id)
+            getLicenseFindingCurations(id)
         } else {
             packageConfigurationProvider.getPackageConfigurations(id, provenance).flatMap { it.licenseFindingCurations }
         }

--- a/helper-cli/src/main/kotlin/utils/Extensions.kt
+++ b/helper-cli/src/main/kotlin/utils/Extensions.kt
@@ -182,7 +182,7 @@ internal fun OrtResult.getLicenseFindingsById(
 ): Map<Provenance, Map<SpdxExpression, Set<TextLocation>>> {
     val result = mutableMapOf<Provenance, MutableMap<SpdxExpression, MutableSet<TextLocation>>>()
 
-    fun getLicenseFindingsCurations(provenance: Provenance): List<LicenseFindingCuration> =
+    fun getLicenseFindingCurations(provenance: Provenance): List<LicenseFindingCuration> =
         if (isProject(id)) {
             getLicenseFindingCurations(id)
         } else {
@@ -194,7 +194,7 @@ internal fun OrtResult.getLicenseFindingsById(
 
         scanResult.summary.licenseFindings.let { findings ->
             if (applyCurations) {
-                FindingCurationMatcher().applyAll(findings, getLicenseFindingsCurations(scanResult.provenance))
+                FindingCurationMatcher().applyAll(findings, getLicenseFindingCurations(scanResult.provenance))
                     .mapNotNullTo(mutableSetOf()) { it.curatedFinding }
             } else {
                 findings

--- a/model/src/main/kotlin/AdvisorRecord.kt
+++ b/model/src/main/kotlin/AdvisorRecord.kt
@@ -67,7 +67,8 @@ data class AdvisorRecord(
         }
     }
 
-    fun collectIssues(): Map<Identifier, Set<Issue>> {
+    @JsonIgnore
+    fun getIssues(): Map<Identifier, Set<Issue>> {
         val collectedIssues = mutableMapOf<Identifier, MutableSet<Issue>>()
 
         advisorResults.forEach { (id, results) ->
@@ -84,7 +85,7 @@ data class AdvisorRecord(
     /**
      * True if any of the [advisorResults] contain [Issue]s.
      */
-    val hasIssues by lazy { collectIssues().isNotEmpty() }
+    val hasIssues by lazy { getIssues().isNotEmpty() }
 
     /**
      * Return a map of all [Package]s and the associated [Vulnerabilities][Vulnerability].

--- a/model/src/main/kotlin/AdvisorRecord.kt
+++ b/model/src/main/kotlin/AdvisorRecord.kt
@@ -68,19 +68,16 @@ data class AdvisorRecord(
     }
 
     @JsonIgnore
-    fun getIssues(): Map<Identifier, Set<Issue>> {
-        val collectedIssues = mutableMapOf<Identifier, MutableSet<Issue>>()
-
-        advisorResults.forEach { (id, results) ->
-            results.forEach { result ->
-                if (result.summary.issues.isNotEmpty()) {
-                    collectedIssues.getOrPut(id) { mutableSetOf() } += result.summary.issues
+    fun getIssues(): Map<Identifier, Set<Issue>> =
+        buildMap<Identifier, MutableSet<Issue>> {
+            advisorResults.forEach { (id, results) ->
+                results.forEach { result ->
+                    if (result.summary.issues.isNotEmpty()) {
+                        getOrPut(id) { mutableSetOf() } += result.summary.issues
+                    }
                 }
             }
         }
-
-        return collectedIssues
-    }
 
     /**
      * True if any of the [advisorResults] contain [Issue]s.

--- a/model/src/main/kotlin/AnalyzerResult.kt
+++ b/model/src/main/kotlin/AnalyzerResult.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
@@ -78,7 +79,8 @@ data class AnalyzerResult(
     /**
      * Return a map of all de-duplicated [Issue]s associated by [Identifier].
      */
-    fun collectIssues(): Map<Identifier, Set<Issue>> {
+    @JsonIgnore
+    fun getAllIssues(): Map<Identifier, Set<Issue>> {
         val collectedIssues = issues.mapValuesTo(mutableMapOf()) { it.value.toMutableSet() }
 
         // Collecting issues from projects is necessary only if they use the dependency tree format; otherwise, the
@@ -103,7 +105,7 @@ data class AnalyzerResult(
     /**
      * True if there were any issues during the analysis, false otherwise.
      */
-    val hasIssues by lazy { collectIssues().isNotEmpty() }
+    val hasIssues by lazy { getAllIssues().isNotEmpty() }
 
     /**
      * Return a result, in which all contained [Project]s have their scope information resolved. If this result

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -98,7 +98,7 @@ data class OrtResult(
 
     /** An object that can be used to navigate the dependency information contained in this result. */
     @get:JsonIgnore
-    val dependencyNavigator: DependencyNavigator by lazy { createDependencyNavigator() }
+    val dependencyNavigator: DependencyNavigator by lazy { CompatibilityDependencyNavigator.create(this) }
 
     private data class ProjectEntry(val project: Project, val isExcluded: Boolean)
 
@@ -525,12 +525,6 @@ data class OrtResult(
                 result = analyzer.result.withResolvedScopes()
             )
         )
-
-    /**
-     * Create the [DependencyNavigator] for this [OrtResult]. The concrete navigator implementation depends on the
-     * format, in which dependency information is stored.
-     */
-    private fun createDependencyNavigator(): DependencyNavigator = CompatibilityDependencyNavigator.create(this)
 
     /**
      * Return the label values corresponding to the given [key] split at the delimiter ',', or an empty set if the label

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -253,7 +253,7 @@ data class OrtResult(
     /**
      * Return the [LicenseFindingCuration]s associated with the given package [id].
      */
-    fun getLicenseFindingsCurations(id: Identifier): List<LicenseFindingCuration> =
+    fun getLicenseFindingCurations(id: Identifier): List<LicenseFindingCuration> =
         if (projects.containsKey(id)) {
             repository.config.curations.licenseFindings
         } else {

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -168,7 +168,7 @@ data class OrtResult(
      * depth of [maxLevel] where counting starts at 0 (for the [Project] or [Package] itself) and 1 are direct
      * dependencies etc. A value below 0 means to not limit the depth.
      */
-    fun collectDependencies(id: Identifier, maxLevel: Int = -1): Set<Identifier> {
+    fun getDependencies(id: Identifier, maxLevel: Int = -1): Set<Identifier> {
         val dependencies = mutableSetOf<Identifier>()
 
         getProjects().forEach { project ->

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -96,14 +96,6 @@ data class OrtResult(
         )
     }
 
-    private data class ProjectEntry(val project: Project, val isExcluded: Boolean)
-
-    private data class PackageEntry(
-        val pkg: Package?,
-        val curatedPackage: CuratedPackage?,
-        val isExcluded: Boolean
-    )
-
     /** An object that can be used to navigate the dependency information contained in this result. */
     @get:JsonIgnore
     val dependencyNavigator: DependencyNavigator by lazy { CompatibilityDependencyNavigator.create(this) }
@@ -575,3 +567,11 @@ private fun applyPackageCurations(
         }
     }
 }
+
+private data class PackageEntry(
+    val pkg: Package?,
+    val curatedPackage: CuratedPackage?,
+    val isExcluded: Boolean
+)
+
+private data class ProjectEntry(val project: Project, val isExcluded: Boolean)

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -199,7 +199,8 @@ data class OrtResult(
      * Return the set of all project or package identifiers in the result, optionally [including those of subprojects]
      * [includeSubProjects].
      */
-    fun collectProjectsAndPackages(includeSubProjects: Boolean = true): Set<Identifier> {
+    @JsonIgnore
+    fun getProjectsAndPackages(includeSubProjects: Boolean = true): Set<Identifier> {
         val projectsAndPackages = mutableSetOf<Identifier>()
         val projects = getProjects(includeSubProjects = includeSubProjects)
 

--- a/model/src/main/kotlin/OrtResult.kt
+++ b/model/src/main/kotlin/OrtResult.kt
@@ -185,10 +185,11 @@ data class OrtResult(
     /**
      * Return a map of all de-duplicated [Issue]s associated by [Identifier].
      */
-    fun collectIssues(): Map<Identifier, Set<Issue>> {
-        val analyzerIssues = analyzer?.result?.collectIssues().orEmpty()
-        val scannerIssues = scanner?.collectIssues().orEmpty()
-        val advisorIssues = advisor?.results?.collectIssues().orEmpty()
+    @JsonIgnore
+    fun getIssues(): Map<Identifier, Set<Issue>> {
+        val analyzerIssues = analyzer?.result?.getAllIssues().orEmpty()
+        val scannerIssues = scanner?.getIssues().orEmpty()
+        val advisorIssues = advisor?.results?.getIssues().orEmpty()
 
         val analyzerAndScannerIssues = analyzerIssues.zipWithCollections(scannerIssues)
         return analyzerAndScannerIssues.zipWithCollections(advisorIssues)
@@ -482,7 +483,7 @@ data class OrtResult(
      * [OrtResult] with severities equal to or over [minSeverity].
      */
     @JsonIgnore
-    fun getOpenIssues(minSeverity: Severity = Severity.WARNING) = collectIssues()
+    fun getOpenIssues(minSeverity: Severity = Severity.WARNING) = getIssues()
         .mapNotNull { (id, issues) -> issues.takeUnless { isExcluded(id) } }
         .flatten()
         .filter { issue -> issue.severity >= minSeverity && getResolutions().issues.none { it.matches(issue) } }

--- a/model/src/main/kotlin/ScannerRun.kt
+++ b/model/src/main/kotlin/ScannerRun.kt
@@ -19,6 +19,7 @@
 
 package org.ossreviewtoolkit.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 import java.time.Instant
@@ -80,7 +81,8 @@ data class ScannerRun(
     /**
      * Return a map of all de-duplicated [Issue]s associated by [Identifier].
      */
-    fun collectIssues(): Map<Identifier, Set<Issue>> {
+    @JsonIgnore
+    fun getIssues(): Map<Identifier, Set<Issue>> {
         val collectedIssues = mutableMapOf<Identifier, MutableSet<Issue>>()
 
         scanResults.forEach { (id, results) ->
@@ -97,5 +99,5 @@ data class ScannerRun(
     /**
      * True if any of the [scanResults] contain [Issue]s.
      */
-    val hasIssues by lazy { collectIssues().isNotEmpty() }
+    val hasIssues by lazy { getIssues().isNotEmpty() }
 }

--- a/model/src/main/kotlin/ScannerRun.kt
+++ b/model/src/main/kotlin/ScannerRun.kt
@@ -82,19 +82,16 @@ data class ScannerRun(
      * Return a map of all de-duplicated [Issue]s associated by [Identifier].
      */
     @JsonIgnore
-    fun getIssues(): Map<Identifier, Set<Issue>> {
-        val collectedIssues = mutableMapOf<Identifier, MutableSet<Issue>>()
-
-        scanResults.forEach { (id, results) ->
-            results.forEach { result ->
-                if (result.summary.issues.isNotEmpty()) {
-                    collectedIssues.getOrPut(id) { mutableSetOf() } += result.summary.issues
+    fun getIssues(): Map<Identifier, Set<Issue>> =
+        buildMap<Identifier, MutableSet<Issue>> {
+            scanResults.forEach { (id, results) ->
+                results.forEach { result ->
+                    if (result.summary.issues.isNotEmpty()) {
+                        getOrPut(id) { mutableSetOf() } += result.summary.issues
+                    }
                 }
             }
         }
-
-        return collectedIssues
-    }
 
     /**
      * True if any of the [scanResults] contain [Issue]s.

--- a/model/src/main/kotlin/utils/OrtResultExtensions.kt
+++ b/model/src/main/kotlin/utils/OrtResultExtensions.kt
@@ -58,7 +58,7 @@ fun OrtResult.addPackageCurations(packageCurationProviders: List<Pair<String, Pa
  */
 fun OrtResult.addResolutions(resolutionProvider: ResolutionProvider): OrtResult {
     val resolutions = ConfigurationResolver.resolveResolutions(
-        issues = collectIssues().values.flatten(),
+        issues = getIssues().values.flatten(),
         ruleViolations = getRuleViolations(),
         vulnerabilities = getVulnerabilities().values.flatten(),
         resolutionProvider = resolutionProvider

--- a/model/src/test/kotlin/AdvisorRecordTest.kt
+++ b/model/src/test/kotlin/AdvisorRecordTest.kt
@@ -61,7 +61,7 @@ class AdvisorRecordTest : WordSpec({
                 langId to listOf(createResult())
             )
 
-            val issues = record.collectIssues()
+            val issues = record.getIssues()
 
             issues.keys shouldNotContain langId
         }
@@ -75,7 +75,7 @@ class AdvisorRecordTest : WordSpec({
                 queryId to listOf(createResult(issues = listOf(issue1, issue2)))
             )
 
-            val issues = record.collectIssues()
+            val issues = record.getIssues()
 
             issues.keys should containExactlyInAnyOrder(langId, queryId)
             issues[langId] should containExactly(issue3)

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -64,8 +64,8 @@ class OrtResultTest : WordSpec({
     "collectProjectsAndPackages" should {
         "be able to get all ids except for ones for sub-projects" {
             val ortResult = readOrtResult("src/test/assets/gradle-all-dependencies-expected-result.yml")
-            val ids = ortResult.collectProjectsAndPackages()
-            val idsWithoutSubProjects = ortResult.collectProjectsAndPackages(includeSubProjects = false)
+            val ids = ortResult.getProjectsAndPackages()
+            val idsWithoutSubProjects = ortResult.getProjectsAndPackages(includeSubProjects = false)
             val actualIds = ids - idsWithoutSubProjects
 
             ids should haveSize(9)

--- a/model/src/test/kotlin/OrtResultTest.kt
+++ b/model/src/test/kotlin/OrtResultTest.kt
@@ -51,7 +51,7 @@ class OrtResultTest : WordSpec({
             )
 
             val id = Identifier("Maven:com.typesafe.akka:akka-stream_2.12:2.5.6")
-            val dependencies = ortResult.collectDependencies(id, 1).map { it.toCoordinates() }
+            val dependencies = ortResult.getDependencies(id, 1).map { it.toCoordinates() }
 
             dependencies should containExactlyInAnyOrder(
                 "Maven:com.typesafe.akka:akka-actor_2.12:2.5.6",

--- a/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/SpdxDocumentModelMapper.kt
@@ -77,7 +77,7 @@ internal object SpdxDocumentModelMapper {
         val projectPackages = projects.map { project ->
             val spdxProjectPackage = project.toPackage().toSpdxPackage(licenseInfoResolver, isProject = true)
 
-            ortResult.collectDependencies(project.id, 1).mapTo(relationships) { dependency ->
+            ortResult.getDependencies(project.id, 1).mapTo(relationships) { dependency ->
                 SpdxRelationship(
                     spdxElementId = spdxProjectPackage.spdxId,
                     relationshipType = SpdxRelationship.Type.DEPENDS_ON,
@@ -92,7 +92,7 @@ internal object SpdxDocumentModelMapper {
             val pkg = curatedPackage.metadata
             val binaryPackage = pkg.toSpdxPackage(licenseInfoResolver)
 
-            ortResult.collectDependencies(pkg.id, 1).mapTo(relationships) { dependency ->
+            ortResult.getDependencies(pkg.id, 1).mapTo(relationships) { dependency ->
                 SpdxRelationship(
                     spdxElementId = binaryPackage.spdxId,
                     relationshipType = SpdxRelationship.Type.DEPENDS_ON,

--- a/reporter/src/main/kotlin/StatisticsCalculator.kt
+++ b/reporter/src/main/kotlin/StatisticsCalculator.kt
@@ -131,7 +131,7 @@ internal object StatisticsCalculator {
         ortResult: OrtResult,
         licenseInfoResolver: LicenseInfoResolver
     ): LicenseStatistics {
-        val ids = ortResult.collectProjectsAndPackages()
+        val ids = ortResult.getProjectsAndPackages()
 
         fun countLicenses(view: LicenseView): SortedMap<String, Int> =
             ids.flatMap { id ->

--- a/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
+++ b/reporter/src/main/kotlin/reporters/freemarker/FreemarkerTemplateProcessor.kt
@@ -295,7 +295,7 @@ class FreemarkerTemplateProcessor(
         @JvmOverloads
         @Suppress("UNUSED") // This function is used in the templates.
         fun hasUnresolvedIssues(threshold: Severity = input.ortConfig.severeIssueThreshold) =
-            input.ortResult.collectIssues().any { (identifier, issues) ->
+            input.ortResult.getIssues().any { (identifier, issues) ->
                 issues.any { issue ->
                     val isResolved = input.resolutionProvider.isResolved(issue)
                     val isExcluded = input.ortResult.isExcluded(identifier)


### PR DESCRIPTION
Rename several `collect...` functions to `get...` and do some minor refactorings. See the commit messages for details.

**Breaking API change**:
Several `OrtResult` functions have changed their name.