### PR TITLE
feat(Osv): Also pass the PURL if known

### DIFF
--- a/advisor/src/main/kotlin/advisors/Osv.kt
+++ b/advisor/src/main/kotlin/advisors/Osv.kt
@@ -158,7 +158,8 @@ private fun createRequest(pkg: Package): VulnerabilitiesForPackageRequest? {
         return VulnerabilitiesForPackageRequest(
             pkg = org.ossreviewtoolkit.clients.osv.Package(
                 name = name,
-                ecosystem = ecosystem
+                ecosystem = ecosystem,
+                purl = pkg.purl.takeUnless { it.isEmpty() }
             ),
             version = pkg.id.version
         )


### PR DESCRIPTION
The optional PURL is recommended to be specified if known, see [1].

[1]: https://ossf.github.io/osv-schema/#affectedpackage-field