### PR TITLE
build(Jenkinsfile): Adjust the generated report types

### DIFF
--- a/integrations/jenkins/Jenkinsfile
+++ b/integrations/jenkins/Jenkinsfile
@@ -673,8 +673,7 @@ pipeline {
                 fi
 
                 /opt/ort/bin/ort $ORT_OPTIONS report \
-                    -f CycloneDX,PlainTextTemplate,SpdxDocument,StaticHTML,WebApp \
-                    -O PlainTextTemplate=template.id=NOTICE_DEFAULT,NOTICE_SUMMARY \
+                    -f CycloneDX,SpdxDocument,PdfTemplate,PlainTextTemplate,StaticHTML,WebApp \
                     -i out/results/current-result.yml \
                     -o out/results/reporter
                 '''.stripIndent().trim()


### PR DESCRIPTION
Do not create `NOTICE_SUMMARY` as `NOTICE_DEFAULT` should be enough, but create the PDF report(s) to demonstrate theming.