### PR TITLE
build(Gradle): Switch from the "dokka" to the "dokkatoo" plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 dependencyAnalysisPlugin = "1.20.0"
 detektPlugin = "1.22.0"
-dokkaPlugin = "1.8.10"
+dokkatooPlugin = "1.3.0"
 downloadPlugin = "5.4.0"
 graalVmNativeImagePlugin = "0.9.22"
 graphQlPlugin = "6.4.1"
@@ -63,7 +63,7 @@ xz = "1.9"
 [plugins]
 dependencyAnalysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependencyAnalysisPlugin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detektPlugin" }
-dokka = { id = "org.jetbrains.dokka", version.ref = "dokkaPlugin" }
+dokkatoo = { id = "dev.adamko.dokkatoo", version.ref = "dokkatooPlugin" }
 download = { id = "de.undercouch.download", version.ref = "downloadPlugin" }
 graalVmNativeImage = { id = "org.graalvm.buildtools.native", version.ref = "graalVmNativeImagePlugin" }
 graphQl = { id = "com.expediagroup.graphql", version.ref = "graphQlPlugin" }


### PR DESCRIPTION
The official "dokka" plugin keeps having Gradle related issues, in
particular out of memory issues. Switch to the unofficial "dokkatoo"
successor [1] to resolve these issues. For simplicity, drop the
dokka-related external link configuration; it needs to be revisited if
and how this needs to be configured with dokkatoo, too. Also generalize
the names of the wrapper tasks to not explicitly mention "dokka"
anymore.

With dokkatoo, run e.g.

    ./gradlew dokkatooGeneratePublicationHtml

to generate HTML documentation files, or run

    ./gradlew docsHtmlJar

to bundle all HTML documentation into a JAR.

[1]: https://github.com/adamko-dev/dokkatoo