### PR TITLE
refactor(scanner): Simplify the message for provenance issues

### DIFF
--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -192,12 +192,7 @@ class Scanner(
                 }.onFailure {
                     controller.addProvenanceResolutionIssue(
                         pkg.id,
-                        Issue(
-                            source = TOOL_NAME,
-                            severity = Severity.ERROR,
-                            message = "Could not resolve provenance for package '${pkg.id.toCoordinates()}': " +
-                                    it.collectMessages()
-                        )
+                        Issue(source = TOOL_NAME, severity = Severity.ERROR, message = it.collectMessages())
                     )
                 }
             }

--- a/scanner/src/main/kotlin/provenance/PackageProvenanceResolver.kt
+++ b/scanner/src/main/kotlin/provenance/PackageProvenanceResolver.kt
@@ -98,7 +98,7 @@ class DefaultPackageProvenanceResolver(
 
         val message = buildString {
             append(
-                "Could not resolve provenance for '${pkg.id.toCoordinates()}' for source code origins " +
+                "Could not resolve provenance for package '${pkg.id.toCoordinates()}' for source code origins " +
                         "$sourceCodeOriginPriority."
             )
 


### PR DESCRIPTION
The underlying `PackageProvenanceResolver` already uses the same prefix for the message, leading to duplications like

    Could not resolve provenance for package '...': IOException: Could not
    resolve provenance for '...' for source code origins [VCS, ARTIFACT].

Simplify that by omitting the first sentence.