### PR TITLE
docs(Gradle): Remove the comments about repeated repository declarations

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -126,8 +126,6 @@ tasks.named<CreateStartScripts>("startScripts") {
 }
 
 repositories {
-    // Need to repeat several custom repository definitions of other submodules here, see
-    // https://github.com/gradle/gradle/issues/4106.
     exclusiveContent {
         forRepository {
             maven("https://repo.gradle.org/gradle/libs-releases/")

--- a/examples/notifications/build.gradle.kts
+++ b/examples/notifications/build.gradle.kts
@@ -32,8 +32,6 @@ repositories {
         }
     }
 
-    // Need to repeat several custom repository definitions of other submodules here, see
-    // https://github.com/gradle/gradle/issues/4106.
     exclusiveContent {
         forRepository {
             maven("https://packages.atlassian.com/maven-external")

--- a/helper-cli/build.gradle.kts
+++ b/helper-cli/build.gradle.kts
@@ -56,8 +56,6 @@ tasks.named<CreateStartScripts>("startScripts") {
 }
 
 repositories {
-    // Need to repeat the analyzer's custom repository definition here, see
-    // https://github.com/gradle/gradle/issues/4106.
     exclusiveContent {
         forRepository {
             maven("https://repo.gradle.org/gradle/libs-releases/")


### PR DESCRIPTION
These comments have not been used consistently (on the first exclusive repository entry), and the Gradle behavior (which is not going to change) is known by now, so just remove the comment.