### PR TITLE
scanner: Create and store file listings for each resolved provenance

### DIFF
--- a/integrations/schemas/ort-configuration-schema.json
+++ b/integrations/schemas/ort-configuration-schema.json
@@ -292,6 +292,9 @@
                 "detectedLicenseMapping": {
                     "$ref": "#/definitions/DetectedLicenseMapping"
                 },
+                "fileListingStorage": {
+                    "$ref": "#/definitions/FileListingStorage"
+                },
                 "options": {
                     "$ref": "#/definitions/ScannerOptions"
                 },
@@ -328,6 +331,18 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "fileStorage": {
+                    "$ref": "#/definitions/FileStorage"
+                },
+                "postgresStorage": {
+                    "$ref": "#/definitions/PostgresConfig"
+                }
+            }
+        },
+        "FileListingStorage": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
                 "fileStorage": {
                     "$ref": "#/definitions/FileStorage"
                 },

--- a/model/src/main/kotlin/config/FileListingStorageConfiguration.kt
+++ b/model/src/main/kotlin/config/FileListingStorageConfiguration.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.model.config
+
+import org.apache.logging.log4j.kotlin.Logging
+
+import org.ossreviewtoolkit.model.utils.DatabaseUtils
+import org.ossreviewtoolkit.model.utils.FileProvenanceFileStorage
+import org.ossreviewtoolkit.model.utils.PostgresProvenanceFileStorage
+import org.ossreviewtoolkit.model.utils.ProvenanceFileStorage
+import org.ossreviewtoolkit.utils.ort.ortDataDirectory
+import org.ossreviewtoolkit.utils.ort.storage.FileStorage
+import org.ossreviewtoolkit.utils.ort.storage.LocalFileStorage
+
+private const val TABLE_NAME = "provenance_file_listings"
+private const val FILENAME = "file_listings.xz"
+
+data class FileListingStorageConfiguration(
+    /**
+     * Configuration of the [FileStorage] used for storing the file listings.
+     */
+    val fileStorage: FileStorageConfiguration? = null,
+
+    /**
+     * Configuration of the [PostgresProvenanceFileStorage] used for storing the file listings.
+     */
+    val postgresStorage: PostgresStorageConfiguration? = null
+) {
+    private companion object : Logging
+
+    init {
+        if (fileStorage != null && postgresStorage != null) {
+            FileListingStorageConfiguration.logger.warn {
+                "'fileStorage' and 'postgresStorage' are both configured but only one storage can be used. " +
+                        "Using 'fileStorage'."
+            }
+        }
+    }
+}
+
+fun FileListingStorageConfiguration?.createStorage(): ProvenanceFileStorage =
+    when {
+        this?.fileStorage != null -> FileProvenanceFileStorage(
+            storage = fileStorage.createFileStorage(),
+            filename = FILENAME
+        )
+        this?.postgresStorage != null -> PostgresProvenanceFileStorage(
+            dataSource = DatabaseUtils.createHikariDataSource(
+                config = postgresStorage.connection,
+                applicationNameSuffix = "file-listings"
+            ),
+            tableName = TABLE_NAME
+        )
+        else -> FileProvenanceFileStorage(
+            storage = LocalFileStorage(ortDataDirectory.resolve("scanner/file-listings")),
+            filename = FILENAME
+        )
+    }

--- a/model/src/main/kotlin/config/ScannerConfiguration.kt
+++ b/model/src/main/kotlin/config/ScannerConfiguration.kt
@@ -75,6 +75,11 @@ data class ScannerConfiguration(
     ),
 
     /**
+     * The storage to store the file listings by provenance.
+     */
+    val fileListingStorage: FileListingStorageConfiguration? = null,
+
+    /**
      * Scanner specific configuration options. The key needs to match the name of the scanner class, e.g. "ScanCode"
      * for the ScanCode wrapper. See the documentation of the scanner for available options.
      */

--- a/model/src/main/resources/reference.yml
+++ b/model/src/main/resources/reference.yml
@@ -168,6 +168,24 @@ ort:
       BSD (Three Clause License): 'BSD-3-clause'
       LicenseRef-scancode-generic-cla: 'NOASSERTION'
 
