### PR TITLE
Simplify `retrievePackageFindings()`'s return value

### DIFF
--- a/advisor/src/funTest/assets/retrieve-package-findings-expected-result.json
+++ b/advisor/src/funTest/assets/retrieve-package-findings-expected-result.json
@@ -1,5 +1,5 @@
 {
-  "NPM::find-my-way:3.0.0" : [ {
+  "NPM::find-my-way:3.0.0" : {
     "advisor" : {
       "name" : "OSV",
       "capabilities" : [ "VULNERABILITIES" ]
@@ -31,8 +31,8 @@
         "severity" : "5.9"
       } ]
     } ]
-  } ],
-  "NPM::discord-markdown:2.3.0" : [ {
+  },
+  "NPM::discord-markdown:2.3.0" : {
     "advisor" : {
       "name" : "OSV",
       "capabilities" : [ "VULNERABILITIES" ]
@@ -60,8 +60,8 @@
         "severity" : "HIGH"
       } ]
     } ]
-  } ],
-  "PyPI::donfig:0.2.0" : [ {
+  },
+  "PyPI::donfig:0.2.0" : {
     "advisor" : {
       "name" : "OSV",
       "capabilities" : [ "VULNERABILITIES" ]
@@ -84,5 +84,5 @@
         "severity" : null
       } ]
     } ]
-  } ]
+  }
 }

--- a/advisor/src/funTest/kotlin/OsvFunTest.kt
+++ b/advisor/src/funTest/kotlin/OsvFunTest.kt
@@ -18,11 +18,8 @@
  */
 
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.inspectors.forAll
-import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNot
 
 import java.time.Instant
 
