### PR TITLE
refactor(model)!: Unqualify scope names by default

### DIFF
--- a/model/src/main/kotlin/DependencyGraph.kt
+++ b/model/src/main/kotlin/DependencyGraph.kt
@@ -154,7 +154,7 @@ data class DependencyGraph(
      * Transform the data stored in this object to the classical layout of dependency information, which is a set of
      * [Scope]s referencing the packages they depend on.
      */
-    fun createScopes(): SortedSet<Scope> = createScopesFor(scopes, unqualify = false)
+    fun createScopes(): SortedSet<Scope> = createScopesFor(scopes, unqualify = true)
 
     /**
      * Transform a subset of the data stored in this object to the classical layout of dependency information. This is


### PR DESCRIPTION
Align the default values of the `createScopes()` functions. In the dependency tree representation usually scopes names are unqualified.