### PR TITLE
test(PackageCurationTest): Add test for 4-digit version range applicability

### DIFF
--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -436,9 +436,11 @@ class PackageCurationTest : WordSpec({
         }
 
         "work for invalid semvers" {
-            packageCurationForVersion("3.0.3.jre11").isApplicable(identifierForVersion("3.0.3.jre11")) shouldBe true
-            packageCurationForVersion("3.0.3.jre11").isApplicable(identifierForVersion("3.0.3.jre8")) shouldBe false
-            packageCurationForVersion("1.2.3.4").isApplicable(identifierForVersion("1.2.3.9")) shouldBe false
+            assertSoftly {
+                packageCurationForVersion("3.0.3.jre11").isApplicable(identifierForVersion("3.0.3.jre11")) shouldBe true
+                packageCurationForVersion("3.0.3.jre11").isApplicable(identifierForVersion("3.0.3.jre8")) shouldBe false
+                packageCurationForVersion("1.2.3.4").isApplicable(identifierForVersion("1.2.3.9")) shouldBe false
+            }
         }
 
         "not apply for invalid version ranges" {

--- a/model/src/test/kotlin/PackageCurationTest.kt
+++ b/model/src/test/kotlin/PackageCurationTest.kt
@@ -454,6 +454,20 @@ class PackageCurationTest : WordSpec({
                 packageCurationForVersion("]1.0,)").isApplicable(identifierForVersion("1.0")) shouldBe false
             }
         }
+
+        "apply three digit ranges to four digit versions" {
+            assertSoftly {
+                packageCurationForVersion("[1.0.0,2.0.0]").isApplicable(identifierForVersion("1.0.0.0")) shouldBe true
+                packageCurationForVersion("[1.0.0,2.0.0]").isApplicable(identifierForVersion("1.2.3.4")) shouldBe true
+                packageCurationForVersion("[1.0.0,2.0.0]").isApplicable(identifierForVersion("2.0.0.0")) shouldBe true
+
+                packageCurationForVersion("[1.0.0,2.0.0]").isApplicable(identifierForVersion("0.9.0.0")) shouldBe false
+                // TODO: This should not be applicable, but currently is due the usage of Semver.coerce() which coerces
+                //       2.0.0.1 to 2.0.0.
+                packageCurationForVersion("[1.0.0,2.0.0]").isApplicable(identifierForVersion("2.0.0.1")) shouldBe true
+                packageCurationForVersion("[1.0.0,2.0.0]").isApplicable(identifierForVersion("2.0.1.0")) shouldBe false
+            }
+        }
     }
 })
 


### PR DESCRIPTION
While this is not mentioned in the spec [1], it makes sense to match four digit versions to three digit version ranges.

[1]: https://ant.apache.org/ivy/history/2.1.0/settings/version-matchers.html