### PR TITLE
utils: Improve the listing of VCS directories

### DIFF
--- a/utils/common/src/main/kotlin/Utils.kt
+++ b/utils/common/src/main/kotlin/Utils.kt
@@ -25,14 +25,14 @@ import java.security.MessageDigest
 import java.util.EnumSet
 
 /**
- * A list of directories used by version control systems to store metadata.
+ * A list of directories used by version control systems to store metadata. The list covers also version control systems
+ * not supported by ORT, because such directories should never be considered.
  */
 val VCS_DIRECTORIES = listOf(
     ".git",
     ".hg",
     ".repo",
     ".svn",
-    // Keep CVS directories in here even if ORT itself does not support CVS anymore.
     "CVS",
     "CVSROOT"
 )

--- a/utils/common/src/main/kotlin/Utils.kt
+++ b/utils/common/src/main/kotlin/Utils.kt
@@ -29,6 +29,7 @@ import java.util.EnumSet
  * not supported by ORT, because such directories should never be considered.
  */
 val VCS_DIRECTORIES = listOf(
+    ".bzr",
     ".git",
     ".hg",
     ".repo",


### PR DESCRIPTION
See individual commits.

Part of #6943, e.g. files under `VCS_DIRECTORIES` will be excluded from the file listings.