### PR TITLE
fix: Drop some (ignored) default values of `ScanSummary`

### DIFF
--- a/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
@@ -393,8 +393,6 @@ scanner:
         start_time: "1970-01-01T00:00:00Z"
         end_time: "1970-01-01T00:00:00Z"
         package_verification_code: "0000000000000000000000000000000000000000"
-        licenses: []
-        copyrights: []
     Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0:
     - provenance:
         vcs_info:
@@ -510,8 +508,6 @@ scanner:
         start_time: "1970-01-01T00:00:00Z"
         end_time: "1970-01-01T00:00:00Z"
         package_verification_code: "0000000000000000000000000000000000000000"
-        licenses: []
-        copyrights: []
     Maven:org.apache.commons:commons-lang3:3.5:
     - provenance:
         source_artifact:
@@ -527,8 +523,6 @@ scanner:
         start_time: "1970-01-01T00:00:00Z"
         end_time: "1970-01-01T00:00:00Z"
         package_verification_code: "0000000000000000000000000000000000000000"
-        licenses: []
-        copyrights: []
     Maven:org.apache.commons:commons-text:1.1:
     - provenance:
         source_artifact:
@@ -544,8 +538,6 @@ scanner:
         start_time: "1970-01-01T00:00:00Z"
         end_time: "1970-01-01T00:00:00Z"
         package_verification_code: "0000000000000000000000000000000000000000"
-        licenses: []
-        copyrights: []
     Maven:org.hamcrest:hamcrest-core:1.3:
     - provenance:
         source_artifact:
@@ -561,8 +553,6 @@ scanner:
         start_time: "1970-01-01T00:00:00Z"
         end_time: "1970-01-01T00:00:00Z"
         package_verification_code: "0000000000000000000000000000000000000000"
-        licenses: []
-        copyrights: []
   storage_stats:
     num_reads: 5
     num_hits: 0

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -393,8 +393,6 @@ scanner:
         start_time: "1970-01-01T00:00:00Z"
         end_time: "1970-01-01T00:00:00Z"
         package_verification_code: "0000000000000000000000000000000000000000"
-        licenses: []
-        copyrights: []
     Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0:
     - provenance:
         vcs_info:
@@ -510,8 +508,6 @@ scanner:
         start_time: "1970-01-01T00:00:00Z"
         end_time: "1970-01-01T00:00:00Z"
         package_verification_code: "0000000000000000000000000000000000000000"
-        licenses: []
-        copyrights: []
     Maven:org.apache.commons:commons-lang3:3.5:
     - provenance:
         source_artifact:
@@ -527,8 +523,6 @@ scanner:
         start_time: "1970-01-01T00:00:00Z"
         end_time: "1970-01-01T00:00:00Z"
         package_verification_code: "0000000000000000000000000000000000000000"
-        licenses: []
-        copyrights: []
     Maven:org.apache.commons:commons-text:1.1:
     - provenance:
         source_artifact:
@@ -544,8 +538,6 @@ scanner:
         start_time: "1970-01-01T00:00:00Z"
         end_time: "1970-01-01T00:00:00Z"
         package_verification_code: "0000000000000000000000000000000000000000"
-        licenses: []
-        copyrights: []
     Maven:org.hamcrest:hamcrest-core:1.3:
     - provenance:
         source_artifact:
@@ -561,8 +553,6 @@ scanner:
         start_time: "1970-01-01T00:00:00Z"
         end_time: "1970-01-01T00:00:00Z"
         package_verification_code: "0000000000000000000000000000000000000000"
-        licenses: []
-        copyrights: []
   storage_stats:
     num_reads: 5
     num_hits: 0

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -393,8 +393,6 @@ scanner:
         start_time: "1970-01-01T00:00:00Z"
         end_time: "1970-01-01T00:00:00Z"
         package_verification_code: "0000000000000000000000000000000000000000"
-        licenses: []
-        copyrights: []
     Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0:
     - provenance:
         vcs_info:
@@ -510,8 +508,6 @@ scanner:
         start_time: "1970-01-01T00:00:00Z"
         end_time: "1970-01-01T00:00:00Z"
         package_verification_code: "0000000000000000000000000000000000000000"
-        licenses: []
-        copyrights: []
     Maven:org.apache.commons:commons-lang3:3.5:
     - provenance:
         source_artifact:
@@ -527,8 +523,6 @@ scanner:
         start_time: "1970-01-01T00:00:00Z"
         end_time: "1970-01-01T00:00:00Z"
         package_verification_code: "0000000000000000000000000000000000000000"
-        licenses: []
-        copyrights: []
     Maven:org.apache.commons:commons-text:1.1:
     - provenance:
         source_artifact:
@@ -544,8 +538,6 @@ scanner:
         start_time: "1970-01-01T00:00:00Z"
         end_time: "1970-01-01T00:00:00Z"
         package_verification_code: "0000000000000000000000000000000000000000"
-        licenses: []
-        copyrights: []
     Maven:org.hamcrest:hamcrest-core:1.3:
     - provenance:
         source_artifact:
@@ -561,8 +553,6 @@ scanner:
         start_time: "1970-01-01T00:00:00Z"
         end_time: "1970-01-01T00:00:00Z"
         package_verification_code: "0000000000000000000000000000000000000000"
-        licenses: []
-        copyrights: []
   storage_stats:
     num_reads: 5
     num_hits: 0

--- a/plugins/reporters/web-app/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
+++ b/plugins/reporters/web-app/src/funTest/assets/dummy-expected-output-for-analyzer-result.yml
@@ -235,8 +235,6 @@ scanner:
         start_time: "1970-01-01T00:00:00Z"
         end_time: "1970-01-01T00:00:00Z"
         package_verification_code: ""
-        licenses: []
-        copyrights: []
         issues:
         - timestamp: "1970-01-01T00:00:00Z"
           source: "scanner"
@@ -281,7 +279,6 @@ scanner:
             path: "org"
             start_line: -1
             end_line: -1
-        copyrights: []
     Maven:org.apache.commons:commons-lang3:3.5:
     - provenance:
         source_artifact:
@@ -308,7 +305,6 @@ scanner:
             path: "org"
             start_line: -1
             end_line: -1
-        copyrights: []
     Maven:org.apache.commons:commons-text:1.1:
     - provenance:
         source_artifact:
@@ -335,7 +331,6 @@ scanner:
             path: "org"
             start_line: -1
             end_line: -1
-        copyrights: []
     Maven:org.hamcrest:hamcrest-core:1.3:
     - provenance:
         source_artifact:
@@ -362,7 +357,6 @@ scanner:
             path: "org"
             start_line: -1
             end_line: -1
-        copyrights: []
   storage_stats:
     num_reads: 0
     num_hits: 0


### PR DESCRIPTION
This is a fix-up for 16f5155.