@@ -54,14 +51,11 @@ class OsvFunTest : StringSpec({
         val packageFindings = osv.retrievePackageFindings(packages)
 
         packageFindings.keys shouldContainExactlyInAnyOrder packages
-        packageFindings.forAll { (_, advisorResult) ->
-            advisorResult shouldNot beEmpty()
-        }
     }
 
     "retrievePackageFindings() returns the expected result for the given package(s)" {
         val expectedResult = getAssetFile("retrieve-package-findings-expected-result.json")
-            .readValue<Map<Identifier, List<AdvisorResult>>>()
+            .readValue<Map<Identifier, AdvisorResult>>()
         val osv = createOsv()
         // The following packages have been chosen because they have only one vulnerability with the oldest possible
         // modified date from the current OSV database, in order to hopefully minimize the flakiness.
@@ -88,14 +82,12 @@ private fun identifierToPackage(id: String): Package =
 private fun createOsv(): Osv =
     Osv("OSV", OsvConfiguration(serverUrl = null))
 
-private fun Map<Identifier, List<AdvisorResult>>.patchTimes(): Map<Identifier, List<AdvisorResult>> =
-    mapValues { (_, advisorResults) ->
-        advisorResults.map { advisorResult ->
-            advisorResult.copy(
-                summary = advisorResult.summary.copy(
-                    startTime = Instant.EPOCH,
-                    endTime = Instant.EPOCH
-                )
+private fun Map<Identifier, AdvisorResult>.patchTimes(): Map<Identifier, AdvisorResult> =
+    mapValues { (_, advisorResult) ->
+        advisorResult.copy(
+            summary = advisorResult.summary.copy(
+                startTime = Instant.EPOCH,
+                endTime = Instant.EPOCH
             )
-        }
+        )
     }

--- a/advisor/src/main/kotlin/AdviceProvider.kt
+++ b/advisor/src/main/kotlin/AdviceProvider.kt
@@ -40,10 +40,9 @@ abstract class AdviceProvider(val providerName: String) {
     private companion object : Logging
 
     /**
-     * For a given set of [Package]s, retrieve findings and return a map that associates each package with a list of
-     * [AdvisorResult]s. Needs to be implemented by child classes.
+     * For a given set of [Package]s, retrieve findings and return a map that associates packages with [AdvisorResult]s.
      */
-    abstract suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, List<AdvisorResult>>
+    abstract suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, AdvisorResult>
 
     /**
      * An object with detail information about this [AdviceProvider].
@@ -58,24 +57,22 @@ abstract class AdviceProvider(val providerName: String) {
         startTime: Instant,
         packages: Set<Package>,
         t: Throwable
-    ): Map<Package, List<AdvisorResult>> {
+    ): Map<Package, AdvisorResult> {
         val endTime = Instant.now()
 
         t.showStackTrace()
 
-        val failedResults = listOf(
-            AdvisorResult(
-                vulnerabilities = emptyList(),
-                advisor = details,
-                summary = AdvisorSummary(
-                    startTime = startTime,
-                    endTime = endTime,
-                    issues = listOf(
-                        createAndLogIssue(
-                            source = providerName,
-                            message = "Failed to retrieve findings from $providerName: " +
-                                    t.collectMessages()
-                        )
+        val failedResults = AdvisorResult(
+            vulnerabilities = emptyList(),
+            advisor = details,
+            summary = AdvisorSummary(
+                startTime = startTime,
+                endTime = endTime,
+                issues = listOf(
+                    createAndLogIssue(
+                        source = providerName,
+                        message = "Failed to retrieve findings from $providerName: " +
+                                t.collectMessages()
                     )
                 )
             )

--- a/advisor/src/main/kotlin/Advisor.kt
+++ b/advisor/src/main/kotlin/Advisor.kt
@@ -90,11 +90,11 @@ class Advisor(
                         val providerResults = provider.retrievePackageFindings(packages)
 
                         logger.info {
-                            "Found ${providerResults.values.flatten().distinct().size} distinct vulnerabilities via " +
+                            "Found ${providerResults.values.distinct().size} distinct vulnerabilities via " +
                                     "${provider.providerName}. "
                         }
 
-                        providerResults.filter { it.value.isNotEmpty() }.keys.takeIf { it.isNotEmpty() }?.let { pkgs ->
+                        providerResults.keys.takeIf { it.isNotEmpty() }?.let { pkgs ->
                             logger.debug {
                                 "Affected packages:\n\n${pkgs.joinToString("\n") { it.id.toCoordinates() }}\n"
                             }
@@ -104,7 +104,7 @@ class Advisor(
                     }
                 }.forEach { providerResults ->
                     providerResults.await().forEach { (pkg, advisorResults) ->
-                        results.merge(pkg.id, advisorResults) { oldResults, newResults ->
+                        results.merge(pkg.id, listOf(advisorResults)) { oldResults, newResults ->
                             oldResults + newResults
                         }
                     }

--- a/advisor/src/main/kotlin/advisors/GitHubDefects.kt
+++ b/advisor/src/main/kotlin/advisors/GitHubDefects.kt
@@ -150,7 +150,7 @@ class GitHubDefects(name: String, config: GitHubDefectsConfiguration) : AdvicePr
 
     /**
      * Produce an [AdvisorResult] for the given [package][pkg], which is assumed to be hosted on GitHub. Query the
-     * GitHub repository  for the necessary information.
+     * GitHub repository for the necessary information.
      */
     private suspend fun findDefectsForGitHubPackage(pkg: GitHubPackage): List<AdvisorResult> {
         logger.info { "Finding defects for package '${pkg.original.id.toCoordinates()}'." }

--- a/advisor/src/main/kotlin/advisors/GitHubDefects.kt
+++ b/advisor/src/main/kotlin/advisors/GitHubDefects.kt
@@ -142,9 +142,8 @@ class GitHubDefects(name: String, config: GitHubDefectsConfiguration) : AdvicePr
      * query the GitHub API; otherwise, return an empty list.
      */
     private suspend fun findDefectsForPackage(pkg: Package): List<AdvisorResult> =
-        REGEX_GITHUB.matchEntire(pkg.vcsProcessed.url)?.let { matchResult ->
-            val gitHubPkg =
-                GitHubPackage(pkg, repoOwner = matchResult.groupValues[1], repoName = matchResult.groupValues[2])
+        REGEX_GITHUB.matchEntire(pkg.vcsProcessed.url)?.let { match ->
+            val gitHubPkg = GitHubPackage(pkg, repoOwner = match.groupValues[1], repoName = match.groupValues[2])
             findDefectsForGitHubPackage(gitHubPkg)
         }.orEmpty()
 

--- a/advisor/src/main/kotlin/advisors/NexusIq.kt
+++ b/advisor/src/main/kotlin/advisors/NexusIq.kt
@@ -81,7 +81,7 @@ class NexusIq(name: String, private val config: NexusIqConfiguration) : AdvicePr
         )
     }
 
-    override suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, List<AdvisorResult>> {
+    override suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, AdvisorResult> {
         val startTime = Instant.now()
 
         val components = packages.filter { it.purl.isNotEmpty() }.map { pkg ->
@@ -114,12 +114,10 @@ class NexusIq(name: String, private val config: NexusIqConfiguration) : AdvicePr
 
             packages.mapNotNullTo(mutableListOf()) { pkg ->
                 componentDetails[pkg.id.toPurl()]?.let { pkgDetails ->
-                    pkg to listOf(
-                        AdvisorResult(
-                            details,
-                            AdvisorSummary(startTime, endTime),
-                            vulnerabilities = pkgDetails.securityData.securityIssues.map { it.toVulnerability() }
-                        )
+                    pkg to AdvisorResult(
+                        details,
+                        AdvisorSummary(startTime, endTime),
+                        vulnerabilities = pkgDetails.securityData.securityIssues.map { it.toVulnerability() }
                     )
                 }
             }.toMap()

--- a/advisor/src/main/kotlin/advisors/OssIndex.kt
+++ b/advisor/src/main/kotlin/advisors/OssIndex.kt
@@ -67,7 +67,7 @@ class OssIndex(name: String, config: OssIndexConfiguration) : AdviceProvider(nam
         )
     }
 
-    override suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, List<AdvisorResult>> {
+    override suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, AdvisorResult> {
         val startTime = Instant.now()
 
         val purls = packages.mapNotNull { pkg -> pkg.purl.takeUnless { it.isEmpty() } }
@@ -90,12 +90,10 @@ class OssIndex(name: String, config: OssIndexConfiguration) : AdviceProvider(nam
 
             packages.mapNotNullTo(mutableListOf()) { pkg ->
                 componentReports[pkg.id.toPurl()]?.let { report ->
-                    pkg to listOf(
-                        AdvisorResult(
-                            details,
-                            AdvisorSummary(startTime, endTime),
-                            vulnerabilities = report.vulnerabilities.map { it.toVulnerability() }
-                        )
+                    pkg to AdvisorResult(
+                        details,
+                        AdvisorSummary(startTime, endTime),
+                        vulnerabilities = report.vulnerabilities.map { it.toVulnerability() }
                     )
                 }
             }.toMap()

--- a/advisor/src/main/kotlin/advisors/VulnerableCode.kt
+++ b/advisor/src/main/kotlin/advisors/VulnerableCode.kt
@@ -72,7 +72,7 @@ class VulnerableCode(name: String, config: VulnerableCodeConfiguration) : Advice
         )
     }
 
-    override suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, List<AdvisorResult>> {
+    override suspend fun retrievePackageFindings(packages: Set<Package>): Map<Package, AdvisorResult> {
         val startTime = Instant.now()
 
         return runCatching {
@@ -93,7 +93,7 @@ class VulnerableCode(name: String, config: VulnerableCodeConfiguration) : Advice
     private suspend fun loadVulnerabilities(
         packages: List<Package>,
         startTime: Instant
-    ): Map<Package, List<AdvisorResult>> {
+    ): Map<Package, AdvisorResult> {
         val packageMap = packages.filter { it.purl.isNotEmpty() }.associateBy { it.purl }
         val packageVulnerabilities = service.getPackageVulnerabilities(PackagesWrapper(packageMap.keys))
         val issues = mutableListOf<Issue>()
@@ -102,7 +102,7 @@ class VulnerableCode(name: String, config: VulnerableCodeConfiguration) : Advice
             packageMap[pv.purl]?.let { pkg ->
                 val vulnerabilities = pv.unresolvedVulnerabilities.map { it.toModel(issues) }
                 val summary = AdvisorSummary(startTime, Instant.now(), issues)
-                pkg to listOf(AdvisorResult(details, summary, vulnerabilities = vulnerabilities))
+                pkg to AdvisorResult(details, summary, vulnerabilities = vulnerabilities)
             }
         }.toMap()
     }

--- a/advisor/src/test/kotlin/AdvisorTest.kt
+++ b/advisor/src/test/kotlin/AdvisorTest.kt
@@ -86,11 +86,12 @@ class AdvisorTest : WordSpec({
             val provider2 = mockkAdviceProvider()
 
             coEvery { provider1.retrievePackageFindings(packages) } returns mapOf(
-                pkg1 to listOf(advisorResult1, advisorResult2),
-                pkg2 to listOf(advisorResult3)
+                pkg1 to advisorResult1,
+                pkg2 to advisorResult3
             )
             coEvery { provider2.retrievePackageFindings(packages) } returns mapOf(
-                pkg2 to listOf(advisorResult4)
+                pkg1 to advisorResult2,
+                pkg2 to advisorResult4
             )
 
             val expectedResults = sortedMapOf(

--- a/advisor/src/test/kotlin/advisors/GitHubDefectsTest.kt
+++ b/advisor/src/test/kotlin/advisors/GitHubDefectsTest.kt
@@ -24,6 +24,7 @@ import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.maps.beEmpty as beEmptyMap
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.contain
@@ -60,7 +61,6 @@ import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.model.config.AdvisorConfiguration
 import org.ossreviewtoolkit.model.config.GitHubDefectsConfiguration
 import org.ossreviewtoolkit.utils.common.enumSetOf
-import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
 class GitHubDefectsTest : WordSpec({
     afterTest {
@@ -75,10 +75,7 @@ class GitHubDefectsTest : WordSpec({
             val advisor = createAdvisor()
             val results = advisor.retrievePackageFindings(setOf(pkg))
 
-            results.keys should containExactly(pkg)
-            results[pkg] shouldNotBeNull {
-                this should beEmpty()
-            }
+            results should beEmptyMap()
         }
 
         "return an empty result for a package without issues" {
@@ -92,10 +89,7 @@ class GitHubDefectsTest : WordSpec({
             val advisor = createAdvisor()
             val results = advisor.retrievePackageFindings(setOf(pkg))
 
-            results.keys should containExactly(pkg)
-            results[pkg] shouldNotBeNull {
-                this should beEmpty()
-            }
+            results should beEmptyMap()
         }
 
         "return issues for a package" {
@@ -450,7 +444,7 @@ private suspend fun GitHubDefects.getSingleResult(pkg: Package): AdvisorResult {
     val results = retrievePackageFindings(setOf(pkg))
 
     results.keys should containExactly(pkg)
-    val result = results.getValue(pkg).single()
+    val result = results.getValue(pkg)
     result.advisor.name shouldBe "GitHubDefects"
     result.advisor.capabilities shouldBe enumSetOf(AdvisorCapability.DEFECTS)
 

--- a/advisor/src/test/kotlin/advisors/OssIndexTest.kt
+++ b/advisor/src/test/kotlin/advisors/OssIndexTest.kt
@@ -30,7 +30,6 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactly
-import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.maps.beEmpty as beEmptyMap
 import io.kotest.matchers.should
@@ -83,34 +82,31 @@ class OssIndexTest : WordSpec({
             result shouldNot beEmptyMap()
             result.keys should containExactly(ID_JUNIT)
             result[ID_JUNIT] shouldNotBeNull {
-                this should haveSize(1)
-                with(single()) {
-                    advisor shouldBe ossIndex.details
-                    vulnerabilities should containExactly(
-                        Vulnerability(
-                            id = "CVE-2020-15250",
-                            summary = "[CVE-2020-15250] In JUnit4 from version 4.7 and before 4.13.1,...",
-                            description = "In JUnit4 from version 4.7 and before 4.13.1, the test...",
-                            references = listOf(
-                                VulnerabilityReference(
-                                    url = URI(
-                                        "https://ossindex.sonatype.org/vulnerability/" +
-                                            "7ea56ad4-8a8b-4e51-8ed9-5aad83d8efb1?component-type=maven" +
-                                            "&component-name=junit.junit&utm_source=mozilla&utm_medium=integration" +
-                                            "&utm_content=5.0"
-                                    ),
-                                    scoringSystem = "CVSS:3.0",
-                                    severity = "5.5"
+                advisor shouldBe ossIndex.details
+                vulnerabilities should containExactly(
+                    Vulnerability(
+                        id = "CVE-2020-15250",
+                        summary = "[CVE-2020-15250] In JUnit4 from version 4.7 and before 4.13.1,...",
+                        description = "In JUnit4 from version 4.7 and before 4.13.1, the test...",
+                        references = listOf(
+                            VulnerabilityReference(
+                                url = URI(
+                                    "https://ossindex.sonatype.org/vulnerability/" +
+                                        "7ea56ad4-8a8b-4e51-8ed9-5aad83d8efb1?component-type=maven" +
+                                        "&component-name=junit.junit&utm_source=mozilla&utm_medium=integration" +
+                                        "&utm_content=5.0"
                                 ),
-                                VulnerabilityReference(
-                                    url = URI("https://nvd.nist.gov/vuln/detail/CVE-2020-15250"),
-                                    scoringSystem = "CVSS:3.0",
-                                    severity = "5.5"
-                                )
+                                scoringSystem = "CVSS:3.0",
+                                severity = "5.5"
+                            ),
+                            VulnerabilityReference(
+                                url = URI("https://nvd.nist.gov/vuln/detail/CVE-2020-15250"),
+                                scoringSystem = "CVSS:3.0",
+                                severity = "5.5"
                             )
                         )
                     )
-                }
+                )
             }
         }
 
@@ -132,9 +128,7 @@ class OssIndexTest : WordSpec({
                 keys should containExactly(COMPONENTS_REQUEST_IDS)
 
                 COMPONENTS_REQUEST_IDS.forEach { pkg ->
-                    val pkgResults = getValue(pkg)
-                    pkgResults shouldHaveSize 1
-                    val pkgResult = pkgResults.first()
+                    val pkgResult = getValue(pkg)
                     pkgResult.advisor shouldBe ossIndex.details
                     pkgResult.vulnerabilities should beEmpty()
                     pkgResult.summary.issues shouldHaveSize 1


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 

> **Note**
> This is a breaking change for advisor API users / implementors of advisor plugins as the return value of `retrievePackageFindings()` changes.