+    fileListingStorage:
+      fileStorage:
+        localFileStorage:
+          directory: ~/.ort/scanner/provenance-file-listings
+          compression: false
+
+      postgresStorage:
+        connection:
+          url: 'jdbc:postgresql://your-postgresql-server:5444/your-database'
+          schema: public
+          username: username
+          password: password
+          sslmode: required
+          sslcert: /defaultdir/postgresql.crt
+          sslkey: /defaultdir/postgresql.pk8
+          sslrootcert: /defaultdir/root.crt
+          parallelTransactions: 5
+
     options:
       # A map of maps from scanner class names to scanner-specific key-value pairs.
       ScanCode:

--- a/model/src/test/kotlin/config/OrtConfigurationTest.kt
+++ b/model/src/test/kotlin/config/OrtConfigurationTest.kt
@@ -200,6 +200,30 @@ class OrtConfigurationTest : WordSpec({
                     "LicenseRef-scancode-generic-cla" to "NOASSERTION"
                 )
 
+                fileListingStorage shouldNotBeNull {
+                    fileStorage shouldNotBeNull {
+                        httpFileStorage should beNull()
+                        localFileStorage shouldNotBeNull {
+                            directory shouldBe File("~/.ort/scanner/provenance-file-listings")
+                        }
+                    }
+
+                    postgresStorage shouldNotBeNull {
+                        with(connection) {
+                            url shouldBe "jdbc:postgresql://your-postgresql-server:5444/your-database"
+                            schema shouldBe "public"
+                            username shouldBe "username"
+                            password shouldBe "password"
+                            sslmode shouldBe "required"
+                            sslcert shouldBe "/defaultdir/postgresql.crt"
+                            sslkey shouldBe "/defaultdir/postgresql.pk8"
+                            sslrootcert shouldBe "/defaultdir/root.crt"
+                        }
+
+                        type shouldBe StorageType.PROVENANCE_BASED
+                    }
+                }
+
                 options shouldNotBeNull {
                     get("ScanCode") shouldNotBeNull {
                         this shouldContainExactly mapOf(

--- a/scanner/src/main/kotlin/FileListing.kt
+++ b/scanner/src/main/kotlin/FileListing.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.util.StdConverter
+
+import java.util.SortedSet
+
+import org.ossreviewtoolkit.scanner.FileListing.FileEntry
+import org.ossreviewtoolkit.utils.common.StringSortedSetConverter
+import org.ossreviewtoolkit.utils.common.getDuplicates
+
+/**
+ * The model to store a file listing for a resolved provenance.
+ */
+internal data class FileListing(
+    /**
+     * The set of glob expressions which have been used to match directories to be excluded from the file listing.
+     */
+    @JsonSerialize(converter = StringSortedSetConverter::class)
+    val ignorePatterns: Set<String>,
+
+    /**
+     * The set of files contained in the resolved provenance, excluding files which are within a directory ignored by
+     * [ignorePatterns].
+     */
+    @JsonSerialize(converter = FileEntrySortedSetConverter::class)
+    val files: Set<FileEntry>
+) {
+    data class FileEntry constructor(
+        val path: String,
+        val sha1: String
+    )
+
+    init {
+        val duplicates = files.getDuplicates { it.path }.keys
+
+        require(duplicates.isEmpty()) {
+            "The file listing contains duplicate paths which is not allowed: ${duplicates.joinToString()}."
+        }
+    }
+}
+
+private class FileEntrySortedSetConverter : StdConverter<Set<FileEntry>, SortedSet<FileEntry>>() {
+    override fun convert(value: Set<FileEntry>) = value.toSortedSet(compareBy { it.path })
+}

--- a/scanner/src/main/kotlin/ScanController.kt
+++ b/scanner/src/main/kotlin/ScanController.kt
@@ -143,6 +143,18 @@ class ScanController(
         nestedProvenances.values.flatMapTo(mutableSetOf()) { it.getProvenances() }
 
     /**
+     * Return all provenances including sub-repositories associated with the identifiers of the packages they belong to.
+     */
+    fun getIdsByProvenance(): Map<KnownProvenance, Set<Identifier>> =
+        buildMap<_, MutableSet<Identifier>> {
+            getNestedProvenancesByPackage().forEach { (pkg, nestedProvenance) ->
+                nestedProvenance.getProvenances().forEach { provenance ->
+                    getOrPut(provenance) { mutableSetOf() } += pkg.id
+                }
+            }
+        }
+
+    /**
      * Get all provenances for which no scan result for the provided [scanner] is available.
      */
     private fun getMissingProvenanceScans(scanner: ScannerWrapper, nestedProvenance: NestedProvenance) =

--- a/scanner/src/main/kotlin/Scanner.kt
+++ b/scanner/src/main/kotlin/Scanner.kt
@@ -45,7 +45,6 @@ import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.ScanResult
 import org.ossreviewtoolkit.model.ScanSummary
 import org.ossreviewtoolkit.model.ScannerRun
-import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.DownloaderConfiguration
 import org.ossreviewtoolkit.model.config.Options
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
@@ -192,7 +191,7 @@ class Scanner(
                 }.onFailure {
                     controller.addProvenanceResolutionIssue(
                         pkg.id,
-                        Issue(source = TOOL_NAME, severity = Severity.ERROR, message = it.collectMessages())
+                        Issue(source = TOOL_NAME, message = it.collectMessages())
                     )
                 }
             }
@@ -222,7 +221,6 @@ class Scanner(
                             id,
                             Issue(
                                 source = TOOL_NAME,
-                                severity = Severity.ERROR,
                                 message = "Could not resolve nested provenance for package " +
                                         "'${id.toCoordinates()}': ${it.collectMessages()}"
                             )
@@ -610,8 +608,7 @@ class Scanner(
                         Issue(
                             source = "Downloader",
                             message = "Could not create file archive for " +
-                                    "'${pkg.id.toCoordinates()}': ${it.collectMessages()}",
-                            severity = Severity.ERROR
+                                    "'${pkg.id.toCoordinates()}': ${it.collectMessages()}"
                         )
                     )
                 }

--- a/scanner/src/main/kotlin/provenance/ProvenanceDownloader.kt
+++ b/scanner/src/main/kotlin/provenance/ProvenanceDownloader.kt
@@ -39,7 +39,7 @@ import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 /**
  * An interface that provides functionality to download source code.
  */
-interface ProvenanceDownloader {
+fun interface ProvenanceDownloader {
     /**
      * Download the source code specified by the provided [provenance] and return the path to the directory that
      * contains the downloaded source code.

--- a/scanner/src/main/kotlin/utils/FileListingResolver.kt
+++ b/scanner/src/main/kotlin/utils/FileListingResolver.kt
@@ -47,6 +47,8 @@ internal class FileListingResolver(
             createFileListing(dir).also { storage.putFileListing(provenance, it) }
         }
     }
+
+    fun has(provenance: KnownProvenance): Boolean = storage.hasFile(provenance)
 }
 
 private fun ProvenanceFileStorage.putFileListing(provenance: KnownProvenance, fileListing: FileListing) {

--- a/scanner/src/main/kotlin/utils/FileListingResolver.kt
+++ b/scanner/src/main/kotlin/utils/FileListingResolver.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.utils
+
+import java.io.File
+
+import org.apache.commons.compress.compressors.xz.XZCompressorInputStream
+import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream
+
+import org.ossreviewtoolkit.model.HashAlgorithm
+import org.ossreviewtoolkit.model.KnownProvenance
+import org.ossreviewtoolkit.model.fromYaml
+import org.ossreviewtoolkit.model.toYaml
+import org.ossreviewtoolkit.model.utils.ProvenanceFileStorage
+import org.ossreviewtoolkit.scanner.FileListing
+import org.ossreviewtoolkit.scanner.FileListing.FileEntry
+import org.ossreviewtoolkit.scanner.provenance.ProvenanceDownloader
+import org.ossreviewtoolkit.utils.common.FileMatcher
+import org.ossreviewtoolkit.utils.common.VCS_DIRECTORIES
+import org.ossreviewtoolkit.utils.ort.createOrtTempFile
+
+internal class FileListingResolver(
+    private val storage: ProvenanceFileStorage,
+    private val provenanceDownloader: ProvenanceDownloader
+) {
+    fun resolve(provenance: KnownProvenance): FileListing {
+        storage.getFileListing(provenance)?.let { return it }
+
+        return provenanceDownloader.download(provenance).let { dir ->
+            createFileListing(dir).also { storage.putFileListing(provenance, it) }
+        }
+    }
+}
+
+private fun ProvenanceFileStorage.putFileListing(provenance: KnownProvenance, fileListing: FileListing) {
+    val tempFile = createOrtTempFile(prefix = "file-listing", suffix = ".yml.xz")
+
+    fileListing.toYaml().byteInputStream().use { input ->
+        XZCompressorOutputStream(tempFile.outputStream()).use { output ->
+            input.copyTo(output)
+        }
+    }
+
+    putFile(provenance, tempFile)
+    tempFile.delete()
+}
+
+private fun ProvenanceFileStorage.getFileListing(provenance: KnownProvenance): FileListing? {
+    val file = getFile(provenance) ?: return null
+
+    val yaml = XZCompressorInputStream(file.inputStream()).use { input ->
+        input.bufferedReader().readText()
+    }
+
+    return yaml.fromYaml()
+}
+
+private val IGNORED_DIRECTORY_MATCHER by lazy {
+    FileMatcher(patterns = VCS_DIRECTORIES.map { "**/$it" })
+}
+
+private fun createFileListing(dir: File): FileListing {
+    val files = dir.walk().onEnter {
+        !IGNORED_DIRECTORY_MATCHER.matches(it.relativeTo(dir).invariantSeparatorsPath)
+    }.filter {
+        it.isFile
+    }.mapTo(mutableSetOf()) {
+        FileEntry(path = it.relativeTo(dir).invariantSeparatorsPath, sha1 = HashAlgorithm.SHA1.calculate(it))
+    }
+
+    return FileListing(ignorePatterns = IGNORED_DIRECTORY_MATCHER.patterns.toSet(), files = files)
+}

--- a/scanner/src/test/assets/expected-file-listing.yml
+++ b/scanner/src/test/assets/expected-file-listing.yml
@@ -1,0 +1,14 @@
+---
+ignore_patterns:
+- "**/.bzr"
+- "**/.git"
+- "**/.hg"
+- "**/.repo"
+- "**/.svn"
+- "**/CVS"
+- "**/CVSROOT"
+files:
+- path: "LICENSE"
+  sha1: "356a192b7913b04c54574d18c28d46e6395428ab"
+- path: "src/cli/main.cpp"
+  sha1: "da4b9237bacccdf19c0760cab7aec4a8359010b0"

--- a/scanner/src/test/kotlin/utils/FileListingResolverTest.kt
+++ b/scanner/src/test/kotlin/utils/FileListingResolverTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.ossreviewtoolkit.scanner.utils
+
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+import java.io.File
+
+import org.ossreviewtoolkit.model.ArtifactProvenance
+import org.ossreviewtoolkit.model.RemoteArtifact
+import org.ossreviewtoolkit.model.toYaml
+import org.ossreviewtoolkit.model.utils.FileProvenanceFileStorage
+import org.ossreviewtoolkit.utils.ort.storage.LocalFileStorage
+import org.ossreviewtoolkit.utils.test.createTestTempDir
+
+class FileListingResolverTest : StringSpec({
+    "resolve() should create the expected file listing" {
+        val resolver = FileListingResolver(
+            storage = FileProvenanceFileStorage(
+                storage = LocalFileStorage(createTestTempDir()),
+                filename = "bytes",
+            ),
+            provenanceDownloader = {
+                createTestTempDirWithFiles(
+                    ".git/index",
+                    "LICENSE",
+                    "src/cli/main.cpp"
+                )
+            },
+        )
+
+        val fileListing = resolver.resolve(ArtifactProvenance(sourceArtifact = RemoteArtifact.EMPTY))
+
+        fileListing.toYaml() shouldBe File("src/test/assets/expected-file-listing.yml").readText()
+    }
+})
+
+private fun Spec.createTestTempDirWithFiles(vararg paths: String) =
+    createTestTempDir().apply {
+        paths.forEachIndexed { index, path ->
+            resolve(path).apply {
+                parentFile.mkdirs()
+                writeText("$index")
+            }
+        }
+    }


### PR DESCRIPTION
Create and store the file listings `(path, sha1)` for each resolved provenance. 
These can be consumed in future iterations (see #6945) for improving the generated SBOMs.

Resolves: #6943.

I've scanned the HEAD of the main branch of npm mime-types which resolved to 335 provenances. The total size of all file listings in the Postgres database is 5605372 bytes. So, about 16.4kb per file listing in average.

BREAKING CHANGE: One does not have to, but should configure a storage backend in `~/.ort/config/config.yml`.
                                      If one doesn't do so, ORT falls back to storing the file listings under `~/.ort` which may not be
                                      desired. See the modified `reference.yml` for how the new configuration feature looks like.
                                     