### PR TITLE
fix(bundler): Make GemSpec parsing more robust

### DIFF
--- a/analyzer/src/main/kotlin/managers/GoDep.kt
+++ b/analyzer/src/main/kotlin/managers/GoDep.kt
@@ -49,6 +49,7 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
+import org.ossreviewtoolkit.model.orEmpty
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.common.ProcessCapture
 import org.ossreviewtoolkit.utils.common.collectMessages
@@ -295,7 +296,7 @@ private fun resolveVcsInfo(importPath: String, revision: String, gopath: File): 
     // the "importPath" (which usually resembles a URL).
     val fallbackVcsInfo = VcsHost.parseUrl("https://$importPath").takeIf {
         it.type != VcsType.UNKNOWN
-    } ?: VcsInfo.EMPTY
+    }.orEmpty()
 
     // We want the revision recorded in Gopkg.lock contained in "vcs", not the one "go get" fetched.
     return PackageManager.processProjectVcs(repoRoot, fallbackVcsInfo).copy(revision = revision)

--- a/plugins/package-managers/gradle-inspector/src/main/kotlin/GradleInspector.kt
+++ b/plugins/package-managers/gradle-inspector/src/main/kotlin/GradleInspector.kt
@@ -54,6 +54,7 @@ import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.PackageManagerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.createAndLogIssue
+import org.ossreviewtoolkit.model.orEmpty
 import org.ossreviewtoolkit.model.utils.parseRepoManifestPath
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.common.splitOnWhitespace
@@ -349,7 +350,7 @@ private fun OrtDependency.toVcsInfo() =
 
             handleValidScmInfo(type, url, tag)
         } ?: handleInvalidScmInfo(connection, tag)
-    } ?: VcsInfo.EMPTY
+    }.orEmpty()
 
 private fun OrtDependency.handleValidScmInfo(type: String, url: String, tag: String) =
     when {


### PR DESCRIPTION
Disregard empty URIs when creating VCS info. This deals with a change in SnakeYaml 2.0 (used by Jackson 2.15) that deserializes YAML maps with missing values as empty values instead of previously null values.