### PR TITLE
test(cli): Ignore the order in found NuGet definition files

### DIFF
--- a/cli/src/funTest/kotlin/PackageManagerFunTest.kt
+++ b/cli/src/funTest/kotlin/PackageManagerFunTest.kt
@@ -115,7 +115,7 @@ class PackageManagerFunTest : WordSpec({
                 )
                 managedFilesByName["Maven"] should containExactly("maven/pom.xml")
                 managedFilesByName["NPM"] should containExactly("npm-pnpm-and-yarn/package.json")
-                managedFilesByName["NuGet"] should containExactly(
+                managedFilesByName["NuGet"] should containExactlyInAnyOrder(
                     "dotnet/test.csproj",
                     "nuget/packages.config"
                 )


### PR DESCRIPTION
This fixes a test flakiness and aligns with the assertions for other package managers.