### PR TITLE
fix(gradle-plugin): Treat unresolved dependencies as errors

### DIFF
--- a/plugins/package-managers/gradle-plugin/src/main/kotlin/OrtModelBuilder.kt
+++ b/plugins/package-managers/gradle-plugin/src/main/kotlin/OrtModelBuilder.kt
@@ -270,8 +270,8 @@ internal class OrtModelBuilder : ToolingModelBuilder {
                         }
                     }
 
-                    logger.warn(message)
-                    warnings += message
+                    logger.error(message)
+                    errors += message
 
                     null
                 }


### PR DESCRIPTION
This aligns with the current `Gradle` behavior.