### PR TITLE
refactor(cli): Do not expose the logger as a public property

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -182,6 +182,7 @@ dependencies {
     implementation(libs.clikt)
     implementation(libs.jacksonModuleKotlin)
     implementation(libs.kotlinxCoroutines)
+    implementation(libs.log4jApiKotlin)
     implementation(libs.logbackClassic)
     implementation(libs.postgres)
     implementation(libs.reflections)

--- a/cli/src/main/kotlin/OrtMain.kt
+++ b/cli/src/main/kotlin/OrtMain.kt
@@ -39,10 +39,11 @@ import com.github.ajalt.clikt.parameters.types.file
 
 import kotlin.system.exitProcess
 
+import org.apache.logging.log4j.kotlin.Logging
+
 import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
-import org.ossreviewtoolkit.plugins.commands.api.utils.logger
 import org.ossreviewtoolkit.utils.common.EnvironmentVariableFilter
 import org.ossreviewtoolkit.utils.common.Os
 import org.ossreviewtoolkit.utils.common.expandTilde
@@ -68,6 +69,8 @@ fun main(args: Array<String>) {
 }
 
 class OrtMain : CliktCommand(name = ORT_NAME, invokeWithoutSubcommand = true) {
+    private companion object : Logging
+
     private val configFile by option("--config", "-c", help = "The path to a configuration file.")
         .convert { it.expandTilde() }
         .file(mustExist = true, canBeFile = true, canBeDir = false, mustBeWritable = false, mustBeReadable = true)

--- a/cli/src/main/kotlin/commands/AnalyzerCommand.kt
+++ b/cli/src/main/kotlin/commands/AnalyzerCommand.kt
@@ -35,6 +35,8 @@ import java.time.Duration
 
 import kotlin.time.toKotlinDuration
 
+import org.apache.logging.log4j.kotlin.Logging
+
 import org.ossreviewtoolkit.analyzer.Analyzer
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.analyzer.PackageManagerFactory
@@ -49,7 +51,6 @@ import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
 import org.ossreviewtoolkit.plugins.commands.api.utils.SeverityStats
 import org.ossreviewtoolkit.plugins.commands.api.utils.configurationGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
-import org.ossreviewtoolkit.plugins.commands.api.utils.logger
 import org.ossreviewtoolkit.plugins.commands.api.utils.outputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.writeOrtResult
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
@@ -64,6 +65,8 @@ class AnalyzerCommand : OrtCommand(
     name = "analyze",
     help = "Determine dependencies of a software project."
 ) {
+    private companion object : Logging
+
     private val inputDir by option(
         "--input-dir", "-i",
         help = "The project directory to analyze. As a special case, if only one package manager is enabled, this " +

--- a/cli/src/main/kotlin/commands/DownloaderCommand.kt
+++ b/cli/src/main/kotlin/commands/DownloaderCommand.kt
@@ -44,6 +44,8 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
+import org.apache.logging.log4j.kotlin.Logging
+
 import org.ossreviewtoolkit.downloader.DownloadException
 import org.ossreviewtoolkit.downloader.Downloader
 import org.ossreviewtoolkit.downloader.VersionControlSystem
@@ -67,7 +69,6 @@ import org.ossreviewtoolkit.plugins.commands.api.utils.GroupTypes.StringType
 import org.ossreviewtoolkit.plugins.commands.api.utils.OPTION_GROUP_INPUT
 import org.ossreviewtoolkit.plugins.commands.api.utils.configurationGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
-import org.ossreviewtoolkit.plugins.commands.api.utils.logger
 import org.ossreviewtoolkit.plugins.commands.api.utils.outputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.readOrtResult
 import org.ossreviewtoolkit.utils.common.ArchiveType
@@ -86,6 +87,8 @@ class DownloaderCommand : OrtCommand(
     name = "download",
     help = "Fetch source code from a remote location."
 ) {
+    private companion object : Logging
+
     private val input by mutuallyExclusiveOptions(
         option(
             "--ort-file", "-i",

--- a/cli/src/main/kotlin/commands/EvaluatorCommand.kt
+++ b/cli/src/main/kotlin/commands/EvaluatorCommand.kt
@@ -35,6 +35,8 @@ import java.time.Duration
 
 import kotlin.time.toKotlinDuration
 
+import org.apache.logging.log4j.kotlin.Logging
+
 import org.ossreviewtoolkit.evaluator.Evaluator
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.ResolvedPackageCurations.Companion.REPOSITORY_CONFIGURATION_PROVIDER_ID
@@ -62,7 +64,6 @@ import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
 import org.ossreviewtoolkit.plugins.commands.api.utils.SeverityStats
 import org.ossreviewtoolkit.plugins.commands.api.utils.configurationGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
-import org.ossreviewtoolkit.plugins.commands.api.utils.logger
 import org.ossreviewtoolkit.plugins.commands.api.utils.outputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.readOrtResult
 import org.ossreviewtoolkit.plugins.commands.api.utils.writeOrtResult
@@ -80,6 +81,8 @@ class EvaluatorCommand : OrtCommand(
     name = "evaluate",
     help = "Evaluate ORT result files against policy rules."
 ) {
+    private companion object : Logging
+
     private val ortFile by option(
         "--ort-file", "-i",
         help = "The ORT result file to read as input."

--- a/cli/src/main/kotlin/commands/NotifierCommand.kt
+++ b/cli/src/main/kotlin/commands/NotifierCommand.kt
@@ -27,6 +27,8 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
+import org.apache.logging.log4j.kotlin.Logging
+
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
 import org.ossreviewtoolkit.model.utils.mergeLabels
 import org.ossreviewtoolkit.notifier.Notifier
@@ -43,6 +45,8 @@ class NotifierCommand : OrtCommand(
     name = "notify",
     help = "Create notifications based on an ORT result."
 ) {
+    private companion object : Logging
+
     private val ortFile by option(
         "--ort-file", "-i",
         help = "The ORT result file to read as input."

--- a/cli/src/main/kotlin/commands/ReporterCommand.kt
+++ b/cli/src/main/kotlin/commands/ReporterCommand.kt
@@ -38,6 +38,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 
+import org.apache.logging.log4j.kotlin.Logging
+
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
@@ -56,7 +58,6 @@ import org.ossreviewtoolkit.model.utils.SimplePackageConfigurationProvider
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
 import org.ossreviewtoolkit.plugins.commands.api.utils.configurationGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
-import org.ossreviewtoolkit.plugins.commands.api.utils.logger
 import org.ossreviewtoolkit.plugins.commands.api.utils.outputGroup
 import org.ossreviewtoolkit.plugins.commands.api.utils.readOrtResult
 import org.ossreviewtoolkit.reporter.DefaultLicenseTextProvider
@@ -78,6 +79,8 @@ class ReporterCommand : OrtCommand(
     name = "report",
     help = "Present Analyzer, Scanner and Evaluator results in various formats."
 ) {
+    private companion object : Logging
+
     private val ortFile by option(
         "--ort-file", "-i",
         help = "The ORT result file to use."

--- a/cli/src/main/kotlin/commands/RequirementsCommand.kt
+++ b/cli/src/main/kotlin/commands/RequirementsCommand.kt
@@ -24,13 +24,14 @@ import com.github.ajalt.clikt.core.ProgramResult
 import java.io.File
 import java.lang.reflect.Modifier
 
+import org.apache.logging.log4j.kotlin.Logging
+
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
-import org.ossreviewtoolkit.plugins.commands.api.utils.logger
 import org.ossreviewtoolkit.scanner.CommandLinePathScannerWrapper
 import org.ossreviewtoolkit.utils.common.CommandLineTool
 import org.ossreviewtoolkit.utils.spdx.scanCodeLicenseTextDir
@@ -43,6 +44,8 @@ class RequirementsCommand : OrtCommand(
     name = "requirements",
     help = "Check for the command line tools required by ORT."
 ) {
+    private companion object : Logging
+
     override fun run() {
         val reflections = Reflections("org.ossreviewtoolkit")
         val classes = reflections.getSubTypesOf(CommandLineTool::class.java)

--- a/cli/src/main/kotlin/commands/ScannerCommand.kt
+++ b/cli/src/main/kotlin/commands/ScannerCommand.kt
@@ -41,6 +41,8 @@ import kotlin.time.toKotlinDuration
 
 import kotlinx.coroutines.runBlocking
 
+import org.apache.logging.log4j.kotlin.Logging
+
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.PackageType
@@ -72,6 +74,8 @@ class ScannerCommand : OrtCommand(
     name = "scan",
     help = "Run external license / copyright scanners."
 ) {
+    private companion object : Logging
+
     private val input by mutuallyExclusiveOptions(
         option(
             "--ort-file", "-i",

--- a/cli/src/main/kotlin/commands/UploadCurationsCommand.kt
+++ b/cli/src/main/kotlin/commands/UploadCurationsCommand.kt
@@ -29,6 +29,8 @@ import com.github.ajalt.clikt.parameters.types.file
 
 import java.net.URI
 
+import org.apache.logging.log4j.kotlin.Logging
+
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionInfo
 import org.ossreviewtoolkit.clients.clearlydefined.ClearlyDefinedService.ContributionPatch
@@ -50,7 +52,6 @@ import org.ossreviewtoolkit.model.utils.toClearlyDefinedCoordinates
 import org.ossreviewtoolkit.model.utils.toClearlyDefinedSourceLocation
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
-import org.ossreviewtoolkit.plugins.commands.api.utils.logger
 import org.ossreviewtoolkit.utils.common.expandTilde
 import org.ossreviewtoolkit.utils.ort.OkHttpClientHelper
 
@@ -58,6 +59,8 @@ class UploadCurationsCommand : OrtCommand(
     name = "upload-curations",
     help = "Upload ORT package curations to ClearlyDefined."
 ) {
+    private companion object : Logging
+
     private val inputFile by option(
         "--input-file", "-i",
         help = "The file with package curations to upload."

--- a/cli/src/main/kotlin/commands/UploadResultToPostgresCommand.kt
+++ b/cli/src/main/kotlin/commands/UploadResultToPostgresCommand.kt
@@ -27,6 +27,8 @@ import com.github.ajalt.clikt.parameters.types.file
 
 import java.sql.SQLException
 
+import org.apache.logging.log4j.kotlin.Logging
+
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.Database
@@ -52,6 +54,8 @@ class UploadResultToPostgresCommand : OrtCommand(
     name = "upload-result-to-postgres",
     help = "Upload an ORT result to a PostgreSQL database."
 ) {
+    private companion object : Logging
+
     private val ortFile by option(
         "--ort-file", "-i",
         help = "The ORT result file to read as input."

--- a/cli/src/main/kotlin/commands/UploadResultToSw360Command.kt
+++ b/cli/src/main/kotlin/commands/UploadResultToSw360Command.kt
@@ -25,6 +25,8 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
+import org.apache.logging.log4j.kotlin.Logging
+
 import org.eclipse.sw360.clients.adapter.AttachmentUploadRequest
 import org.eclipse.sw360.clients.adapter.SW360ProjectClientAdapter
 import org.eclipse.sw360.clients.adapter.SW360ReleaseClientAdapter
@@ -43,7 +45,6 @@ import org.ossreviewtoolkit.model.config.Sw360StorageConfiguration
 import org.ossreviewtoolkit.model.utils.toPurl
 import org.ossreviewtoolkit.plugins.commands.api.OrtCommand
 import org.ossreviewtoolkit.plugins.commands.api.utils.inputGroup
-import org.ossreviewtoolkit.plugins.commands.api.utils.logger
 import org.ossreviewtoolkit.plugins.commands.api.utils.readOrtResult
 import org.ossreviewtoolkit.scanner.storages.Sw360Storage
 import org.ossreviewtoolkit.utils.common.collectMessages
@@ -56,6 +57,8 @@ class UploadResultToSw360Command : OrtCommand(
     name = "upload-result-to-sw360",
     help = "Upload an ORT result to SW360."
 ) {
+    private companion object : Logging
+
     private val ortFile by option(
         "--ort-file", "-i",
         help = "The ORT result file to read as input."

--- a/plugins/commands/advisor/build.gradle.kts
+++ b/plugins/commands/advisor/build.gradle.kts
@@ -32,4 +32,5 @@ dependencies {
 
     implementation(libs.clikt)
     implementation(libs.kotlinxCoroutines)
+    implementation(libs.log4jApiKotlin)
 }

--- a/plugins/commands/advisor/src/main/kotlin/AdvisorCommand.kt
+++ b/plugins/commands/advisor/src/main/kotlin/AdvisorCommand.kt
@@ -37,6 +37,8 @@ import kotlin.time.toKotlinDuration
 
 import kotlinx.coroutines.runBlocking
 
+import org.apache.logging.log4j.kotlin.Logging
+
 import org.ossreviewtoolkit.advisor.Advisor
 import org.ossreviewtoolkit.model.FileFormat
 import org.ossreviewtoolkit.model.utils.DefaultResolutionProvider
@@ -56,6 +58,8 @@ class AdvisorCommand : OrtCommand(
     name = "advise",
     help = "Check dependencies for security vulnerabilities."
 ) {
+    private companion object : Logging
+
     private val ortFile by option(
         "--ort-file", "-i",
         help = "An ORT result file with an analyzer result to use."

--- a/plugins/commands/api/src/main/kotlin/utils/Extensions.kt
+++ b/plugins/commands/api/src/main/kotlin/utils/Extensions.kt
@@ -19,7 +19,6 @@
 
 package org.ossreviewtoolkit.plugins.commands.api.utils
 
-import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.GroupableOption
 
 import java.io.File
@@ -27,7 +26,7 @@ import java.io.File
 import kotlin.time.measureTime
 import kotlin.time.measureTimedValue
 
-import org.apache.logging.log4j.kotlin.cachedLoggerOf
+import org.apache.logging.log4j.kotlin.Logging
 
 import org.ossreviewtoolkit.model.HashAlgorithm
 import org.ossreviewtoolkit.model.OrtResult
@@ -44,15 +43,9 @@ fun <T : GroupableOption> T.outputGroup(): T = group(OPTION_GROUP_OUTPUT)
 fun <T : GroupableOption> T.configurationGroup(): T = group(OPTION_GROUP_CONFIGURATION)
 
 /**
- * An extension property for adding a logger property to any [CliktCommand].
- */
-val CliktCommand.logger
-    inline get() = cachedLoggerOf(javaClass)
-
-/**
  * Read [ortFile] into an [OrtResult] and return it.
  */
-fun CliktCommand.readOrtResult(ortFile: File): OrtResult {
+fun Logging.readOrtResult(ortFile: File): OrtResult {
     logger.debug { "Input ORT result file has SHA-1 hash ${HashAlgorithm.SHA1.calculate(ortFile)}." }
 
     val (ortResult, duration) = measureTimedValue { ortFile.readValue<OrtResult>() }
@@ -65,7 +58,7 @@ fun CliktCommand.readOrtResult(ortFile: File): OrtResult {
 /**
  * Write the [ortResult] to all [outputFiles] for the given [resultName].
  */
-fun CliktCommand.writeOrtResult(ortResult: OrtResult, outputFiles: Collection<File>, resultName: String) {
+fun Logging.writeOrtResult(ortResult: OrtResult, outputFiles: Collection<File>, resultName: String) {
     outputFiles.forEach { file ->
         println("Writing $resultName result to '$file'.")
         val duration = measureTime { file.writeValue(ortResult) }


### PR DESCRIPTION
Avoid the logger implementation to become part of the API by aligning with remaining code that uses a non-public companion object to make use of logging.