### PR TITLE
chore(clearly-defined): Remove ORT's comment from curations

### DIFF
--- a/plugins/package-curation-providers/clearly-defined/src/main/kotlin/ClearlyDefinedPackageCurationProvider.kt
+++ b/plugins/package-curation-providers/clearly-defined/src/main/kotlin/ClearlyDefinedPackageCurationProvider.kt
@@ -173,12 +173,8 @@ class ClearlyDefinedPackageCurationProvider(
                 vcs = sourceLocation as? VcsInfoCurationData
             )
 
-            if (data != PackageCurationData()) {
-                pkgCurations += PackageCuration(
-                    id = pkgId,
-                    data = data.copy(comment = "Provided by ClearlyDefined.")
-                )
-            }
+            // Add the curation if it is non-empty.
+            if (data != PackageCurationData()) pkgCurations += PackageCuration(pkgId, data)
         }
 
         return pkgCurations


### PR DESCRIPTION
The custom comment was used as a work-around to document the provider the curation is coming from. But now that the resolved configuration contains the provider explicitly, this is not needed anymore.