### PR TITLE
fix(SpdxFile): Default `licenseInfoInFiles` to `NOASSERTION`

### DIFF
--- a/utils/spdx/src/main/kotlin/model/SpdxFile.kt
+++ b/utils/spdx/src/main/kotlin/model/SpdxFile.kt
@@ -102,7 +102,7 @@ data class SpdxFile(
      * The license information found in this file. To represent a not present value [SpdxConstants.NONE] or
      * [SpdxConstants.NOASSERTION] must be used.
      */
-    val licenseInfoInFiles: List<String>,
+    val licenseInfoInFiles: List<String> = listOf(SpdxConstants.NOASSERTION),
 
     /**
      * License notices or other such related notices found in the file. This may include copyright statements.


### PR DESCRIPTION
According to the SPDX 2.3 specification [1] the field `licenseInfoInFiles` is not mandatory, but should default to `NOASSERTION`. While the SPDX 2.2 specification does not mention the default value, the field is also optional in this version [2].

[1]: https://github.com/spdx/spdx-spec/blob/5c893ae8010d5d972ecdf1af953a95d9f53de415/schemas/spdx-schema.json#L561-L574
[2]: https://github.com/spdx/spdx-spec/blob/2dffb51097904e03d5e9b19782e9d1b5cd7c9682/schemas/spdx-schema.json#L453-L459
